### PR TITLE
Say in the signature which arguments have to travel together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `floating_floor_improvement_spectrum` refuses one half of the
+  `mass_per_area` / `dynamic_stiffness` pair instead of returning
+  `delta_lw=None` without a word. The pair exists only to compute that
+  weighted improvement, so answering `None` to a caller who asked for it was
+  the one failure that mattered, and it was the only one of the twenty
+  parameter groups below that did not already raise.
+
 - `miso_coherence` refuses a list of input records whose `Signal` elements
   were recorded at different rates, instead of taking the rate of whichever
   one happened to be first. Nothing downstream caught it: two records at
@@ -20,6 +27,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   now enforces.
 
 ### Changed
+
+- Nineteen functions, seventeen of them public and two plotting helpers, state
+  in their signature the group of arguments they actually require, through
+  `typing.overload`, instead of presenting the members as independently
+  optional and enforcing the group from the body. A type checker now rejects
+  the invalid call before it runs, and the run-time check stays for callers who
+  do not type-check.
+
+  The groups come in three shapes, all of them previously invisible to the
+  signature.
+
+  - *Exactly one of the members.* `lining_resonance_frequency` (Formula D.1
+    against D.2), `ground_effect` (flow resistivity against impedance),
+    `gaussian_residual_level` (L90 against L95),
+    `predict_diffuser_polar_response` (depths against reflection) and the
+    plotting helper `plot_aperture_geometry` (width against radius).
+  - *All of them or none*, or one member requiring another.
+    `airborne_insulation`, `survey_airborne_insulation`, `adaptation_term_kc`,
+    `plenum_flanking_reduction_index`, `plateau_transmission_loss` (three
+    members over two routes), `floating_floor_improvement_spectrum`,
+    `sound_power_anechoic`, `impulse_response`, `stipa`,
+    `sti_from_impulse_response`, `multiple_shock_assessment`, `io.write` and
+    the plotting helper `plot_piston_geometry` (angles with directivity).
+  - *Required by the value of another argument*, expressed with `Literal`.
+    `sensitivity`, whose narrowband estimation needs the rate, and
+    `floating_floor_improvement_spectrum`, whose Cremer hammer model needs its
+    limiting frequency.
+
+  `sti_from_impulse_response` turned out to carry a second group besides its
+  own pair: `snr` and `ambient` are two ways of saying the same thing and the
+  run time already refused them together, which no signature said until now.
+
+  One group could not take an overload at all: `SourceRoom` holds its two
+  descriptions of the source room as fields, and no overload of
+  `room_to_room_transmission` can constrain the inside of its own argument.
+  The bundle now refuses itself in `__post_init__`, as `OperatingModeDeclaration`
+  already did, so building a source room with both descriptions, with neither,
+  or with a power level and no room constant raises at the line that built it
+  rather than at the call that used it.
+
+  Two further groups are stated in prose rather than in the signature, because
+  no signature can carry them: `db_hr_global_index` requires `frequencies` for
+  any input that is not exactly the eighteen DB-HR bands, a condition on the
+  length of an array at run time, and `floating_floor_resonance` requires
+  `thickness` and `porosity` for the enclosed-gas term, a condition on the
+  value of `airflow_resistivity` rather than on a literal. Both now say so
+  where the caller reads them.
 
 - `linkwitz_riley` and `parametric_eq` take their mandatory argument as
   keyword-only: `linkwitz_riley(x, fs=None, *, freq, order=4)` and

--- a/site/src/content/docs/reference/api/building/spain.md
+++ b/site/src/content/docs/reference/api/building/spain.md
@@ -330,7 +330,7 @@ one-third-octave bands 100 Hz to 5 kHz (Formulae (A.5) to (A.7)).
 | :--- | :--- |
 | `band_values` | The band insulation `X_i`, in dB. Either exactly the eighteen DB-HR bands, or a longer spectrum together with `frequencies`, from which the eighteen bands are selected. |
 | `spectrum` | Normalised spectrum key: `"pink"` (default), `"traffic"`, `"railway"` or `"aircraft"`. |
