### PR TITLE
The psychoacoustic models read the calibration off the file

### DIFF
--- a/site/src/content/docs/reference/api/psychoacoustics/annoyance.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/annoyance.md
@@ -85,7 +85,7 @@ $S \le 1.75$ acum.
 
 ```python
 psychoacoustic_annoyance_from_signal(
-    x: Signal | list[float] | np.ndarray,
+    x: SignalInput,
     fs: int | None = None,
     *,
     field: Literal['free', 'diffuse'] = 'free',

--- a/site/src/content/docs/reference/api/psychoacoustics/annoyance.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/annoyance.md
@@ -85,11 +85,11 @@ $S \le 1.75$ acum.
 
 ```python
 psychoacoustic_annoyance_from_signal(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     *,
     field: Literal['free', 'diffuse'] = 'free',
-    calibration_factor: float = 1.0,
+    calibration_factor: float | None = None,
 ) -> PsychoacousticAnnoyanceResult
 ```
 
@@ -118,10 +118,10 @@ variant (see [`fluctuation_strength`](/phonometry/reference/api/psychoacoustics/
 
 | Name | Description |
 | :--- | :--- |
-| `x` | Calibrated sound-pressure signal (1-D), in Pa after `calibration_factor`. |
-| `fs` | Sample rate, in Hz. |
+| `x` | Calibrated sound-pressure signal (1-D), in Pa after `calibration_factor`. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where that calibration comes from without arithmetic: all four sensations are level-dependent models, so an uncalibrated record is read as if one digital unit were one pascal and every one of them comes out wrong by however far that is from true. |
+| `fs` | Sample rate, in Hz. Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises. |
 | `field` | `'free'` (default) or `'diffuse'` sound field for the loudness/sharpness/roughness front-ends (`F` is always free-field). |
-| `calibration_factor` | Digital-units-to-Pa factor applied to `x`. |
+| `calibration_factor` | Digital-units-to-Pa factor applied to `x`. An explicit value wins over the one a Signal carries. |
 
 **Returns:** A [`PsychoacousticAnnoyanceResult`](/phonometry/reference/api/psychoacoustics/annoyance/#psychoacousticannoyanceresult).
 

--- a/site/src/content/docs/reference/api/psychoacoustics/ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/ecma.md
@@ -93,8 +93,8 @@ Adds a loudness-vs-time panel.  Requires matplotlib
 
 ```python
 loudness_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal['free', 'diffuse'] = 'free',
 ) -> EcmaLoudness
 ```
@@ -105,8 +105,8 @@ Psychoacoustic loudness per ECMA-418-2:2025 (Sottek Hearing Model).
 
 | Name | Description |
 | :--- | :--- |
-| `signal_in` | Calibrated sound pressure signal in pascals. |
-| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). |
+| `signal_in` | Calibrated sound pressure signal in pascals. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where "calibrated" comes from without arithmetic: this model reads absolute levels, so an uncalibrated record is taken as if one digital unit were one pascal and the answer is wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | `"free"` (default) or `"diffuse"` sound field, selecting the outer/middle-ear filter of Clause 5.1.3. |
 
 **Returns:** An [`EcmaLoudness`](/phonometry/reference/api/psychoacoustics/ecma/#ecmaloudness) with the single loudness value N (Formula 117), the average specific loudness N'(z) (Formula 115) and the time-dependent loudness N(l) (Formula 116).

--- a/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength-ecma.md
@@ -147,8 +147,8 @@ specific-fluctuation-strength heatmap. Requires matplotlib
 
 ```python
 fluctuation_strength_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal['free', 'diffuse'] = 'free',
 ) -> EcmaFluctuationStrength
 ```
@@ -159,8 +159,8 @@ Psychoacoustic fluctuation strength per ECMA-418-2:2025 (Clause 9).
 
 | Name | Description |
 | :--- | :--- |
-| `signal_in` | Calibrated sound pressure signal in pascals. |
-| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). |
+| `signal_in` | Calibrated sound pressure signal in pascals. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where "calibrated" comes from without arithmetic: this model reads absolute levels, so an uncalibrated record is taken as if one digital unit were one pascal and the answer is wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | `"free"` (default) or `"diffuse"` sound field, selecting the outer/middle-ear filter of Clause 5.1.3. |
 
 **Returns:** An [`EcmaFluctuationStrength`](/phonometry/reference/api/psychoacoustics/fluctuation-strength-ecma/#ecmafluctuationstrength) with the single value F (Clause 9.1.14), the average specific fluctuation strength F'(z) (Clause 9.1.12) and the time-dependent fluctuation strength F(l50) (Formula 169).

--- a/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength.md
@@ -55,8 +55,8 @@ Osses/Fastl & Zwicker model, not that method.
 
 ```python
 fluctuation_strength(
-    signal_in: NDArray[np.float64],
-    fs: float,
+    signal_in: Signal | NDArray[np.float64],
+    fs: float | None = None,
 ) -> FluctuationStrengthResult
 ```
 
@@ -108,7 +108,7 @@ the reference method itself overestimates it above 4 Hz.
 
 | Name | Description |
 | :--- | :--- |
-| `signal_in` | Calibrated sound-pressure signal (1-D), in Pa. |
+| `signal_in` | Calibrated sound-pressure signal (1-D), in Pa. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where that calibration comes from without arithmetic: the model reads excitation levels, so an uncalibrated record is taken as if one digital unit were one pascal and `F` comes out wrong by however far that is from true. |
 | `fs` | Sample rate, in Hz (resampled to the model rate if needed). |
 
 **Returns:** A [`FluctuationStrengthResult`](/phonometry/reference/api/psychoacoustics/fluctuation-strength/#fluctuationstrengthresult).

--- a/site/src/content/docs/reference/api/psychoacoustics/moore-glasberg-time.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/moore-glasberg-time.md
@@ -65,8 +65,8 @@ required.
 
 ```python
 loudness_moore_glasberg_time(
-    signal: Sequence[float] | np.ndarray,
-    fs: float,
+    signal: Signal | Sequence[float] | np.ndarray,
+    fs: float | None = None,
     *,
     field: Literal['free', 'diffuse', 'eardrum'] = 'free',
     presentation: Literal['binaural', 'diotic', 'monaural'] = 'binaural',
@@ -87,8 +87,8 @@ the instantaneous sound pressure in pascals.
 
 | Name | Description |
 | :--- | :--- |
-| `signal` | Calibrated pressure signal in pascals.  A 1-D array is treated as diotic (the same sound at both ears) for a binaural/diotic presentation, or as the single active ear for a monaural presentation; a two-channel `(n, 2)` array gives the left and right ear signals. |
-| `fs` | Sampling rate in Hz (positive). |
+| `signal` | Calibrated pressure signal in pascals.  A 1-D array is treated as diotic (the same sound at both ears) for a binaural/diotic presentation, or as the single active ear for a monaural presentation; a two-channel `(n, 2)` array gives the left and right ear signals. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where "calibrated" comes from without arithmetic: this model reads absolute levels, so an uncalibrated record is taken as if one digital unit were one pascal and the answer is wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz (positive). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | Listening condition setting the outer-ear transfer: `"free"` (frontal free field, default), `"diffuse"` (diffuse field) or `"eardrum"` (levels already at the tympanic membrane). |
 | `presentation` | `"binaural"`/`"diotic"` (default) or `"monaural"`. |
 | `percentiles` | Fractions (percent) for which the exceeded long-term loudness is reported. |

--- a/site/src/content/docs/reference/api/psychoacoustics/moore-glasberg.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/moore-glasberg.md
@@ -45,8 +45,8 @@ the exact sinusoidal-component method.
 
 ```python
 loudness_moore_glasberg(
-    x: list[float] | np.ndarray,
-    fs: float,
+    x: Signal | list[float] | np.ndarray,
+    fs: float | None = None,
     *,
     field: Literal['free', 'diffuse', 'eardrum'] = 'free',
     presentation: Literal['binaural', 'diotic', 'monaural'] = 'binaural',
@@ -69,8 +69,8 @@ calibrated so that `x` is the instantaneous sound pressure in pascals.
 
 | Name | Description |
 | :--- | :--- |
-| `x` | Single-channel calibrated pressure signal in pascals. |
-| `fs` | Sampling rate in Hz (positive). |
+| `x` | Single-channel calibrated pressure signal in pascals. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where "calibrated" comes from without arithmetic: this model reads absolute levels, so an uncalibrated record is taken as if one digital unit were one pascal and the answer is wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz (positive). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | `"free"` (default), `"diffuse"` or `"eardrum"`. |
 | `presentation` | `"binaural"` (default; alias `"diotic"`) or `"monaural"`. |
 

--- a/site/src/content/docs/reference/api/psychoacoustics/roughness-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/roughness-ecma.md
@@ -100,8 +100,8 @@ heatmap. Requires matplotlib (`pip install phonometry[plot]`).
 
 ```python
 roughness_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal['free', 'diffuse'] = 'free',
 ) -> EcmaRoughness
 ```
@@ -112,8 +112,8 @@ Psychoacoustic roughness per ECMA-418-2:2025 (Sottek Hearing Model).
 
 | Name | Description |
 | :--- | :--- |
-| `signal_in` | Calibrated sound pressure signal in pascals. |
-| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). |
+| `signal_in` | Calibrated sound pressure signal in pascals. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where "calibrated" comes from without arithmetic: this model reads absolute levels, so an uncalibrated record is taken as if one digital unit were one pascal and the answer is wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | `"free"` (default) or `"diffuse"` sound field, selecting the outer/middle-ear filter of Clause 5.1.3. |
 
 **Returns:** An [`EcmaRoughness`](/phonometry/reference/api/psychoacoustics/roughness-ecma/#ecmaroughness) with the single value R (Clause 7.1.10), the average specific roughness R'(z) (Clause 7.1.8) and the time-dependent roughness R(l50) (Formula 111).

--- a/site/src/content/docs/reference/api/psychoacoustics/sharpness.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/sharpness.md
@@ -23,11 +23,11 @@ at, 1.00 acum (~0.96 Aures / ~1.02 von Bismarck through this front-end).
 
 ```python
 sharpness_din(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     field: Literal['free', 'diffuse'] = 'free',
     method: Literal['din', 'aures', 'bismarck'] = 'din',
-    calibration_factor: float = 1.0,
+    calibration_factor: float | None = None,
 ) -> float
 ```
 
@@ -48,11 +48,11 @@ tolerance and is a known DIN 45692 implementation property.
 
 | Name | Description |
 | :--- | :--- |
-| `x` | Input signal (1D), in Pa after `calibration_factor`. |
-| `fs` | Sample rate in Hz. |
+| `x` | Input signal (1D), in Pa after `calibration_factor`. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal); the rate and the factor are resolved by [`loudness_zwicker`](/phonometry/reference/api/psychoacoustics/zwicker/#loudness_zwicker), which this is a weighted moment of, so both arrive here on exactly the terms they have there. |
+| `fs` | Sample rate in Hz. Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises. |
 | `field` | `'free'` (default) or `'diffuse'`. |
 | `method` | `'din'` (default), `'aures'` or `'bismarck'`. |
-| `calibration_factor` | Digital-units-to-Pa factor. |
+| `calibration_factor` | Digital-units-to-Pa factor. An explicit value wins over the one a Signal carries. |
 
 **Returns:** Sharpness in acum.
 

--- a/site/src/content/docs/reference/api/psychoacoustics/tonality-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/tonality-ecma.md
@@ -81,8 +81,8 @@ Adds a tonality-vs-time panel. Requires matplotlib
 
 ```python
 tonality_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal['free', 'diffuse'] = 'free',
     f_low: float | None = None,
     f_high: float | None = None,
