### PR TITLE
Import matplotlib lazily in the emission drawing so the base install imports

### DIFF
--- a/src/phonometry/_plot/geometry/emission.py
+++ b/src/phonometry/_plot/geometry/emission.py
@@ -18,7 +18,6 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from matplotlib.colors import to_rgb
 from numpy.typing import ArrayLike
 
 from ..common import (
@@ -105,6 +104,8 @@ def _number_points(ax: Any, pts: np.ndarray, colours: Any) -> None:
     as well as the index and never has to compete with the mesh underneath.
     Its ink is whichever of black or white the chip can actually carry.
     """
+    from matplotlib.colors import to_rgb
+
     if isinstance(colours, str) or not isinstance(colours, Sequence):
         colours = [colours] * len(pts)
     for index, ((x, y, z), chip) in enumerate(zip(pts, colours, strict=True), start=1):

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -55,11 +55,12 @@ def _imports_matplotlib(node: ast.stmt) -> bool:
         names = [node.module or ""] if node.level == 0 else []
     else:
         return False
-    return any(name == "matplotlib" or name.startswith("matplotlib.")
-               for name in names)
+    return any(name == "matplotlib" or name.startswith("matplotlib.") for name in names)
 
 
-def _eager_matplotlib_imports(body: list[ast.stmt], *, guarded: bool = False) -> list[int]:
+def _eager_matplotlib_imports(
+    body: list[ast.stmt], *, guarded: bool = False
+) -> list[int]:
     """Line numbers of the matplotlib imports that run at import time.
 
     Only two placements are lazy: inside a function body, and under
@@ -80,8 +81,12 @@ def _eager_matplotlib_imports(body: list[ast.stmt], *, guarded: bool = False) ->
             eager += _eager_matplotlib_imports(node.body, guarded=deferred)
             eager += _eager_matplotlib_imports(node.orelse, guarded=guarded)
         elif isinstance(node, ast.Try):
-            for block in (node.body, node.orelse, node.finalbody,
-                          *(handler.body for handler in node.handlers)):
+            for block in (
+                node.body,
+                node.orelse,
+                node.finalbody,
+                *(handler.body for handler in node.handlers),
+            ):
                 eager += _eager_matplotlib_imports(block, guarded=guarded)
         elif isinstance(node, (ast.With, ast.ClassDef)):
             eager += _eager_matplotlib_imports(node.body, guarded=guarded)

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -1,16 +1,22 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 
 """
-Tests ensuring the package does not hijack the global matplotlib backend.
+Tests ensuring the package treats matplotlib as the optional dependency it is.
 
-Importing phonometry must not force a specific (e.g. non-interactive)
-backend, so the package can be used during interactive exploration
-(IPython, Jupyter). See issue #52.
+Two promises are kept here. Importing phonometry must not force a specific
+(e.g. non-interactive) backend, so the package can be used during interactive
+exploration (IPython, Jupyter); see issue #52. And the base install must run on
+NumPy and SciPy alone, so ``import phonometry`` has to succeed with matplotlib
+absent, plotting failing only when a plot is actually asked for.
 """
 
+import ast
 import os
 import subprocess
 import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "phonometry"
 
 
 def test_import_does_not_override_matplotlib_backend() -> None:
@@ -39,31 +45,125 @@ def test_import_does_not_override_matplotlib_backend() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_filters_design_has_no_toplevel_matplotlib_import() -> None:
-    """matplotlib must be imported lazily so the package works without it."""
-    import ast
-    import inspect
+def _imports_matplotlib(node: ast.stmt) -> bool:
+    """Whether ``node`` is an import statement that pulls in matplotlib."""
+    if isinstance(node, ast.Import):
+        names = [alias.name for alias in node.names]
+    elif isinstance(node, ast.ImportFrom):
+        # A relative import (level > 0) names a module of this package, never
+        # matplotlib, whatever the module happens to be called.
+        names = [node.module or ""] if node.level == 0 else []
+    else:
+        return False
+    return any(name == "matplotlib" or name.startswith("matplotlib.")
+               for name in names)
 
-    from phonometry.filters import design
 
-    tree = ast.parse(inspect.getsource(design))
+def _eager_matplotlib_imports(body: list[ast.stmt], *, guarded: bool = False) -> list[int]:
+    """Line numbers of the matplotlib imports that run at import time.
 
-    # Only imports inside a function body are lazy; module-scope imports
-    # (even wrapped in try/if blocks) still run at import time.
-    inside_functions: set[ast.AST] = set()
-    for func in ast.walk(tree):
-        if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            for sub in ast.walk(func):
-                inside_functions.add(sub)
+    Only two placements are lazy: inside a function body, and under
+    ``if TYPE_CHECKING:``, which never executes. Everything else at module
+    scope runs the moment the package is imported, including a class body and
+    the branches of a runtime ``if``, a ``try`` or a ``with`` -- so this
+    descends into those rather than assuming a bare top-level statement is the
+    only way to import something eagerly.
+    """
+    eager: list[int] = []
+    for node in body:
+        if _imports_matplotlib(node):
+            if not guarded:
+                eager.append(node.lineno)
+        elif isinstance(node, ast.If):
+            # ``else`` is the runtime branch of a TYPE_CHECKING guard.
+            deferred = guarded or "TYPE_CHECKING" in ast.unparse(node.test)
+            eager += _eager_matplotlib_imports(node.body, guarded=deferred)
+            eager += _eager_matplotlib_imports(node.orelse, guarded=guarded)
+        elif isinstance(node, ast.Try):
+            for block in (node.body, node.orelse, node.finalbody,
+                          *(handler.body for handler in node.handlers)):
+                eager += _eager_matplotlib_imports(block, guarded=guarded)
+        elif isinstance(node, (ast.With, ast.ClassDef)):
+            eager += _eager_matplotlib_imports(node.body, guarded=guarded)
+    return eager
 
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            module = getattr(node, "module", None) or ""
-            aliases = [a.name for a in node.names]
-            if any("matplotlib" in n for n in [module, *aliases]):
-                assert node in inside_functions, (
-                    "matplotlib imported at module scope in filters.design"
-                )
+
+def test_no_module_scope_matplotlib_import_anywhere() -> None:
+    """No module in the package may import matplotlib at import time.
+
+    Scoped to the whole package rather than to one module: this used to check
+    ``filters.design`` alone, which is where the first such import was found,
+    and a later one in a rendering leaf sailed past it and broke
+    ``import phonometry`` on a base install.
+    """
+    offenders = [
+        f"{path.relative_to(SRC)}:{lineno}"
+        for path in sorted(SRC.rglob("*.py"))
+        for lineno in _eager_matplotlib_imports(
+            ast.parse(path.read_text(encoding="utf-8")).body
+        )
+    ]
+    assert not offenders, (
+        "matplotlib imported at module scope (import it inside the function "
+        "that needs it, or under TYPE_CHECKING when it is only a type):\n"
+        + "\n".join(offenders)
+    )
+
+
+#: Run in a subprocess: matplotlib is imported by the time the suite reaches
+#: this file, and a blocker installed in-process cannot undo that. A fresh
+#: interpreter is the only place the base install can honestly be simulated.
+_IMPORT_WITHOUT_MATPLOTLIB = """
+import sys
+
+
+class Blocker:
+    '''Deny matplotlib and every submodule of it.
+
+    The hook Python consults is ``find_spec``. A blocker written against the
+    long-removed ``find_module`` protocol is simply never called, so matplotlib
+    imports normally and the test passes while proving nothing at all.
+    '''
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "matplotlib" or fullname.startswith("matplotlib."):
+            raise ImportError("No module named %r (blocked)" % fullname)
+        return None
+
+
+for name in [n for n in sys.modules if n.split(".")[0] == "matplotlib"]:
+    del sys.modules[name]
+sys.meta_path.insert(0, Blocker())
+
+# Prove the blocker bites before trusting what it certifies.
+try:
+    import matplotlib
+except ImportError:
+    pass
+else:
+    raise AssertionError("the blocker let matplotlib through: gate proves nothing")
+
+import phonometry
+
+print(phonometry.__version__)
+"""
+
+
+def test_import_succeeds_without_matplotlib() -> None:
+    """The base install is NumPy and SciPy: importing must not need plotting."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_WITHOUT_MATPLOTLIB],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "import phonometry failed without matplotlib:\n" + result.stderr
+    )
 
 
 def test_showfilter_raises_helpful_error_without_matplotlib(monkeypatch) -> None:

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 SRC = Path(__file__).resolve().parent.parent / "src" / "phonometry"
 
 
@@ -58,6 +60,22 @@ def _imports_matplotlib(node: ast.stmt) -> bool:
     return any(name == "matplotlib" or name.startswith("matplotlib.") for name in names)
 
 
+def _is_type_checking_guard(test: ast.expr) -> bool:
+    """Whether ``test`` is the one condition that never runs.
+
+    Only a bare ``TYPE_CHECKING`` or ``typing.TYPE_CHECKING`` qualifies. This
+    used to ask whether the unparsed test *contained* the name, which is the
+    same question with the wrong answer for the two conditions that matter:
+    ``if not TYPE_CHECKING:`` runs exactly when the guard does not, and
+    ``if TYPE_CHECKING or enabled:`` runs whenever ``enabled`` is true. Both
+    read as guarded to a substring search, so an import placed in either would
+    have been waved through by the gate meant to catch it.
+    """
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    return isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+
+
 def _eager_matplotlib_imports(
     body: list[ast.stmt], *, guarded: bool = False
 ) -> list[int]:
@@ -66,9 +84,14 @@ def _eager_matplotlib_imports(
     Only two placements are lazy: inside a function body, and under
     ``if TYPE_CHECKING:``, which never executes. Everything else at module
     scope runs the moment the package is imported, including a class body and
-    the branches of a runtime ``if``, a ``try`` or a ``with`` -- so this
-    descends into those rather than assuming a bare top-level statement is the
-    only way to import something eagerly.
+    the branches of a runtime ``if``, a ``try``, a ``with``, a loop or a
+    ``match`` -- so this descends into those rather than assuming a bare
+    top-level statement is the only way to import something eagerly.
+
+    The compound statements are enumerated rather than walked generically
+    because the distinction being drawn is exactly the one a generic walk
+    erases: a function body is the *point* of the lazy placement and must not
+    be descended into, while every other block runs on import and must be.
     """
     eager: list[int] = []
     for node in body:
@@ -77,7 +100,7 @@ def _eager_matplotlib_imports(
                 eager.append(node.lineno)
         elif isinstance(node, ast.If):
             # ``else`` is the runtime branch of a TYPE_CHECKING guard.
-            deferred = guarded or "TYPE_CHECKING" in ast.unparse(node.test)
+            deferred = guarded or _is_type_checking_guard(node.test)
             eager += _eager_matplotlib_imports(node.body, guarded=deferred)
             eager += _eager_matplotlib_imports(node.orelse, guarded=guarded)
         elif isinstance(node, ast.Try):
@@ -88,7 +111,14 @@ def _eager_matplotlib_imports(
                 *(handler.body for handler in node.handlers),
             ):
                 eager += _eager_matplotlib_imports(block, guarded=guarded)
-        elif isinstance(node, (ast.With, ast.ClassDef)):
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.While)):
+            # A loop that never iterates still executes its ``else``.
+            for block in (node.body, node.orelse):
+                eager += _eager_matplotlib_imports(block, guarded=guarded)
+        elif isinstance(node, ast.Match):
+            for case in node.cases:
+                eager += _eager_matplotlib_imports(case.body, guarded=guarded)
+        elif isinstance(node, (ast.With, ast.AsyncWith, ast.ClassDef)):
             eager += _eager_matplotlib_imports(node.body, guarded=guarded)
     return eager
 