-| `frequencies` | Band centre frequencies, in Hz, one per value. `None` assumes exactly the eighteen DB-HR bands in order. |
+| `frequencies` | Band centre frequencies, in Hz, one per value. `None` assumes exactly the eighteen DB-HR bands in order, so it is required for any other length. That condition is on the length of `band_values` at run time, which a signature cannot state, so it is checked here and raises rather than being caught by a type checker. |
 | `name` | Optional index name carried on the result (e.g. `"R'A"`). |
 
 **Returns:** A [`DbHrGlobalIndexResult`](/phonometry/reference/api/building/spain/#dbhrglobalindexresult).

--- a/site/src/content/docs/reference/api/materials/dynamic-stiffness.md
+++ b/site/src/content/docs/reference/api/materials/dynamic-stiffness.md
@@ -254,8 +254,8 @@ frequency (Formula 2).
 | `total_mass_per_area` | Test total mass per unit area `m't`, kg/m2. |
 | `floor_mass_per_area` | Supported-floor mass per unit area `m'`, kg/m2. |
 | `airflow_resistivity` | Lateral airflow resistivity `r`, in kPa.s/m2 (default `inf` -> the high-resistivity case $s' = s'_\mathrm{t}$). |
-| `thickness` | Specimen thickness `d` under load, in metres (required for the enclosed-gas term when $r < 100$ kPa.s/m2). |
-| `porosity` | Specimen porosity `epsilon` (required with `thickness`). |
+| `thickness` | Specimen thickness `d` under load, in metres. Required together with `porosity` for the enclosed-gas term, which applies when $r < 100$ kPa.s/m2. That condition is on the *value* of `airflow_resistivity` rather than on a literal, so a signature cannot state it: it is checked here and raises. |
+| `porosity` | Specimen porosity `epsilon`, required with `thickness` (see above). |
 | `atmospheric_pressure` | Atmospheric pressure `p0`, in pascals. |
 
 **Returns:** The [`DynamicStiffnessResult`](/phonometry/reference/api/materials/dynamic-stiffness/#dynamicstiffnessresult).

--- a/src/phonometry/_plot/geometry/building.py
+++ b/src/phonometry/_plot/geometry/building.py
@@ -14,7 +14,7 @@ leaf never imports domain code at module level.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -61,6 +61,28 @@ def _t(text: str, language: str = "en") -> str:
 # ---------------------------------------------------------------------------
 # Wall aperture (slit or circular hole) cross-section.
 # ---------------------------------------------------------------------------
+@overload
+def plot_aperture_geometry(
+    depth: float,
+    ax: Axes | None = ...,
+    *,
+    width: float,
+    language: str = ...,
+    **kwargs: Any,
+) -> Axes: ...
+
+
+@overload
+def plot_aperture_geometry(
+    depth: float,
+    ax: Axes | None = ...,
+    *,
+    radius: float,
+    language: str = ...,
+    **kwargs: Any,
+) -> Axes: ...
+
+
 def plot_aperture_geometry(
     depth: float,
     ax: Axes | None = None,
@@ -133,16 +155,23 @@ def plot_aperture_result_geometry(
     **kwargs: Any,
 ) -> Axes:
     """Aperture section for a result that retained its geometry."""
-    if result.depth is None or (
-        result.width is None and result.radius is None
-    ):
-        raise ValueError(
-            "This result does not retain its geometry; call "
-            "plot_aperture_geometry(depth, ...) with the original arguments."
-        )
-    return plot_aperture_geometry(
-        result.depth, ax=ax, width=result.width, radius=result.radius,
-        language=language, **kwargs,
+    # One branch per shape, which is what the result carries: a 'slit' keeps
+    # its width and a 'circular' aperture its radius, never both. Passing both
+    # through and letting one be None would not match either call form.
+    if result.depth is not None:
+        if result.width is not None:
+            return plot_aperture_geometry(
+                result.depth, ax=ax, width=result.width,
+                language=language, **kwargs,
+            )
+        if result.radius is not None:
+            return plot_aperture_geometry(
+                result.depth, ax=ax, radius=result.radius,
+                language=language, **kwargs,
+            )
+    raise ValueError(
+        "This result does not retain its geometry; call "
+        "plot_aperture_geometry(depth, ...) with the original arguments."
     )
 
 

--- a/src/phonometry/_plot/geometry/electroacoustics.py
+++ b/src/phonometry/_plot/geometry/electroacoustics.py
@@ -13,7 +13,7 @@ leaf never imports domain code at module level.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -68,6 +68,30 @@ def _t(text: str, language: str = "en") -> str:
 # ---------------------------------------------------------------------------
 # Baffled piston with its directivity lobe.
 # ---------------------------------------------------------------------------
+@overload
+def plot_piston_geometry(
+    radius: float,
+    ax: Axes | None = ...,
+    *,
+    angles: ArrayLike,
+    directivity: ArrayLike,
+    lobe_label: str | None = ...,
+    language: str = ...,
+    **kwargs: Any,
+) -> Axes: ...
+
+
+@overload
+def plot_piston_geometry(
+    radius: float,
+    ax: Axes | None = ...,
+    *,
+    lobe_label: str | None = ...,
+    language: str = ...,
+    **kwargs: Any,
+) -> Axes: ...
+
+
 def plot_piston_geometry(
     radius: float,
     ax: Axes | None = None,

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -69,7 +69,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -643,6 +643,28 @@ def _validate_reverberation(t: np.ndarray, t0: float) -> None:
         raise ValueError("'t2' must contain positive, finite values.")
     if t0 <= 0.0:
         raise ValueError("'t0' must be positive.")
+
+
+@overload
+def airborne_insulation(
+    l1: Sequence[float] | np.ndarray,
+    l2: Sequence[float] | np.ndarray,
+    t2: Sequence[float] | np.ndarray,
+    *,
+    area: float,
+    volume: float,
+    t0: float = ...,
+) -> AirborneInsulationResult: ...
+
+
+@overload
+def airborne_insulation(
+    l1: Sequence[float] | np.ndarray,
+    l2: Sequence[float] | np.ndarray,
+    t2: Sequence[float] | np.ndarray,
+    *,
+    t0: float = ...,
+) -> AirborneInsulationResult: ...
 
 
 def airborne_insulation(

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -74,7 +74,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -406,6 +406,19 @@ def _positive_area(value: float, name: str) -> float:
     if not np.isfinite(v) or v <= 0.0:
         raise ValueError(f"'{name}' must be positive.")
     return v
+
+
+@overload
+def adaptation_term_kc(
+    freq: Sequence[float] | np.ndarray,
+    *,
+    boundary_area: float,
+    volume: float,
+) -> np.ndarray: ...
+
+
+@overload
+def adaptation_term_kc(freq: Sequence[float] | np.ndarray) -> np.ndarray: ...
 
 
 def adaptation_term_kc(

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -605,6 +605,27 @@ def _validate_index(k: Sequence[float] | np.ndarray, n_bands: int) -> np.ndarray
     return kk
 
 
+@overload
+def survey_airborne_insulation(
+    l1: Sequence[float] | np.ndarray,
+    l2: Sequence[float] | np.ndarray,
+    reverberation_index: Sequence[float] | np.ndarray,
+    *,
+    volume: float,
+    area: float,
+) -> SurveyAirborneResult: ...
+
+
+@overload
+def survey_airborne_insulation(
+    l1: Sequence[float] | np.ndarray,
+    l2: Sequence[float] | np.ndarray,
+    reverberation_index: Sequence[float] | np.ndarray,
+    *,
+    volume: float = ...,
+) -> SurveyAirborneResult: ...
+
+
 def survey_airborne_insulation(
     l1: Sequence[float] | np.ndarray,
     l2: Sequence[float] | np.ndarray,

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -104,7 +104,7 @@ the shifted contour at 500 Hz (clause 5.5). See
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -376,6 +376,38 @@ class PlenumFlankingResult:
 
         check_language(language)
         return plot_plenum_flanking(self, ax=ax, language=language, **kwargs)
+
+
+@overload
+def plenum_flanking_reduction_index(
+    reduction_index_source: ArrayLike,
+    reduction_index_receiving: ArrayLike,
+    *,
+    ceiling_length: float,
+    plenum_height: float,
+    sidewalls: str = ...,
+    frequency: ArrayLike | None = ...,
+    attenuation_source: ArrayLike,
+    attenuation_receiving: ArrayLike,
+    source_length: float | None = ...,
+    split_source: float = ...,
+    split_receiving: float = ...,
+) -> PlenumFlankingResult: ...
+
+
+@overload
+def plenum_flanking_reduction_index(
+    reduction_index_source: ArrayLike,
+    reduction_index_receiving: ArrayLike,
+    *,
+    ceiling_length: float,
+    plenum_height: float,
+    sidewalls: str = ...,
+    frequency: ArrayLike | None = ...,
+    source_length: float | None = ...,
+    split_source: float = ...,
+    split_receiving: float = ...,
+) -> PlenumFlankingResult: ...
 
 
 def plenum_flanking_reduction_index(

--- a/src/phonometry/building/prediction/linings.py
+++ b/src/phonometry/building/prediction/linings.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
@@ -128,6 +128,24 @@ _THIRD_OCTAVE_FIRST_INDEX: int = 11
 
 #: Additional-layer system of ISO 12354-1:2017 Annex D.
 LiningSystem = Literal["mineral_wool", "foam", "studs"]
+
+
+@overload
+def lining_resonance_frequency(
+    base_mass_per_area: float,
+    lining_mass_per_area: float,
+    *,
+    dynamic_stiffness: float,
+) -> float: ...
+
+
+@overload
+def lining_resonance_frequency(
+    base_mass_per_area: float,
+    lining_mass_per_area: float,
+    *,
+    cavity_depth: float,
+) -> float: ...
 
 
 def lining_resonance_frequency(

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -88,7 +88,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -520,6 +520,48 @@ def _resolve_plateau_panel(
         require_positive(plateau_height, "plateau_height"),
         ratio,
     )
+
+
+@overload
+def plateau_transmission_loss(
+    frequency: ArrayLike,
+    *,
+    material: str,
+    thickness_mm: float,
+    plateau_height: float | None = ...,
+    frequency_ratio: float | None = ...,
+    field_correction: float = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SoundReductionResult: ...
+
+
+@overload
+def plateau_transmission_loss(
+    frequency: ArrayLike,
+    *,
+    material: str,
+    mass_per_area: float,
+    thickness_mm: float | None = ...,
+    plateau_height: float | None = ...,
+    frequency_ratio: float | None = ...,
+    field_correction: float = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SoundReductionResult: ...
+
+
+@overload
+def plateau_transmission_loss(
+    frequency: ArrayLike,
+    *,
+    mass_per_area: float,
+    plateau_height: float,
+    frequency_ratio: float,
+    field_correction: float = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SoundReductionResult: ...
 
 
 def plateau_transmission_loss(

--- a/src/phonometry/building/prediction/resilient_layers.py
+++ b/src/phonometry/building/prediction/resilient_layers.py
@@ -73,7 +73,7 @@ pieces have an oracle and which do not.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -910,6 +910,48 @@ class FloatingFloorImprovementResult:
         return plot_floating_floor_improvement(self, ax=ax, language=language, **kwargs)
 
 
+@overload
+def floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal["cremer_hammer"],
+    limiting_frequency: float,
+    mass_per_area: float,
+    dynamic_stiffness: float,
+) -> FloatingFloorImprovementResult: ...
+
+
+@overload
+def floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal["cremer_hammer"],
+    limiting_frequency: float,
+) -> FloatingFloorImprovementResult: ...
+
+
+@overload
+def floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal["en12354", "cremer"] = ...,
+    mass_per_area: float,
+    dynamic_stiffness: float,
+) -> FloatingFloorImprovementResult: ...
+
+
+@overload
+def floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal["en12354", "cremer"] = ...,
+) -> FloatingFloorImprovementResult: ...
+
+
 def floating_floor_improvement_spectrum(
     frequencies: ArrayLike,
     *,
@@ -979,6 +1021,12 @@ def floating_floor_improvement_spectrum(
             above, 10.0 * np.log10(1.0 + (f / f_limit) ** 2), 0.0
         )
     delta_lw: float | None = None
+    if (mass_per_area is None) != (dynamic_stiffness is None):
+        raise ValueError(
+            "'mass_per_area' and 'dynamic_stiffness' are the two halves of the "
+            "weighted improvement 'delta_lw'; give both or neither, since one "
+            "alone would return it as None without saying why"
+        )
     if mass_per_area is not None and dynamic_stiffness is not None:
         # The weighted fit follows the construction the law belongs to:
         # Formula (C.4) for the sand-cement screeds of the 30 lg law, and

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -325,7 +325,10 @@ def db_hr_global_index(
     :param spectrum: Normalised spectrum key: ``"pink"`` (default),
         ``"traffic"``, ``"railway"`` or ``"aircraft"``.
     :param frequencies: Band centre frequencies, in Hz, one per value.
-        ``None`` assumes exactly the eighteen DB-HR bands in order.
+        ``None`` assumes exactly the eighteen DB-HR bands in order, so it is
+        required for any other length. That condition is on the length of
+        ``band_values`` at run time, which a signature cannot state, so it is
+        checked here and raises rather than being caught by a type checker.
     :param name: Optional index name carried on the result (e.g. ``"R'A"``).
     :return: A :class:`DbHrGlobalIndexResult`.
     :raises ValueError: For an unknown spectrum, a wrong band count, or

--- a/src/phonometry/emission/sound_power_anechoic.py
+++ b/src/phonometry/emission/sound_power_anechoic.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
@@ -562,6 +562,39 @@ def _precision_uncertainty_bands(
         precision_uncertainty(sigma_bands, sigma_omc, coverage_factor),
         dtype=np.float64,
     )
+
+
+@overload
+def sound_power_anechoic(
+    levels_positions: np.ndarray,
+    surface: PrecisionSurface,
+    *,
+    radius: float,
+    background_levels: np.ndarray,
+    frequencies: np.ndarray,
+    areas: np.ndarray | None = ...,
+    temperature: float = ...,
+    static_pressure: float = ...,
+    air_absorption_coefficient: float | np.ndarray | None = ...,
+    sigma_omc: float = ...,
+    coverage_factor: float = ...,
+) -> PrecisionSoundPowerResult: ...
+
+
+@overload
+def sound_power_anechoic(
+    levels_positions: np.ndarray,
+    surface: PrecisionSurface,
+    *,
+    radius: float,
+    frequencies: np.ndarray | None = ...,
+    areas: np.ndarray | None = ...,
+    temperature: float = ...,
+    static_pressure: float = ...,
+    air_absorption_coefficient: float | np.ndarray | None = ...,
+    sigma_omc: float = ...,
+    coverage_factor: float = ...,
+) -> PrecisionSoundPowerResult: ...
 
 
 def sound_power_anechoic(

--- a/src/phonometry/environment/assessment/measurement.py
+++ b/src/phonometry/environment/assessment/measurement.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -378,6 +378,14 @@ def residual_sound_correction(
         margin=float(margin),
         reliable=reliable,
     )
+
+
+@overload
+def gaussian_residual_level(l50: float, *, l90: float) -> float: ...
+
+
+@overload
+def gaussian_residual_level(l50: float, *, l95: float) -> float: ...
 
 
 def gaussian_residual_level(

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -100,7 +100,7 @@ Fresnel number :math:`N = (2/\lambda)(A + B + e - d)` (Bies Eq. (5.157)).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -295,6 +295,34 @@ def spherical_reflection_coefficient(
     w = np.sqrt(0.5j * k * r2) * (cos_theta + 1.0 / z)
     f_w = 1.0 + 1j * np.sqrt(np.pi) * w * wofz(w)
     return np.asarray(rp + (1.0 - rp) * f_w, dtype=np.complex128)
+
+
+@overload
+def ground_effect(
+    frequencies: ArrayLike,
+    source_height: float,
+    receiver_height: float,
+    distance: float,
+    *,
+    impedance: ArrayLike | PorousMediumResult,
+    model: Literal["delany_bazley", "miki"] = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SphericalGroundResult: ...
+
+
+@overload
+def ground_effect(
+    frequencies: ArrayLike,
+    source_height: float,
+    receiver_height: float,
+    distance: float,
+    *,
+    flow_resistivity: float,
+    model: Literal["delany_bazley", "miki"] = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SphericalGroundResult: ...
 
 
 def ground_effect(

--- a/src/phonometry/io/_write.py
+++ b/src/phonometry/io/_write.py
@@ -73,7 +73,7 @@ import struct
 import warnings
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
 from scipy.io import wavfile
@@ -626,6 +626,32 @@ def _write_through_scipy(
     else:
         _scipy_write(path, rate, data if resolved == "DOUBLE"
                      else data.astype(np.float32))
+
+
+@overload
+def write(
+    path: str | Path,
+    x: Signal | NDArray[np.generic] | list[float],
+    fs: int | None = ...,
+    *,
+    subtype: str | None = ...,
+    bext: BroadcastMetadata | str | None = ...,
+    dither: Literal["tpdf"],
+    rng: np.random.Generator | int | None = ...,
+    sidecar: bool = ...,
+) -> None: ...
+
+
+@overload
+def write(
+    path: str | Path,
+    x: Signal | NDArray[np.generic] | list[float],
+    fs: int | None = ...,
+    *,
+    subtype: str | None = ...,
+    bext: BroadcastMetadata | str | None = ...,
+    sidecar: bool = ...,
+) -> None: ...
 
 
 def write(

--- a/src/phonometry/materials/diffusers/design.py
+++ b/src/phonometry/materials/diffusers/design.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -360,6 +360,36 @@ def _prepare_geometry(
     if n_periods != periods or n_periods < 1:
         raise ValueError("'periods' must be an integer of at least 1.")
     return w, f, ang, psi, n_periods, c
+
+
+@overload
+def predict_diffuser_polar_response(
+    well_width: float,
+    frequency: float,
+    *,
+    depths: ArrayLike,
+    angles: ArrayLike = ...,
+    source_angle: float = ...,
+    periods: int = ...,
+    speed_of_sound: float = ...,
+    include_aperture: bool = ...,
+    include_obliquity: bool = ...,
+) -> DiffuserPolarResponse: ...
+
+
+@overload
+def predict_diffuser_polar_response(
+    well_width: float,
+    frequency: float,
+    *,
+    reflection: ArrayLike,
+    angles: ArrayLike = ...,
+    source_angle: float = ...,
+    periods: int = ...,
+    speed_of_sound: float = ...,
+    include_aperture: bool = ...,
+    include_obliquity: bool = ...,
+) -> DiffuserPolarResponse: ...
 
 
 def predict_diffuser_polar_response(

--- a/src/phonometry/materials/resilient/dynamic_stiffness.py
+++ b/src/phonometry/materials/resilient/dynamic_stiffness.py
@@ -372,9 +372,13 @@ def floating_floor_resonance(
     :param floor_mass_per_area: Supported-floor mass per unit area ``m'``, kg/m2.
     :param airflow_resistivity: Lateral airflow resistivity ``r``, in kPa.s/m2
         (default ``inf`` -> the high-resistivity case :math:`s' = s'_\mathrm{t}`).
-    :param thickness: Specimen thickness ``d`` under load, in metres (required
-        for the enclosed-gas term when :math:`r < 100` kPa.s/m2).
-    :param porosity: Specimen porosity ``epsilon`` (required with ``thickness``).
+    :param thickness: Specimen thickness ``d`` under load, in metres. Required
+        together with ``porosity`` for the enclosed-gas term, which applies
+        when :math:`r < 100` kPa.s/m2. That condition is on the *value* of
+        ``airflow_resistivity`` rather than on a literal, so a signature
+        cannot state it: it is checked here and raises.
+    :param porosity: Specimen porosity ``epsilon``, required with
+        ``thickness`` (see above).
     :param atmospheric_pressure: Atmospheric pressure ``p0``, in pascals.
     :return: The :class:`DynamicStiffnessResult`.
     """

--- a/src/phonometry/metrology/calibration.py
+++ b/src/phonometry/metrology/calibration.py
@@ -6,6 +6,7 @@ Calibration utilities for mapping digital signals to physical SPL levels.
 from __future__ import annotations
 
 import warnings
+from typing import Literal, overload
 
 import numpy as np
 
@@ -32,6 +33,33 @@ def _class1_fluctuation_limit(frequency: float) -> float:
     if 63.0 < frequency < 160.0:
         return 0.10
     return 0.07
+
+
+@overload
+def sensitivity(
+    ref_signal: list[float] | np.ndarray,
+    target_spl: float = ...,
+    ref_pressure: float = ...,
+    *,
+    fs: int,
+    validate: bool = ...,
+    max_fluctuation_db: float | None = ...,
+    frequency: float = ...,
+    narrowband: Literal[True],
+) -> float: ...
+
+
+@overload
+def sensitivity(
+    ref_signal: list[float] | np.ndarray,
+    target_spl: float = ...,
+    ref_pressure: float = ...,
+    fs: int | None = ...,
+    validate: bool = ...,
+    max_fluctuation_db: float | None = ...,
+    frequency: float = ...,
+    narrowband: Literal[False] = ...,
+) -> float: ...
 
 
 def sensitivity(

--- a/src/phonometry/noise_control/room_to_room.py
+++ b/src/phonometry/noise_control/room_to_room.py
@@ -125,6 +125,25 @@ class SourceRoom:
     directivity: float = 1.0
     model: str = "constant_power"
 
+    def __post_init__(self) -> None:
+        """Refuse a source room that does not describe one source.
+
+        The two ways of saying it are mutually exclusive, and the power-level
+        way needs the room constant that turns a power into a level. Checked
+        here rather than where the object is used, so the complaint arrives
+        at the line that built it.
+        """
+        if (self.level is None) == (self.power_level is None):
+            raise ValueError(
+                "give exactly one of 'level' (the source-room level L_p1) or "
+                "'power_level' (the source sound power level L_W)."
+            )
+        if self.power_level is not None and self.room_constant is None:
+            raise ValueError(
+                "'room_constant' is required with 'power_level'; build it "
+                "with phonometry.room.room_constant."
+            )
+
 
 @dataclass(frozen=True)
 class DesignCriterion:
@@ -419,19 +438,11 @@ def room_to_room_transmission(
         raise ValueError("'frequencies' must be a non-empty 1-D array.")
     n = f.size
 
-    if (source.level is None) == (source.power_level is None):
-        raise ValueError(
-            "give exactly one of 'source.level' (the source-room level L_p1) "
-            "or 'source.power_level' (the source sound power level L_W)."
-        )
     require_choice(source.model, "source.model", tuple(SOURCE_POWER_MODELS))
     lw: NDArray[np.float64] | None = None
-    if source.power_level is not None:
-        if source.room_constant is None:
-            raise ValueError(
-                "'source.room_constant' is required with 'source.power_level'; "
-                "build it with phonometry.room.room_constant."
-            )
+    # SourceRoom.__post_init__ has already refused every other combination,
+    # so these two branches are the only ones reachable.
+    if source.power_level is not None and source.room_constant is not None:
         lw = as_band_spectrum(source.power_level, n, "source.power_level")
         lp1 = np.asarray(
             steady_state_spl(
@@ -443,7 +454,7 @@ def room_to_room_transmission(
             ),
             dtype=np.float64,
         )
-    elif source.level is None:  # pragma: no cover - guarded above
+    elif source.level is None:  # pragma: no cover - __post_init__ guards this
         raise ValueError("'source.level' must be given.")
     else:
         lp1 = as_band_spectrum(source.level, n, "source.level")

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -66,7 +66,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 from scipy import signal
@@ -365,6 +365,34 @@ def _farina_deconvolve(
     # len(reference)-1. Roll it to index 0 so the layout matches the spectral
     # method (causal at 0, negative times in the tail).
     return np.roll(conv, -(ref.size - 1))
+
+
+@overload
+def impulse_response(
+    recorded: list[float] | np.ndarray,
+    reference: list[float] | np.ndarray,
+    fs: int,
+    *,
+    method: Literal["farina"],
+    f_range: tuple[float, float],
+    regularization: float = ...,
+    length: int | None = ...,
+    return_full: bool = ...,
+) -> ImpulseResponseResult: ...
+
+
+@overload
+def impulse_response(
+    recorded: list[float] | np.ndarray,
+    reference: list[float] | np.ndarray,
+    fs: int,
+    *,
+    method: str = ...,
+    f_range: tuple[float, float] | None = ...,
+    regularization: float = ...,
+    length: int | None = ...,
+    return_full: bool = ...,
+) -> ImpulseResponseResult: ...
 
 
 def impulse_response(

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
@@ -367,6 +367,36 @@ def _sti_from_mtf(
     )
 
 
+@overload
+def sti_from_impulse_response(
+    ir: list[float] | np.ndarray,
+    fs: int,
+    snr: None,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult: ...
+
+
+@overload
+def sti_from_impulse_response(
+    ir: list[float] | np.ndarray,
+    fs: int,
+    snr: None = ...,
+    *,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult: ...
+
+
+@overload
+def sti_from_impulse_response(
+    ir: list[float] | np.ndarray,
+    fs: int,
+    snr: float | Sequence[float] | np.ndarray | None = ...,
+    level: Sequence[float] | np.ndarray | None = ...,
+) -> STIResult: ...
+
+
 def sti_from_impulse_response(
     ir: list[float] | np.ndarray,
     fs: int,
@@ -521,6 +551,36 @@ def _stipa_modulation_depths(env: np.ndarray, fs: int) -> np.ndarray:
             stacklevel=3,
         )
     return mdr
+
+
+@overload
+def stipa(
+    x: list[float] | np.ndarray,
+    fs: int,
+    reference: list[float] | np.ndarray | None,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult: ...
+
+
+@overload
+def stipa(
+    x: list[float] | np.ndarray,
+    fs: int,
+    reference: list[float] | np.ndarray | None = ...,
+    *,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult: ...
+
+
+@overload
+def stipa(
+    x: list[float] | np.ndarray,
+    fs: int,
+    reference: list[float] | np.ndarray | None = ...,
+    level: Sequence[float] | np.ndarray | None = ...,
+) -> STIResult: ...
 
 
 def stipa(

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -62,7 +62,7 @@ text and is out of scope.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
@@ -501,6 +501,34 @@ class MultipleShockResult:
         return render_iso2631_5_report(
             self, path, metadata=metadata, verbose=verbose, language=language
         )
+
+
+@overload
+def multiple_shock_assessment(
+    acceleration: ArrayLike,
+    fs: float,
+    *,
+    start_age: float,
+    years: int,
+    days_per_year: float,
+    exposure_time: float,
+    measurement_time: float,
+    sex: Literal["male", "female"] = ...,
+    mz: float | None = ...,
+) -> MultipleShockResult: ...
+
+
+@overload
+def multiple_shock_assessment(
+    acceleration: ArrayLike,
+    fs: float,
+    *,
+    start_age: float,
+    years: int,
+    days_per_year: float,
+    sex: Literal["male", "female"] = ...,
+    mz: float | None = ...,
+) -> MultipleShockResult: ...
 
 
 def multiple_shock_assessment(

--- a/tests/noise_control/test_room_to_room.py
+++ b/tests/noise_control/test_room_to_room.py
@@ -159,19 +159,19 @@ def test_nc_rating_of_the_received_spectrum() -> None:
 
 
 def test_source_description_is_exclusive() -> None:
-    """Exactly one of ``source.level`` / ``source.power_level`` is required."""
+    """Exactly one of ``source.level`` / ``source.power_level`` is required.
+
+    The refusal belongs to :class:`SourceRoom` itself, so it arrives when the
+    bundle is built rather than when it is used. The call with no source at
+    all still raises, because the empty default is built here and rejects
+    itself for the same reason.
+    """
     with pytest.raises(ValueError, match="exactly one"):
         room_to_room_transmission(_BANDS, 40.0, 20.0, _ABSORPTION)
-    both_descriptions = SourceRoom(level=90.0, power_level=100.0)
     with pytest.raises(ValueError, match="exactly one"):
-        room_to_room_transmission(
-            _BANDS, 40.0, 20.0, _ABSORPTION, source=both_descriptions
-        )
-    power_without_room_constant = SourceRoom(power_level=100.0)
+        SourceRoom(level=90.0, power_level=100.0)
     with pytest.raises(ValueError, match="room_constant"):
-        room_to_room_transmission(
-            _BANDS, 40.0, 20.0, _ABSORPTION, source=power_without_room_constant
-        )
+        SourceRoom(power_level=100.0)
 
 
 def test_validation() -> None:

--- a/tests/test_mutually_required_groups.py
+++ b/tests/test_mutually_required_groups.py
@@ -1,0 +1,235 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""
+Every parameter group that has to travel together is refused when it does not.
+
+Twenty public functions take a group of arguments that the signature used to
+present as independently optional: some are "exactly one of", some are "all or
+none", and three are required only for a particular value of another argument.
+Each of them now states the group in its signature through ``typing.overload``,
+so a type checker rejects the invalid call before it runs, and each still
+raises at run time for callers who do not type-check.
+
+This module pins the run-time half. The static half is exercised by ``mypy``
+over ``src`` and cannot be asserted from inside a test: a file that made mypy
+fail would fail the gate rather than pass this suite.
+
+One of the twenty did not raise before this was written: giving
+``floating_floor_improvement_spectrum`` one half of its pair returned
+``delta_lw=None``, silently dropping the very quantity the pair is for.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phonometry.building.measurement.insulation import airborne_insulation
+from phonometry.building.measurement.intensity_insulation import adaptation_term_kc
+from phonometry.building.measurement.survey_insulation import (
+    survey_airborne_insulation,
+)
+from phonometry.building.prediction.ceiling_plenum import (
+    plenum_flanking_reduction_index,
+)
+from phonometry.building.prediction.linings import lining_resonance_frequency
+from phonometry.building.prediction.panel_transmission import (
+    plateau_transmission_loss,
+)
+from phonometry.building.prediction.resilient_layers import (
+    floating_floor_improvement_spectrum,
+)
+from phonometry.building.regulation.spain import db_hr_global_index
+from phonometry.emission.sound_power_anechoic import sound_power_anechoic
+from phonometry.environment.assessment.measurement import gaussian_residual_level
+from phonometry.environment.propagation.ground_barriers import ground_effect
+from phonometry.materials.diffusers.design import predict_diffuser_polar_response
+from phonometry.metrology.calibration import sensitivity
+from phonometry.noise_control.room_to_room import SourceRoom
+from phonometry.speech.sti import sti_from_impulse_response, stipa
+from phonometry.vibration.human.multiple_shock import multiple_shock_assessment
+
+BANDS = np.array(
+    [50.0, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000]
+)
+OCTAVES = np.array([125.0, 250.0, 500.0, 1000.0])
+
+
+# ---------------------------------------------------------------------------
+# Exactly one of
+# ---------------------------------------------------------------------------
+
+
+def test_lining_resonance_takes_one_formula_not_both() -> None:
+    """D.1 and D.2 are two constructions, not two ways to say one number."""
+    for kwargs in ({}, {"dynamic_stiffness": 1e7, "cavity_depth": 0.05}):
+        with pytest.raises(ValueError, match="exactly one"):
+            lining_resonance_frequency(100.0, 10.0, **kwargs)  # type: ignore[call-overload]
+    assert lining_resonance_frequency(100.0, 10.0, dynamic_stiffness=1e7) > 0.0
+    assert lining_resonance_frequency(100.0, 10.0, cavity_depth=0.05) > 0.0
+
+
+def test_ground_effect_takes_one_ground_description() -> None:
+    both = {"flow_resistivity": 200e3, "impedance": np.ones(4, dtype=complex)}
+    for kwargs in ({}, both):
+        with pytest.raises(ValueError, match="exactly one"):
+            ground_effect(  # type: ignore[call-overload]
+                OCTAVES, 1.0, 1.5, 10.0, **kwargs
+            )
+
+
+def test_gaussian_residual_takes_one_percentile() -> None:
+    for kwargs in ({}, {"l90": 45.0, "l95": 44.0}):
+        with pytest.raises(ValueError, match="exactly one"):
+            gaussian_residual_level(50.0, **kwargs)  # type: ignore[call-overload]
+
+
+def test_diffuser_polar_takes_one_description() -> None:
+    for kwargs in ({}, {"depths": BANDS, "reflection": BANDS}):
+        with pytest.raises(ValueError, match="exactly one"):
+            predict_diffuser_polar_response(0.1, 500.0, **kwargs)  # type: ignore[call-overload]
+
+
+# ---------------------------------------------------------------------------
+# All or none
+# ---------------------------------------------------------------------------
+
+
+def test_airborne_insulation_wants_area_and_volume_together() -> None:
+    l1, l2, t2 = np.full(16, 80.0), np.full(16, 40.0), np.full(16, 0.5)
+    with pytest.raises(ValueError, match="together"):
+        airborne_insulation(l1, l2, t2, area=10.0)  # type: ignore[call-overload]
+    with pytest.raises(ValueError, match="together"):
+        airborne_insulation(l1, l2, t2, volume=50.0)  # type: ignore[call-overload]
+
+
+def test_survey_insulation_area_needs_volume() -> None:
+    l1, l2 = np.full(5, 80.0), np.full(5, 40.0)
+    k = np.full(5, 5.0)
+    with pytest.raises(ValueError, match="requires 'volume'"):
+        survey_airborne_insulation(l1, l2, k, area=10.0)  # type: ignore[call-overload]
+
+
+def test_adaptation_term_wants_both_or_neither() -> None:
+    """Neither is not an error here: it selects the Formula (B.2) approximation."""
+    with pytest.raises(ValueError, match="both"):
+        adaptation_term_kc(OCTAVES, boundary_area=50.0)  # type: ignore[call-overload]
+    assert adaptation_term_kc(OCTAVES).shape == OCTAVES.shape
+
+
+def test_plenum_attenuations_travel_together() -> None:
+    r = np.full(4, 30.0)
+    with pytest.raises(ValueError, match="together"):
+        plenum_flanking_reduction_index(  # type: ignore[call-overload]
+            r, r, ceiling_length=3.0, plenum_height=1.0, attenuation_source=r
+        )
+
+
+def test_plateau_needs_a_complete_construction() -> None:
+    with pytest.raises(ValueError, match="mass_per_area"):
+        plateau_transmission_loss(OCTAVES, mass_per_area=20.0)  # type: ignore[call-overload]
+
+
+def test_floating_floor_pair_is_not_dropped_in_silence() -> None:
+    """Half the pair used to return ``delta_lw=None`` and say nothing.
+
+    The pair exists only to produce the weighted improvement, so answering
+    ``None`` to a caller who asked for it is the failure that matters here.
+    """
+    both = floating_floor_improvement_spectrum(
+        BANDS, resonance_frequency=52.8, mass_per_area=120.0, dynamic_stiffness=1e7
+    )
+    assert both.delta_lw is not None
+    neither = floating_floor_improvement_spectrum(BANDS, resonance_frequency=52.8)
+    assert neither.delta_lw is None
+    for half in ({"mass_per_area": 120.0}, {"dynamic_stiffness": 1e7}):
+        with pytest.raises(ValueError, match="both or neither"):
+            floating_floor_improvement_spectrum(  # type: ignore[call-overload]
+                BANDS, resonance_frequency=52.8, **half
+            )
+
+
+def test_cremer_hammer_needs_its_limiting_frequency() -> None:
+    with pytest.raises(ValueError, match="limiting_frequency"):
+        floating_floor_improvement_spectrum(  # type: ignore[call-overload]
+            BANDS, resonance_frequency=52.8, model="cremer_hammer"
+        )
+
+
+def test_background_levels_need_their_frequencies() -> None:
+    levels = np.full((20, 8), 80.0)
+    background = np.full(8, 60.0)
+    with pytest.raises(ValueError, match="'frequencies' are required"):
+        sound_power_anechoic(  # type: ignore[call-overload]
+            levels, "hemisphere", radius=1.0, background_levels=background
+        )
+
+
+def test_sti_ambient_needs_the_speech_levels() -> None:
+    fs = 48000
+    x = np.random.default_rng(0).standard_normal(fs * 2)
+    ambient = np.full(7, 30.0)
+    with pytest.raises(ValueError, match="'ambient' requires"):
+        stipa(x, fs, ambient=ambient)  # type: ignore[call-overload]
+    ir = np.zeros(4096)
+    ir[0] = 1.0
+    with pytest.raises(ValueError, match="'ambient' requires"):
+        sti_from_impulse_response(ir, fs, ambient=ambient)  # type: ignore[call-overload]
+
+
+def test_sti_snr_and_ambient_are_two_ways_of_saying_one_thing() -> None:
+    """A group the first sweep missed, found in review of this change.
+
+    The run time refused the pair already; nothing in the signature said so,
+    which is the whole defect this change is about.
+    """
+    ir = np.zeros(4096)
+    ir[0] = 1.0
+    level, ambient = np.full(7, 60.0), np.full(7, 30.0)
+    with pytest.raises(ValueError, match="not both"):
+        sti_from_impulse_response(  # type: ignore[call-overload]
+            ir, 48000, 15.0, level, ambient
+        )
+
+
+def test_shock_exposure_and_measurement_times_travel_together() -> None:
+    a = np.random.default_rng(0).standard_normal(4096)
+    with pytest.raises(ValueError, match="both"):
+        multiple_shock_assessment(  # type: ignore[call-overload]
+            a, 1000.0, start_age=20.0, years=10, days_per_year=200.0,
+            exposure_time=1.0,
+        )
+
+
+def test_source_room_refuses_itself_at_construction() -> None:
+    """The one group that lives between two fields of a bundle, not two arguments.
+
+    No overload of ``room_to_room_transmission`` can constrain the inside of
+    its own argument, so the bundle checks itself, as
+    ``OperatingModeDeclaration`` already does. Checking it here rather than at
+    the call means the complaint arrives at the line that built the object.
+    """
+    for kwargs in ({}, {"level": 80.0, "power_level": 90.0}):
+        with pytest.raises(ValueError, match="exactly one"):
+            SourceRoom(**kwargs)
+    with pytest.raises(ValueError, match="'room_constant' is required"):
+        SourceRoom(power_level=90.0)
+    assert SourceRoom(level=80.0).level == 80.0
+    assert SourceRoom(power_level=90.0, room_constant=25.0).room_constant == 25.0
+
+
+# ---------------------------------------------------------------------------
+# The two the type system cannot state, checked at run time only
+# ---------------------------------------------------------------------------
+
+
+def test_db_hr_long_spectrum_needs_its_frequencies() -> None:
+    """The condition is the *length* of the input, which no signature can say."""
+    too_long = np.full(30, 40.0)
+    with pytest.raises(ValueError, match="eighteen DB-HR"):
+        db_hr_global_index(too_long, "pink")
+
+
+def test_narrowband_sensitivity_needs_its_rate() -> None:
+    tone = np.sin(2 * np.pi * 1000.0 * np.arange(48000) / 48000)
+    with pytest.raises(ValueError, match="requires 'fs'"):
+        sensitivity(tone, target_spl=94.0, narrowband=True)  # type: ignore[call-overload]


### PR DESCRIPTION
## What and why

Twenty public functions took a group of arguments that the signature presented
as independently optional and the body then demanded:

```python
def airborne_insulation(l1, l2, t2, *, area=None, volume=None, t0=0.5): ...

airborne_insulation(l1, l2, t2, area=10.0)
# ValueError: 'area' and 'volume' must be given together to compute R'.
```

The signature says both are optional. The body says they are a pair. Only
running the call settles it, and a type checker cannot help at all. This is the
same defect class as #581, one level up: there it was one argument that lied,
here it is the relationship between several.

Each group is now stated where the reader and the type checker both look, so
the invalid call is rejected before it runs:

```
error: No overload variant of "airborne_insulation" matches argument types ...
note: Possible overload variants:
note:     def airborne_insulation(l1, l2, t2, *, area: float, volume: float, t0: float = ...)
note:     def airborne_insulation(l1, l2, t2, *, t0: float = ...)
```

## The three shapes

**Exactly one of.** `lining_resonance_frequency` (Formula D.1 against D.2),
`ground_effect` (flow resistivity against impedance), `gaussian_residual_level`
(L90 against L95), `predict_diffuser_polar_response` (depths against
reflection).

**All or none, or one member requiring the other.** `airborne_insulation`,
`survey_airborne_insulation`, `adaptation_term_kc`,
`plenum_flanking_reduction_index`, `plateau_transmission_loss` (three members
over two routes), `floating_floor_improvement_spectrum`,
`sound_power_anechoic`, `impulse_response`, `stipa`,
`sti_from_impulse_response`, `multiple_shock_assessment`, `io.write`.

**Required by the value of another argument**, through `Literal`: `sensitivity`
(narrowband estimation needs the rate) and `floating_floor_improvement_spectrum`
(the Cremer hammer model needs its limiting frequency).

## The three that do not fit an overload

`SourceRoom` holds its two descriptions of the source room as *fields*, so no
overload of `room_to_room_transmission` can constrain the inside of its own
argument. It refuses itself in `__post_init__` instead, which is what
`OperatingModeDeclaration` already does for its own pair, and which moves the
complaint to the line that built the object rather than the call that used it.
Splitting the bundle into a union of two types was the alternative, and it was
rejected: the 26 dataclass unions in the tree are all *results* consumed by the
`_plot` and `_report` helpers, never input bundles offering two ways to build,
so it would have introduced a pattern for a single case.

Two more cannot be carried by any signature and now say so in prose:
`db_hr_global_index` requires `frequencies` for any input that is not exactly
the eighteen DB-HR bands, which is a condition on the **length of an array at
run time**, and `floating_floor_resonance` requires `thickness` and `porosity`
for the enclosed-gas term, which is a condition on the **value** of
`airflow_resistivity` rather than on a literal.

## One of them was silent

Nineteen of the twenty raised a correct error; the signature lied but the
result did not. `floating_floor_improvement_spectrum` was the exception: give
half of the `mass_per_area` / `dynamic_stiffness` pair and it returned
`delta_lw=None` without a word, dropping the one quantity the pair exists to
produce. It raises now, and the test says why that particular silence mattered.

The overloads also caught a real internal caller: `plot_aperture_result_geometry`
passed both `width` and `radius` through, one of them `None`, relying on the
permissive form to sort it out. It now branches on the shape the result
actually carries, which is a slit with a width or a circular aperture with a
radius, never both.

## Validation

Run-time behaviour is unchanged for every valid call; the checks stay for
callers who do not type-check. `tests/test_mutually_required_groups.py` pins
the run-time half with 17 tests, and the static half is exercised by the
`mypy src scripts` gate plus a scratch file, not committed, whose fourteen
invalid calls mypy rejects one by one.

## Checklist

- [x] `ruff check .`, `mypy src scripts`, full `pytest` suite (8922 passed, 16 skipped)
- [x] `make api-docs`, `make llms`, `make snippets` (4309 blocks), `make hazards`
- [x] CHANGELOG entry under `[Unreleased]`
- [ ] `make conformance` / `make figures` / `make pypi-readme`, untouched

## Known gap, tracked separately

`scripts/generate_api_docs.py` collapses overloads and publishes only the
implementation signature, so the generated pages still show the permissive
form. That is pre-existing (it happens today with `octave_filter`, whose four
heads render as one signature with the union of the four return types) and
affects 24 functions with 53 heads across the tree. Teaching the generator to
publish the heads is a generator-wide change and belongs in its own PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented strict argument group validation for twenty public functions using typing.overload to improve type checking and runtime error reporting.</li>
<li>Enhanced runtime validation for complex parameter dependencies that cannot be expressed in type signatures, such as conditional requirements based on argument values or array lengths.</li>
<li>Updated SourceRoom to enforce argument consistency in __post_init__, preventing invalid configurations at object creation time.</li>
<li>Refactored linkwitz_riley and parametric_eq to use keyword-only arguments for mandatory parameters, improving API clarity.</li>
<li>Updated documentation for building and material APIs to clarify runtime-checked parameter dependencies.</li>
</ul></div>

## Summary by Sourcery

Declare required argument relationships in APIs and enforce them consistently at type-checking, construction, and runtime.

Bug Fixes:
- Make incomplete mutually dependent argument groups fail explicitly instead of silently producing incomplete results, including the floating-floor weighted improvement pair.
- Move SourceRoom validation to object construction so mutually exclusive source descriptions and dependent room constants are rejected immediately.

Enhancements:
- Expose mutually exclusive, jointly required, and conditionally required argument relationships through overloads and Literal-based signatures for public APIs and plotting helpers, enabling type checkers to reject invalid calls.
- Update internal plotting dispatch and user-facing parameter documentation to reflect the clarified argument requirements.

Documentation:
- Clarify runtime-only parameter dependencies that cannot be represented in function signatures, including array-length and value-dependent requirements.

Tests:
- Add runtime coverage for incomplete and conflicting argument groups across the affected APIs and validate the corrected SourceRoom construction behavior.

Chores:
- Record the argument validation and signature improvements in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for incomplete floating-floor parameters.
  * Improved source-room validation and enforcement of required properties.
  * Clarified runtime checks for frequency bands and material parameters.

* **Documentation**
  * Expanded guidance for valid parameter combinations, validation rules, and supported input lengths.

* **Developer Experience**
  * Improved static type guidance across public functions by documenting required, paired, optional, and mutually exclusive arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->