### PR TITLE
Name the warning class the transition stub really raises, and cap its dependency below the next major

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,10 +54,45 @@ jobs:
       run: python scripts/check_animation_freshness.py
     - name: Lint with Ruff
       run: ruff check .
+    # `stub/src` is in the list because it was in no list at all. The
+    # PyOctaveBand transition shim lives outside the package this repository
+    # installs, so nothing here ever imported, linted or type checked it, and
+    # two defects reached its published page that way.
     - name: Type check with Mypy
-      run: mypy src scripts
+      run: mypy src scripts stub/src
     - name: Security check with Bandit
       run: bandit -r src
+
+  # The PyOctaveBand transition stub under stub/ is built from the tree by a
+  # workflow_dispatch publish job, so until now the first time anything looked
+  # at it was the moment it went to PyPI: a README that named the wrong
+  # warning class and a dependency line with no ceiling were both discovered
+  # after they had shipped. Building it on every pull request costs seconds
+  # and moves `twine check` (which is what renders the long description and
+  # would reject a malformed one) to where a mistake is still cheap.
+  transition-stub:
+    name: Transition stub builds and its metadata is sound
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.13"
+    - name: Build the stub and check its long description
+      run: |
+        python -m pip install --upgrade pip build twine
+        python -m build stub/
+        twine check stub/dist/*
+    # The resolver reads the built metadata, not stub/pyproject.toml, so the
+    # cap that keeps `pip install -U PyOctaveBand` on the line whose API the
+    # shim re-exports is asserted where it will actually be enforced.
+    - name: Fail if the built metadata does not cap phonometry below the next major
+      run: python scripts/check_stub_metadata.py
 
   # Fast gate (~12 s harness, runtime deps only, no pytest): the committed
   # docs/CONFORMANCE.md, and every count quoted from it, must equal a fresh

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -54,10 +54,12 @@ jobs:
       run: python scripts/check_animation_freshness.py
     - name: Lint with Ruff
       run: ruff check .
-    # `stub/src` is in the list because it was in no list at all. The
+    # `stub/src` is in this list because it was in no path list at all. The
     # PyOctaveBand transition shim lives outside the package this repository
-    # installs, so nothing here ever imported, linted or type checked it, and
-    # two defects reached its published page that way.
+    # installs, so nothing here ever imported or type checked it, and two
+    # defects reached its published page that way. Ruff walks the tree from
+    # `.` and has always reached the shim; mypy takes the paths it is given,
+    # and this one was never among them.
     - name: Type check with Mypy
       run: mypy src scripts stub/src
     - name: Security check with Bandit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2372,7 +2372,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   asserts the class it warns with, asserts that the class the README names is
   that same class, and asserts the pin admits every 3.x and no 4.0. `mypy`
   covers `stub/src`, and the stub is built and `twine check`ed on every pull
-  request rather than first at publish time.
+  request rather than first at publish time, with the cap re-asserted against
+  the `Requires-Dist` of the built wheel and sdist, which is what a resolver
+  actually reads.
 
 ## [3.3.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2347,6 +2347,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   detailed prediction and CNOSSOS road emission (two). The Spanish tree now
   references no English asset at all.
 
+- The PyOctaveBand transition stub, on both counts its published page got
+  wrong, and the reason nothing had noticed. `stub/README.md` is the rendered
+  long description of PyOctaveBand on PyPI, and it said the shim re-exports
+  the API with a `DeprecationWarning`. It raises a `FutureWarning`, and
+  deliberately so, because that is the class Python shows by default; a reader
+  acting on the published sentence and calling
+  `warnings.simplefilter("ignore", DeprecationWarning)` silenced nothing. The
+  3.0.0 entry above repeated the same wrong class and says `FutureWarning`
+  now. Second, the stub asked for `phonometry>=3.0.0` with no ceiling, so the
+  day the next major ships, `pip install -U PyOctaveBand` would resolve to a
+  phonometry that has retired the `octavefilter`, `getansifrequencies`,
+  `normalizedfreq` and `calculate_sensitivity` aliases the 3.x `__all__` still
+  carries, and `pyoctaveband.octavefilter(...)` would raise `AttributeError`
+  with nothing naming the cause. That falsifies exactly the two promises this
+  package is for, that a plain rename of the import is a complete migration
+  and that upgrading keeps existing code working. The pin is
+  `phonometry>=3.0.0,<4` now, which ties the transition package to the line
+  whose API is the API of the last release under the old name, and the README
+  says so; the stub is 2.1.1. Underneath both defects was the same gap: the
+  stub is built straight from the tree by a manual workflow and nothing else
+  in the repository imported, type checked or tested it. It now has a test
+  module of its own in the ordinary suite, which executes the shipped shim,
+  asserts the class it warns with, asserts that the class the README names is
+  that same class, and asserts the pin admits every 3.x and no 4.0. `mypy`
+  covers `stub/src`, and the stub is built and `twine check`ed on every pull
+  request rather than first at publish time.
+
 ## [3.3.0] - 2026-07-27
 
 ### Added
@@ -5905,10 +5932,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **The library is now `phonometry`** (formerly `PyOctaveBand`). Install with
   `pip install phonometry` and `import phonometry`. The API is unchanged — a
-  plain rename of the import is a complete migration. The final
-  `PyOctaveBand 2.1.0` release on PyPI is a transition stub that depends on
+  plain rename of the import is a complete migration. The `PyOctaveBand 2.1.0`
+  release on PyPI is a transition stub that depends on
   `phonometry` and re-exports it under the old `pyoctaveband` module name with
-  a `DeprecationWarning`, so `pip install -U PyOctaveBand` keeps existing code
+  a `FutureWarning`, so `pip install -U PyOctaveBand` keeps existing code
   working. The last state under the old name is preserved in the locked
   [`pyoctaveband-v2`](https://github.com/jmrplens/phonometry/tree/pyoctaveband-v2) branch.
 - **Python >= 3.13 required** (was >= 3.11). CI now tests 3.13 and 3.14

--- a/scripts/check_stub_metadata.py
+++ b/scripts/check_stub_metadata.py
@@ -1,0 +1,147 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""Hold the built PyOctaveBand stub to the pin its README promises.
+
+``stub/`` builds the final ``PyOctaveBand`` release: a shim that installs
+``phonometry`` and re-exports it under the old ``pyoctaveband`` module name.
+Its whole promise is that ``pip install -U PyOctaveBand`` keeps existing code
+working and that renaming the import is the entire migration. That holds only
+while the resolved ``phonometry`` still exports the names the last release
+under the old name exported, and a major release is exactly where those go, so
+the requirement has to be capped below the next major.
+
+``tests/test_transition_stub.py`` asserts the cap in ``stub/pyproject.toml``.
+This asserts it in the artifact, because ``pyproject.toml`` is not what a
+resolver reads: pip reads ``Requires-Dist`` out of the built metadata, and a
+build backend or a packaging config can put something else there. The two
+checks are deliberately at opposite ends of the build.
+
+Run after ``python -m build stub/``::
+
+    python scripts/check_stub_metadata.py
+
+CI runs it in the ``transition-stub`` job, right after ``twine check``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tarfile
+import zipfile
+from email import message_from_string
+from email.message import Message
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_DIST = _ROOT / "stub" / "dist"
+
+#: The first version the stub must refuse. Everything below it is a release of
+#: the line whose API the shim re-exports; this one may have retired a name.
+_NEXT_MAJOR = Version("4.0.0")
+
+#: Excluded as well, because pip will install a pre-release of the excluded
+#: major when a specifier's upper bound admits one.
+_NEXT_MAJOR_PRERELEASE = Version("4.0.0rc1")
+
+#: The oldest release that carries the API the shim re-exports.
+_OLDEST_SUPPORTED = Version("3.0.0")
+
+#: A late 3.x, to catch a cap that shuts the door on the line it should keep
+#: open (``==3.0.*``, say, or a stray ``<3.1``).
+_LATEST_SUPPORTED_LINE = Version("3.99.0")
+
+
+def _metadata_of_wheel(path: pathlib.Path) -> Message:
+    with zipfile.ZipFile(path) as archive:
+        names = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(names) != 1:
+            raise SystemExit(f"{path.name}: expected one METADATA, found {names}")
+        return message_from_string(archive.read(names[0]).decode("utf-8"))
+
+
+def _metadata_of_sdist(path: pathlib.Path) -> Message:
+    with tarfile.open(path) as archive:
+        names = [name for name in archive.getnames() if name.endswith("/PKG-INFO")]
+        # The top-level PKG-INFO, not one belonging to a vendored tree.
+        names = [name for name in names if name.count("/") == 1]
+        if len(names) != 1:
+            raise SystemExit(f"{path.name}: expected one PKG-INFO, found {names}")
+        handle = archive.extractfile(names[0])
+        if handle is None:
+            raise SystemExit(f"{path.name}: {names[0]} is not a regular file")
+        return message_from_string(handle.read().decode("utf-8"))
+
+
+def _phonometry_requirement(metadata: Message, label: str) -> Requirement:
+    declared = [
+        Requirement(str(value)) for value in metadata.get_all("Requires-Dist", [])
+    ]
+    named = [item for item in declared if item.name == "phonometry"]
+    if len(named) != 1:
+        raise SystemExit(
+            f"{label}: expected exactly one phonometry requirement, "
+            f"found {[str(item) for item in named]}"
+        )
+    return named[0]
+
+
+def _problems(requirement: Requirement, label: str) -> list[str]:
+    specifier = requirement.specifier
+    found: list[str] = []
+    if not specifier.contains(_OLDEST_SUPPORTED):
+        found.append(
+            f"{label}: '{requirement}' excludes phonometry {_OLDEST_SUPPORTED}, "
+            f"the oldest release that carries the API the shim re-exports."
+        )
+    if not specifier.contains(_LATEST_SUPPORTED_LINE):
+        found.append(
+            f"{label}: '{requirement}' excludes phonometry "
+            f"{_LATEST_SUPPORTED_LINE}; every release of that line must stay "
+            f"eligible."
+        )
+    for rejected, what in (
+        (_NEXT_MAJOR, "the next major"),
+        (_NEXT_MAJOR_PRERELEASE, "a pre-release of the next major"),
+    ):
+        if specifier.contains(rejected, prereleases=True):
+            found.append(
+                f"{label}: '{requirement}' admits phonometry {rejected} ({what}). "
+                f"The stub would then re-export a phonometry that may have "
+                f"retired names 'import pyoctaveband' promises, and user code "
+                f"would raise AttributeError with nothing naming the cause. "
+                f"Cap the requirement in stub/pyproject.toml."
+            )
+    return found
+
+
+def main() -> int:
+    artifacts = sorted(_DIST.glob("*.whl")) + sorted(_DIST.glob("*.tar.gz"))
+    if not artifacts:
+        raise SystemExit(
+            f"no built artifacts in {_DIST.relative_to(_ROOT)}; "
+            f"run 'python -m build stub/' first"
+        )
+
+    problems: list[str] = []
+    for artifact in artifacts:
+        label = artifact.name
+        metadata = (
+            _metadata_of_wheel(artifact)
+            if artifact.suffix == ".whl"
+            else _metadata_of_sdist(artifact)
+        )
+        requirement = _phonometry_requirement(metadata, label)
+        print(f"{label}: Requires-Dist: {requirement}")
+        problems.extend(_problems(requirement, label))
+
+    for problem in problems:
+        print(f"::error::{problem}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stub/README.md
+++ b/stub/README.md
@@ -4,8 +4,9 @@
 
 This is a transition package: installing or upgrading `PyOctaveBand` installs
 `phonometry` and provides a `pyoctaveband` module that re-exports the full,
-unchanged API with a `DeprecationWarning`. Your existing code keeps working,
-but new code should use the new name:
+unchanged API with a `FutureWarning`, which Python shows by default so the
+migration notice actually reaches you. Your existing code keeps working, but
+new code should use the new name:
 
 ```bash
 pip install phonometry
@@ -26,6 +27,12 @@ import phonometry  # instead of: import pyoctaveband
 ```
 
 The API is identical — renaming the import is a complete migration.
+
+This package requires `phonometry>=3.0.0,<4`. The 3.x line is the one whose
+API is the API of the last release under the old name, so that pin is what
+makes the sentence above true: it cannot hand you a release that has retired a
+name `pyoctaveband` promises. Later lines are reached by renaming the import,
+which is the whole of the migration.
 
 - Documentation: https://jmrplens.github.io/phonometry/
 - Repository: https://github.com/jmrplens/phonometry

--- a/stub/pyproject.toml
+++ b/stub/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PyOctaveBand"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
   { name="José Manuel Requena Plens", email="mail@jmrp.io" },
 ]
@@ -16,7 +16,14 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
-    "phonometry>=3.0.0",
+    # Capped below the next major on purpose. This package exists to keep
+    # `import pyoctaveband` working, and it can only keep that promise while
+    # the resolved phonometry still exports what the last release under the
+    # old name exported. A major release is exactly where those names go, so
+    # an uncapped pin would silently upgrade a user into a phonometry that
+    # raises AttributeError for them. The migration path off 3.x is renaming
+    # the import, not a newer stub.
+    "phonometry>=3.0.0,<4",
 ]
 
 [project.urls]

--- a/tests/test_transition_stub.py
+++ b/tests/test_transition_stub.py
@@ -1,0 +1,159 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""
+The PyOctaveBand transition stub that lives under ``stub/``.
+
+It is the one package in the tree nothing else looks at. It is not installed
+by the test environment, it is not imported by the library, `mypy` was pointed
+at ``src`` and ``scripts``, and the publish workflow builds it straight from
+these files on a manual dispatch. So its README ships as the rendered PyPI
+long description of PyOctaveBand without anything ever comparing it to the
+shim it describes, and its dependency line ships as the resolver's only
+instruction without anything ever asking which phonometry releases it admits.
+Both were wrong: the README named a warning class the shim does not raise, and
+the unbounded pin would have carried the next major into a shim whose promise
+that release breaks.
+
+These tests execute the shipped shim and hold the published prose and the
+published pin to what it actually does.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import tomllib
+import types
+import warnings
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+import phonometry
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_STUB = _ROOT / "stub"
+_SHIM = _STUB / "src" / "pyoctaveband" / "__init__.py"
+_README = _STUB / "README.md"
+_PYPROJECT = _STUB / "pyproject.toml"
+
+# Any CamelCase name ending in "Warning", which is how the README refers to the
+# class the shim raises. Deliberately not a search for one hard-coded name:
+# the point is to read whatever the prose claims and compare it with reality.
+_WARNING_CLASS = re.compile(r"\b([A-Z][A-Za-z]*Warning)\b")
+
+# The migration notice, matched on its stable half so the assertion survives
+# an edit to the wording.
+_NOTICE = "renamed to 'phonometry'"
+
+
+def _stub_project() -> dict[str, object]:
+    with _PYPROJECT.open("rb") as handle:
+        project: dict[str, object] = tomllib.load(handle)["project"]
+    return project
+
+
+def _phonometry_requirement() -> Requirement:
+    dependencies = _stub_project()["dependencies"]
+    assert isinstance(dependencies, list)
+    requirements = [Requirement(str(item)) for item in dependencies]
+    named = [req for req in requirements if req.name == "phonometry"]
+    assert len(named) == 1, "the stub must depend on phonometry exactly once"
+    return named[0]
+
+
+def _import_shim() -> tuple[types.ModuleType, list[warnings.WarningMessage]]:
+    """Execute the shipped shim and return it together with what it warned.
+
+    Loaded from its path under a private name rather than imported by name:
+    the stub is not installed in the test environment, and a real import would
+    be cached in ``sys.modules``, so the module body would run once per session
+    and only the first test to ask would see the warning.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_pyoctaveband_transition_shim", _SHIM, submodule_search_locations=[]
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        spec.loader.exec_module(module)
+    return module, list(caught)
+
+
+def test_shim_raises_one_migration_notice_and_it_is_a_futurewarning() -> None:
+    """The class matters: DeprecationWarning is hidden from users by default."""
+    _, caught = _import_shim()
+    notices = [w for w in caught if _NOTICE in str(w.message)]
+    assert len(notices) == 1, "importing the shim must warn exactly once"
+    assert notices[0].category is FutureWarning
+
+
+def test_readme_names_the_warning_class_the_shim_actually_raises() -> None:
+    """The published page must not tell a user to filter the wrong class.
+
+    ``stub/pyproject.toml`` makes this README the long description, so a reader
+    who acts on it types ``warnings.simplefilter("ignore", <class>)``. Named
+    wrongly, that call is a silent no-op.
+    """
+    _, caught = _import_shim()
+    raised = {w.category.__name__ for w in caught if _NOTICE in str(w.message)}
+    named = set(_WARNING_CLASS.findall(_README.read_text(encoding="utf-8")))
+    assert named, "the README must name the warning class the shim raises"
+    assert named == raised, (
+        f"stub/README.md names {sorted(named)}, the shim raises {sorted(raised)}"
+    )
+
+
+def test_stub_readme_is_the_published_long_description() -> None:
+    """What makes the assertion above load-bearing rather than decorative."""
+    assert _stub_project()["readme"] == "README.md"
+
+
+def test_shim_reexports_every_name_phonometry_publishes() -> None:
+    """The promise the stub is built on: the old name still resolves them all."""
+    module, _ = _import_shim()
+    missing = [name for name in phonometry.__all__ if not hasattr(module, name)]
+    assert not missing, f"the shim does not re-export {missing}"
+    assert module.__version__ == phonometry.__version__
+
+
+def test_stub_pin_excludes_the_major_that_may_break_its_promise() -> None:
+    """The stub is a 3.x transition package and its pin has to say so.
+
+    Its README and the 3.0.0 changelog entry promise that ``pip install -U
+    PyOctaveBand`` keeps existing code working and that renaming the import is
+    a complete migration. That promise holds only for as long as the resolved
+    phonometry still exports the names the last release under the old name
+    exported, and a major release is exactly where those go: 4.0 removes the
+    ``octavefilter``, ``getansifrequencies``, ``normalizedfreq`` and
+    ``calculate_sensitivity`` aliases that are in the 3.x ``__all__``. Without
+    a ceiling the resolver would hand a 2.x stub a phonometry that raises
+    ``AttributeError`` for them, with no diagnostic naming the cause.
+    """
+    specifier = _phonometry_requirement().specifier
+    assert specifier.contains(Version("3.0.0")), "the stub needs the 3.0 API"
+    assert specifier.contains(Version("3.99.0")), "every 3.x must stay eligible"
+    assert not specifier.contains(Version("4.0.0")), (
+        "stub/pyproject.toml must cap phonometry below the next major"
+    )
+    assert not specifier.contains(Version("4.0.0rc1")), (
+        "a pre-release of the next major must be excluded too"
+    )
+
+
+def test_tree_version_still_falls_inside_the_pin_the_stub_publishes() -> None:
+    """A forcing gate for the day the ceiling above starts to bite.
+
+    When this tree becomes the major the stub excludes, the published
+    PyOctaveBand stops tracking the library and its README has to be rewritten
+    to say so, or the stub has to be republished against the new line. Neither
+    is a decision to discover from a user's traceback.
+    """
+    specifier: SpecifierSet = _phonometry_requirement().specifier
+    assert specifier.contains(Version(phonometry.__version__)), (
+        f"phonometry {phonometry.__version__} is outside the transition stub's "
+        f"pin '{specifier}'. Decide what PyOctaveBand should now install and "
+        f"say it in stub/README.md before releasing."
+    )

--- a/tests/test_transition_stub.py
+++ b/tests/test_transition_stub.py
@@ -2,13 +2,16 @@
 """
 The PyOctaveBand transition stub that lives under ``stub/``.
 
-It is the one package in the tree nothing else looks at. It is not installed
-by the test environment, it is not imported by the library, `mypy` was pointed
-at ``src`` and ``scripts``, and the publish workflow builds it straight from
-these files on a manual dispatch. So its README ships as the rendered PyPI
-long description of PyOctaveBand without anything ever comparing it to the
-shim it describes, and its dependency line ships as the resolver's only
-instruction without anything ever asking which phonometry releases it admits.
+Almost nothing in the tree looks at it. It is not installed by the test
+environment, it is not imported by the library, `mypy` was pointed at ``src``
+and ``scripts``, and the publish workflow builds it straight from these files
+on a manual dispatch. The lint step is the exception: it walks the tree from
+the root, so it has always read the shim, though not its README or its pin,
+which are prose and metadata rather than Python. So its README ships as the
+rendered PyPI long description of PyOctaveBand without anything ever comparing
+it to the shim it describes, and its dependency line ships as the resolver's
+only instruction without anything ever asking which phonometry releases it
+admits.
 Both were wrong: the README named a warning class the shim does not raise, and
 the unbounded pin would have carried the next major into a shim whose promise
 that release breaks.
@@ -22,10 +25,13 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 import re
+import shutil
+import subprocess
 import tomllib
 import types
 import warnings
 
+import pytest
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -37,6 +43,13 @@ _STUB = _ROOT / "stub"
 _SHIM = _STUB / "src" / "pyoctaveband" / "__init__.py"
 _README = _STUB / "README.md"
 _PYPROJECT = _STUB / "pyproject.toml"
+_WORKFLOW = _ROOT / ".github" / "workflows" / "python-app.yml"
+
+# A claim that some gate never reached the shim, made in the same sentence as
+# linting. The lint step has covered `stub/` since the shim was committed, so
+# any such sentence is false; a sentence that says linting *does* cover it is
+# not matched, and neither is a claim about the gates that really did miss it.
+_UNLINTED_CLAIM = re.compile(r"\b(?:nothing|never|no)\b[^.;]*\blint", re.IGNORECASE)
 
 # Any CamelCase name ending in "Warning", which is how the README refers to the
 # class the shim raises. Deliberately not a search for one hard-coded name:
@@ -46,6 +59,33 @@ _WARNING_CLASS = re.compile(r"\b([A-Z][A-Za-z]*Warning)\b")
 # The migration notice, matched on its stable half so the assertion survives
 # an edit to the wording.
 _NOTICE = "renamed to 'phonometry'"
+
+
+def _gate(tool: str) -> tuple[str, str]:
+    """The CI command that invokes *tool*, and the comment introducing its step.
+
+    Read as text rather than parsed as YAML: the comments are half of what the
+    tests below check, and a YAML parser throws them away. The comment of a
+    step is the run of ``#`` lines above it, whether it sits above the step's
+    ``- name:`` or between that name and its ``run:``.
+    """
+    lines = _WORKFLOW.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("run:"):
+            continue
+        command = stripped.removeprefix("run:").strip()
+        if not command.startswith(tool):
+            continue
+        comment: list[str] = []
+        for previous in reversed(lines[:index]):
+            text = previous.strip()
+            if text.startswith("#"):
+                comment.append(text.lstrip("#").strip())
+            elif not text.startswith("- name:"):
+                break
+        return command, " ".join(reversed(comment))
+    raise AssertionError(f"no step in {_WORKFLOW.name} runs {tool}")
 
 
 def _stub_project() -> dict[str, object]:
@@ -157,4 +197,52 @@ def test_tree_version_still_falls_inside_the_pin_the_stub_publishes() -> None:
         f"phonometry {phonometry.__version__} is outside the transition stub's "
         f"pin '{specifier}'. Decide what PyOctaveBand should now install and "
         f"say it in stub/README.md before releasing."
+    )
+
+
+def test_the_lint_gate_reaches_the_shim() -> None:
+    """The one gate the shim was never outside of, asked rather than assumed.
+
+    ``ruff check .`` discovers its own files by walking the tree, so the shim
+    is covered only for as long as the root stays the argument and nothing
+    excludes ``stub/``. Either could change without anyone noticing that the
+    shim had quietly dropped out of the only gate that reads it. Measured by
+    asking ruff which files the gate's own command visits.
+    """
+    command, _ = _gate("ruff")
+    assert command == "ruff check .", (
+        f"the lint gate is now `{command}`; confirm it still reaches the shim"
+    )
+    executable = shutil.which("ruff")
+    if executable is None:  # pragma: no cover - ruff is a dev dependency
+        pytest.skip("ruff is not installed")
+    listing = subprocess.run(
+        [executable, "check", ".", "--show-files"],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    visited = {pathlib.Path(p).resolve() for p in listing.stdout.splitlines() if p}
+    assert _SHIM.resolve() in visited, (
+        f"`{command}` no longer checks {_SHIM.relative_to(_ROOT)}"
+    )
+
+
+def test_the_type_check_step_does_not_claim_the_shim_went_unlinted() -> None:
+    """The comment explaining the mypy path list must not overstate the gap.
+
+    It was written as `nothing here ever imported, linted or type checked it`,
+    three lines under the ``ruff check .`` that had been linting the shim since
+    the day it was committed. The gap is real for the other two, and naming a
+    third gate that never had it makes the comment argue for the change on a
+    false premise.
+    """
+    command, comment = _gate("mypy")
+    assert "stub/src" in command, "the type check must still cover the shim"
+    assert "stub/src" in comment, "the comment must still explain why it does"
+    overstated = _UNLINTED_CLAIM.search(comment)
+    assert overstated is None, (
+        f"{_WORKFLOW.name} says '{overstated.group(0) if overstated else ''}', "
+        f"but `{_gate('ruff')[0]}` above it already checks the shim"
     )

--- a/tests/test_transition_stub.py
+++ b/tests/test_transition_stub.py
@@ -74,7 +74,8 @@ def _import_shim() -> tuple[types.ModuleType, list[warnings.WarningMessage]]:
     spec = importlib.util.spec_from_file_location(
         "_pyoctaveband_transition_shim", _SHIM, submodule_search_locations=[]
     )
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")


### PR DESCRIPTION
## What was wrong

Two defects in the PyOctaveBand transition package under `stub/`, and the structural gap that let both reach PyPI.

**A. The published page named a warning class the shim does not raise.**
`stub/pyproject.toml` sets `readme = "README.md"`, so `stub/README.md` is the rendered long description of PyOctaveBand 2.1.0 on PyPI. It said the shim re-exports the API "with a `DeprecationWarning`". `stub/src/pyoctaveband/__init__.py` raises a `FutureWarning`, deliberately, with the comment `# FutureWarning (not DeprecationWarning): visible by default`. A reader who acted on the published sentence and called `warnings.simplefilter("ignore", DeprecationWarning)` silenced nothing. The 3.0.0 changelog entry repeated the same wrong class.

**B. The unbounded pin would break the migration path at the next major.**
`stub/pyproject.toml` declared `phonometry>=3.0.0` with no ceiling, while `[Unreleased]` removes the aliases `octavefilter`, `getansifrequencies`, `normalizedfreq` and `calculate_sensitivity`, all four of which are in the `__all__` of the last release under the old name. So the day 4.0.0 ships, `pip install -U PyOctaveBand` silently resolves to a phonometry where `pyoctaveband.octavefilter(...)` raises `AttributeError` with nothing naming the cause. That falsifies exactly the two sentences this package exists for: "a plain rename of the import is a complete migration" and "keeps existing code working".

**Why both shipped.** Nothing in the repository built, imported, type checked or tested `stub/`. `mypy` ran on `src scripts`, pytest never reached it, `sonar.sources=src`, and `publish-stub.yml` ran `twine check` for the first time at publish time. Even `manual_verify_install.yml` installs and imports phonometry only, never the stub. The lint step is the one exception, and I first wrote this sentence with "linted" wrongly in that list: `ruff check .` walks the tree from the root and has always read the shim's Python. What it cannot read is the README that named the wrong class or the pin with no ceiling, which are prose and metadata. See the last section.

## Evidence I measured

The class the shim actually raises, and what a reader acting on the published README got, executing the shipped `stub/src/pyoctaveband/__init__.py`:

```
class raised: FutureWarning
message     : PyOctaveBand has been renamed to 'phonometry'. The API is id ...

-- a user acting on the published README --
warnings still shown after ignoring DeprecationWarning: 1
```

The four aliases, verified both ways. Against the `v3.3.0` tree:

```
v3.3.0 phonometry 3.3.0
  octavefilter         | in __all__: True | resolves: True
  getansifrequencies   | in __all__: True | resolves: True
  normalizedfreq       | in __all__: True | resolves: True
  calculate_sensitivity| in __all__: True | resolves: True
```

Against this working tree:

```
octavefilter          ABSENT from __all__ | hasattr False
getansifrequencies    ABSENT from __all__ | hasattr False
normalizedfreq        ABSENT from __all__ | hasattr False
calculate_sensitivity ABSENT from __all__ | hasattr False
```

And the resolver scenario played out for real, running the uncapped shim against a phonometry that has retired them:

```
-- resolver scenario: stub on a phonometry that dropped the aliases --
AttributeError: module 'pyoctaveband' has no attribute 'octavefilter'
```

The new test module run against the **unfixed** `stub/` (HEAD of `main` extracted into a scratch tree, so the gate sees the shipped files):

```
FAILED tests/test_transition_stub.py::test_readme_names_the_warning_class_the_shim_actually_raises
  - AssertionError: stub/README.md names ['DeprecationWarning'], the shim raises ['FutureWarning']
FAILED tests/test_transition_stub.py::test_stub_pin_excludes_the_major_that_may_break_its_promise
  - AssertionError: stub/pyproject.toml must cap phonometry below the next major
2 failed, 4 passed
```

After the fix:

```
$ python -m pytest tests/test_transition_stub.py -q
8 passed in 1.29s
```

The new build gate, run against a build of the **unfixed** stub:

```
$ python -m build stub/ && python scripts/check_stub_metadata.py
::error::pyoctaveband-2.1.0-py3-none-any.whl: 'phonometry>=3.0.0' admits phonometry 4.0.0 (the next major). ...
::error::pyoctaveband-2.1.0.tar.gz: 'phonometry>=3.0.0' admits phonometry 4.0.0rc1 (a pre-release of the next major). ...
exit=1
```

and against the fixed one:

```
$ python -m build stub/ && twine check stub/dist/* && python scripts/check_stub_metadata.py
Checking stub/dist/pyoctaveband-2.1.1-py3-none-any.whl: PASSED
Checking stub/dist/pyoctaveband-2.1.1.tar.gz: PASSED
pyoctaveband-2.1.1-py3-none-any.whl: Requires-Dist: phonometry<4,>=3.0.0
pyoctaveband-2.1.1.tar.gz: Requires-Dist: phonometry<4,>=3.0.0
exit=0
```

## What I changed

- `stub/README.md` names `FutureWarning` and says why that class was chosen, and states the requirement the package installs.
- `stub/pyproject.toml`: `phonometry>=3.0.0,<4`, with a comment giving the reason, and the version is 2.1.1. **This pins the transition package to the 3.x line by design.** That is what keeps the documented migration promise true: the stub can only guarantee `import pyoctaveband` while the resolved phonometry still exports what the last release under the old name exported. The path off 3.x is renaming the import, which is the whole of the migration, not a newer stub. This had to be decided before 4.0.0 ships, not after.
- `CHANGELOG.md`: the 3.0.0 entry says `FutureWarning`, and `[Unreleased]` records the whole change.
- `tests/test_transition_stub.py`, in the ordinary suite so it runs on every pull request. It executes the shipped shim from its path (not by import, so the module body runs per test rather than once per session), asserts the class it warns with, and asserts that the set of `*Warning` class names the README mentions equals the set the shim raises. That last assertion is the one that would have caught defect A: it reads whatever the prose claims rather than looking for one hard-coded name. It also asserts the pin admits 3.0.0 and every later 3.x and excludes 4.0.0 and `4.0.0rc1`, and that the tree's own version still falls inside the pin, which is a forcing gate: the day this tree becomes the excluded major, the test fails and the decision about what PyOctaveBand should then install has to be made deliberately instead of discovered from a user's traceback.
- CI: `mypy src scripts stub/src`, and a new `transition-stub` job that builds the package and runs `twine check` on ordinary pull requests instead of first at publish time. It then runs `scripts/check_stub_metadata.py`, which re-asserts the cap against the `Requires-Dist` of the built wheel and sdist, because that, and not `stub/pyproject.toml`, is what a resolver reads.

## Correction: the lint step had always read the shim

The comment I added above the mypy step overstated the gap. It said that because the shim lives outside the installed package, "nothing here ever imported, linted or type checked it". The step three lines above it is `ruff check .`, and that had been checking the shim since the day it was committed, so the comment argued for a real change on a premise that is a third false. The same sentence was in this description, above, and is corrected there too. The `CHANGELOG.md` entry got it right already ("nothing else in the repository imported, type checked or tested it") and is unchanged.

There is no ruff configuration anywhere in the tree (no `ruff.toml`, no `[tool.ruff]` in either `pyproject.toml`), so ruff runs on its defaults, whose exclude list does not cover `stub/`. `.gitignore` excludes only `stub/dist/` and `stub/src/*.egg-info/`. Asking ruff which files the lint gate visits:

```
$ ruff check . --show-files | grep stub
.../stub/pyproject.toml
.../stub/src/pyoctaveband/__init__.py
```

And the decisive form, an unused import appended to the shim, with `ruff check .` run from the root exactly as CI runs it:

```
$ ruff check .
F401 `os` imported but unused
  --> stub/src/pyoctaveband/__init__.py:23:8
F401 `sys` imported but unused
  --> stub/src/pyoctaveband/__init__.py:23:12
Found 3 errors.
exit=1
```

`stub/src/pyoctaveband/__init__.py` is byte identical to its state at the merge base, so this was true before this branch existed. The other two thirds of the claim hold: `mypy src scripts` never named `stub/src`, and nothing in the tree imports the shim.

Two tests hold the corrected version in place. `test_the_lint_gate_reaches_the_shim` reads the lint command out of the workflow, asks ruff which files that command visits, and requires the shim among them. `test_the_type_check_step_does_not_claim_the_shim_went_unlinted` reads the comment introducing the mypy step and fails on a sentence that denies the shim is linted, while leaving a sentence that says it is. Against the uncorrected comment:

```
$ python -m pytest tests/test_transition_stub.py -q
FAILED tests/test_transition_stub.py::test_the_type_check_step_does_not_claim_the_shim_went_unlinted
  - AssertionError: python-app.yml says 'nothing here ever imported, lint', but `ruff check .` above it already checks the shim
1 failed, 7 passed in 1.38s
```

After the correction, `8 passed in 1.31s`. Neither test is vacuous: appending `[tool.ruff] extend-exclude = ["stub"]` to `pyproject.toml` fails the first one with `` `ruff check .` no longer checks stub/src/pyoctaveband/__init__.py ``, which is the regression it exists to catch.

## Local gates

```
ruff check .                       All checks passed!
ruff format --check <touched .py>  1 file already formatted
mypy src scripts                   Success: no issues found in 440 source files
mypy src scripts stub/src          Success: no issues found in 441 source files
pytest tests/test_transition_stub.py   8 passed
bandit -r src                      clean
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a CI job to build and validate the PyOctaveBand transition stub on every pull request.</li>
<li>Fixed the PyOctaveBand transition stub metadata by capping the phonometry dependency to <4.</li>
<li>Corrected the README documentation for the transition stub to accurately reflect the warning class used.</li>
<li>Added a new test module to verify the transition stub's behavior and metadata.</li>
<li>Updated Mypy configuration to include the stub source code in type checking.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the migration notice to use `FutureWarning` rather than `DeprecationWarning`.
  - Restricted the transition package to compatible `phonometry` 3.x releases, excluding potentially incompatible 4.x versions.
  - Corrected the 3.0.0 changelog entry.

- **Documentation**
  - Clarified the migration path, import renaming, compatibility requirements, and warning behavior.
  - Updated the Unreleased changelog with validation and compatibility details.

- **Tests**
  - Added coverage for warnings, metadata, re-exports, version compatibility, and published package documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