@@ -112,6 +142,46 @@ def test_no_module_scope_matplotlib_import_anywhere() -> None:
         "matplotlib imported at module scope (import it inside the function "
         "that needs it, or under TYPE_CHECKING when it is only a type):\n"
         + "\n".join(offenders)
+    )
+
+
+#: ``(label, module source, is it eager?)``. The gate above is only as good as
+#: this classifier, and a gate that quietly answers "nothing to report" is
+#: worse than no gate, so the classifier is pinned against the placements that
+#: decide it: the two conditions that merely mention ``TYPE_CHECKING`` without
+#: being it, the block statements that run on import, and the two placements
+#: that genuinely are lazy and must stay unreported.
+_PLACEMENTS = [
+    ("type-checking guard", "if TYPE_CHECKING:\n    import matplotlib\n", False),
+    ("qualified guard", "if typing.TYPE_CHECKING:\n    import matplotlib\n", False),
+    ("function body", "def f():\n    import matplotlib\n", False),
+    ("negated guard", "if not TYPE_CHECKING:\n    import matplotlib\n", True),
+    ("guard in an or", "if TYPE_CHECKING or x:\n    import matplotlib\n", True),
+    (
+        "guard's else",
+        "if TYPE_CHECKING:\n    pass\nelse:\n    import matplotlib\n",
+        True,
+    ),
+    ("for body", "for i in x:\n    import matplotlib\n", True),
+    ("for else", "for i in x:\n    pass\nelse:\n    import matplotlib\n", True),
+    ("while body", "while x:\n    import matplotlib\n", True),
+    ("match case", "match v:\n    case _:\n        import matplotlib\n", True),
+    ("with body", "with ctx():\n    import matplotlib\n", True),
+    ("class body", "class C:\n    import matplotlib\n", True),
+    ("try body", "try:\n    import matplotlib\nexcept ImportError:\n    pass\n", True),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "source", "eager"),
+    _PLACEMENTS,
+    ids=[label for label, _, _ in _PLACEMENTS],
+)
+def test_eager_import_classifier(label: str, source: str, eager: bool) -> None:
+    """The classifier behind the gate reports exactly the eager placements."""
+    found = _eager_matplotlib_imports(ast.parse(source).body)
+    assert bool(found) is eager, (
+        f"{label}: expected {'an eager' if eager else 'no'} import, got {found}"
     )
 
 

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -153,19 +153,33 @@ def test_cross_package_edges_are_whitelisted() -> None:
 
 
 def test_render_modules_only_type_check_domain_imports() -> None:
+    """A rendering leaf must not reach domain code at module level.
+
+    ``rglob``, not ``glob``: the rendering trees grew subpackages, and a
+    non-recursive scan left every module inside them outside this gate.
+
+    How many dots escape the tree depends on how deep the module sits, so the
+    threshold is measured rather than fixed at ``level == 2``. For
+    ``_plot/common.py`` one dot is ``_plot`` and two reach the package root;
+    for ``_plot/geometry/emission.py`` two dots are still ``_plot`` and it
+    takes three. An import escapes when its level exceeds the module's own
+    depth below the rendering root.
+    """
     checked = False
     for sub in ("_plot", "_report"):
         render_dir = SRC / sub
         if not render_dir.is_dir():
             continue
         checked = True
-        for path in render_dir.glob("*.py"):
+        for path in sorted(render_dir.rglob("*.py")):
+            depth = len(path.relative_to(render_dir).parts)
             tree = ast.parse(path.read_text(encoding="utf-8"))
             for node in tree.body:  # module level only
-                if isinstance(node, ast.ImportFrom) and node.level == 2:
+                if isinstance(node, ast.ImportFrom) and node.level > depth:
                     pytest.fail(
-                        f"{sub}/{path.name}: module-level import of domain code "
-                        "(must live under TYPE_CHECKING)"
+                        f"{path.relative_to(SRC)}:{node.lineno}: module-level "
+                        f"import of domain code '{'.' * node.level}"
+                        f"{node.module or ''}' (must live under TYPE_CHECKING)"
                     )
     if not checked:
         pytest.skip("neither _plot nor _report created yet")


