### PR TITLE
Publish every call form a function has, not the union of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The generated API reference publishes every call form a function has,
+  instead of the single permissive signature that accepts all of them.
+  `inspect.signature` returns the implementation signature, which for an
+  overloaded function is not one of its call forms: it is the union that
+  admits every head plus the combinations the heads exist to refuse, so the
+  site was documenting a contract the library rejects. `octave_filter` shows
+  what that cost: its page carried one signature returning
+  `tuple[...] | tuple[...] | tuple[...] | tuple[...]` with nothing to say
+  which combination of `sigbands` and `nominal` produced which, and it now
+  carries its four forms with the return type each one gives. Nineteen pages
+  change, covering the functions in the tree that declare overloads. Functions
+  that declare none render exactly as before.
+
 ### Fixed
 
 - `floating_floor_improvement_spectrum` refuses one half of the

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -40,7 +40,7 @@ import sys
 from collections.abc import Mapping
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, get_overloads
 
 from api_taxonomy import (
     OBJECT_MODULE_OVERRIDES,
@@ -595,11 +595,38 @@ def format_signature(
     drop_first: bool = False,
     omit_return: bool = False,
 ) -> str:
-    """Render ``name(params) -> ret`` from ``inspect.signature``.
+    """Render the call forms of ``obj``, one per ``typing.overload`` head.
+
+    A function that declares overloads has more than one way to be called, and
+    the implementation signature is not one of them: it is the permissive union
+    that accepts every head plus the combinations none of them allow. Publishing
+    only that would document a contract the library refuses, so every head is
+    rendered, separated by a blank line, the way a stub file shows them.
 
     Stringized annotations (PEP 563, the repo style) are emitted verbatim.
     Multi-line when the one-line form would be hard to read.
     """
+    heads = get_overloads(obj)
+    if heads:
+        return "\n\n".join(
+            _format_one_signature(
+                name, head, drop_first=drop_first, omit_return=omit_return
+            )
+            for head in heads
+        )
+    return _format_one_signature(
+        name, obj, drop_first=drop_first, omit_return=omit_return
+    )
+
+
+def _format_one_signature(
+    name: str,
+    obj: Any,
+    *,
+    drop_first: bool = False,
+    omit_return: bool = False,
+) -> str:
+    """Render a single ``name(params) -> ret`` from ``inspect.signature``."""
     signature = inspect.signature(obj)
     parameters = list(signature.parameters.values())
     if drop_first and parameters and parameters[0].name in ("self", "cls"):
@@ -659,7 +686,11 @@ def _format_parameter(parameter: inspect.Parameter) -> str:
     if annotated:
         text = f"{text}: {_format_annotation(parameter.annotation)}"
     if parameter.default is not inspect.Parameter.empty:
-        if type(parameter.default).__module__ not in ("builtins", "types"):
+        if parameter.default is Ellipsis:
+            # The placeholder an overload head uses for "whatever the
+            # implementation defaults to"; `repr` would print `Ellipsis`.
+            default = "..."
+        elif type(parameter.default).__module__ not in ("builtins", "types"):
             # Third-party reprs (numpy arrays) are not pinned, so a repr here
             # would make the drift gate hostage to dependency upgrades; the
             # parameter description documents the effective default.

--- a/site/src/content/docs/reference/api/building/aperture-transmission.md
+++ b/site/src/content/docs/reference/api/building/aperture-transmission.md
@@ -196,11 +196,19 @@ A bare opening enters with $R = 0$ ($\tau = 1$).
 ```python
 plot_aperture_geometry(
     depth: float,
-    ax: Axes | None = None,
+    ax: Axes | None = ...,
     *,
-    width: float | None = None,
-    radius: float | None = None,
-    language: str = 'en',
+    width: float,
+    language: str = ...,
+    **kwargs: Any,
+) -> Axes
+
+plot_aperture_geometry(
+    depth: float,
+    ax: Axes | None = ...,
+    *,
+    radius: float,
+    language: str = ...,
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/building/ceiling-plenum.md
+++ b/site/src/content/docs/reference/api/building/ceiling-plenum.md
@@ -270,13 +270,26 @@ plenum_flanking_reduction_index(
     *,
     ceiling_length: float,
     plenum_height: float,
-    sidewalls: str = 'reflecting',
-    frequency: ArrayLike | None = None,
-    attenuation_source: ArrayLike | None = None,
-    attenuation_receiving: ArrayLike | None = None,
-    source_length: float | None = None,
-    split_source: float = 0.5,
-    split_receiving: float = 0.5,
+    sidewalls: str = ...,
+    frequency: ArrayLike | None = ...,
+    attenuation_source: ArrayLike,
+    attenuation_receiving: ArrayLike,
+    source_length: float | None = ...,
+    split_source: float = ...,
+    split_receiving: float = ...,
+) -> PlenumFlankingResult
+
+plenum_flanking_reduction_index(
+    reduction_index_source: ArrayLike,
+    reduction_index_receiving: ArrayLike,
+    *,
+    ceiling_length: float,
+    plenum_height: float,
+    sidewalls: str = ...,
+    frequency: ArrayLike | None = ...,
+    source_length: float | None = ...,
+    split_source: float = ...,
+    split_receiving: float = ...,
 ) -> PlenumFlankingResult
 ```
 

--- a/site/src/content/docs/reference/api/building/insulation.md
+++ b/site/src/content/docs/reference/api/building/insulation.md
@@ -79,9 +79,17 @@ airborne_insulation(
     l2: Sequence[float] | np.ndarray,
     t2: Sequence[float] | np.ndarray,
     *,
-    area: float | None = None,
-    volume: float | None = None,
-    t0: float = 0.5,
+    area: float,
+    volume: float,
+    t0: float = ...,
+) -> AirborneInsulationResult
+
+airborne_insulation(
+    l1: Sequence[float] | np.ndarray,
+    l2: Sequence[float] | np.ndarray,
+    t2: Sequence[float] | np.ndarray,
+    *,
+    t0: float = ...,
 ) -> AirborneInsulationResult
 ```
 

--- a/site/src/content/docs/reference/api/building/intensity-insulation.md
+++ b/site/src/content/docs/reference/api/building/intensity-insulation.md
@@ -80,9 +80,11 @@ one-third-octave (100-3150 Hz) or 5 octave (125-2000 Hz) values are supplied.
 adaptation_term_kc(
     freq: Sequence[float] | np.ndarray,
     *,
-    boundary_area: float | None = None,
-    volume: float | None = None,
+    boundary_area: float,
+    volume: float,
 ) -> np.ndarray
+
+adaptation_term_kc(freq: Sequence[float] | np.ndarray) -> np.ndarray
 ```
 
 Adaptation term `Kc` per ISO 15186-1:2000, Annex B.

--- a/site/src/content/docs/reference/api/building/linings.md
+++ b/site/src/content/docs/reference/api/building/linings.md
@@ -141,8 +141,14 @@ lining_resonance_frequency(
     base_mass_per_area: float,
     lining_mass_per_area: float,
     *,
-    dynamic_stiffness: float | None = None,
-    cavity_depth: float | None = None,
+    dynamic_stiffness: float,
+) -> float
+
+lining_resonance_frequency(
+    base_mass_per_area: float,
+    lining_mass_per_area: float,
+    *,
+    cavity_depth: float,
 ) -> float
 ```
 

--- a/site/src/content/docs/reference/api/building/panel-transmission.md
+++ b/site/src/content/docs/reference/api/building/panel-transmission.md
@@ -565,14 +565,37 @@ PLATEAU_MATERIALS = {'aluminium': (2.66, 29.0, 11.0), 'brick': (2.1, 37.0, 4.5),
 plateau_transmission_loss(
     frequency: ArrayLike,
     *,
-    material: str | None = None,
-    thickness_mm: float | None = None,
-    mass_per_area: float | None = None,
-    plateau_height: float | None = None,
-    frequency_ratio: float | None = None,
-    field_correction: float = 5.0,
-    speed_of_sound: float = 343.0,
-    air_density: float = 1.205,
+    material: str,
+    thickness_mm: float,
+    plateau_height: float | None = ...,
+    frequency_ratio: float | None = ...,
+    field_correction: float = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SoundReductionResult
+
+plateau_transmission_loss(
+    frequency: ArrayLike,
+    *,
+    material: str,
+    mass_per_area: float,
+    thickness_mm: float | None = ...,
+    plateau_height: float | None = ...,
+    frequency_ratio: float | None = ...,
+    field_correction: float = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SoundReductionResult
+
+plateau_transmission_loss(
+    frequency: ArrayLike,
+    *,
+    mass_per_area: float,
+    plateau_height: float,
+    frequency_ratio: float,
+    field_correction: float = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
 ) -> SoundReductionResult
 ```
 

--- a/site/src/content/docs/reference/api/building/resilient-layers.md
+++ b/site/src/content/docs/reference/api/building/resilient-layers.md
@@ -303,10 +303,34 @@ floating_floor_improvement_spectrum(
     frequencies: ArrayLike,
     *,
     resonance_frequency: float,
-    model: FloatingFloorModel = 'en12354',
-    limiting_frequency: float | None = None,
-    mass_per_area: float | None = None,
-    dynamic_stiffness: float | None = None,
+    model: Literal['cremer_hammer'],
+    limiting_frequency: float,
+    mass_per_area: float,
+    dynamic_stiffness: float,
+) -> FloatingFloorImprovementResult
+
+floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal['cremer_hammer'],
+    limiting_frequency: float,
+) -> FloatingFloorImprovementResult
+
+floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal['en12354', 'cremer'] = ...,
+    mass_per_area: float,
+    dynamic_stiffness: float,
+) -> FloatingFloorImprovementResult
+
+floating_floor_improvement_spectrum(
+    frequencies: ArrayLike,
+    *,
+    resonance_frequency: float,
+    model: Literal['en12354', 'cremer'] = ...,
 ) -> FloatingFloorImprovementResult
 ```
 

--- a/site/src/content/docs/reference/api/building/survey-insulation.md
+++ b/site/src/content/docs/reference/api/building/survey-insulation.md
@@ -79,8 +79,15 @@ estimate_reverberation_index(
     volume: float,
     room: str,
     *,
-    weighted: bool = False,
-) -> np.ndarray | float
+    weighted: Literal[False] = False,
+) -> np.ndarray
+
+estimate_reverberation_index(
+    volume: float,
+    room: str,
+    *,
+    weighted: Literal[True],
+) -> float
 ```
 
 Estimate the reverberation index from room type and volume (Clause 6.5).
@@ -148,8 +155,16 @@ survey_airborne_insulation(
     l2: Sequence[float] | np.ndarray,
     reverberation_index: Sequence[float] | np.ndarray,
     *,
-    volume: float | None = None,
-    area: float | None = None,
+    volume: float,
+    area: float,
+) -> SurveyAirborneResult
+
+survey_airborne_insulation(
+    l1: Sequence[float] | np.ndarray,
+    l2: Sequence[float] | np.ndarray,
+    reverberation_index: Sequence[float] | np.ndarray,
+    *,
+    volume: float = ...,
 ) -> SurveyAirborneResult
 ```
 

--- a/site/src/content/docs/reference/api/electroacoustics/piston.md
+++ b/site/src/content/docs/reference/api/electroacoustics/piston.md
@@ -232,12 +232,21 @@ matplotlib (`pip install phonometry[plot]`).
 ```python
 plot_piston_geometry(
     radius: float,
-    ax: Axes | None = None,
+    ax: Axes | None = ...,
     *,
-    angles: ArrayLike | None = None,
-    directivity: ArrayLike | None = None,
-    lobe_label: str | None = None,
-    language: str = 'en',
+    angles: ArrayLike,
+    directivity: ArrayLike,
+    lobe_label: str | None = ...,
+    language: str = ...,
+    **kwargs: Any,
+) -> Axes
+
+plot_piston_geometry(
+    radius: float,
+    ax: Axes | None = ...,
+    *,
+    lobe_label: str | None = ...,
+    language: str = ...,
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/environment/ground-barriers.md
+++ b/site/src/content/docs/reference/api/environment/ground-barriers.md
@@ -344,11 +344,22 @@ ground_effect(
     receiver_height: float,
     distance: float,
     *,
-    impedance: ArrayLike | PorousMediumResult | None = None,
-    flow_resistivity: float | None = None,
-    model: Literal['delany_bazley', 'miki'] = 'delany_bazley',
-    speed_of_sound: float = 343.0,
-    air_density: float = 1.205,
+    impedance: ArrayLike | PorousMediumResult,
+    model: Literal['delany_bazley', 'miki'] = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
+) -> SphericalGroundResult
+
+ground_effect(
+    frequencies: ArrayLike,
+    source_height: float,
+    receiver_height: float,
+    distance: float,
+    *,
+    flow_resistivity: float,
+    model: Literal['delany_bazley', 'miki'] = ...,
+    speed_of_sound: float = ...,
+    air_density: float = ...,
 ) -> SphericalGroundResult
 ```
 

--- a/site/src/content/docs/reference/api/environment/measurement.md
+++ b/site/src/content/docs/reference/api/environment/measurement.md
@@ -172,12 +172,9 @@ Warning for unreliable environmental-noise determinations.
 ## gaussian_residual_level
 
 ```python
-gaussian_residual_level(
-    l50: float,
-    *,
-    l90: float | None = None,
-    l95: float | None = None,
-) -> float
+gaussian_residual_level(l50: float, *, l90: float) -> float
+
+gaussian_residual_level(l50: float, *, l95: float) -> float
 ```
 
 Estimate the residual equivalent level from percentiles (Annex I).

--- a/site/src/content/docs/reference/api/filters/core.md
+++ b/site/src/content/docs/reference/api/filters/core.md
@@ -78,14 +78,62 @@ octave_filter(
     order: int = 6,
     limits: list[float] | None = None,
     *,
-    sigbands: bool = False,
+    sigbands: Literal[False] = False,
     detrend: bool = True,
     mode: str = 'rms',
-    nominal: bool = False,
+    nominal: Literal[False] = False,
     design: FilterDesign = ...,
     calibration: LevelCalibration = ...,
     response_plot: ResponsePlot = ...,
-) -> tuple[np.ndarray, list[float]] | tuple[np.ndarray, list[str]] | tuple[np.ndarray, list[float], list[np.ndarray]] | tuple[np.ndarray, list[str], list[np.ndarray]]
+) -> tuple[np.ndarray, list[float]]
+
+octave_filter(
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
+    fraction: float = 1,
+    order: int = 6,
+    limits: list[float] | None = None,
+    *,
+    sigbands: Literal[True] = True,
+    detrend: bool = True,
+    mode: str = 'rms',
+    nominal: Literal[False] = False,
+    design: FilterDesign = ...,
+    calibration: LevelCalibration = ...,
+    response_plot: ResponsePlot = ...,
+) -> tuple[np.ndarray, list[float], list[np.ndarray]]
+
+octave_filter(
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
+    fraction: float = 1,
+    order: int = 6,
+    limits: list[float] | None = None,
+    *,
+    sigbands: Literal[False] = False,
+    detrend: bool = True,
+    mode: str = 'rms',
+    nominal: Literal[True] = ...,
+    design: FilterDesign = ...,
+    calibration: LevelCalibration = ...,
+    response_plot: ResponsePlot = ...,
+) -> tuple[np.ndarray, list[str]]
+
+octave_filter(
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
+    fraction: float = 1,
+    order: int = 6,
+    limits: list[float] | None = None,
+    *,
+    sigbands: Literal[True] = True,
+    detrend: bool = True,
+    mode: str = 'rms',
+    nominal: Literal[True] = ...,
+    design: FilterDesign = ...,
+    calibration: LevelCalibration = ...,
+    response_plot: ResponsePlot = ...,
+) -> tuple[np.ndarray, list[str], list[np.ndarray]]
 ```
 
 Filter a signal with octave or fractional octave filter bank.
@@ -154,13 +202,83 @@ Initialize the Octave Filter Bank.
 ```python
 OctaveFilterBank.filter(
     x: Signal | list[float] | np.ndarray,
-    sigbands: bool = False,
+    sigbands: Literal[False] = False,
     mode: str = 'rms',
     detrend: bool = True,
-    calculate_level: bool = True,
-    nominal: bool = False,
+    calculate_level: Literal[True] = True,
+    nominal: Literal[False] = False,
     zero_phase: bool = False,
-) -> tuple[np.ndarray | None, list[float] | list[str]] | tuple[np.ndarray | None, list[float] | list[str], list[np.ndarray]]
+) -> tuple[np.ndarray, list[float]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[True],
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[True] = True,
+    nominal: Literal[False] = False,
+    zero_phase: bool = False,
+) -> tuple[np.ndarray, list[float], list[np.ndarray]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[False] = False,
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[False] = False,
+    nominal: Literal[False] = False,
+    zero_phase: bool = False,
+) -> tuple[None, list[float]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[True],
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[False] = False,
+    nominal: Literal[False] = False,
+    zero_phase: bool = False,
+) -> tuple[None, list[float], list[np.ndarray]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[False] = False,
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[True] = True,
+    nominal: Literal[True] = ...,
+    zero_phase: bool = False,
+) -> tuple[np.ndarray, list[str]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[True],
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[True] = True,
+    nominal: Literal[True] = ...,
+    zero_phase: bool = False,
+) -> tuple[np.ndarray, list[str], list[np.ndarray]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[False] = False,
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[False] = False,
+    nominal: Literal[True] = ...,
+    zero_phase: bool = False,
+) -> tuple[None, list[str]]
+
+OctaveFilterBank.filter(
+    x: Signal | list[float] | np.ndarray,
+    sigbands: Literal[True],
+    mode: str = 'rms',
+    detrend: bool = True,
+    calculate_level: Literal[False] = False,
+    nominal: Literal[True] = ...,
+    zero_phase: bool = False,
+) -> tuple[None, list[str], list[np.ndarray]]
 ```
 
 Apply the pre-designed filter bank to a signal.

--- a/site/src/content/docs/reference/api/io/io.md
+++ b/site/src/content/docs/reference/api/io/io.md
@@ -519,13 +519,23 @@ has scrolled away.
 write(
     path: str | Path,
     x: Signal | NDArray[np.generic] | list[float],
-    fs: int | None = None,
+    fs: int | None = ...,
     *,
-    subtype: str | None = None,
-    bext: BroadcastMetadata | str | None = None,
-    dither: str | None = None,
-    rng: np.random.Generator | int | None = None,
-    sidecar: bool = False,
+    subtype: str | None = ...,
+    bext: BroadcastMetadata | str | None = ...,
+    dither: Literal['tpdf'],
+    rng: np.random.Generator | int | None = ...,
+    sidecar: bool = ...,
+) -> None
+
+write(
+    path: str | Path,
+    x: Signal | NDArray[np.generic] | list[float],
+    fs: int | None = ...,
+    *,
+    subtype: str | None = ...,
+    bext: BroadcastMetadata | str | None = ...,
+    sidecar: bool = ...,
 ) -> None
 ```
 

--- a/site/src/content/docs/reference/api/materials/design.md
+++ b/site/src/content/docs/reference/api/materials/design.md
@@ -179,14 +179,26 @@ predict_diffuser_polar_response(
     well_width: float,
     frequency: float,
     *,
-    depths: ArrayLike | None = None,
-    reflection: ArrayLike | None = None,
-    angles: ArrayLike = (-90, -85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90),
-    source_angle: float = 0.0,
-    periods: int = 1,
-    speed_of_sound: float = 343.0,
-    include_aperture: bool = True,
-    include_obliquity: bool = True,
+    depths: ArrayLike,
+    angles: ArrayLike = ...,
+    source_angle: float = ...,
+    periods: int = ...,
+    speed_of_sound: float = ...,
+    include_aperture: bool = ...,
+    include_obliquity: bool = ...,
+) -> DiffuserPolarResponse
+
+predict_diffuser_polar_response(
+    well_width: float,
+    frequency: float,
+    *,
+    reflection: ArrayLike,
+    angles: ArrayLike = ...,
+    source_angle: float = ...,
+    periods: int = ...,
+    speed_of_sound: float = ...,
+    include_aperture: bool = ...,
+    include_obliquity: bool = ...,
 ) -> DiffuserPolarResponse
 ```
 

--- a/site/src/content/docs/reference/api/metrology/calibration.md
+++ b/site/src/content/docs/reference/api/metrology/calibration.md
@@ -18,13 +18,25 @@ The calibration reference recording looks unreliable.
 ```python
 sensitivity(
     ref_signal: list[float] | np.ndarray,
-    target_spl: float = 94.0,
-    ref_pressure: float = 2e-05,
-    fs: int | None = None,
-    validate: bool = True,
-    max_fluctuation_db: float | None = None,
-    frequency: float = 1000.0,
-    narrowband: bool = False,
+    target_spl: float = ...,
+    ref_pressure: float = ...,
+    *,
+    fs: int,
+    validate: bool = ...,
+    max_fluctuation_db: float | None = ...,
+    frequency: float = ...,
+    narrowband: Literal[True],
+) -> float
+
+sensitivity(
+    ref_signal: list[float] | np.ndarray,
+    target_spl: float = ...,
+    ref_pressure: float = ...,
+    fs: int | None = ...,
+    validate: bool = ...,
+    max_fluctuation_db: float | None = ...,
+    frequency: float = ...,
+    narrowband: Literal[False] = ...,
 ) -> float
 ```
 

--- a/site/src/content/docs/reference/api/power/sound-power-anechoic.md
+++ b/site/src/content/docs/reference/api/power/sound-power-anechoic.md
@@ -311,14 +311,28 @@ sound_power_anechoic(
     surface: PrecisionSurface,
     *,
     radius: float,
-    background_levels: np.ndarray | None = None,
-    frequencies: np.ndarray | None = None,
-    areas: np.ndarray | None = None,
-    temperature: float = 23.0,
-    static_pressure: float = 101.325,
-    air_absorption_coefficient: float | np.ndarray | None = None,
-    sigma_omc: float = 0.0,
-    coverage_factor: float = 2.0,
+    background_levels: np.ndarray,
+    frequencies: np.ndarray,
+    areas: np.ndarray | None = ...,
+    temperature: float = ...,
+    static_pressure: float = ...,
+    air_absorption_coefficient: float | np.ndarray | None = ...,
+    sigma_omc: float = ...,
+    coverage_factor: float = ...,
+) -> PrecisionSoundPowerResult
+
+sound_power_anechoic(
+    levels_positions: np.ndarray,
+    surface: PrecisionSurface,
+    *,
+    radius: float,
+    frequencies: np.ndarray | None = ...,
+    areas: np.ndarray | None = ...,
+    temperature: float = ...,
+    static_pressure: float = ...,
+    air_absorption_coefficient: float | np.ndarray | None = ...,
+    sigma_omc: float = ...,
+    coverage_factor: float = ...,
 ) -> PrecisionSoundPowerResult
 ```
 

--- a/site/src/content/docs/reference/api/rooms/impulse-response.md
+++ b/site/src/content/docs/reference/api/rooms/impulse-response.md
@@ -155,11 +155,23 @@ impulse_response(
     reference: list[float] | np.ndarray,
     fs: int,
     *,
-    method: str = 'spectral',
-    f_range: tuple[float, float] | None = None,
-    regularization: float = 1e-06,
-    length: int | None = None,
-    return_full: bool = False,
+    method: Literal['farina'],
+    f_range: tuple[float, float],
+    regularization: float = ...,
+    length: int | None = ...,
+    return_full: bool = ...,
+) -> ImpulseResponseResult
+
+impulse_response(
+    recorded: list[float] | np.ndarray,
+    reference: list[float] | np.ndarray,
+    fs: int,
+    *,
+    method: str = ...,
+    f_range: tuple[float, float] | None = ...,
+    regularization: float = ...,
+    length: int | None = ...,
+    return_full: bool = ...,
 ) -> ImpulseResponseResult
 ```
 

--- a/site/src/content/docs/reference/api/speech/sti.md
+++ b/site/src/content/docs/reference/api/speech/sti.md
@@ -27,9 +27,25 @@ the male test-signal spectrum (A.6.1).
 sti_from_impulse_response(
     ir: list[float] | np.ndarray,
     fs: int,
-    snr: float | Sequence[float] | np.ndarray | None = None,
-    level: Sequence[float] | np.ndarray | None = None,
-    ambient: Sequence[float] | np.ndarray | None = None,
+    snr: None,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult
+
+sti_from_impulse_response(
+    ir: list[float] | np.ndarray,
+    fs: int,
+    snr: None = ...,
+    *,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult
+
+sti_from_impulse_response(
+    ir: list[float] | np.ndarray,
+    fs: int,
+    snr: float | Sequence[float] | np.ndarray | None = ...,
+    level: Sequence[float] | np.ndarray | None = ...,
 ) -> STIResult
 ```
 
@@ -85,9 +101,25 @@ STI itself stays within ~0.001.
 stipa(
     x: list[float] | np.ndarray,
     fs: int,
-    reference: list[float] | np.ndarray | None = None,
-    level: Sequence[float] | np.ndarray | None = None,
-    ambient: Sequence[float] | np.ndarray | None = None,
+    reference: list[float] | np.ndarray | None,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult
+
+stipa(
+    x: list[float] | np.ndarray,
+    fs: int,
+    reference: list[float] | np.ndarray | None = ...,
+    *,
+    level: Sequence[float] | np.ndarray,
+    ambient: Sequence[float] | np.ndarray,
+) -> STIResult
+
+stipa(
+    x: list[float] | np.ndarray,
+    fs: int,
+    reference: list[float] | np.ndarray | None = ...,
+    level: Sequence[float] | np.ndarray | None = ...,
 ) -> STIResult
 ```
 

--- a/site/src/content/docs/reference/api/vibration/multiple-shock.md
+++ b/site/src/content/docs/reference/api/vibration/multiple-shock.md
@@ -236,10 +236,21 @@ multiple_shock_assessment(
     start_age: float,
     years: int,
     days_per_year: float,
-    exposure_time: float | None = None,
-    measurement_time: float | None = None,
-    sex: Literal['male', 'female'] = 'male',
-    mz: float | None = None,
+    exposure_time: float,
+    measurement_time: float,
+    sex: Literal['male', 'female'] = ...,
+    mz: float | None = ...,
+) -> MultipleShockResult
+
+multiple_shock_assessment(
+    acceleration: ArrayLike,
+    fs: float,
+    *,
+    start_age: float,
+    years: int,
+    days_per_year: float,
+    sex: Literal['male', 'female'] = ...,
+    mz: float | None = ...,
 ) -> MultipleShockResult
 ```
 

--- a/tests/test_api_docs_generator.py
+++ b/tests/test_api_docs_generator.py
@@ -472,7 +472,8 @@ def test_overloaded_function_publishes_every_call_form() -> None:
     # One form takes the pair, the other takes neither; no form takes one.
     with_pair = [f for f in forms if "area" in f]
     without = [f for f in forms if "area" not in f]
-    assert len(with_pair) == 1 and len(without) == 1
+    assert len(with_pair) == 1
+    assert len(without) == 1
     assert "volume" in with_pair[0]
     assert "volume" not in without[0]
     # The permissive union is exactly what must NOT be published.

--- a/tests/test_api_docs_generator.py
+++ b/tests/test_api_docs_generator.py
@@ -450,3 +450,47 @@ def test_quick_table_version_literal_is_current() -> None:
     assert car.version_problems(markdown, phonometry.__version__) == []
     # And it says it exactly once, so no second copy can drift unseen.
     assert car._VERSION_LITERAL.findall(markdown) == [phonometry.__version__]
+
+
+# ---------------------------------------------------------------------------
+# Overloaded call forms
+# ---------------------------------------------------------------------------
+
+
+def test_overloaded_function_publishes_every_call_form() -> None:
+    """A function with overloads has more than one way to be called.
+
+    The implementation signature is not one of them: it is the permissive
+    union that accepts every head plus the combinations the heads refuse, so
+    publishing only that would document a contract the library rejects.
+    """
+    from phonometry.building.measurement.insulation import airborne_insulation
+
+    rendered = gad.format_signature("airborne_insulation", airborne_insulation)
+    forms = rendered.split("\n\n")
+    assert len(forms) == 2, rendered
+    # One form takes the pair, the other takes neither; no form takes one.
+    with_pair = [f for f in forms if "area" in f]
+    without = [f for f in forms if "area" not in f]
+    assert len(with_pair) == 1 and len(without) == 1
+    assert "volume" in with_pair[0]
+    assert "volume" not in without[0]
+    # The permissive union is exactly what must NOT be published.
+    assert "area: float | None = None" not in rendered
+
+
+def test_overload_placeholder_default_reads_as_ellipsis() -> None:
+    """``= ...`` is the head's placeholder; ``repr`` would print ``Ellipsis``."""
+    from phonometry.emission.sound_power_anechoic import sound_power_anechoic
+
+    rendered = gad.format_signature("sound_power_anechoic", sound_power_anechoic)
+    assert "= ..." in rendered
+    assert "Ellipsis" not in rendered
+
+
+def test_plain_function_still_renders_one_form() -> None:
+    """Nothing changes for the functions that declare no overloads."""
+    from phonometry.signals.levels import leq
+
+    rendered = gad.format_signature("leq", leq)
+    assert "\n\n" not in rendered


### PR DESCRIPTION
## What and why

`inspect.signature` returns the *implementation* signature. For an overloaded
function that is not one of its call forms: it is the permissive union that
admits every head, plus the combinations the heads exist to refuse. The
generated reference published only that, so a reader of the site saw a contract
the library rejects.

`octave_filter` shows the cost, and it predates #583. Its page carried one
signature ending in

```
-> tuple[np.ndarray, list[float]] | tuple[np.ndarray, list[str]] | tuple[np.ndarray, list[float], list[np.ndarray]] | tuple[np.ndarray, list[str], list[np.ndarray]]
```

with nothing to say which combination of `sigbands` and `nominal` produced
which. It now carries its four forms, each with the return type it actually
gives:

```python
octave_filter(..., *, sigbands: Literal[False] = False, nominal: Literal[False] = False, ...)
    -> tuple[np.ndarray, list[float]]

octave_filter(..., *, sigbands: Literal[True] = True, nominal: Literal[False] = False, ...)
    -> tuple[np.ndarray, list[float], list[np.ndarray]]
```

The same applies to the twenty groups that landed in #583: their overloads say
which arguments travel together, and the page was flattening that back into the
permissive form the whole change existed to remove.

## How

`typing.get_overloads` reaches the heads from the run time, so no AST work and
no second source of truth. `format_signature` renders one form per head,
separated by a blank line, the way a stub file shows them; the single-signature
path is unchanged for the functions that declare none.

One rendering bug came with it: a head writes `= ...` as its placeholder for
"whatever the implementation defaults to", and `repr` printed that as
`Ellipsis`. It now prints as written.

## Scope

Nineteen pages, covering the 24 functions in the tree that declare overloads.
No library code changes.

## Validation

- Three new tests in `tests/test_api_docs_generator.py`: an overloaded function
  publishes one form per head and never the permissive union, the placeholder
  reads as `...`, and a function without overloads still renders a single form.
- The generator is deterministic across runs, which the drift gate depends on:
  a second `make api-docs && make llms` leaves the tree unchanged.

## Checklist

- [x] `ruff check .`, `mypy src scripts`, full `pytest` suite (8926 passed, 16 skipped)
- [x] `make api-docs`, `make llms`, `make snippets` (4309 blocks), `make hazards`
- [x] CHANGELOG entry under `[Unreleased]`
- [ ] `make conformance` / `make figures` / `make pypi-readme`, untouched


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Publish accurate overload-specific call forms in the generated API reference.

Enhancements:
- Update API documentation generation to publish each declared overload call form with its corresponding parameters and return type instead of the permissive implementation signature.
- Preserve readable `...` placeholders for unspecified overload defaults while leaving non-overloaded function rendering unchanged.

Documentation:
- Regenerate 19 API reference pages and document the accurate overload-specific signatures.
- Add an Unreleased changelog entry describing the improved overloaded API reference output.

Tests:
- Add coverage for rendering all overload forms, formatting ellipsis defaults, and retaining single-form output for ordinary functions.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated API documentation generator to render all `typing.overload` call forms instead of just the implementation signature.</li>
<li>Modified `scripts/generate_api_docs.py` to use `get_overloads` for extracting and formatting individual function signatures.</li>
<li>Improved parameter default rendering to correctly handle `Ellipsis` as a placeholder for overloaded function heads.</li>
<li>Updated 19 API reference documentation pages to reflect the more accurate, overloaded function signatures.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - API reference pages now show every supported overload instead of a single broad signature.
  - Clarified required and mutually exclusive parameters across building, acoustics, environment, filters, speech, and other APIs.
  - Improved return-type documentation for options such as weighted results, filtering modes, and level calculations.
  - Updated literal options and overload-specific defaults, including clearer placeholder values.
  - Non-overloaded function references remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->