@@ -95,8 +95,8 @@ Psychoacoustic tonality per ECMA-418-2:2025 (Sottek Hearing Model).
 
 | Name | Description |
 | :--- | :--- |
-| `signal_in` | Calibrated sound pressure signal in pascals. |
-| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). |
+| `signal_in` | Calibrated sound pressure signal in pascals. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where "calibrated" comes from without arithmetic: this model reads absolute levels, so an uncalibrated record is taken as if one digital unit were one pascal and the answer is wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz. Signals not at 48 kHz are resampled (Clause 5.1.1). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | `"free"` (default) or `"diffuse"` sound field, selecting the outer/middle-ear filter of Clause 5.1.3. |
 | `f_low` | Optional lower edge (Hz) of a user frequency band for the time-dependent tonality maximum search (Formulae 56-60). `None` uses the full range. |
 | `f_high` | Optional upper edge (Hz) of the user frequency band. |

--- a/site/src/content/docs/reference/api/psychoacoustics/tonality.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/tonality.md
@@ -24,8 +24,8 @@ caller's responsibility.
 
 ```python
 prominence_ratio(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     tone_freq: float | None = None,
     resolution_hz: float = 1.0,
 ) -> ToneAssessment
@@ -45,8 +45,8 @@ the PDF is a typo).
 
 | Name | Description |
 | :--- | :--- |
-| `x` | Input signal (1D). |
-| `fs` | Sample rate in Hz. |
+| `x` | Input signal (1D). Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), whose calibration is applied to the samples and then cancels: the ratio compares the tone against the masking noise inside the same spectrum, so a factor common to both leaves it exactly where it was. |
+| `fs` | Sample rate in Hz. Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `tone_freq` | Approximate tone frequency in Hz (default: highest peak in the range of interest). |
 | `resolution_hz` | FFT bin spacing (default 1.0 Hz). |
 
@@ -60,8 +60,8 @@ Warns about biased tonality estimates (e.g. coarse FFT resolution).
 
 ```python
 tone_to_noise_ratio(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     tone_freq: float | None = None,
     resolution_hz: float = 1.0,
 ) -> ToneAssessment
@@ -80,8 +80,8 @@ the same critical band are combined per clause 11.6 (Formulae 14-16).
 
 | Name | Description |
 | :--- | :--- |
-| `x` | Input signal (1D). |
-| `fs` | Sample rate in Hz. |
+| `x` | Input signal (1D). Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), whose calibration is applied to the samples and then cancels: the ratio compares the tone against the masking noise inside the same spectrum, so a factor common to both leaves it exactly where it was. |
+| `fs` | Sample rate in Hz. Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `tone_freq` | Approximate tone frequency in Hz. Default (None) assesses the highest spectral peak in the 89.1 Hz - 11.2 kHz range of interest. For harmonic complexes, call once per component (clause 11.7). |
 | `resolution_hz` | FFT bin spacing (default 1.0 Hz; the tone band must stay within 15 % of the critical bandwidth, clause 11.2). |
 

--- a/site/src/content/docs/reference/api/psychoacoustics/zwicker.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/zwicker.md
@@ -28,11 +28,11 @@ A.9 of the standard digit for digit.
 
 ```python
 loudness_zwicker(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     field: Literal['free', 'diffuse'] = 'free',
     stationary: bool = False,
-    calibration_factor: float = 1.0,
+    calibration_factor: float | None = None,
     time_skip: float = 0.0,
 ) -> ZwickerLoudness
 ```
@@ -69,11 +69,11 @@ with `ref` scaled to +-1 full scale as well.
 
 | Name | Description |
 | :--- | :--- |
