### PR TITLE
Stop the docs job paying for blobs, serial encodes and an idle audit queue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,8 +76,34 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-          # Full history: add-sitemap-lastmod.mjs stamps per-file git dates.
+          # Full history: add-sitemap-lastmod.mjs stamps per-file git dates
+          # and check:redirects re-derives the redirect map from renames.
           fetch-depth: 0
+          # ... but the history those two need is commits and trees, never
+          # blob contents, and the repository's pack is dominated by the
+          # committed artwork's blobs (2.4 GiB, over half of it
+          # .github/images, which nothing in this job reads: the site
+          # references the figures remotely). Fetching the pack whole made
+          # the checkout the third-largest step of the job at close to
+          # three minutes. `blob:none` defers blob download to first use,
+          # and the sparse set below keeps first use to the trees this job
+          # actually walks. Rename detection in check:redirects can still
+          # demand the odd content blob when a page was edited in the same
+          # commit that moved it; those are small text files served by the
+          # same promisor remote, which is why this stays correct rather
+          # than merely fast.
+          filter: blob:none
+          # Cone mode: these directories plus every repository-root file.
+          # docs/ and scripts/ feed the mirror, glossary and llms checks;
+          # site/ is the build itself; .github/workflows is a few kilobytes
+          # that check-redirects reads to hold this very file's redirect
+          # count in step, and naming the subdirectory keeps its sibling
+          # images/ (the half-gigabyte artwork tree) out of the cone.
+          sparse-checkout: |
+            .github/workflows
+            docs
+            scripts
+            site
       - uses: actions/setup-node@v7
         with:
           node-version: 22

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,27 +80,35 @@ jobs:
           # and check:redirects re-derives the redirect map from renames.
           fetch-depth: 0
           # ... but the history those two need is commits and trees, never
-          # blob contents, and the repository's pack is dominated by the
-          # committed artwork's blobs (2.4 GiB, over half of it
-          # .github/images, which nothing in this job reads: the site
-          # references the figures remotely). Fetching the pack whole made
-          # the checkout the third-largest step of the job at close to
-          # three minutes. `blob:none` defers blob download to first use,
-          # and the sparse set below keeps first use to the trees this job
-          # actually walks. Rename detection in check:redirects can still
-          # demand the odd content blob when a page was edited in the same
-          # commit that moved it; those are small text files served by the
-          # same promisor remote, which is why this stays correct rather
-          # than merely fast.
+          # blob contents, while a plain fetch-depth-0 downloads the whole
+          # 2.4 GiB pack, most of it superseded generations of the
+          # committed artwork. That made the checkout the third-largest
+          # step of the job at close to three minutes. `blob:none` fetches
+          # blobs only for what is checked out, so the artwork arrives at
+          # its HEAD size once instead of every size it has ever been.
+          # Rename detection in check:redirects can still demand the odd
+          # historical blob when a page was edited in the same commit that
+          # moved it; those are small text files served on demand by the
+          # same remote, which is why this stays correct rather than
+          # merely fast.
           filter: blob:none
           # Cone mode: these directories plus every repository-root file.
           # docs/ and scripts/ feed the mirror, glossary and llms checks;
-          # site/ is the build itself; .github/workflows is a few kilobytes
-          # that check-redirects reads to hold this very file's redirect
-          # count in step, and naming the subdirectory keeps its sibling
-          # images/ (the half-gigabyte artwork tree) out of the cone.
+          # site/ is the build itself. .github goes in whole, because the
+          # site reaches into it three ways, each found the hard way when
+          # a narrower cone broke the build: stage-media.mjs copies
+          # images/ and reports/ into the site's own asset tree (the pages
+          # stopped hotlinking raw.githubusercontent long ago, and
+          # repo-stats.mjs refuses to recognise a repository root without
+          # the images tree), brand.ts inlines brand/lockup.svg, and
+          # check-redirects reads workflows/docs.yml to hold this very
+          # file's redirect count in step. Everything .github holds beyond
+          # the artwork is kilobytes, so there is nothing left worth
+          # excluding; the saving all comes from the blob filter, which
+          # fetches the artwork at its HEAD size once instead of every
+          # size it has ever been.
           sparse-checkout: |
-            .github/workflows
+            .github
             docs
             scripts
             site

--- a/site/.pa11yci.json
+++ b/site/.pa11yci.json
@@ -3,6 +3,7 @@
     "standard": "WCAG2AA",
     "timeout": 15000,
     "wait": 2000,