### PR DESCRIPTION
## What was wrong

`import phonometry` failed outright when matplotlib was not installed, which contradicts the promise made in `README.md:53` and `docs/start/getting-started.md:24` that the "base install computes every metric on NumPy and SciPy alone". `pyproject.toml` backs that up: the base dependencies are `numpy` and `scipy`, and matplotlib is the `[plot]` extra.

`src/phonometry/_plot/geometry/emission.py` imported `to_rgb` at module scope, and the facade imports that module on the way in, so the whole package became unimportable without the optional dependency:

```
IMPORT FAILED: No module named 'matplotlib' (blocked)
   __init__.py:10                        from ._plot.geometry import (
   _plot/geometry/__init__.py:38         from .emission import (
   _plot/geometry/emission.py:21         from matplotlib.colors import to_rgb
```

The symbol is used exactly once, at `emission.py:111`, inside `_number_points`. Every other call site in the codebase already imports it inside the function that needs it (`_plot/common.py` lines 133, 296, 341, 376), so this one was the outlier rather than the pattern.

**This regression landed after the v3.3.0 tag, in f68dab23b (#514), so PyPI is not affected today.** `git tag --contains f68dab23b` is empty. The next release would have shipped it.

## Why the existing gates missed it

Two gates should have caught this, and both were too narrow:

- `tests/test_matplotlib_backend.py` AST-checked for a top-level matplotlib import in exactly one module, `phonometry.filters.design`, which is where the first such import was once found.
- `tests/test_package_architecture.py:155` used `render_dir.glob("*.py")`, which is non-recursive. Measured: that left **11 modules under `_plot/geometry/` outside the gate** (`glob=20`, `rglob=31` for `_plot`; `_report` was unaffected at 58/58).

## Evidence

A census of every matplotlib import in the package, by placement:

```
matplotlib imports in package : 218
  inside a function (lazy)    : 46
  under TYPE_CHECKING         : 172
  EAGER at module scope       : 1   <- _plot/geometry/emission.py:21
```

After the fix that last number is `0`.

**Before** (fix reverted, gates in place) both new gates fail:

```
FAILED tests/test_matplotlib_backend.py::test_no_module_scope_matplotlib_import_anywhere
E   AssertionError: matplotlib imported at module scope:
E     _plot/geometry/emission.py:21

FAILED tests/test_matplotlib_backend.py::test_import_succeeds_without_matplotlib
E   AssertionError: import phonometry failed without matplotlib:
E     File "src/phonometry/_plot/geometry/emission.py", line 21, in <module>
E       from matplotlib.colors import to_rgb
E   ImportError: No module named 'matplotlib' (blocked)
```

**After**, matplotlib fully blocked on `sys.meta_path`:

```
blocker active: matplotlib unavailable
import phonometry OK, version 3.3.0
numpy/scipy only: True        # no matplotlib module loaded at all
```

The drawing still renders when matplotlib *is* present, so the lazy import works at call time:

```
rendered OK; numbered labels = ['Reflecting plane', '1', '2', '3', '4']
```

## The `find_spec` trap

The new subprocess gate blocks matplotlib with a `find_spec`-based meta path hook. A blocker written against the legacy `find_module` protocol is never consulted on modern Python, so it blocks nothing and certifies nothing. Measured on this interpreter:

```
LEGACY find_module BLOCKER: matplotlib imported anyway -> 3.11.1
python: Python 3.13.5
```

The test therefore asserts its own blocker bites before it trusts what it proves, and it runs in a subprocess because matplotlib is already imported by the time the suite reaches this file and an in-process blocker cannot undo that.

## What changed

- `_plot/geometry/emission.py`: `to_rgb` now imported inside `_number_points`. It is a runtime use, so it is a function-body import, not a `TYPE_CHECKING` one.
- `tests/test_matplotlib_backend.py`: the top-level-import check now walks the whole package instead of one module. It descends into class bodies and into the branches of a runtime `if`, `try` and `with`, since those all execute at import time, and treats only function bodies and `TYPE_CHECKING` blocks as lazy. Adds the subprocess gate above.
- `tests/test_package_architecture.py`: `rglob` instead of `glob`. The escape threshold is now measured from the module's own depth rather than fixed at `level == 2`, because how many dots leave the rendering tree depends on how deep the module sits: from `_plot/common.py` two dots reach the package root, from `_plot/geometry/emission.py` it takes three. Nothing newly tripped.

## Gates

```
ruff check .            All checks passed!
mypy src scripts        Success: no issues found in 439 source files
pytest tests/test_matplotlib_backend.py tests/test_package_architecture.py
                        32 passed
make api-docs           regenerated, no diff
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored matplotlib imports to be lazy, ensuring the package can be imported without matplotlib installed.</li>
<li>Updated dependency versions across pyproject.toml, requirements files, and site/package.json.</li>
<li>Enhanced test suite to verify that matplotlib is not imported at the top level.</li>
<li>Moved matplotlib import inside a function in emission.py to support optional dependency usage.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The package can now be imported successfully even when Matplotlib is not installed.
  - Matplotlib is loaded only when plotting functionality is used, improving compatibility for installations that do not require visualizations.
  - Existing backend selection is preserved during package import.
  - Plotting and reporting components now follow safer import boundaries, reducing the risk of unnecessary rendering-related import errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->