### PR TITLE
Give plot_excitation the module home the other twenty-three plots have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `plot_excitation` is exported by `phonometry.room`, the package that owns it.
+  It was the one of the twenty-four plotting helpers that no domain published:
+  it is defined in the private `_plot.room`, the top level re-exported it, and
+  `phonometry.room` did not, so it was reachable through the flat shortcut and
+  through no module path at all. A reader following the domain, which is how
+  the documentation teaches the library, could not find it.
+
+  Two architecture rules now hold the invariant it broke. One fails when the
+  top level publishes a name no domain package does, naming the orphan. The
+  other fails when two domains publish the same spelling, which is what forces
+  a rename at the top level and what would make a call through a domain
+  ambiguous about the module it reaches. The second was impossible to satisfy
+  until the `environmental` alias went: the same module answered to two names,
+  so 170 names had two owners.
+
 - `floating_floor_improvement_spectrum` refuses one half of the
   `mass_per_area` / `dynamic_stiffness` pair instead of returning
   `delta_lw=None` without a word. The pair exists only to compute that

--- a/src/phonometry/room/__init__.py
+++ b/src/phonometry/room/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from .._plot.geometry import (
     plot_open_plan_geometry,
 )
+from .._plot.room import plot_excitation
 from .acoustics import (
     DecayCurve,
     RoomAcousticsResult,
@@ -136,6 +137,7 @@ __all__ = [
     "noise_criterion",
     "object_fraction",
     "open_plan_metrics",
+    "plot_excitation",
     "plot_open_plan_geometry",
     "rc_curve",
     "reflection_density",

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -320,3 +320,77 @@ def test_sonar_configuration_names_files_that_exist() -> None:
     ]
     missing = [path for path in keyed + excluded if not (root / path).exists()]
     assert not missing, f"sonar-project.properties names missing files: {missing}"
+
+
+#: Public names that live on the package top level and nowhere else, because
+#: they belong to no single domain. Everything else the root publishes must be
+#: reachable from the domain that owns it: the root re-export is a shortcut,
+#: not a name's home. ``environmental_expanded_uncertainty`` is the exception
+#: that proves it, a rename that exists only so two domains can both spell
+#: their expanded uncertainty in one flat namespace.
+ROOT_ONLY: frozenset[str] = frozenset(
+    {
+        "PhonometryWarning",
+        "ReportMetadata",
+        "__version__",
+        "environmental_expanded_uncertainty",
+    }
+)
+
+
+def test_every_public_name_is_reachable_from_its_domain() -> None:
+    """A name published only by the root is a name with no documented home.
+
+    ``plot_excitation`` was one: it lives in the private ``_plot.room``, the
+    root re-exported it, and ``phonometry.room`` did not, so the twenty-third
+    of the twenty-four geometry plots was reachable through the flat shortcut
+    and through no module path at all. A reader following the domain, which is
+    how the documentation teaches the library, could not find it.
+    """
+    import inspect
+
+    import phonometry
+
+    domains = {
+        name
+        for name in dir(phonometry)
+        if not name.startswith("_")
+        and inspect.ismodule(getattr(phonometry, name))
+    }
+    published: dict[str, list[str]] = {}
+    for domain in sorted(domains):
+        for name in getattr(getattr(phonometry, domain), "__all__", ()):
+            published.setdefault(name, []).append(domain)
+
+    orphans = sorted(set(phonometry.__all__) - set(published) - ROOT_ONLY)
+    assert not orphans, (
+        "public names the root publishes and no domain package does: "
+        f"{orphans}. Export each from the package that owns it, or add it to "
+        "ROOT_ONLY if it genuinely belongs to no domain."
+    )
+
+
+def test_no_public_name_is_published_by_two_domains() -> None:
+    """One name, one owner: what makes the flat root a shortcut and not a map.
+
+    Two domains exporting the same spelling is what forces a rename at the
+    root (see ``environmental_expanded_uncertainty``), and it is what would
+    make ``from phonometry import <domain>`` ambiguous about which module a
+    call reaches.
+    """
+    import inspect
+
+    import phonometry
+
+    published: dict[str, list[str]] = {}
+    for domain in sorted(
+        name
+        for name in dir(phonometry)
+        if not name.startswith("_")
+        and inspect.ismodule(getattr(phonometry, name))
+    ):
+        for name in getattr(getattr(phonometry, domain), "__all__", ()):
+            published.setdefault(name, []).append(domain)
+
+    shared = {name: owners for name, owners in published.items() if len(owners) > 1}
+    assert not shared, f"names published by more than one domain: {shared}"


### PR DESCRIPTION
Reopens #591, which GitHub closed when its base branch was deleted on merging
#590. Same branch, same commit, now on top of main.

`plot_excitation` is defined in the private `_plot.room`, the top level
re-exported it, and `phonometry.room` did not. It was the one of the
twenty-four plotting helpers reachable only through the flat shortcut and
through no module path at all: every other one is published by the domain that
owns it, and `scripts/api_taxonomy.py` already documented this one as belonging
to `phonometry.room.impulse_response`. A reader following the domain, which is
how the documentation teaches the library, could not find it.

## The gates

Two architecture rules in `tests/test_package_architecture.py` now hold the
invariant this broke.

`test_every_public_name_is_reachable_from_its_domain` fails when the top level
publishes a name no domain package does, and names the orphan. Verified against
the real defect rather than assumed: reverting the export makes it fail with

    AssertionError: public names the root publishes and no domain package does:
    ['plot_excitation']. Export each from the package that owns it, or add it
    to ROOT_ONLY if it genuinely belongs to no domain.

and restoring it makes it pass. `ROOT_ONLY` lists the four names that genuinely
belong to no domain: `PhonometryWarning`, `ReportMetadata`, `__version__` and
`environmental_expanded_uncertainty`.

`test_no_public_name_is_published_by_two_domains` fails when two domains publish
the same spelling. That is what forces a rename at the top level, which
`environmental_expanded_uncertainty` is the living proof of, and what would make
a call through a domain ambiguous about the module it reaches. This rule was
impossible to satisfy until #590: the `environmental` alias made the same module
answer to two names, so 170 names had two owners.

## Effect

The union of the domain `__all__` and the top-level `__all__` now agree at 1351
names each. The only names not in both are the four in `ROOT_ONLY` and the four
the top level declines to publish because their spelling is too generic to
survive a flat namespace: `AUDIOMETRIC_FREQUENCIES`, `FIELDS` and `SEXES` from
`hearing`, and `expanded_uncertainty` from `environment`.

No drift in the generated API reference or the llms dumps: `plot_excitation`
keeps the module the taxonomy already assigned it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Exported `plot_excitation` from `phonometry.room` to make it reachable via the domain module path.</li>
<li>Added architectural tests to ensure all public names are reachable from their owning domain.</li>
<li>Added architectural tests to prevent public names from being published by multiple domains.</li>
<li>Updated `CHANGELOG.md` to document the fix for the `plot_excitation` orphan issue.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `plot_excitation` is now publicly available through the room package.

- **Documentation**
  - Added an Unreleased changelog entry describing the new export and package architecture safeguards.

- **Tests**
  - Added checks to ensure public names belong to the correct package domain.
  - Added safeguards against duplicate public names across domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->