+    "concurrency": 4,
     "chromeLaunchConfig": {
       "args": [
         "--no-sandbox",

--- a/site/.pa11yci.json
+++ b/site/.pa11yci.json
@@ -3,7 +3,6 @@
     "standard": "WCAG2AA",
     "timeout": 15000,
     "wait": 2000,
-    "concurrency": 4,
     "chromeLaunchConfig": {
       "args": [
         "--no-sandbox",

--- a/site/scripts/optimize-images.mjs
+++ b/site/scripts/optimize-images.mjs
@@ -70,13 +70,20 @@ function isIndexedPng(file, buffer) {
 	return extname(file).toLowerCase() === '.png' && buffer.length > 25 && buffer[25] === 3;
 }
 
-let totalBefore = 0;
-let totalAfter = 0;
-for (const file of walk(dist)) {
+// How many images are in flight at once. The step used to run one image at
+// a time and took two minutes over the ~630 rasters a build emits, almost
+// all of it inside sharp's native encoders, which do their work off the
+// event loop, on libuv's thread pool. Four matches the CI runner's cores;
+// the encode order changes, the bytes written do not, and the log is
+// printed per file as before, merely interleaved.
+const IN_FLIGHT = 4;
+
+/** @param {string} file - Absolute path of one raster inside dist/. */
+async function optimize(file) {
 	const encode = encoders[extname(file).toLowerCase()];
-	if (!encode) continue;
+	if (!encode) return null;
 	const original = readFileSync(file);
-	if (isIndexedPng(file, original)) continue;
+	if (isIndexedPng(file, original)) return null;
 	let optimized;
 	try {
 		optimized = await (await encode(sharp(original))).toBuffer();
@@ -86,17 +93,33 @@ for (const file of walk(dist)) {
 		console.warn(
 			`[optimize-images] skipping ${file.slice(dist.length + 1)}: ${error.message}`,
 		);
-		continue;
+		return null;
 	}
 	const kept = optimized.length < original.length ? optimized : original;
 	if (kept !== original) writeFileSync(file, kept);
-	totalBefore += original.length;
-	totalAfter += kept.length;
 	console.log(
 		`[optimize-images] ${file.slice(dist.length + 1)}: ` +
 			`${(original.length / 1024).toFixed(0)} KiB -> ${(kept.length / 1024).toFixed(0)} KiB`,
 	);
+	return { before: original.length, after: kept.length };
 }
+
+let totalBefore = 0;
+let totalAfter = 0;
+const files = [...walk(dist)];
+let next = 0;
+await Promise.all(
+	Array.from({ length: IN_FLIGHT }, async () => {
+		while (next < files.length) {
+			const file = files[next++];
+			const result = await optimize(file);
+			if (result) {
+				totalBefore += result.before;
+				totalAfter += result.after;
+			}
+		}
+	}),
+);
 if (totalBefore === 0) {
 	console.log('[optimize-images] nothing to recompress in dist/');
 } else {


### PR DESCRIPTION
The docs job on the run that prompted this took 17 minutes. Two of its costs were structural waste; a third suspect turned out to be fleet noise, and the honest numbers follow.

**Measured across five runs of the same evening** (two on main before the change, the flagged baseline, and two on this branch), the runner fleet itself slowed as the evening went on: the route render, which this change does not touch, went 157 s, 158 s, 199 s, 358 s, 319 s on identical code, and the serial image pass went 82 s to 122 s. So per-step comparisons against the single 17-minute run flatter the change; against the fleet's fast runs it still holds:

| step | main (fast runs) | this branch (slow run) | like for like |
|---|---|---|---|
| checkout | 136 to 144 s | **59 to 63 s** | about 2.3x |
| raster pass in the build | 82 to 83 s serial | **48 s** pooled on a roughly 2x slower runner | about 3.5x |
| pa11y | 226 s | 226 s | reverted, see below |

**Checkout.** The two consumers of history, `add-sitemap-lastmod` and `check:redirects`, need commits and trees, never blob contents, while `fetch-depth: 0` was downloading the whole 2.4 GiB pack, most of it superseded generations of the committed artwork. The checkout now uses `filter: blob:none` with a sparse cone of `.github`, `docs`, `scripts` and `site`. Rehearsed on a local partial clone: 416 MB of git objects instead of 2.36 GiB, the lastmod log identical line for line (7,741 lines), the redirect check passing with the same 432 redirects, and the full `pnpm build` green end to end. The rehearsals caught two out-of-cone dependencies the hard way, which is why `.github` rides whole: `stage-media.mjs` copies `images/` and `reports/` into the site's asset tree, `repo-stats.mjs` refuses to recognise a repository root without the images tree, and `brand.ts` inlines `brand/lockup.svg`. Everything `.github` holds beyond the artwork is kilobytes; the saving is the history the filter leaves behind.

**Raster pass.** Four images in flight instead of one; sharp's encoders do their work off the event loop and never saw a second core. Output proven byte for byte identical to the serial version on the same inputs before committing.

**pa11y.** Raising its queue to four crashed 40 of the 66 audits with `Protocol error (Target.closeTarget)`: every concurrent run shares one Chrome, and closing tabs races beyond the default two. An audit that fails to run is worth less than one that takes two minutes longer, so the queue went back to the default.

Nothing is skipped, sampled or cached away: every page still builds, every audit still runs, the same bytes deploy. On equal fleet the job lands around 11.5 minutes against the 13.8 the fast runs show.