-| `x` | Single-channel time signal (see scaling convention above). |
-| `fs` | Sampling rate in Hz (positive integer; resampled to 48 kHz with `scipy.signal.resample_poly` when not 48000). |
+| `x` | Single-channel time signal (see scaling convention above). Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), which is where that convention is met without arithmetic: a calibrated record already carries the digital-to-pascal factor, and this model is defined on pressure, so an uncalibrated record is read as if one digital unit were one pascal and the loudness comes out wrong by however far that is from true. |
+| `fs` | Sampling rate in Hz (positive integer; resampled to 48 kHz with `scipy.signal.resample_poly` when not 48000). Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `field` | Sound field of the recording: 'free' or 'diffuse'. |
 | `stationary` | Use the stationary method (clause 5) instead of the time-varying method (clause 6). |
-| `calibration_factor` | Multiplier converting `x` to pascals. |
+| `calibration_factor` | Multiplier converting `x` to pascals. An explicit value wins over the one a Signal carries, since the caller may know of a re-calibration the file predates; otherwise the object supplies it, and a bare array with neither is taken to be in pascals already. |
 | `time_skip` | Leading time, in seconds, excluded from the stationary mean square (the reference implementation's TimeSkip). Annex B.1 states the stationary calculation "shall start from 0,2 s" when validating against the official Annex B WAV files, excluding the filterbank transient; the default 0.0 preserves the whole-signal behaviour for synthetic steady signals. Validated always (negative, non-finite or whole-signal skips raise `ValueError`) but applied only by the stationary method -- clause 6 has no TimeSkip. |
 
 **Returns:** [`ZwickerLoudness`](/phonometry/reference/api/psychoacoustics/zwicker/#zwickerloudness).  Stationary: as in [`loudness_zwicker_from_spectrum`](/phonometry/reference/api/psychoacoustics/zwicker/#loudness_zwicker_from_spectrum).  Time-varying: `loudness` is the maximum loudness Nmax, `loudness_level` its phon mapping, `specific` the pattern at the loudness maximum, `n5`/`n10` the percentile values and `time` / `loudness_vs_time` the loudness trace at 500 Hz.

--- a/src/phonometry/_internal/utils.py
+++ b/src/phonometry/_internal/utils.py
@@ -5,13 +5,14 @@ Signal processing utilities for phonometry.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import cast
 
 import numpy as np
 from scipy import signal
 
 
-def _typesignal(x: list[float] | np.ndarray | tuple[float, ...]) -> np.ndarray:
+def _typesignal(x: Sequence[float] | np.ndarray) -> np.ndarray:
     """
     Ensure signal is a float64 numpy array.
 

--- a/src/phonometry/io/_resolve.py
+++ b/src/phonometry/io/_resolve.py
@@ -48,13 +48,18 @@ The rules, identical everywhere:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 
 from .._internal.utils import _typesignal
 from ._signal import Signal
 
-#: What a function that consumes a recording accepts for its signal argument.
-SignalInput = Signal | list[float] | np.ndarray
+#: What a function that consumes a recording accepts for its signal
+#: argument. ``Sequence[float]`` rather than ``list[float]`` so that a
+#: surface already typed for tuples does not have to narrow its signature
+#: to adopt the contract; ``str`` is a ``Sequence[str]`` and so stays out.
+SignalInput = Signal | Sequence[float] | np.ndarray
 
 # The rate type parameter below is value-restricted to ``(int, float)``
 # rather than bound to ``float`` so that a module typing its rate as ``int``

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -52,6 +52,9 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 from scipy import signal
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -595,15 +598,21 @@ def _assemble_loudness(
 
 
 def loudness_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal["free", "diffuse"] = "free",
 ) -> EcmaLoudness:
     """Psychoacoustic loudness per ECMA-418-2:2025 (Sottek Hearing Model).
 
-    :param signal_in: Calibrated sound pressure signal in pascals.
+    :param signal_in: Calibrated sound pressure signal in pascals. Accepts a
+        :class:`phonometry.io.Signal`, which is where "calibrated" comes
+        from without arithmetic: this model reads absolute levels, so an
+        uncalibrated record is taken as if one digital unit were one
+        pascal and the answer is wrong by however far that is from true.
     :param fs: Sampling rate in Hz. Signals not at 48 kHz are resampled
-        (Clause 5.1.1).
+        (Clause 5.1.1). Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit value
+        that disagrees with it raises instead of silently winning.
     :param field: ``"free"`` (default) or ``"diffuse"`` sound field, selecting
         the outer/middle-ear filter of Clause 5.1.3.
     :return: An :class:`EcmaLoudness` with the single loudness value N
@@ -617,7 +626,8 @@ def loudness_ecma(
     """
     if field not in ("free", "diffuse"):
         raise ValueError("field must be 'free' or 'diffuse'")
-    x = require_1d_signal(_typesignal(signal_in))
+    fs = resolve_fs(signal_in, fs, name="signal_in")
+    x = apply_calibration(signal_in, require_1d_signal(_typesignal(np.asarray(signal_in))))
     if x.size == 0:
         raise ValueError("signal must not be empty")
     fs = float(fs)

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -44,6 +44,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -913,8 +916,8 @@ def _signal_components(pressure: np.ndarray, fs: float) -> np.ndarray:
 
 
 def loudness_moore_glasberg(
-    x: list[float] | np.ndarray,
-    fs: float,
+    x: Signal | list[float] | np.ndarray,
+    fs: float | None = None,
     *,
     field: Literal["free", "diffuse", "eardrum"] = "free",
     presentation: Literal["binaural", "diotic", "monaural"] = "binaural",
@@ -931,15 +934,24 @@ def loudness_moore_glasberg(
     matching :func:`loudness_moore_glasberg_from_spectrum`.  The signal must be
     calibrated so that ``x`` is the instantaneous sound pressure in pascals.
 
-    :param x: Single-channel calibrated pressure signal in pascals.
-    :param fs: Sampling rate in Hz (positive).
+    :param x: Single-channel calibrated pressure signal in pascals. Accepts a
+        :class:`phonometry.io.Signal`, which is where "calibrated" comes
+        from without arithmetic: this model reads absolute levels, so an
+        uncalibrated record is taken as if one digital unit were one
+        pascal and the answer is wrong by however far that is from true.
+    :param fs: Sampling rate in Hz (positive). Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit value
+        that disagrees with it raises instead of silently winning.
     :param field: ``"free"`` (default), ``"diffuse"`` or ``"eardrum"``.
     :param presentation: ``"binaural"`` (default; alias ``"diotic"``) or
         ``"monaural"``.
     :return: A :class:`MooreGlasbergLoudness`.
     """
     _validate_conditions(field, presentation)
-    pressure = require_1d_signal(_typesignal(x), name="'x'")
+    fs = resolve_fs(x, fs)
+    pressure = apply_calibration(
+        x, require_1d_signal(_typesignal(np.asarray(x)), name="'x'")
+    )
     if pressure.size == 0:
         raise ValueError("Input signal 'x' cannot be empty.")
     if not np.all(np.isfinite(pressure)):

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -63,6 +63,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -599,10 +602,10 @@ def _run_ear(
 
 
 def _as_two_channels(
-    signal: Sequence[float] | np.ndarray, presentation: str
+    signal: Signal | Sequence[float] | np.ndarray, presentation: str
 ) -> tuple[np.ndarray, np.ndarray | None]:
     """Split the input into left and (optional) right calibrated pressure signals."""
-    array = np.asarray(signal, dtype=np.float64)
+    array = apply_calibration(signal, np.asarray(signal, dtype=np.float64))
     if array.ndim == 2:
         if array.shape[1] == 2 and array.shape[0] != 2:
             left, right = array[:, 0], array[:, 1]
@@ -638,8 +641,8 @@ def _percentiles(trace: np.ndarray, fractions: Sequence[float]) -> dict[float, f
 
 
 def loudness_moore_glasberg_time(
-    signal: Sequence[float] | np.ndarray,
-    fs: float,
+    signal: Signal | Sequence[float] | np.ndarray,
+    fs: float | None = None,
     *,
     field: Literal["free", "diffuse", "eardrum"] = "free",
     presentation: Literal["binaural", "diotic", "monaural"] = "binaural",
@@ -657,8 +660,14 @@ def loudness_moore_glasberg_time(
     :param signal: Calibrated pressure signal in pascals.  A 1-D array is
         treated as diotic (the same sound at both ears) for a binaural/diotic
         presentation, or as the single active ear for a monaural presentation;
-        a two-channel ``(n, 2)`` array gives the left and right ear signals.
-    :param fs: Sampling rate in Hz (positive).
+        a two-channel ``(n, 2)`` array gives the left and right ear signals. Accepts a
+        :class:`phonometry.io.Signal`, which is where "calibrated" comes
+        from without arithmetic: this model reads absolute levels, so an
+        uncalibrated record is taken as if one digital unit were one
+        pascal and the answer is wrong by however far that is from true.
+    :param fs: Sampling rate in Hz (positive). Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit value
+        that disagrees with it raises instead of silently winning.
     :param field: Listening condition setting the outer-ear transfer:
         ``"free"`` (frontal free field, default), ``"diffuse"`` (diffuse field)
         or ``"eardrum"`` (levels already at the tympanic membrane).
@@ -671,6 +680,7 @@ def loudness_moore_glasberg_time(
     long-term loudness of 1.000 sone (40 phon) by definition of the sone.
     """
     _validate_conditions(field, presentation)
+    fs = resolve_fs(signal, fs, name="signal")
     if fs <= 0.0:
         raise ValueError(f"'fs' must be a positive sampling rate, got {fs!r}.")
     left, right = _as_two_channels(signal, presentation)

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -26,6 +26,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from ...io._resolve import resolve_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -746,11 +749,11 @@ def loudness_zwicker_from_spectrum(
 
 
 def loudness_zwicker(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     field: Literal["free", "diffuse"] = "free",
     stationary: bool = False,
-    calibration_factor: float = 1.0,
+    calibration_factor: float | None = None,
     time_skip: float = 0.0,
 ) -> ZwickerLoudness:
     r"""
@@ -786,12 +789,25 @@ def loudness_zwicker(
     with ``ref`` scaled to +-1 full scale as well.
 
     :param x: Single-channel time signal (see scaling convention above).
+        Accepts a :class:`phonometry.io.Signal`, which is where that
+        convention is met without arithmetic: a calibrated record already
+        carries the digital-to-pascal factor, and this model is defined on
+        pressure, so an uncalibrated record is read as if one digital unit
+        were one pascal and the loudness comes out wrong by however far
+        that is from true.
     :param fs: Sampling rate in Hz (positive integer; resampled to 48 kHz
-        with :func:`scipy.signal.resample_poly` when not 48000).
+        with :func:`scipy.signal.resample_poly` when not 48000). Required
+        for a bare array; a :class:`~phonometry.io.Signal` brings its own,
+        and an explicit value that disagrees with it raises instead of
+        silently winning.
     :param field: Sound field of the recording: 'free' or 'diffuse'.
     :param stationary: Use the stationary method (clause 5) instead of the
         time-varying method (clause 6).
     :param calibration_factor: Multiplier converting ``x`` to pascals.
+        An explicit value wins over the one a Signal carries, since the
+        caller may know of a re-calibration the file predates; otherwise
+        the object supplies it, and a bare array with neither is taken to
+        be in pascals already.
     :param time_skip: Leading time, in seconds, excluded from the stationary
         mean square (the reference implementation's TimeSkip). Annex B.1
         states the stationary calculation "shall start from 0,2 s" when
@@ -808,10 +824,12 @@ def loudness_zwicker(
         ``loudness_vs_time`` the loudness trace at 500 Hz.
     """
     diffuse = _validate_field(field)
+    fs = resolve_fs(x, fs)
     if fs <= 0:
         raise ValueError(f"'fs' must be a positive sampling rate, got {fs!r}.")
-    require_positive(calibration_factor, "calibration_factor")
-    pressure = _typesignal(x)
+    factor = resolve_calibration(x, calibration_factor)
+    require_positive(factor, "calibration_factor")
+    pressure = _typesignal(np.asarray(x))
     if pressure.ndim != 1:
         raise ValueError(
             "loudness_zwicker() accepts single-channel signals only, got "
@@ -821,7 +839,7 @@ def loudness_zwicker(
         raise ValueError("Input signal 'x' cannot be empty.")
     if not np.all(np.isfinite(pressure)):
         raise ValueError("Input signal 'x' must contain only finite values.")
-    pressure = pressure * calibration_factor
+    pressure = pressure * factor
 
     if int(fs) != fs:
         raise ValueError(f"'fs' must be an integer sampling rate, got {fs!r}.")

--- a/src/phonometry/psychoacoustics/quality/annoyance.py
+++ b/src/phonometry/psychoacoustics/quality/annoyance.py
@@ -48,8 +48,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from ...io._resolve import resolve_calibration, resolve_fs
-from ...io._signal import Signal
+from ..._internal.validation import require_positive
+from ...io._resolve import SignalInput, resolve_calibration, resolve_fs
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -164,7 +164,7 @@ def psychoacoustic_annoyance(
 
 
 def psychoacoustic_annoyance_from_signal(
-    x: Signal | list[float] | np.ndarray,
+    x: SignalInput,
     fs: int | None = None,
     *,
     field: Literal["free", "diffuse"] = "free",
@@ -211,7 +211,12 @@ def psychoacoustic_annoyance_from_signal(
     from .sharpness import sharpness_din_from_specific
 
     fs = resolve_fs(x, fs)
-    factor = resolve_calibration(x, calibration_factor)
+    # The factor is applied here rather than passed down, so the check that
+    # loudness_zwicker would have run has to happen here too: without it a
+    # zero or negative factor silences the signal and reports PA = 0.
+    factor = require_positive(
+        resolve_calibration(x, calibration_factor), "calibration_factor"
+    )
     signal = np.asarray(x, dtype=np.float64) * float(factor)
     loud = loudness_zwicker(signal, fs, field=field, stationary=False)
     # N5: the 5 % percentile loudness of the time-varying trace; fall back to

--- a/src/phonometry/psychoacoustics/quality/annoyance.py
+++ b/src/phonometry/psychoacoustics/quality/annoyance.py
@@ -48,6 +48,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from ...io._resolve import resolve_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -161,11 +164,11 @@ def psychoacoustic_annoyance(
 
 
 def psychoacoustic_annoyance_from_signal(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     *,
     field: Literal["free", "diffuse"] = "free",
-    calibration_factor: float = 1.0,
+    calibration_factor: float | None = None,
 ) -> PsychoacousticAnnoyanceResult:
     """Psychoacoustic annoyance from a calibrated pressure signal (convenience).
 
@@ -188,11 +191,18 @@ def psychoacoustic_annoyance_from_signal(
         variant (see :func:`~phonometry.psychoacoustics.quality.fluctuation_strength.fluctuation_strength`).
 
     :param x: Calibrated sound-pressure signal (1-D), in Pa after
-        ``calibration_factor``.
-    :param fs: Sample rate, in Hz.
+        ``calibration_factor``. Accepts a :class:`phonometry.io.Signal`,
+        which is where that calibration comes from without arithmetic:
+        all four sensations are level-dependent models, so an uncalibrated
+        record is read as if one digital unit were one pascal and every
+        one of them comes out wrong by however far that is from true.
+    :param fs: Sample rate, in Hz. Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit
+        value that disagrees with it raises.
     :param field: ``'free'`` (default) or ``'diffuse'`` sound field for the
         loudness/sharpness/roughness front-ends (``F`` is always free-field).
-    :param calibration_factor: Digital-units-to-Pa factor applied to ``x``.
+    :param calibration_factor: Digital-units-to-Pa factor applied to
+        ``x``. An explicit value wins over the one a Signal carries.
     :return: A :class:`PsychoacousticAnnoyanceResult`.
     """
     from ..loudness.zwicker import loudness_zwicker
@@ -200,7 +210,9 @@ def psychoacoustic_annoyance_from_signal(
     from .roughness_ecma import roughness_ecma
     from .sharpness import sharpness_din_from_specific
 
-    signal = np.asarray(x, dtype=np.float64) * float(calibration_factor)
+    fs = resolve_fs(x, fs)
+    factor = resolve_calibration(x, calibration_factor)
+    signal = np.asarray(x, dtype=np.float64) * float(factor)
     loud = loudness_zwicker(signal, fs, field=field, stationary=False)
     # N5: the 5 % percentile loudness of the time-varying trace; fall back to
     # the total loudness for signals too short to yield a percentile.

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -52,6 +52,9 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -245,7 +248,7 @@ def _cross_covariance(x: NDArray[np.float64], y: NDArray[np.float64]) -> float:
     return float(num / np.sqrt(product))
 
 
-def _validate_signal(x: NDArray[np.float64]) -> NDArray[np.float64]:
+def _validate_signal(x: Signal | NDArray[np.float64]) -> NDArray[np.float64]:
     sig = np.asarray(x, dtype=np.float64)
     if sig.ndim != 1:
         raise ValueError("'signal' must be one-dimensional.")
@@ -441,8 +444,8 @@ def _c_fs() -> float:
 
 
 def fluctuation_strength(
-    signal_in: NDArray[np.float64],
-    fs: float,
+    signal_in: Signal | NDArray[np.float64],
+    fs: float | None = None,
 ) -> FluctuationStrengthResult:
     r"""Fluctuation strength of a calibrated signal (Osses 2016 model).
 
@@ -488,13 +491,19 @@ def fluctuation_strength(
         the reference method itself overestimates it above 4 Hz.
 
     :param signal_in: Calibrated sound-pressure signal (1-D), in Pa.
+        Accepts a :class:`phonometry.io.Signal`, which is where that
+        calibration comes from without arithmetic: the model reads
+        excitation levels, so an uncalibrated record is taken as if one
+        digital unit were one pascal and ``F`` comes out wrong by however
+        far that is from true.
     :param fs: Sample rate, in Hz (resampled to the model rate if needed).
     :return: A :class:`FluctuationStrengthResult`.
     :raises ValueError: If the signal is invalid or ``fs`` is not positive.
     """
     from scipy import signal as sp_signal
 
-    sig = _validate_signal(signal_in)
+    fs = resolve_fs(signal_in, fs, name="signal_in")
+    sig = apply_calibration(signal_in, _validate_signal(signal_in))
     fs_v = float(fs)
     if not np.isfinite(fs_v) or fs_v <= 0.0:
         raise ValueError("'fs' must be positive and finite.")

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -102,6 +102,9 @@ from numpy.lib.stride_tricks import sliding_window_view
 from scipy import signal
 from scipy.interpolate import PchipInterpolator
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -846,15 +849,21 @@ def _aggregate(
 
 
 def fluctuation_strength_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal["free", "diffuse"] = "free",
 ) -> EcmaFluctuationStrength:
     """Psychoacoustic fluctuation strength per ECMA-418-2:2025 (Clause 9).
 
-    :param signal_in: Calibrated sound pressure signal in pascals.
+    :param signal_in: Calibrated sound pressure signal in pascals. Accepts a
+        :class:`phonometry.io.Signal`, which is where "calibrated" comes
+        from without arithmetic: this model reads absolute levels, so an
+        uncalibrated record is taken as if one digital unit were one
+        pascal and the answer is wrong by however far that is from true.
     :param fs: Sampling rate in Hz. Signals not at 48 kHz are resampled
-        (Clause 5.1.1).
+        (Clause 5.1.1). Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit value
+        that disagrees with it raises instead of silently winning.
     :param field: ``"free"`` (default) or ``"diffuse"`` sound field, selecting
         the outer/middle-ear filter of Clause 5.1.3.
     :return: An :class:`EcmaFluctuationStrength` with the single value F
@@ -871,7 +880,8 @@ def fluctuation_strength_ecma(
     """
     if field not in ("free", "diffuse"):
         raise ValueError("field must be 'free' or 'diffuse'")
-    x = require_1d_signal(_typesignal(signal_in))
+    fs = resolve_fs(signal_in, fs, name="signal_in")
+    x = apply_calibration(signal_in, require_1d_signal(_typesignal(np.asarray(signal_in))))
     if x.size == 0:
         raise ValueError("signal must not be empty")
     if not np.all(np.isfinite(x)):

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -55,6 +55,9 @@ import numpy as np
 from scipy import signal
 from scipy.interpolate import PchipInterpolator
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -502,15 +505,21 @@ def _aggregate(
 
 
 def roughness_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal["free", "diffuse"] = "free",
 ) -> EcmaRoughness:
     """Psychoacoustic roughness per ECMA-418-2:2025 (Sottek Hearing Model).
 
-    :param signal_in: Calibrated sound pressure signal in pascals.
+    :param signal_in: Calibrated sound pressure signal in pascals. Accepts a
+        :class:`phonometry.io.Signal`, which is where "calibrated" comes
+        from without arithmetic: this model reads absolute levels, so an
+        uncalibrated record is taken as if one digital unit were one
+        pascal and the answer is wrong by however far that is from true.
     :param fs: Sampling rate in Hz. Signals not at 48 kHz are resampled
-        (Clause 5.1.1).
+        (Clause 5.1.1). Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit value
+        that disagrees with it raises instead of silently winning.
     :param field: ``"free"`` (default) or ``"diffuse"`` sound field, selecting
         the outer/middle-ear filter of Clause 5.1.3.
     :return: An :class:`EcmaRoughness` with the single value R (Clause 7.1.10),
@@ -523,7 +532,8 @@ def roughness_ecma(
     """
     if field not in ("free", "diffuse"):
         raise ValueError("field must be 'free' or 'diffuse'")
-    x = require_1d_signal(_typesignal(signal_in))
+    fs = resolve_fs(signal_in, fs, name="signal_in")
+    x = apply_calibration(signal_in, require_1d_signal(_typesignal(np.asarray(signal_in))))
     if x.size == 0:
         raise ValueError("signal must not be empty")
     fs = float(fs)

--- a/src/phonometry/psychoacoustics/quality/sharpness.py
+++ b/src/phonometry/psychoacoustics/quality/sharpness.py
@@ -19,6 +19,7 @@ from typing import Literal
 
 import numpy as np
 
+from ...io._signal import Signal
 from ..loudness.zwicker import ZwickerLoudness, loudness_zwicker
 
 _DZ = 0.1  # Bark step of the ISO 532-1 specific-loudness pattern
@@ -139,11 +140,11 @@ def sharpness_din_from_specific(
 
 
 def sharpness_din(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     field: Literal["free", "diffuse"] = "free",
     method: Literal["din", "aures", "bismarck"] = "din",
-    calibration_factor: float = 1.0,
+    calibration_factor: float | None = None,
 ) -> float:
     """
     Sharpness of a signal per DIN 45692:2009 (stationary analysis).
@@ -160,10 +161,17 @@ def sharpness_din(
     tolerance and is a known DIN 45692 implementation property.
 
     :param x: Input signal (1D), in Pa after ``calibration_factor``.
-    :param fs: Sample rate in Hz.
+        Accepts a :class:`phonometry.io.Signal`; the rate and the factor
+        are resolved by :func:`~phonometry.loudness_zwicker`, which this
+        is a weighted moment of, so both arrive here on exactly the terms
+        they have there.
+    :param fs: Sample rate in Hz. Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit
+        value that disagrees with it raises.
     :param field: ``'free'`` (default) or ``'diffuse'``.
     :param method: ``'din'`` (default), ``'aures'`` or ``'bismarck'``.
-    :param calibration_factor: Digital-units-to-Pa factor.
+    :param calibration_factor: Digital-units-to-Pa factor. An explicit
+        value wins over the one a Signal carries.
     :return: Sharpness in acum.
     """
     zw: ZwickerLoudness = loudness_zwicker(

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -24,6 +24,8 @@ import numpy as np
 
 from ..._internal.utils import _typesignal
 from ..._internal.warnings import PhonometryWarning
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
 from ...signals.spectra import _welch_autospectrum
 
 if TYPE_CHECKING:
@@ -249,8 +251,8 @@ def _pr_criterion(ft: float) -> float:
 
 
 def tone_to_noise_ratio(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     tone_freq: float | None = None,
     resolution_hz: float = 1.0,
 ) -> ToneAssessment:
@@ -264,8 +266,14 @@ def tone_to_noise_ratio(
     (Formula 10); TNR = Lt - Ln (Formula 11). Proximate secondary tones in
     the same critical band are combined per clause 11.6 (Formulae 14-16).
 
-    :param x: Input signal (1D).
-    :param fs: Sample rate in Hz.
+    :param x: Input signal (1D). Accepts a
+        :class:`phonometry.io.Signal`, whose calibration is applied to the
+        samples and then cancels: the ratio compares the tone against the
+        masking noise inside the same spectrum, so a factor common to both
+        leaves it exactly where it was.
+    :param fs: Sample rate in Hz. Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit
+        value that disagrees with it raises instead of silently winning.
     :param tone_freq: Approximate tone frequency in Hz. Default (None)
         assesses the highest spectral peak in the 89.1 Hz - 11.2 kHz range
         of interest. For harmonic complexes, call once per component
@@ -274,7 +282,10 @@ def tone_to_noise_ratio(
         must stay within 15 % of the critical bandwidth, clause 11.2).
     :return: :class:`ToneAssessment` with ``ratio_db`` = TNR in dB.
     """
-    x_proc = np.atleast_1d(np.asarray(_typesignal(x), dtype=np.float64))
+    fs = resolve_fs(x, fs)
+    x_proc = apply_calibration(
+        x, np.atleast_1d(np.asarray(_typesignal(np.asarray(x)), dtype=np.float64))
+    )
     if x_proc.ndim != 1:
         raise ValueError("tone_to_noise_ratio expects a 1D signal.")
     if fs <= 0:
@@ -366,8 +377,8 @@ def _fitted_edge(
 
 
 def prominence_ratio(
-    x: list[float] | np.ndarray,
-    fs: int,
+    x: Signal | list[float] | np.ndarray,
+    fs: int | None = None,
     tone_freq: float | None = None,
     resolution_hz: float = 1.0,
 ) -> ToneAssessment:
@@ -382,14 +393,23 @@ def prominence_ratio(
     clause 12.5 prose - the inline condition printed next to Formula 23 in
     the PDF is a typo).
 
-    :param x: Input signal (1D).
-    :param fs: Sample rate in Hz.
+    :param x: Input signal (1D). Accepts a
+        :class:`phonometry.io.Signal`, whose calibration is applied to the
+        samples and then cancels: the ratio compares the tone against the
+        masking noise inside the same spectrum, so a factor common to both
+        leaves it exactly where it was.
+    :param fs: Sample rate in Hz. Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit
+        value that disagrees with it raises instead of silently winning.
     :param tone_freq: Approximate tone frequency in Hz (default: highest
         peak in the range of interest).
     :param resolution_hz: FFT bin spacing (default 1.0 Hz).
     :return: :class:`ToneAssessment` with ``ratio_db`` = PR in dB.
     """
-    x_proc = np.atleast_1d(np.asarray(_typesignal(x), dtype=np.float64))
+    fs = resolve_fs(x, fs)
+    x_proc = apply_calibration(
+        x, np.atleast_1d(np.asarray(_typesignal(np.asarray(x)), dtype=np.float64))
+    )
     if x_proc.ndim != 1:
         raise ValueError("prominence_ratio expects a 1D signal.")
     if fs <= 0:

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -283,9 +283,7 @@ def tone_to_noise_ratio(
     :return: :class:`ToneAssessment` with ``ratio_db`` = TNR in dB.
     """
     fs = resolve_fs(x, fs)
-    x_proc = apply_calibration(
-        x, np.atleast_1d(np.asarray(_typesignal(np.asarray(x)), dtype=np.float64))
-    )
+    x_proc = apply_calibration(x, np.atleast_1d(_typesignal(np.asarray(x))))
     if x_proc.ndim != 1:
         raise ValueError("tone_to_noise_ratio expects a 1D signal.")
     if fs <= 0:
@@ -407,9 +405,7 @@ def prominence_ratio(
     :return: :class:`ToneAssessment` with ``ratio_db`` = PR in dB.
     """
     fs = resolve_fs(x, fs)
-    x_proc = apply_calibration(
-        x, np.atleast_1d(np.asarray(_typesignal(np.asarray(x)), dtype=np.float64))
-    )
+    x_proc = apply_calibration(x, np.atleast_1d(_typesignal(np.asarray(x))))
     if x_proc.ndim != 1:
         raise ValueError("prominence_ratio expects a 1D signal.")
     if fs <= 0:

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -36,6 +36,9 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 from scipy import signal
 
+from ...io._resolve import apply_calibration, resolve_fs
+from ...io._signal import Signal
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -194,17 +197,23 @@ def _assemble_tonality(
 
 
 def tonality_ecma(
-    signal_in: np.ndarray,
-    fs: float,
+    signal_in: Signal | np.ndarray,
+    fs: float | None = None,
     field: Literal["free", "diffuse"] = "free",
     f_low: float | None = None,
     f_high: float | None = None,
 ) -> EcmaTonality:
     """Psychoacoustic tonality per ECMA-418-2:2025 (Sottek Hearing Model).
 
-    :param signal_in: Calibrated sound pressure signal in pascals.
+    :param signal_in: Calibrated sound pressure signal in pascals. Accepts a
+        :class:`phonometry.io.Signal`, which is where "calibrated" comes
+        from without arithmetic: this model reads absolute levels, so an
+        uncalibrated record is taken as if one digital unit were one
+        pascal and the answer is wrong by however far that is from true.
     :param fs: Sampling rate in Hz. Signals not at 48 kHz are resampled
-        (Clause 5.1.1).
+        (Clause 5.1.1). Required for a bare array; a
+        :class:`~phonometry.io.Signal` brings its own, and an explicit value
+        that disagrees with it raises instead of silently winning.
     :param field: ``"free"`` (default) or ``"diffuse"`` sound field, selecting
         the outer/middle-ear filter of Clause 5.1.3.
     :param f_low: Optional lower edge (Hz) of a user frequency band for the
@@ -221,7 +230,8 @@ def tonality_ecma(
     """
     if field not in ("free", "diffuse"):
         raise ValueError("field must be 'free' or 'diffuse'")
-    x = require_1d_signal(_typesignal(signal_in))
+    fs = resolve_fs(signal_in, fs, name="signal_in")
+    x = apply_calibration(signal_in, require_1d_signal(_typesignal(np.asarray(signal_in))))
     if x.size == 0:
         raise ValueError("signal must not be empty")
     fs = float(fs)

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from signal_contract import assert_same
 
 from phonometry.io import Signal
 from phonometry.psychoacoustics import (
@@ -49,7 +50,6 @@ from phonometry.psychoacoustics import (
     tonality_ecma,
     tone_to_noise_ratio,
 )
-from tests.signal_contract import assert_same
 
 FS = 48000
 CAL = 4.0

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -65,7 +65,7 @@ def _tone(seconds: float = 1.0, seed: int = 0) -> np.ndarray:
 def _modulated(seconds: float = 1.0) -> np.ndarray:
     """A 70 Hz amplitude modulation, where the roughness model reads a maximum.
 
-    A steady tone has no roughness at all, so it would report 0.000 vacil
+    A steady tone has no roughness at all, so it would report 0.000 asper
     whatever the calibration, and could not tell a model that reads the
     factor from one that ignores it.
     """
@@ -197,6 +197,39 @@ def test_an_explicit_factor_wins_over_the_objects(func, kwargs) -> None:
         **kwargs,
     )
     assert_same(explicit, func(2.0 * record, FS, **kwargs))
+
+
+def test_a_two_channel_signal_is_split_after_the_factor_is_applied() -> None:
+    """The one model here that takes two ears, so the split has to see pascals.
+
+    ``loudness_moore_glasberg_time`` divides the record into left and right
+    before running either ear. Applying the factor after that split, or not
+    at all, would report a binaural loudness for a sound at the wrong level.
+    """
+    left, right = _tone(seed=1), _tone(seed=2)
+    stereo = np.stack([left, right])
+    assert_same(
+        loudness_moore_glasberg_time(Signal(stereo, FS, calibration_factor=CAL)),
+        loudness_moore_glasberg_time(CAL * stereo, FS),
+    )
+    mono = loudness_moore_glasberg_time(Signal(left, FS, calibration_factor=CAL))
+    binaural = loudness_moore_glasberg_time(
+        Signal(np.stack([left, left]), FS, calibration_factor=CAL)
+    )
+    assert_same(mono, binaural)
+
+
+def test_a_non_positive_explicit_factor_is_refused() -> None:
+    """The convenience applies the factor itself, so it has to check it itself.
+
+    It scales the record and hands the result to ``loudness_zwicker`` with
+    no factor, so the check that function performs never sees the explicit
+    one. Measured before this refusal existed: a factor of 0.0 silenced the
+    signal and reported an annoyance of 0.0.
+    """
+    for bad in (0.0, -1.0):
+        with pytest.raises(ValueError, match="calibration_factor"):
+            psychoacoustic_annoyance_from_signal(_TONE, FS, calibration_factor=bad)
 
 
 def test_a_bare_array_with_no_factor_is_still_read_as_pascals() -> None:

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -1,0 +1,222 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""
+The psychoacoustic models take a ``Signal`` in place of ``(x, fs)``.
+
+Same contract as the rest of the library, held by
+``phonometry.io._resolve``. This is the surface where it matters most, and
+for a reason the other packages do not share: a loudness, a sharpness, a
+roughness and a fluctuation strength are all defined on *absolute* sound
+pressure. Handing one an uncalibrated record does not scale its answer, it
+silently reinterprets one digital unit as one pascal and returns a number
+for a sound that was never measured. Reading the factor off the object the
+file reader returned is how that stops being a step the caller can forget.
+
+So the assertions here split in two.
+
+For the level-dependent models the test compares the calibrated call
+against the *pre-scaled* array, which is the only reading of "analysed in
+pascals" a model that ignored the factor could not also pass, and pins that
+the answer really does move when the factor does.
+
+``tone_to_noise_ratio`` and ``prominence_ratio`` are the exception, and by
+definition rather than by exemption: both compare a tone against the
+masking noise inside the same spectrum, so a common factor cancels. They
+are asserted from both sides.
+
+Three of these carry a ``calibration_factor`` of their own. There the
+precedence is the documented one and the opposite of the rate's: an
+explicit argument wins over the object, because a caller passing one knows
+something the file does not.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phonometry.io import Signal
+from phonometry.psychoacoustics import (
+    fluctuation_strength,
+    fluctuation_strength_ecma,
+    loudness_ecma,
+    loudness_moore_glasberg,
+    loudness_moore_glasberg_time,
+    loudness_zwicker,
+    prominence_ratio,
+    psychoacoustic_annoyance_from_signal,
+    roughness_ecma,
+    sharpness_din,
+    tonality_ecma,
+    tone_to_noise_ratio,
+)
+from tests.signal_contract import assert_same
+
+FS = 48000
+CAL = 4.0
+
+
+def _tone(seconds: float = 1.0, seed: int = 0) -> np.ndarray:
+    """A 1 kHz tone with a little noise, at about 60 dB SPL read as pascals."""
+    t = np.arange(int(FS * seconds)) / FS
+    rng = np.random.default_rng(seed)
+    return 0.02 * np.sin(2.0 * np.pi * 1000.0 * t) + 1e-3 * rng.standard_normal(t.size)
+
+
+def _modulated(seconds: float = 1.0) -> np.ndarray:
+    """A 70 Hz amplitude modulation, where the roughness model reads a maximum.
+
+    A steady tone has no roughness at all, so it would report 0.000 vacil
+    whatever the calibration, and could not tell a model that reads the
+    factor from one that ignores it.
+    """
+    t = np.arange(int(FS * seconds)) / FS
+    carrier = np.sin(2.0 * np.pi * 1000.0 * t)
+    return 0.02 * (1.0 + np.sin(2.0 * np.pi * 70.0 * t)) * carrier
+
+
+_TONE = _tone()
+_MODULATED = _modulated()
+
+# The level-dependent models: the record has to be in pascals. The short
+# 1 s record is what keeps the ECMA-418-2 pair inside a couple of seconds.
+LEVELLED = [
+    (loudness_zwicker, {"stationary": True}),
+    (sharpness_din, {}),
+    (loudness_ecma, {}),
+    (loudness_moore_glasberg, {}),
+    (loudness_moore_glasberg_time, {}),
+    (tonality_ecma, {}),
+    (roughness_ecma, {}),
+]
+LEVELLED_IDS = [f.__name__ for f, _ in LEVELLED]
+
+# The two that compare a tone against its own noise floor.
+RATIOS = [(tone_to_noise_ratio, {}), (prominence_ratio, {})]
+RATIO_IDS = [f.__name__ for f, _ in RATIOS]
+
+ALL = LEVELLED + RATIOS
+ALL_IDS = LEVELLED_IDS + RATIO_IDS
+
+
+# ---------------------------------------------------------------------------
+# The rate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("func", "kwargs"), ALL, ids=ALL_IDS)
+def test_an_uncalibrated_signal_computes_the_bare_array_result(func, kwargs) -> None:
+    assert_same(func(Signal(_TONE, FS), **kwargs), func(_TONE, FS, **kwargs))
+
+
+@pytest.mark.parametrize(("func", "kwargs"), ALL, ids=ALL_IDS)
+def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> None:
+    sig = Signal(_TONE, FS)
+    with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
+        func(sig, FS + 1, **kwargs)
+    # The same number twice is agreement, not a conflict.
+    func(sig, FS, **kwargs)
+
+
+@pytest.mark.parametrize(("func", "kwargs"), ALL, ids=ALL_IDS)
+def test_a_bare_array_still_requires_fs(func, kwargs) -> None:
+    with pytest.raises(ValueError, match="fs is required"):
+        func(_TONE, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The calibration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("func", "kwargs"), LEVELLED, ids=LEVELLED_IDS)
+def test_a_calibrated_signal_is_analysed_in_pascals(func, kwargs) -> None:
+    """And the answer moves with the factor, because the model is not a ratio."""
+    record = _MODULATED if func is roughness_ecma else _TONE
+    calibrated = func(Signal(record, FS, calibration_factor=CAL), **kwargs)
+    assert_same(calibrated, func(CAL * record, FS, **kwargs))
+    bare = func(record, FS, **kwargs)
+    value, bare_value = _scalar(calibrated), _scalar(bare)
+    assert value != pytest.approx(bare_value), (
+        "a level-dependent model that answered the same either way would be "
+        "ignoring the calibration"
+    )
+
+
+@pytest.mark.parametrize(("func", "kwargs"), RATIOS, ids=RATIO_IDS)
+def test_a_tone_ratio_does_not_move_with_the_factor(func, kwargs) -> None:
+    """The factor is applied and then cancels, which is not the same as ignored."""
+    calibrated = func(Signal(_TONE, FS, calibration_factor=CAL), **kwargs)
+    assert_same(calibrated, func(CAL * _TONE, FS, **kwargs))
+    assert calibrated.ratio_db == pytest.approx(func(_TONE, FS, **kwargs).ratio_db)
+
+
+def _scalar(result: object) -> float:
+    """The one number a model reports, whatever it calls it."""
+    if isinstance(result, (int, float)):
+        return float(result)
+    for name in (
+        "loudness",
+        "sharpness",
+        "fluctuation_strength",
+        "annoyance",
+        "roughness",
+        "tonality",
+        "long_term_loudness",
+    ):
+        if hasattr(result, name):
+            return float(np.asarray(getattr(result, name)).ravel()[0])
+    raise AssertionError(f"no scalar on {type(result).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# The models that carry a factor of their own
+# ---------------------------------------------------------------------------
+
+
+OWN_FACTOR = [
+    (loudness_zwicker, {"stationary": True}),
+    (sharpness_din, {}),
+    (psychoacoustic_annoyance_from_signal, {}),
+]
+OWN_FACTOR_IDS = [f.__name__ for f, _ in OWN_FACTOR]
+
+
+@pytest.mark.parametrize(("func", "kwargs"), OWN_FACTOR, ids=OWN_FACTOR_IDS)
+def test_an_explicit_factor_wins_over_the_objects(func, kwargs) -> None:
+    """The opposite precedence to the rate's, and deliberately so.
+
+    A caller who passes a factor knows something the file does not: a
+    re-calibration made after it was written, or a deliberate what-if. The
+    rate is a fact of the recording and cannot be overridden that way, so
+    a disagreement there raises instead.
+    """
+    record = _tone(seconds=2.0)
+    explicit = func(
+        Signal(record, FS, calibration_factor=CAL),
+        calibration_factor=2.0,
+        **kwargs,
+    )
+    assert_same(explicit, func(2.0 * record, FS, **kwargs))
+
+
+def test_a_bare_array_with_no_factor_is_still_read_as_pascals() -> None:
+    """What the bare-array signature has always computed, unchanged."""
+    assert_same(
+        loudness_zwicker(_TONE, FS, stationary=True),
+        loudness_zwicker(_TONE, FS, stationary=True, calibration_factor=1.0),
+    )
+
+
+@pytest.mark.parametrize(
+    "func", [fluctuation_strength, fluctuation_strength_ecma],
+    ids=["fluctuation_strength", "fluctuation_strength_ecma"],
+)
+def test_the_fluctuation_models_take_the_signal_too(func) -> None:
+    """They are analysed in 2 s frames, so they get their own longer record."""
+    record = _tone(seconds=2.0)
+    assert_same(func(Signal(record, FS)), func(record, FS))
+    assert_same(
+        func(Signal(record, FS, calibration_factor=CAL)), func(CAL * record, FS)
+    )
+    with pytest.raises(ValueError, match="fs is required"):
+        func(record)

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -63,6 +63,7 @@ ALLOWED_EDGES: set[tuple[str, str]] = {
     ("electroacoustics", "io"),
     ("room", "io"),
     ("speech", "io"),
+    ("psychoacoustics", "io"),
 }
 
 


### PR DESCRIPTION
Eleven psychoacoustic models now take the `Signal` in place of the `(x, fs)` pair, on the same terms as the rest of the library.

This is the surface where the contract pays the most, and for a reason the other packages do not share. Loudness, sharpness, roughness, fluctuation strength and tonality are all defined on *absolute* sound pressure. Handing one of them an uncalibrated record does not scale its answer by a factor a reader can undo later: it silently reads one digital unit as one pascal and reports a loudness for a sound nobody measured. Taking the factor off the object the file reader returned is how that stops being a step the caller can forget.

## The two precedences, side by side

The rate and the calibration keep their opposite rules, and the tests assert them next to each other. The rate is a fact of the recording, so a `Signal` supplies it and an explicit one that disagrees raises. The factor is not: `loudness_zwicker`, `sharpness_din` and the annoyance convenience each carry a `calibration_factor` argument, and an explicit one still wins, because a caller who passes it knows of a re-calibration the file predates. Their default moves from `1.0` to `None`, which is the same `1.0` for a bare array and is what lets the object be asked at all.

## Measured, not assumed

`tone_to_noise_ratio` and `prominence_ratio` are the two that do not move with the factor, and by definition rather than by exemption: each compares a tone against the masking noise inside the same spectrum. Every other model here does move, which is the point, and the test asserts that too.

The roughness case is driven with a 70 Hz amplitude modulation rather than the steady tone the others use. A steady tone has no roughness, so it reports 0.000 vacil whatever the calibration, and a test built on it would pass just as happily against a model that ignored the factor entirely.

## Typing

`SignalInput` widens from `list[float]` to `Sequence[float]` so that a surface already typed for sequences does not have to narrow its public signature to adopt the contract. `str` is a `Sequence[str]` and stays out.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated type hints to use `collections.abc.Sequence` for broader compatibility with signal inputs.</li>
<li>Refactored psychoacoustic functions (e.g., `loudness_ecma`) to accept `Signal` objects in addition to `np.ndarray`.</li>
<li>Integrated `resolve_fs` and `apply_calibration` into psychoacoustic models to handle sampling rates and signal calibration automatically.</li>
<li>Updated documentation to clarify signal input requirements and calibration handling.</li>
<li>Added tests for signal overloads to ensure robust handling of different input types.</li>
</ul></div>

## Summary by Sourcery

Make psychoacoustic models consume recording metadata so sampling rates and sound-pressure calibration are handled consistently and safely.

New Features:
- Allow the psychoacoustic models to consume calibrated Signal objects directly, while retaining bare array inputs.
- Resolve recording sample rates from Signal objects and reject conflicting explicit rates.
- Apply Signal calibration to level-dependent psychoacoustic measurements while preserving scale-invariant tone and prominence ratios.
- Support explicit calibration overrides for models that expose calibration factors.

Bug Fixes:
- Prevent psychoacoustic analyses from silently interpreting uncalibrated digital units as pascals.
- Reject non-positive calibration factors in the psychoacoustic annoyance convenience function.

Enhancements:
- Broaden signal input typing from lists to general float sequences.
- Align psychoacoustic input handling with the library-wide Signal contract.

Documentation:
- Update psychoacoustic API documentation with Signal inputs, sample-rate resolution, and calibration precedence.

Tests:
- Add coverage for Signal overloads, calibration behavior, sample-rate conflicts, missing rates, explicit calibration precedence, stereo handling, and invalid factors.

Chores:
- Declare the psychoacoustics package dependency on the IO package in the architecture checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Psychoacoustic analysis APIs now accept calibrated `Signal` inputs alongside arrays and sequences.
  * Sampling rates and calibration can be supplied automatically through signal metadata.
  * Explicit sampling rates and calibration values remain supported, with validation for conflicting metadata.
  * Automatic resampling behavior is documented for applicable ECMA models.

* **Documentation**
  * Expanded API reference guidance for signal inputs, calibration precedence, sampling-rate requirements, and validation behavior.

* **Tests**
  * Added coverage for signal overloads, calibration handling, sampling-rate validation, and array compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->