### PR TITLE
Ignore plan whether it is a directory or a symlink to one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ issues_final*.json
 node_modules/
 
 # Local work plans (brainstorming specs, implementation plans, source library)
-plan/
+plan
 docs/superpowers/
 
 # Full copies of the heavy oracle sets that cannot be redistributed (the

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ issues_final*.json
 node_modules/
 
 # Local work plans (brainstorming specs, implementation plans, source library)
-plan
+/plan
 docs/superpowers/
 
 # Full copies of the heavy oracle sets that cannot be redistributed (the


### PR DESCRIPTION
In a linked worktree the local `plan` is a symlink back to the main checkout's directory, and the ignore rule `plan/` matches only directories, so every worktree's `git status` listed `plan` as untracked, one careless `git add` away from committing a pointer into the tree. Dropping the slash matches both shapes. Verified both ways with `git check-ignore` and a scratch repository: with `plan/` the symlink shows as untracked, with `plan` it does not, and the real directory stays ignored.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Ensure the local `plan` path is ignored whether it is a directory or a symlink to a directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version-control ignore rules for local work-plan files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->