### PR TITLE
Reach every function through its package when the package itself is the import

### DIFF
--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -119,8 +119,15 @@ def run_airport_contour() -> np.ndarray:
     import phonometry as ph
 
     a = airport_inputs()
-    res = ph.noise_contour(a["path"], a["powers"], a["distances"], a["sel"],
-                           a["lmax"], x=a["grid_x"], y=a["grid_y"])
+    res = ph.aircraft.noise_contour(
+        a["path"],
+        a["powers"],
+        a["distances"],
+        a["sel"],
+        a["lmax"],
+        x=a["grid_x"],
+        y=a["grid_y"],
+    )
     return np.asarray(res.level)
 
 
@@ -128,8 +135,14 @@ def run_event_level() -> np.ndarray:
     import phonometry as ph
 
     a = airport_inputs()
-    res = ph.event_level(a["path"], a["observer"], a["powers"], a["distances"],
-                         a["sel"], a["lmax"])
+    res = ph.aircraft.event_level(
+        a["path"],
+        a["observer"],
+        a["powers"],
+        a["distances"],
+        a["sel"],
+        a["lmax"],
+    )
     return np.concatenate([[res.level], np.asarray(res.segment_levels)])
 
 
@@ -138,16 +151,21 @@ def run_npd_batch() -> np.ndarray:
 
     a = airport_inputs()
     q = np.array([75.0, 150.0, 300.0, 600.0, 1200.0, 2400.0, 5000.0])
-    return np.asarray(ph.npd_level(a["powers"], a["distances"], a["sel"], 10000.0, q))
+    return np.asarray(
+        ph.aircraft.npd_level(
+            a["powers"], a["distances"], a["sel"], 10000.0, q
+        )
+    )
 
 
 def run_hemisphere_queries() -> np.ndarray:
     import phonometry as ph
 
     h = hemisphere_inputs()
-    hemi = ph.RotorcraftHemisphere(h["frequencies"], h["azimuth"], h["polar"],
-                                   h["levels"])
-    out = [ph.hemisphere_source_level(hemi, phi, theta)
+    hemi = ph.aircraft.RotorcraftHemisphere(
+        h["frequencies"], h["azimuth"], h["polar"], h["levels"]
+    )
+    out = [ph.aircraft.hemisphere_source_level(hemi, phi, theta)
            for phi, theta in h["queries"]]
     return np.concatenate(out)
 
@@ -156,11 +174,15 @@ def run_parabolic_equation() -> np.ndarray:
     import phonometry as ph
 
     p = pe_inputs()
-    res = ph.parabolic_equation(p["frequency_hz"], p["depths"], p["sound_speeds"],
-                                source_depth=p["source_depth"],
-                                max_range=p["max_range"],
-                                range_step=p["range_step"],
-                                n_depth_points=p["n_depth_points"])
+    res = ph.underwater.parabolic_equation(
+        p["frequency_hz"],
+        p["depths"],
+        p["sound_speeds"],
+        source_depth=p["source_depth"],
+        max_range=p["max_range"],
+        range_step=p["range_step"],
+        n_depth_points=p["n_depth_points"],
+    )
     pl = np.asarray(res.propagation_loss)
     return pl[::16, 1::10].ravel()  # skip the r = 0 column (PL is inf there)
 
@@ -169,7 +191,7 @@ def run_ecma_loudness() -> np.ndarray:
     import phonometry as ph
 
     sig, fs = ecma_signal()
-    res = ph.loudness_ecma(sig, fs)
+    res = ph.psychoacoustics.loudness_ecma(sig, fs)
     return np.concatenate([[float(res.loudness)],
                            np.asarray(res.specific_loudness).ravel()])
 
@@ -178,7 +200,7 @@ def run_ecma_roughness() -> np.ndarray:
     import phonometry as ph
 
     sig, fs = ecma_signal()
-    res = ph.roughness_ecma(sig, fs)
+    res = ph.psychoacoustics.roughness_ecma(sig, fs)
     return np.concatenate([[float(res.roughness)],
                            np.asarray(res.specific_roughness).ravel()])
 
@@ -187,7 +209,7 @@ def run_ecma_tonality() -> np.ndarray:
     import phonometry as ph
 
     sig, fs = ecma_signal()
-    res = ph.tonality_ecma(sig, fs)
+    res = ph.psychoacoustics.tonality_ecma(sig, fs)
     return np.concatenate([[float(res.tonality)],
                            np.asarray(res.specific_tonality).ravel()])
 

--- a/scripts/conformance/domains/absorbers.py
+++ b/scripts/conformance/domains/absorbers.py
@@ -43,7 +43,7 @@ _PA_C0 = 343.0
 )
 def _chk_porous_db_real() -> Outcome:
     f = np.array([0.1 * _PA_SIGMA / _PA_RHO0])
-    res = ph.delany_bazley(
+    res = ph.materials.delany_bazley(
         f, _PA_SIGMA, speed_of_sound=_PA_C0, air_density=_PA_RHO0
     )
     return numeric(
@@ -59,7 +59,7 @@ def _chk_porous_db_real() -> Outcome:
 )
 def _chk_porous_db_imag() -> Outcome:
     f = np.array([0.1 * _PA_SIGMA / _PA_RHO0])
-    res = ph.delany_bazley(
+    res = ph.materials.delany_bazley(
         f, _PA_SIGMA, speed_of_sound=_PA_C0, air_density=_PA_RHO0
     )
     return numeric(
@@ -75,7 +75,9 @@ def _chk_porous_db_imag() -> Outcome:
 )
 def _chk_porous_miki() -> Outcome:
     f = np.array([0.1 * _PA_SIGMA])
-    res = ph.miki(f, _PA_SIGMA, speed_of_sound=_PA_C0, air_density=_PA_RHO0)
+    res = ph.materials.miki(
+        f, _PA_SIGMA, speed_of_sound=_PA_C0, air_density=_PA_RHO0
+    )
     return numeric(
         ref.POROUS_MIKI_K_EXPECTED.real,
         float(res.normalized_wavenumber[0].real), 1e-9,
@@ -89,7 +91,7 @@ def _chk_porous_miki() -> Outcome:
 )
 def _chk_porous_jca_dc() -> Outcome:
     f = np.array([1e-3])
-    res = ph.johnson_champoux_allard(
+    res = ph.materials.johnson_champoux_allard(
         f, _PA_SIGMA, porosity=0.95, tortuosity=1.3,
         viscous_length=6e-5, thermal_length=1.2e-4, air_density=_PA_RHO0,
     )
@@ -104,9 +106,9 @@ def _chk_porous_jca_dc() -> Outcome:
 )
 def _chk_porous_rigid_backed() -> Outcome:
     f = np.linspace(200.0, 4000.0, 200)
-    med = ph.delany_bazley(f, _PA_SIGMA, air_density=_PA_RHO0)
-    res = ph.layered_absorber(
-        f, [ph.PorousLayer(0.05, med)],
+    med = ph.materials.delany_bazley(f, _PA_SIGMA, air_density=_PA_RHO0)
+    res = ph.materials.layered_absorber(
+        f, [ph.materials.PorousLayer(0.05, med)],
         speed_of_sound=_PA_C0, air_density=_PA_RHO0,
     )
     zs_ref = -1j * med.characteristic_impedance / np.tan(med.wavenumber * 0.05)
@@ -122,8 +124,11 @@ def _chk_porous_rigid_backed() -> Outcome:
 def _chk_porous_air_cavity() -> Outcome:
     d = 0.1
     f = np.array([_PA_C0 / (4.0 * d)])
-    res = ph.layered_absorber(
-        f, [ph.AirLayer(d)], speed_of_sound=_PA_C0, air_density=_PA_RHO0
+    res = ph.materials.layered_absorber(
+        f,
+        [ph.materials.AirLayer(d)],
+        speed_of_sound=_PA_C0,
+        air_density=_PA_RHO0,
     )
     return numeric(0.0, float(res.absorption[0]), 1e-12, places=4)
 
@@ -135,7 +140,7 @@ def _chk_porous_air_cavity() -> Outcome:
 )
 def _chk_porous_statistical_max() -> Outcome:
     z = np.linspace(1.0, 3.0, 2001).astype(complex)
-    value = float(np.max(ph.statistical_absorption(z)))
+    value = float(np.max(ph.materials.statistical_absorption(z)))
     return numeric(ref.POROUS_STATISTICAL_ALPHA_MAX, value, 1e-3, places=3)
 
 
@@ -145,7 +150,7 @@ def _chk_porous_statistical_max() -> Outcome:
     "Membrane resonance 60/sqrt(m d), m = 5 kg/m2, d = 5 cm, Hz",
 )
 def _chk_porous_membrane_resonance() -> Outcome:
-    value = ph.membrane_resonance_frequency(
+    value = ph.materials.membrane_resonance_frequency(
         surface_density=5.0, cavity_depth=0.05,
         speed_of_sound=_PA_C0, air_density=_PA_RHO0,
     )
@@ -161,13 +166,13 @@ def _chk_porous_membrane_resonance() -> Outcome:
 def _chk_porous_mpp_peak() -> Outcome:
     eps = (math.pi / 4.0) * (ref.MAA_FIG5_DIAMETER / ref.MAA_FIG5_SEPARATION) ** 2
     f = np.linspace(100.0, 4000.0, 2000)
-    res = ph.layered_absorber(
+    res = ph.materials.layered_absorber(
         f,
         [
-            ph.MicroperforatedPlateLayer(
+            ph.materials.MicroperforatedPlateLayer(
                 ref.MAA_FIG5_THICKNESS, ref.MAA_FIG5_DIAMETER / 2.0, eps
             ),
-            ph.AirLayer(ref.MAA_FIG5_CAVITY),
+            ph.materials.AirLayer(ref.MAA_FIG5_CAVITY),
         ],
         speed_of_sound=_PA_C0, air_density=_PA_RHO0,
     )
@@ -190,11 +195,11 @@ def _chk_porous_maa_peak_closed_form() -> Outcome:
     t = ref.MAA_FIG5_THICKNESS
     eps = (math.pi / 4.0) * (d / ref.MAA_FIG5_SEPARATION) ** 2
     f = np.linspace(400.0, 1200.0, 4000)
-    res = ph.layered_absorber(
+    res = ph.materials.layered_absorber(
         f,
         [
-            ph.MicroperforatedPlateLayer(t, d / 2.0, eps),
-            ph.AirLayer(ref.MAA_FIG5_CAVITY),
+            ph.materials.MicroperforatedPlateLayer(t, d / 2.0, eps),
+            ph.materials.AirLayer(ref.MAA_FIG5_CAVITY),
         ],
         speed_of_sound=_PA_C0, air_density=_PA_RHO0,
     )
@@ -234,7 +239,9 @@ _AA_TABLE_11_2_RHO1 = 30.0
     "Zwikker-Kosten decoupling frequency Fd, Hz",
 )
 def _chk_limp_decoupling_frequency() -> Outcome:
-    fd = ph.decoupling_frequency(40.0e3, porosity=0.94, frame_density=130.0)
+    fd = ph.materials.decoupling_frequency(
+        40.0e3, porosity=0.94, frame_density=130.0
+    )
     return numeric(43.27, fd, 0.005, unit="Hz", places=3)
 
 
@@ -244,11 +251,11 @@ def _chk_limp_decoupling_frequency() -> Outcome:
     "Limp effective density at DC = apparent total density rho_t, kg/m3",
 )
 def _chk_limp_low_frequency_limit() -> Outcome:
-    rigid = ph.johnson_champoux_allard(
+    rigid = ph.materials.johnson_champoux_allard(
         np.array([1.0e-4]), _AA_TABLE_11_2_SIGMA,
         speed_of_sound=_PA_C0, air_density=_PA_RHO0, **_AA_TABLE_11_2,
     )
-    limp = ph.limp_frame(
+    limp = ph.materials.limp_frame(
         rigid, _AA_TABLE_11_2_RHO1, porosity=_AA_TABLE_11_2["porosity"]
     )
     expected = _AA_TABLE_11_2_RHO1 + _AA_TABLE_11_2["porosity"] * _PA_RHO0
@@ -263,11 +270,11 @@ def _chk_limp_low_frequency_limit() -> Outcome:
 )
 def _chk_limp_heavy_frame_limit() -> Outcome:
     f = np.array([50.0, 125.0, 500.0, 2000.0])
-    rigid = ph.johnson_champoux_allard(
+    rigid = ph.materials.johnson_champoux_allard(
         f, _AA_TABLE_11_2_SIGMA, speed_of_sound=_PA_C0,
         air_density=_PA_RHO0, **_AA_TABLE_11_2,
     )
-    limp = ph.limp_frame(
+    limp = ph.materials.limp_frame(
         rigid, 1.0e12, porosity=_AA_TABLE_11_2["porosity"]
     )
     deviation = float(np.max(np.abs(
@@ -284,9 +291,9 @@ def _chk_limp_heavy_frame_limit() -> Outcome:
 def _chk_limp_frame_criterion_limit() -> Outcome:
     # The book states "lower than 20 kPa" for |Kc/Kf| < 0.2 with Kf = P0.
     limit = 0.2 * 101325.0
-    ok = ph.limp_frame_applicable(limit) and not ph.limp_frame_applicable(
-        limit * (1.0 + 1e-9)
-    )
+    ok = ph.materials.limp_frame_applicable(
+        limit
+    ) and not ph.materials.limp_frame_applicable(limit * (1.0 + 1e-9))
     return numeric(20.0, limit / 1000.0 if ok else float("nan"),
                    0.3, unit="kPa", places=2)
 
@@ -310,13 +317,13 @@ _AA_TABLE_6_1_SHEAR = 220.0e4 * (1.0 + 0.1j)
 
 def _aa_glass_wool_medium(frequency: np.ndarray) -> Any:
     """The rigid-frame JCA equivalent fluid of the Table 6.1 glass wool."""
-    return ph.johnson_champoux_allard(
+    return ph.materials.johnson_champoux_allard(
         frequency, _AA_TABLE_6_1_SIGMA, **_AA_TABLE_6_1
     )
 
 
 def _aa_glass_wool_waves(frequency: np.ndarray) -> Any:
-    return ph.biot_waves(
+    return ph.materials.biot_waves(
         _aa_glass_wool_medium(frequency),
         porosity=_AA_TABLE_6_1["porosity"],
         tortuosity=_AA_TABLE_6_1["tortuosity"],
@@ -329,7 +336,7 @@ def _aa_glass_wool_layer(
     medium: Any, thickness: float, scale: float = 1.0
 ) -> Any:
     """The same material as a poroelastic layer, optionally frozen stiff."""
-    return ph.PoroelasticLayer(
+    return ph.materials.PoroelasticLayer(
         thickness,
         medium,
         _AA_TABLE_6_1["porosity"],
@@ -345,7 +352,7 @@ def _aa_glass_wool_layer(
     "Frame lambda/4 resonance of a 10 cm layer, Hz",
 )
 def _chk_biot_frame_resonance() -> Outcome:
-    value = ph.frame_quarter_wave_resonance(
+    value = ph.materials.frame_quarter_wave_resonance(
         0.10, shear_modulus=_AA_TABLE_6_1_SHEAR, poisson_ratio=0.0,
         frame_density=_AA_TABLE_6_1_RHO1,
     )
@@ -383,7 +390,9 @@ def _chk_biot_frame_borne_ratio() -> Outcome:
 )
 def _chk_biot_impedance_peak() -> Outcome:
     grid = np.arange(500.0, 1200.0, 0.25)
-    impedance = ph.biot_surface_impedance(_aa_glass_wool_waves(grid), 0.056)
+    impedance = ph.materials.biot_surface_impedance(
+        _aa_glass_wool_waves(grid), 0.056
+    )
     peak = float(grid[int(np.argmax(impedance.imag))])
     return numeric(860.0, peak, 0.02, rel=True, unit="Hz", places=1)
 
@@ -396,10 +405,12 @@ def _chk_biot_impedance_peak() -> Outcome:
 def _chk_biot_rigid_frame_limit() -> Outcome:
     frequency = np.geomspace(50.0, 5000.0, 40)
     medium = _aa_glass_wool_medium(frequency)
-    reference = ph.layered_absorber(
-        frequency, [ph.PorousLayer(0.05, medium)], angle=math.pi / 4.0
+    reference = ph.materials.layered_absorber(
+        frequency,
+        [ph.materials.PorousLayer(0.05, medium)],
+        angle=math.pi / 4.0,
     ).surface_impedance
-    frozen = ph.layered_absorber(
+    frozen = ph.materials.layered_absorber(
         frequency,
         [_aa_glass_wool_layer(medium, 0.05, 1e8)],
         angle=math.pi / 4.0,
@@ -416,8 +427,10 @@ def _chk_biot_rigid_frame_limit() -> Outcome:
 def _chk_biot_assembly_vs_closed_form() -> Outcome:
     frequency = np.geomspace(20.0, 5000.0, 80)
     medium = _aa_glass_wool_medium(frequency)
-    closed = ph.biot_surface_impedance(_aa_glass_wool_waves(frequency), 0.10)
-    assembled = ph.layered_absorber(
+    closed = ph.materials.biot_surface_impedance(
+        _aa_glass_wool_waves(frequency), 0.10
+    )
+    assembled = ph.materials.layered_absorber(
         frequency, [_aa_glass_wool_layer(medium, 0.10)]
     ).surface_impedance
     deviation = float(np.max(np.abs(assembled / closed - 1.0)))
@@ -436,15 +449,15 @@ _SLOW_SOUND = "Slow-sound perfect absorbers (Jimenez et al. Appl. Sci. 2017)"
     "Critical coupling: alpha at the design frequency (300 Hz, normal)",
 )
 def _chk_slow_sound_perfect_absorption() -> Outcome:
-    res = ph.HelmholtzResonator(
+    res = ph.materials.HelmholtzResonator(
         neck_length=1.0e-3, neck_side=3.0e-3,
         cavity_length=30.0e-3, cavity_side=27.0e-3,
     )
-    air = ph.AirProperties(density=_PA_RHO0, speed_of_sound=_PA_C0)
-    design = ph.critical_coupling_design(
+    air = ph.materials.AirProperties(density=_PA_RHO0, speed_of_sound=_PA_C0)
+    design = ph.materials.critical_coupling_design(
         300.0, res, lattice_step=3.0e-2, period=5.0e-2, air=air,
     )
-    out = ph.slit_helmholtz_absorber(
+    out = ph.materials.slit_helmholtz_absorber(
         np.array([300.0]), design.resonator, slit_height=design.slit_height,
         lattice_step=3.0e-2, period=5.0e-2, air=air,
     )
@@ -464,9 +477,9 @@ def _chk_slow_sound_slit_resistivity() -> Outcome:
     eta = 1.84e-5
     h = 1.2e-3
     f = np.array([1.0e-2])
-    rho_s, _ = ph.slit_effective_properties(
+    rho_s, _ = ph.materials.slit_effective_properties(
         f, slit_height=h,
-        air=ph.AirProperties(density=_PA_RHO0, viscosity=eta),
+        air=ph.materials.AirProperties(density=_PA_RHO0, viscosity=eta),
     )
     sigma = float((1j * 2.0 * math.pi * f * rho_s)[0].real)
     return numeric(12.0 * eta / h**2, sigma, 1e-3, rel=True,
@@ -482,9 +495,9 @@ def _chk_slow_sound_duct_resistivity() -> Outcome:
     eta = 1.84e-5
     side = 3.0e-3
     f = np.array([1.0e-2])
-    rho, _ = ph.rectangular_duct_properties(
+    rho, _ = ph.materials.rectangular_duct_properties(
         f, side=side,
-        air=ph.AirProperties(density=_PA_RHO0, viscosity=eta),
+        air=ph.materials.AirProperties(density=_PA_RHO0, viscosity=eta),
     )
     sigma = float((1j * 2.0 * math.pi * f * rho)[0].real)
     return numeric(28.454 * eta / side**2, sigma, 2e-3, rel=True,

--- a/scripts/conformance/domains/aircraft.py
+++ b/scripts/conformance/domains/aircraft.py
@@ -35,7 +35,7 @@ _AIRCRAFT = "Aircraft noise (ICAO Annex 16 / IEC 61265)"
 )
 def _chk_ecac_noise_fraction() -> Outcome:
     # A half-infinite segment (Sp at the start) receives half the energy: −3.01 dB.
-    got = float(ph.noise_fraction(0.0, 10_000.0, 100.0))
+    got = float(ph.aircraft.noise_fraction(0.0, 10_000.0, 100.0))
     return numeric(-10.0 * math.log10(2.0), got, 1e-3, unit="dB", places=4)
 
 
@@ -57,13 +57,15 @@ def _chk_ecac_event_level() -> Outcome:
     xs = _np.linspace(-40000.0, 40000.0, 801)
     path = _np.column_stack([xs, _np.zeros_like(xs), _np.full_like(xs, 300.0),
                              _np.full_like(xs, 10000.0), _np.full_like(xs, vref)])
-    got = ph.event_level(path, [0.0, 300.0, 0.0], npd_p, npd_d, sel, lmax, metric="exposure").level
+    got = ph.aircraft.event_level(
+        path, [0.0, 300.0, 0.0], npd_p, npd_d, sel, lmax, metric="exposure"
+    ).level
     dp = math.hypot(300.0, 300.0)
     beta = math.degrees(math.acos(300.0 / dp))
-    expected = (float(ph.npd_level(npd_p, npd_d, sel, 10000.0, dp)[0])
-                + ph.impedance_adjustment()
-                + ph.engine_installation_correction(beta, "wing")
-                - ph.lateral_attenuation(beta, 300.0))
+    expected = (float(ph.aircraft.npd_level(npd_p, npd_d, sel, 10000.0, dp)[0])
+                + ph.aircraft.impedance_adjustment()
+                + ph.aircraft.engine_installation_correction(beta, "wing")
+                - ph.aircraft.lateral_attenuation(beta, 300.0))
     return numeric(expected, float(got), 1e-2, unit="dB", places=3)
 
 
@@ -75,7 +77,13 @@ def _chk_ecac_event_level() -> Outcome:
 def _chk_ecac_impedance() -> Outcome:
     # ECAC Doc 29 Vol 2 §4.2.1 states the standard-atmosphere adjustment is
     # +0.074 dB (ρc = 416.86, reference impedance 409.81 N·s/m³).
-    return numeric(0.074, float(ph.impedance_adjustment()), 5e-4, unit="dB", places=4)
+    return numeric(
+        0.074,
+        float(ph.aircraft.impedance_adjustment()),
+        5e-4,
+        unit="dB",
+        places=4,
+    )
 
 
 @register(
@@ -90,7 +98,7 @@ def _chk_ecac_workbook_segment() -> Outcome:
     # and Λ = 6.3769 dB. Here we anchor the Λ(β, ℓ) formula to those reference
     # values (the β/φ geometry itself is validated in tests/test_airport_noise).
     beta_ref, lateral_m = 4.2225708673, 81363.2829 * 0.3048
-    got = float(ph.lateral_attenuation(beta_ref, lateral_m))
+    got = float(ph.aircraft.lateral_attenuation(beta_ref, lateral_m))
     return numeric(6.3768594165, got, 1e-2, unit="dB", places=4)
 
 
@@ -102,7 +110,9 @@ def _chk_ecac_workbook_segment() -> Outcome:
 def _chk_ecac_start_of_roll() -> Outcome:
     # ECAC Doc 29 5th ed. Vol 3 Part 1 workbook, case JETFDC: at ψ = 112.8895°,
     # dSOR = 217.09 m the turbofan directivity (Eq. 4-24a) is +0.3196 dB.
-    got = float(ph.start_of_roll_directivity(112.889545, 217.0934, "jet"))
+    got = float(
+        ph.aircraft.start_of_roll_directivity(112.889545, 217.0934, "jet")
+    )
     return numeric(0.31961, got, 1e-2, unit="dB", places=4)
 
 
@@ -114,7 +124,11 @@ def _chk_ecac_start_of_roll() -> Outcome:
 def _chk_ecac_start_of_roll_prop() -> Outcome:
     # Same workbook, case PROPDC: at ψ = 128.1824°, dSOR = 254.44 m the turboprop
     # directivity (Eq. 4-24b) is +1.0943 dB.
-    got = float(ph.start_of_roll_directivity(128.182381, 254.4361, "turboprop"))
+    got = float(
+        ph.aircraft.start_of_roll_directivity(
+            128.182381, 254.4361, "turboprop"
+        )
+    )
     return numeric(1.09434, got, 1e-2, unit="dB", places=4)
 
 
@@ -165,7 +179,9 @@ def _chk_anp_round_trip() -> Outcome:
     # (power, distance) node the loader/interpolation must recover the
     # published value exactly. Boeing 747-100 (JT9DBD), departure SEL,
     # 28000 lb corrected net thrust, 2000 ft slant distance = 98.8 dB.
-    curves = ph.load_anp_database().npd_curves("747100", "departure", "SEL")
+    curves = ph.aircraft.load_anp_database().npd_curves(
+        "747100", "departure", "SEL"
+    )
     got = float(curves.level(28000.0, 2000.0 * 0.3048)[0])
     return numeric(98.8, got, 1e-9, unit="dB", places=4)
 
@@ -179,7 +195,9 @@ def _chk_ecac_npd() -> Outcome:
     # Log-midpoint distance -> arithmetic mean of the bracketing node levels.
     p, d = [1000.0, 2000.0], [200.0, 400.0, 800.0, 1600.0]
     lv = [[100.0, 94.0, 88.0, 82.0], [110.0, 104.0, 98.0, 92.0]]
-    got = float(ph.npd_level(p, d, lv, 1000.0, math.sqrt(200.0 * 400.0))[0])
+    got = float(
+        ph.aircraft.npd_level(p, d, lv, 1000.0, math.sqrt(200.0 * 400.0))[0]
+    )
     return numeric(97.0, got, 1e-9, unit="dB", places=4)
 
 
@@ -193,7 +211,9 @@ _ROTORCRAFT = "Rotorcraft noise (ECAC Doc 32 / NORAH2)"
 )
 def _chk_doc32_atmospheric() -> Outcome:
     # NORAH2 guidance Table 4: 6.3 dB/km at 1 kHz (ICAO reference conditions).
-    got = -float(ph.atmospheric_adjustment([1000.0], 1000.0 + 60.0)[0])
+    got = -float(
+        ph.aircraft.atmospheric_adjustment([1000.0], 1000.0 + 60.0)[0]
+    )
     return numeric(6.3, got, 0.2, unit="dB", places=3)
 
 
@@ -203,8 +223,13 @@ def _chk_doc32_atmospheric() -> Outcome:
     "ΔLs at ten times the 60 m hemisphere reference distance (Eq. 24), dB",
 )
 def _chk_doc32_spreading() -> Outcome:
-    return numeric(-20.0, float(ph.spherical_spreading_adjustment(600.0)), 1e-9,
-                   unit="dB", places=3)
+    return numeric(
+        -20.0,
+        float(ph.aircraft.spherical_spreading_adjustment(600.0)),
+        1e-9,
+        unit="dB",
+        places=3,
+    )
 
 
 @register(
@@ -216,7 +241,11 @@ def _chk_doc32_ground() -> Outcome:
     # Over a near-rigid surface (Zs -> inf), coherent reflection at a small path
     # difference reinforces the direct ray towards the +6.02 dB pressure-doubling
     # limit. A low frequency and near-grazing geometry approaches it.
-    got = float(ph.ground_effect_adjustment([20.0], 50.0, 1.2, 400.0, flow_resistivity="H")[0])
+    got = float(
+        ph.aircraft.ground_effect_adjustment(
+            [20.0], 50.0, 1.2, 400.0, flow_resistivity="H"
+        )[0]
+    )
     return numeric(6.0, got, 1.0, unit="dB", places=2)
 
 
@@ -247,9 +276,9 @@ def _chk_doc32_chain() -> Outcome:
                                  * np.sqrt((x**2 + f2**2) * (x**2 + f3**2))
                                  * (x**2 + f4**2))
 
-    level = (spec + float(ph.spherical_spreading_adjustment(223.66))
-             + ph.atmospheric_adjustment(bands, 223.66)
-             + ph.ground_effect_adjustment(bands, 5.0, 0.2, 223.607,
+    level = (spec + float(ph.aircraft.spherical_spreading_adjustment(223.66))
+             + ph.aircraft.atmospheric_adjustment(bands, 223.66)
+             + ph.aircraft.ground_effect_adjustment(bands, 5.0, 0.2, 223.607,
                                            flow_resistivity=1.0e6)
              + 20.0 * np.log10(_ra(bands) / _ra(np.array(1000.0))))
     got = float(10.0 * np.log10(np.sum(10.0 ** (level / 10.0))))
@@ -261,7 +290,7 @@ def _uniform_hemisphere(level: float, bands: list[float] | None = None) -> Any:
     freqs = np.asarray(bands if bands is not None else [50.0], dtype=np.float64)
     az = np.arange(-90.0, 91.0, 10.0)
     po = np.arange(0.0, 181.0, 10.0)
-    return ph.RotorcraftHemisphere(
+    return ph.aircraft.RotorcraftHemisphere(
         freqs, az, po, np.full((az.size, po.size, freqs.size), level))
 
 
@@ -276,8 +305,10 @@ def _chk_doc32_hover_ring() -> Outcome:
     # bin at theta = 150 reads the ring at +150 deg. Ring level = 60 +
     # bearing/10 dB -> 75 dB by hand.
     brg = np.arange(-180.0, 151.0, 30.0)
-    h = ph.hover_ring_hemisphere([500.0], brg, (60.0 + brg / 10.0)[:, None])
-    got = float(ph.hemisphere_source_level(h, 90.0, 150.0)[0])
+    h = ph.aircraft.hover_ring_hemisphere(
+        [500.0], brg, (60.0 + brg / 10.0)[:, None]
+    )
+    got = float(ph.aircraft.hemisphere_source_level(h, 90.0, 150.0)[0])
     return numeric(75.0, got, 1e-9, unit="dB", places=3)
 
 
@@ -290,11 +321,11 @@ def _chk_doc32_hover_offset() -> Outcome:
     # Table 3, Approach 3: LA_HOGE(theta) = LA_HIGE(theta) + 12 dB from the
     # in-ground-hover disk. A uniform 80 dB ring derives to 92 dB everywhere;
     # the bin under the aircraft is compared.
-    hige = ph.hover_ring_hemisphere(
+    hige = ph.aircraft.hover_ring_hemisphere(
         [500.0], np.arange(-180.0, 151.0, 30.0), np.full((12, 1), 80.0))
-    hoge = ph.hover_derived_hemisphere(hige, "out_of_ground_hover")
-    got = float(ph.hemisphere_source_level(hoge, 0.0, 90.0)[0]
-                - ph.hemisphere_source_level(hige, 0.0, 90.0)[0])
+    hoge = ph.aircraft.hover_derived_hemisphere(hige, "out_of_ground_hover")
+    got = float(ph.aircraft.hemisphere_source_level(hoge, 0.0, 90.0)[0]
+                - ph.aircraft.hemisphere_source_level(hige, 0.0, 90.0)[0])
     return numeric(12.0, got, 1e-9, unit="dB", places=3)
 
 
@@ -311,7 +342,7 @@ def _chk_doc32_flight_condition() -> Outcome:
     # 100 / 90 / 95 dB blend to 10*lg(sum w*10^(L/10)) = 97.0367 dB by hand.
     hems = [_uniform_hemisphere(100.0), _uniform_hemisphere(90.0),
             _uniform_hemisphere(95.0)]
-    got = float(ph.interpolated_source_level(
+    got = float(ph.aircraft.interpolated_source_level(
         hems, [50.0, 70.0, 60.0], [0.0, 0.0, 10.0], 60.0, 2.5, 0.0, 90.0)[0])
     return numeric(97.0367, got, 1e-3, unit="dB", places=4)
 
@@ -329,7 +360,7 @@ def _chk_doc32_kinematics() -> Outcome:
     heading = np.radians(30.0)
     pos = np.column_stack([vg * np.sin(heading) * t, vg * np.cos(heading) * t,
                            100.0 + vg * np.tan(gamma) * t])
-    kin = ph.flight_path_kinematics(t, pos)
+    kin = ph.aircraft.flight_path_kinematics(t, pos)
     return numeric(40.152786, float(kin.airspeed[10]), 1e-4, unit="m/s", places=5)
 
 
@@ -345,9 +376,17 @@ def _chk_doc32_retarded_time() -> Outcome:
     t = np.arange(0.0, 20.5, 0.5)
     pos = np.column_stack([np.zeros_like(t), 50.0 * (t - 10.0),
                            np.full_like(t, 101.2)])
-    res = ph.rotorcraft_event_level(
-        [_uniform_hemisphere(100.0)], [50.0], [0.0], t, pos, (0.0, 0.0),
-        ground=ph.RotorcraftGround(receiver_height=1.2, flow_resistivity="H"))
+    res = ph.aircraft.rotorcraft_event_level(
+        [_uniform_hemisphere(100.0)],
+        [50.0],
+        [0.0],
+        t,
+        pos,
+        (0.0, 0.0),
+        ground=ph.aircraft.RotorcraftGround(
+            receiver_height=1.2, flow_resistivity="H"
+        ),
+    )
     k = int(np.argmin(res.distance))
     return numeric(0.288934, float(res.times[k] - res.emission_times[k]), 1e-5,
                    unit="s", places=6)
@@ -367,9 +406,17 @@ def _chk_doc32_event_sel() -> Outcome:
     t = np.arange(0.0, 240.1, 0.5)
     pos = np.column_stack([np.zeros_like(t), 50.0 * (t - 120.0),
                            np.full_like(t, 100.1)])
-    res = ph.rotorcraft_event_level(
-        [_uniform_hemisphere(100.0, [31.5])], [50.0], [0.0], t, pos, (0.0, 0.0),
-        ground=ph.RotorcraftGround(receiver_height=0.1, flow_resistivity="H"))
+    res = ph.aircraft.rotorcraft_event_level(
+        [_uniform_hemisphere(100.0, [31.5])],
+        [50.0],
+        [0.0],
+        t,
+        pos,
+        (0.0, 0.0),
+        ground=ph.aircraft.RotorcraftGround(
+            receiver_height=0.1, flow_resistivity="H"
+        ),
+    )
     return numeric(7.982, res.sel - res.la_max, 0.1, unit="dB", places=3)
 
 
@@ -381,7 +428,7 @@ def _chk_doc32_event_sel() -> Outcome:
 def _chk_doc32_mean_plane() -> Outcome:
     # Roof (0,0)-(100,20)-(200,0): by symmetry the continuous least-squares
     # line is horizontal at the mean height, area/span = 2000/200 = 10 m.
-    res = ph.mean_ground_plane([0.0, 100.0, 200.0], [0.0, 20.0, 0.0])
+    res = ph.aircraft.mean_ground_plane([0.0, 100.0, 200.0], [0.0, 20.0, 0.0])
     return numeric(10.0, res.intercept, 1e-6, unit="m", places=4)
 
 
@@ -392,7 +439,7 @@ def _chk_doc32_mean_plane() -> Outcome:
 )
 def _chk_doc32_mean_sigma() -> Outcome:
     # Equal lengths: sigma_bar = 10^((log 1e4 + log 1e6)/2) = 1e5 by hand.
-    got = ph.mean_flow_resistivity([120.0, 120.0], [1.0e4, 1.0e6])
+    got = ph.aircraft.mean_flow_resistivity([120.0, 120.0], [1.0e4, 1.0e6])
     return numeric(1.0e5, got, 1e-3, unit="Pa·s/m²", places=1)
 
 
@@ -402,7 +449,9 @@ def _chk_doc32_mean_sigma() -> Outcome:
     "Pure diffraction with the edge on the line of sight, 10·lg 3, dB",
 )
 def _chk_doc32_diffraction_grazing() -> Outcome:
-    got = float(ph.diffraction_attenuation([1000.0], 0.0, edge_height=10.0)[0])
+    got = float(
+        ph.aircraft.diffraction_attenuation([1000.0], 0.0, edge_height=10.0)[0]
+    )
     return numeric(4.7712, got, 1e-4, unit="dB", places=4)
 
 
@@ -415,7 +464,7 @@ def _chk_doc32_screening_delta() -> Outcome:
     # Source (0, 20), receiver (400, 1.2), single edge at (200, 40):
     # delta = SO + OR - SR = sqrt(200^2+20^2) + sqrt(200^2+38.8^2)
     #         - sqrt(400^2+18.8^2) = 4.28480 m by hand.
-    res = ph.terrain_screening_adjustment(
+    res = ph.aircraft.terrain_screening_adjustment(
         [500.0], (0.0, 20.0), (400.0, 1.2),
         [0.0, 190.0, 200.0, 210.0, 400.0], [0.0, 0.0, 40.0, 0.0, 0.0])
     expected = (np.hypot(200.0, 20.0) + np.hypot(200.0, 38.8)
@@ -430,8 +479,14 @@ def _chk_doc32_screening_delta() -> Outcome:
 )
 def _chk_arp5534_coefficient() -> Outcome:
     # ARP 5534 §3.1: the pure-tone coefficient is the ISO 9613-1 one.
-    expected = float(ph.air_attenuation(1000.0, 25.0, 70.0, 101.325, exact_midband=True))
-    res = ph.sae_band_attenuation([1000.0], 1000.0, temperature=25.0, relative_humidity=70.0)
+    expected = float(
+        ph.environment.air_attenuation(
+            1000.0, 25.0, 70.0, 101.325, exact_midband=True
+        )
+    )
+    res = ph.aircraft.sae_band_attenuation(
+        [1000.0], 1000.0, temperature=25.0, relative_humidity=70.0
+    )
     return numeric(expected, float(res.coefficient[0]), 1e-9, unit="dB/m", places=6)
 
 # ICAO Doc 9501 ETM Vol. I (2018) Table 3-7 turbofan spectrum (bands 1-2 blank).
@@ -461,7 +516,9 @@ _ETM_DTR_44 = [
 def _chk_ac_noy() -> Outcome:
     spl = np.full(24, -999.0)
     spl[13] = 40.0  # 1000 Hz, SPL(b) -> n = 1
-    return numeric(1.0, float(ph.perceived_noisiness(spl)[13]), 1e-6, places=4)
+    return numeric(
+        1.0, float(ph.aircraft.perceived_noisiness(spl)[13]), 1e-6, places=4
+    )
 
 
 @register(
@@ -470,7 +527,9 @@ def _chk_ac_noy() -> Outcome:
     "Tone correction of the turbofan example, dB",
 )
 def _chk_ac_tone() -> Outcome:
-    return numeric(2.0, ph.tone_correction(_ETM_SPL_37), 1e-6, places=4)
+    return numeric(
+        2.0, ph.aircraft.tone_correction(_ETM_SPL_37), 1e-6, places=4
+    )
 
 
 @register(
@@ -479,7 +538,9 @@ def _chk_ac_tone() -> Outcome:
     "Integrated-method reference EPNL, EPNdB",
 )
 def _chk_ac_epnl() -> Outcome:
-    epnl, _, _, _ = ph.epnl_from_pnlt(np.array(_ETM_PNLTR_44), np.array(_ETM_DTR_44))
+    epnl, _, _, _ = ph.aircraft.epnl_from_pnlt(
+        np.array(_ETM_PNLTR_44), np.array(_ETM_DTR_44)
+    )
     return numeric(92.61892, epnl, 1e-2, unit="EPNdB", places=3)
 
 

--- a/scripts/conformance/domains/assessment.py
+++ b/scripts/conformance/domains/assessment.py
@@ -33,13 +33,13 @@ _NTA = "Impulsive-sound prominence (NT ACOU 112)"
 
 @register(_NTA, "NT ACOU 112:2002 Formula 1", "Predicted prominence, OR=1000 dB/s, LD=30 dB")
 def _chk_impulse_prominence() -> Outcome:
-    value = float(ph.predicted_prominence(1000.0, 30.0))
+    value = float(ph.environment.predicted_prominence(1000.0, 30.0))
     return numeric(ref.NTACOU112_PROMINENCE, value, 1e-4, places=4)
 
 
 @register(_NTA, "NT ACOU 112:2002 Formula 2", "Adjustment KI to LAeq at prominence P=10")
 def _chk_impulse_adjustment() -> Outcome:
-    value = float(ph.impulse_adjustment(10.0))
+    value = float(ph.environment.impulse_adjustment(10.0))
     return numeric(ref.NTACOU112_ADJUSTMENT_P10, value, 1e-9, unit="dB", places=3)
 
 
@@ -66,7 +66,9 @@ def _chk_iso1996_3_onset_rate() -> Outcome:
 
 @register(_ISO1996_3, "ISO/PAS 1996-3:2022 Formula 3", "Adjustment KI of the ramp onset")
 def _chk_iso1996_3_adjustment() -> Outcome:
-    value = float(ph.impulse_adjustment(_iso1996_3_ramp_onset().prominence))
+    value = float(
+        ph.environment.impulse_adjustment(_iso1996_3_ramp_onset().prominence)
+    )
     return numeric(ref.ISO1996_3_RAMP_ADJUSTMENT, value, 1e-6, unit="dB", places=4)
 
 
@@ -75,18 +77,28 @@ _RN = "Room noise (ANSI S12.2-2019)"
 
 @register(_RN, "ANSI S12.2-2019 Table 1", "NC-40 curve, tangency self-consistency")
 def _chk_rn_nc_self() -> Outcome:
-    rating = ph.noise_criterion(ph.nc_curve(40.0)).tangency_rating
+    rating = ph.room.noise_criterion(ph.room.nc_curve(40.0)).tangency_rating
     return numeric(ref.ANSIS12_2_NC40_SELF, rating, 1e-9, places=3)
 
 
 @register(_RN, "ANSI S12.2-2019 Table D.1", "RC-31 Mark II curve, 63 Hz level")
 def _chk_rn_rc_curve() -> Outcome:
-    return numeric(ref.ANSIS12_2_RC31_63HZ, float(ph.rc_curve(31.0)[2]), 1e-9, places=3)
+    return numeric(
+        ref.ANSIS12_2_RC31_63HZ,
+        float(ph.room.rc_curve(31.0)[2]),
+        1e-9,
+        places=3,
+    )
 
 
 @register(_RN, "ANSI S12.2-2019 clause D.4", "RC-35 curve, mid-frequency average LMF")
 def _chk_rn_rc_lmf() -> Outcome:
-    return numeric(ref.ANSIS12_2_RC35_LMF, ph.room_criterion(ph.rc_curve(35.0)).lmf, 1e-9, places=3)
+    return numeric(
+        ref.ANSIS12_2_RC35_LMF,
+        ph.room.room_criterion(ph.room.rc_curve(35.0)).lmf,
+        1e-9,
+        places=3,
+    )
 
 
 _HEAR = "Hearing threshold (ISO 7029 / ISO 389-7)"
@@ -94,19 +106,19 @@ _HEAR = "Hearing threshold (ISO 7029 / ISO 389-7)"
 
 @register(_HEAR, "ISO 7029:2017 Table 1", "Median threshold, male age 60 at 4 kHz")
 def _chk_hearing_median() -> Outcome:
-    value = float(ph.age_threshold(60, "male", 0.5).median[8])
+    value = float(ph.hearing.age_threshold(60, "male", 0.5).median[8])
     return numeric(ref.ISO7029_MEDIAN_MALE_60_4KHZ, value, 1e-3, unit="dB", places=3)
 
 
 @register(_HEAR, "ISO 7029:2017 Table 2", "Upper spread su, male age 60 at 1 kHz")
 def _chk_hearing_spread() -> Outcome:
-    value = float(ph.age_threshold(60, "male", 0.5).spread_upper[4])
+    value = float(ph.hearing.age_threshold(60, "male", 0.5).spread_upper[4])
     return numeric(ref.ISO7029_SU_MALE_60_1KHZ, value, 1e-3, unit="dB", places=3)
 
 
 @register(_HEAR, "ISO 389-7:2005 Table 1", "Free-field reference threshold at 1 kHz")
 def _chk_hearing_reference() -> Outcome:
-    value = float(ph.reference_threshold("free-field")[4])
+    value = float(ph.hearing.reference_threshold("free-field")[4])
     return numeric(ref.ISO389_7_REF_FREE_1KHZ, value, 1e-9, unit="dB", places=3)
 
 
@@ -115,8 +127,10 @@ _GUM = "Measurement uncertainty (GUM / Supplement 1)"
 
 @register(_GUM, "ISO/IEC Guide 98-3-1 clause 9.2", "Combined uncertainty, additive model")
 def _chk_gum_additive() -> Outcome:
-    quantities = [ph.Quantity(0.0, 1.0) for _ in range(4)]
-    result = ph.combine_uncertainty(lambda a, b, c, d: a + b + c + d, quantities)
+    quantities = [ph.metrology.Quantity(0.0, 1.0) for _ in range(4)]
+    result = ph.metrology.combine_uncertainty(
+        lambda a, b, c, d: a + b + c + d, quantities
+    )
     return numeric(ref.GUM_ADDITIVE_UC, result.combined_uncertainty, 1e-9, places=4)
 
 
@@ -129,17 +143,22 @@ def _chk_gum_coverage() -> Outcome:
 
 @register(_GUM, "ISO/IEC Guide 98-3 Annex G.4", "Welch-Satterthwaite effective dof")
 def _chk_gum_welch() -> Outcome:
-    quantities = [ph.Quantity(0.0, 1.0, dof=10) for _ in range(4)]
-    result = ph.combine_uncertainty(lambda a, b, c, d: a + b + c + d, quantities)
+    quantities = [ph.metrology.Quantity(0.0, 1.0, dof=10) for _ in range(4)]
+    result = ph.metrology.combine_uncertainty(
+        lambda a, b, c, d: a + b + c + d, quantities
+    )
     return numeric(ref.GUM_WELCH_VEFF, result.effective_dof, 1e-6, places=3)
 
 
 def _gum_h1_result() -> Any:
-    quantities = [ph.Quantity(v, unc, dof=dof) for v, unc, dof in ref.GUM_H1_INPUTS]
+    quantities = [
+        ph.metrology.Quantity(v, unc, dof=dof)
+        for v, unc, dof in ref.GUM_H1_INPUTS
+    ]
     with warnings.catch_warnings():
         # alphaS and theta are genuinely flat directions at the H.1 estimates.
         warnings.simplefilter("ignore")
-        return ph.combine_uncertainty(
+        return ph.metrology.combine_uncertainty(
             lambda ls, d, a_s, th, da, dth: ls + d - ls * (da * th + a_s * dth),
             quantities,
         )
@@ -169,8 +188,8 @@ def _chk_gum_h2_correlated() -> Outcome:
     means = obs.mean(axis=0)
     u_means = obs.std(axis=0, ddof=1) / math.sqrt(obs.shape[0])
     r = np.corrcoef(obs.T)
-    quantities = [ph.Quantity(m, s) for m, s in zip(means, u_means)]
-    result = ph.combine_uncertainty(
+    quantities = [ph.metrology.Quantity(m, s) for m, s in zip(means, u_means)]
+    result = ph.metrology.combine_uncertainty(
         lambda v, i, p: v / i * math.cos(p), quantities, correlation=r
     )
     return numeric(
@@ -185,8 +204,10 @@ def _chk_gum_h2_correlated() -> Outcome:
     "Seeded Monte Carlo, rectangular sum: 95 % interval endpoint",
 )
 def _chk_gum_s1_table3_monte_carlo() -> Outcome:
-    quantities = [ph.Quantity(0.0, 1.0, "rectangular") for _ in range(4)]
-    mc = ph.monte_carlo(
+    quantities = [
+        ph.metrology.Quantity(0.0, 1.0, "rectangular") for _ in range(4)
+    ]
+    mc = ph.metrology.monte_carlo(
         lambda a, b, c, d: a + b + c + d, quantities,
         trials=1_000_000, coverage=0.95, seed=1996,
     )
@@ -206,19 +227,19 @@ _NIHL = "Noise-induced hearing loss (ISO 1999)"
 
 @register(_NIHL, "ISO 1999:2013 Table D.2", "Median NIPTS, 4 kHz, 90 dB, 20 yr")
 def _chk_nihl_median() -> Outcome:
-    value = float(ph.nipts(90.0, 20.0, 0.5).value[4])
+    value = float(ph.hearing.nipts(90.0, 20.0, 0.5).value[4])
     return numeric(ref.ISO1999_N50_4K_90_20, value, 0.5, unit="dB", places=1)
 
 
 @register(_NIHL, "ISO 1999:2013 Table D.2", "Worst-10 % NIPTS, 4 kHz, 90 dB, 20 yr")
 def _chk_nihl_fractile() -> Outcome:
-    value = float(ph.nipts(90.0, 20.0, 0.9).value[4])
+    value = float(ph.hearing.nipts(90.0, 20.0, 0.9).value[4])
     return numeric(ref.ISO1999_N10_4K_90_20, value, 0.5, unit="dB", places=1)
 
 
 @register(_NIHL, "ISO 1999:2013 Table D.4", "Worst-10 % NIPTS, 3 kHz, 100 dB, 40 yr")
 def _chk_nihl_high() -> Outcome:
-    value = float(ph.nipts(100.0, 40.0, 0.9).value[3])
+    value = float(ph.hearing.nipts(100.0, 40.0, 0.9).value[3])
     return numeric(ref.ISO1999_N10_3K_100_40, value, 0.5, unit="dB", places=1)
 
 
@@ -230,7 +251,9 @@ def _chk_nihl_high() -> Outcome:
 def _chk_nihl_annex_c_nipts() -> Outcome:
     """The Table D.2 shifts the Annex C example takes as its noise input."""
     value = np.round(
-        ph.nipts(90.0, 30.0, 0.9, frequencies=[1000.0, 2000.0, 4000.0]).value
+        ph.hearing.nipts(
+            90.0, 30.0, 0.9, frequencies=[1000.0, 2000.0, 4000.0]
+        ).value
     )
     expected = np.asarray(ref.ISO1999_ANNEX_C_N, dtype=float)
     delta = float(np.max(np.abs(value - expected)))
@@ -252,7 +275,7 @@ def _chk_nihl_annex_c_compression() -> Outcome:
     h = ref.ISO1999_ANNEX_C_H[2]
     n = ref.ISO1999_ANNEX_C_N[2]
     # H' - H is what Formula (1) leaves of the noise component at that band.
-    value = float(ph.combine_age_and_noise(h, n)) - h
+    value = float(ph.hearing.combine_age_and_noise(h, n)) - h
     return numeric(
         ref.ISO1999_ANNEX_C_N_4K_COMPRESSED, value, 0.05, unit="dB", places=1
     )
@@ -276,7 +299,7 @@ def _chk_nihl_annex_c_htlan() -> Outcome:
     """
     h = np.asarray(ref.ISO1999_ANNEX_C_H, dtype=float)
     n = np.asarray(ref.ISO1999_ANNEX_C_N, dtype=float)
-    compressed = ph.combine_age_and_noise(h, n) - h
+    compressed = ph.hearing.combine_age_and_noise(h, n) - h
     noise = np.where(h + n > ref.ISO1999_ANNEX_C_COMPRESSION_FENCE, compressed, n)
     value = float(np.mean(h) + np.mean(noise))
     return numeric(ref.ISO1999_ANNEX_C_HTLAN, value, 0.05, unit="dB", places=1)
@@ -287,22 +310,35 @@ _MSV = "Multiple-shock whole-body vibration (ISO 2631-5)"
 
 @register(_MSV, "ISO 2631-5:2018 Formula 3", "Daily acceleration dose, 5 x 40 m/s2 peaks")
 def _chk_multiple_shock_dose() -> Outcome:
-    value = ph.dose_from_peaks([40.0] * 5)
+    value = ph.vibration.dose_from_peaks([40.0] * 5)
     return numeric(ref.ISO2631_5_DZD_MALE, value, 0.01, unit="m/s2", places=2)
 
 
 @register(_MSV, "ISO 2631-5:2018 Formula C.3", "Stress variable R, Annex C male example")
 def _chk_multiple_shock_risk() -> Outcome:
-    sd = ph.compression_dose(ph.dose_from_peaks([40.0] * 5))
-    value = ph.injury_risk(sd, start_age=20, years=20, days_per_year=120, sex="male")
+    sd = ph.vibration.compression_dose(
+        ph.vibration.dose_from_peaks([40.0] * 5)
+    )
+    value = ph.vibration.injury_risk(
+        sd, start_age=20, years=20, days_per_year=120, sex="male"
+    )
     return numeric(ref.ISO2631_5_R_MALE, value, 0.01, places=2)
 
 
 @register(_MSV, "ISO 2631-5:2018 Formula C.5", "Injury probability, Annex C male example")
 def _chk_multiple_shock_probability() -> Outcome:
-    sd = ph.compression_dose(ph.dose_from_peaks([40.0] * 5))
-    r = ph.injury_risk(sd, start_age=20, years=20, days_per_year=120, sex="male")
-    return numeric(ref.ISO2631_5_PI_MALE, float(ph.injury_probability(r)), 0.01, places=2)
+    sd = ph.vibration.compression_dose(
+        ph.vibration.dose_from_peaks([40.0] * 5)
+    )
+    r = ph.vibration.injury_risk(
+        sd, start_age=20, years=20, days_per_year=120, sex="male"
+    )
+    return numeric(
+        ref.ISO2631_5_PI_MALE,
+        float(ph.vibration.injury_probability(r)),
+        0.01,
+        places=2,
+    )
 
 
 @register(
@@ -311,7 +347,9 @@ def _chk_multiple_shock_probability() -> Outcome:
 def _chk_multiple_shock_female_sd() -> Outcome:
     from phonometry.vibration.human.multiple_shock import MZ_FEMALE
 
-    sd = ph.compression_dose(ph.dose_from_peaks([40.0] * 5), mz=MZ_FEMALE)
+    sd = ph.vibration.compression_dose(
+        ph.vibration.dose_from_peaks([40.0] * 5), mz=MZ_FEMALE
+    )
     return numeric(ref.ISO2631_5_SD_FEMALE, sd, 0.01, unit="MPa", places=2)
 
 
@@ -321,8 +359,12 @@ def _chk_multiple_shock_female_sd() -> Outcome:
 def _chk_multiple_shock_female_r() -> Outcome:
     from phonometry.vibration.human.multiple_shock import MZ_FEMALE
 
-    sd = ph.compression_dose(ph.dose_from_peaks([40.0] * 5), mz=MZ_FEMALE)
-    r = ph.injury_risk(sd, start_age=20, years=20, days_per_year=120, sex="female")
+    sd = ph.vibration.compression_dose(
+        ph.vibration.dose_from_peaks([40.0] * 5), mz=MZ_FEMALE
+    )
+    r = ph.vibration.injury_risk(
+        sd, start_age=20, years=20, days_per_year=120, sex="female"
+    )
     return numeric(ref.ISO2631_5_R_FEMALE, r, 0.01, places=2)
 
 
@@ -333,7 +375,7 @@ def _chk_multiple_shock_female_r() -> Outcome:
 )
 def _chk_multiple_shock_annex_d_filter() -> Outcome:
     freqs = np.array([0.5, 2.0, 5.0, 10.0, 20.0, 40.0, 60.0, 80.0])
-    formula = np.abs(ph.seat_to_spine_transfer(freqs))
+    formula = np.abs(ph.vibration.seat_to_spine_transfer(freqs))
     _, h = sg.freqz(
         ref.ISO2631_5_ANNEX_D_B,
         ref.ISO2631_5_ANNEX_D_A,
@@ -351,12 +393,18 @@ _ABS = "Sound absorption in enclosed spaces (EN 12354-6)"
 
 @register(_ABS, "EN 12354-6:2003 Formula 1", "Equivalent absorption area, Annex E bare room")
 def _chk_enclosed_space_area() -> Outcome:
-    value = float(ph.equivalent_absorption_area(ref.EN12354_6_ANNEX_E_BARE_SURFACES))
+    value = float(
+        ph.room.equivalent_absorption_area(ref.EN12354_6_ANNEX_E_BARE_SURFACES)
+    )
     return numeric(ref.EN12354_6_A_BARE, value, 0.01, unit="m2", places=2)
 
 
 @register(_ABS, "EN 12354-6:2003 Formula 5", "Reverberation time, Annex E bare room")
 def _chk_enclosed_space_rt() -> Outcome:
-    area = ph.equivalent_absorption_area(ref.EN12354_6_ANNEX_E_BARE_SURFACES)
-    value = float(ph.reverberation_time(area, ref.EN12354_6_ANNEX_E_VOLUME))
+    area = ph.room.equivalent_absorption_area(
+        ref.EN12354_6_ANNEX_E_BARE_SURFACES
+    )
+    value = float(
+        ph.room.reverberation_time(area, ref.EN12354_6_ANNEX_E_VOLUME)
+    )
     return numeric(ref.EN12354_6_T_BARE, value, 0.05, unit="s", places=1)

--- a/scripts/conformance/domains/atmospheric_refraction.py
+++ b/scripts/conformance/domains/atmospheric_refraction.py
@@ -28,9 +28,16 @@ def _chk_atm_ray_turning() -> Outcome:
     c0, gradient, angle = 343.0, 0.2, 10.0
     rc = c0 / (gradient * math.cos(math.radians(angle)))
     turn = rc * (1.0 - math.cos(math.radians(angle)))
-    prof = ph.linear_sound_speed_profile(gradient, ground_speed=c0, max_height=3000.0)
-    res = ph.atmospheric_ray_paths(prof, source_height=0.0, launch_angles_deg=[angle],
-                                   max_range=600.0, n_steps=8000)
+    prof = ph.environment.linear_sound_speed_profile(
+        gradient, ground_speed=c0, max_height=3000.0
+    )
+    res = ph.environment.atmospheric_ray_paths(
+        prof,
+        source_height=0.0,
+        launch_angles_deg=[angle],
+        max_range=600.0,
+        n_steps=8000,
+    )
     return numeric(turn, float(res.heights[0].max()), 0.1, unit="m", places=3)
 
 
@@ -41,14 +48,29 @@ def _chk_atm_ray_turning() -> Outcome:
 )
 def _chk_atm_pe_ground_effect() -> Outcome:
     freq, zs, zr, z = 250.0, 1.0, 1.0, 11.0 + 8.0j
-    flat = ph.linear_sound_speed_profile(1e-12, ground_speed=343.0, max_height=200.0)
-    pe = ph.atmospheric_parabolic_equation(freq, flat, source_height=zs,
-                                           impedance=z, max_range=520.0,
-                                           max_height=40.0)
+    flat = ph.environment.linear_sound_speed_profile(
+        1e-12, ground_speed=343.0, max_height=200.0
+    )
+    pe = ph.environment.atmospheric_parabolic_equation(
+        freq,
+        flat,
+        source_height=zs,
+        impedance=z,
+        max_range=520.0,
+        max_height=40.0,
+    )
     i = int(min(range(pe.ranges.size), key=lambda k: abs(pe.ranges[k] - 500.0)))
     got = float(pe.level_at_height(zr)[i])
-    oracle = float(ph.ground_effect([freq], zs, zr, float(pe.ranges[i]),
-                                    impedance=z, speed_of_sound=343.0).excess_attenuation[0])
+    oracle = float(
+        ph.environment.ground_effect(
+            [freq],
+            zs,
+            zr,
+            float(pe.ranges[i]),
+            impedance=z,
+            speed_of_sound=343.0,
+        ).excess_attenuation[0]
+    )
     return numeric(oracle, got, 0.5, unit="dB", places=3)
 
 
@@ -59,10 +81,17 @@ def _chk_atm_pe_ground_effect() -> Outcome:
 )
 def _chk_atm_pe_hard_ground() -> Outcome:
     freq, zs, zr = 500.0, 2.0, 2.0
-    flat = ph.linear_sound_speed_profile(1e-12, ground_speed=343.0, max_height=200.0)
-    pe = ph.atmospheric_parabolic_equation(freq, flat, source_height=zs,
-                                           impedance=1e6 + 0j, max_range=520.0,
-                                           max_height=150.0)
+    flat = ph.environment.linear_sound_speed_profile(
+        1e-12, ground_speed=343.0, max_height=200.0
+    )
+    pe = ph.environment.atmospheric_parabolic_equation(
+        freq,
+        flat,
+        source_height=zs,
+        impedance=1e6 + 0j,
+        max_range=520.0,
+        max_height=150.0,
+    )
     i = int(min(range(pe.ranges.size), key=lambda k: abs(pe.ranges[k] - 500.0)))
     r = float(pe.ranges[i])
     r1, r2 = math.hypot(r, zs - zr), math.hypot(r, zs + zr)

--- a/scripts/conformance/domains/building.py
+++ b/scripts/conformance/domains/building.py
@@ -47,7 +47,9 @@ def _exponential_ir(t60: float, seconds: float) -> np.ndarray:
 )
 def _chk_room_t30() -> Outcome:
     t60 = 1.0
-    res = ph.room_parameters(_exponential_ir(t60, 3.0 * t60), _FS, limits=None)
+    res = ph.room.room_parameters(
+        _exponential_ir(t60, 3.0 * t60), _FS, limits=None
+    )
     return numeric(t60, float(res.t30[0]), 0.01, unit="s", rel=True, places=4)
 
 
@@ -60,9 +62,9 @@ def _chk_iso18233_sweep_deconvolution() -> Outcome:
     # Closed-form identity: an exponential sweep through a known Butterworth
     # band-pass, deconvolved back, must reproduce the filter's freqz response.
     b, a = sg.butter(4, [200.0, 2000.0], btype="band", fs=_FS)
-    x = ph.sweep_signal(_FS, 20.0, 20000.0, 2.0)
+    x = ph.room.sweep_signal(_FS, 20.0, 20000.0, 2.0)
     y = sg.lfilter(b, a, x)
-    ir = np.asarray(ph.impulse_response(y, x, _FS, length=16384))
+    ir = np.asarray(ph.room.impulse_response(y, x, _FS, length=16384))
     freqs = np.fft.rfftfreq(ir.size, d=1.0 / _FS)
     h_est = np.fft.rfft(ir)
     _, h_true = sg.freqz(b, a, worN=freqs, fs=_FS)
@@ -84,7 +86,7 @@ def _chk_iso18233_sweep_deconvolution() -> Outcome:
 )
 def _chk_iso717_rw() -> Outcome:
     exp = ref.ISO717_1_ANNEX_C_EXPECTED
-    res = ph.weighted_rating(ref.ISO717_1_ANNEX_C_R)
+    res = ph.building.weighted_rating(ref.ISO717_1_ANNEX_C_R)
     ok = res.rating == exp["rw"] and res.c == exp["c"] and res.ctr == exp["ctr"]
     return Outcome(
         expected=f"Rw {exp['rw']} (C {exp['c']}; Ctr {exp['ctr']})",
@@ -103,7 +105,9 @@ def _chk_iso717_1_extended() -> Outcome:
     exp = ref.ISO717_1_ANNEX_C2_EXPECTED
     freqs = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500,
              630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000]
-    res = ph.weighted_rating_extended(ref.ISO717_1_ANNEX_C2_R_50_5000, freqs)
+    res = ph.building.weighted_rating_extended(
+        ref.ISO717_1_ANNEX_C2_R_50_5000, freqs
+    )
     ok = (
         res.rating == exp["rw"] and res.c == exp["c"] and res.ctr == exp["ctr"]
         and res.c_50_5000 == exp["c_50_5000"]
@@ -136,7 +140,7 @@ def _chk_iso717_2_lnw() -> Outcome:
     # Integer ratings and CI must match exactly; the unfavourable sum is a
     # one-decimal tabulated intermediate, so 1e-9 = exact up to float noise.
     exp = ref.ISO717_2_ANNEX_C1_EXPECTED
-    res = ph.weighted_impact_rating(ref.ISO717_2_ANNEX_C1_LN)
+    res = ph.building.weighted_impact_rating(ref.ISO717_2_ANNEX_C1_LN)
     sum_ok = abs(res.unfavourable_sum - exp["unfavourable_sum"]) <= 1e-9
     ok = res.rating == exp["ln_w"] and res.ci == exp["ci"] and sum_ok
     return Outcome(
@@ -154,7 +158,7 @@ def _chk_iso717_2_lnw() -> Outcome:
 )
 def _chk_iso717_2_lnw_covered() -> Outcome:
     exp = ref.ISO717_2_ANNEX_C1_COVERED_EXPECTED
-    res = ph.weighted_impact_rating(ref.ISO717_2_ANNEX_C1_COVERED_LN)
+    res = ph.building.weighted_impact_rating(ref.ISO717_2_ANNEX_C1_COVERED_LN)
     sum_ok = abs(res.unfavourable_sum - exp["unfavourable_sum"]) <= 1e-9
     ok = res.rating == exp["ln_w"] and res.ci == exp["ci"] and sum_ok
     return Outcome(
@@ -172,8 +176,12 @@ def _chk_iso717_2_lnw_covered() -> Outcome:
     " the normative Table 4 floor, not the 2020 print's misprinted C.2 chain)",
 )
 def _chk_iso717_2_c2_improvement() -> Outcome:
-    dlw = ph.weighted_impact_improvement(ref.ISO717_2_ANNEX_C2_DELTA_L)
-    ci_d = ph.impact_improvement_adaptation_term(ref.ISO717_2_ANNEX_C2_DELTA_L)
+    dlw = ph.building.weighted_impact_improvement(
+        ref.ISO717_2_ANNEX_C2_DELTA_L
+    )
+    ci_d = ph.building.impact_improvement_adaptation_term(
+        ref.ISO717_2_ANNEX_C2_DELTA_L
+    )
     ok = (
         dlw == ref.ISO717_2_ANNEX_C2_DELTA_LW
         and ci_d == ref.ISO717_2_ANNEX_C2_CI_DELTA
@@ -197,7 +205,9 @@ def _chk_iso717_2_c2_improvement() -> Outcome:
 def _chk_iso354_absorption() -> Outcome:
     v, c, t = 200.0, 343.0, 3.5
     expected = 55.3 * v / (c * t)
-    computed = float(np.asarray(ph.absorption_area(t, v, speed_of_sound=c))[()])
+    computed = float(
+        np.asarray(ph.materials.absorption_area(t, v, speed_of_sound=c))[()]
+    )
     return numeric(expected, computed, 1e-9, unit="m^2", places=6)
 
 
@@ -210,7 +220,7 @@ def _chk_open_plan_d2s() -> Outcome:
     r = np.array([2.0, 4.0, 8.0, 16.0])
     lp = 70.0 - 6.0 * np.log2(r)
     sti = 0.6 - 0.02 * r
-    res = ph.open_plan_metrics(r, lp, sti)
+    res = ph.room.open_plan_metrics(r, lp, sti)
     return numeric(6.0, float(res.d2s), 1e-9, unit="dB", places=6)
 
 
@@ -222,7 +232,7 @@ def _chk_open_plan_d2s() -> Outcome:
 def _chk_facade_r45() -> Outcome:
     # With S = A the 10 lg(S/A) coupling term vanishes, so R' = L1,s - L2 - 1,5.
     n = 3
-    res = ph.facade_insulation(
+    res = ph.building.facade_insulation(
         np.full(n, 55.0),
         np.full(n, ref.ISO16283_3_R45_RECEIVE_LEVEL_DB),
         np.full(n, ref.ISO16283_3_R45_REVERB_TIME_S),
@@ -251,7 +261,7 @@ def _chk_facade_r45() -> Outcome:
 def _chk_lab_airborne_rw() -> Outcome:
     # S = A (A = 0,16*50/0,8 = 10 = area) => R = L1 - L2 = the reference curve.
     ref_r = np.asarray(ref.ISO10140_2_REF_AIRBORNE_R, dtype=float)
-    res = ph.lab_airborne_insulation(
+    res = ph.building.lab_airborne_insulation(
         np.full(16, 90.0), 90.0 - ref_r, np.full(16, 0.8), area=10.0, volume=50.0
     )
     assert res.rating is not None
@@ -281,7 +291,7 @@ def _chk_iso10140_5_reference_elements() -> Outcome:
     ok = True
     for r, expected in rows:
         # S = A (10 m2) so the ISO 10140-2 chain returns R = L1 - L2 exactly.
-        res = ph.lab_airborne_insulation(
+        res = ph.building.lab_airborne_insulation(
             np.full(16, 90.0), 90.0 - np.asarray(r, dtype=float),
             np.full(16, 0.8), area=10.0, volume=50.0,
         )
@@ -311,7 +321,7 @@ def _chk_iso10140_5_reference_floors() -> Outcome:
     ok = True
     for ln, expected in rows:
         # A = A0 (V = 31,25 m3, T = 0,5 s) so Ln equals the receiving level.
-        res = ph.lab_impact_insulation(
+        res = ph.building.lab_impact_insulation(
             np.asarray(ln, dtype=float), np.full(16, 0.5), volume=31.25
         )
         assert res.rating is not None
@@ -336,7 +346,7 @@ def _chk_intensity_ri_rw() -> Outcome:
     # curve construction below inverts the same formula, so -6 dB and
     # 10 lg(Sm/S) would cancel there): Lp1 = 80, LIn = 40, Sm = S
     # -> RI = 80 - 6 - 40 - 0 = 34 dB exactly.
-    scalar = ph.intensity_sound_reduction(
+    scalar = ph.building.intensity_sound_reduction(
         [80.0], [40.0], measurement_area=10.0, area=10.0
     )
     scalar_ok = abs(float(scalar.r_i[0]) - 34.0) <= 1e-9
@@ -345,7 +355,7 @@ def _chk_intensity_ri_rw() -> Outcome:
     ref_ri = np.asarray(ref.ISO15186_1_REF_RI, dtype=float)
     lp1, sm, s = ref.ISO15186_1_REF_LP1, ref.ISO15186_1_REF_SM, ref.ISO15186_1_REF_S
     lin = lp1 - 6.0 - 10.0 * np.log10(sm / s) - ref_ri
-    res = ph.intensity_sound_reduction(
+    res = ph.building.intensity_sound_reduction(
         np.full(16, lp1), lin, measurement_area=sm, area=s
     )
     assert res.rating is not None
@@ -368,8 +378,8 @@ def _chk_intensity_kc_annexb() -> Outcome:
     # The printed Table B.1 (21 one-third-octave rows, one decimal) is the
     # independent oracle; additionally Formula (B.1) with Sb2 = 117 m²,
     # V2 = 81 m³, c = 340 m/s must reduce to (B.2) Kc = 10 lg(1 + 61,4/f).
-    b2 = ph.adaptation_term_kc(ref.ISO15186_1_KC_BANDS)
-    b1 = ph.adaptation_term_kc(
+    b2 = ph.building.adaptation_term_kc(ref.ISO15186_1_KC_BANDS)
+    b1 = ph.building.adaptation_term_kc(
         ref.ISO15186_1_KC_BANDS, boundary_area=117.0, volume=81.0
     )
     printed = np.asarray(ref.ISO15186_1_KC_B1_PRINTED, dtype=float)
@@ -393,7 +403,7 @@ def _chk_survey_rprime_area_rule() -> Outcome:
     # V/7,5 = 120/7,5 = 16 m^2 > S = 5 m^2, so the larger value replaces S.
     # With k = 0 (T = T0), R' = D + 10 lg(16 * T0 / (0,16 V)).
     v, s, d = 120.0, 5.0, 30.0
-    res = ph.survey_airborne_insulation(
+    res = ph.building.survey_airborne_insulation(
         np.full(5, 70.0), np.full(5, 40.0), np.zeros(5), volume=v, area=s
     )
     assert res.r_prime is not None
@@ -410,7 +420,7 @@ def _chk_survey_rprime_area_rule() -> Outcome:
 def _chk_survey_service_equipment() -> Outcome:
     # Energy average of 35 / 30 / 32 dB(A), then standardized by k.
     levels = [35.0, 30.0, 32.0]
-    res = ph.survey_service_equipment_level(levels, 3.0, volume=50.0)
+    res = ph.building.survey_service_equipment_level(levels, 3.0, volume=50.0)
     expected = 10.0 * np.log10(sum(10.0 ** (0.1 * x) for x in levels) / 3.0)
     return numeric(expected, float(np.asarray(res.l_xy)[()]), 1e-9, unit="dB", places=6)
 
@@ -423,7 +433,9 @@ def _chk_survey_service_equipment() -> Outcome:
 def _chk_survey_reverberation_estimate() -> Outcome:
     # Table 4 row 'g' for 35 <= V < 60: 4,5 / 5 / 5,5 / 5,5 / 5,5 dB.
     expected = [4.5, 5.0, 5.5, 5.5, 5.5]
-    got = np.asarray(ph.estimate_reverberation_index(50.0, "g"), dtype=float)
+    got = np.asarray(
+        ph.building.estimate_reverberation_index(50.0, "g"), dtype=float
+    )
     ok = bool(np.array_equal(got, expected))
     return Outcome(
         expected=f"k = {expected} dB",
@@ -439,7 +451,9 @@ def _chk_survey_reverberation_estimate() -> Outcome:
     "Reference-floor weighted level Ln,r,0,w and CI (ISO 16251-1 ΔLw anchor)",
 )
 def _chk_iso717_2_reference_floor() -> Outcome:
-    res = ph.weighted_impact_rating(ref.ISO717_2_REFERENCE_FLOOR_LN_R0)
+    res = ph.building.weighted_impact_rating(
+        ref.ISO717_2_REFERENCE_FLOOR_LN_R0
+    )
     ok = (
         res.rating == ref.ISO717_2_REFERENCE_FLOOR_LN_R0_W
         and res.ci == ref.ISO717_2_REFERENCE_FLOOR_CI
@@ -461,7 +475,7 @@ def _chk_iso717_2_reference_floor() -> Outcome:
 def _chk_iso16251_zero_improvement() -> Outcome:
     import numpy as _np
 
-    dlw = ph.weighted_impact_improvement(_np.zeros(16))
+    dlw = ph.building.weighted_impact_improvement(_np.zeros(16))
     return Outcome(
         expected="ΔLw = 0 dB (ΔL = 0 -> Ln,r = Ln,r,0)",
         computed=f"ΔLw = {dlw} dB",
@@ -484,7 +498,9 @@ def _chk_iso16251_carpet_foret2011() -> Outcome:
     # provenance and the +/- 0,5 dB digitization tolerance.
     bare = np.full(len(ref.FORET2011_CARPET_FREQ), 100.0)
     delta_l = np.asarray(ref.FORET2011_CARPET_ISO16251_DELTA_L, dtype=float)
-    res = ph.impact_improvement(bare, bare - delta_l, ref.FORET2011_CARPET_FREQ)
+    res = ph.building.impact_improvement(
+        bare, bare - delta_l, ref.FORET2011_CARPET_FREQ
+    )
     dlw = res.delta_lw
     return Outcome(
         expected=f"ΔLw = {ref.FORET2011_CARPET_ISO16251_DELTA_LW} dB (paper, ISO 16251-1)",
@@ -502,7 +518,7 @@ def _chk_iso16251_carpet_foret2011() -> Outcome:
 def _chk_iso10848_kij_simplified() -> Outcome:
     # No worked example in the standard; anchor on the closed form recomputed
     # independently here (delta is "exact" to keep the report byte-stable).
-    res = ph.vibration_reduction_index(
+    res = ph.building.vibration_reduction_index(
         [ref.ISO10848_KIJ_DBAR],
         ref.ISO10848_KIJ_LIJ,
         ref.ISO10848_KIJ_AREA,
@@ -526,7 +542,7 @@ def _chk_iso10848_kij_simplified() -> Outcome:
     "Flanking equivalent absorption length aj at f_ref",
 )
 def _chk_iso10848_absorption_length() -> Outcome:
-    a = ph.equivalent_absorption_length(
+    a = ph.building.equivalent_absorption_length(
         ref.ISO10848_ABS_AREA,
         ref.ISO10848_ABS_TS,
         [1000.0],
@@ -552,7 +568,7 @@ def _chk_iso10848_absorption_length() -> Outcome:
     "Flanking total loss factor η = 2,2/(f·Ts)",
 )
 def _chk_iso10848_loss_factor() -> Outcome:
-    eta = ph.total_loss_factor([1000.0], [0.5])
+    eta = ph.building.total_loss_factor([1000.0], [0.5])
     computed = float(eta[0])
     expected = 2.2 / (1000.0 * 0.5)
     return Outcome(
@@ -575,9 +591,11 @@ def _chk_flanking_critical_frequency() -> Outcome:
     # agree to within that rounding (< 1 %).
     e, rho, nu, h, c0 = 6.2e10, 2500.0, 0.24, 0.006, 343.0
     c_l = math.sqrt(e / (rho * (1.0 - nu**2)))
-    fc_flank = ph.critical_frequency(c_l, h, speed_of_sound=c0)
-    fc_coinc = ph.coincidence_frequency(
-        rho * h, ph.plate_bending_stiffness(e, h, nu), speed_of_sound=c0
+    fc_flank = ph.building.critical_frequency(c_l, h, speed_of_sound=c0)
+    fc_coinc = ph.vibration.coincidence_frequency(
+        rho * h,
+        ph.vibration.plate_bending_stiffness(e, h, nu),
+        speed_of_sound=c0,
     )
     return numeric(fc_coinc, fc_flank, 0.01, rel=True, unit="Hz", places=1)
 
@@ -589,7 +607,9 @@ def _chk_flanking_critical_frequency() -> Outcome:
     "Apparent dynamic stiffness s't = 4π²·m't·fr²  (m't=200 kg/m², fr=25 Hz)",
 )
 def _chk_en29052_apparent() -> Outcome:
-    computed = float(ph.apparent_dynamic_stiffness(25.0, 200.0)) / 1e6
+    computed = (
+        float(ph.materials.apparent_dynamic_stiffness(25.0, 200.0)) / 1e6
+    )
     expected = 4.0 * math.pi**2 * 200.0 * 25.0**2 / 1e6
     return numeric(expected, computed, 1e-6, unit="MN/m³", places=6)
 
@@ -601,7 +621,9 @@ def _chk_en29052_apparent() -> Outcome:
 )
 def _chk_en29052_enclosed_gas() -> Outcome:
     # NOTE: s'a = 111/d MN/m3 for d in mm; the closed form gives 100/0,9 = 111.11.
-    sa_mn = float(ph.enclosed_gas_stiffness(0.020, 0.9)) / 1e6   # d = 20 mm
+    sa_mn = (
+        float(ph.materials.enclosed_gas_stiffness(0.020, 0.9)) / 1e6
+    )  # d = 20 mm
     return numeric(111.111111 / 20.0, sa_mn, 1e-4, unit="MN/m³", places=5)
 
 
@@ -611,7 +633,7 @@ def _chk_en29052_enclosed_gas() -> Outcome:
     "Floating-floor natural frequency f0 = (1/2π)√(s'/m')  (s'=10 MN/m³, m'=100 kg/m²)",
 )
 def _chk_en29052_resonance() -> Outcome:
-    computed = float(ph.natural_frequency(10.0e6, 100.0))
+    computed = float(ph.materials.natural_frequency(10.0e6, 100.0))
     expected = math.sqrt(10.0e6 / 100.0) / (2.0 * math.pi)
     return numeric(expected, computed, 1e-6, unit="Hz", places=5)
 
@@ -629,7 +651,7 @@ _MOB_F0 = math.sqrt(_MOB_K / _MOB_M) / (2.0 * math.pi)
     "Closed-form SDOF driving-point mobility peak mag(Y(f0)) = 1/c  (c=5 N·s/m)",
 )
 def _chk_iso7626_mobility_peak() -> Outcome:
-    y0 = complex(ph.sdof_mobility(_MOB_F0, _MOB_M, _MOB_K, _MOB_C))
+    y0 = complex(ph.vibration.sdof_mobility(_MOB_F0, _MOB_M, _MOB_K, _MOB_C))
     return numeric(1.0 / _MOB_C, abs(y0), 1e-6, unit="m/(N·s)", places=6)
 
 
@@ -639,7 +661,7 @@ def _chk_iso7626_mobility_peak() -> Outcome:
     "Closed-form SDOF static receptance H(0) = 1/k  (k=8000 N/m)",
 )
 def _chk_iso7626_static_receptance() -> Outcome:
-    h = complex(ph.sdof_receptance(1e-6, _MOB_M, _MOB_K, _MOB_C))
+    h = complex(ph.vibration.sdof_receptance(1e-6, _MOB_M, _MOB_K, _MOB_C))
     return numeric(1.0 / _MOB_K, h.real, 1e-6, unit="m/N", rel=True, places=8)
 
 
@@ -649,8 +671,8 @@ def _chk_iso7626_static_receptance() -> Outcome:
     "FRF reciprocity: impedance × mobility = 1  (at 37 Hz)",
 )
 def _chk_iso7626_reciprocity() -> Outcome:
-    y = complex(ph.sdof_mobility(37.0, _MOB_M, _MOB_K, _MOB_C))
-    z = complex(ph.convert_frf(y, 37.0, "mobility", "impedance"))
+    y = complex(ph.vibration.sdof_mobility(37.0, _MOB_M, _MOB_K, _MOB_C))
+    z = complex(ph.vibration.convert_frf(y, 37.0, "mobility", "impedance"))
     return numeric(1.0, abs(z * y), 1e-9, expected_label="1 (= Z·Y)")
 
 
@@ -667,7 +689,7 @@ _ISO717_2_D4_LEVELS = (65.3, 64.5, 58.0, 55.8)
     "A-weighted maximum impact level LiA,Fmax of the Annex D worked example",
 )
 def _chk_iso717_2_annex_d_rating() -> Outcome:
-    res = ph.a_weighted_maximum_impact_level(_ISO717_2_D4_LEVELS)
+    res = ph.building.a_weighted_maximum_impact_level(_ISO717_2_D4_LEVELS)
     return numeric(
         55.350_667, res.unrounded, 1e-4, unit="dB", places=6,
         expected_label="55,350 66... dB (rated 55 dB)",
@@ -688,9 +710,9 @@ def _chk_iso16283_2_rubber_ball_spectrum() -> Outcome:
     # ISO 16283-2 Table A.1, ISO 10140-5 Table F.1 and JIS A 1418-2 Table A.2
     # print the same five values; the tolerance band is +/-1,0 / 1,5 / 1,5 /
     # 2,0 / 2,0 dB, and a source on the nominal must conform in every band.
-    freqs, lower, upper = ph.heavy_impact_source_limits("rubber_ball")
+    freqs, lower, upper = ph.building.heavy_impact_source_limits("rubber_ball")
     nominal = 0.5 * (lower + upper)
-    check = ph.check_heavy_impact_source(nominal)
+    check = ph.building.check_heavy_impact_source(nominal)
     printed = "39,0 / 31,0 / 23,0 / 17,0 / 12,5 dB re 1 N"
     return Outcome(
         expected=f"{printed} at 31,5 to 500 Hz",
@@ -698,7 +720,7 @@ def _chk_iso16283_2_rubber_ball_spectrum() -> Outcome:
         delta=f"max |dev| {float(np.max(np.abs(check.deviation))):.3f} dB",
         passed=bool(
             check.passed
-            and np.allclose(freqs, ph.HEAVY_IMPACT_OCTAVE_BANDS)
+            and np.allclose(freqs, ph.building.HEAVY_IMPACT_OCTAVE_BANDS)
             and np.allclose(upper - lower, [2.0, 3.0, 3.0, 4.0, 4.0])
         ),
     )
@@ -712,7 +734,7 @@ def _chk_iso16283_2_rubber_ball_spectrum() -> Outcome:
 def _chk_iso16283_2_standardization_identity() -> Outcome:
     # Li,Fmax = 70 dB in a 100 m3 room at the reference T0 = 0,5 s: the Fast
     # correction term is identically zero, leaving 10 lg(100/50) = 3,0103 dB.
-    res = ph.standardized_maximum_impact_level([70.0], 100.0, 0.5)
+    res = ph.building.standardized_maximum_impact_level([70.0], 100.0, 0.5)
     return numeric(
         70.0 + 10.0 * math.log10(2.0), float(res.standardized[0]), 1e-9,
         unit="dB", places=6,
@@ -739,8 +761,8 @@ _INTERTEK_DNC = (8, 13, 15, 15, 19, 23, 24, 21, 23, 26, 26, 27, 29, 32, 34, 36)
     "Ceiling attenuation class of two accredited E1414 test reports",
 )
 def _chk_astm_e413_cac() -> Outcome:
-    ala = ph.ceiling_attenuation_class(_ALA_DNC)
-    intertek = ph.ceiling_attenuation_class(_INTERTEK_DNC)
+    ala = ph.building.ceiling_attenuation_class(_ALA_DNC)
+    intertek = ph.building.ceiling_attenuation_class(_INTERTEK_DNC)
     ok = (
         ala.rating == 34
         and intertek.rating == 25
@@ -763,7 +785,7 @@ def _chk_astm_e413_cac() -> Outcome:
     "Normalized ceiling attenuation Dn,c = D - 10 lg(A/A0), A0 = 10 m2",
 )
 def _chk_iso140_9_normalization() -> Outcome:
-    dnc = ph.normalized_ceiling_attenuation([90.0], [50.0], 5.0)
+    dnc = ph.building.normalized_ceiling_attenuation([90.0], [50.0], 5.0)
     return numeric(40.0 + 10.0 * math.log10(2.0), float(dnc[0]), 1e-9, unit="dB")
 
 
@@ -779,10 +801,10 @@ def _chk_vigran_plenum_convergence() -> Outcome:
     # attenuated form of Eq. (9.18) has to reproduce its own small-attenuation
     # limit, Eq. (9.20). That fails outright on the printed reading of the
     # receiving-side coefficient (see docs/ERRATA.md).
-    undamped = ph.plenum_flanking_reduction_index(
+    undamped = ph.building.plenum_flanking_reduction_index(
         [50.0], [100.0], ceiling_length=4.75, plenum_height=0.43
     )
-    attenuated = ph.plenum_flanking_reduction_index(
+    attenuated = ph.building.plenum_flanking_reduction_index(
         [50.0], [100.0], ceiling_length=4.75, plenum_height=0.43,
         attenuation_source=[1e-5], attenuation_receiving=[1e-5],
     )
@@ -803,9 +825,9 @@ def _chk_vigran_plenum_convergence() -> Outcome:
 def _chk_hopkins_wall_tie_resonance() -> Outcome:
     # Fig. 4.35: two 140 kg/m2 leaves, empty 75 mm cavity, then 2,5 ties/m2 of
     # s_75mm = 2e6 N/m. The caption prints fmsm = 26 Hz and fmsm = 50 Hz.
-    ties = ph.wall_tie_stiffness_per_area(2.5, 2.0e6)
-    untied = ph.mass_spring_mass_resonance(140.0, 140.0, 0.075)
-    tied = ph.mass_spring_mass_resonance(
+    ties = ph.building.wall_tie_stiffness_per_area(2.5, 2.0e6)
+    untied = ph.building.mass_spring_mass_resonance(140.0, 140.0, 0.075)
+    tied = ph.building.mass_spring_mass_resonance(
         140.0, 140.0, 0.075, tie_stiffness_per_area=ties
     )
     ok = round(untied) == 26 and round(tied) == 50
@@ -829,7 +851,7 @@ def _chk_hopkins_wall_tie_table() -> Outcome:
         "vertical_twist": (0.050, 94.0e6),
         "vertical_twist_100mm": (0.100, 43.4e6),
     }
-    computed = {name: ph.wall_tie_stiffness(name) for name in printed}
+    computed = {name: ph.building.wall_tie_stiffness(name) for name in printed}
     ok = all(
         abs(computed[n][0] - x) < 1e-12 and abs(computed[n][1] - k) < 1e-3
         for n, (x, k) in printed.items()
@@ -848,7 +870,7 @@ def _chk_hopkins_wall_tie_table() -> Outcome:
     "Transfer-stiffness level Lk = 20 lg(|k|/k0), k0 = 1 N/m  (|k| = 1 MN/m)",
 )
 def _chk_iso10846_level() -> Outcome:
-    lk = float(ph.transfer_stiffness_level(1.0e6))
+    lk = float(ph.vibration.transfer_stiffness_level(1.0e6))
     return numeric(120.0, lk, 1e-6, unit="dB")
 
 
@@ -860,7 +882,9 @@ def _chk_iso10846_level() -> Outcome:
 def _chk_iso10846_indirect() -> Outcome:
     f, m2, t = 500.0, 10.0, 0.01
     expected = -((2.0 * math.pi * f) ** 2) * m2 * t
-    computed = complex(ph.transfer_stiffness_indirect(f, t + 0j, m2)).real
+    computed = complex(
+        ph.vibration.transfer_stiffness_indirect(f, t + 0j, m2)
+    ).real
     return numeric(expected, computed, 1e-3, rel=True, unit="N/m", places=1)
 
 
@@ -873,7 +897,9 @@ def _chk_iso10846_stiffness_impedance() -> Outcome:
     f = 250.0
     w = 2.0 * math.pi * f
     k = 1.0e6 + 1j * 5.0e4
-    z = complex(ph.convert_frf(k, f, "dynamic_stiffness", "impedance"))
+    z = complex(
+        ph.vibration.convert_frf(k, f, "dynamic_stiffness", "impedance")
+    )
     return numeric(abs(k), abs(1j * w * z), 1e-6, rel=True, unit="N/m", places=1)
 
 
@@ -883,7 +909,7 @@ def _chk_iso10846_stiffness_impedance() -> Outcome:
     "Rigid-mass calibration: accelerance mag(A) = 1/m  (m=10 kg)",
 )
 def _chk_iso7626_2_rigid_mass_accelerance() -> Outcome:
-    res = ph.rigid_mass_calibration_check(
+    res = ph.vibration.rigid_mass_calibration_check(
         [ref.ISO7626_2_CAL_ACCELERANCE], [100.0], ref.ISO7626_2_CAL_MASS_KG
     )
     value = float(res.expected[0]) if res.passed else math.nan
@@ -896,7 +922,7 @@ def _chk_iso7626_2_rigid_mass_accelerance() -> Outcome:
     "Rigid-mass calibration: mobility mag(Y) = 1/(2πf·m) at 100 Hz  (m=10 kg)",
 )
 def _chk_iso7626_2_rigid_mass_mobility() -> Outcome:
-    res = ph.rigid_mass_calibration_check(
+    res = ph.vibration.rigid_mass_calibration_check(
         [ref.ISO7626_2_CAL_MOBILITY_100HZ],
         [100.0],
         ref.ISO7626_2_CAL_MASS_KG,
@@ -915,7 +941,7 @@ def _chk_iso7626_2_rigid_mass_mobility() -> Outcome:
     "Normalized random error ε = √((1−γ²)/(2nγ²)): γ²=0,8, n=75 → 4,08 % (< 5 %)",
 )
 def _chk_iso7626_2_random_error() -> Outcome:
-    eps = float(ph.random_error_percent(0.8, 75))
+    eps = float(ph.vibration.random_error_percent(0.8, 75))
     return numeric(ref.ISO7626_2_RANDOM_ERROR_PCT, eps, 0.005, unit="%", places=2)
 
 
@@ -926,8 +952,14 @@ def _chk_iso7626_2_random_error() -> Outcome:
 )
 def _chk_iso7626_decade_identity() -> Outcome:
     f = ref.ISO7626_1_DECADE_FREQ_HZ
-    y = abs(complex(ph.convert_frf(1.0, f, "apparent_mass", "mobility")))
-    h = abs(complex(ph.convert_frf(1.0, f, "apparent_mass", "receptance")))
+    y = abs(
+        complex(ph.vibration.convert_frf(1.0, f, "apparent_mass", "mobility"))
+    )
+    h = abs(
+        complex(
+            ph.vibration.convert_frf(1.0, f, "apparent_mass", "receptance")
+        )
+    )
     ok = abs(h - ref.ISO7626_1_DECADE_COMPLIANCE) <= 1e-15
     return numeric(
         ref.ISO7626_1_DECADE_MOBILITY, y if ok else math.nan, 1e-9, rel=True,
@@ -941,7 +973,7 @@ def _chk_iso7626_decade_identity() -> Outcome:
     "Indirect-method validity limit mag(T) = 0,1 ↔ ΔL1,2 = 20 dB",
 )
 def _chk_iso10846_3_validity_threshold() -> Outcome:
-    delta_l = 20.0 * math.log10(1.0 / ph.TRANSMISSIBILITY_LIMIT)
+    delta_l = 20.0 * math.log10(1.0 / ph.vibration.TRANSMISSIBILITY_LIMIT)
     return numeric(
         ref.ISO10846_3_LIMIT_DELTA_L_DB, delta_l, 1e-9, unit="dB", places=1
     )
@@ -956,8 +988,8 @@ def _chk_iso10846_3_validity_bias() -> Outcome:
     # Undamped mass-spring model at omega^2 m = 11 k, i.e. T = -0,1 exactly.
     k, m = 1.0e6, 1.0
     f = math.sqrt(11.0 * k / m) / (2.0 * math.pi)
-    t = complex(ph.base_transmissibility(f, m, k))
-    k_ind = abs(complex(ph.transfer_stiffness_indirect(f, t, m)))
+    t = complex(ph.vibration.base_transmissibility(f, m, k))
+    k_ind = abs(complex(ph.vibration.transfer_stiffness_indirect(f, t, m)))
     ratio = k_ind / k
     bias_ok = (
         20.0 * math.log10(ratio) <= ref.ISO10846_3_ACCURACY_DB
@@ -975,7 +1007,7 @@ def _chk_iso10846_3_validity_bias() -> Outcome:
     "Delivered/blocking force F2/F2,b = 1/1,1 at mag(k2,2/kt) = 0,1 (within 10 %)",
 )
 def _chk_iso10846_1_blocking_force() -> Outcome:
-    value = abs(complex(ph.blocking_force_ratio(1.0e5, 1.0e6)))
+    value = abs(complex(ph.vibration.blocking_force_ratio(1.0e5, 1.0e6)))
     return numeric(ref.ISO10846_1_EQ6_FORCE_RATIO, value, 1e-9, places=4)
 
 
@@ -987,8 +1019,16 @@ def _chk_iso10846_1_blocking_force() -> Outcome:
 def _chk_iso10846_linearity() -> Outcome:
     k, u_a = 1.0e6 + 3.0e4j, 1.0e-6 + 0j
     u_b = u_a * 10.0 ** (-ref.ISO10846_LINEARITY_STEP_DB / 20.0)
-    lk_a = float(ph.transfer_stiffness_level(ph.transfer_stiffness_direct(k * u_a, u_a)))
-    lk_b = float(ph.transfer_stiffness_level(ph.transfer_stiffness_direct(k * u_b, u_b)))
+    lk_a = float(
+        ph.vibration.transfer_stiffness_level(
+            ph.vibration.transfer_stiffness_direct(k * u_a, u_a)
+        )
+    )
+    lk_b = float(
+        ph.vibration.transfer_stiffness_level(
+            ph.vibration.transfer_stiffness_direct(k * u_b, u_b)
+        )
+    )
     return numeric(
         0.0, abs(lk_a - lk_b), ref.ISO10846_LINEARITY_TOL_DB, unit="dB", places=3,
         expected_label="ΔLk ≤ 1,5 dB (7.6 c)",
@@ -1002,7 +1042,7 @@ def _chk_iso10846_linearity() -> Outcome:
     "Calibration L_v from â = 9,81 m/s² at 100 Hz  (standard's EXAMPLE)",
 )
 def _chk_iso7849_calibration() -> Outcome:
-    lv = float(ph.velocity_level_from_acceleration(9.81, 100.0))
+    lv = float(ph.emission.velocity_level_from_acceleration(9.81, 100.0))
     return numeric(106.9, lv, 0.05, unit="dB", places=1)
 
 
@@ -1013,9 +1053,11 @@ def _chk_iso7849_calibration() -> Outcome:
 )
 def _chk_iso7849_power_round_trip() -> Outcome:
     p, s, v2 = 3.0e-4, 2.0, (1.0e-3) ** 2
-    eps = float(ph.radiation_factor(p, s, v2))
-    lv = float(ph.velocity_level(math.sqrt(v2)))
-    lw = float(ph.radiated_sound_power_level(lv, s, radiation_factor=eps))
+    eps = float(ph.emission.radiation_factor(p, s, v2))
+    lv = float(ph.emission.velocity_level(math.sqrt(v2)))
+    lw = float(
+        ph.emission.radiated_sound_power_level(lv, s, radiation_factor=eps)
+    )
     return numeric(10.0 * math.log10(p / 1e-12), lw, 1e-6, unit="dB", places=3)
 
 
@@ -1025,7 +1067,7 @@ def _chk_iso7849_power_round_trip() -> Outcome:
     "Impedance term: L_W − L_v = 10 lg(411/400) at ε = 1, S = S0",
 )
 def _chk_iso7849_impedance_term() -> Outcome:
-    lw = float(ph.radiated_sound_power_level(80.0, 1.0))
+    lw = float(ph.emission.radiated_sound_power_level(80.0, 1.0))
     return numeric(10.0 * math.log10(411.0 / 400.0), lw - 80.0, 1e-9, unit="dB")
 
 
@@ -1037,7 +1079,7 @@ def _chk_iso7849_impedance_term() -> Outcome:
 )
 def _chk_en15657_power_balance() -> Outcome:
     lv, f, m, s, eta = 82.0, 800.0, 15.0, 1.5, 0.02
-    lw = float(ph.structure_borne_power_level(lv, f, m, s, eta))
+    lw = float(ph.building.structure_borne_power_level(lv, f, m, s, eta))
     v2 = (1e-9) ** 2 * 10.0 ** (0.1 * lv)
     p = 2.0 * math.pi * f * eta * (m * s) * v2
     return numeric(10.0 * math.log10(p / 1e-12), lw, 1e-6, unit="dB", places=3)
@@ -1049,7 +1091,7 @@ def _chk_en15657_power_balance() -> Outcome:
     "Plate loss factor η = 2,2/(f·Ts) at 1 kHz, Ts = 0,3 s",
 )
 def _chk_en15657_loss_factor() -> Outcome:
-    eta = float(ph.plate_loss_factor([1000.0], 0.3)[0])
+    eta = float(ph.building.plate_loss_factor([1000.0], 0.3)[0])
     return numeric(2.2 / (1000.0 * 0.3), eta, 1e-9)
 
 
@@ -1063,12 +1105,12 @@ def _chk_en15657_conversion_chain() -> Outcome:
     # characteristic reception-plate level (17, Y_R,inf,low = 5e-6) ->
     # Annex I mobility correction to the wall (Y_wall = 24,1e-6). The printed
     # Table I.8 row is the oracle (one-decimal intermediates, +/-0,15 dB).
-    lwsn = ph.characteristic_reception_plate_power(
-        ph.equivalent_blocked_force_level(
+    lwsn = ph.building.characteristic_reception_plate_power(
+        ph.building.equivalent_blocked_force_level(
             ref.EN12354_5_I8_WALL_LWS, ref.EN12354_5_I8_PLATE_MOBILITY
         )
     )
-    installed = ph.installed_power_from_reception_plate(
+    installed = ph.building.installed_power_from_reception_plate(
         lwsn, ref.EN12354_5_I8_Y_WALL
     )
     worst = float(np.max(np.abs(
@@ -1084,7 +1126,9 @@ def _chk_en15657_conversion_chain() -> Outcome:
     "Mean free velocity level (energy mean, v0 = 5e-8 m/s)",
 )
 def _chk_iso9611_mean_velocity() -> Outcome:
-    computed = float(ph.mean_free_velocity_level(ref.ISO9611_MEAN_LEVELS))
+    computed = float(
+        ph.building.mean_free_velocity_level(ref.ISO9611_MEAN_LEVELS)
+    )
     return numeric(ref.ISO9611_MEAN_EXPECTED, computed, 1e-9, unit="dB", places=4)
 
 
@@ -1094,8 +1138,11 @@ def _iso12354_detailed_situ() -> tuple[Any, dict[str, Any], np.ndarray]:
     import iso12354_building as bld
 
     bands = np.asarray(ref.ISO12354_ANNEX_L_BANDS, dtype=np.float64)
-    situ = {k: ph.in_situ_element(e, bands) for k, e in bld.elements().items()}
-    delta = ph.floating_floor_improvement(
+    situ = {
+        k: ph.building.in_situ_element(e, bands)
+        for k, e in bld.elements().items()
+    }
+    delta = ph.building.floating_floor_improvement(
         bands, resonance_frequency=bld.floating_floor_resonance()
     )
     return bands, situ, delta
@@ -1144,9 +1191,9 @@ def _chk_iso12354_annex_l1() -> Outcome:
     import iso12354_building as bld
 
     bands, situ, delta = _iso12354_detailed_situ()
-    result = ph.detailed_airborne_prediction(
+    result = ph.building.detailed_airborne_prediction(
         bands,
-        direct_index=ph.direct_reduction_index(
+        direct_index=ph.building.direct_reduction_index(
             situ["floor"].sound_reduction_index, delta_r_source=delta),
         flanking_paths=bld.airborne_paths(situ, delta),
     )
@@ -1177,9 +1224,11 @@ def _chk_iso12354_annex_g1() -> Outcome:
     import iso12354_building as bld
 
     bands, situ, delta = _iso12354_detailed_situ()
-    result = ph.detailed_impact_prediction(
+    result = ph.building.detailed_impact_prediction(
         bands,
-        direct_level=ph.direct_impact_level(situ["floor"].impact_level, delta_l=delta),
+        direct_level=ph.building.direct_impact_level(
+            situ["floor"].impact_level, delta_l=delta
+        ),
         flanking_paths=bld.impact_paths(situ, delta),
     )
     worst = float(np.max(np.abs(
@@ -1220,10 +1269,12 @@ def _hopkins_plate(
 ) -> tuple[float, float]:
     """``(contact stiffness, driving-point impedance)`` of a Hopkins Table A2 plate."""
     modulus = density * longitudinal**2 * (1.0 - poisson**2)
-    stiffness = float(ph.plate_contact_stiffness(modulus, poisson_ratio=poisson))
+    stiffness = float(
+        ph.building.plate_contact_stiffness(modulus, poisson_ratio=poisson)
+    )
     impedance = float(
-        ph.infinite_plate_impedance(
-            ph.plate_bending_stiffness(modulus, thickness, poisson),
+        ph.vibration.infinite_plate_impedance(
+            ph.vibration.plate_bending_stiffness(modulus, thickness, poisson),
             density * thickness,
         )
     )
@@ -1238,18 +1289,20 @@ def _hopkins_plate(
 )
 def _chk_hopkins_tapping_cut_off() -> Outcome:
     _stiffness, impedance = _hopkins_plate(2200.0, 3800.0, 0.2, 0.14)
-    worst = abs(float(ph.hammer_impact_velocity()) / 0.886 - 1.0)
+    worst = abs(float(ph.building.hammer_impact_velocity()) / 0.886 - 1.0)
     printed = ((None, 7000.0), (1.5e11, 2300.0), (2.8e8, 100.0))
     for modulus_over_thickness, expected in printed:
         if modulus_over_thickness is None:
             stiffness = _stiffness
         else:
             stiffness = float(
-                ph.covering_contact_stiffness(
+                ph.building.covering_contact_stiffness(
                     modulus_over_thickness * 0.005, 0.005
                 )
             )
-        computed = float(ph.tapping_cut_off_frequency(stiffness, impedance))
+        computed = float(
+            ph.building.tapping_cut_off_frequency(stiffness, impedance)
+        )
         worst = max(worst, abs(computed / expected - 1.0))
     return numeric(0.0, worst, 0.02, rel=False, places=4)
 
@@ -1270,10 +1323,12 @@ def _chk_hopkins_resilient_layers() -> Outcome:
     cases_ok = True
     for _label, rho, c_l, nu, thickness, over in plates:
         stiffness, impedance = _hopkins_plate(rho, c_l, nu, thickness)
-        result = ph.tapping_force_spectrum([100.0], stiffness, impedance)
+        result = ph.building.tapping_force_spectrum(
+            [100.0], stiffness, impedance
+        )
         cases_ok = cases_ok and result.over_critical is over
     mass_per_area = 710.0 * 0.018
-    lower, upper = ph.double_floating_floor_resonances(
+    lower, upper = ph.building.double_floating_floor_resonances(
         7.25e6, mass_per_area, 7.25e6, mass_per_area
     )
     worst = max(abs(lower / 74.0 - 1.0), abs(upper / 195.0 - 1.0))
@@ -1296,8 +1351,8 @@ def _chk_iso12354_2_floating_floor() -> Outcome:
     bands = np.asarray(ref.ISO12354_ANNEX_L_BANDS, dtype=np.float64)
     stiffness = ref.ISO12354_ANNEX_L_FLOATING_STIFFNESS * 1e6
     mass = ref.ISO12354_ANNEX_L_FLOATING_MASS
-    f0 = float(ph.floating_floor_resonance_frequency(stiffness, mass))
-    spectrum = ph.floating_floor_improvement_spectrum(
+    f0 = float(ph.building.floating_floor_resonance_frequency(stiffness, mass))
+    spectrum = ph.building.floating_floor_improvement_spectrum(
         bands, resonance_frequency=f0
     )
     printed = np.asarray(ref.ISO12354_ANNEX_G4_DELTA_L)
@@ -1308,7 +1363,9 @@ def _chk_iso12354_2_floating_floor() -> Outcome:
     # stops the row passing on a near-miss inside the rounding quantum.
     if not np.array_equal(np.round(spectrum.improvement, 1), printed):
         worst = float("inf")
-    delta_lw = float(ph.weighted_floating_floor_improvement(mass, stiffness))
+    delta_lw = float(
+        ph.building.weighted_floating_floor_improvement(mass, stiffness)
+    )
     worst = max(worst, abs(delta_lw - ref.ISO12354_ANNEX_G10_DELTA_LW))
     # The resonance frequency is in hertz, so it is verified separately rather
     # than folded into the decibel residual reported below.
@@ -1323,16 +1380,20 @@ def _chk_iso12354_2_floating_floor() -> Outcome:
     "Lining resonance (Formula D.1) 542 Hz and the Table D.1 improvement branches",
 )
 def _chk_iso12354_1_annex_d() -> Outcome:
-    f0 = float(ph.lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6))
+    f0 = float(
+        ph.building.lining_resonance_frequency(
+            51.0, 6.3, dynamic_stiffness=65e6
+        )
+    )
     worst = abs(f0 / 542.0 - 1.0)
     table_ok = all(
-        ph.weighted_lining_improvement(resonance, 45.0) == expected
+        ph.building.weighted_lining_improvement(resonance, 45.0) == expected
         for resonance, expected in (
             (200.0, -1.0), (250.0, -3.0), (315.0, -5.0), (400.0, -7.0),
             (500.0, -9.0), (1000.0, -10.0), (2000.0, -5.0),
         )
     )
-    branch = float(ph.weighted_lining_improvement(100.0, 40.0))
+    branch = float(ph.building.weighted_lining_improvement(100.0, 40.0))
     table_ok = table_ok and abs(branch - (74.4 - 40.0 - 20.0)) <= 1e-9
     return Outcome(
         expected="fo = 542 Hz (+/-1%); 8/8 Table D.1 rows",
@@ -1350,8 +1411,8 @@ def _chk_iso12354_1_annex_d() -> Outcome:
 )
 def _chk_en12354_5_coupling_limit() -> Outcome:
     ys, yi = 1e-3 + 0j, 1e-7 + 0j
-    dc = float(ph.coupling_term(ys, yi))
-    limit = float(ph.coupling_term_force_source(ys, yi))
+    dc = float(ph.building.coupling_term(ys, yi))
+    limit = float(ph.building.coupling_term_force_source(ys, yi))
     return numeric(limit, dc, 1e-2, unit="dB", places=3)
 
 
@@ -1366,10 +1427,10 @@ def _chk_en12354_5_annex_i9() -> Outcome:
     # catch a mistranscribed constant): both power components through
     # D_C (Table I.9), Formula (18a) per path and the energetic total.
     tol = ref.EN12354_5_ANNEX_I_TOL
-    inst_wall = ph.installed_structure_borne_power_level(
+    inst_wall = ph.building.installed_structure_borne_power_level(
         ref.EN12354_5_I8_WALL_LWSC, ref.EN12354_5_I9_DC_WALL
     )
-    inst_floor = ph.installed_structure_borne_power_level(
+    inst_floor = ph.building.installed_structure_borne_power_level(
         ref.EN12354_5_I8_FLOOR_LWSC, ref.EN12354_5_I9_DC_FLOOR
     )
     paths = [
@@ -1385,10 +1446,12 @@ def _chk_en12354_5_annex_i9() -> Outcome:
     worst = 0.0
     rows = []
     for inst, dsa, rij, s_i, expected in paths:
-        lns = ph.structure_borne_pressure_level_path(inst, dsa, rij, s_i)
+        lns = ph.building.structure_borne_pressure_level_path(
+            inst, dsa, rij, s_i
+        )
         worst = max(worst, float(np.max(np.abs(lns - np.asarray(expected)))))
         rows.append(np.asarray(lns))
-    total = ph.total_structure_borne_pressure_level(np.vstack(rows))
+    total = ph.building.total_structure_borne_pressure_level(np.vstack(rows))
     worst = max(worst, float(np.max(np.abs(
         total - np.asarray(ref.EN12354_5_I9_LNS_TOTAL)
     ))))
@@ -1411,13 +1474,13 @@ def _chk_en12354_5_annex_i9() -> Outcome:
 )
 def _chk_en12354_5_annex_i6a() -> Outcome:
     tol = ref.EN12354_5_ANNEX_I_TOL
-    inst = ph.installed_power_from_reception_plate(
+    inst = ph.building.installed_power_from_reception_plate(
         ref.EN12354_5_I6A_LWSN_FLOOR, ref.EN12354_5_I6A_Y_FLOOR
     )
     dev_inst = float(np.max(np.abs(
         np.asarray(inst) - np.asarray(ref.EN12354_5_I6A_LWSN_INST_FLOOR)
     )))
-    lns = ph.structure_borne_pressure_level_path(
+    lns = ph.building.structure_borne_pressure_level_path(
         inst, ref.EN12354_5_I6A_DSA_FLOOR, ref.EN12354_5_I6A_R11, 10.0
     )
     dev_path = float(np.max(np.abs(

--- a/scripts/conformance/domains/building_prediction.py
+++ b/scripts/conformance/domains/building_prediction.py
@@ -23,12 +23,12 @@ import phonometry as ph
 from ..registry import Outcome, numeric, register
 
 
-def _annex_h3_paths() -> list[ph.FlankingPath]:
+def _annex_h3_paths() -> list[ph.building.FlankingPath]:
     """The EN 12354-1 Annex H.3 flanking paths from the shared input table."""
     ss = ref.EN12354_1_ANNEX_H3_SEPARATING_AREA
-    paths: list[ph.FlankingPath] = []
+    paths: list[ph.building.FlankingPath] = []
     for label, rw, kff, kfd, lf in ref.EN12354_1_ANNEX_H3_ELEMENTS:
-        ff, df, fd = ph.flanking_element(
+        ff, df, fd = ph.building.flanking_element(
             label=label, r_flanking=rw, r_separating=ref.EN12354_1_ANNEX_H3_R_DIRECT,
             k_ff=kff, k_fd=kfd, k_df=kfd, separating_area=ss, coupling_length=lf,
         )
@@ -42,7 +42,7 @@ def _annex_h3_paths() -> list[ph.FlankingPath]:
     "Airborne prediction R'w (direct + 12 flanking paths)",
 )
 def _chk_en12354_1_airborne() -> Outcome:
-    res = ph.predicted_airborne_insulation(
+    res = ph.building.predicted_airborne_insulation(
         r_direct=ref.EN12354_1_ANNEX_H3_R_DIRECT, flanking_paths=_annex_h3_paths()
     )
     expected = ref.EN12354_1_ANNEX_H3_RPRIME_W
@@ -62,7 +62,7 @@ def _chk_en12354_1_airborne() -> Outcome:
     "All 12 printed flanking-path values Rij,w",
 )
 def _chk_en12354_1_h3_paths() -> Outcome:
-    res = ph.predicted_airborne_insulation(
+    res = ph.building.predicted_airborne_insulation(
         r_direct=ref.EN12354_1_ANNEX_H3_R_DIRECT, flanking_paths=_annex_h3_paths()
     )
     by_label = {p.label: p.r_w for p in res.paths}
@@ -82,8 +82,8 @@ def _chk_en12354_1_h3_paths() -> Outcome:
 def _chk_en12354_1_dnt_closure() -> Outcome:
     v = ref.EN12354_1_ANNEX_H3_VOLUME
     ss = ref.EN12354_1_ANNEX_H3_SEPARATING_AREA
-    first = float(ph.standardized_level_difference(52.2, v, ss))
-    second = float(ph.standardized_level_difference(52.7, v, ss))
+    first = float(ph.building.standardized_level_difference(52.2, v, ss))
+    second = float(ph.building.standardized_level_difference(52.7, v, ss))
     ok = (
         round(first) == ref.EN12354_1_ANNEX_H3_DNT_W
         and round(second) == ref.EN12354_1_ANNEX_H3_DNT_W_SECOND
@@ -105,11 +105,11 @@ def _chk_en12354_1_dnt_closure() -> Outcome:
     "Impact prediction L'n,w = Ln,w,eq - dLw + K",
 )
 def _chk_en12354_2_impact() -> Outcome:
-    ln_eq = ph.equivalent_impact_level(ref.EN12354_2_ANNEX_E3_MASS)
-    k = ph.impact_flanking_correction(
+    ln_eq = ph.building.equivalent_impact_level(ref.EN12354_2_ANNEX_E3_MASS)
+    k = ph.building.impact_flanking_correction(
         ref.EN12354_2_ANNEX_E3_MASS, ref.EN12354_2_ANNEX_E3_FLANKING_MEAN_MASS
     )
-    res = ph.predicted_impact_insulation(
+    res = ph.building.predicted_impact_insulation(
         ln_w_eq=round(ln_eq), delta_l_w=ref.EN12354_2_ANNEX_E3_DELTA_LW,
         k_correction=k,
     )
@@ -129,7 +129,7 @@ def _chk_en12354_2_impact() -> Outcome:
 def _chk_en12354_2_standardized() -> Outcome:
     # Exact Formula (3): 45 - 10 lg(0,032 x 50) = 42,96 dB. The E.3 chain's own
     # "10 lg(V/30)" rounding gives 42,8 dB; both round to 43 dB.
-    lnt = float(ph.standardized_impact_level(45.0, 50.0))
+    lnt = float(ph.building.standardized_impact_level(45.0, 50.0))
     ok = round(lnt) == 43 and abs(lnt - 42.96) <= 0.01
     return Outcome(
         expected="L'nT,w 43 dB (exact 42,96; E.3 prints 42,8)",
@@ -139,14 +139,18 @@ def _chk_en12354_2_standardized() -> Outcome:
     )
 
 
-def _en12354_3_annex_f() -> ph.FacadePredictionResult:
+def _en12354_3_annex_f() -> ph.building.FacadePredictionResult:
     """The EN 12354-3 Annex F facade prediction from the shared input table."""
     elements = [
-        ph.FacadeElement(name=name, area=area, r=r)
+        ph.building.FacadeElement(name=name, area=area, r=r)
         for name, area, r in ref.EN12354_3_ANNEX_F_ELEMENTS
     ]
-    elements.append(ph.FacadeElement(name="inlet", dn_e=ref.EN12354_3_ANNEX_F_INLET_DNE))
-    return ph.facade_sound_reduction(
+    elements.append(
+        ph.building.FacadeElement(
+            name="inlet", dn_e=ref.EN12354_3_ANNEX_F_INLET_DNE
+        )
+    )
+    return ph.building.facade_sound_reduction(
         elements,
         area=ref.EN12354_3_ANNEX_F_AREA,
         volume=ref.EN12354_3_ANNEX_F_VOLUME,
@@ -188,14 +192,14 @@ def _chk_en12354_3_facade() -> Outcome:
     "Radiated LW of a wall+door segment (side 1, low bands)",
 )
 def _chk_en12354_4_radiated() -> Outcome:
-    res = ph.radiated_sound_power(
+    res = ph.building.radiated_sound_power(
         [
-            ph.FacadeElement(
+            ph.building.FacadeElement(
                 name="wall",
                 area=ref.EN12354_4_ANNEX_G_SEGMENT_AREA - ref.EN12354_4_ANNEX_G_DOOR_AREA,
                 r=ref.EN12354_4_ANNEX_G_CONCRETE_R,
             ),
-            ph.FacadeElement(
+            ph.building.FacadeElement(
                 name="door", area=ref.EN12354_4_ANNEX_G_DOOR_AREA,
                 r=ref.EN12354_4_ANNEX_G_DOOR_R,
             ),
@@ -240,8 +244,8 @@ def _chk_en12354_4_propagation() -> Outcome:
     worst = 0.0
     computed_lp = []
     for w, h, d, a_tot, lwa, lp_expected in cells:
-        att = float(ph.outdoor_attenuation(w, h, d))
-        lp = float(ph.outdoor_level(lwa, att))
+        att = float(ph.building.outdoor_attenuation(w, h, d))
+        lp = float(ph.building.outdoor_level(lwa, att))
         worst = max(worst, abs(att - a_tot), abs(lp - lp_expected))
         computed_lp.append(lp)
     return Outcome(
@@ -258,7 +262,7 @@ def _chk_en12354_4_propagation() -> Outcome:
     "Airborne band uncertainty, situation A @ 1 kHz",
 )
 def _chk_iso12999_table2_band() -> Outcome:
-    res = ph.band_uncertainty("airborne", "A")
+    res = ph.building.band_uncertainty("airborne", "A")
     idx = list(res.frequencies).index(1000)
     computed = float(res.uncertainties[idx])
     return numeric(
@@ -272,7 +276,7 @@ def _chk_iso12999_table2_band() -> Outcome:
     "One-decimal single numbers Rw / Rw+C50-5000 / Rw+Ctr,50-5000",
 )
 def _chk_iso12999_annex_b_values() -> Outcome:
-    res = ph.weighted_rating_extended(
+    res = ph.building.weighted_rating_extended(
         ref.ISO12999_1_ANNEX_B_RI, ref.ISO12999_1_ANNEX_B_FREQ,
         one_decimal=True,
     )
@@ -309,16 +313,16 @@ def _chk_iso12999_annex_b_uncertainties() -> Outcome:
 
     ri = np.asarray(ref.ISO12999_1_ANNEX_B_RI, dtype=float)
     ui = np.asarray(ref.ISO12999_1_ANNEX_B_UI, dtype=float)
-    u_c = float(ph.single_number_uncertainty_uncorrelated(
+    u_c = float(ph.building.single_number_uncertainty_uncorrelated(
         ui, np.asarray(_SPECTRUM1_50_5000, dtype=float) - ri
     ))
-    u_ctr = float(ph.single_number_uncertainty_uncorrelated(
+    u_ctr = float(ph.building.single_number_uncertainty_uncorrelated(
         ui, np.asarray(_SPECTRUM2_50_5000, dtype=float) - ri
     ))
-    up = ph.weighted_rating_extended(
+    up = ph.building.weighted_rating_extended(
         ri + ui, ref.ISO12999_1_ANNEX_B_FREQ, one_decimal=True
     ).rating
-    down = ph.weighted_rating_extended(
+    down = ph.building.weighted_rating_extended(
         ri - ui, ref.ISO12999_1_ANNEX_B_FREQ, one_decimal=True
     ).rating
     u_rw = (float(up) - float(down)) / 2.0
@@ -347,7 +351,9 @@ def _chk_iso12999_annex_b_uncertainties() -> Outcome:
 def _chk_iso12999_expanded() -> Outcome:
     u = ref.ISO12999_1_RW_A_STANDARD_UNCERTAINTY
     expected = ref.ISO12999_1_COVERAGE_K_95 * u
-    computed = float(ph.insulation_expanded_uncertainty(u, coverage=0.95))
+    computed = float(
+        ph.building.insulation_expanded_uncertainty(u, coverage=0.95)
+    )
     return numeric(expected, computed, 1e-9, unit="dB", places=6)
 
 
@@ -357,7 +363,7 @@ def _chk_iso12999_expanded() -> Outcome:
     "Absorption coefficient +/-U (k=2), reproducibility, 20 x 1/3-oct bands",
 )
 def _chk_iso12999_2_table4() -> Outcome:
-    res = ph.sound_absorption_coefficient_uncertainty(
+    res = ph.materials.sound_absorption_coefficient_uncertainty(
         ref.ISO12999_2_TABLE4_ALPHA_S, ref.ISO12999_2_TABLE4_FREQ, confidence=0.95
     )
     got = res.reported_expanded_uncertainty
@@ -377,7 +383,7 @@ def _chk_iso12999_2_table4() -> Outcome:
     "Practical coefficient +/-U (k=2), reproducibility, 5 octave bands",
 )
 def _chk_iso12999_2_table5() -> Outcome:
-    res = ph.practical_coefficient_uncertainty(
+    res = ph.materials.practical_coefficient_uncertainty(
         ref.ISO12999_2_TABLE5_ALPHA_P, ref.ISO12999_2_TABLE5_FREQ
     )
     got = res.reported_expanded_uncertainty
@@ -398,12 +404,12 @@ def _chk_iso12999_2_table5() -> Outcome:
 )
 def _chk_iso12999_2_single_numbers() -> Outcome:
     u_aw = float(
-        ph.weighted_coefficient_uncertainty(
+        ph.materials.weighted_coefficient_uncertainty(
             ref.ISO12999_2_ALPHA_W_EXAMPLE
         ).reported_expanded_uncertainty[0]
     )
     u_dl = float(
-        ph.single_number_rating_uncertainty(
+        ph.materials.single_number_rating_uncertainty(
             ref.ISO12999_2_DLALPHA_EXAMPLE
         ).reported_expanded_uncertainty[0]
     )

--- a/scripts/conformance/domains/cnossos_rail.py
+++ b/scripts/conformance/domains/cnossos_rail.py
@@ -42,7 +42,7 @@ def _cnossos_rail_case(case: dict[str, str]) -> Any:
     lam = [float(w) for w in ref.CNOSSOS_RAIL_2015_WAVELENGTHS]
     idling = case["condition"] == "idling"
     traction = "traction_idling" if idling else "traction_constant"
-    stock = ph.RollingStock(
+    stock = ph.environment.RollingStock(
         axles=int(vehicle["axles"]),
         wheel_roughness=(lam, wavelength[("wheel_roughness", vehicle["wheel_roughness"])]),
         contact_filter=(lam, wavelength[("contact_filter", vehicle["contact_filter"])]),
@@ -56,7 +56,7 @@ def _cnossos_rail_case(case: dict[str, str]) -> Any:
                      frequency[("aerodynamic", vehicle["aerodynamic"], "B")]),
         aerodynamic_alpha=float(case["aero_alpha"]),
     )
-    track = ph.RailwayTrack(
+    track = ph.environment.RailwayTrack(
         rail_roughness=(lam, wavelength[("rail_roughness", case["rail_roughness"])]),
         track_transfer=frequency[("track_transfer", case["track_transfer"], "")],
         impact_roughness=(
@@ -66,17 +66,17 @@ def _cnossos_rail_case(case: dict[str, str]) -> Any:
         joint_density=float(case["joint_density_per_m"]),
         squeal_excess=float(case["squeal_excess_db"]) + float(case["bridge_constant_db"]),
     )
-    return ph.railway_source_power(
-        ph.RailwayVehicle(
+    return ph.environment.railway_source_power(
+        ph.environment.RailwayVehicle(
             stock=stock, flow_rate=float(case["flow_veh_per_h"]),
             speed=float(case["speed_kmh"]),
-            condition=(ph.RunningCondition.IDLING if idling
-                       else ph.RunningCondition.CONSTANT),
+            condition=(ph.environment.RunningCondition.IDLING if idling
+                       else ph.environment.RunningCondition.CONSTANT),
             idling_time=float(case["idling_time_h"]),
         ),
         track, psi=float(case["psi_deg"]), phi=float(case["phi_deg"]),
         reference_time=12.0, minimum_speed=0.0,
-        directivity_edition=ph.DirectivityEdition.ORIGINAL_2015,
+        directivity_edition=ph.environment.DirectivityEdition.ORIGINAL_2015,
     )
 
 
@@ -108,10 +108,10 @@ def _chk_cnossos_rail_roughness_tables() -> Outcome:
     for brake, expected in (("c", ref.CNOSSOS_RAIL_G1A_CAST_IRON),
                             ("k", ref.CNOSSOS_RAIL_G1A_COMPOSITE),
                             ("n", ref.CNOSSOS_RAIL_G1A_NON_TREAD)):
-        _, levels = ph.wheel_roughness(brake)
+        _, levels = ph.environment.wheel_roughness(brake)
         bad += sum(1 for a, b in zip(levels, expected) if a != b)
     for cls, expected in (("E", ref.CNOSSOS_RAIL_G1B_E), ("M", ref.CNOSSOS_RAIL_G1B_M)):
-        _, levels = ph.rail_roughness(cls)
+        _, levels = ph.environment.rail_roughness(cls)
         bad += sum(1 for a, b in zip(levels, expected) if a != b)
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
                    expected_label="166 coefficients identical")
@@ -125,7 +125,7 @@ def _chk_cnossos_rail_roughness_tables() -> Outcome:
 def _chk_cnossos_rail_table_g2() -> Outcome:
     bad = 0
     for key, expected in ref.CNOSSOS_RAIL_G2.items():
-        _, levels = ph.contact_filter(key)
+        _, levels = ph.environment.contact_filter(key)
         bad += sum(1 for a, b in zip(levels, expected) if a != b)
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
                    expected_label="175 coefficients identical")
@@ -139,11 +139,24 @@ def _chk_cnossos_rail_table_g2() -> Outcome:
 def _chk_cnossos_rail_table_g3() -> Outcome:
     bad = 0
     for key, expected in ref.CNOSSOS_RAIL_G3A.items():
-        bad += sum(1 for a, b in zip(ph.track_transfer(key), expected) if a != b)
+        bad += sum(
+            1
+            for a, b in zip(ph.environment.track_transfer(key), expected)
+            if a != b
+        )
     for diameter, expected in ref.CNOSSOS_RAIL_G3B.items():
-        bad += sum(1 for a, b in zip(ph.wheel_transfer(diameter), expected) if a != b)
-    bad += sum(1 for a, b in zip(ph.superstructure_transfer(), ref.CNOSSOS_RAIL_G3C)
-               if a != b)
+        bad += sum(
+            1
+            for a, b in zip(ph.environment.wheel_transfer(diameter), expected)
+            if a != b
+        )
+    bad += sum(
+        1
+        for a, b in zip(
+            ph.environment.superstructure_transfer(), ref.CNOSSOS_RAIL_G3C
+        )
+        if a != b
+    )
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
                    expected_label="312 coefficients identical")
 
@@ -155,17 +168,21 @@ def _chk_cnossos_rail_table_g3() -> Outcome:
 )
 def _chk_cnossos_rail_source_tables() -> Outcome:
     bad = 0
-    _, impact = ph.impact_roughness_single()
+    _, impact = ph.environment.impact_roughness_single()
     bad += sum(1 for a, b in zip(impact, ref.CNOSSOS_RAIL_G4) if a != b)
     for key, (low, high) in ref.CNOSSOS_RAIL_G5.items():
-        got_low, got_high = ph.traction_sound_power(key)
+        got_low, got_high = ph.environment.traction_sound_power(key)
         bad += sum(1 for a, b in zip(got_low, low) if a != b)
         bad += sum(1 for a, b in zip(got_high, high) if a != b)
-    got_low, got_high = ph.aerodynamic_sound_power()
+    got_low, got_high = ph.environment.aerodynamic_sound_power()
     bad += sum(1 for a, b in zip(got_low, ref.CNOSSOS_RAIL_G6_A) if a != b)
     bad += sum(1 for a, b in zip(got_high, ref.CNOSSOS_RAIL_G6_B) if a != b)
     for key, expected in ref.CNOSSOS_RAIL_G7.items():
-        bad += sum(1 for a, b in zip(ph.bridge_transfer(key), expected) if a != b)
+        bad += sum(
+            1
+            for a, b in zip(ph.environment.bridge_transfer(key), expected)
+            if a != b
+        )
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
                    expected_label="371 coefficients identical")
 
@@ -176,7 +193,7 @@ def _chk_cnossos_rail_source_tables() -> Outcome:
     "Horizontal dipole directivity along the track: 10 lg(0,01) at phi = 0",
 )
 def _chk_cnossos_rail_horizontal_directivity() -> Outcome:
-    got = float(ph.horizontal_directivity(0.0)[0])
+    got = float(ph.environment.horizontal_directivity(0.0)[0])
     return numeric(10.0 * math.log10(0.01), got, 1e-12, unit="dB")
 
 
@@ -186,7 +203,7 @@ def _chk_cnossos_rail_horizontal_directivity() -> Outcome:
     "Aerodynamic speed law at v0 = 300 km/h reduces to Table G-6 verbatim",
 )
 def _chk_cnossos_rail_aerodynamic_law() -> Outcome:
-    low, high = ph.aerodynamic_sound_power(600.0)
+    low, high = ph.environment.aerodynamic_sound_power(600.0)
     step = ref.CNOSSOS_RAIL_G6_ALPHA * math.log10(2.0)
     worst = max(
         max(abs(float(a) - b - step) for a, b in zip(low, ref.CNOSSOS_RAIL_G6_A)),
@@ -202,9 +219,9 @@ def _chk_cnossos_rail_aerodynamic_law() -> Outcome:
     "Impact roughness at the tabulated joint density n_l = 0,01 per m",
 )
 def _chk_cnossos_rail_joint_density() -> Outcome:
-    _, single = ph.impact_roughness_single()
+    _, single = ph.environment.impact_roughness_single()
     frequency_grid = np.asarray(single[:24])
-    got = ph.impact_roughness(frequency_grid, 0.01)
+    got = ph.environment.impact_roughness(frequency_grid, 0.01)
     worst = float(np.max(np.abs(got - frequency_grid)))
     return numeric(0.0, worst, 1e-12, unit="dB", places=6,
                    expected_label="Table G-4 verbatim")

--- a/scripts/conformance/domains/distortion.py
+++ b/scripts/conformance/domains/distortion.py
@@ -55,7 +55,9 @@ def _electro_harmonic_signal() -> np.ndarray:
     "THD (rel. total RMS, the R convention the clause defines)",
 )
 def _chk_thd_r() -> Outcome:
-    value = ph.thd(_electro_harmonic_signal(), _electro_fs(), 1000.0, kind="R")
+    value = ph.electroacoustics.thd(
+        _electro_harmonic_signal(), _electro_fs(), 1000.0, kind="R"
+    )
     return numeric(ref.DISTORTION_THD_R, value, 1e-4, places=6)
 
 
@@ -65,7 +67,9 @@ def _chk_thd_r() -> Outcome:
     "THD (rel. fundamental, the widespread datasheet convention)",
 )
 def _chk_thd_f() -> Outcome:
-    value = ph.thd(_electro_harmonic_signal(), _electro_fs(), 1000.0, kind="F")
+    value = ph.electroacoustics.thd(
+        _electro_harmonic_signal(), _electro_fs(), 1000.0, kind="F"
+    )
     return numeric(ref.DISTORTION_THD_F, value, 1e-4, places=6)
 
 
@@ -87,7 +91,9 @@ def _loudspeaker_flat_response() -> tuple[np.ndarray, np.ndarray]:
 )
 def _chk_loudspeaker_sensitivity() -> Outcome:
     f, spl = _loudspeaker_flat_response()
-    result = ph.loudspeaker_characteristics(f, spl, 8.0, sensitivity_band=(200.0, 4000.0))
+    result = ph.electroacoustics.loudspeaker_characteristics(
+        f, spl, 8.0, sensitivity_band=(200.0, 4000.0)
+    )
     # A flat 90 dB response driven at sqrt(8) V (1 W) at 1 m has a
     # characteristic sensitivity level of 90 dB exactly (the corrections vanish).
     return numeric(90.0, result.sensitivity_level_db, 1e-6, unit="dB", places=6)
@@ -100,7 +106,9 @@ def _chk_loudspeaker_sensitivity() -> Outcome:
 )
 def _chk_loudspeaker_effective_range() -> Outcome:
     f, spl = _loudspeaker_flat_response()
-    result = ph.loudspeaker_characteristics(f, spl, 8.0, sensitivity_band=(200.0, 4000.0))
+    result = ph.electroacoustics.loudspeaker_characteristics(
+        f, spl, 8.0, sensitivity_band=(200.0, 4000.0)
+    )
     lo, hi = result.effective_range
     ok = abs(lo - 50.0) <= 5e-3 and abs(hi - 18000.0) <= 2.0
     return Outcome(
@@ -117,7 +125,7 @@ def _chk_loudspeaker_effective_range() -> Outcome:
     "2nd-order harmonic distortion d2 (rel. total)",
 )
 def _chk_harmonic_d2() -> Outcome:
-    value = ph.harmonic_distortion(
+    value = ph.electroacoustics.harmonic_distortion(
         _electro_harmonic_signal(), _electro_fs(), fundamental=1000.0, order=2
     )
     return numeric(ref.DISTORTION_D2, value, 1e-4, places=6)
@@ -141,7 +149,9 @@ def _microphone_flat_response() -> tuple[np.ndarray, np.ndarray]:
 )
 def _chk_microphone_sensitivity_level() -> Outcome:
     f, rel = _microphone_flat_response()
-    result = ph.microphone_characteristics(f, rel, 12.5, tolerance_db=3.0)
+    result = ph.electroacoustics.microphone_characteristics(
+        f, rel, 12.5, tolerance_db=3.0
+    )
     # Hand-computed: 20 lg 0.0125 = -38.061800 dB re 1 V/Pa.
     return numeric(-38.061800, result.sensitivity_level_db, 1e-5, unit="dB", places=6)
 
@@ -153,7 +163,9 @@ def _chk_microphone_sensitivity_level() -> Outcome:
 )
 def _chk_microphone_effective_range() -> Outcome:
     f, rel = _microphone_flat_response()
-    result = ph.microphone_characteristics(f, rel, 12.5, tolerance_db=3.0)
+    result = ph.electroacoustics.microphone_characteristics(
+        f, rel, 12.5, tolerance_db=3.0
+    )
     lo, hi = result.effective_range
     ok = abs(lo - 40.0) <= 5e-3 and abs(hi - 18000.0) <= 2.0
     return Outcome(
@@ -173,9 +185,14 @@ def _chk_microphone_cardioid_di() -> Outcome:
     f, rel = _microphone_flat_response()
     angles = np.linspace(0.0, 179.9, 1800)
     pattern = 20.0 * np.log10((1.0 + np.cos(np.radians(angles))) / 2.0)
-    result = ph.microphone_characteristics(
-        f, rel, 12.5, tolerance_db=3.0,
-        directivity=ph.MicrophoneDirectivity(polar=(angles, pattern)),
+    result = ph.electroacoustics.microphone_characteristics(
+        f,
+        rel,
+        12.5,
+        tolerance_db=3.0,
+        directivity=ph.electroacoustics.MicrophoneDirectivity(
+            polar=(angles, pattern)
+        ),
     )
     di = result.directivity_index_db
     if di is None:
@@ -193,8 +210,12 @@ def _chk_microphone_cardioid_di() -> Outcome:
 )
 def _chk_microphone_equivalent_noise() -> Outcome:
     f, rel = _microphone_flat_response()
-    result = ph.microphone_characteristics(
-        f, rel, 12.5, tolerance_db=3.0, noise=ph.MicrophoneNoise(voltage=2.5e-6)
+    result = ph.electroacoustics.microphone_characteristics(
+        f,
+        rel,
+        12.5,
+        tolerance_db=3.0,
+        noise=ph.electroacoustics.MicrophoneNoise(voltage=2.5e-6),
     )
     noise = result.equivalent_noise_level_db
     if noise is None:
@@ -227,7 +248,9 @@ def _electro_smpte_signal() -> tuple[np.ndarray, float, float]:
 def _chk_modulation_d2() -> Outcome:
     x, fl, fh = _electro_smpte_signal()
     # Sidebands 0.02 + 0.02 over the 0.25 carrier: d_m,2 = 0.16 exactly.
-    value = ph.modulation_distortion(x, _electro_fs(), f_low=fl, f_high=fh).d2
+    value = ph.electroacoustics.modulation_distortion(
+        x, _electro_fs(), f_low=fl, f_high=fh
+    ).d2
     return numeric(0.16, value, 1e-4, places=6)
 
 
@@ -239,7 +262,9 @@ def _chk_modulation_d2() -> Outcome:
 def _chk_modulation_d3() -> Outcome:
     x, fl, fh = _electro_smpte_signal()
     # Sidebands 0.01 + 0.01 over the 0.25 carrier: d_m,3 = 0.08 exactly.
-    value = ph.modulation_distortion(x, _electro_fs(), f_low=fl, f_high=fh).d3
+    value = ph.electroacoustics.modulation_distortion(
+        x, _electro_fs(), f_low=fl, f_high=fh
+    ).d3
     return numeric(0.08, value, 1e-4, places=6)
 
 
@@ -265,7 +290,7 @@ def _electro_dfd_signal() -> tuple[np.ndarray, float, float]:
 def _chk_dfd_d2() -> Outcome:
     x, f1, f2 = _electro_dfd_signal()
     # Product 0.03 over the tone-amplitude sum 1.0: d_d,2 = 0.03 exactly.
-    value = ph.difference_frequency_distortion(
+    value = ph.electroacoustics.difference_frequency_distortion(
         x, _electro_fs(), f1=f1, f2=f2, order=2
     )
     return numeric(0.03, value, 1e-4, places=6)
@@ -279,7 +304,7 @@ def _chk_dfd_d2() -> Outcome:
 def _chk_dfd_d3() -> Outcome:
     x, f1, f2 = _electro_dfd_signal()
     # Products 0.02 + 0.02 over the tone-amplitude sum 1.0: d_d,3 = 0.04.
-    value = ph.difference_frequency_distortion(
+    value = ph.electroacoustics.difference_frequency_distortion(
         x, _electro_fs(), f1=f1, f2=f2, order=3
     )
     return numeric(0.04, value, 1e-4, places=6)
@@ -302,7 +327,7 @@ def _chk_tdfd() -> Outcome:
     )
     # Only the in-band products at f0 -/+ delta (3950/4050 Hz) enter:
     # d_TDFD = sqrt(0.02^2 + 0.03^2) / (0.5 + 0.5) = sqrt(0.0013).
-    value = ph.total_difference_frequency_distortion(x, fs)
+    value = ph.electroacoustics.total_difference_frequency_distortion(x, fs)
     return numeric(0.03605551275463989, value, 1e-4, places=8)
 
 
@@ -312,7 +337,7 @@ def _chk_tdfd() -> Outcome:
     "Weighting network response at the 6.3 kHz peak (14.12.11 network)",
 )
 def _chk_itu_468_peak() -> Outcome:
-    value = float(ph.itu_r_468_weighting([6300.0])[0])
+    value = float(ph.electroacoustics.itu_r_468_weighting([6300.0])[0])
     return numeric(12.2, value, 1e-9, unit="dB", places=2)
 
 
@@ -334,7 +359,12 @@ def _chk_dim() -> Outcome:
     for c, a in zip(comps, amps):
         x = x + _electro_tone(t, c, a)
     expected = math.sqrt(sum(a**2 for a in amps))
-    return numeric(expected, ph.dynamic_intermodulation_distortion(x, fs), 1e-4, places=6)
+    return numeric(
+        expected,
+        ph.electroacoustics.dynamic_intermodulation_distortion(x, fs),
+        1e-4,
+        places=6,
+    )
 
 
 @register(
@@ -348,7 +378,7 @@ def _chk_h1_gain() -> Outcome:
     x = rng.standard_normal(200000)
     b, a = sg.butter(1, 2000.0 / (fs / 2.0), btype="low")
     y = sg.lfilter(b, a, x)
-    res = ph.transfer_function(x, y, fs, estimator="H1")
+    res = ph.electroacoustics.transfer_function(x, y, fs, estimator="H1")
     _, h = sg.freqz(b, a, worN=res.frequencies, fs=fs)
     idx = int(np.argmin(np.abs(res.frequencies - 1000.0)))
     return numeric(
@@ -367,7 +397,7 @@ def _chk_coherence_unity() -> Outcome:
     x = rng.standard_normal(200000)
     b, a = sg.butter(1, 2000.0 / (fs / 2.0), btype="low")
     y = sg.lfilter(b, a, x)
-    f, g = ph.coherence(x, y, fs)
+    f, g = ph.electroacoustics.coherence(x, y, fs)
     band = (f > 100.0) & (f < 5000.0)
     return numeric(1.0, float(np.mean(g[band])), 1e-3, places=6)
 
@@ -383,7 +413,13 @@ def _chk_aes17_idle_noise() -> Outcome:
     # 468 is 0 dB at 1 kHz, so CCIR-RMS reads -5.63 dB there: a -20 dBFS tone
     # measures -25.63 dBFS CCIR-RMS in closed form.
     sig = _electro_tone(t, 1000.0, 10.0 ** (-20.0 / 20.0))
-    return numeric(-25.63, ph.idle_channel_noise(sig, fs), 1e-2, unit="dB", places=2)
+    return numeric(
+        -25.63,
+        ph.electroacoustics.idle_channel_noise(sig, fs),
+        1e-2,
+        unit="dB",
+        places=2,
+    )
 
 
 @register(
@@ -400,4 +436,10 @@ def _chk_aes17_dynamic_range() -> Outcome:
     # (a small notch lift aside).
     sig = _electro_tone(t, 997.0, 10.0 ** (-60.0 / 20.0))
     sig = sig + _electro_tone(t, 2000.0, 10.0 ** (-40.0 / 20.0))
-    return numeric(40.0, ph.dynamic_range(sig, fs, 997.0), 0.6, unit="dB", places=2)
+    return numeric(
+        40.0,
+        ph.electroacoustics.dynamic_range(sig, fs, 997.0),
+        0.6,
+        unit="dB",
+        places=2,
+    )

--- a/scripts/conformance/domains/electroacoustics.py
+++ b/scripts/conformance/domains/electroacoustics.py
@@ -26,7 +26,12 @@ _ELECTROACOUSTICS = "Electroacoustics"
     "Piston resistance R1(x) = 1 - 2 J1(x)/x at x = 2ka = 2",
 )
 def _chk_piston_resistance() -> Outcome:
-    return numeric(0.423275, float(ph.piston_resistance(2.0)), 1e-5, places=6)
+    return numeric(
+        0.423275,
+        float(ph.electroacoustics.piston_resistance(2.0)),
+        1e-5,
+        places=6,
+    )
 
 
 @register(
@@ -35,7 +40,12 @@ def _chk_piston_resistance() -> Outcome:
     "Piston reactance X1(x) = 2 H1(x)/x at x = 2ka = 2",
 )
 def _chk_piston_reactance() -> Outcome:
-    return numeric(0.646764, float(ph.piston_reactance(2.0)), 1e-5, places=6)
+    return numeric(
+        0.646764,
+        float(ph.electroacoustics.piston_reactance(2.0)),
+        1e-5,
+        places=6,
+    )
 
 
 @register(
@@ -45,8 +55,13 @@ def _chk_piston_reactance() -> Outcome:
 )
 def _chk_piston_resistance_limit() -> Outcome:
     ka = 0.01
-    return numeric(ka**2 / 2.0, float(ph.piston_resistance(2.0 * ka)), 1e-4,
-                   rel=True, places=8)
+    return numeric(
+        ka**2 / 2.0,
+        float(ph.electroacoustics.piston_resistance(2.0 * ka)),
+        1e-4,
+        rel=True,
+        places=8,
+    )
 
 
 @register(
@@ -55,7 +70,7 @@ def _chk_piston_resistance_limit() -> Outcome:
     "Radiation mass M = 8 rho a^3 / 3  (a = 0.1 m, rho = 1.206)",
 )
 def _chk_piston_radiation_mass() -> Outcome:
-    res = ph.radiating_piston(0.1, [100.0], density=1.206)
+    res = ph.electroacoustics.radiating_piston(0.1, [100.0], density=1.206)
     return numeric(8.0 * 1.206 * 0.1**3 / 3.0, res.radiation_mass, 1e-9,
                    unit="kg", places=8)
 
@@ -67,7 +82,11 @@ def _chk_piston_radiation_mass() -> Outcome:
 )
 def _chk_piston_directivity_null() -> Outcome:
     # ka sin(theta) = 3.8317 at ka = 3.8317, theta = pi/2.
-    d = float(ph.piston_directivity(3.8317059702075125, math.pi / 2.0))
+    d = float(
+        ph.electroacoustics.piston_directivity(
+            3.8317059702075125, math.pi / 2.0
+        )
+    )
     return numeric(0.0, d, 1e-6, places=8)
 
 
@@ -77,7 +96,7 @@ def _chk_piston_directivity_null() -> Outcome:
     "Directivity index DI -> 10 lg 2 = 3.01 dB as ka -> 0",
 )
 def _chk_piston_directivity_index() -> Outcome:
-    res = ph.radiating_piston(0.01, [1.0])
+    res = ph.electroacoustics.radiating_piston(0.01, [1.0])
     return numeric(10.0 * math.log10(2.0), float(res.directivity_index[0]),
                    1e-3, unit="dB")
 
@@ -88,7 +107,7 @@ def _chk_piston_directivity_index() -> Outcome:
     "Omnidirectional mic at Zs = -6 dB: L(H-M) <= L(H-L) - 4 dB",
 )
 def _chk_feedback_omnidirectional() -> Outcome:
-    res = ph.feedback_stability(-6.0, 76.0, 80.0)
+    res = ph.electroacoustics.feedback_stability(-6.0, 76.0, 80.0)
     return numeric(80.0 - 4.0, res.maximum_level_at_microphone, 1e-9,
                    unit="dB", places=6)
 
@@ -99,7 +118,9 @@ def _chk_feedback_omnidirectional() -> Outcome:
     "Cardioid mic (DM = -2 dB) at Zs = -6 dB: L(H-M) <= L(H-L) - 2 dB",
 )
 def _chk_feedback_cardioid() -> Outcome:
-    res = ph.feedback_stability(-6.0, 78.0, 80.0, microphone_directivity=-2.0)
+    res = ph.electroacoustics.feedback_stability(
+        -6.0, 78.0, 80.0, microphone_directivity=-2.0
+    )
     return numeric(80.0 - 2.0, res.maximum_level_at_microphone, 1e-9,
                    unit="dB", places=6)
 
@@ -110,5 +131,10 @@ def _chk_feedback_cardioid() -> Outcome:
     "Number-of-open-microphones correction 10 lg Nm at Nm = 4",
 )
 def _chk_open_microphone_correction() -> Outcome:
-    return numeric(10.0 * math.log10(4.0), ph.open_microphone_correction(4),
-                   1e-12, unit="dB", places=6)
+    return numeric(
+        10.0 * math.log10(4.0),
+        ph.electroacoustics.open_microphone_correction(4),
+        1e-12,
+        unit="dB",
+        places=6,
+    )

--- a/scripts/conformance/domains/environmental_sources.py
+++ b/scripts/conformance/domains/environmental_sources.py
@@ -55,20 +55,24 @@ def _chk_cnossos_road_workbook() -> Outcome:
     worst = 0.0
     for case in ref.cnossos_road_workbook_cases():
         traffic = [
-            ph.RoadTraffic(
-                ph.RoadVehicleCategory(c), float(case[f"q_{c}"]), float(case[f"v_{c}"]),
+            ph.environment.RoadTraffic(
+                ph.environment.RoadVehicleCategory(c),
+                float(case[f"q_{c}"]),
+                float(case[f"v_{c}"]),
                 studded_fraction=0.5 if c == "1" else 0.0,
             )
             for c in ("1", "2", "3", "4a", "4b")
         ]
-        result = ph.road_source_power(
+        result = ph.environment.road_source_power(
             traffic,
             surface=surfaces[case["surface"]],
             temperature=float(case["temperature_c"]),
             gradient=float(case["gradient_pct"]),
             studded_months=float(case["studded_months"]),
             junction_distance=float(case["junction_distance_m"]),
-            junction_type=ph.JunctionType(int(case["junction_type"])),
+            junction_type=ph.environment.JunctionType(
+                int(case["junction_type"])
+            ),
             coefficients=coefficients,
         )
         for got, band in zip(result.total_line_power, ref.CNOSSOS_ROAD_BANDS):
@@ -86,10 +90,22 @@ def _chk_cnossos_road_table_f1() -> Outcome:
     bad = 0
     for category, expected in ref.CNOSSOS_ROAD_TABLE_F1.items():
         pairs = (
-            (ph.ROAD_COEFFICIENTS.rolling_a[category], expected["AR"]),
-            (ph.ROAD_COEFFICIENTS.rolling_b[category], expected["BR"]),
-            (ph.ROAD_COEFFICIENTS.propulsion_a[category], expected["AP"]),
-            (ph.ROAD_COEFFICIENTS.propulsion_b[category], expected["BP"]),
+            (
+                ph.environment.ROAD_COEFFICIENTS.rolling_a[category],
+                expected["AR"],
+            ),
+            (
+                ph.environment.ROAD_COEFFICIENTS.rolling_b[category],
+                expected["BR"],
+            ),
+            (
+                ph.environment.ROAD_COEFFICIENTS.propulsion_a[category],
+                expected["AP"],
+            ),
+            (
+                ph.environment.ROAD_COEFFICIENTS.propulsion_b[category],
+                expected["BP"],
+            ),
         )
         bad += sum(1 for got, want in pairs for a, b in zip(got, want) if a != b)
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
@@ -103,8 +119,8 @@ def _chk_cnossos_road_table_f1() -> Outcome:
 )
 def _chk_cnossos_road_table_f4() -> Outcome:
     bad = 0
-    for surface in ph.RoadSurface:
-        row = ph.road_surface_coefficients(surface)
+    for surface in ph.environment.RoadSurface:
+        row = ph.environment.road_surface_coefficients(surface)
         expected = ref.CNOSSOS_ROAD_TABLE_F4[surface.value]
         for category in ("1", "2", "3", "4a", "4b"):
             key = category if category in expected else "4a/4b"
@@ -123,14 +139,23 @@ def _chk_cnossos_road_tables_f2_f3() -> Outcome:
     bad = sum(
         1
         for got, want in (
-            (ph.ROAD_COEFFICIENTS.studded_a, ref.CNOSSOS_ROAD_TABLE_F2["ai"]),
-            (ph.ROAD_COEFFICIENTS.studded_b, ref.CNOSSOS_ROAD_TABLE_F2["bi"]),
+            (
+                ph.environment.ROAD_COEFFICIENTS.studded_a,
+                ref.CNOSSOS_ROAD_TABLE_F2["ai"],
+            ),
+            (
+                ph.environment.ROAD_COEFFICIENTS.studded_b,
+                ref.CNOSSOS_ROAD_TABLE_F2["bi"],
+            ),
         )
         for a, b in zip(got, want)
         if a != b
     )
     for category, expected in ref.CNOSSOS_ROAD_TABLE_F3.items():
-        bad += int(ph.ROAD_COEFFICIENTS.junction_c[category] != (expected[1], expected[2]))
+        bad += int(
+            ph.environment.ROAD_COEFFICIENTS.junction_c[category]
+            != (expected[1], expected[2])
+        )
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
                    expected_label="36 coefficients identical")
 
@@ -146,11 +171,14 @@ def _chk_cnossos_road_reference_conditions() -> Outcome:
     """
     worst = 0.0
     for category in ("1", "2", "3", "4a", "4b"):
-        rolling = ph.road_rolling_noise(category, 70.0)
-        propulsion = ph.road_propulsion_noise(category, 70.0)
+        rolling = ph.environment.road_rolling_noise(category, 70.0)
+        propulsion = ph.environment.road_propulsion_noise(category, 70.0)
         for got, want in (
-            (rolling, ph.ROAD_COEFFICIENTS.rolling_a[category]),
-            (propulsion, ph.ROAD_COEFFICIENTS.propulsion_a[category]),
+            (rolling, ph.environment.ROAD_COEFFICIENTS.rolling_a[category]),
+            (
+                propulsion,
+                ph.environment.ROAD_COEFFICIENTS.propulsion_a[category],
+            ),
         ):
             worst = max(worst, max(abs(float(a) - b) for a, b in zip(got, want)))
     return numeric(0.0, worst, 0.0, unit="dB", places=6,
@@ -164,7 +192,11 @@ def _chk_cnossos_road_reference_conditions() -> Outcome:
 )
 def _chk_cnossos_a_weighting() -> Outcome:
     bad = sum(
-        1 for a, b in zip(ph.CNOSSOS_A_WEIGHTING, ref.CNOSSOS_A_WEIGHTING_TABLE) if a != b
+        1
+        for a, b in zip(
+            ph.environment.CNOSSOS_A_WEIGHTING, ref.CNOSSOS_A_WEIGHTING_TABLE
+        )
+        if a != b
     )
     return numeric(0.0, float(bad), 0.0, unit="mismatches", places=0,
                    expected_label="8 values identical")
@@ -196,7 +228,13 @@ def _chk_wt_critical_bandwidth() -> Outcome:
 def _chk_wt_apparent_power() -> Outcome:
     r1 = 150.0
     expected = 100.0 - 6.0 + 10.0 * math.log10(4.0 * math.pi * r1**2)
-    return numeric(expected, ph.apparent_sound_power_level([100.0], r1), 1e-4, unit="dB", places=4)
+    return numeric(
+        expected,
+        ph.environment.apparent_sound_power_level([100.0], r1),
+        1e-4,
+        unit="dB",
+        places=4,
+    )
 
 
 @register(
@@ -209,5 +247,5 @@ def _chk_wt_tonal_audibility() -> Outcome:
     freqs = np.arange(440.0, 560.0 + df, df)
     levels = np.full(freqs.size, 30.0)
     levels[int(np.argmin(np.abs(freqs - 500.0)))] = 60.0
-    res = ph.wind_turbine_tonality(levels, freqs)
+    res = ph.environment.wind_turbine_tonality(levels, freqs)
     return numeric(16.38, res.tonal_audibility, 6e-2, unit="dB", places=2)

--- a/scripts/conformance/domains/fdtd.py
+++ b/scripts/conformance/domains/fdtd.py
@@ -32,9 +32,9 @@ _FDTD = "2D FDTD wave simulation (Attenborough & Van Renterghem 2021, Ch. 4)"
 def _chk_fdtd_box_mode() -> Outcome:
     lx, ly, dx, c = 1.0, 0.7, 0.02, 343.0
     nx, ny = round(lx / dx), round(ly / dx)
-    res = ph.fdtd_simulation(
+    res = ph.simulation.fdtd_simulation(
         c, dx, 0.35, shape=(ny, nx),
-        sources=[ph.GaussianPulse(ix=7, iy=5, width=2.0e-4)],
+        sources=[ph.simulation.GaussianPulse(ix=7, iy=5, width=2.0e-4)],
         probes=[(nx - 4, ny - 3)])
     expected = 0.5 * c * math.hypot(1.0 / lx, 1.0 / ly)
     pressure = res.pressures[0]
@@ -53,9 +53,9 @@ def _chk_fdtd_box_mode() -> Outcome:
 )
 def _chk_fdtd_pulse_delay() -> Outcome:
     c, dx = 343.0, 0.01
-    res = ph.fdtd_simulation(
+    res = ph.simulation.fdtd_simulation(
         c, dx, 6.5e-3, shape=(200, 300),
-        sources=[ph.GaussianPulse(ix=40, iy=100, width=1.5e-4)],
+        sources=[ph.simulation.GaussianPulse(ix=40, iy=100, width=1.5e-4)],
         probes=[(100, 100), (160, 100)],
         boundaries="absorbing", absorbing_layer_cells=30)
     t1 = res.times[int(np.argmax(res.pressures[0]))]
@@ -84,8 +84,10 @@ def _ntff_monopole() -> tuple[Any, complex, float]:
 
     c, dx, f = 343.0, 0.005, 2000.0
     k = 2.0 * np.pi * f / c
-    sim = ph.FDTD2D(c, dx, shape=(300, 300), sponge_width=40)
-    sim.add_source(ph.CWSource(ix=150, iy=150, frequency=f, ramp_cycles=4.0))
+    sim = ph.simulation.FDTD2D(c, dx, shape=(300, 300), sponge_width=40)
+    sim.add_source(
+        ph.simulation.CWSource(ix=150, iy=150, frequency=f, ramp_cycles=4.0)
+    )
     probe = sim.add_contour_probe(90, 210, 90, 210, frequencies=[f])
     sim.run(round(4.5e-3 / sim.dt))
     probe.reset()
@@ -97,7 +99,7 @@ def _ntff_monopole() -> tuple[Any, complex, float]:
             -2j * np.pi * f * sim.n * sim.dt)
     amplitude = (2.0 * acc / probe.samples) / hankel2(
         0, k * (probe_col - 150) * dx)
-    pattern = ph.far_field_from_contour(
+    pattern = ph.simulation.far_field_from_contour(
         probe.phasors(f), np.arange(0.0, 360.0, 5.0),
         origin=(150.5 * dx, 150.5 * dx))
     expected = abs(amplitude) * math.sqrt(2.0 / (math.pi * k))

--- a/scripts/conformance/domains/filters.py
+++ b/scripts/conformance/domains/filters.py
@@ -67,7 +67,7 @@ def _chk_butter_class0_1995() -> Outcome:
         48000, fraction=1, order=6, limits=[100, 10000],
         design=filters.FilterDesign(filter_type="butter"),
     )
-    result = ph.verify_filter_class(bank, edition="1995")
+    result = ph.filters.verify_filter_class(bank, edition="1995")
     margin = min(b["margin_class0_db"] for b in result["bands"])
     ok = result["overall_class"] == 0
     return Outcome(

--- a/scripts/conformance/domains/ground_barriers.py
+++ b/scripts/conformance/domains/ground_barriers.py
@@ -29,7 +29,9 @@ _GROUND_BARRIERS = "Spherical ground & barriers (Attenborough / Salomons / Bies)
     "abs(Q) as Z grows large (Rp -> 1 so (1 - Rp) -> 0 and Q -> 1)",
 )
 def _chk_hard_ground_q_unity() -> Outcome:
-    q = ph.spherical_reflection_coefficient([500.0], 1e12, 1.0, 1.5, 50.0)
+    q = ph.environment.spherical_reflection_coefficient(
+        [500.0], 1e12, 1.0, 1.5, 50.0
+    )
     return numeric(1.0, float(abs(q[0])), 1e-6, places=6)
 
 
@@ -39,7 +41,7 @@ def _chk_hard_ground_q_unity() -> Outcome:
     "dL enhancement at small path difference (constructive, +6 dB)",
 )
 def _chk_hard_ground_6db() -> Outcome:
-    res = ph.ground_effect([31.5], 0.5, 0.5, 200.0, impedance=1e12)
+    res = ph.environment.ground_effect([31.5], 0.5, 0.5, 200.0, impedance=1e12)
     return numeric(6.0206, float(res.excess_attenuation[0]), 0.1, unit="dB")
 
 
@@ -49,7 +51,9 @@ def _chk_hard_ground_6db() -> Outcome:
     "Re(Rp) at grazing (hs, hr -> 0, cos(theta) -> 0 so Rp -> -1)",
 )
 def _chk_grazing_rp_minus_one() -> Outcome:
-    res = ph.ground_effect([500.0], 1e-4, 1e-4, 100.0, impedance=12.0 + 6.0j)
+    res = ph.environment.ground_effect(
+        [500.0], 1e-4, 1e-4, 100.0, impedance=12.0 + 6.0j
+    )
     return numeric(-1.0, float(res.plane_reflection_coefficient[0].real), 1e-3)
 
 
@@ -64,7 +68,9 @@ def _chk_salomons_fig_d3_dip() -> Outcome:
         # The bands sit below the Delany-Bazley published fit range for this
         # sigma; the model extrapolates there by design (Salomons Sec. 3.1).
         warnings.simplefilter("ignore")
-        res = ph.ground_effect(freqs, 2.0, 2.0, 100.0, flow_resistivity=2e5)
+        res = ph.environment.ground_effect(
+            freqs, 2.0, 2.0, 100.0, flow_resistivity=2e5
+        )
     return numeric(-12.7, float(res.excess_attenuation.min()), 0.3, unit="dB",
                    places=2)
 
@@ -75,7 +81,12 @@ def _chk_salomons_fig_d3_dip() -> Outcome:
     "Barrier attenuation at the shadow boundary N = 0",
 )
 def _chk_kurze_anderson_zero() -> Outcome:
-    return numeric(5.0, float(ph.kurze_anderson_attenuation(0.0)), 1e-9, unit="dB")
+    return numeric(
+        5.0,
+        float(ph.environment.kurze_anderson_attenuation(0.0)),
+        1e-9,
+        unit="dB",
+    )
 
 
 @register(
@@ -84,8 +95,8 @@ def _chk_kurze_anderson_zero() -> Outcome:
     "Delta(N=10) - Delta(N=1) vs the 10 lg(10) = 10 dB decade growth",
 )
 def _chk_kurze_anderson_slope() -> Outcome:
-    d1 = float(ph.kurze_anderson_attenuation(1.0))
-    d10 = float(ph.kurze_anderson_attenuation(10.0))
+    d1 = float(ph.environment.kurze_anderson_attenuation(1.0))
+    d10 = float(ph.environment.kurze_anderson_attenuation(10.0))
     return numeric(10.0, d10 - d1, 0.5, unit="dB")
 
 
@@ -95,6 +106,7 @@ def _chk_kurze_anderson_slope() -> Outcome:
     "Exact thin-screen insertion loss at grazing (field halved, 6 dB)",
 )
 def _chk_exact_screen_shadow_boundary() -> Outcome:
-    il = ph.barrier_insertion_loss([500.0], 1.0, 50.0, 1.0 + 1e-3, 100.0, 1.0,
-                                   method="exact")
+    il = ph.environment.barrier_insertion_loss(
+        [500.0], 1.0, 50.0, 1.0 + 1e-3, 100.0, 1.0, method="exact"
+    )
     return numeric(6.0206, float(il.insertion_loss[0]), 0.6, unit="dB")

--- a/scripts/conformance/domains/human_vibration.py
+++ b/scripts/conformance/domains/human_vibration.py
@@ -25,25 +25,27 @@ def _true_centre(n: int) -> float:
 
 @register(_HUMAN_VIB, "ISO 8041-1:2017 Table B.8", "Wk design-goal factor at 6,31 Hz")
 def _chk_iso8041_wk_annex_b() -> Outcome:
-    factor = float(ph.weighting_factors("Wk", _true_centre(8))[0])
+    factor = float(ph.vibration.weighting_factors("Wk", _true_centre(8))[0])
     return numeric(ref.ISO8041_1_WK_FACTOR_6P31HZ, factor, 1e-3, rel=True, places=4)
 
 
 @register(_HUMAN_VIB, "ISO 8041-1:2017 Table B.9", "Wm design-goal factor at 1,585 Hz")
 def _chk_iso8041_wm_annex_b() -> Outcome:
-    factor = float(ph.weighting_factors("Wm", _true_centre(2))[0])
+    factor = float(ph.vibration.weighting_factors("Wm", _true_centre(2))[0])
     return numeric(ref.ISO8041_1_WM_FACTOR_1P585HZ, factor, 1e-3, rel=True, places=4)
 
 
 @register(_HUMAN_VIB, "ISO 8041-1:2017 Table 1", "Wh factor at the 500 rad/s reference")
 def _chk_iso8041_wh_reference() -> Outcome:
-    factor = float(ph.weighting_factors("Wh", ref.ISO8041_1_WH_REF_FREQ_HZ)[0])
+    factor = float(
+        ph.vibration.weighting_factors("Wh", ref.ISO8041_1_WH_REF_FREQ_HZ)[0]
+    )
     return numeric(ref.ISO8041_1_WH_REF_FACTOR, factor, 1.5e-3, rel=True, places=4)
 
 
 @register(_HUMAN_VIB, "ISO 8041-1:2017 Table B.1", "Wb design-goal factor at 6,31 Hz")
 def _chk_iso8041_wb_annex_b() -> Outcome:
-    factor = float(ph.weighting_factors("Wb", _true_centre(8))[0])
+    factor = float(ph.vibration.weighting_factors("Wb", _true_centre(8))[0])
     return numeric(ref.ISO8041_1_WB_FACTOR_6P31HZ, factor, 1e-3, rel=True, places=4)
 
 
@@ -52,7 +54,11 @@ def _chk_iso8041_wb_annex_b() -> Outcome:
 )
 def _chk_iso8041_wb_annex_b_edges() -> Outcome:
     worst = max(
-        abs(float(ph.weighting_factors("Wb", _true_centre(n))[0]) / expected - 1.0)
+        abs(
+            float(ph.vibration.weighting_factors("Wb", _true_centre(n))[0])
+            / expected
+            - 1.0
+        )
         for n, expected in (
             (0, ref.ISO8041_1_WB_FACTOR_1HZ),
             (20, ref.ISO8041_1_WB_FACTOR_100HZ),
@@ -65,7 +71,9 @@ def _chk_iso8041_wb_annex_b_edges() -> Outcome:
 
 @register(_HUMAN_VIB, "ISO 8041-1:2017 Table 1", "Wc factor at the 100 rad/s reference")
 def _chk_iso8041_wc_reference() -> Outcome:
-    factor = float(ph.weighting_factors("Wc", ref.ISO8041_1_WBV_REF_FREQ_HZ)[0])
+    factor = float(
+        ph.vibration.weighting_factors("Wc", ref.ISO8041_1_WBV_REF_FREQ_HZ)[0]
+    )
     return numeric(ref.ISO8041_1_WC_REF_FACTOR, factor, 1e-3, rel=True, places=4)
 
 
@@ -77,7 +85,8 @@ def _chk_iso8041_wc_reference() -> Outcome:
 def _chk_iso8041_wd_reference_and_annex_b() -> Outcome:
     worst = max(
         abs(
-            float(ph.weighting_factors("Wd", freq)[0]) / expected - 1.0
+            float(ph.vibration.weighting_factors("Wd", freq)[0]) / expected
+            - 1.0
         )
         for freq, expected in (
             (ref.ISO8041_1_WBV_REF_FREQ_HZ, ref.ISO8041_1_WD_REF_FACTOR),
@@ -91,7 +100,7 @@ def _chk_iso8041_wd_reference_and_annex_b() -> Outcome:
 
 @register(_HUMAN_VIB, "ISO 8041-1:2017 Table B.4", "We design-goal factor at 8 Hz")
 def _chk_iso8041_we_annex_b() -> Outcome:
-    factor = float(ph.weighting_factors("We", _true_centre(9))[0])
+    factor = float(ph.vibration.weighting_factors("We", _true_centre(9))[0])
     return numeric(ref.ISO8041_1_WE_FACTOR_8HZ, factor, 1e-3, rel=True, places=4)
 
 
@@ -100,7 +109,11 @@ def _chk_iso8041_we_annex_b() -> Outcome:
 )
 def _chk_iso8041_wf_annex_b() -> Outcome:
     worst = max(
-        abs(float(ph.weighting_factors("Wf", _true_centre(n))[0]) / expected - 1.0)
+        abs(
+            float(ph.vibration.weighting_factors("Wf", _true_centre(n))[0])
+            / expected
+            - 1.0
+        )
         for n, expected in (
             (-8, ref.ISO8041_1_WF_FACTOR_0P1585HZ),
             (-10, ref.ISO8041_1_WF_FACTOR_0P1HZ),
@@ -116,7 +129,11 @@ def _chk_iso8041_wf_annex_b() -> Outcome:
 )
 def _chk_iso8041_wj_annex_b() -> Outcome:
     worst = max(
-        abs(float(ph.weighting_factors("Wj", _true_centre(n))[0]) / expected - 1.0)
+        abs(
+            float(ph.vibration.weighting_factors("Wj", _true_centre(n))[0])
+            / expected
+            - 1.0
+        )
         for n, expected in (
             (8, ref.ISO8041_1_WJ_FACTOR_6P31HZ),
             (9, ref.ISO8041_1_WJ_FACTOR_8HZ),
@@ -149,7 +166,10 @@ def _chk_iso8041_table5_envelope() -> Outcome:
             else:
                 region = 4
             upper, lower = ref.ISO8041_1_TABLE5_TOLERANCES[region]
-            ratio = float(ph.weighting_factors(name, freq)[0]) / printed - 1.0
+            ratio = (
+                float(ph.vibration.weighting_factors(name, freq)[0]) / printed
+                - 1.0
+            )
             if not -lower <= ratio <= upper:
                 violations += 1
     return numeric(
@@ -160,13 +180,13 @@ def _chk_iso8041_table5_envelope() -> Outcome:
 
 @register(_HUMAN_VIB, "ISO 5349-2:2001 Example E.2.1", "Single-tool daily exposure A(8)")
 def _chk_iso5349_e21() -> Outcome:
-    a8 = ph.daily_exposure(7.4, 2.5 * 3600.0)
+    a8 = ph.vibration.daily_exposure(7.4, 2.5 * 3600.0)
     return numeric(ref.ISO5349_2_E21_A8, a8, 0.05, unit="m/s^2", places=2)
 
 
 @register(_HUMAN_VIB, "ISO 5349-2:2001 Example E.3", "Forestry three-task A(8)")
 def _chk_iso5349_e3() -> Outcome:
-    a8 = ph.hav_daily_exposure(
+    a8 = ph.vibration.hav_daily_exposure(
         [4.6, 6.0, 3.6], [2 * 3600.0, 1 * 3600.0, 2 * 3600.0]
     )
     return numeric(ref.ISO5349_2_E3_A8, a8, 0.05, unit="m/s^2", places=2)
@@ -174,14 +194,14 @@ def _chk_iso5349_e3() -> Outcome:
 
 @register(_HUMAN_VIB, "ISO 5349-1:2001 Eq. (C.1)", "VWF 10 % lifetime Dy at A(8)=7")
 def _chk_iso5349_vwf() -> Outcome:
-    dy = ph.hav_vwf_lifetime_years(ref.ISO5349_1_VWF_A8)
+    dy = ph.vibration.hav_vwf_lifetime_years(ref.ISO5349_1_VWF_A8)
     return numeric(ref.ISO5349_1_VWF_DY_YEARS, dy, 0.1, unit="yr", places=2)
 
 
 @register(_HUMAN_VIB, "Directive 2002/44/EC Art. 3", "HAV/WBV action & limit values")
 def _chk_directive_2002_44() -> Outcome:
-    hav = ph.exposure_assessment(1.0, kind="hav")
-    wbv = ph.exposure_assessment(0.1, kind="wbv")
+    hav = ph.vibration.exposure_assessment(1.0, kind="hav")
+    wbv = ph.vibration.exposure_assessment(0.1, kind="wbv")
     ok = (
         hav.action_value == ref.DIRECTIVE_2002_44_HAV_EAV
         and hav.limit_value == ref.DIRECTIVE_2002_44_HAV_ELV

--- a/scripts/conformance/domains/intelligibility.py
+++ b/scripts/conformance/domains/intelligibility.py
@@ -34,7 +34,7 @@ def _chk_sii_band_importance_sum() -> Outcome:
 
 @register(_SII, "ASA WG S3-79 SII.C (clause 5.4)", "Equivalent masking spectrum level at 200 Hz")
 def _chk_sii_masking() -> Outcome:
-    result = ph.speech_intelligibility_index("normal")
+    result = ph.speech.speech_intelligibility_index("normal")
     return numeric(ref.ANSIS3_5_MASKING_Z_200HZ, float(result.masking[1]), 1e-3, places=3)
 
 
@@ -86,7 +86,7 @@ def _chk_sii_annex_c2_masking() -> Outcome:
 
 @register(_SII, "ASA WG S3-79 SII.C (clause 6)", "SII, standard speech in quiet, normal hearing")
 def _chk_sii_standard_quiet() -> Outcome:
-    result = ph.speech_intelligibility_index("normal")
+    result = ph.speech.speech_intelligibility_index("normal")
     return numeric(ref.ANSIS3_5_STANDARD_QUIET, result.sii, 1e-6, places=8)
 
 
@@ -206,19 +206,23 @@ def _chk_sii_annex_c1_level_distortion() -> Outcome:
 
 @register(_SII, "ANSI S3.5-1997 Table 1", "Critical-band importance normalisation")
 def _chk_sii_critical_importance_sum() -> Outcome:
-    total = float(ph.sii_procedure("critical-band").band_importance.sum())
+    total = float(
+        ph.speech.sii_procedure("critical-band").band_importance.sum()
+    )
     return numeric(ref.ANSIS3_5_CRITICAL_IMPORTANCE_SUM, total, 1e-9, places=6)
 
 
 @register(_SII, "ANSI S3.5-1997 Table 2", "Equally-contributing importance, 17 x 0.0588")
 def _chk_sii_equal_importance_sum() -> Outcome:
-    total = float(ph.sii_procedure("equally-contributing").band_importance.sum())
+    total = float(
+        ph.speech.sii_procedure("equally-contributing").band_importance.sum()
+    )
     return numeric(ref.ANSIS3_5_EQUAL_IMPORTANCE_SUM, total, 1e-9, places=6)
 
 
 @register(_SII, "ANSI S3.5-1997 Table 4", "Octave-band importance normalisation")
 def _chk_sii_octave_importance_sum() -> Outcome:
-    total = float(ph.sii_procedure("octave").band_importance.sum())
+    total = float(ph.speech.sii_procedure("octave").band_importance.sum())
     return numeric(ref.ANSIS3_5_OCTAVE_IMPORTANCE_SUM, total, 1e-9, places=6)
 
 
@@ -227,8 +231,8 @@ def _chk_sii_octave_matches_table3() -> Outcome:
     # Both are spectrum (per-hertz) levels, so Table 4 repeats Table 3's Ui and
     # Xi at all six shared centre frequencies. Reported as the largest
     # disagreement over the twelve cells.
-    octave = ph.sii_procedure("octave")
-    third = ph.sii_procedure("one-third-octave")
+    octave = ph.speech.sii_procedure("octave")
+    third = ph.speech.sii_procedure("one-third-octave")
     worst = 0.0
     for fc, speech, noise in ref.ANSIS3_5_OCTAVE_TABLE4_SHARED:
         k = int(np.flatnonzero(np.isclose(octave.frequencies, fc))[0])
@@ -247,7 +251,7 @@ def _chk_sii_octave_matches_table3() -> Outcome:
 def _chk_sii_critical_table1() -> Outcome:
     # Every cell of Table 1 as shipped: centre, both limits, Ii, Ui and Xi.
     # Reported as the largest absolute disagreement over the 126 cells.
-    proc = ph.sii_procedure("critical-band")
+    proc = ph.speech.sii_procedure("critical-band")
     worst = 0.0
     for i, (fc, lo, hi, imp, speech, noise) in enumerate(
         ref.ANSIS3_5_CRITICAL_TABLE1
@@ -271,7 +275,7 @@ def _chk_sii_flat_cases() -> Outcome:
     # Reported as the largest deviation from the committee code over the twelve.
     worst = 0.0
     for method, _regime, speech, noise, committee in ref.ANSIS3_5_WG_FLAT_CASES:
-        n = ph.sii_procedure(method).frequencies.size
+        n = ph.speech.sii_procedure(method).frequencies.size
         result = ph.speech.sii.speech_intelligibility_index(
             np.full(n, speech), np.full(n, noise), method=method
         )
@@ -313,8 +317,14 @@ def _stoi_speech_like(seed: int) -> np.ndarray:
 )
 def _chk_stoi_identity() -> Outcome:
     x = _stoi_speech_like(1)
-    return numeric(1.0, ph.stoi(x, x, ph.speech.objective_intelligibility.SAMPLE_RATE).value,
-                   1e-6, places=6)
+    return numeric(
+        1.0,
+        ph.speech.stoi(
+            x, x, ph.speech.objective_intelligibility.SAMPLE_RATE
+        ).value,
+        1e-6,
+        places=6,
+    )
 
 
 @register(
@@ -325,7 +335,9 @@ def _chk_stoi_identity() -> Outcome:
 def _chk_estoi_identity() -> Outcome:
     x = _stoi_speech_like(1)
     fs = ph.speech.objective_intelligibility.SAMPLE_RATE
-    return numeric(1.0, ph.stoi(x, x, fs, extended=True).value, 1e-6, places=6)
+    return numeric(
+        1.0, ph.speech.stoi(x, x, fs, extended=True).value, 1e-6, places=6
+    )
 
 
 @register(
@@ -339,8 +351,12 @@ def _chk_stoi_monotonic() -> Outcome:
     rng = np.random.default_rng(10)
     noise = rng.standard_normal(x.size)
     scale = np.sqrt(np.mean(x**2)) / np.sqrt(np.mean(noise**2))
-    lo = ph.stoi(x, x + scale * 10.0 ** (15.0 / 20.0) * noise, fs).value  # -15 dB
-    hi = ph.stoi(x, x + scale * 10.0 ** (-25.0 / 20.0) * noise, fs).value  # +25 dB
+    lo = ph.speech.stoi(
+        x, x + scale * 10.0 ** (15.0 / 20.0) * noise, fs
+    ).value  # -15 dB
+    hi = ph.speech.stoi(
+        x, x + scale * 10.0 ** (-25.0 / 20.0) * noise, fs
+    ).value  # +25 dB
     return Outcome(
         expected="STOI(+25 dB) - STOI(-15 dB) > 0.2",
         computed=f"{hi - lo:.3f} ({lo:.3f} -> {hi:.3f})",

--- a/scripts/conformance/domains/intensity.py
+++ b/scripts/conformance/domains/intensity.py
@@ -48,7 +48,9 @@ def _plane_wave_pair(
 def _chk_plane_wave_intensity() -> Outcome:
     rho, c, spacing = 1.204, 343.0, 0.012
     p1, p2 = _plane_wave_pair(spacing / c)
-    res = ph.sound_intensity(p1, p2, _FS, spacing=spacing, rho=rho, c=c)
+    res = ph.emission.sound_intensity(
+        p1, p2, _FS, spacing=spacing, rho=rho, c=c
+    )
     expected = float(np.mean(((p1 + p2) / 2.0) ** 2)) / (rho * c)
     return numeric(
         expected, float(res.total_intensity), 0.015, unit="W/m^2", rel=True, places=5
@@ -63,7 +65,9 @@ def _chk_plane_wave_intensity() -> Outcome:
 def _chk_monopole_lw() -> Outcome:
     lw_true, r = 95.0, 4.0
     lp = lw_true - 10.0 * math.log10(2.0 * math.pi * r**2)
-    res = ph.sound_power_pressure(np.full((10, 1), lp), "hemisphere", radius=r)
+    res = ph.emission.sound_power_pressure(
+        np.full((10, 1), lp), "hemisphere", radius=r
+    )
     return numeric(lw_true, float(res.sound_power_level[0]), 1e-9, unit="dB", places=6)
 
 
@@ -76,7 +80,7 @@ def _chk_intensity_scan_lw() -> Outcome:
     w = 1.0e-3  # 90 dB re 1 pW
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     intensity = np.full((4, 1), w / areas.sum())
-    res = ph.sound_power_intensity(intensity, areas)
+    res = ph.emission.sound_power_intensity(intensity, areas)
     return numeric(90.0, float(res.sound_power_level[0]), 1e-6, unit="dB", places=6)
 
 
@@ -90,7 +94,7 @@ def _chk_iec61043_table2() -> Outcome:
     columns = {"probe": (1, 2), "processor": (3, 4), "instrument": (5, 6)}
     worst = 0.0
     for device, (col1, col2) in columns.items():
-        _, class1, class2 = ph.residual_index_limits(device)
+        _, class1, class2 = ph.emission.residual_index_limits(device)
         for i, row in enumerate(ref.IEC61043_TABLE2):
             worst = max(
                 worst,
@@ -120,8 +124,8 @@ def _chk_iec61043_spacing_rule() -> Outcome:
     expected = 10.0 * math.log10(2.0)
     offsets: list[float] = []
     for device in ("probe", "processor", "instrument"):
-        base = ph.residual_index_limits(device)
-        wide = ph.residual_index_limits(device, spacing=0.050)
+        base = ph.emission.residual_index_limits(device)
+        wide = ph.emission.residual_index_limits(device, spacing=0.050)
         for cls in (1, 2):
             offsets.extend(
                 (np.asarray(wide[cls]) - np.asarray(base[cls])).tolist()
@@ -138,7 +142,7 @@ def _chk_iec61043_spacing_rule() -> Outcome:
     "delta_pI0 = 20 dB is a phase mismatch of 0.26 deg (1 kHz, 25 mm)",
 )
 def _chk_iec61043_phase_mismatch() -> Outcome:
-    phi = ph.phase_mismatch_from_residual_index(
+    phi = ph.emission.phase_mismatch_from_residual_index(
         ref.IEC61043_PHASE_INDEX_DB,
         ref.IEC61043_PHASE_FREQUENCY_HZ,
         ref.IEC61043_PHASE_SPACING_M,
@@ -162,7 +166,10 @@ def _chk_iso9614_1_f1() -> Outcome:
         math.sqrt(float(np.sum((samples - mean) ** 2)) / (samples.size - 1)) / mean
     )
     return numeric(
-        expected, float(ph.temporal_variability_indicator(samples)), 1e-12, places=6
+        expected,
+        float(ph.emission.temporal_variability_indicator(samples)),
+        1e-12,
+        places=6,
     )
 
 
@@ -172,7 +179,7 @@ def _chk_iso9614_1_f1() -> Outcome:
     "Declared L_WAd = L_WA + K_WA (Annex B, L_WA=88, K_WA=2)",
 )
 def _chk_iso4871_declared_value() -> Outcome:
-    mode = ph.OperatingModeDeclaration("Operating mode 1", 88.0, 2.0)
+    mode = ph.emission.OperatingModeDeclaration("Operating mode 1", 88.0, 2.0)
     return numeric(90.0, float(mode.declared_sound_power_level), 0.0, unit="dB", places=1)
 
 
@@ -182,8 +189,12 @@ def _chk_iso4871_declared_value() -> Outcome:
     "Single-machine verification boundary L_1 <= L_WAd",
 )
 def _chk_iso4871_verification() -> Outcome:
-    at_boundary = ph.OperatingModeDeclaration("m", 88.0, 2.0, verification_level=90.0)
-    just_over = ph.OperatingModeDeclaration("m", 88.0, 2.0, verification_level=91.0)
+    at_boundary = ph.emission.OperatingModeDeclaration(
+        "m", 88.0, 2.0, verification_level=90.0
+    )
+    just_over = ph.emission.OperatingModeDeclaration(
+        "m", 88.0, 2.0, verification_level=91.0
+    )
     ok = at_boundary.verified is True and just_over.verified is False
     return Outcome(
         expected="L_1=90 verified, L_1=91 rejected (L_WAd=90)",
@@ -229,7 +240,7 @@ def _chk_reverberation_lw() -> Outcome:
     theta, ps = 23.0, 101.325
     lw_target = np.array([80.0, 85.0, 90.0, 82.0, 75.0])
     lp = lw_target - _reverb_bracket(t60, volume, surface, freqs, theta, ps)
-    res = ph.sound_power_reverberation(
+    res = ph.emission.sound_power_reverberation(
         lp, t60, volume, surface, freqs, temperature=theta, static_pressure=ps
     )
     worst = float(np.max(np.abs(np.asarray(res.sound_power_level) - lw_target)))

--- a/scripts/conformance/domains/levels.py
+++ b/scripts/conformance/domains/levels.py
@@ -41,7 +41,7 @@ def _tone(freq: float, seconds: float = 1.0, amp: float = 1.0) -> np.ndarray:
 )
 def _chk_leq_sine() -> Outcome:
     # 20*log10((1/sqrt2) / 20e-6) = 90.97 dB.
-    computed = float(ph.leq(_tone(1000.0)))
+    computed = float(ph.signals.leq(_tone(1000.0)))
     return numeric(90.97, computed, 0.05, unit="dB", places=3)
 
 
@@ -53,7 +53,7 @@ def _chk_leq_sine() -> Outcome:
 def _chk_lex_8h() -> Outcome:
     rms = 2e-5 * 10 ** (90.0 / 20.0)
     x = math.sqrt(2) * rms * _tone(1000.0, seconds=2.0)
-    computed = float(ph.lex_8h(x, _FS, duration_hours=8.0))
+    computed = float(ph.signals.lex_8h(x, _FS, duration_hours=8.0))
     return numeric(90.0, computed, 0.05, unit="dB", places=3)
 
 
@@ -64,7 +64,7 @@ def _chk_lex_8h() -> Outcome:
 )
 def _chk_lden() -> Outcome:
     offset = 10.0 * math.log10((12 + 4 * 10**0.5 + 8 * 10) / 24)
-    computed = float(ph.lden(60.0, 60.0, 60.0))
+    computed = float(ph.environment.lden(60.0, 60.0, 60.0))
     return numeric(60.0 + offset, computed, 1e-6, unit="dB", places=4)
 
 
@@ -75,7 +75,7 @@ def _chk_lden() -> Outcome:
 )
 def _chk_iso1996_2_tonal_audibility() -> Outcome:
     lpt, lpn, fc, delta_expected, _kt = ref.ISO1996_2_TONAL_EXAMPLES[0]
-    computed = ph.tonal_audibility(lpt, lpn, fc)
+    computed = ph.environment.tonal_audibility(lpt, lpn, fc)
     return numeric(delta_expected, computed, 0.05, unit="dB", places=2)
 
 
@@ -86,7 +86,9 @@ def _chk_iso1996_2_tonal_audibility() -> Outcome:
 )
 def _chk_iso1996_2_tonal_adjustment() -> Outcome:
     lpt, lpn, fc, _delta, kt_expected = ref.ISO1996_2_TONAL_EXAMPLES[0]
-    computed = ph.tonal_adjustment(ph.tonal_audibility(lpt, lpn, fc))
+    computed = ph.environment.tonal_adjustment(
+        ph.environment.tonal_audibility(lpt, lpn, fc)
+    )
     return numeric(kt_expected, computed, 1e-9, unit="dB", places=2)
 
 
@@ -96,7 +98,9 @@ def _chk_iso1996_2_tonal_adjustment() -> Outcome:
     "Combined measurement uncertainty u = √(Σ(cj·uj)²)",
 )
 def _chk_iso1996_2_uncertainty() -> Outcome:
-    computed = ph.combined_standard_uncertainty(ref.ISO1996_2_G2_CONTRIBUTIONS)
+    computed = ph.environment.combined_standard_uncertainty(
+        ref.ISO1996_2_G2_CONTRIBUTIONS
+    )
     return numeric(ref.ISO1996_2_G2_COMBINED, computed, 0.01, unit="dB", places=2)
 
 
@@ -129,11 +133,16 @@ _DBHR_R_PRIME = [
 )
 def _chk_rd1367_period_level() -> Outcome:
     phases = [
-        ph.NoisePhase(hours, laeq, kt=kt, kf=kf)
+        ph.environment.NoisePhase(hours, laeq, kt=kt, kf=kf)
         for hours, laeq, kt, kf in _RD1367_DAY_PHASES
     ]
-    level = ph.evaluation_period_level(phases, hours=12.0)
-    return numeric(57.0, float(ph.round_reported_level(level)), 1e-9, unit="dB")
+    level = ph.environment.evaluation_period_level(phases, hours=12.0)
+    return numeric(
+        57.0,
+        float(ph.environment.round_reported_level(level)),
+        1e-9,
+        unit="dB",
+    )
 
 
 @register(
@@ -142,8 +151,15 @@ def _chk_rd1367_period_level() -> Outcome:
     "Long-term level LK,d (Manual Ejemplo 3.2: 303 operating days of 365)",
 )
 def _chk_rd1367_long_term_level() -> Outcome:
-    level = ph.long_term_corrected_level([57.0, 0.0], weights=[303.0, 62.0])
-    return numeric(56.0, float(ph.round_reported_level(level)), 1e-9, unit="dB")
+    level = ph.environment.long_term_corrected_level(
+        [57.0, 0.0], weights=[303.0, 62.0]
+    )
+    return numeric(
+        56.0,
+        float(ph.environment.round_reported_level(level)),
+        1e-9,
+        unit="dB",
+    )
 
 
 @register(
@@ -153,13 +169,16 @@ def _chk_rd1367_long_term_level() -> Outcome:
 )
 def _chk_rd1367_activity_verdict() -> Outcome:
     day = [
-        ph.NoisePhase(hours, laeq, kt=kt, kf=kf)
+        ph.environment.NoisePhase(hours, laeq, kt=kt, kf=kf)
         for hours, laeq, kt, kf in _RD1367_DAY_PHASES
     ]
-    evening = [ph.NoisePhase(2.0, 48.0, kt=3.0, kf=3.0), ph.NoisePhase(2.0, 0.0)]
-    verdict = ph.assess_activity(
+    evening = [
+        ph.environment.NoisePhase(2.0, 48.0, kt=3.0, kf=3.0),
+        ph.environment.NoisePhase(2.0, 0.0),
+    ]
+    verdict = ph.environment.assess_activity(
         {"day": day, "evening": evening},
-        ph.activity_limits("a"),
+        ph.environment.activity_limits("a"),
         operating_days=303,
     )
     # The book: the phase and daily criteria pass, the annual one does not, so
@@ -188,7 +207,7 @@ def _chk_rd1367_activity_verdict() -> Outcome:
     "Global index R'A for pink noise (Manual Ejemplo 7.2)",
 )
 def _chk_dbhr_ra() -> Outcome:
-    computed = ph.ra(_DBHR_R_PRIME).intermediate
+    computed = ph.building.ra(_DBHR_R_PRIME).intermediate
     return numeric(51.4, float(computed), 0.05, unit="dBA", places=2)
 
 
@@ -202,7 +221,7 @@ def _chk_dbhr_d2m_nt_atr() -> Outcome:
         28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
         38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5, 39.4, 41.5,
     ]
-    computed = ph.d2m_nt_atr(values).intermediate
+    computed = ph.building.d2m_nt_atr(values).intermediate
     return numeric(32.8, float(computed), 0.05, unit="dBA", places=2)
 
 
@@ -216,7 +235,7 @@ def _chk_dbhr_route_agreement() -> Outcome:
     # comparing the direct route against the library's own ISO 717-1 engine
     # would be a self-consistency check, not an external validation. The unit
     # test pins R'w = 52 and C = -1 against the same printed example.
-    computed = float(ph.ra(_DBHR_R_PRIME).reported)
+    computed = float(ph.building.ra(_DBHR_R_PRIME).reported)
     return numeric(51.0, computed, 1e-9, unit="dBA", places=1)
 
 
@@ -226,7 +245,7 @@ def _chk_dbhr_route_agreement() -> Outcome:
     "Reported R'A,tr of the same wall (printed 47 dBA = R'w 52 + Ctr -5)",
 )
 def _chk_dbhr_ra_tr() -> Outcome:
-    computed = float(ph.ra_tr(_DBHR_R_PRIME).reported)
+    computed = float(ph.building.ra_tr(_DBHR_R_PRIME).reported)
     return numeric(47.0, computed, 1e-9, unit="dBA", places=1)
 
 
@@ -236,7 +255,7 @@ def _chk_dbhr_ra_tr() -> Outcome:
     "Window size correction of RA (Manual Ejemplo 7.4: 4 m2 window, -2 dB)",
 )
 def _chk_dbhr_window_correction() -> Outcome:
-    computed = 26.0 + ph.window_size_correction(4.0)
+    computed = 26.0 + ph.building.window_size_correction(4.0)
     return numeric(24.0, float(computed), 1e-9, unit="dBA", places=1)
 
 
@@ -260,7 +279,9 @@ _RT_SURFACES = [
     "Reverberation time T = k·V/A  (V=120 m³, S=158 m², α=0.2)",
 )
 def _chk_sabine_rt() -> Outcome:
-    computed = float(ph.sabine_reverberation_time(_RT_VOLUME, _RT_SURFACES))
+    computed = float(
+        ph.room.sabine_reverberation_time(_RT_VOLUME, _RT_SURFACES)
+    )
     return numeric(0.6118246547, computed, 1e-6, unit="s", places=6)
 
 
@@ -273,7 +294,9 @@ def _chk_long_room_modes() -> Outcome:
     # Long's Chapter 2 quotes c0 = 344 m/s at 20 degC; the printed table is
     # consistent with 344.7 m/s, so the tolerance is one printed digit.
     printed = np.array([24.6, 34.5, 42.4, 49.2, 57.4, 60.1])
-    res = ph.room_modes((7.0, 5.0, 3.0), max_frequency=61.0, speed_of_sound=344.0)
+    res = ph.room.room_modes(
+        (7.0, 5.0, 3.0), max_frequency=61.0, speed_of_sound=344.0
+    )
     computed = np.asarray(res.frequencies, dtype=float)
     worst = int(np.argmax(np.abs(computed - printed)))
     return numeric(printed[worst], computed[worst], 0.13, unit="Hz", places=2)
@@ -287,7 +310,9 @@ def _chk_long_room_modes() -> Outcome:
 def _chk_long_modal_density() -> Outcome:
     density = float(
         np.asarray(
-            ph.room_modal_density(1000.0, (7.0, 5.0, 3.0), speed_of_sound=344.0)
+            ph.room.room_modal_density(
+                1000.0, (7.0, 5.0, 3.0), speed_of_sound=344.0
+            )
         )[()]
     )
     return numeric(34.0, density, 0.5, unit="modes/Hz", places=2)
@@ -299,7 +324,7 @@ def _chk_long_modal_density() -> Outcome:
     "Restaurant self-noise, 20 talkers over 20 metric sabins = 76 dB",
 )
 def _chk_long_restaurant_self_noise() -> Outcome:
-    level = float(np.asarray(ph.crowd_noise_level(20, 20.0))[()])
+    level = float(np.asarray(ph.room.crowd_noise_level(20, 20.0))[()])
     return numeric(76.0, level, 0.05, unit="dB", places=3)
 
 
@@ -309,7 +334,7 @@ def _chk_long_restaurant_self_noise() -> Outcome:
     "Privacy bound A_tab < 3.16 rt^2 (Q = 2, L_SN = -9 dB)",
 )
 def _chk_long_privacy_bound() -> Outcome:
-    a_tab = float(np.asarray(ph.absorption_per_table(1.0, -9.0))[()])
+    a_tab = float(np.asarray(ph.room.absorption_per_table(1.0, -9.0))[()])
     return numeric(3.16, a_tab, 0.005, unit="m^2", places=4)
 
 
@@ -323,7 +348,9 @@ def _chk_sabine_everest() -> Outcome:
         (ref.EVEREST_EX1_FLOOR_AREA, ref.EVEREST_EX1_FLOOR_ALPHA[3]),
         (ref.EVEREST_EX1_SHELL_AREA, ref.EVEREST_EX1_SHELL_ALPHA[3]),
     ]
-    computed = float(ph.sabine_reverberation_time(ref.EVEREST_EX1_VOLUME, surfaces))
+    computed = float(
+        ph.room.sabine_reverberation_time(ref.EVEREST_EX1_VOLUME, surfaces)
+    )
     return numeric(ref.EVEREST_EX1_RT[3], computed, 0.02, unit="s", places=3)
 
 
@@ -333,7 +360,9 @@ def _chk_sabine_everest() -> Outcome:
     "Reverberation time T = k·V/(-S·ln(1-ᾱ))  (α=0.2)",
 )
 def _chk_eyring_rt() -> Outcome:
-    computed = float(ph.eyring_reverberation_time(_RT_VOLUME, _RT_SURFACES))
+    computed = float(
+        ph.room.eyring_reverberation_time(_RT_VOLUME, _RT_SURFACES)
+    )
     return numeric(0.5483686633, computed, 1e-6, unit="s", places=6)
 
 
@@ -343,7 +372,9 @@ def _chk_eyring_rt() -> Outcome:
     "T (α=0.5/0.1/0.1 per wall pair, dims 8×5×3 m)",
 )
 def _chk_arau_rt() -> Outcome:
-    computed = float(ph.arau_puchades_reverberation_time(_RT_DIMS, (0.5, 0.1, 0.1)))
+    computed = float(
+        ph.room.arau_puchades_reverberation_time(_RT_DIMS, (0.5, 0.1, 0.1))
+    )
     return numeric(0.8121469281, computed, 1e-6, unit="s", places=6)
 
 
@@ -353,8 +384,10 @@ def _chk_arau_rt() -> Outcome:
     "Arau-Puchades ≡ Eyring when ᾱ is uniform",
 )
 def _chk_arau_eyring_identity() -> Outcome:
-    eyring = float(ph.eyring_reverberation_time(_RT_VOLUME, _RT_SURFACES))
-    arau = float(ph.arau_puchades_reverberation_time(_RT_DIMS, (0.2, 0.2, 0.2)))
+    eyring = float(ph.room.eyring_reverberation_time(_RT_VOLUME, _RT_SURFACES))
+    arau = float(
+        ph.room.arau_puchades_reverberation_time(_RT_DIMS, (0.2, 0.2, 0.2))
+    )
     return numeric(eyring, arau, 1e-9, unit="s", places=6,
                    expected_label=f"{eyring:.6f} s (= Eyring)")
 
@@ -365,7 +398,7 @@ def _chk_arau_eyring_identity() -> Outcome:
     "Image-source direct-sound amplitude 1/(4πr) and delay r/c (r = 4 m)",
 )
 def _chk_image_source_direct() -> Outcome:
-    res = ph.image_source_rir((8.0, 5.0, 3.0), (2.0, 2.5, 1.5),
+    res = ph.room.image_source_rir((8.0, 5.0, 3.0), (2.0, 2.5, 1.5),
                               (6.0, 2.5, 1.5), 0.2, fs=48000, max_order=2)
     amp = float(np.atleast_1d(res.amplitudes)[0])
     return numeric(1.0 / (4.0 * math.pi * 4.0), amp, 1e-9, places=7)
@@ -377,7 +410,7 @@ def _chk_image_source_direct() -> Outcome:
     "Audible shoebox image count up to order 10 (= 1560)",
 )
 def _chk_image_source_count() -> Outcome:
-    computed = float(ph.audible_image_count(10))
+    computed = float(ph.room.audible_image_count(10))
     return numeric(1560.0, computed, 0.0, places=0)
 
 
@@ -387,7 +420,7 @@ def _chk_image_source_count() -> Outcome:
     "Temporal reflection density dN/dt = 4πc³t²/V (t = 0.1 s, V = 120 m³)",
 )
 def _chk_reflection_density() -> Outcome:
-    computed = float(ph.reflection_density(0.1, 120.0))
+    computed = float(ph.room.reflection_density(0.1, 120.0))
     expected = 4.0 * math.pi * 343.0**3 * 0.1**2 / 120.0
     return numeric(expected, computed, 1e-6, unit="1/s", places=2)
 
@@ -398,7 +431,7 @@ def _chk_reflection_density() -> Outcome:
     "Room constant R = Sᾱ/(1-ᾱ)  (S = 100 m², ᾱ = 0.2 → 25 m²)",
 )
 def _chk_room_constant() -> Outcome:
-    return numeric(25.0, float(ph.room_constant(100.0, 0.2)), 1e-9,
+    return numeric(25.0, float(ph.room.room_constant(100.0, 0.2)), 1e-9,
                    unit="m²", places=6)
 
 
@@ -408,7 +441,7 @@ def _chk_room_constant() -> Outcome:
     "Critical distance rc: direct field = reverberant field (R = 25, Q = 1)",
 )
 def _chk_critical_distance_crossover() -> Outcome:
-    rc = float(ph.critical_distance(25.0))
+    rc = float(ph.room.critical_distance(25.0))
     direct = 1.0 / (4.0 * math.pi * rc**2)
     reverberant = 4.0 / 25.0
     return numeric(reverberant, direct, 1e-9, places=6,
@@ -421,7 +454,7 @@ def _chk_critical_distance_crossover() -> Outcome:
     "Schroeder frequency f_s = 2000√(T/V)  (V = 200 m³, T = 1 s)",
 )
 def _chk_schroeder_frequency() -> Outcome:
-    computed = float(ph.schroeder_frequency(1.0, 200.0))
+    computed = float(ph.room.schroeder_frequency(1.0, 200.0))
     return numeric(2000.0 * math.sqrt(1.0 / 200.0), computed, 1e-6,
                    unit="Hz", places=3)
 
@@ -432,6 +465,6 @@ def _chk_schroeder_frequency() -> Outcome:
     "Steady-state SPL Lp = Lw + 10lg(Q/4πr² + 4/R)  (Lw=90, r=1, R=25, Q=1)",
 )
 def _chk_steady_state_spl() -> Outcome:
-    computed = float(ph.steady_state_spl(90.0, 1.0, 25.0))
+    computed = float(ph.room.steady_state_spl(90.0, 1.0, 25.0))
     expected = 90.0 + 10.0 * math.log10(1.0 / (4.0 * math.pi) + 4.0 / 25.0)
     return numeric(expected, computed, 1e-6, unit="dB", places=4)

--- a/scripts/conformance/domains/noise_control.py
+++ b/scripts/conformance/domains/noise_control.py
@@ -32,7 +32,9 @@ _NOISE_CONTROL = "Industrial noise control"
 def _chk_expansion_chamber_peak() -> Outcome:
     c, length, s_duct = 343.0, 0.3, 0.01
     f = np.array([c / (4.0 * length)])  # kL = pi/2
-    res = ph.expansion_chamber(f, length, 4.0 * s_duct, s_duct, speed_of_sound=c)
+    res = ph.noise_control.expansion_chamber(
+        f, length, 4.0 * s_duct, s_duct, speed_of_sound=c
+    )
     expected = 10.0 * math.log10(1.0 + 0.25 * (4.0 - 0.25) ** 2)
     return numeric(expected, float(res.transmission_loss[0]), 1e-6, unit="dB")
 
@@ -45,7 +47,9 @@ def _chk_expansion_chamber_peak() -> Outcome:
 def _chk_expansion_chamber_trough() -> Outcome:
     c, length, s_duct = 343.0, 0.3, 0.01
     f = np.array([c / (2.0 * length)])  # kL = pi
-    res = ph.expansion_chamber(f, length, 4.0 * s_duct, s_duct, speed_of_sound=c)
+    res = ph.noise_control.expansion_chamber(
+        f, length, 4.0 * s_duct, s_duct, speed_of_sound=c
+    )
     return numeric(0.0, float(res.transmission_loss[0]), 1e-9, unit="dB")
 
 
@@ -56,7 +60,9 @@ def _chk_expansion_chamber_trough() -> Outcome:
 )
 def _chk_quarter_wave_tuning() -> Outcome:
     area = math.pi * 0.05**2 / 4.0
-    res = ph.quarter_wave_resonator([100.0], area, 1.516, area, speed_of_sound=343.24)
+    res = ph.noise_control.quarter_wave_resonator(
+        [100.0], area, 1.516, area, speed_of_sound=343.24
+    )
     assert res.resonances is not None
     return numeric(56.6, float(res.resonances[0]), 0.1, unit="Hz", places=2)
 
@@ -68,7 +74,9 @@ def _chk_quarter_wave_tuning() -> Outcome:
 )
 def _chk_helmholtz_resonance() -> Outcome:
     c = 343.0
-    res = ph.helmholtz_resonator([100.0], 0.01, 1e-4, 0.02, 1e-3, speed_of_sound=c)
+    res = ph.noise_control.helmholtz_resonator(
+        [100.0], 0.01, 1e-4, 0.02, 1e-3, speed_of_sound=c
+    )
     assert res.resonances is not None
     expected = c / (2.0 * math.pi) * math.sqrt(1e-4 / (0.02 * 1e-3))
     return numeric(expected, float(res.resonances[0]), 1e-6, unit="Hz", places=3)
@@ -114,7 +122,7 @@ def _chk_insertion_loss_equals_tl() -> Outcome:
     "Plenum TL = -10 lg[S_out(cos0/pi r^2 + (1-a)/(Sw a))] (S_out=.1,r=1,Sw=20,a=.2)",
 )
 def _chk_plenum_wells() -> Outcome:
-    tl = float(ph.plenum_attenuation(0.1, 1.0, 20.0, 0.2))
+    tl = float(ph.noise_control.plenum_attenuation(0.1, 1.0, 20.0, 0.2))
     direct = 1.0 / (math.pi * 1.0**2)
     reverb = (1.0 - 0.2) / (20.0 * 0.2)
     expected = -10.0 * math.log10(0.1 * (direct + reverb))
@@ -127,7 +135,9 @@ def _chk_plenum_wells() -> Outcome:
     "Duct end reflection D = 200 mm at 125 Hz = 10 dB (table node)",
 )
 def _chk_end_reflection_table() -> Outcome:
-    res = ph.end_reflection_loss([125.0], 0.200, termination="flush")
+    res = ph.noise_control.end_reflection_loss(
+        [125.0], 0.200, termination="flush"
+    )
     return numeric(10.0, float(res.values[0]), 1e-6, unit="dB")
 
 
@@ -137,7 +147,7 @@ def _chk_end_reflection_table() -> Outcome:
     "Forward-curved fan at Q_REF, P_REF, peak efficiency -> K_F + C_BFI at 500 Hz",
 )
 def _chk_fan_sound_power_reference_point() -> Outcome:
-    res = ph.fan_sound_power(
+    res = ph.noise_control.fan_sound_power(
         0.472e-3, 249.0, fan_type="forward_curved", relative_efficiency=100.0
     )
     # Table 13.5 forward-curved 500 Hz entry (36 dB) plus the Table 13.7
@@ -151,7 +161,7 @@ def _chk_fan_sound_power_reference_point() -> Outcome:
     "18 x 12 in duct, 6 ft, 1 in lining at 1 kHz -> 1.77 (10/3)^0.695 6 dB",
 )
 def _chk_lined_rectangular_duct() -> Outcome:
-    res = ph.lined_rectangular_duct_attenuation(
+    res = ph.noise_control.lined_rectangular_duct_attenuation(
         None, 18.0 * 0.0254, 12.0 * 0.0254, 6.0 * 0.3048, 0.0254
     )
     expected = 1.7700 * (10.0 / 3.0) ** 0.695 * 6.0
@@ -164,7 +174,9 @@ def _chk_lined_rectangular_duct() -> Outcome:
     "8 in diameter, 9 ft long -> 6/8/16/25/28/28/18 dB (table node)",
 )
 def _chk_flexible_duct_table() -> Outcome:
-    res = ph.flexible_duct_insertion_loss(None, 8.0 * 0.0254, 9.0 * 0.3048)
+    res = ph.noise_control.flexible_duct_insertion_loss(
+        None, 8.0 * 0.0254, 9.0 * 0.3048
+    )
     printed = np.array([6, 8, 16, 25, 28, 28, 18], dtype=float)
     worst = float(np.max(np.abs(res.values - printed)))
     return numeric(0.0, worst, 1e-9, unit="dB",
@@ -177,7 +189,7 @@ def _chk_flexible_duct_table() -> Outcome:
     "25 per cent split with area-matched branches -> -10 lg 0.25 = 6.02 dB",
 )
 def _chk_split_loss() -> Outcome:
-    loss = ph.split_loss(0.6, [0.15, 0.15, 0.15, 0.15], branch=0)
+    loss = ph.noise_control.split_loss(0.6, [0.15, 0.15, 0.15, 0.15], branch=0)
     return numeric(-10.0 * math.log10(0.25), loss, 1e-9, unit="dB")
 
 
@@ -221,7 +233,7 @@ def _chk_duct_path_table_14_9() -> Outcome:
     "row of Table 14.9",
 )
 def _chk_diffuser_sound_power() -> Outcome:
-    res = ph.diffuser_sound_power(
+    res = ph.noise_control.diffuser_sound_power(
         None, (24.0 * 0.0254) ** 2, 312.0 * 0.0004719474432, 0.05 * 249.0
     )
     printed = np.array([33.0, 32.0, 29.0, 23.0, 15.0])
@@ -236,7 +248,9 @@ def _chk_diffuser_sound_power() -> Outcome:
     "Max neck velocity of a supply outlet for design RC(30) -> 2.2 m/s",
 )
 def _chk_air_terminal_velocity() -> Outcome:
-    return numeric(2.2, ph.air_terminal_velocity_limit(30), 1e-9, unit="m/s")
+    return numeric(
+        2.2, ph.noise_control.air_terminal_velocity_limit(30), 1e-9, unit="m/s"
+    )
 
 
 @register(
@@ -245,7 +259,7 @@ def _chk_air_terminal_velocity() -> Outcome:
     "254 mm duct, steam, 200 m/s: (1,0) cut-on 812 Hz and k_x = -8.23 1/m",
 )
 def _chk_duct_cut_on_with_flow() -> Outcome:
-    res = ph.circular_duct_cut_on(
+    res = ph.noise_control.circular_duct_cut_on(
         0.254, flow_velocity=200.0, speed_of_sound=405.0, count=1
     )
     worst = max(
@@ -262,7 +276,9 @@ def _chk_duct_cut_on_with_flow() -> Outcome:
     "0.65 x 0.4 m duct, 15 m/s: first three cut-on 264 / 428 / 503 Hz",
 )
 def _chk_rectangular_duct_cut_on() -> Outcome:
-    res = ph.rectangular_duct_cut_on(0.65, 0.4, flow_velocity=15.0, count=3)
+    res = ph.noise_control.rectangular_duct_cut_on(
+        0.65, 0.4, flow_velocity=15.0, count=3
+    )
     printed = np.array([264.0, 428.0, 503.0])
     worst = float(np.max(np.abs(np.round(res.cut_on) - printed)))
     return numeric(0.0, worst, 1e-9, unit="Hz",
@@ -275,7 +291,7 @@ def _chk_rectangular_duct_cut_on() -> Outcome:
     "Enclosure correction C -> 10 lg 0.3 = -5.23 dB as alpha_i -> 1",
 )
 def _chk_enclosure_floor() -> Outcome:
-    res = ph.enclosure_insertion_loss([40.0], 6.0, 5.0, 0.999999)
+    res = ph.noise_control.enclosure_insertion_loss([40.0], 6.0, 5.0, 0.999999)
     return numeric(10.0 * math.log10(0.3), float(res.correction[0]), 1e-3,
                    unit="dB")
 
@@ -299,12 +315,12 @@ _N421_SURFACES = (
     "Double brick wall into an 8 x 9 x 3 m room -> NR 37.5/40.8/49.0/62.8/65.3/65.9 dB",
 )
 def _chk_room_to_room_noise_reduction() -> Outcome:
-    res = ph.room_to_room_transmission(
+    res = ph.noise_control.room_to_room_transmission(
         _N421_BANDS,
         [37.0, 41.0, 48.0, 60.0, 61.0, 61.0],
         8.0 * 3.0,
-        ph.equivalent_absorption_area(_N421_SURFACES),
-        source=ph.SourceRoom(level=90.0),
+        ph.room.equivalent_absorption_area(_N421_SURFACES),
+        source=ph.noise_control.SourceRoom(level=90.0),
     )
     printed = np.array([37.5, 40.8, 49.0, 62.8, 65.3, 65.9])
     worst = float(np.max(np.abs(np.asarray(res.noise_reduction) - printed)))
@@ -331,14 +347,16 @@ def _chk_room_to_room_chain() -> Outcome:
         (25.0, ceiling),
         (60.0, walls),
     )
-    res = ph.room_to_room_transmission(
+    res = ph.noise_control.room_to_room_transmission(
         _N421_BANDS,
         [39.0, 42.0, 50.0, 58.0, 63.0, 67.0],
         15.0,
-        ph.equivalent_absorption_area(operator),
-        source=ph.SourceRoom(
+        ph.room.equivalent_absorption_area(operator),
+        source=ph.noise_control.SourceRoom(
             power_level=[105.0, 103.0, 98.0, 108.0, 107.0, 109.0],
-            room_constant=ph.room_constant(268.0, ph.mean_absorption(plant)),
+            room_constant=ph.room.room_constant(
+                268.0, ph.room.mean_absorption(plant)
+            ),
             directivity=4.0,
             model="constant_volume",
         ),
@@ -363,11 +381,11 @@ def _chk_enclosure_required_transmission_loss() -> Outcome:
     concrete = np.array([0.01, 0.01, 0.01, 0.02, 0.02, 0.02, 0.03, 0.03])
     lp1 = np.array([72.0, 79.0, 81.0, 84.0, 83.0, 81.0, 80.0, 75.0])
     lp2 = np.array([67.0, 60.0, 54.0, 49.0, 46.0, 44.0, 43.0, 41.0])
-    res = ph.enclosure_required_transmission_loss(
+    res = ph.noise_control.enclosure_required_transmission_loss(
         lp1 - lp2,
         external,
         external + bare_floor + machine,
-        ph.mean_absorption(
+        ph.room.mean_absorption(
             ((external, wool), (bare_floor + machine, concrete))
         ),
         frequencies=[63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
@@ -385,9 +403,9 @@ def _chk_enclosure_required_transmission_loss() -> Outcome:
     "Source in the intersection of two flat surfaces (Q = 4) -> +10 lg 4 = 6.02 dB",
 )
 def _chk_constant_volume_source_model() -> Outcome:
-    base = float(ph.steady_state_spl(100.0, None, 40.0, directivity=4.0))
+    base = float(ph.room.steady_state_spl(100.0, None, 40.0, directivity=4.0))
     raised = float(
-        ph.steady_state_spl(
+        ph.room.steady_state_spl(
             100.0, None, 40.0, directivity=4.0, source_model="constant_volume"
         )
     )

--- a/scripts/conformance/domains/outdoor.py
+++ b/scripts/conformance/domains/outdoor.py
@@ -32,7 +32,7 @@ def _iso9613_table1(point: tuple[float, float, float, float]) -> Outcome:
     """Compare air_attenuation against an ISO 9613-1 Table 1 grid point (dB/km)."""
     temp, rh, freq, alpha_km = point
     computed = float(
-        ph.air_attenuation(freq, temp, rh, exact_midband=True)[()]
+        ph.environment.air_attenuation(freq, temp, rh, exact_midband=True)[()]
     ) * 1000.0  # dB/m -> dB/km
     # Tolerance = 1 in the last printed (3-significant-figure) digit.
     tol = 10.0 ** (math.floor(math.log10(alpha_km)) - 2)
@@ -71,7 +71,7 @@ def _chk_iso9613_2_table2_grid() -> Outcome:
     """
     worst = 0.0
     for (temp, rh), row in ref.ISO9613_2_TABLE2.items():
-        alpha = ph.air_attenuation(
+        alpha = ph.environment.air_attenuation(
             ref.ISO9613_2_TABLE2_BANDS, temp, rh, 101.325, exact_midband=True
         ) * 1000.0
         for got, printed, band in zip(alpha, row, ref.ISO9613_2_TABLE2_BANDS):
@@ -99,7 +99,7 @@ def _chk_iso9613_2_table2_grid() -> Outcome:
     "Geometrical divergence Adiv = 20 lg(d/d0) + 11 at 100 m",
 )
 def _chk_iso9613_2_adiv() -> Outcome:
-    computed = ph.geometric_divergence(100.0)
+    computed = ph.environment.geometric_divergence(100.0)
     return numeric(ref.ISO9613_2_ADIV_100M, computed, 1e-9, unit="dB", places=6)
 
 
@@ -113,8 +113,9 @@ def _chk_iso9613_2_ground_limit() -> Outcome:
     # (hs = hr = 0), fully-developed path (dp -> inf): the 250 Hz band isolates
     # the Table 3 limit b'(0) = 1,5 + 8,6 = 10,1, so Agr = 2(-1,5 + 10,1) = 17,2.
     big = 1.0e7
-    agr = ph.ground_attenuation(big, 0.0, 0.0, [250.0], 1.0, 1.0, 1.0,
-                                projected_distance=big)
+    agr = ph.environment.ground_attenuation(
+        big, 0.0, 0.0, [250.0], 1.0, 1.0, 1.0, projected_distance=big
+    )
     return numeric(
         ref.ISO9613_2_GROUND_AGR_250_POROUS, float(agr[0]), 1e-6, unit="dB",
         places=4,
@@ -127,8 +128,10 @@ def _chk_iso9613_2_ground_limit() -> Outcome:
     "Single-edge diffraction saturates at the 20 dB cap",
 )
 def _chk_iso9613_2_barrier_single_cap() -> Outcome:
-    b = ph.Barrier(source_to_edge=50.0, edge_to_receiver=50.0)
-    dz = ph.barrier_attenuation(b, 60.0, ph.DEFAULT_FREQUENCIES)
+    b = ph.environment.Barrier(source_to_edge=50.0, edge_to_receiver=50.0)
+    dz = ph.environment.barrier_attenuation(
+        b, 60.0, ph.environment.DEFAULT_FREQUENCIES
+    )
     return numeric(
         ref.ISO9613_2_BARRIER_CAP_SINGLE, float(np.max(dz)), 1e-9, unit="dB",
         places=6,
@@ -141,15 +144,19 @@ def _chk_iso9613_2_barrier_single_cap() -> Outcome:
     "Double-edge diffraction saturates at the 25 dB cap",
 )
 def _chk_iso9613_2_barrier_double_cap() -> Outcome:
-    b = ph.Barrier(source_to_edge=50.0, edge_to_receiver=50.0, edge_separation=5.0)
-    dz = ph.barrier_attenuation(b, 60.0, ph.DEFAULT_FREQUENCIES)
+    b = ph.environment.Barrier(
+        source_to_edge=50.0, edge_to_receiver=50.0, edge_separation=5.0
+    )
+    dz = ph.environment.barrier_attenuation(
+        b, 60.0, ph.environment.DEFAULT_FREQUENCIES
+    )
     return numeric(
         ref.ISO9613_2_BARRIER_CAP_DOUBLE, float(np.max(dz)), 1e-9, unit="dB",
         places=6,
     )
 
 
-def _iso9612_annex_d_tasks() -> list[ph.Task]:
+def _iso9612_annex_d_tasks() -> list[ph.hearing.Task]:
     """Rebuild the ISO 9612 Annex D Task objects from the shared input table."""
     from phonometry.hearing.occupational_exposure import Task
 
@@ -178,7 +185,7 @@ def _lex_and_u(lex: float, u: float, exp_lex: float, exp_u: float,
     "Task-based LEX,8h + U (welder day, case a)",
 )
 def _chk_iso9612_annex_d() -> Outcome:
-    res = ph.task_based_exposure(
+    res = ph.hearing.task_based_exposure(
         _iso9612_annex_d_tasks(), include_duration_uncertainty=False, warn=False
     )
     return _lex_and_u(
@@ -193,7 +200,7 @@ def _chk_iso9612_annex_d() -> Outcome:
     "Job-based LEX,8h + U (production line, 18 workers)",
 )
 def _chk_iso9612_annex_e() -> Outcome:
-    res = ph.job_based_exposure(
+    res = ph.hearing.job_based_exposure(
         list(ref.ISO9612_ANNEX_E_SAMPLES), ref.ISO9612_ANNEX_E_TE_HOURS
     )
     return _lex_and_u(
@@ -208,7 +215,7 @@ def _chk_iso9612_annex_e() -> Outcome:
     "Full-day LEX,8h + U (forklift drivers)",
 )
 def _chk_iso9612_annex_f() -> Outcome:
-    res = ph.full_day_exposure(
+    res = ph.hearing.full_day_exposure(
         list(ref.ISO9612_ANNEX_F_SAMPLES), ref.ISO9612_ANNEX_F_TE_HOURS
     )
     return _lex_and_u(
@@ -225,7 +232,7 @@ _MATERIALS = "Materials: absorption, airflow & impedance"
 
 @register(_MATERIALS, "ISO 11654:1997 Annex A.1", "Weighted absorption alpha_w (no indicator)")
 def _chk_iso11654_a1() -> Outcome:
-    res = ph.weighted_absorption(list(ref.ISO11654_ANNEX_A1_ALPHA_P))
+    res = ph.materials.weighted_absorption(list(ref.ISO11654_ANNEX_A1_ALPHA_P))
     out = numeric(ref.ISO11654_ANNEX_A1_ALPHA_W, res.alpha_w, 5e-4, places=2)
     # alpha_w matches AND no shape indicator applies AND class is C.
     ok = (
@@ -243,7 +250,7 @@ def _chk_iso11654_a1() -> Outcome:
 
 @register(_MATERIALS, "ISO 11654:1997 Annex A.2", "Weighted absorption alpha_w with M indicator")
 def _chk_iso11654_a2() -> Outcome:
-    res = ph.weighted_absorption(list(ref.ISO11654_ANNEX_A2_ALPHA_P))
+    res = ph.materials.weighted_absorption(list(ref.ISO11654_ANNEX_A2_ALPHA_P))
     out = numeric(ref.ISO11654_ANNEX_A2_ALPHA_W, res.alpha_w, 5e-4, places=2)
     ok = out.passed and res.shape_indicator == ref.ISO11654_ANNEX_A2_INDICATOR
     return Outcome(
@@ -256,7 +263,9 @@ def _chk_iso11654_a2() -> Outcome:
 
 @register(_MATERIALS, "ISO 9053-2:2020 Annex A.3", "Thermal boundary-layer thickness b")
 def _chk_iso9053_2_boundary() -> Outcome:
-    b = ph.thermal_boundary_layer_thickness(frequency=ref.ISO9053_2_ANNEX_A_FREQUENCY)
+    b = ph.materials.thermal_boundary_layer_thickness(
+        frequency=ref.ISO9053_2_ANNEX_A_FREQUENCY
+    )
     return numeric(
         ref.ISO9053_2_ANNEX_A_BOUNDARY_LAYER, b, 5e-6, unit="m", places=5,
     )
@@ -264,7 +273,7 @@ def _chk_iso9053_2_boundary() -> Outcome:
 
 @register(_MATERIALS, "ISO 9053-2:2020 Annex A.3", "Effective ratio of specific heats kappa'")
 def _chk_iso9053_2_kappa() -> Outcome:
-    kp = ph.effective_kappa(
+    kp = ph.materials.effective_kappa(
         cavity_surface=ref.ISO9053_2_ANNEX_A_SURFACE,
         cavity_volume=ref.ISO9053_2_ANNEX_A_VOLUME,
         frequency=ref.ISO9053_2_ANNEX_A_FREQUENCY,
@@ -274,7 +283,7 @@ def _chk_iso9053_2_kappa() -> Outcome:
 
 @register(_MATERIALS, "ISO 10534-1:1996 Eqs (9)/(13)/(14)", "Absorption from standing-wave ratio s=3")
 def _chk_iso10534_1_swr() -> Outcome:
-    alpha = float(ph.standing_wave_absorption(ref.ISO10534_1_SWR))
+    alpha = float(ph.materials.standing_wave_absorption(ref.ISO10534_1_SWR))
     # The intermediate |r| = (s-1)/(s+1) (Eq. (13)) must match its shared
     # oracle too, so both steps of the chain are pinned.
     from phonometry.materials.absorbers.standing_wave import (
@@ -332,7 +341,7 @@ _SCATTERING = "Scattering & diffusion (ISO 17497)"
 
 @register(_SCATTERING, "ISO 17497-1:2004 Eq (2)", "Reference speed of sound at 20 C")
 def _chk_iso17497_1_speed() -> Outcome:
-    c = float(ph.speed_of_sound(20.0))
+    c = float(ph.materials.speed_of_sound(20.0))
     return numeric(ref.ISO17497_1_SPEED_OF_SOUND_20C, c, 1e-6, unit="m/s", places=4)
 
 
@@ -340,19 +349,19 @@ def _chk_iso17497_1_speed() -> Outcome:
 def _chk_iso17497_1_scattering() -> Outcome:
     t1, t2, t3, t4 = ref.ISO17497_1_CHAIN_T
     c = ref.ISO17497_1_CHAIN_C
-    alpha_s = ph.random_incidence_absorption(
+    alpha_s = ph.materials.random_incidence_absorption(
         ref.ISO17497_1_CHAIN_V, ref.ISO17497_1_CHAIN_S, c1=c, t1=t1, c2=c, t2=t2
     )
-    alpha_spec = ph.specular_absorption_coefficient(
+    alpha_spec = ph.materials.specular_absorption_coefficient(
         ref.ISO17497_1_CHAIN_V, ref.ISO17497_1_CHAIN_S, c3=c, t3=t3, c4=c, t4=t4
     )
-    s = float(ph.scattering_coefficient(alpha_spec, alpha_s))
+    s = float(ph.materials.scattering_coefficient(alpha_spec, alpha_s))
     return numeric(ref.ISO17497_1_CHAIN_SCATTERING, s, 1e-9, places=4)
 
 
 @register(_SCATTERING, "ISO 17497-1:2004 Annex A.5", "Expanded uncertainty of scattering coefficient")
 def _chk_iso17497_1_uncertainty() -> Outcome:
-    u = float(ph.scattering_coefficient_uncertainty(
+    u = float(ph.materials.scattering_coefficient_uncertainty(
         ref.ISO17497_1_A5_ALPHA_SPEC,
         ref.ISO17497_1_A5_ALPHA_S,
         ref.ISO17497_1_A5_U_ALPHA_SPEC,
@@ -369,21 +378,33 @@ def _chk_iso17497_1_uncertainty() -> Outcome:
 # anchor against published third-party BEM data is the Appendix B rows below.
 @register(_SCATTERING, "ISO 17497-2:2012 Formula (5)", "Directional diffusion coefficient (QRD, model arc)")
 def _chk_iso17497_2_diffusion_qrd() -> Outcome:
-    d = float(ph.directional_diffusion_coefficient(list(ref.ISO17497_2_QRD_LEVELS)))
+    d = float(
+        ph.materials.directional_diffusion_coefficient(
+            list(ref.ISO17497_2_QRD_LEVELS)
+        )
+    )
     return numeric(ref.ISO17497_2_QRD_DIFFUSION, d, 1e-6, places=4)
 
 
 @register(_SCATTERING, "ISO 17497-2:2012 Formula (5)", "Directional diffusion coefficient (flat reference)")
 def _chk_iso17497_2_diffusion_flat() -> Outcome:
-    d = float(ph.directional_diffusion_coefficient(list(ref.ISO17497_2_FLAT_LEVELS)))
+    d = float(
+        ph.materials.directional_diffusion_coefficient(
+            list(ref.ISO17497_2_FLAT_LEVELS)
+        )
+    )
     return numeric(ref.ISO17497_2_FLAT_DIFFUSION, d, 1e-6, places=4)
 
 
 @register(_SCATTERING, "ISO 17497-2:2012 Formula (7)", "Normalised diffusion coefficient (QRD, model arc)")
 def _chk_iso17497_2_diffusion_normalized() -> Outcome:
-    d_qrd = ph.directional_diffusion_coefficient(list(ref.ISO17497_2_QRD_LEVELS))
-    d_flat = ph.directional_diffusion_coefficient(list(ref.ISO17497_2_FLAT_LEVELS))
-    d_n = float(ph.normalized_diffusion_coefficient(d_qrd, d_flat))
+    d_qrd = ph.materials.directional_diffusion_coefficient(
+        list(ref.ISO17497_2_QRD_LEVELS)
+    )
+    d_flat = ph.materials.directional_diffusion_coefficient(
+        list(ref.ISO17497_2_FLAT_LEVELS)
+    )
+    d_n = float(ph.materials.normalized_diffusion_coefficient(d_qrd, d_flat))
     return numeric(ref.ISO17497_2_NORMALIZED_DIFFUSION, d_n, 1e-6, places=4)
 
 
@@ -418,20 +439,20 @@ for _band, _published in zip(
 
 @register(_SCATTERING, "ISO 17497-2:2012 Formula (8)", "Zenith area factor (radians convention)")
 def _chk_iso17497_2_area_factor() -> Outcome:
-    n = ph.area_factors([0.0, 30.0, 60.0, 90.0], delta_theta=5.0)
+    n = ph.materials.area_factors([0.0, 30.0, 60.0, 90.0], delta_theta=5.0)
     return numeric(ref.ISO17497_2_AREA_FACTOR_ZENITH, float(n[0]), 1e-6, places=5)
 
 
 @register(_SCATTERING, "Cox & D'Antonio Eq (10.3)", "QRD deepest well depth (N=7, f0=500 Hz)")
 def _chk_diffuser_qrd_depth() -> Outcome:
-    d = ph.qrd_well_depths(7, 500.0, speed_of_sound=343.0)
+    d = ph.materials.qrd_well_depths(7, 500.0, speed_of_sound=343.0)
     return numeric(ref.DIFFUSER_QRD7_MAX_DEPTH, float(d.max()), 1e-12, unit="m", places=4)
 
 
 @register(_SCATTERING, "Cox & D'Antonio Eq (5.8) + ISO 17497-2 Formula (7)",
           "Flat-panel predicted normalised diffusion (self-reference zero)")
 def _chk_diffuser_flat_normalized() -> Outcome:
-    spectrum = ph.predicted_diffusion_spectrum(
+    spectrum = ph.materials.predicted_diffusion_spectrum(
         0.10, [2000.0], depths=[0.0] * 7, periods=5
     )
     assert spectrum.normalized is not None
@@ -444,8 +465,8 @@ def _chk_diffuser_flat_normalized() -> Outcome:
 @register(_SCATTERING, "Cox & D'Antonio Eq (5.8) + ISO 17497-2 Formula (7)",
           "QRD predicted normalised diffusion at 2 kHz (above flat panel)")
 def _chk_diffuser_qrd_normalized() -> Outcome:
-    depths = ph.qrd_well_depths(7, 500.0, speed_of_sound=343.0)
-    spectrum = ph.predicted_diffusion_spectrum(
+    depths = ph.materials.qrd_well_depths(7, 500.0, speed_of_sound=343.0)
+    spectrum = ph.materials.predicted_diffusion_spectrum(
         0.10, [2000.0], depths=depths, periods=5
     )
     assert spectrum.normalized is not None
@@ -463,19 +484,19 @@ _ROAD = "In-situ road absorption (ISO 13472)"
 
 @register(_ROAD, "ISO 13472-1:2002 Clause 4.2", "Geometrical-spreading factor Kr")
 def _chk_iso13472_1_kr() -> Outcome:
-    kr = ph.geometric_spreading_factor()
+    kr = ph.materials.geometric_spreading_factor()
     return numeric(ref.ISO13472_1_KR, kr, 1e-12, places=4)
 
 
 @register(_ROAD, "ISO 13472-1:2002 Annex A", "Maximum-sampled-area radius")
 def _chk_iso13472_1_msa() -> Outcome:
-    r = ph.max_sampled_area_radius(ref.ISO13472_1_MSA_WINDOW)
+    r = ph.materials.max_sampled_area_radius(ref.ISO13472_1_MSA_WINDOW)
     return numeric(ref.ISO13472_1_MSA_RADIUS, r, 1e-6, unit="m", places=4)
 
 
 @register(_ROAD, "ISO 13472-2:2010 Clause 5.4.1", "Spot-tube upper usable frequency f_u")
 def _chk_iso13472_2_fu() -> Outcome:
-    fu = ph.spot_tube_upper_frequency(
+    fu = ph.materials.spot_tube_upper_frequency(
         ref.ISO13472_2_SPOT_DIAMETER, ref.ISO13472_2_SPOT_SPEED
     )
     return numeric(ref.ISO13472_2_SPOT_FU, fu, 0.1, unit="Hz", places=1)
@@ -489,7 +510,7 @@ _PRECISION_POWER = "Precision sound power (ISO 3745 / 9614-3)"
 
 @register(_PRECISION_POWER, "ISO 3745:2012 Clause 10.5 EXAMPLE", "Expanded uncertainty U (k=2)")
 def _chk_iso3745_uncertainty() -> Outcome:
-    u = float(ph.precision_uncertainty(
+    u = float(ph.emission.precision_uncertainty(
         ref.ISO3745_U_SIGMA_R0, ref.ISO3745_U_SIGMA_OMC, ref.ISO3745_U_COVERAGE
     ))
     return numeric(ref.ISO3745_U_EXPANDED, u, 1e-3, unit="dB", places=3)
@@ -497,7 +518,7 @@ def _chk_iso3745_uncertainty() -> Outcome:
 
 @register(_PRECISION_POWER, "ISO 3745:2012 Eq (11)", "K1 background floor (6 dB edge band)")
 def _chk_iso3745_k1_floor() -> Outcome:
-    k1 = ph.precision_background_correction(
+    k1 = ph.emission.precision_background_correction(
         np.array([[ref.ISO3745_K1_EDGE_LEVEL]]),
         np.array([[ref.ISO3745_K1_EDGE_BACKGROUND]]),
         np.array([ref.ISO3745_K1_EDGE_FREQUENCY]),
@@ -507,7 +528,7 @@ def _chk_iso3745_k1_floor() -> Outcome:
 
 @register(_PRECISION_POWER, "ISO 3745:2012 Eq (16)", "Meteorological C1 at 23 C reference")
 def _chk_iso3745_c1() -> Outcome:
-    c1 = ph.meteorological_corrections(23.0, 101.325).c1
+    c1 = ph.emission.meteorological_corrections(23.0, 101.325).c1
     return numeric(ref.ISO3745_C1_REFERENCE, c1, 1e-4, unit="dB", places=4)
 
 
@@ -515,5 +536,5 @@ def _chk_iso3745_c1() -> Outcome:
 def _chk_iso9614_3_uniform() -> Outcome:
     areas = np.array(ref.ISO9614_3_UNIFORM_AREAS, dtype=float)
     i_n = np.full(areas.shape, ref.ISO9614_3_UNIFORM_POWER / float(areas.sum()))
-    res = ph.sound_power_intensity_precision(i_n, areas)
+    res = ph.emission.sound_power_intensity_precision(i_n, areas)
     return numeric(ref.ISO9614_3_UNIFORM_LW, float(res.sound_power_level[0]), 1e-9, unit="dB", places=4)

--- a/scripts/conformance/domains/panels.py
+++ b/scripts/conformance/domains/panels.py
@@ -26,48 +26,62 @@ _PANEL = "Panel & aperture sound insulation (Bies / Hopkins / Cremer)"
 
 @register(_PANEL, "Bies 5e Eq. 7.40 (mass law)", "6 dB per octave (500 -> 1000 Hz)")
 def _chk_mass_law_octave_slope() -> Outcome:
-    lo = float(ph.mass_law_transmission_loss(500.0, 20.0, incidence="normal"))
-    hi = float(ph.mass_law_transmission_loss(1000.0, 20.0, incidence="normal"))
+    lo = float(
+        ph.building.mass_law_transmission_loss(500.0, 20.0, incidence="normal")
+    )
+    hi = float(
+        ph.building.mass_law_transmission_loss(
+            1000.0, 20.0, incidence="normal"
+        )
+    )
     return numeric(6.0206, hi - lo, 0.01, unit="dB")
 
 
 @register(_PANEL, "Bies 5e Eq. 7.40 (mass law)", "6 dB per doubling of mass")
 def _chk_mass_law_mass_slope() -> Outcome:
-    lo = float(ph.mass_law_transmission_loss(500.0, 20.0, incidence="normal"))
-    hi = float(ph.mass_law_transmission_loss(500.0, 40.0, incidence="normal"))
+    lo = float(
+        ph.building.mass_law_transmission_loss(500.0, 20.0, incidence="normal")
+    )
+    hi = float(
+        ph.building.mass_law_transmission_loss(500.0, 40.0, incidence="normal")
+    )
     return numeric(6.0206, hi - lo, 0.01, unit="dB")
 
 
 @register(_PANEL, "Bies 5e Eq. 7.42 (field incidence)", "One-third-octave correction 5.5 dB")
 def _chk_field_incidence_correction() -> Outcome:
-    n = float(ph.mass_law_transmission_loss(500.0, 20.0, incidence="normal"))
-    fld = float(ph.mass_law_transmission_loss(500.0, 20.0, incidence="field"))
+    n = float(
+        ph.building.mass_law_transmission_loss(500.0, 20.0, incidence="normal")
+    )
+    fld = float(
+        ph.building.mass_law_transmission_loss(500.0, 20.0, incidence="field")
+    )
     return numeric(5.5, n - fld, 0.001, unit="dB")
 
 
 @register(_PANEL, "Hopkins Eq. 2.201 / Bies Eq. 7.3", "Coincidence frequency, 6 mm glass")
 def _chk_coincidence_frequency_glass() -> Outcome:
-    bp = ph.plate_bending_stiffness(6.2e10, 0.006, 0.24)
-    fc = ph.coincidence_frequency(2500.0 * 0.006, bp)
+    bp = ph.vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+    fc = ph.vibration.coincidence_frequency(2500.0 * 0.006, bp)
     return numeric(2079.0, fc, 0.03, rel=True, unit="Hz")
 
 
 @register(_PANEL, "Cremer Table 5.1", "Thin-plate point impedance Z = 8 sqrt(B' m'')")
 def _chk_plate_point_impedance() -> Outcome:
-    z = ph.infinite_plate_impedance(1.0e4, 10.0)
+    z = ph.vibration.infinite_plate_impedance(1.0e4, 10.0)
     return numeric(8.0 * math.sqrt(1.0e4 * 10.0), z, 1e-6, unit="N.s/m")
 
 
 @register(_PANEL, "Cremer Table 5.1", "Infinite-beam mobility phase -45 deg")
 def _chk_beam_mobility_phase() -> Outcome:
-    y = complex(ph.infinite_beam_mobility(137.0, 200.0, 5.0))
+    y = complex(ph.vibration.infinite_beam_mobility(137.0, 200.0, 5.0))
     return numeric(-45.0, math.degrees(math.atan2(y.imag, y.real)), 1e-6, unit="deg")
 
 
 @register(_PANEL, "Hopkins Eq. 2.229 (Leppington/Maidanik)",
           "Radiation efficiency at f = 2 fc")
 def _chk_radiation_above_coincidence() -> Outcome:
-    res = ph.radiation_efficiency([4000.0], 1.5, 1.25, 2000.0)
+    res = ph.vibration.radiation_efficiency([4000.0], 1.5, 1.25, 2000.0)
     return numeric(1.0 / math.sqrt(1.0 - 0.5), float(res.radiation_efficiency[0]),
                    1e-9)
 
@@ -75,7 +89,7 @@ def _chk_radiation_above_coincidence() -> Outcome:
 @register(_PANEL, "Bies Eq. 7.62 / Hopkins Eq. 4.73",
           "Mass-air-mass resonance f0, empty cavity")
 def _chk_mass_spring_mass() -> Outcome:
-    f0 = ph.mass_spring_mass_resonance(12.16, 12.16, 0.1)
+    f0 = ph.building.mass_spring_mass_resonance(12.16, 12.16, 0.1)
     expected = 60.0 * math.sqrt((12.16 + 12.16) / (12.16 * 12.16 * 0.1))
     return numeric(expected, f0, 0.005, rel=True, unit="Hz")
 
@@ -83,25 +97,30 @@ def _chk_mass_spring_mass() -> Outcome:
 @register(_PANEL, "Bies Eq. 7.64 (double wall)",
           "Below f0 = mass law of the combined mass")
 def _chk_double_wall_low_frequency() -> Outcome:
-    f0 = ph.mass_spring_mass_resonance(12.16, 12.16, 0.1)
-    dw = float(ph.double_wall_transmission_loss([0.5 * f0], 12.16, 12.16, 0.1)
-               .transmission_loss[0])
-    ml = float(ph.mass_law_transmission_loss(0.5 * f0, 24.32))
+    f0 = ph.building.mass_spring_mass_resonance(12.16, 12.16, 0.1)
+    dw = float(
+        ph.building.double_wall_transmission_loss(
+            [0.5 * f0], 12.16, 12.16, 0.1
+        ).transmission_loss[0]
+    )
+    ml = float(ph.building.mass_law_transmission_loss(0.5 * f0, 24.32))
     return numeric(ml, dw, 1e-6, unit="dB")
 
 
 @register(_PANEL, "Hopkins Eq. 4.92 (composite)",
           "1 % open area caps R at 10 lg(S/Sa)")
 def _chk_composite_open_area_limit() -> Outcome:
-    r = float(ph.composite_transmission_loss([0.99, 0.01], [60.0, 0.0]))
+    r = float(
+        ph.building.composite_transmission_loss([0.99, 0.01], [60.0, 0.0])
+    )
     return numeric(10.0 * math.log10(1.0 / 0.01), r, 0.05, unit="dB")
 
 
 @register(_PANEL, "Vigran Building Acoustics Eq. (3.109), printed p. 96",
           "Flat 1 mm steel plate 1 m x 1 m, f(1,1)")
 def _chk_flat_plate_first_mode() -> Outcome:
-    b = ph.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-    f11 = ph.orthotropic_plate_resonance(
+    b = ph.vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+    f11 = ph.building.orthotropic_plate_resonance(
         1, 1, length_x=1.0, length_z=1.0, mass_per_area=7.8,
         bending_stiffness_x=b, bending_stiffness_z=b, bending_stiffness_xz=b,
     )
@@ -111,11 +130,11 @@ def _chk_flat_plate_first_mode() -> Outcome:
 @register(_PANEL, "Vigran Eqs. (3.113)/(3.115), printed p. 96",
           "Corrugated 1 mm steel plate (H = 10 mm, L = 100 mm), f(2,2)")
 def _chk_corrugated_plate_mode_22() -> Outcome:
-    b_x, b_z, b_xz = ph.corrugated_plate_stiffness(
+    b_x, b_z, b_xz = ph.building.corrugated_plate_stiffness(
         1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3
     )
-    mass = 7.8 * ph.corrugated_plate_mass_factor(0.010, 0.100)
-    f22 = ph.orthotropic_plate_resonance(
+    mass = 7.8 * ph.building.corrugated_plate_mass_factor(0.010, 0.100)
+    f22 = ph.building.orthotropic_plate_resonance(
         2, 2, length_x=1.0, length_z=1.0, mass_per_area=mass,
         bending_stiffness_x=b_x, bending_stiffness_z=b_z,
         bending_stiffness_xz=b_xz,
@@ -127,7 +146,7 @@ def _chk_corrugated_plate_mode_22() -> Outcome:
           "Heckl coincidence-branch constant, dB (rho c = 414)")
 def _chk_heckl_coincidence_constant() -> Outcome:
     f, mass, fc1, fc2 = 800.0, 7.5, 400.0, 4000.0
-    tl = float(ph.orthotropic_transmission_loss(
+    tl = float(ph.building.orthotropic_transmission_loss(
         [f], mass, critical_frequency_lower=fc1,
         critical_frequency_upper=fc2, method="heckl",
         air_density=414.0 / 343.0,
@@ -144,7 +163,7 @@ def _chk_heckl_coincidence_constant() -> Outcome:
           "Heckl recovery-branch constant, dB (rho c = 414)")
 def _chk_heckl_recovery_constant() -> Outcome:
     f, mass, fc1, fc2 = 12500.0, 7.5, 400.0, 4000.0
-    tl = float(ph.orthotropic_transmission_loss(
+    tl = float(ph.building.orthotropic_transmission_loss(
         [f], mass, critical_frequency_lower=fc1,
         critical_frequency_upper=fc2, method="heckl",
         air_density=414.0 / 343.0,
@@ -160,7 +179,7 @@ def _chk_heckl_recovery_constant() -> Outcome:
           "Orthotropic diffuse integral below fc1 vs its exact mass-law form")
 def _chk_orthotropic_mass_law_integral() -> Outcome:
     mass, f, angle = 7.5, 50.0, 78.0
-    tl = float(ph.orthotropic_transmission_loss(
+    tl = float(ph.building.orthotropic_transmission_loss(
         [f], mass, critical_frequency_lower=4.0e5,
         critical_frequency_upper=4.0e6, limiting_angle=angle,
     ).transmission_loss[0])
@@ -176,16 +195,23 @@ def _chk_hopkins_table_a2_products() -> Outcome:
     rho, nu, h = 2500.0, 0.24, 0.01
     worst = 0.0
     for c_l, product in ref.HOPKINS_TABLE_A2_H_FC:
-        b = ph.plate_bending_stiffness(rho * c_l**2 * (1.0 - nu**2), h, nu)
-        worst = max(worst, abs(h * ph.coincidence_frequency(rho * h, b) - product))
+        b = ph.vibration.plate_bending_stiffness(
+            rho * c_l**2 * (1.0 - nu**2), h, nu
+        )
+        worst = max(
+            worst,
+            abs(h * ph.vibration.coincidence_frequency(rho * h, b) - product),
+        )
     return numeric(0.0, worst, 0.06, unit="m.Hz", places=4)
 
 
 @register(_PANEL, "Hopkins Eq. 4.99/4.101 (Gomperts slit)",
           "Transmission maximum at first resonance")
 def _chk_slit_resonance() -> Outcome:
-    fr = float(ph.slit_resonance_frequencies(0.1, 0.005, orders=1)[0])
+    fr = float(ph.building.slit_resonance_frequencies(0.1, 0.005, orders=1)[0])
     f = np.linspace(fr - 300.0, fr + 300.0, 601)
-    res = ph.slit_transmission_coefficient(f, 0.005, 0.1, field="normal")
+    res = ph.building.slit_transmission_coefficient(
+        f, 0.005, 0.1, field="normal"
+    )
     peak = float(f[int(np.argmax(res.transmission_coefficient))])
     return numeric(fr, peak, 15.0, unit="Hz")

--- a/scripts/conformance/domains/plate_junctions.py
+++ b/scripts/conformance/domains/plate_junctions.py
@@ -26,36 +26,46 @@ _JUNCTION = "Bending-wave plate-junction transmission (Cremer / Craik / Hopkins)
           "X-junction corner tau12(0 deg) = 1/8")
 def _chk_junction_x_corner_normal() -> Outcome:
     # chi = psi = 1 -> denominator (J2 psi + chi)**2 = 4, numerator 0.5.
-    tau = float(ph.corner_transmission_coefficient(0.0, 1.0, 1.0, "X"))
+    tau = float(
+        ph.vibration.corner_transmission_coefficient(0.0, 1.0, 1.0, "X")
+    )
     return numeric(0.125, tau, 1e-9)
 
 
 @register(_JUNCTION, "Hopkins Eqs 5.12 + 5.6 (identical plates)",
           "X-junction corner angular average = 1/12")
 def _chk_junction_x_average() -> Outcome:
-    avg = ph.angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")
+    avg = ph.vibration.angular_average_transmission_coefficient(
+        1.0, 1.0, "X", section="corner"
+    )
     return numeric(1.0 / 12.0, avg, 1e-6)
 
 
 @register(_JUNCTION, "Hopkins Eqs 5.12 + 5.6 (identical plates)",
           "L-junction corner angular average = 1/3")
 def _chk_junction_l_average() -> Outcome:
-    avg = ph.angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")
+    avg = ph.vibration.angular_average_transmission_coefficient(
+        1.0, 1.0, "L", section="corner"
+    )
     return numeric(1.0 / 3.0, avg, 1e-6)
 
 
 @register(_JUNCTION, "Hopkins Eq. 5.14 (identical plates)",
           "In-line junction tau12(0 deg) = 1")
 def _chk_junction_inline_identical() -> Outcome:
-    return numeric(1.0, ph.inline_transmission_coefficient(1.0, 1.0), 1e-9)
+    return numeric(
+        1.0, ph.vibration.inline_transmission_coefficient(1.0, 1.0), 1e-9
+    )
 
 
 @register(_JUNCTION, "Hopkins Eq. 5.7 (SEA consistency)",
           "X-junction reciprocity tau_bar_12 / tau_bar_21 = chi")
 def _chk_junction_reciprocity() -> Outcome:
     chi = 1.5
-    fwd = ph.angular_average_transmission_coefficient(chi, 0.8, "X", section="corner")
-    rev = ph.angular_average_transmission_coefficient(
+    fwd = ph.vibration.angular_average_transmission_coefficient(
+        chi, 0.8, "X", section="corner"
+    )
+    rev = ph.vibration.angular_average_transmission_coefficient(
         1.0 / chi, 1.0 / 0.8, "X", section="corner")
     return numeric(chi, fwd / rev, 1e-6)
 
@@ -64,5 +74,7 @@ def _chk_junction_reciprocity() -> Outcome:
           "X-junction vibration reduction index = 10 lg(12)")
 def _chk_junction_kij() -> Outcome:
     # fc_j = f_ref = 1000 Hz cancels the 5 lg(fc_j / f_ref) correction term.
-    kij = float(ph.wave_vibration_reduction_index(1.0 / 12.0, 1000.0))
+    kij = float(
+        ph.vibration.wave_vibration_reduction_index(1.0 / 12.0, 1000.0)
+    )
     return numeric(10.0 * math.log10(12.0), kij, 1e-6, unit="dB")

--- a/scripts/conformance/domains/program_loudness.py
+++ b/scripts/conformance/domains/program_loudness.py
@@ -42,7 +42,7 @@ def _ebu_stereo_steps(segments: tuple[tuple[float, float], ...]) -> np.ndarray:
 )
 def _chk_bs1770_anchor() -> Outcome:
     x = np.vstack([_ebu_tone(0.0, 10.0, freq=997.0), np.zeros(10 * _EBU_FS)])
-    computed = ph.integrated_loudness(x, _EBU_FS)
+    computed = ph.broadcast.integrated_loudness(x, _EBU_FS)
     return numeric(ref.BS1770_ANCHOR_997_LKFS, computed, 0.01, unit="LKFS", places=2)
 
 
@@ -53,7 +53,9 @@ def _chk_bs1770_anchor() -> Outcome:
 )
 def _chk_tech3341_case1() -> Outcome:
     _, segments, expected = ref.EBU_TECH3341_INTEGRATED_CASES[0]
-    computed = ph.integrated_loudness(_ebu_stereo_steps(segments), _EBU_FS)
+    computed = ph.broadcast.integrated_loudness(
+        _ebu_stereo_steps(segments), _EBU_FS
+    )
     return numeric(expected, computed, ref.EBU_TECH3341_TOL_LU, unit="LUFS", places=2)
 
 
@@ -64,7 +66,9 @@ def _chk_tech3341_case1() -> Outcome:
 )
 def _chk_tech3341_case5() -> Outcome:
     _, segments, expected = ref.EBU_TECH3341_INTEGRATED_CASES[4]
-    computed = ph.integrated_loudness(_ebu_stereo_steps(segments), _EBU_FS)
+    computed = ph.broadcast.integrated_loudness(
+        _ebu_stereo_steps(segments), _EBU_FS
+    )
     return numeric(expected, computed, ref.EBU_TECH3341_TOL_LU, unit="LUFS", places=2)
 
 
@@ -75,7 +79,7 @@ def _chk_tech3341_case5() -> Outcome:
 )
 def _chk_tech3341_case6() -> Outcome:
     x = np.vstack([_ebu_tone(lvl, 20.0) for lvl in ref.EBU_TECH3341_CASE6_LEVELS])
-    computed = ph.integrated_loudness(x, _EBU_FS)
+    computed = ph.broadcast.integrated_loudness(x, _EBU_FS)
     return numeric(
         ref.EBU_TECH3341_CASE6_EXPECTED,
         computed,
@@ -97,7 +101,7 @@ def _ebu_true_peak_case(index: int) -> tuple[float, float]:
     n = int(0.01 * _EBU_FS)
     x[:n] *= np.linspace(0.0, 1.0, n)
     x[-n:] *= np.linspace(1.0, 0.0, n)
-    return expected, float(ph.true_peak_level(x, _EBU_FS))
+    return expected, float(ph.broadcast.true_peak_level(x, _EBU_FS))
 
 
 def _true_peak_outcome(expected: float, computed: float) -> Outcome:
@@ -141,7 +145,7 @@ def _chk_tech3341_case19() -> Outcome:
 def _chk_tech3342_case1() -> Outcome:
     _, levels, expected = ref.EBU_TECH3342_LRA_CASES[0]
     x = _ebu_stereo_steps(tuple((lvl, 20.0) for lvl in levels))
-    res = ph.program_loudness(x, _EBU_FS)
+    res = ph.broadcast.program_loudness(x, _EBU_FS)
     return numeric(
         expected, res.loudness_range, ref.EBU_TECH3342_TOL_LU, unit="LU", places=2
     )
@@ -155,7 +159,7 @@ def _chk_tech3342_case1() -> Outcome:
 def _chk_tech3342_case3() -> Outcome:
     _, levels, expected = ref.EBU_TECH3342_LRA_CASES[2]
     x = _ebu_stereo_steps(tuple((lvl, 20.0) for lvl in levels))
-    res = ph.program_loudness(x, _EBU_FS)
+    res = ph.broadcast.program_loudness(x, _EBU_FS)
     return numeric(
         expected, res.loudness_range, ref.EBU_TECH3342_TOL_LU, unit="LU", places=2
     )

--- a/scripts/conformance/domains/psychoacoustics.py
+++ b/scripts/conformance/domains/psychoacoustics.py
@@ -47,7 +47,7 @@ def _iso532_levels() -> np.ndarray:
     "ERB_N number of 1000 Hz = 15.59 Cam",
 )
 def _chk_cam_of_1_khz() -> Outcome:
-    cam = float(np.asarray(ph.cam_from_frequency(1000.0))[()])
+    cam = float(np.asarray(ph.psychoacoustics.cam_from_frequency(1000.0))[()])
     return numeric(15.59, cam, 0.005, unit="Cam", places=4)
 
 
@@ -58,7 +58,7 @@ def _chk_cam_of_1_khz() -> Outcome:
 )
 def _chk_erb_bandwidth_1_khz() -> Outcome:
     published = 24.7 * (4.37 * 1.0 + 1.0)
-    erb = float(np.asarray(ph.erb_bandwidth(1000.0))[()])
+    erb = float(np.asarray(ph.psychoacoustics.erb_bandwidth(1000.0))[()])
     return numeric(published, erb, 3e-3, unit="Hz", rel=True, places=3)
 
 
@@ -69,7 +69,9 @@ def _chk_erb_bandwidth_1_khz() -> Outcome:
 )
 def _chk_iso532_stationary() -> Outcome:
     expected_n, nmin, nmax = _iso532_stationary_expected()
-    res = ph.loudness_zwicker_from_spectrum(_iso532_levels(), field="free")
+    res = ph.psychoacoustics.loudness_zwicker_from_spectrum(
+        _iso532_levels(), field="free"
+    )
     computed = float(res.loudness)
     out = numeric(expected_n, computed, 0.001, unit="sone", rel=True, places=4)
     within_band = nmin <= computed <= nmax
@@ -119,7 +121,7 @@ def _iso532_b5_signal(
 )
 def _chk_iso532_b5_free() -> Outcome:
     signal, fs, nmax, field = _iso532_b5_signal(14)
-    res = ph.loudness_zwicker(signal, fs, field=field)
+    res = ph.psychoacoustics.loudness_zwicker(signal, fs, field=field)
     return numeric(nmax, float(res.loudness), 0.001, unit="sone", rel=True, places=4)
 
 
@@ -130,7 +132,7 @@ def _chk_iso532_b5_free() -> Outcome:
 )
 def _chk_iso532_b5_diffuse() -> Outcome:
     signal, fs, nmax, field = _iso532_b5_signal(15)
-    res = ph.loudness_zwicker(signal, fs, field=field)
+    res = ph.psychoacoustics.loudness_zwicker(signal, fs, field=field)
     return numeric(nmax, float(res.loudness), 0.001, unit="sone", rel=True, places=4)
 
 
@@ -142,7 +144,7 @@ def _chk_iso532_b5_diffuse() -> Outcome:
 def _chk_sharpness_reference() -> Outcome:
     # Definitional: the clause 5.2 constant k is derived so this very signal
     # reads 1.00 acum. The independent Table A.2 oracle is checked below.
-    computed = float(ph.sharpness_din(reference_sound(), _FS))
+    computed = float(ph.psychoacoustics.sharpness_din(reference_sound(), _FS))
     return numeric(1.0, computed, 1e-9, unit="acum", places=6)
 
 
@@ -171,9 +173,13 @@ def _chk_sharpness_table_a2() -> Outcome:
     lo, hi = 30.0, 90.0
     for _ in range(13):  # set the clause 6 loudness of 4 sone
         mid = (lo + hi) / 2
-        n = ph.loudness_zwicker(narrowband(mid), _FS, stationary=True).loudness
+        n = ph.psychoacoustics.loudness_zwicker(
+            narrowband(mid), _FS, stationary=True
+        ).loudness
         lo, hi = (mid, hi) if n < 4.0 else (lo, mid)
-    computed = float(ph.sharpness_din(narrowband((lo + hi) / 2), _FS))
+    computed = float(
+        ph.psychoacoustics.sharpness_din(narrowband((lo + hi) / 2), _FS)
+    )
     return numeric(1.78, computed, 0.05 * 1.78, unit="acum", places=3)
 
 
@@ -186,7 +192,7 @@ def _chk_iso226_contour() -> Outcome:
     # Anchored off 1 kHz (where SPL == phon is a trivial identity) at a
     # tabulated point that exercises the Table 1 contour formula.
     phon, freq, spl_ref = ref.ISO226_2023_TABLE_B1_ANCHOR
-    freqs, spl = ph.equal_loudness_contour(phon)
+    freqs, spl = ph.psychoacoustics.equal_loudness_contour(phon)
     computed = float(spl[np.asarray(freqs) == freq][0])
     return numeric(spl_ref, computed, 0.05, unit="dB SPL", places=3)
 
@@ -225,7 +231,11 @@ def _chk_ecma_loudness() -> Outcome:
     # With the full Clause 6.2.3 band averaging the chain computes 0.9845
     # sone_HMS for the calibration tone; the residual's origin is documented
     # in the loudness_ecma module docstring (c_N stays the verbatim value).
-    computed = float(ph.loudness_ecma(_spl_tone(1000.0, 40.0, 0.6), _FS).loudness)
+    computed = float(
+        ph.psychoacoustics.loudness_ecma(
+            _spl_tone(1000.0, 40.0, 0.6), _FS
+        ).loudness
+    )
     return numeric(
         ref.ECMA418_2_LOUDNESS_1KHZ_40DB_SONE,
         computed,
@@ -241,7 +251,11 @@ def _chk_ecma_loudness() -> Outcome:
     "HMS tonality of a 1 kHz / 40 dB tone (c_T=2.8758615)",
 )
 def _chk_ecma_tonality() -> Outcome:
-    computed = float(ph.tonality_ecma(_spl_tone(1000.0, 40.0, 0.7), _FS).tonality)
+    computed = float(
+        ph.psychoacoustics.tonality_ecma(
+            _spl_tone(1000.0, 40.0, 0.7), _FS
+        ).tonality
+    )
     return numeric(
         ref.ECMA418_2_TONALITY_1KHZ_40DB_TU,
         computed,
@@ -260,7 +274,7 @@ def _chk_ecma_roughness() -> Outcome:
     # Clause 7 calibration: the reference signal at an overall sound pressure
     # level of 60 dB SPL is 1 asper (computed: 0.9999 with the tabulated c_R).
     sig = _am_tone(1000.0, 70.0, 1.0, 60.0, 2.0)
-    computed = float(ph.roughness_ecma(sig, _FS).roughness)
+    computed = float(ph.psychoacoustics.roughness_ecma(sig, _FS).roughness)
     return numeric(
         ref.ECMA418_2_ROUGHNESS_1KHZ_70HZ_60DB_ASPER,
         computed,
@@ -277,7 +291,9 @@ def _chk_ecma_roughness() -> Outcome:
 )
 def _chk_mg_loudness() -> Outcome:
     computed = float(
-        ph.loudness_moore_glasberg_from_spectrum([(1000.0, 40.0)]).loudness
+        ph.psychoacoustics.loudness_moore_glasberg_from_spectrum(
+            [(1000.0, 40.0)]
+        ).loudness
     )
     return numeric(
         ref.ISO532_2_ANCHOR_1KHZ_40DB_SONE, computed, 0.01, unit="sone", places=4
@@ -293,7 +309,9 @@ def _chk_mg_time_loudness() -> Outcome:
     fs = 32000.0
     t = np.arange(round(0.8 * fs)) / fs
     x = math.sqrt(2.0) * 2e-5 * 10.0 ** (40.0 / 20.0) * np.sin(2.0 * np.pi * 1000.0 * t)
-    computed = float(ph.loudness_moore_glasberg_time(x, fs).n_max)
+    computed = float(
+        ph.psychoacoustics.loudness_moore_glasberg_time(x, fs).n_max
+    )
     return numeric(
         ref.ISO532_3_ANCHOR_1KHZ_40DB_SONE, computed, 0.02, unit="sone", places=4
     )
@@ -309,7 +327,11 @@ def _chk_ecma_fluctuation_strength() -> Outcome:
     # level of 60 dB SPL is 1 vacil_HMS (computed: 0.9931 for this 5 s signal
     # with the tabulated c_F; 0.9958 converged for longer signals).
     sig = _am_tone(1000.0, 4.0, 1.0, 60.0, 5.0)
-    computed = float(ph.fluctuation_strength_ecma(sig, _FS).fluctuation_strength)
+    computed = float(
+        ph.psychoacoustics.fluctuation_strength_ecma(
+            sig, _FS
+        ).fluctuation_strength
+    )
     return numeric(
         ref.ECMA418_2_FLUCTUATION_1KHZ_4HZ_60DB_VACIL,
         computed,

--- a/scripts/conformance/domains/signal_analysis.py
+++ b/scripts/conformance/domains/signal_analysis.py
@@ -36,7 +36,9 @@ def _spectra_fs() -> float:
 
 
 def _spectra_white(seed: int, rms: float = 1.0) -> np.ndarray:
-    return ph.noise_signal(_spectra_fs(), 4.0, color="white", rms=rms, seed=seed)
+    return ph.signals.noise_signal(
+        _spectra_fs(), 4.0, color="white", rms=rms, seed=seed
+    )
 
 
 @register(
@@ -46,7 +48,9 @@ def _spectra_white(seed: int, rms: float = 1.0) -> np.ndarray:
 )
 def _chk_psd_white_level() -> Outcome:
     fs = _spectra_fs()
-    res = ph.power_spectral_density(_spectra_white(1, rms=2.0), fs, nperseg=1024)
+    res = ph.signals.power_spectral_density(
+        _spectra_white(1, rms=2.0), fs, nperseg=1024
+    )
     band = (res.frequencies > 200.0) & (res.frequencies < 3800.0)
     expected = 4.0 / (fs / 2.0)
     return numeric(
@@ -64,7 +68,7 @@ def _chk_psd_random_error() -> Outcome:
     estimates = []
     nd = 0.0
     for seed in range(100):
-        res = ph.power_spectral_density(
+        res = ph.signals.power_spectral_density(
             _spectra_white(100 + seed), fs, nperseg=1024, overlap=0.0
         )
         estimates.append(res.psd[50:200])
@@ -84,7 +88,9 @@ def _chk_psd_ci_coverage() -> Outcome:
     true_psd = 1.0 / (fs / 2.0)
     hits, total = 0, 0
     for seed in range(150):
-        res = ph.power_spectral_density(_spectra_white(300 + seed), fs, nperseg=1024)
+        res = ph.signals.power_spectral_density(
+            _spectra_white(300 + seed), fs, nperseg=1024
+        )
         for b in (60, 120, 240):
             hits += int(res.ci_lower[b] <= true_psd <= res.ci_upper[b])
             total += 1
@@ -99,8 +105,10 @@ def _chk_psd_ci_coverage() -> Outcome:
 def _chk_coherent_output_snr() -> Outcome:
     fs = _spectra_fs()
     x = _spectra_white(11)
-    noise = ph.noise_signal(fs, 4.0, color="white", rms=0.5, seed=12)
-    res = ph.coherent_output_spectrum(x, 0.8 * x + noise, fs, nperseg=1024)
+    noise = ph.signals.noise_signal(fs, 4.0, color="white", rms=0.5, seed=12)
+    res = ph.signals.coherent_output_spectrum(
+        x, 0.8 * x + noise, fs, nperseg=1024
+    )
     snr = 0.64 / 0.25
     band = slice(50, 400)
     return numeric(
@@ -118,8 +126,8 @@ def _chk_coherent_output_snr() -> Outcome:
 )
 def _chk_pink_noise_slope() -> Outcome:
     fs = 48000.0
-    x = ph.noise_signal(fs, 40.0, color="pink", seed=3)
-    res = ph.power_spectral_density(x, fs, nperseg=8192)
+    x = ph.signals.noise_signal(fs, 40.0, color="pink", seed=3)
+    res = ph.signals.power_spectral_density(x, fs, nperseg=8192)
     band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
     slope = float(
         np.polyfit(
@@ -139,7 +147,7 @@ def _chk_tone_burst_rms() -> Outcome:
     # Over exactly 25 full periods (240 samples) the mean square of the
     # sine is exactly 1/2, so the gate RMS is A/sqrt(2) to machine
     # precision.
-    res = ph.tone_burst(48000.0, 5000.0, 25, amplitude=1.0)
+    res = ph.signals.tone_burst(48000.0, 5000.0, 25, amplitude=1.0)
     if res.burst_samples != 240:  # 5 ms at 48 kHz, from Table AII
         return numeric(240.0, float(res.burst_samples), 0.0, places=0)
     rms = float(np.sqrt(np.mean(res.signal[:240] ** 2)))
@@ -152,7 +160,7 @@ def _chk_tone_burst_rms() -> Outcome:
     "Hann window ENBW = n*sum(w^2)/sum(w)^2 = 3/2 exactly",
 )
 def _chk_hann_enbw() -> Outcome:
-    res = ph.window_metrics("hann", 1024)
+    res = ph.signals.window_metrics("hann", 1024)
     return numeric(1.5, float(res.enbw_bins), 1e-12, places=6)
 
 
@@ -166,7 +174,7 @@ def _chk_smoothing_line_level() -> Outcome:
     power = np.zeros_like(f)
     i0 = 999  # 1000 Hz
     power[i0] = 5.0
-    out = ph.fractional_octave_smoothing(f, power, 3.0)
+    out = ph.signals.fractional_octave_smoothing(f, power, 3.0)
     width = 1000.0 * (2.0 ** (1.0 / 6.0) - 2.0 ** (-1.0 / 6.0))
     return numeric(5.0 / width, float(out[i0]), 1e-9, rel=True, places=6)
 
@@ -192,7 +200,9 @@ def _chk_multitaper_dpss_eigenvalue() -> Outcome:
 )
 def _chk_multitaper_white_level() -> Outcome:
     fs = _spectra_fs()
-    res = ph.multitaper_psd(np.asarray(_spectra_white(41, rms=2.0))[:8192], fs)
+    res = ph.signals.multitaper_psd(
+        np.asarray(_spectra_white(41, rms=2.0))[:8192], fs
+    )
     expected = 4.0 / (fs / 2.0)
     return numeric(
         expected, float(np.mean(res.psd[1:-1])), 0.03, rel=True, places=6
@@ -208,7 +218,7 @@ def _chk_multitaper_tone_peak() -> Outcome:
     fs = _spectra_fs()
     t = np.arange(4096) / fs
     x = 3.0 * np.sin(2.0 * np.pi * 1024.0 * t)
-    res = ph.multitaper_psd(x, fs, scaling="spectrum", adaptive=False)
+    res = ph.signals.multitaper_psd(x, fs, scaling="spectrum", adaptive=False)
     return numeric(
         4.5, float(res.psd[int(np.argmax(res.psd))]), 1e-4, rel=True, places=6
     )
@@ -221,7 +231,7 @@ def _chk_multitaper_tone_peak() -> Outcome:
 )
 def _chk_multitaper_adaptive_dof() -> Outcome:
     fs = _spectra_fs()
-    res = ph.multitaper_psd(np.asarray(_spectra_white(42))[:4096], fs)
+    res = ph.signals.multitaper_psd(np.asarray(_spectra_white(42))[:4096], fs)
     return numeric(
         2.0 * res.n_tapers,
         float(np.mean(res.degrees_of_freedom[1:-1])),
@@ -289,8 +299,10 @@ def _chk_miso_multiple_snr() -> Outcome:
     fs = _spectra_fs()
     x1 = _spectra_white(201)
     x2 = _spectra_white(202)
-    noise = ph.noise_signal(fs, 4.0, color="white", rms=0.5, seed=203)
-    res = ph.miso_coherence([x1, x2], x1 + x2 + noise, fs, nperseg=1024)
+    noise = ph.signals.noise_signal(fs, 4.0, color="white", rms=0.5, seed=203)
+    res = ph.signals.miso_coherence(
+        [x1, x2], x1 + x2 + noise, fs, nperseg=1024
+    )
     band = (res.frequencies > 200.0) & (res.frequencies < 3800.0)
     snr = 2.0 / 0.25  # Gvv = 2*sigma^2, Gnn = 0.5^2, both flat
     return numeric(
@@ -310,8 +322,10 @@ def _chk_miso_independent_sum() -> Outcome:
     fs = _spectra_fs()
     x1 = _spectra_white(211)
     x2 = _spectra_white(212)
-    noise = ph.noise_signal(fs, 4.0, color="white", rms=0.4, seed=213)
-    res = ph.miso_coherence([x1, x2], x1 + 0.7 * x2 + noise, fs, nperseg=1024)
+    noise = ph.signals.noise_signal(fs, 4.0, color="white", rms=0.4, seed=213)
+    res = ph.signals.miso_coherence(
+        [x1, x2], x1 + 0.7 * x2 + noise, fs, nperseg=1024
+    )
     band = (res.frequencies > 200.0) & (res.frequencies < 3800.0)
     diff = (res.multiple_coherence
             - res.ordinary_coherence.sum(axis=0))[band]
@@ -328,8 +342,10 @@ def _chk_miso_output_decomposition() -> Outcome:
     fs = _spectra_fs()
     x1 = _spectra_white(221)
     x2 = 0.5 * x1 + _spectra_white(222)
-    noise = ph.noise_signal(fs, 4.0, color="white", rms=0.3, seed=223)
-    res = ph.miso_coherence([x1, x2], x1 + x2 + noise, fs, nperseg=1024)
+    noise = ph.signals.noise_signal(fs, 4.0, color="white", rms=0.3, seed=223)
+    res = ph.signals.miso_coherence(
+        [x1, x2], x1 + x2 + noise, fs, nperseg=1024
+    )
     reconstructed = res.coherent_output_spectra.sum(axis=0) + res.noise_psd
     resid = float(np.max(np.abs(reconstructed - res.output_psd)))
     return numeric(0.0, resid, 1e-12, places=12)
@@ -350,7 +366,7 @@ def _chk_spectrogram_tone_mean_square() -> Outcome:
     fs = _spectra_fs()
     t = np.arange(int(4 * fs)) / fs
     x = 2.0 * np.cos(2.0 * np.pi * 1024.0 * t)  # bin 128 of a 1024-segment
-    res = ph.spectrogram(x, fs, nperseg=1024, scaling="spectrum")
+    res = ph.signals.spectrogram(x, fs, nperseg=1024, scaling="spectrum")
     b = int(np.argmin(np.abs(res.frequencies - 1024.0)))
     worst = res.power[b][int(np.argmax(np.abs(res.power[b] - 2.0)))]
     return numeric(2.0, float(worst), 1e-9, rel=True, places=6)
@@ -365,7 +381,7 @@ def _chk_spectrogram_parseval_cola() -> Outcome:
     fs = _spectra_fs()
     x = np.zeros(8192)
     x[2048:4096] = np.asarray(_spectra_white(21))[:2048]
-    res = ph.spectrogram(x, fs, nperseg=256, overlap=0.75)
+    res = ph.signals.spectrogram(x, fs, nperseg=256, overlap=0.75)
     df = float(res.frequencies[1] - res.frequencies[0])
     stft_energy = (res.hop / fs) * float(np.sum(res.power)) * df
     return numeric(
@@ -387,7 +403,9 @@ def _chk_zoom_fft_demodulation_chain() -> Outcome:
     n = 4096
     t = np.arange(n) / fs
     x = 0.7 * np.cos(2.0 * np.pi * 1100.0 * t + 0.3)
-    res = ph.zoom_fft(x, fs, f_min=1000.0, f_max=1256.0, n_points=257, window="boxcar")
+    res = ph.signals.zoom_fft(
+        x, fs, f_min=1000.0, f_max=1256.0, n_points=257, window="boxcar"
+    )
     peak = int(np.argmax(res.amplitude))
     # Eqs. (11.128)-(11.130): demodulate by exp(-j*2*pi*1000*t), decimate
     # by d = fs/(2B) = 16 and read bin 50 ((1100-1000) Hz / 2 Hz) of the
@@ -415,7 +433,7 @@ def _corr_fractional_pair(
 ) -> tuple[np.ndarray, np.ndarray]:
     """White noise and its exact circular fractional delay by ``shift``."""
     fs = _corr_fs()
-    x = ph.noise_signal(fs, 4.0, color="white", seed=seed)
+    x = ph.signals.noise_signal(fs, 4.0, color="white", seed=seed)
     ramp = np.exp(-2j * np.pi * np.fft.rfftfreq(x.size) * shift)
     return x, np.fft.irfft(np.fft.rfft(x) * ramp, x.size)
 
@@ -427,8 +445,8 @@ def _corr_fractional_pair(
 )
 def _chk_tde_integer_delay() -> Outcome:
     fs = _corr_fs()
-    x = ph.noise_signal(fs, 4.0, color="white", seed=40)
-    res = ph.time_delay(x, np.roll(x, 16), fs, method="direct")
+    x = ph.signals.noise_signal(fs, 4.0, color="white", seed=40)
+    res = ph.signals.time_delay(x, np.roll(x, 16), fs, method="direct")
     return numeric(16.0, res.delay_samples, 1e-3, places=4)
 
 
@@ -439,7 +457,7 @@ def _chk_tde_integer_delay() -> Outcome:
 )
 def _chk_tde_gcc_phat_fractional() -> Outcome:
     x, y = _corr_fractional_pair(41, 12.25)
-    res = ph.time_delay(
+    res = ph.signals.time_delay(
         x, y, _corr_fs(), method="gcc", weighting="phat", nperseg=2048,
         upsample=16,
     )
@@ -453,7 +471,7 @@ def _chk_tde_gcc_phat_fractional() -> Outcome:
 )
 def _chk_tde_phase_slope_fractional() -> Outcome:
     x, y = _corr_fractional_pair(41, 12.25)
-    res = ph.time_delay(x, y, _corr_fs(), method="phase", nperseg=2048)
+    res = ph.signals.time_delay(x, y, _corr_fs(), method="phase", nperseg=2048)
     return numeric(12.25, res.delay_samples, 1e-3, places=4)
 
 
@@ -465,11 +483,11 @@ def _chk_tde_phase_slope_fractional() -> Outcome:
 def _chk_blwn_autocorrelation_sinc() -> Outcome:
     fs = _corr_fs()
     bandwidth = fs / 5.0
-    x = ph.noise_signal(fs, 4.0, color="white", seed=41)
+    x = ph.signals.noise_signal(fs, 4.0, color="white", seed=41)
     spectrum = np.fft.rfft(x)
     spectrum[np.fft.rfftfreq(x.size, 1.0 / fs) > bandwidth] = 0.0
     xb = np.fft.irfft(spectrum, x.size)
-    res = ph.correlation(xb, fs=fs, normalization="coefficient",
+    res = ph.signals.correlation(xb, fs=fs, normalization="coefficient",
                          max_lag=0.005)
     lag = int(np.argmin(np.abs(res.lags))) + 3
     arg = 2.0 * math.pi * bandwidth * res.lags[lag]
@@ -485,7 +503,7 @@ def _chk_blwn_autocorrelation_sinc() -> Outcome:
 )
 def _chk_correlation_random_error_example_8_5() -> Outcome:
     # rho_peak = S/sqrt((S+M)(S+N)) = 1/11 (Eq. 8.115); the book gives 0.35.
-    eps = ph.correlation_random_error(1.0 / 11.0, 100.0, 5.0)
+    eps = ph.signals.correlation_random_error(1.0 / 11.0, 100.0, 5.0)
     return numeric(0.35, eps, 1e-3, places=4)
 
 
@@ -498,7 +516,7 @@ def _chk_hilbert_cos_to_sin() -> Outcome:
     fs = _corr_fs()
     n = 16384
     t = np.arange(n) / fs
-    res = ph.envelope(np.cos(2.0 * np.pi * 500.0 * t), fs)
+    res = ph.signals.envelope(np.cos(2.0 * np.pi * 500.0 * t), fs)
     interior = slice(1024, n - 1024)
     reconstructed = res.envelope * np.sin(res.phase)
     err = float(np.max(np.abs(
@@ -517,7 +535,7 @@ def _chk_am_envelope_exact() -> Outcome:
     n = 16384
     t = np.arange(n) / fs
     exact = 1.0 + 0.5 * np.cos(2.0 * np.pi * 10.0 * t)
-    res = ph.envelope(exact * np.cos(2.0 * np.pi * 1000.0 * t), fs)
+    res = ph.signals.envelope(exact * np.cos(2.0 * np.pi * 1000.0 * t), fs)
     interior = slice(1024, n - 1024)
     err = float(np.max(np.abs(res.envelope[interior] - exact[interior])))
     return numeric(0.0, err, 1e-9, places=6)
@@ -543,7 +561,7 @@ def _cepstrum_echo_signal() -> np.ndarray:
     "Power-cepstrum height at the echo delay = reflection coefficient a",
 )
 def _chk_power_cepstrum_echo() -> Outcome:
-    res = ph.echo_detection(_cepstrum_echo_signal(), 8192.0)
+    res = ph.signals.echo_detection(_cepstrum_echo_signal(), 8192.0)
     if res.delay_samples != 313:
         return numeric(313.0, float(res.delay_samples), 0.5, places=0)
     return numeric(0.4, res.reflection_coefficient, 1e-10, places=6)
@@ -555,7 +573,7 @@ def _chk_power_cepstrum_echo() -> Outcome:
     "Second rahmonic of a reflection a = 0.4 equals -a^2/2",
 )
 def _chk_complex_cepstrum_rahmonic() -> Outcome:
-    res = ph.cepstrum(_cepstrum_echo_signal(), 8192.0, kind="complex")
+    res = ph.signals.cepstrum(_cepstrum_echo_signal(), 8192.0, kind="complex")
     return numeric(-0.08, float(res.cepstrum[2 * 313]), 1e-10, places=6)
 
 
@@ -571,7 +589,7 @@ def _chk_envelope_spectrum_am_line() -> Outcome:
     x = 2.0 * (1.0 + 0.35 * np.cos(2.0 * np.pi * 16.0 * t)) * np.cos(
         2.0 * np.pi * 1000.0 * t
     )
-    res = ph.envelope_spectrum(x, fs)
+    res = ph.signals.envelope_spectrum(x, fs)
     line = float(res.amplitude[round(16.0 * n / fs)])
     return numeric(0.7, line, 2e-3, places=4)
 
@@ -589,7 +607,11 @@ _TSA = "Time synchronous averaging (McFadden 1987)"
 )
 def _chk_tsa_comb_tooth() -> Outcome:
     period = 1.0 / 32.0
-    value = float(ph.comb_filter_response(np.array([16.0 / period]), period, 8)[0])
+    value = float(
+        ph.signals.comb_filter_response(np.array([16.0 / period]), period, 8)[
+            0
+        ]
+    )
     return numeric(1.0, value, 1e-10, places=8)
 
 
@@ -601,7 +623,9 @@ def _chk_tsa_comb_tooth() -> Outcome:
 def _chk_tsa_comb_midbin() -> Outcome:
     period = 1.0 / 32.0
     value = float(
-        ph.comb_filter_response(np.array([0.25 / period]), period, 2)[0]
+        ph.signals.comb_filter_response(np.array([0.25 / period]), period, 2)[
+            0
+        ]
     )
     return numeric(1.0 / math.sqrt(2.0), value, 1e-10, places=8)
 
@@ -614,8 +638,8 @@ def _chk_tsa_comb_midbin() -> Outcome:
 def _chk_tsa_node_selection() -> Outcome:
     period = 1.0 / 32.0
     freq = np.array([32.05 / period])
-    c20 = float(ph.comb_filter_response(freq, period, 20)[0])
-    c32 = float(ph.comb_filter_response(freq, period, 32)[0])
+    c20 = float(ph.signals.comb_filter_response(freq, period, 20)[0])
+    c32 = float(ph.signals.comb_filter_response(freq, period, 32)[0])
     if not c32 > 0.15:  # sanity: the power-of-two choice does not reject it
         return numeric(0.0, c32, 0.0, places=8)
     return numeric(0.0, c20, 1e-10, places=10)
@@ -634,7 +658,9 @@ def _chk_tsa_exact_recovery() -> Outcome:
     one = np.cos(2.0 * np.pi * phase) + 0.5 * np.cos(
         2.0 * np.pi * 3.0 * phase + 0.4
     )
-    res = ph.time_synchronous_average(np.tile(one, 24), fs, period=period)
+    res = ph.signals.time_synchronous_average(
+        np.tile(one, 24), fs, period=period
+    )
     err = float(np.max(np.abs(res.period_waveform - one)))
     return numeric(0.0, err, 1e-10, places=12)
 
@@ -653,7 +679,7 @@ def _chk_tsa_sqrt_n_law() -> Outcome:
     one = np.cos(2.0 * np.pi * phase)
     rng = np.random.default_rng(2024)
     noise = rng.standard_normal(n_avg * m)
-    res = ph.time_synchronous_average(
+    res = ph.signals.time_synchronous_average(
         np.tile(one, n_avg) + noise, fs, period=period, n_averages=n_avg
     )
     measured = float(np.std(res.period_waveform - one))
@@ -679,7 +705,7 @@ _BP_EXAMPLE_4_4 = [
     "Reverse arrangements of the 20-observation sequence",
 )
 def _chk_reverse_arrangements_example_4_4() -> Outcome:
-    res = ph.trend_test(_BP_EXAMPLE_4_4)
+    res = ph.metrology.trend_test(_BP_EXAMPLE_4_4)
     if not res.trend_free:  # the book accepts the hypothesis at 5 %
         return numeric(1.0, 0.0, 0.0, places=0)
     return numeric(86.0, float(res.statistic), 0.0, places=0)
@@ -691,7 +717,7 @@ def _chk_reverse_arrangements_example_4_4() -> Outcome:
     "Lower percentage point A(20; 0.975) at alpha = 0.05",
 )
 def _chk_table_a6_lower() -> Outcome:
-    res = ph.trend_test(_BP_EXAMPLE_4_4)
+    res = ph.metrology.trend_test(_BP_EXAMPLE_4_4)
     return numeric(64.0, float(res.bounds[0]), 0.0, places=0)
 
 
@@ -701,13 +727,13 @@ def _chk_table_a6_lower() -> Outcome:
     "Upper percentage point A(20; 0.025) at alpha = 0.05",
 )
 def _chk_table_a6_upper() -> Outcome:
-    res = ph.trend_test(_BP_EXAMPLE_4_4)
+    res = ph.metrology.trend_test(_BP_EXAMPLE_4_4)
     return numeric(125.0, float(res.bounds[1]), 0.0, places=0)
 
 
-def _runs_reference_result() -> ph.TrendTestResult:
+def _runs_reference_result() -> ph.metrology.TrendTestResult:
     rng = np.random.default_rng(20)
-    return ph.trend_test(rng.standard_normal(20), method="runs")
+    return ph.metrology.trend_test(rng.standard_normal(20), method="runs")
 
 
 @register(
@@ -753,7 +779,7 @@ def _bandlimited_gaussian_record(
 )
 def _chk_rice_zero_crossings_bandpass() -> Outcome:
     x = _bandlimited_gaussian_record(0, 20480.0, 1 << 19, 800.0, 1200.0)
-    res = ph.level_crossing_rate(x, 20480.0, levels=[0.0])
+    res = ph.metrology.level_crossing_rate(x, 20480.0, levels=[0.0])
     expected = 2.0 * float(np.sqrt(1000.0**2 + 400.0**2 / 12.0))
     return numeric(expected, res.zero_crossing_rate, 0.01, rel=True, places=0)
 
@@ -765,7 +791,7 @@ def _chk_rice_zero_crossings_bandpass() -> Outcome:
 )
 def _chk_rice_apparent_frequency_lowpass() -> Outcome:
     x = _bandlimited_gaussian_record(1, 20480.0, 1 << 19, 0.0, 2000.0)
-    res = ph.level_crossing_rate(x, 20480.0, levels=[0.0])
+    res = ph.metrology.level_crossing_rate(x, 20480.0, levels=[0.0])
     expected = 2000.0 / float(np.sqrt(3.0))
     return numeric(expected, res.apparent_frequency, 0.01, rel=True, places=0)
 
@@ -778,7 +804,7 @@ def _chk_rice_apparent_frequency_lowpass() -> Outcome:
 def _chk_rice_narrowband_peak_exceedance() -> Outcome:
     fs = 8192.0
     t = np.arange(1 << 16) / fs
-    res = ph.peak_statistics(np.sin(2.0 * np.pi * 60.0 * t), fs)
+    res = ph.metrology.peak_statistics(np.sin(2.0 * np.pi * 60.0 * t), fs)
     return numeric(
         float(np.exp(-8.0)),
         float(res.peak_exceedance(4.0)[0]),

--- a/scripts/conformance/domains/sound_quality.py
+++ b/scripts/conformance/domains/sound_quality.py
@@ -79,15 +79,17 @@ _TONE_AUD = "Tonal audibility (ISO/PAS 20065)"
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formulae (12)-(14)", "Audibility at 137.3 Hz, Annex E spectrum 1")
 def _chk_iso20065_audibility() -> Outcome:
     fT, ls, lt, expected = ref.ISO20065_ANNEX_E_TONES[1]  # 137.3 Hz tone
-    value = ph.tone_audibility(lt, ls, fT, ref.ISO20065_LINE_SPACING)
+    value = ph.psychoacoustics.tone_audibility(
+        lt, ls, fT, ref.ISO20065_LINE_SPACING
+    )
     # 0.05 dB absorbs the standard's 2-decimal table rounding of LS/LT/LG/av.
     return numeric(expected, value, 0.05, unit="dB", places=2)
 
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formula (13)", "Masking index av at 137.3 / 592.2 Hz")
 def _chk_iso20065_masking_index() -> Outcome:
-    av137 = ph.masking_index(137.3)
-    av592 = ph.masking_index(592.2)
+    av137 = ph.psychoacoustics.masking_index(137.3)
+    av592 = ph.psychoacoustics.masking_index(592.2)
     ok = (
         abs(av137 - ref.ISO20065_AV_137) <= 0.005
         and abs(av592 - ref.ISO20065_AV_592) <= 0.005
@@ -104,14 +106,16 @@ def _chk_iso20065_masking_index() -> Outcome:
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formula (20)", "Mean audibility of the five spectra, Annex E")
 def _chk_iso20065_mean_audibility() -> Outcome:
-    value = ph.mean_audibility(ref.ISO20065_DECISIVE_AUDIBILITIES)
+    value = ph.psychoacoustics.mean_audibility(
+        ref.ISO20065_DECISIVE_AUDIBILITIES
+    )
     # 0.05 dB absorbs the 2-decimal rounding of the tabulated decisive values.
     return numeric(ref.ISO20065_MEAN_AUDIBILITY, value, 0.05, unit="dB", places=2)
 
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formula (6)", "Mean narrow-band level LS from spectrum, Table E.1")
 def _chk_iso20065_mean_narrowband_level() -> Outcome:
-    value = ph.mean_narrowband_level(
+    value = ph.psychoacoustics.mean_narrowband_level(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, 137.3
     )
     # Iterative Formula (6) with Hanning correction; 0.02 dB absorbs rounding.
@@ -120,7 +124,7 @@ def _chk_iso20065_mean_narrowband_level() -> Outcome:
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Clause 6", "Extended uncertainty U of the 137.3 Hz tone, Table E.2")
 def _chk_iso20065_uncertainty() -> Outcome:
-    res = ph.analyze_spectrum(
+    res = ph.psychoacoustics.analyze_spectrum(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
     )
     assert res.extended_uncertainties is not None
@@ -132,7 +136,9 @@ def _chk_iso20065_uncertainty() -> Outcome:
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formulae (28)-(29)", "Extended uncertainty of the mean audibility, Annex E Step 4")
 def _chk_iso20065_mean_uncertainty() -> Outcome:
     u_j = [row[6] for row in ref.ISO20065_E4_DECISIVE_ROWS]
-    value = ph.mean_audibility_uncertainty(ref.ISO20065_DECISIVE_AUDIBILITIES, u_j)
+    value = ph.psychoacoustics.mean_audibility_uncertainty(
+        ref.ISO20065_DECISIVE_AUDIBILITIES, u_j
+    )
     return numeric(
         ref.ISO20065_E4_MEAN_UNCERTAINTY, value, 0.01, unit="dB", places=2
     )
@@ -140,10 +146,10 @@ def _chk_iso20065_mean_uncertainty() -> Outcome:
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formula (8)", "Tone level LT from spectrum, Table E.1")
 def _chk_iso20065_tone_level() -> Outcome:
-    ls = ph.mean_narrowband_level(
+    ls = ph.psychoacoustics.mean_narrowband_level(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, 137.3
     )
-    value = ph.tone_level(
+    value = ph.psychoacoustics.tone_level(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, 137.3, ls
     )
     return numeric(ref.ISO20065_E1_LT, value, 0.02, unit="dB", places=2)
@@ -151,7 +157,7 @@ def _chk_iso20065_tone_level() -> Outcome:
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Clause 5.3.8", "Tone detection over the spectrum, Table E.1")
 def _chk_iso20065_peak_detection() -> Outcome:
-    result = ph.analyze_spectrum(
+    result = ph.psychoacoustics.analyze_spectrum(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
     )
     assert result.group_sizes is not None
@@ -173,7 +179,7 @@ def _chk_iso20065_peak_detection() -> Outcome:
     "Same-band FG combination inside analyze_spectrum, Table E.2 row 2 FG",
 )
 def _chk_iso20065_step3_fg() -> Outcome:
-    result = ph.analyze_spectrum(
+    result = ph.psychoacoustics.analyze_spectrum(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
     )
     assert result.group_sizes is not None
@@ -184,7 +190,7 @@ def _chk_iso20065_step3_fg() -> Outcome:
 
 @register(_TONE_AUD, "ISO/PAS 20065:2016 Formula (17)", "Multi-tone FG combination, Table E.1")
 def _chk_iso20065_fg_combination() -> Outcome:
-    value = ph.combined_tone_level(
+    value = ph.psychoacoustics.combined_tone_level(
         ref.ISO20065_E1_LEVELS,
         ref.ISO20065_E1_FREQUENCIES,
         ref.ISO20065_E1_TONE_FREQUENCIES,
@@ -199,11 +205,13 @@ def _chk_iso20065_fg_combination() -> Outcome:
     "Two-tone separation fD (DIN 45681 Annex J), 137.3 / 212 Hz",
 )
 def _chk_iso20065_two_tone_separation() -> Outcome:
-    fd_137 = ph.two_tone_separation_frequency(137.3)
-    fd_212 = ph.two_tone_separation_frequency(212.0)
+    fd_137 = ph.psychoacoustics.two_tone_separation_frequency(137.3)
+    fd_212 = ph.psychoacoustics.two_tone_separation_frequency(212.0)
     # Annex E consistency: the 118.4/137.3 Hz pair is combined, not separated
     # (|Δf| = 18.9 Hz < fD ≈ 24 Hz at the more prominent tone).
-    annex_e_combined = not ph.resolve_tones_separately(118.4, 137.3, 4.0, 5.0)
+    annex_e_combined = not ph.psychoacoustics.resolve_tones_separately(
+        118.4, 137.3, 4.0, 5.0
+    )
     ok = (
         round(fd_137, 2) == ref.ISO20065_FD_137
         and round(fd_212, 2) == ref.ISO20065_FD_212
@@ -236,7 +244,7 @@ _PA_FS = "Psychoacoustic annoyance & fluctuation strength (Fastl & Zwicker)"
 )
 def _chk_psychoacoustic_annoyance() -> Outcome:
     n5, s, f, r = ref.PA_WORKED_INPUT
-    value = ph.psychoacoustic_annoyance(n5, s, f, r).annoyance
+    value = ph.psychoacoustics.psychoacoustic_annoyance(n5, s, f, r).annoyance
     return numeric(ref.PA_WORKED_VALUE, value, 1e-3, places=4)
 
 
@@ -246,7 +254,7 @@ def _chk_psychoacoustic_annoyance() -> Outcome:
     "Fluctuation strength of AM broadband noise (60 dB, m=1, 4 Hz)",
 )
 def _chk_fluctuation_strength_am_noise() -> Outcome:
-    value = ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0)
+    value = ph.psychoacoustics.fluctuation_strength_am_noise(60.0, 1.0, 4.0)
     return numeric(ref.FS_BBN_60_1_4, value, 1e-3, unit="vacil", places=4)
 
 
@@ -262,7 +270,9 @@ def _chk_fluctuation_strength_calibration() -> Outcome:
     t = np.arange(int(fs * 2.0)) / fs
     tone = (1.0 + np.sin(2.0 * np.pi * 4.0 * t)) * np.sin(2.0 * np.pi * 1000.0 * t)
     tone = tone / np.sqrt(np.mean(tone**2)) * 2e-5 * 10.0 ** (60.0 / 20.0)
-    value = ph.fluctuation_strength(tone, fs).fluctuation_strength
+    value = ph.psychoacoustics.fluctuation_strength(
+        tone, fs
+    ).fluctuation_strength
     return numeric(
         ref.FS_CALIBRATION_VACIL, value, 0.05, unit="vacil", places=3
     )

--- a/scripts/conformance/domains/speech.py
+++ b/scripts/conformance/domains/speech.py
@@ -142,7 +142,7 @@ def _chk_stipa_staircase(m: float) -> Outcome:
     # audio path (octave bank, envelopes, correlation, TI chain). The
     # certified stipa.info WAV bench (same construction) measures a worst
     # deviation of 0,0031 STI; tolerance +/-0,01.
-    computed = float(ph.stipa(_stipa_sine_signal(m), _FS).sti)
+    computed = float(ph.speech.stipa(_stipa_sine_signal(m), _FS).sti)
     return numeric(_STI_STAIRCASE[m], computed, 0.01, places=4)
 
 
@@ -199,7 +199,7 @@ def _chk_sti_indirect_expdecay() -> Outcome:
         1.0 + (2.0 * np.pi * mod_freqs * rt60 / (6.0 * np.log(10.0))) ** 2
     )
     expected = float(_sti_from_mtf(np.tile(m_formula, (_NUM_STI_BANDS, 1))).sti)
-    computed = float(ph.sti_from_impulse_response(x, _FS).sti)
+    computed = float(ph.speech.sti_from_impulse_response(x, _FS).sti)
     return numeric(expected, computed, 0.005, places=4)
 
 
@@ -225,7 +225,7 @@ def _chk_sti_filter_slope() -> Outcome:
     with warnings.catch_warnings():
         # Bands other than 125 Hz are legitimately (near-)empty here.
         warnings.simplefilter("ignore", UserWarning)
-        m_observed = float(np.min(ph.stipa(x, _FS).mtf[0]))
+        m_observed = float(np.min(ph.speech.stipa(x, _FS).mtf[0]))
     return Outcome(
         expected="m >= 0.5 (C.4.2 pass criterion)",
         computed=_fmt(m_observed, places=4),
@@ -245,7 +245,7 @@ def _chk_sti_weighting_pair_audio() -> Outcome:
     # modulated (m = 1) -> STI = alpha_3 + alpha_4 - beta_3 = 0,398.
     # Certified WAV bench worst deviation vs the identity: 0,0002 STI.
     x = _stipa_sine_signal(1.0, bands=(2, 3), flat_levels=True)
-    computed = float(ph.stipa(x, _FS).sti)
+    computed = float(ph.speech.stipa(x, _FS).sti)
     return numeric(0.398, computed, 0.005, places=4)
 
 
@@ -261,7 +261,7 @@ def _chk_sti_edge_carriers() -> Outcome:
     # normative criterion is |STI bias| < 0,01 over TI = 0,1 .. 0,9; the
     # zero-phase bank measures -0,0029 worst on the certified WAVs.
     x = _stipa_sine_signal(0.94065, edge_carriers=True, flat_levels=True)
-    computed = float(ph.stipa(x, _FS).sti)
+    computed = float(ph.speech.stipa(x, _FS).sti)
     return numeric(0.9, computed, 0.01, places=4)
 
 
@@ -277,7 +277,7 @@ _SYSMEAS = "System measurement (Golay / Kirkeby / Mueller-Massarani)"
     "Golay pair: sum of periodic autocorrelations = 2L*delta (L = 4096)",
 )
 def _chk_golay_complementary() -> Outcome:
-    a, b = ph.golay_pair(12)
+    a, b = ph.room.golay_pair(12)
     length = a.size
     acorr = np.fft.irfft(
         np.abs(np.fft.rfft(a)) ** 2 + np.abs(np.fft.rfft(b)) ** 2, length
@@ -296,9 +296,9 @@ def _chk_golay_complementary() -> Outcome:
     "Golay chain recovers a delay+gain system IR (noiseless, exact)",
 )
 def _chk_golay_recovery() -> Outcome:
-    pair = ph.golay_pair(10)
+    pair = ph.room.golay_pair(10)
     gain, delay = 0.75, 37
-    res = ph.golay_impulse_response(
+    res = ph.room.golay_impulse_response(
         gain * np.roll(pair[0], delay), gain * np.roll(pair[1], delay), pair
     )
     expected = np.zeros(pair[0].size)
@@ -312,7 +312,7 @@ def _sysmeas_inverse() -> Any:
     b, a = sg.butter(2, [100.0, 8000.0], btype="bandpass", fs=float(_FS))
     imp = np.zeros(1024)
     imp[0] = 1.0
-    return ph.regularized_inverse_filter(
+    return ph.signals.regularized_inverse_filter(
         sg.lfilter(b, a, imp), float(_FS), f_range=(200.0, 4000.0)
     )
 
@@ -356,7 +356,7 @@ def _chk_kirkeby_out_of_band() -> Outcome:
     "Shaped sweep's Welch spectrum follows the pink target, in-band",
 )
 def _chk_shaped_sweep_pink() -> Outcome:
-    res = ph.shaped_sweep_signal(_FS, 50.0, 5000.0, 2.0, target="pink")
+    res = ph.room.shaped_sweep_signal(_FS, 50.0, 5000.0, 2.0, target="pink")
     nperseg = 8192
     freqs, psd = sg.welch(
         np.asarray(res), fs=float(_FS), nperseg=nperseg,

--- a/scripts/conformance/domains/swept_sine.py
+++ b/scripts/conformance/domains/swept_sine.py
@@ -32,9 +32,11 @@ _SS_A2, _SS_A3 = 0.1, 0.2
 
 def _swept_sine_polynomial() -> Any:
     fs, f1, f2, seconds = 48000, 20.0, 6000.0, 2.0
-    x = ph.synchronized_sweep_signal(fs, f1, f2, seconds)
+    x = ph.electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
     y = x + _SS_A2 * x**2 + _SS_A3 * x**3
-    return ph.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+    return ph.electroacoustics.swept_sine_distortion(
+        y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3
+    )
 
 
 def _ss_response_at(res: Any, order: int, freq: float) -> complex:
@@ -88,8 +90,8 @@ def _chk_swept_sine_linear_floor() -> Outcome:
     # A longer sweep than the polynomial checks: the floor is deconvolution
     # residue, and 4 s of sweep leaves 3x headroom under the 1e-3 bound.
     fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
-    x = ph.synchronized_sweep_signal(fs, f1, f2, seconds)
-    res = ph.swept_sine_distortion(
+    x = ph.electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
+    res = ph.electroacoustics.swept_sine_distortion(
         0.5 * x, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3
     )
     band = (res.thd_frequencies > 100.0) & (res.thd_frequencies < 2000.0)
@@ -107,7 +109,7 @@ def _chk_minimum_phase_biquad() -> Outcome:
     b = np.array([1.0 + alpha * gain, -2.0 * math.cos(w0), 1.0 - alpha * gain])
     a = np.array([1.0 + alpha / gain, -2.0 * math.cos(w0), 1.0 - alpha / gain])
     _, resp = sg.freqz(b, a, worN=np.linspace(0.0, math.pi, 4097))
-    rec = ph.minimum_phase(resp)
+    rec = ph.signals.minimum_phase(resp)
     err = float(np.max(np.abs(np.angle(rec) - np.angle(resp))))
     return numeric(0.0, err, 1e-9, unit="rad", places=6)
 
@@ -121,7 +123,7 @@ def _chk_group_delay_allpass() -> Outcome:
     a_coef = 0.5
     grid = np.linspace(0.0, math.pi, 4097)
     _, resp = sg.freqz([a_coef, 1.0], [1.0, a_coef], worN=grid)
-    tau = ph.group_delay(resp, 1.0)  # fs = 1 -> samples
+    tau = ph.signals.group_delay(resp, 1.0)  # fs = 1 -> samples
     idx = int(np.argmin(np.abs(grid - math.pi / 2.0)))
     expected = (1.0 - a_coef**2) / (1.0 + a_coef**2)
     return numeric(expected, float(tau[idx]), 1e-5, places=5)
@@ -140,5 +142,5 @@ def _chk_excess_group_delay() -> Outcome:
     grid = np.linspace(0.0, math.pi, 4097)
     _, resp = sg.freqz(b, a, worN=grid)
     delayed = resp * np.exp(-1j * grid * 7.25)
-    res = ph.phase_decomposition(delayed, 1.0)  # fs = 1 -> samples
+    res = ph.signals.phase_decomposition(delayed, 1.0)  # fs = 1 -> samples
     return numeric(7.25, float(res.excess_group_delay[2048]), 1e-6, places=5)

--- a/scripts/conformance/domains/underwater.py
+++ b/scripts/conformance/domains/underwater.py
@@ -40,7 +40,9 @@ def _chk_uw_spl() -> Outcome:
     amp = 2.0  # Pa
     x = amp * np.sin(2.0 * np.pi * 500.0 * t)
     expected = 20.0 * math.log10((amp / math.sqrt(2.0)) / 1e-6)
-    return numeric(expected, ph.sound_pressure_level(x), 1e-4, places=4)
+    return numeric(
+        expected, ph.underwater.sound_pressure_level(x), 1e-4, places=4
+    )
 
 
 @register(
@@ -55,7 +57,9 @@ def _chk_uw_sel() -> Outcome:
     x = amp * np.sin(2.0 * np.pi * 500.0 * t)
     spl = 20.0 * math.log10((amp / math.sqrt(2.0)) / 1e-6)
     expected = spl + 10.0 * math.log10(2.0)
-    return numeric(expected, ph.sound_exposure_level(x, fs), 1e-3, places=4)
+    return numeric(
+        expected, ph.underwater.sound_exposure_level(x, fs), 1e-3, places=4
+    )
 
 
 @register(
@@ -69,7 +73,9 @@ def _chk_uw_peak() -> Outcome:
     amp = 3.0
     x = amp * np.sin(2.0 * np.pi * 500.0 * t)
     expected = 20.0 * math.log10(amp / 1e-6)
-    return numeric(expected, ph.peak_sound_pressure_level(x), 1e-4, places=4)
+    return numeric(
+        expected, ph.underwater.peak_sound_pressure_level(x), 1e-4, places=4
+    )
 
 
 @register(
@@ -79,7 +85,12 @@ def _chk_uw_peak() -> Outcome:
 )
 def _chk_uw_rnl() -> Outcome:
     expected = 20.0 * math.log10(2.0) + 40.0  # p = 2 µPa, r = 100 m
-    return numeric(expected, ph.radiated_noise_level(2e-6, 100.0), 1e-4, places=4)
+    return numeric(
+        expected,
+        ph.underwater.radiated_noise_level(2e-6, 100.0),
+        1e-4,
+        places=4,
+    )
 
 
 @register(
@@ -92,7 +103,7 @@ def _chk_uw_delta_l() -> Outcome:
     ds = 0.7 * draught
     u = 2.0 * math.pi * f / c * ds
     expected = -10.0 * math.log10((2 * u**4 + 14 * u**2) / (14 + 2 * u**2 + u**4))
-    res = ph.monopole_source_level(120.0, f, draught, c=c)
+    res = ph.underwater.monopole_source_level(120.0, f, draught, c=c)
     return numeric(expected, float(res.surface_correction[0]), 1e-4, places=4)
 
 
@@ -104,7 +115,7 @@ def _chk_uw_delta_l() -> Outcome:
 def _chk_uw_cumulative_sel() -> Outcome:
     return numeric(
         180.0 + 10.0 * math.log10(50),
-        ph.cumulative_sel_identical(180.0, 50),
+        ph.underwater.cumulative_sel_identical(180.0, 50),
         1e-6,
         places=4,
     )
@@ -124,7 +135,9 @@ _UW_PROP = "Underwater sound propagation (propagation loss)"
 def _chk_uwp_mackenzie() -> Outcome:
     return numeric(
         1550.744,
-        ph.sea_water_sound_speed(25.0, 35.0, 1000.0, model="mackenzie"),
+        ph.underwater.sea_water_sound_speed(
+            25.0, 35.0, 1000.0, model="mackenzie"
+        ),
         1e-2,
         unit="m/s",
         places=3,
@@ -137,8 +150,12 @@ def _chk_uwp_mackenzie() -> Outcome:
     "Sound-speed agreement at 10 °C, 35 ‰, 1000 m (cross-model), m/s",
 )
 def _chk_uwp_unesco() -> Outcome:
-    expected = ph.sea_water_sound_speed(10.0, 35.0, 1000.0, model="mackenzie")
-    got = ph.sea_water_sound_speed(10.0, 35.0, 1000.0, model="unesco")
+    expected = ph.underwater.sea_water_sound_speed(
+        10.0, 35.0, 1000.0, model="mackenzie"
+    )
+    got = ph.underwater.sea_water_sound_speed(
+        10.0, 35.0, 1000.0, model="unesco"
+    )
     return numeric(expected, got, 1.0, unit="m/s", places=3)
 
 
@@ -148,8 +165,12 @@ def _chk_uwp_unesco() -> Outcome:
     "Sound-speed agreement at 10 °C, 35 ‰, 1000 m (cross-model), m/s",
 )
 def _chk_uwp_del_grosso() -> Outcome:
-    expected = ph.sea_water_sound_speed(10.0, 35.0, 1000.0, model="mackenzie")
-    got = ph.sea_water_sound_speed(10.0, 35.0, 1000.0, model="del_grosso")
+    expected = ph.underwater.sea_water_sound_speed(
+        10.0, 35.0, 1000.0, model="mackenzie"
+    )
+    got = ph.underwater.sea_water_sound_speed(
+        10.0, 35.0, 1000.0, model="del_grosso"
+    )
     return numeric(expected, got, 1.0, unit="m/s", places=3)
 
 
@@ -161,7 +182,7 @@ def _chk_uwp_del_grosso() -> Outcome:
 def _chk_uwp_spreading() -> Outcome:
     return numeric(
         20.0 * math.log10(1000.0),
-        float(ph.spreading_loss([1000.0], law="spherical")[0]),
+        float(ph.underwater.spreading_loss([1000.0], law="spherical")[0]),
         1e-9,
         unit="dB",
         places=4,
@@ -176,7 +197,7 @@ def _chk_uwp_spreading() -> Outcome:
 def _chk_uwp_thorp() -> Outcome:
     f = 10.0  # kHz
     expected = 1.0936 * (0.1 * f**2 / (1 + f**2) + 40 * f**2 / (4100 + f**2))
-    got = float(ph.seawater_absorption(10_000.0, model="thorp")[0])
+    got = float(ph.underwater.seawater_absorption(10_000.0, model="thorp")[0])
     return numeric(expected, got, 1e-6, unit="dB/km", places=4)
 
 
@@ -187,8 +208,16 @@ def _chk_uwp_thorp() -> Outcome:
 )
 def _chk_uwp_absorption_agreement() -> Outcome:
     kw = {"temperature": 10.0, "salinity": 35.0, "depth": 0.0, "ph": 8.0}
-    fg = float(ph.seawater_absorption(10_000.0, model="francois-garrison", **kw)[0])
-    am = float(ph.seawater_absorption(10_000.0, model="ainslie-mccolm", **kw)[0])
+    fg = float(
+        ph.underwater.seawater_absorption(
+            10_000.0, model="francois-garrison", **kw
+        )[0]
+    )
+    am = float(
+        ph.underwater.seawater_absorption(
+            10_000.0, model="ainslie-mccolm", **kw
+        )[0]
+    )
     return numeric(fg, am, 0.1 * fg, unit="dB/km", places=4)
 
 
@@ -202,7 +231,11 @@ def _chk_uwp_fg_printed_table() -> Outcome:
     # Soc. Am. 72(6), 1982); tolerance is half a unit of the last printed
     # digit, i.e. the print's own rounding.
     kw = {"temperature": 10.0, "salinity": 35.0, "depth": 0.0, "ph": 8.0}
-    got = float(ph.seawater_absorption(100_000.0, model="francois-garrison", **kw)[0])
+    got = float(
+        ph.underwater.seawater_absorption(
+            100_000.0, model="francois-garrison", **kw
+        )[0]
+    )
     return numeric(33.6, got, 0.05, unit="dB/km", places=3)
 
 
@@ -229,7 +262,9 @@ def _chk_uwp_del_grosso_printed_check() -> Outcome:
 def _chk_uwp_wales_heitmeyer() -> Outcome:
     # Oracle: the mean-spectrum closed form printed in J. Acoust. Soc. Am.
     # 111(3), 2002, hand-evaluated at 100 Hz.
-    s = ph.ship_source_spectrum(model="wales-heitmeyer", frequency_hz=[100.0])
+    s = ph.underwater.ship_source_spectrum(
+        model="wales-heitmeyer", frequency_hz=[100.0]
+    )
     return numeric(158.4504, float(s.source_psd[0]), 1e-3, unit="dB", places=3)
 
 
@@ -239,7 +274,9 @@ def _chk_uwp_wales_heitmeyer() -> Outcome:
     "Figure of merit SL − (NL − DI) − DT, dB",
 )
 def _chk_uwp_sonar() -> Outcome:
-    res = ph.passive_sonar_equation(140.0, 80.0, 60.0, directivity_index=10.0, detection_threshold=5.0)
+    res = ph.underwater.passive_sonar_equation(
+        140.0, 80.0, 60.0, directivity_index=10.0, detection_threshold=5.0
+    )
     return numeric(85.0, res.figure_of_merit, 1e-9, unit="dB", places=4)
 
 
@@ -252,7 +289,9 @@ def _chk_uwp_seabed() -> Outcome:
     # Normal-incidence oracle: R = (Z2 − Z1)/(Z2 + Z1), BL = −20·lg|R|.
     z1, z2 = 1000.0 * 1500.0, 1900.0 * 1650.0
     expected = -20.0 * math.log10(abs((z2 - z1) / (z2 + z1)))
-    res = ph.bottom_reflection_loss(90.0, rho1=1000.0, c1=1500.0, rho2=1900.0, c2=1650.0)
+    res = ph.underwater.bottom_reflection_loss(
+        90.0, rho1=1000.0, c1=1500.0, rho2=1900.0, c2=1650.0
+    )
     return numeric(expected, float(res.reflection_loss[0]), 1e-6, unit="dB", places=4)
 
 
@@ -265,7 +304,7 @@ def _chk_uwp_wind_noise() -> Outcome:
     # Wenz/Knudsen "25 dB (5 x 5)" is re 0.0002 dyn/cm2 = 20 uPa; re 1 uPa
     # (ISO 18405) the anchor is 25 + 20*lg(20) = 51.0206 dB (matches the
     # published Wenz chart: ~50 dB at 1 kHz for 4-6 kn).
-    got = float(ph.wind_noise_spectrum(1000.0, 5.0)[0])
+    got = float(ph.underwater.wind_noise_spectrum(1000.0, 5.0)[0])
     return numeric(51.0206, got, 1e-4, unit="dB", places=4)
 
 
@@ -278,7 +317,11 @@ def _chk_uwp_thermal_noise() -> Outcome:
     f, t, rho, c = 5.0e4, 16.85, 1025.0, 1500.0
     p2 = 4.0 * math.pi * 1.380649e-23 * (t + 273.15) * rho * f**2 / c
     expected = 10.0 * math.log10(p2 / (1e-6) ** 2)
-    got = float(ph.thermal_noise_spectrum(f, temperature=t, density=rho, sound_speed=c)[0])
+    got = float(
+        ph.underwater.thermal_noise_spectrum(
+            f, temperature=t, density=rho, sound_speed=c
+        )[0]
+    )
     return numeric(expected, got, 1e-6, unit="dB", places=4)
 
 
@@ -289,7 +332,9 @@ def _chk_uwp_thermal_noise() -> Outcome:
 )
 def _chk_uwp_ship_traffic() -> Outcome:
     # Oracle: authors' Excel reference calculator (File S1), decidecade band.
-    s = ph.ship_source_spectrum(13.5, 211.0, vessel_class="bulker", model="jomopans-echo")
+    s = ph.underwater.ship_source_spectrum(
+        13.5, 211.0, vessel_class="bulker", model="jomopans-echo"
+    )
     idx = int(min(range(len(s.frequency)), key=lambda i: abs(s.frequency[i] - 1000.0)))
     return numeric(161.394, float(s.band_level[idx]), 1e-2, unit="dB", places=3)
 
@@ -339,8 +384,13 @@ _UW_WESTON = "Underwater propagation regimes (Weston flux theory)"
 )
 def _chk_uww_eta_sand() -> Outcome:
     # Oracle: the printed value 0.28 Np/rad of Table 9.1 (printed p. 454).
-    return numeric(0.28, float(ph.reflection_loss_gradient("sand")), 5e-3,
-                   unit="Np/rad", places=4)
+    return numeric(
+        0.28,
+        float(ph.underwater.reflection_loss_gradient("sand")),
+        5e-3,
+        unit="Np/rad",
+        places=4,
+    )
 
 
 @register(
@@ -350,7 +400,9 @@ def _chk_uww_eta_sand() -> Outcome:
 )
 def _chk_uww_eta_mud() -> Outcome:
     # Oracle: Table 9.1 prints η_mud = 0.021·f̂ Np/rad.
-    got = float(ph.reflection_loss_gradient("mud", frequency_hz=1.0))
+    got = float(
+        ph.underwater.reflection_loss_gradient("mud", frequency_hz=1.0)
+    )
     return numeric(0.021, got, 5e-4, unit="Np/rad", places=5)
 
 
@@ -368,14 +420,19 @@ def _chk_uww_flux_vs_modes() -> Outcome:
 
     ranges = _np.linspace(20_000.0, 30_000.0, 1001)
     energies = [
-        _np.mean(10.0 ** (-ph.normal_modes(
+        _np.mean(10.0 ** (-ph.underwater.normal_modes(
             100.0, [0.0, 100.0], [1500.0, 1500.0], source_depth=41.0,
             receiver_depth=float(zr), ranges_m=ranges).propagation_loss / 10.0))
         for zr in _np.linspace(10.0, 90.0, 9)
     ]
     numeric_pl = -10.0 * math.log10(float(_np.mean(energies)))
-    flux = ph.weston_propagation_loss(ranges, 100.0, 100.0, critical_angle=90.0,
-                                      reflection_loss_gradient_value=0.0)
+    flux = ph.underwater.weston_propagation_loss(
+        ranges,
+        100.0,
+        100.0,
+        critical_angle=90.0,
+        reflection_loss_gradient_value=0.0,
+    )
     expected = -10.0 * math.log10(
         float(_np.mean(10.0 ** (-flux.propagation_loss / 10.0))))
     return numeric(expected, numeric_pl, 1.0, unit="dB", places=3)
@@ -392,7 +449,11 @@ _UW_FAUNA = "Marine-mammal auditory weighting (NMFS / Southall)"
 def _chk_uwf_appendix_d() -> Outcome:
     # Oracle: the published worked example (printed p. 130) lists W(1 kHz) for
     # the five hearing groups; the HF value is -37.55 dB.
-    got = float(ph.auditory_weighting(1000.0, "HF", guidance="nmfs-2018").weighting[0])
+    got = float(
+        ph.underwater.auditory_weighting(
+            1000.0, "HF", guidance="nmfs-2018"
+        ).weighting[0]
+    )
     return numeric(-37.55, got, 0.01, unit="dB", places=3)
 
 
@@ -406,9 +467,14 @@ def _chk_uwf_otariid_c() -> Outcome:
     # C = -max W(f) from the same row's a/b/f1/f2 gives 1.3643 dB.
     import numpy as _np
 
-    params = ph.weighting_parameters("OW", guidance="nmfs-2024")
+    params = ph.underwater.weighting_parameters("OW", guidance="nmfs-2024")
     freqs = _np.logspace(0.0, 6.0, 400_001)
-    shape = ph.auditory_weighting(freqs, "OW", guidance="nmfs-2024").weighting - params.c_db
+    shape = (
+        ph.underwater.auditory_weighting(
+            freqs, "OW", guidance="nmfs-2024"
+        ).weighting
+        - params.c_db
+    )
     return numeric(1.3643, -float(_np.max(shape)), 5e-4, unit="dB", places=4)
 
 
@@ -420,8 +486,13 @@ def _chk_uwf_otariid_c() -> Outcome:
 def _chk_uwf_orca() -> Outcome:
     # Oracle: "The threshold ... at the pulse center frequency (50 kHz) is
     # 51.2 dB re µPa²" (printed p. 619); the second branch would give 50.5 dB.
-    return numeric(51.2, float(ph.orca_audiogram(50e3).threshold[0]), 0.05,
-                   unit="dB", places=3)
+    return numeric(
+        51.2,
+        float(ph.underwater.orca_audiogram(50e3).threshold[0]),
+        0.05,
+        unit="dB",
+        places=3,
+    )
 
 
 @register(
@@ -431,8 +502,14 @@ def _chk_uwf_orca() -> Outcome:
 )
 def _chk_uwf_orca_fom() -> Outcome:
     # Oracle: Table 11.7 (printed p. 624) prints FOM_NL = 51.0 dB re m².
-    res = ph.active_sonar_equation(198.2, [0.0], -29.0, 75.0, directivity_index=16.5,
-                                   detection_threshold=8.7)
+    res = ph.underwater.active_sonar_equation(
+        198.2,
+        [0.0],
+        -29.0,
+        75.0,
+        directivity_index=16.5,
+        detection_threshold=8.7,
+    )
     return numeric(51.0, res.figure_of_merit, 1e-6, unit="dB", places=3)
 
 
@@ -448,8 +525,15 @@ def _chk_uwn_modes() -> Outcome:
     d, c, f = 100.0, 1500.0, 20.0
     k = 2.0 * math.pi * f / c
     kr1 = math.sqrt(k**2 - (math.pi / d) ** 2)
-    res = ph.normal_modes(f, [0.0, d], [c, c], source_depth=36.0, receiver_depth=46.0,
-                          bottom="pressure-release", n_depth_points=800)
+    res = ph.underwater.normal_modes(
+        f,
+        [0.0, d],
+        [c, c],
+        source_depth=36.0,
+        receiver_depth=46.0,
+        bottom="pressure-release",
+        n_depth_points=800,
+    )
     return numeric(kr1, float(res.wavenumbers[0]), 1e-4, unit="rad/m", places=6)
 
 
@@ -462,9 +546,15 @@ def _chk_uwn_modes_absolute() -> Outcome:
     # Independent absolute anchor (does not share the Eq. 5.14 prefactor with
     # the implementation): converged image-source sum for D = 100 m, f = 20 Hz,
     # zs = 36 m, zr = 46 m gives PL(1 km) = 48.238 dB.
-    res = ph.normal_modes(20.0, [0.0, 100.0], [1500.0, 1500.0], source_depth=36.0,
-                          receiver_depth=46.0, ranges_m=[1000.0],
-                          n_depth_points=3000)
+    res = ph.underwater.normal_modes(
+        20.0,
+        [0.0, 100.0],
+        [1500.0, 1500.0],
+        source_depth=36.0,
+        receiver_depth=46.0,
+        ranges_m=[1000.0],
+        n_depth_points=3000,
+    )
     return numeric(48.238, float(res.propagation_loss[0]), 0.02, unit="dB", places=3)
 
 
@@ -477,8 +567,14 @@ def _chk_uwn_rays() -> Outcome:
     c0, g = 1500.0, 0.05
     xi = math.cos(math.radians(10.0)) / c0
     z_turn = (1.0 / xi - c0) / g
-    res = ph.ray_trace([0.0, 2000.0], [c0, c0 + g * 2000.0], source_depth=0.0,
-                       launch_angles_deg=[10.0], max_range=10_500.0, n_steps=20_000)
+    res = ph.underwater.ray_trace(
+        [0.0, 2000.0],
+        [c0, c0 + g * 2000.0],
+        source_depth=0.0,
+        launch_angles_deg=[10.0],
+        max_range=10_500.0,
+        n_steps=20_000,
+    )
     return numeric(z_turn, float(res.depths[0].max()), 1.0, unit="m", places=2)
 
 
@@ -497,8 +593,14 @@ def _chk_uwn_ray_time() -> Outcome:
     sin_th2 = math.sin(th) - xi * g * 10_000.0
     c2 = math.sqrt(1.0 - sin_th2**2) / xi
     t = math.log((c2 / c0) * (1.0 + math.sin(th)) / (1.0 + sin_th2)) / g
-    res = ph.ray_trace([0.0, 2000.0], [c0, c0 + g * 2000.0], source_depth=0.0,
-                       launch_angles_deg=[10.0], max_range=10_000.0, n_steps=20_001)
+    res = ph.underwater.ray_trace(
+        [0.0, 2000.0],
+        [c0, c0 + g * 2000.0],
+        source_depth=0.0,
+        launch_angles_deg=[10.0],
+        max_range=10_000.0,
+        n_steps=20_001,
+    )
     return numeric(t, float(res.travel_times[0, -1]), 1e-6, unit="s", places=6)
 
 
@@ -508,9 +610,15 @@ def _chk_uwn_ray_time() -> Outcome:
     "PE propagation loss at 2 km, homogeneous medium (spherical spreading), dB",
 )
 def _chk_uwn_pe() -> Outcome:
-    res = ph.parabolic_equation(50.0, [0.0, 20_000.0], [1500.0, 1500.0],
-                                source_depth=10_000.0, max_range=3000.0,
-                                range_step=2.0, n_depth_points=8192)
+    res = ph.underwater.parabolic_equation(
+        50.0,
+        [0.0, 20_000.0],
+        [1500.0, 1500.0],
+        source_depth=10_000.0,
+        max_range=3000.0,
+        range_step=2.0,
+        n_depth_points=8192,
+    )
     zi = int(min(range(res.depths.size), key=lambda i: abs(res.depths[i] - 10_000.0)))
     ri = int(min(range(res.ranges.size), key=lambda i: abs(res.ranges[i] - 2000.0)))
     return numeric(20.0 * math.log10(2000.0), float(res.propagation_loss[zi][ri]),

--- a/scripts/figures/metrology.py
+++ b/scripts/figures/metrology.py
@@ -423,15 +423,17 @@ def generate_uncertainty(output_dir: str) -> None:
     # A-weighted level: reading plus calibration, instrument and positional
     # corrections (all zero-mean); the model is their sum.
     quantities = [
-        ph.Quantity(74.0, 0.0, name="Reading"),
-        ph.rectangular(0.0, 0.20, name="Calibration"),
-        ph.rectangular(0.0, 0.30, name="Instrument"),
-        ph.Quantity(0.0, 0.35, dof=9, name="Position (Type A)"),
+        ph.metrology.Quantity(74.0, 0.0, name="Reading"),
+        ph.metrology.rectangular(0.0, 0.20, name="Calibration"),
+        ph.metrology.rectangular(0.0, 0.30, name="Instrument"),
+        ph.metrology.Quantity(0.0, 0.35, dof=9, name="Position (Type A)"),
     ]
     model = lambda a, b, c, d: a + b + c + d
 
-    result = ph.combine_uncertainty(model, quantities)
-    mc = ph.monte_carlo(model, quantities, trials=1_000_000, coverage=0.95, seed=1)
+    result = ph.metrology.combine_uncertainty(model, quantities)
+    mc = ph.metrology.monte_carlo(
+        model, quantities, trials=1_000_000, coverage=0.95, seed=1
+    )
     k, big = result.expanded(0.95)
 
     _fig, (ax_b, ax_m) = plt.subplots(1, 2, figsize=(12.5, 5.4))
@@ -664,19 +666,22 @@ def generate_uncertainty_gum_vs_mc(output_dir: str) -> None:
 
     # A. One dominant rectangular input: the output is nearly rectangular and
     # the Gaussian interval overcovers it.
-    q_a = [ph.rectangular(0.0, 1.0, name="Dominant rectangular"),
-           ph.Quantity(0.0, 0.1, name="Small Gaussian")]
+    q_a = [ph.metrology.rectangular(0.0, 1.0, name="Dominant rectangular"),
+           ph.metrology.Quantity(0.0, 0.1, name="Small Gaussian")]
     panels.append(("A dominant rectangular input", lambda a, b: a + b, q_a,
                    "Correction [dB]", None))
 
     # B. Non-linear model: the energy sum of two levels with wide inputs.
-    q_b = [ph.Quantity(70.0, 3.0, name="L1"), ph.Quantity(70.0, 3.0, name="L2")]
+    q_b = [
+        ph.metrology.Quantity(70.0, 3.0, name="L1"),
+        ph.metrology.Quantity(70.0, 3.0, name="L2"),
+    ]
     panels.append(("A non-linear model (energy sum)",
                    lambda l1, l2: 10 * np.log10(10 ** (l1 / 10) + 10 ** (l2 / 10)),
                    q_b, "Combined level [dB]", None))
 
     # C. An output against a physical bound.
-    q_c = [ph.Quantity(0.95, 0.06, name="alpha")]
+    q_c = [ph.metrology.Quantity(0.95, 0.06, name="alpha")]
     # The clamp piles a finite probability mass exactly on the bound, so the
     # histogram spike there is cut off to keep the rest of the shape readable.
     panels.append(("An output against a physical bound",
@@ -685,9 +690,15 @@ def generate_uncertainty_gum_vs_mc(output_dir: str) -> None:
 
     _fig, axes = plt.subplots(3, 1, figsize=(10, 11))
     for ax, (title, model, quantities, xlabel, ymax) in zip(axes, panels):
-        gum = ph.combine_uncertainty(model, quantities)
-        mc = ph.monte_carlo(model, quantities, trials=400_000, coverage=0.95,
-                            seed=1, keep_samples=True)
+        gum = ph.metrology.combine_uncertainty(model, quantities)
+        mc = ph.metrology.monte_carlo(
+            model,
+            quantities,
+            trials=400_000,
+            coverage=0.95,
+            seed=1,
+            keep_samples=True,
+        )
         _k, big = gum.expanded(0.95)
         # Asked for with `keep_samples=True` above. The type is optional
         # because callers that only want the interval do not pay for them.
@@ -733,16 +744,19 @@ def generate_uncertainty_correlation(output_dir: str) -> None:
     import phonometry as ph
 
     u_i = 0.3
-    pair = [ph.Quantity(0.0, u_i, name="Term 1"),
-            ph.Quantity(0.0, u_i, name="Term 2")]
+    pair = [ph.metrology.Quantity(0.0, u_i, name="Term 1"),
+            ph.metrology.Quantity(0.0, u_i, name="Term 2")]
     rho = np.linspace(-1.0, 1.0, 81)
     same, opposite = [], []
     for r in rho:
         corr = [[1.0, float(r)], [float(r), 1.0]]
-        same.append(ph.combine_uncertainty(lambda a, b: a + b, pair,
+        same.append(ph.metrology.combine_uncertainty(lambda a, b: a + b, pair,
                                            correlation=corr).combined_uncertainty)
-        opposite.append(ph.combine_uncertainty(lambda a, b: a - b, pair,
-                                               correlation=corr).combined_uncertainty)
+        opposite.append(
+            ph.metrology.combine_uncertainty(
+                lambda a, b: a - b, pair, correlation=corr
+            ).combined_uncertainty
+        )
     quad = float(np.hypot(u_i, u_i))
 
     _fig, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(12.5, 5.4))

--- a/scripts/reports/building.py
+++ b/scripts/reports/building.py
@@ -41,7 +41,7 @@ _RATING_FREQS = np.array(
 
 def _airborne_example() -> tuple[object, ReportMetadata, str]:
     """Airborne fiche: a predicted single-panel sound reduction index."""
-    result = ph.single_panel_transmission_loss(
+    result = ph.building.single_panel_transmission_loss(
         _RATING_FREQS, 15.0, critical_frequency=2000.0, loss_factor=0.02
     )
     metadata = ReportMetadata(
@@ -75,7 +75,7 @@ def _impact_example() -> tuple[object, ReportMetadata, str]:
         [45, 47, 48, 49, 51, 52, 53, 54, 55, 56, 57, 58, 55, 52, 49, 46],
         dtype=float,
     )
-    result = ph.weighted_impact_rating(ln)
+    result = ph.building.weighted_impact_rating(ln)
     metadata = ReportMetadata(
         specimen="150 mm concrete slab with a floating floor",
         client="Example client",
@@ -163,7 +163,9 @@ def _field_airborne_example() -> tuple[object, ReportMetadata, str]:
             0.42,
         ]
     )
-    result = ph.airborne_insulation(l1, l1 - d, t2, area=12.5, volume=30.4)
+    result = ph.building.airborne_insulation(
+        l1, l1 - d, t2, area=12.5, volume=30.4
+    )
     metadata = ReportMetadata(
         specimen="Separating wall, 240 mm brick with independent lining",
         client="Example client",
@@ -224,7 +226,7 @@ def _field_impact_example() -> tuple[object, ReportMetadata, str]:
             0.42,
         ]
     )
-    result = ph.impact_insulation(li, t2, volume=30.4)
+    result = ph.building.impact_insulation(li, t2, volume=30.4)
     metadata = ReportMetadata(
         specimen="Timber-joist floor with a floating chipboard deck",
         client="Example client",
@@ -271,7 +273,7 @@ def _lab_airborne_example() -> tuple[object, ReportMetadata, str]:
         ]
     )
     l1 = np.full(16, 90.0)
-    result = ph.lab_airborne_insulation(
+    result = ph.building.lab_airborne_insulation(
         l1, l1 - r, np.full(16, 0.8), area=10.0, volume=50.0
     )
     metadata = ReportMetadata(
@@ -326,7 +328,9 @@ def _lab_impact_example() -> tuple[object, ReportMetadata, str]:
             71.2,
         ]
     )
-    result = ph.lab_impact_insulation(li, np.full(16, 0.8), volume=50.0)
+    result = ph.building.lab_impact_insulation(
+        li, np.full(16, 0.8), volume=50.0
+    )
     # The impact fiche's plot legend carries an extra "500 Hz read" entry that
     # wraps to a second row, making the embedded figure taller than the
     # airborne one; the header is kept to the essential accredited fields so

--- a/scripts/reports/building_design.py
+++ b/scripts/reports/building_design.py
@@ -51,7 +51,7 @@ def _airborne_prediction_example() -> tuple[object, ReportMetadata, str]:
         ("intwall", 33.0, 33.5, 15.7, 2.55),
     ]
     for label, rw, kff, kfd, lf in elements:
-        ff, df, fd = ph.flanking_element(
+        ff, df, fd = ph.building.flanking_element(
             label=label,
             r_flanking=rw,
             r_separating=57.0,
@@ -62,7 +62,9 @@ def _airborne_prediction_example() -> tuple[object, ReportMetadata, str]:
             coupling_length=lf,
         )
         paths += [ff, df, fd]
-    result = ph.predicted_airborne_insulation(r_direct=57.0, flanking_paths=paths)
+    result = ph.building.predicted_airborne_insulation(
+        r_direct=57.0, flanking_paths=paths
+    )
     metadata = ReportMetadata(
         specimen="Separating wall, Rs,w = 57 dB (EN 12354-1 Annex H.3)",
         client="Example client",
@@ -95,9 +97,9 @@ def _impact_prediction_example() -> tuple[object, ReportMetadata, str]:
     = 45 dB (Formula 21). The element set and its L'n,w are the standard's own
     worked example, run through the tested prediction code.
     """
-    ln_w_eq = ph.equivalent_impact_level(322.0)
-    k = ph.impact_flanking_correction(322.0, 145.0)
-    result = ph.predicted_impact_insulation(
+    ln_w_eq = ph.building.equivalent_impact_level(322.0)
+    k = ph.building.impact_flanking_correction(322.0, 145.0)
+    result = ph.building.predicted_impact_insulation(
         ln_w_eq=ln_w_eq, delta_l_w=33.0, k_correction=k
     )
     metadata = ReportMetadata(
@@ -187,7 +189,7 @@ def _structure_borne_power_example() -> tuple[object, ReportMetadata, str]:
     """
     freqs = np.array([125, 250, 500, 1000, 2000, 4000], dtype=float)
     lv = np.array([70.0, 72.0, 68.0, 64.0, 60.0, 55.0])
-    result = ph.reception_plate_power(
+    result = ph.building.reception_plate_power(
         lv, freqs, mass_per_area=230.0, area=7.0, reverberation_time=0.25
     )
     metadata = ReportMetadata(
@@ -241,7 +243,7 @@ def _installed_structure_borne_example() -> tuple[object, ReportMetadata, str]:
             "element_area": 12.8,
         },
     ]
-    result = ph.installed_source_prediction(
+    result = ph.building.installed_source_prediction(
         characteristic_power, coupling, paths, frequencies=bands
     )
     metadata = ReportMetadata(
@@ -270,8 +272,11 @@ def _detailed_building() -> tuple[dict[str, Any], np.ndarray, np.ndarray]:
     import iso12354_building as bld
 
     bands = np.asarray(ref.ISO12354_ANNEX_L_BANDS, dtype=np.float64)
-    situ = {key: ph.in_situ_element(el, bands) for key, el in bld.elements().items()}
-    delta = ph.floating_floor_improvement(
+    situ = {
+        key: ph.building.in_situ_element(el, bands)
+        for key, el in bld.elements().items()
+    }
+    delta = ph.building.floating_floor_improvement(
         bands, resonance_frequency=bld.floating_floor_resonance()
     )
     return situ, bands, delta
@@ -296,9 +301,9 @@ def _detailed_airborne_example() -> tuple[object, ReportMetadata, str]:
     import iso12354_building as bld
 
     situ, bands, delta = _detailed_building()
-    result = ph.detailed_airborne_prediction(
+    result = ph.building.detailed_airborne_prediction(
         bands,
-        direct_index=ph.direct_reduction_index(
+        direct_index=ph.building.direct_reduction_index(
             situ["floor"].sound_reduction_index, delta_r_source=delta
         ),
         flanking_paths=bld.airborne_paths(situ, delta),
@@ -337,9 +342,9 @@ def _detailed_impact_example() -> tuple[object, ReportMetadata, str]:
     import iso12354_building as bld
 
     situ, bands, delta = _detailed_building()
-    result = ph.detailed_impact_prediction(
+    result = ph.building.detailed_impact_prediction(
         bands,
-        direct_level=ph.direct_impact_level(
+        direct_level=ph.building.direct_impact_level(
             situ["floor"].impact_level, delta_l=delta
         ),
         flanking_paths=bld.impact_paths(situ, delta),

--- a/scripts/reports/devices.py
+++ b/scripts/reports/devices.py
@@ -22,8 +22,10 @@ def _filter_class_example() -> tuple[object, ReportMetadata, str]:
     4 kHz clears class 1 across every band, so the fiche boxes a Class 1
     COMPLIES result and passes the required-class-1 verdict.
     """
-    bank = ph.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-    result = ph.filter_class_compliance(bank)
+    bank = ph.filters.OctaveFilterBank(
+        fs=48000, fraction=1, order=6, limits=[125, 4000]
+    )
+    result = ph.filters.filter_class_compliance(bank)
     metadata = ReportMetadata(
         specimen="1/1-octave filter bank",
         client="Example client",
@@ -47,8 +49,10 @@ def _filter_class_1995_example() -> tuple[object, ReportMetadata, str]:
     that mask, and the default (order 6) octave bank clears the stricter
     class 0, so the fiche boxes a Class 0 COMPLIES result.
     """
-    bank = ph.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
-    result = ph.filter_class_compliance(bank, edition="1995")
+    bank = ph.filters.OctaveFilterBank(
+        fs=48000, fraction=1, order=6, limits=[250, 4000]
+    )
+    result = ph.filters.filter_class_compliance(bank, edition="1995")
     metadata = ReportMetadata(
         specimen="1/1-octave filter bank",
         client="Example client",
@@ -78,11 +82,17 @@ def _intensity_class_example() -> tuple[object, ReportMetadata, str]:
     required-class-1 verdict, showing both halves of the layout at once.
     """
     spacing = 0.012
-    freqs, _, _ = ph.residual_index_limits("instrument", spacing=spacing)
+    freqs, _, _ = ph.emission.residual_index_limits(
+        "instrument", spacing=spacing
+    )
     phase_mismatch = 0.05 * np.maximum(1.0, freqs / 1000.0)  # degrees
-    measured = ph.residual_index_from_phase_mismatch(phase_mismatch, freqs, spacing)
+    measured = ph.emission.residual_index_from_phase_mismatch(
+        phase_mismatch, freqs, spacing
+    )
     measured = measured - 4.0 * np.exp(-((np.log(freqs / 100.0) / 0.25) ** 2))
-    result = ph.intensity_class_compliance(measured, freqs, spacing=spacing)
+    result = ph.emission.intensity_class_compliance(
+        measured, freqs, spacing=spacing
+    )
     metadata = ReportMetadata(
         specimen="p-p sound intensity probe and analyser, 12 mm spacer",
         client="Example client",
@@ -127,11 +137,11 @@ def _loudspeaker_example() -> tuple[object, ReportMetadata, str]:
     thd_percent = 0.3 + 2.6 * np.exp(-((np.log2(thd_freqs / 70.0)) ** 2) / 0.45)
 
     angles = np.radians(np.linspace(0.0, 90.0, 46))
-    directivity = ph.radiating_piston(
+    directivity = ph.electroacoustics.radiating_piston(
         0.075, np.array([1000.0, 2000.0, 4000.0]), angles=angles
     )
 
-    result = ph.loudspeaker_characteristics(
+    result = ph.electroacoustics.loudspeaker_characteristics(
         freqs,
         spl,
         8.0,
@@ -139,10 +149,10 @@ def _loudspeaker_example() -> tuple[object, ReportMetadata, str]:
         tolerance_db=3.0,
         impedance=(imp_freqs, impedance),
         distortion=(thd_freqs, thd_percent),
-        directivity=ph.LoudspeakerDirectivity(
+        directivity=ph.electroacoustics.LoudspeakerDirectivity(
             piston=directivity, frequency=2000.0
         ),
-        ratings=ph.LoudspeakerRatings(
+        ratings=ph.electroacoustics.LoudspeakerRatings(
             frequency_range=(45.0, 22000.0),
             noise_power=80.0,
             sinusoidal_power=120.0,
@@ -202,24 +212,24 @@ def _microphone_example() -> tuple[object, ReportMetadata, str]:
         18.0 - 5.4 * np.log2(noise_freqs / 20.0) + 1.5 * np.sin(np.log2(noise_freqs))
     )
 
-    result = ph.microphone_characteristics(
+    result = ph.electroacoustics.microphone_characteristics(
         freqs,
         response,
         12.5,
         tolerance_db=3.0,
-        directivity=ph.MicrophoneDirectivity(
+        directivity=ph.electroacoustics.MicrophoneDirectivity(
             polar=(angles, cardioid_db),
             frequency=1000.0,
         ),
-        noise=ph.MicrophoneNoise(
+        noise=ph.electroacoustics.MicrophoneNoise(
             voltage=1.25e-6,
             spectrum=(noise_freqs, noise_levels),
         ),
-        overload=ph.MicrophoneOverload(
+        overload=ph.electroacoustics.MicrophoneOverload(
             distortion=(thd_spl, thd_percent),
             thd_percent=0.5,
         ),
-        electrical=ph.MicrophoneElectrical(
+        electrical=ph.electroacoustics.MicrophoneElectrical(
             rated_impedance=150.0,
             minimum_load_impedance=1000.0,
             powering="Phantom P48 (IEC 61938)",

--- a/scripts/reports/emission.py
+++ b/scripts/reports/emission.py
@@ -38,7 +38,7 @@ def _epnl_example() -> tuple[object, ReportMetadata, str]:
     gain = 24.0 * np.exp(-((idx - 12.0) ** 2) / (2 * 3.5**2)) - 3.0
     spectra = (46.0 + shape)[None, :] + gain[:, None]
     spectra[:, 17] += 10.0 * np.exp(-((idx - 12.0) ** 2) / (2 * 4.0**2))  # 2500 Hz tone
-    result = ph.effective_perceived_noise_level(spectra, dt)
+    result = ph.aircraft.effective_perceived_noise_level(spectra, dt)
     metadata = ReportMetadata(
         specimen="Example twin-turbofan transport (synthetic flyover)",
         manufacturer="Example Aircraft Company",
@@ -65,7 +65,7 @@ def _iso4871_declaration_example() -> tuple[object, ReportMetadata, str]:
     (clause 6.2): mode 1 passes (89 <= 90) and mode 2 fails (98 > 97),
     exercising the verdict both ways.
     """
-    mode1 = ph.OperatingModeDeclaration(
+    mode1 = ph.emission.OperatingModeDeclaration(
         mode="Operating mode 1",
         sound_power_level=88.0,
         sound_power_uncertainty=2.0,
@@ -73,7 +73,7 @@ def _iso4871_declaration_example() -> tuple[object, ReportMetadata, str]:
         emission_pressure_uncertainty=2.0,
         verification_level=89.0,
     )
-    mode2 = ph.OperatingModeDeclaration(
+    mode2 = ph.emission.OperatingModeDeclaration(
         mode="Operating mode 2",
         sound_power_level=95.0,
         sound_power_uncertainty=2.0,
@@ -81,7 +81,7 @@ def _iso4871_declaration_example() -> tuple[object, ReportMetadata, str]:
         emission_pressure_uncertainty=2.0,
         verification_level=98.0,
     )
-    result = ph.NoiseEmissionDeclaration(
+    result = ph.emission.NoiseEmissionDeclaration(
         modes=(mode1, mode2),
         machine="Type 990, Model 11-TC",
         operating_conditions="50 Hz, 230 V, rated load",

--- a/scripts/reports/environment.py
+++ b/scripts/reports/environment.py
@@ -116,7 +116,7 @@ def _tone_audibility_example() -> tuple[object, ReportMetadata, str]:
         ],
         dtype=float,
     )
-    result = ph.analyze_spectrum(levels, frequencies, 2.7)
+    result = ph.psychoacoustics.analyze_spectrum(levels, frequencies, 2.7)
     metadata = ReportMetadata(
         specimen="Combustion engine, steady operation",
         client="Example client",
@@ -181,7 +181,7 @@ def _wind_turbine_tonality_example() -> tuple[object, ReportMetadata, str]:
     frequencies = np.arange(440.0, 560.0 + df, df)
     levels = np.full(frequencies.size, 30.0)
     levels[int(np.argmin(np.abs(frequencies - 500.0)))] = 60.0
-    result = ph.wind_turbine_tonality(levels, frequencies)
+    result = ph.environment.wind_turbine_tonality(levels, frequencies)
     metadata = ReportMetadata(
         specimen="Horizontal-axis wind turbine, gearbox tone",
         client="Example client",
@@ -206,7 +206,9 @@ class _WithSourceEmission:
     keeping the generator loop unchanged.
     """
 
-    def __init__(self, result: Any, emission: ph.SourceEmission) -> None:
+    def __init__(
+        self, result: Any, emission: ph.environment.SourceEmission
+    ) -> None:
         self._result = result
         self._emission = emission
 
@@ -231,12 +233,14 @@ def _outdoor_attenuation_example() -> tuple[object, ReportMetadata, str]:
     """
     freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
     lw = np.array([95, 100, 103, 105, 104, 101, 95, 88], dtype=float)
-    barrier = ph.Barrier(source_to_edge=105.0, edge_to_receiver=105.0)
-    result = ph.outdoor_propagation_attenuation(
+    barrier = ph.environment.Barrier(
+        source_to_edge=105.0, edge_to_receiver=105.0
+    )
+    result = ph.environment.outdoor_propagation_attenuation(
         200.0, 4.0, 2.0, freqs, 1.0, 1.0, 1.0, barrier=barrier,
         temperature=10.0, relative_humidity=70.0,
     )
-    emission = ph.SourceEmission(sound_power_level=lw)
+    emission = ph.environment.SourceEmission(sound_power_level=lw)
     metadata = ReportMetadata(
         specimen="Industrial fan plant (point source)",
         client="Example client",
@@ -267,7 +271,9 @@ def _barrier_insertion_loss_example() -> tuple[object, ReportMetadata, str]:
     tests/environment/propagation/test_ground_barriers.py).
     """
     freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
-    result = ph.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+    result = ph.environment.barrier_insertion_loss(
+        freqs, 1.0, 50.0, 4.0, 100.0, 1.5
+    )
     metadata = ReportMetadata(
         specimen="Roadside noise barrier, 4 m high",
         client="Example client",
@@ -300,17 +306,23 @@ def _rd1367_example() -> tuple[object, ReportMetadata, str]:
     The fiche renders in Spanish, the language of the regulation it applies.
     """
     day = [
-        ph.NoisePhase(2.0, 0.0, label="Actividad cerrada"),
-        ph.NoisePhase(6.0, 50.0, kt=6.0, kf=3.0, label="Maquina ruidosa activa"),
-        ph.NoisePhase(4.0, 48.0, kt=3.0, kf=3.0, label="Resto de fuentes"),
+        ph.environment.NoisePhase(2.0, 0.0, label="Actividad cerrada"),
+        ph.environment.NoisePhase(
+            6.0, 50.0, kt=6.0, kf=3.0, label="Maquina ruidosa activa"
+        ),
+        ph.environment.NoisePhase(
+            4.0, 48.0, kt=3.0, kf=3.0, label="Resto de fuentes"
+        ),
     ]
     evening = [
-        ph.NoisePhase(2.0, 48.0, kt=3.0, kf=3.0, label="Resto de fuentes"),
-        ph.NoisePhase(2.0, 0.0, label="Actividad cerrada"),
+        ph.environment.NoisePhase(
+            2.0, 48.0, kt=3.0, kf=3.0, label="Resto de fuentes"
+        ),
+        ph.environment.NoisePhase(2.0, 0.0, label="Actividad cerrada"),
     ]
-    result = ph.assess_activity(
+    result = ph.environment.assess_activity(
         {"day": day, "evening": evening},
-        ph.activity_limits("a"),
+        ph.environment.activity_limits("a"),
         operating_days=303,
     )
     metadata = ReportMetadata(

--- a/scripts/reports/materials.py
+++ b/scripts/reports/materials.py
@@ -148,7 +148,7 @@ def _sound_absorption_example() -> tuple[object, ReportMetadata, str]:
             2.85,
         ]
     )
-    result = ph.measure_sound_absorption(
+    result = ph.materials.measure_sound_absorption(
         freqs,
         t_empty,
         t_specimen,

--- a/scripts/reports/noise_control.py
+++ b/scripts/reports/noise_control.py
@@ -35,7 +35,7 @@ def _enclosure_example() -> tuple[object, ReportMetadata, str]:
     """
     freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
     panel_r = np.array([18, 22, 28, 33, 38, 42, 45], dtype=float)
-    result = ph.enclosure_insertion_loss(
+    result = ph.noise_control.enclosure_insertion_loss(
         panel_r, 24.0, 30.0, 0.30, frequencies=freqs
     )
     metadata = ReportMetadata(

--- a/scripts/reports/perception.py
+++ b/scripts/reports/perception.py
@@ -52,7 +52,9 @@ def _loudness_example() -> tuple[object, ReportMetadata, str]:
         ],
         dtype=float,
     )
-    result = ph.loudness_zwicker_from_spectrum(levels, field="free")
+    result = ph.psychoacoustics.loudness_zwicker_from_spectrum(
+        levels, field="free"
+    )
     metadata = ReportMetadata(
         specimen="Household appliance, steady operating noise",
         client="Example client",

--- a/scripts/reports/room.py
+++ b/scripts/reports/room.py
@@ -41,7 +41,7 @@ def _room_acoustics_example() -> tuple[object, ReportMetadata, str]:
     ir = np.zeros_like(time)
     for freq, decay in zip(bands, t60):
         ir += np.sin(2.0 * np.pi * freq * time) * np.exp(-0.5 * a60 * time / decay)
-    result = ph.room_parameters(ir, fs)
+    result = ph.room.room_parameters(ir, fs)
     metadata = ReportMetadata(
         specimen="Small auditorium, unoccupied, fully furnished",
         client="Example client",
@@ -82,7 +82,7 @@ def _reverberation_prediction_example() -> tuple[object, ReportMetadata, str]:
     treated = [0.10, 0.15, 0.30, 0.45, 0.55, 0.60]  # broadband absorber wall
     side = [0.08, 0.10, 0.12, 0.15, 0.18, 0.20]      # lightly absorptive walls
     floor_ceiling = [0.05, 0.08, 0.10, 0.12, 0.15, 0.18]
-    result = ph.reverberation_time_models(
+    result = ph.room.reverberation_time_models(
         (8.0, 5.0, 3.0), (treated, side, floor_ceiling), frequencies=freqs
     )
     metadata = ReportMetadata(
@@ -119,9 +119,9 @@ def _enclosed_space_absorption_example() -> tuple[object, ReportMetadata, str]:
         (45.0, [0.02, 0.02, 0.03, 0.04, 0.05, 0.05, 0.05]),   # painted-plaster walls
     ]
     object_volumes = [0.5, 0.8, 0.3]  # furniture and fittings, m3
-    objects = ph.hard_object_absorption(object_volumes)
-    psi = ph.object_fraction(object_volumes, 50.0)
-    result = ph.enclosed_space_reverberation(
+    objects = ph.room.hard_object_absorption(object_volumes)
+    psi = ph.room.object_fraction(object_volumes, 50.0)
+    result = ph.room.enclosed_space_reverberation(
         surfaces, 50.0, objects=objects, object_fraction=psi,
         air_condition="20C_50-70",
     )
@@ -153,10 +153,10 @@ def _noise_criteria_example() -> tuple[object, ReportMetadata, str]:
     falls to the tangency method, which returns NC-40 with the 250 Hz band
     governing.
     """
-    contour = ph.nc_curve(40.0)
+    contour = ph.room.nc_curve(40.0)
     levels = contour - 5.0
     levels[4] = contour[4]  # 250 Hz sits on the NC-40 curve and governs.
-    result = ph.noise_criterion(levels)
+    result = ph.room.noise_criterion(levels)
     metadata = ReportMetadata(
         specimen="Open-plan office, air handling at nominal flow",
         client="Example client",
@@ -186,9 +186,9 @@ def _room_criteria_example() -> tuple[object, ReportMetadata, str]:
     is RC-35; the raised low band exceeds the reference by more than 5 dB, so
     the spectral-quality tag is rumble (clause D.3), giving RC-35(R).
     """
-    levels = ph.rc_curve(35.0)
+    levels = ph.room.rc_curve(35.0)
     levels[4] += 8.0  # 250 Hz rumble.
-    result = ph.room_criterion(levels)
+    result = ph.room.room_criterion(levels)
     metadata = ReportMetadata(
         specimen="Conference room, variable-air-volume terminal",
         client="Example client",

--- a/scripts/reports/vibration.py
+++ b/scripts/reports/vibration.py
@@ -191,8 +191,8 @@ def _transfer_stiffness_example() -> tuple[object, ReportMetadata, str]:
     omega = 2.0 * np.pi * freqs
     k21 = stiffness + 1j * omega * damping
     u1 = 1.0e-6 + 0.0j
-    measured = ph.transfer_stiffness_direct(k21 * u1, u1)
-    result = ph.TransferStiffnessResult(
+    measured = ph.vibration.transfer_stiffness_direct(k21 * u1, u1)
+    result = ph.vibration.TransferStiffnessResult(
         frequencies=freqs, transfer_stiffness=measured, blocking_mass=None
     )
     metadata = ReportMetadata(

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -191,7 +191,10 @@ def test_epnl_result_plot_smoke() -> None:
 def test_epnl_exposed_at_package_top_level() -> None:
     import phonometry
 
-    assert phonometry.effective_perceived_noise_level is effective_perceived_noise_level
+    assert (
+        phonometry.aircraft.effective_perceived_noise_level
+        is effective_perceived_noise_level
+    )
 
 
 def test_bandsharing_adjustment_applied() -> None:

--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -261,7 +261,7 @@ def test_coverage_factors_table_is_public():
     import phonometry
     from phonometry.building.measurement.uncertainty import COVERAGE_FACTORS
 
-    assert phonometry.COVERAGE_FACTORS is COVERAGE_FACTORS
+    assert phonometry.building.COVERAGE_FACTORS is COVERAGE_FACTORS
     # Keyed by (confidence, one_sided); matches the functional lookup.
     assert COVERAGE_FACTORS[(0.95, False)] == pytest.approx(1.96)
     assert COVERAGE_FACTORS[(0.95, True)] == pytest.approx(1.65)

--- a/tests/building/test_building_plots.py
+++ b/tests/building/test_building_plots.py
@@ -53,7 +53,7 @@ def _line_by_label(ax, needle: str):
 @pytest.mark.parametrize("language", ["en", "es"])
 def test_source_check_plot_draws_the_measured_spectrum(language: str) -> None:
     measured = [39.0, 31.0, 23.0, 17.0, 12.5]
-    res = ph.check_heavy_impact_source(measured)
+    res = ph.building.check_heavy_impact_source(measured)
     ax = res.plot(language=language)
     line = _line_by_label(ax, "L_{FE}")
     np.testing.assert_allclose(line.get_ydata(), measured)
@@ -65,7 +65,7 @@ def test_source_check_plot_draws_the_measured_spectrum(language: str) -> None:
 def test_source_check_plot_marks_the_failing_band() -> None:
     """A band outside its tolerance gets its own marker series."""
     measured = [39.0, 31.0, 23.0, 17.0, 20.0]
-    res = ph.check_heavy_impact_source(measured)
+    res = ph.building.check_heavy_impact_source(measured)
     assert not res.passed
     ax = res.plot()
     marked = [ln for ln in ax.lines if ln.get_marker() == "X"]
@@ -74,21 +74,22 @@ def test_source_check_plot_marks_the_failing_band() -> None:
 
 
 def test_source_check_plot_has_no_failure_marker_when_conforming() -> None:
-    res = ph.check_heavy_impact_source([39.0, 31.0, 23.0, 17.0, 12.5])
+    res = ph.building.check_heavy_impact_source([39.0, 31.0, 23.0, 17.0, 12.5])
     ax = res.plot()
     assert not [ln for ln in ax.lines if ln.get_marker() == "X"]
 
 
 def test_source_check_plot_shades_the_printed_tolerance_band() -> None:
-    res = ph.check_heavy_impact_source(
-        [v for v, _ in ph.HEAVY_IMPACT_SOURCES["bang_machine"]], "bang_machine"
+    res = ph.building.check_heavy_impact_source(
+        [v for v, _ in ph.building.HEAVY_IMPACT_SOURCES["bang_machine"]],
+        "bang_machine",
     )
     ax = res.plot()
     assert ax.collections, "the tolerance band was not drawn"
 
 
 def test_source_check_plot_forwards_kwargs() -> None:
-    res = ph.check_heavy_impact_source([39.0, 31.0, 23.0, 17.0, 12.5])
+    res = ph.building.check_heavy_impact_source([39.0, 31.0, 23.0, 17.0, 12.5])
     ax = res.plot(linewidth=3.0)
     assert _line_by_label(ax, "measured").get_linewidth() == 3.0
 
@@ -100,7 +101,7 @@ def test_source_check_plot_forwards_kwargs() -> None:
 
 @pytest.mark.parametrize("language", ["en", "es"])
 def test_standardization_plot_draws_both_spectra(language: str) -> None:
-    res = ph.standardized_maximum_impact_level(
+    res = ph.building.standardized_maximum_impact_level(
         _TABLE_D4, 41.4, [1.43, 3.7, 3.1, 2.38],
         frequency=[63.0, 125.0, 250.0, 500.0],
     )
@@ -113,13 +114,13 @@ def test_standardization_plot_draws_both_spectra(language: str) -> None:
 
 
 def test_standardization_plot_without_frequencies_uses_band_indices() -> None:
-    res = ph.standardized_maximum_impact_level(_TABLE_D4, 41.4, 2.0)
+    res = ph.building.standardized_maximum_impact_level(_TABLE_D4, 41.4, 2.0)
     ax = res.plot()
     assert [t.get_text() for t in ax.get_xticklabels()] == ["1", "2", "3", "4"]
 
 
 def test_standardization_plot_forwards_kwargs() -> None:
-    res = ph.standardized_maximum_impact_level(_TABLE_D4, 41.4, 2.0)
+    res = ph.building.standardized_maximum_impact_level(_TABLE_D4, 41.4, 2.0)
     ax = res.plot(linewidth=2.5)
     assert any(ln.get_linewidth() == 2.5 for ln in ax.lines)
 
@@ -131,7 +132,7 @@ def test_standardization_plot_forwards_kwargs() -> None:
 
 @pytest.mark.parametrize("language", ["en", "es"])
 def test_rating_plot_bars_carry_the_corrected_values(language: str) -> None:
-    res = ph.a_weighted_maximum_impact_level(_TABLE_D4)
+    res = ph.building.a_weighted_maximum_impact_level(_TABLE_D4)
     ax = res.plot(language=language)
     heights = [p.get_height() for p in ax.patches]
     np.testing.assert_allclose(heights, res.corrected, atol=1e-9)
@@ -142,13 +143,13 @@ def test_rating_plot_bars_carry_the_corrected_values(language: str) -> None:
 
 
 def test_rating_plot_third_octave_has_twelve_bars() -> None:
-    res = ph.a_weighted_maximum_impact_level([60.0] * 12)
+    res = ph.building.a_weighted_maximum_impact_level([60.0] * 12)
     ax = res.plot()
     assert len(ax.patches) == 12
 
 
 def test_rating_plot_forwards_kwargs_to_the_bars() -> None:
-    res = ph.a_weighted_maximum_impact_level(_TABLE_D4)
+    res = ph.building.a_weighted_maximum_impact_level(_TABLE_D4)
     ax = res.plot(color="red")
     red = plt.matplotlib.colors.to_rgba("red")
     assert any(tuple(p.get_facecolor()) == red for p in ax.patches)
@@ -161,7 +162,7 @@ def test_rating_plot_forwards_kwargs_to_the_bars() -> None:
 
 @pytest.mark.parametrize("language", ["en", "es"])
 def test_ceiling_attenuation_plot_draws_data_and_contour(language: str) -> None:
-    res = ph.ceiling_attenuation_class(_ALA_DNC)
+    res = ph.building.ceiling_attenuation_class(_ALA_DNC)
     ax = res.plot(language=language)
     values = [ln.get_ydata() for ln in ax.lines]
     assert any(np.allclose(v, res.measured) for v in values)
@@ -170,13 +171,13 @@ def test_ceiling_attenuation_plot_draws_data_and_contour(language: str) -> None:
 
 
 def test_ceiling_attenuation_plot_shades_the_deficiencies() -> None:
-    res = ph.ceiling_attenuation_class(_ALA_DNC)
+    res = ph.building.ceiling_attenuation_class(_ALA_DNC)
     ax = res.plot()
     assert ax.collections, "the deficiencies were not shaded"
 
 
 def test_ceiling_attenuation_plot_forwards_kwargs() -> None:
-    res = ph.ceiling_attenuation_class(_ALA_DNC)
+    res = ph.building.ceiling_attenuation_class(_ALA_DNC)
     ax = res.plot(linewidth=2.0)
     assert any(ln.get_linewidth() == 2.0 for ln in ax.lines)
 
@@ -188,7 +189,7 @@ def test_ceiling_attenuation_plot_forwards_kwargs() -> None:
 
 def _plenum(**kwargs):
     ceiling = [17.0, 21.0, 25.0, 29.0, 32.0]
-    return ph.plenum_flanking_reduction_index(
+    return ph.building.plenum_flanking_reduction_index(
         ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, **kwargs
     )
 
@@ -238,7 +239,7 @@ def test_plenum_plot_forwards_kwargs() -> None:
 
 def _coupling(**kwargs):
     freq = np.logspace(np.log10(50.0), np.log10(4000.0), 24)
-    return ph.wall_tie_coupling_loss_factor(
+    return ph.building.wall_tie_coupling_loss_factor(
         freq, 150.0, 170.0, 1.0e5, 1.2e5, ties_per_area=2.5, **kwargs
     )
 
@@ -280,10 +281,14 @@ def test_wall_tie_plot_forwards_kwargs() -> None:
 @pytest.mark.parametrize(
     "factory",
     [
-        lambda: ph.check_heavy_impact_source([39.0, 31.0, 23.0, 17.0, 12.5]),
-        lambda: ph.standardized_maximum_impact_level(_TABLE_D4, 41.4, 2.0),
-        lambda: ph.a_weighted_maximum_impact_level(_TABLE_D4),
-        lambda: ph.ceiling_attenuation_class(_ALA_DNC),
+        lambda: ph.building.check_heavy_impact_source(
+            [39.0, 31.0, 23.0, 17.0, 12.5]
+        ),
+        lambda: ph.building.standardized_maximum_impact_level(
+            _TABLE_D4, 41.4, 2.0
+        ),
+        lambda: ph.building.a_weighted_maximum_impact_level(_TABLE_D4),
+        lambda: ph.building.ceiling_attenuation_class(_ALA_DNC),
         _plenum,
         lambda: _coupling(tie="butterfly"),
     ],

--- a/tests/building/test_building_result_plots.py
+++ b/tests/building/test_building_result_plots.py
@@ -87,7 +87,9 @@ def test_impact_rating_uses_opposite_sign_mask() -> None:
 
 
 def test_rating_without_curve_data_raises() -> None:
-    bare = ph.WeightedRatingResult(rating=52, c=-1, ctr=-3, unfavourable_sum=10.0)
+    bare = ph.building.WeightedRatingResult(
+        rating=52, c=-1, ctr=-3, unfavourable_sum=10.0
+    )
     with pytest.raises(ValueError, match="no band curve"):
         bare.plot()
 
@@ -167,7 +169,7 @@ def test_octave_impact_plot_keeps_curve_honest_and_annotates_offset() -> None:
     # rule of Clause 4.3.2. The drawn shifted-reference curve is genuinely
     # ref - shift (so it reads 59 at 500 Hz); the rating (54) is annotated
     # with the -5 dB note rather than the curve being distorted down.
-    res = ph.weighted_impact_rating(_ANNEX_C3_LN_OCTAVE)
+    res = ph.building.weighted_impact_rating(_ANNEX_C3_LN_OCTAVE)
     assert res.rating == 54
     idx500 = int(np.argmin(np.abs(res.band_centers - 500.0)))
     read_value = float(res.shifted_reference[idx500])
@@ -204,7 +206,7 @@ def test_third_octave_impact_plot_reads_rating_at_500() -> None:
 def test_facade_plot_accepts_label_kwarg() -> None:
     # Regression: kwargs used to be forwarded to all four curves, so a user
     # label= collided with the per-curve labels and raised TypeError.
-    res = ph.facade_insulation(
+    res = ph.building.facade_insulation(
         [70.0, 72.0, 74.0], [40.0, 41.0, 42.0], [0.5, 0.5, 0.5]
     )
     ax = res.plot(label="my measurement")

--- a/tests/electroacoustics/test_electroacoustics_plot_i18n.py
+++ b/tests/electroacoustics/test_electroacoustics_plot_i18n.py
@@ -37,7 +37,7 @@ def _tone() -> np.ndarray:
 
 
 def test_harmonic_distortion_es() -> None:
-    res = ph.harmonic_analysis(_tone(), FS, 1000.0)
+    res = ph.electroacoustics.harmonic_analysis(_tone(), FS, 1000.0)
     ax = res.plot(language="es")
     assert ax.get_ylabel() == "Nivel respecto al fundamental [dB]"
     assert ax.get_xlabel().startswith("Orden del armónico")
@@ -49,7 +49,7 @@ def test_harmonic_distortion_es() -> None:
 def test_frequency_response_es() -> None:
     x = RNG.standard_normal(2 ** 15)
     y = np.convolve(x, np.array([0.5, 0.3, 0.1]), mode="same")
-    axes = ph.transfer_function(x, y, FS).plot(language="es")
+    axes = ph.electroacoustics.transfer_function(x, y, FS).plot(language="es")
     text = _labels(axes)
     assert "Respuesta en frecuencia" in text
     assert "coherencia" in text
@@ -59,9 +59,11 @@ def test_frequency_response_es() -> None:
 
 def test_swept_sine_distortion_es() -> None:
     f1, f2, seconds = 100.0, 8000.0, 1.0
-    sweep = ph.synchronized_sweep_signal(FS, f1, f2, seconds)
+    sweep = ph.electroacoustics.synchronized_sweep_signal(FS, f1, f2, seconds)
     rec = sweep + 0.01 * sweep ** 2
-    res = ph.swept_sine_distortion(rec, FS, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+    res = ph.electroacoustics.swept_sine_distortion(
+        rec, FS, f1=f1, f2=f2, seconds=seconds, n_harmonics=3
+    )
     # Two-panel figure: harmonic responses (title) + THD(f) (excitation axis).
     axes = res.plot(language="es")
     text = _labels(axes)
@@ -78,13 +80,13 @@ def test_swept_sine_distortion_es() -> None:
 
 
 def test_feedback_stability_es() -> None:
-    res = ph.feedback_stability(-6.0, 74.0, 80.0)
+    res = ph.electroacoustics.feedback_stability(-6.0, 74.0, 80.0)
     ax = res.plot(language="es")
     assert "Ganancia antes de la realimentación" in ax.get_title()
     assert "Ganancia [dB]" in ax.get_ylabel()
     assert "Oscilación (0 dB)" in _labels(ax)
     plt.close("all")
-    unstable = ph.feedback_stability(0.0, 80.0, 80.0)
+    unstable = ph.electroacoustics.feedback_stability(0.0, 80.0, 80.0)
     assert "inestable" in unstable.plot(language="es").get_title()
     plt.close("all")
     with pytest.raises(ValueError):
@@ -92,16 +94,22 @@ def test_feedback_stability_es() -> None:
 
 
 def test_sound_reinforcement_geometry_es() -> None:
-    ax = ph.plot_sound_reinforcement_geometry(0.3, 4.0, 12.0, language="es")
+    ax = ph.electroacoustics.plot_sound_reinforcement_geometry(
+        0.3, 4.0, 12.0, language="es"
+    )
     assert "Lazo de realimentación" in ax.get_title()
     assert "Camino de realimentación" in _labels(ax)
     plt.close("all")
     with pytest.raises(ValueError):
-        ph.plot_sound_reinforcement_geometry(0.3, 4.0, 12.0, language="xx")
+        ph.electroacoustics.plot_sound_reinforcement_geometry(
+            0.3, 4.0, 12.0, language="xx"
+        )
 
 
 def test_piston_impedance_es() -> None:
-    res = ph.radiating_piston(0.05, np.geomspace(50.0, 5000.0, 60))
+    res = ph.electroacoustics.radiating_piston(
+        0.05, np.geomspace(50.0, 5000.0, 60)
+    )
     ax = res.plot(language="es")
     assert "pistón circular con pantalla" in ax.get_title()
     assert "Impedancia de radiación normalizada" in ax.get_ylabel()
@@ -111,7 +119,7 @@ def test_piston_impedance_es() -> None:
 
 
 def test_piston_directivity_es() -> None:
-    res = ph.piston_directivity_pattern([3.0, 8.0, 16.0])
+    res = ph.electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0])
     ax = res.plot(language="es")
     assert ax.name == "polar"
     assert ax.get_title() == "Directividad de un pistón circular con pantalla"
@@ -124,12 +132,12 @@ def _loudspeaker() -> ph.electroacoustics.LoudspeakerCharacteristics:
     f = np.geomspace(30.0, 24000.0, 200)
     spl = 87.0 - 10 * np.log10(1 + (50.0 / f) ** 6) - 10 * np.log10(1 + (f / 16000.0) ** 7)
     fz = np.geomspace(20.0, 20000.0, 120)
-    return ph.loudspeaker_characteristics(
+    return ph.electroacoustics.loudspeaker_characteristics(
         f, spl, 8.0, sensitivity_band=(200.0, 4000.0),
         impedance=(fz, 6.6 + 20 * np.exp(-(np.log2(fz / 52.0) ** 2) / 0.12)),
         distortion=(np.geomspace(50.0, 5000.0, 90),
                     0.4 + 2.0 * np.ones(90)),
-        directivity=ph.LoudspeakerDirectivity(
+        directivity=ph.electroacoustics.LoudspeakerDirectivity(
             polar=(np.linspace(0.0, 90.0, 46), -np.linspace(0.0, 12.0, 46)),
             frequency=2000.0,
         ),
@@ -141,16 +149,16 @@ def _microphone() -> ph.electroacoustics.MicrophoneCharacteristics:
     resp = -10 * np.log10(1 + (30.0 / f) ** 4) - 10 * np.log10(1 + (f / 19000.0) ** 8)
     ang = np.linspace(0.0, 179.0, 180)
     spl = np.linspace(100.0, 140.0, 41)
-    return ph.microphone_characteristics(
+    return ph.electroacoustics.microphone_characteristics(
         f, resp, 12.5, tolerance_db=3.0,
-        noise=ph.MicrophoneNoise(
+        noise=ph.electroacoustics.MicrophoneNoise(
             voltage=1.25e-6,
             spectrum=(np.geomspace(20.0, 20000.0, 31), np.full(31, 10.0)),
         ),
-        overload=ph.MicrophoneOverload(
+        overload=ph.electroacoustics.MicrophoneOverload(
             distortion=(spl, 0.5 * 10 ** ((spl - 130.0) * 0.08)), thd_percent=0.5
         ),
-        directivity=ph.MicrophoneDirectivity(
+        directivity=ph.electroacoustics.MicrophoneDirectivity(
             polar=(ang, 20 * np.log10((1 + np.cos(np.radians(ang))) / 2)),
             frequency=1000.0,
         ),

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -218,10 +218,14 @@ def test_distortion_from_swept_sine_result() -> None:
     import phonometry as ph
 
     fs = 48000
-    sweep = ph.synchronized_sweep_signal(fs, 100.0, 5000.0, 1.0)
+    sweep = ph.electroacoustics.synchronized_sweep_signal(
+        fs, 100.0, 5000.0, 1.0
+    )
     a2, a3 = 0.05, 0.02
     y = sweep + a2 * sweep**2 + a3 * sweep**3
-    swept = ph.swept_sine_distortion(y, fs, f1=100.0, f2=5000.0, seconds=1.0)
+    swept = ph.electroacoustics.swept_sine_distortion(
+        y, fs, f1=100.0, f2=5000.0, seconds=1.0
+    )
     f, spl = _flat_response()
     result = electroacoustics.loudspeaker_characteristics(
         f, spl, _R, sensitivity_band=(200.0, 4000.0), distortion=swept

--- a/tests/electroacoustics/test_swept_sine.py
+++ b/tests/electroacoustics/test_swept_sine.py
@@ -40,9 +40,11 @@ def _polynomial_recording(sweep: np.ndarray) -> np.ndarray:
     return sweep + A2 * sweep**2 + A3 * sweep**3
 
 
-def _analyze(**kwargs: object) -> ph.SweptSineDistortionResult:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
-    return ph.swept_sine_distortion(
+def _analyze(
+    **kwargs: object,
+) -> ph.electroacoustics.SweptSineDistortionResult:
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    return ph.electroacoustics.swept_sine_distortion(
         _polynomial_recording(x), FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=3, **kwargs
     )
 
@@ -58,7 +60,7 @@ def _at(freqs: np.ndarray, values: np.ndarray, f: float) -> complex:
 
 def test_synchronized_sweep_rate_is_integer_periods_of_f1() -> None:
     """L·f1 must be an integer (the Eq. 49 rounding)."""
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
     rate = round(F1 * SECONDS / np.log(F2 / F1)) / F1
     assert rate * F1 == round(rate * F1)
     assert x.size == int(np.ceil(rate * np.log(F2 / F1) * FS))
@@ -75,39 +77,51 @@ def test_synchronized_sweep_time_shift_equals_harmonic() -> None:
 
 
 def test_synchronized_sweep_starts_at_zero_phase() -> None:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
     assert abs(x[0]) < 1e-9
 
 
 def test_synchronized_sweep_band_and_duration_validation() -> None:
     with pytest.raises(ValueError, match="f2"):
-        ph.synchronized_sweep_signal(FS, 100.0, 50.0, SECONDS)
+        ph.electroacoustics.synchronized_sweep_signal(FS, 100.0, 50.0, SECONDS)
     with pytest.raises(ValueError, match="Nyquist"):
-        ph.synchronized_sweep_signal(FS, 100.0, 30000.0, SECONDS)
+        ph.electroacoustics.synchronized_sweep_signal(
+            FS, 100.0, 30000.0, SECONDS
+        )
     with pytest.raises(ValueError, match="synchronize"):
-        ph.synchronized_sweep_signal(FS, 1.0, 1000.0, 0.5)
+        ph.electroacoustics.synchronized_sweep_signal(FS, 1.0, 1000.0, 0.5)
     with pytest.raises(ValueError, match="fade"):
-        ph.synchronized_sweep_signal(FS, F1, F2, SECONDS, fade=0.7)
+        ph.electroacoustics.synchronized_sweep_signal(
+            FS, F1, F2, SECONDS, fade=0.7
+        )
 
 
 def test_synchronized_sweep_rejects_bad_amplitude() -> None:
     for bad in (0.0, -1.0, float("inf")):
         with pytest.raises(ValueError, match="amplitude"):
-            ph.synchronized_sweep_signal(FS, F1, F2, SECONDS, amplitude=bad)
+            ph.electroacoustics.synchronized_sweep_signal(
+                FS, F1, F2, SECONDS, amplitude=bad
+            )
 
 
 def test_empty_thd_grid_raises_actionably() -> None:
     """f1 above fs/4: every order-2 product would exceed Nyquist."""
     f1, f2, seconds = 13000.0, 20000.0, 0.5
-    x = ph.synchronized_sweep_signal(FS, f1, f2, seconds)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, f1, f2, seconds)
     with pytest.raises(ValueError, match="order-2 product"):
-        ph.swept_sine_distortion(x, FS, f1=f1, f2=f2, seconds=seconds, n_harmonics=2)
+        ph.electroacoustics.swept_sine_distortion(
+            x, FS, f1=f1, f2=f2, seconds=seconds, n_harmonics=2
+        )
 
 
 def test_synchronized_sweep_amplitude_and_fade() -> None:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS, amplitude=0.25)
+    x = ph.electroacoustics.synchronized_sweep_signal(
+        FS, F1, F2, SECONDS, amplitude=0.25
+    )
     assert 0.24 < np.max(np.abs(x)) <= 0.25 + 1e-12
-    faded = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS, fade=0.05)
+    faded = ph.electroacoustics.synchronized_sweep_signal(
+        FS, F1, F2, SECONDS, fade=0.05
+    )
     assert abs(faded[-1]) < 1e-3  # the fade-out lands on the last samples
 
 
@@ -161,7 +175,9 @@ def test_sweep_thd_matches_classical_tone_analyzer() -> None:
     """Same nonlinearity, same orders: sweep separator vs phonometry.thd."""
     t = np.arange(FS) / FS
     tone = np.sin(2.0 * np.pi * 1000.0 * t)
-    classical = ph.thd(_polynomial_recording(tone), FS, 1000.0, n_harmonics=3)
+    classical = ph.electroacoustics.thd(
+        _polynomial_recording(tone), FS, 1000.0, n_harmonics=3
+    )
     res = _analyze()
     idx = int(np.argmin(np.abs(res.thd_frequencies - 1000.0)))
     assert classical == pytest.approx(THD_EXPECTED, rel=1e-6)
@@ -170,8 +186,10 @@ def test_sweep_thd_matches_classical_tone_analyzer() -> None:
 
 def test_linear_system_thd_is_noise_floor() -> None:
     """A purely linear path leaves only the deconvolution residue."""
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
-    res = ph.swept_sine_distortion(0.5 * x, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=3)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    res = ph.electroacoustics.swept_sine_distortion(
+        0.5 * x, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=3
+    )
     h1 = abs(_at(res.frequencies, res.harmonic_responses[0], 1000.0))
     assert h1 == pytest.approx(0.5, rel=1e-3)
     band = (res.thd_frequencies > 100.0) & (res.thd_frequencies < 2000.0)
@@ -180,11 +198,13 @@ def test_linear_system_thd_is_noise_floor() -> None:
 
 def test_hammerstein_composition_delay_and_gain() -> None:
     """A linear post-filter (gain+delay) scales every harmonic response."""
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
     rec = np.concatenate(
         [np.zeros(100), 0.5 * _polynomial_recording(x), np.zeros(4096)]
     )
-    res = ph.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=3)
+    res = ph.electroacoustics.swept_sine_distortion(
+        rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=3
+    )
     h1 = abs(_at(res.frequencies, res.harmonic_responses[0], 1000.0))
     h3 = abs(_at(res.frequencies, res.harmonic_responses[2], 3000.0))
     assert h1 == pytest.approx(0.5 * H1_EXPECTED, rel=2e-3)
@@ -206,10 +226,11 @@ def test_delays_follow_l_ln_n() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _analyze_farina() -> ph.SweptSineDistortionResult:
-    x = ph.sweep_signal(FS, F1, F2, SECONDS)
+def _analyze_farina() -> ph.electroacoustics.SweptSineDistortionResult:
+    x = ph.room.sweep_signal(FS, F1, F2, SECONDS)
     rec = np.concatenate([_polynomial_recording(x), np.zeros(4096)])
-    return ph.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, method="farina", n_harmonics=3
+    return ph.electroacoustics.swept_sine_distortion(
+        rec, FS, f1=F1, f2=F2, seconds=SECONDS, method="farina", n_harmonics=3
     )
 
 
@@ -257,8 +278,10 @@ def test_synchronized_band_extends_beyond_f2() -> None:
 
 def test_amplitude_referencing_recovers_unit_gain() -> None:
     amp = 0.25
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS, amplitude=amp)
-    res = ph.swept_sine_distortion(
+    x = ph.electroacoustics.synchronized_sweep_signal(
+        FS, F1, F2, SECONDS, amplitude=amp
+    )
+    res = ph.electroacoustics.swept_sine_distortion(
         x.copy(), FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2, amplitude=amp
     )
     h1 = abs(_at(res.frequencies, res.harmonic_responses[0], 1000.0))
@@ -266,35 +289,51 @@ def test_amplitude_referencing_recovers_unit_gain() -> None:
 
 
 def test_dc_offset_is_removed_by_default() -> None:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
-    res_clean = ph.swept_sine_distortion(x, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2)
-    res_dc = ph.swept_sine_distortion(x + 0.5, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    res_clean = ph.electroacoustics.swept_sine_distortion(
+        x, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2
+    )
+    res_dc = ph.electroacoustics.swept_sine_distortion(
+        x + 0.5, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2
+    )
     h_clean = abs(_at(res_clean.frequencies, res_clean.harmonic_responses[0], 1000.0))
     h_dc = abs(_at(res_dc.frequencies, res_dc.harmonic_responses[0], 1000.0))
     assert h_dc == pytest.approx(h_clean, rel=1e-6)
 
 
 def test_validation_errors() -> None:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
     rec = _polynomial_recording(x)
     two_dimensional = rec.reshape(2, -1)
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.swept_sine_distortion(two_dimensional, FS, f1=F1, f2=F2, seconds=SECONDS)
+        ph.electroacoustics.swept_sine_distortion(
+            two_dimensional, FS, f1=F1, f2=F2, seconds=SECONDS
+        )
     not_finite = np.full(rec.size, np.nan)
     with pytest.raises(ValueError, match="finite"):
-        ph.swept_sine_distortion(not_finite, FS, f1=F1, f2=F2, seconds=SECONDS)
+        ph.electroacoustics.swept_sine_distortion(
+            not_finite, FS, f1=F1, f2=F2, seconds=SECONDS
+        )
     with pytest.raises(ValueError, match="method"):
-        ph.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, method="nope")  # type: ignore[arg-type]
+        ph.electroacoustics.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, method="nope")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="n_harmonics"):
-        ph.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=1)
+        ph.electroacoustics.swept_sine_distortion(
+            rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=1
+        )
     with pytest.raises(ValueError, match="whole sweep"):
-        ph.swept_sine_distortion(rec[: rec.size // 2], FS, f1=F1, f2=F2, seconds=SECONDS)
+        ph.electroacoustics.swept_sine_distortion(
+            rec[: rec.size // 2], FS, f1=F1, f2=F2, seconds=SECONDS
+        )
     with pytest.raises(ValueError, match="overlap"):
-        ph.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, ir_length=1 << 16)
+        ph.electroacoustics.swept_sine_distortion(
+            rec, FS, f1=F1, f2=F2, seconds=SECONDS, ir_length=1 << 16
+        )
     with pytest.raises(ValueError, match="Lengthen the sweep"):
         # So many orders that the two closest arrivals are < 16 samples
         # apart and no usable window exists.
-        ph.swept_sine_distortion(rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2500)
+        ph.electroacoustics.swept_sine_distortion(
+            rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=2500
+        )
 
 
 def test_farina_rejects_orders_beyond_the_sweep_ratio() -> None:
@@ -305,16 +344,24 @@ def test_farina_rejects_orders_beyond_the_sweep_ratio() -> None:
     causal linear response and read back a spurious copy of H1.
     """
     fs, f1, f2, seconds = 48000, 1000.0, 2000.0, 1.0
-    x = ph.sweep_signal(fs, f1, f2, seconds)
+    x = ph.room.sweep_signal(fs, f1, f2, seconds)
     rec = np.concatenate([x, np.zeros(4096)])
     with pytest.raises(ValueError, match="anticausal"):
-        ph.swept_sine_distortion(rec, fs, f1=f1, f2=f2, seconds=seconds, method="farina", n_harmonics=3,
+        ph.electroacoustics.swept_sine_distortion(
+            rec,
+            fs,
+            f1=f1,
+            f2=f2,
+            seconds=seconds,
+            method="farina",
+            n_harmonics=3,
             ir_length=1024,
         )
     # The synchronized path handles the same request: absent orders read
     # only the deconvolution floor, never a copy of the linear response.
-    xs = ph.synchronized_sweep_signal(fs, f1, f2, seconds)
-    res = ph.swept_sine_distortion(xs, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3, ir_length=1024
+    xs = ph.electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
+    res = ph.electroacoustics.swept_sine_distortion(
+        xs, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3, ir_length=1024
     )
     band = (res.frequencies > 1.2 * f1) & (res.frequencies < 1.8 * f2)
     assert float(np.max(np.abs(res.harmonic_responses[2][band]))) < 0.05
@@ -324,23 +371,32 @@ def test_farina_window_overrun_blames_the_window_not_the_ratio() -> None:
     """When the order fits but its window does not, the message says so."""
     fs, f1, seconds = 48000, 500.0, 1.0
     f2 = f1 * float(np.e)  # ratio e: the order-2 arrival itself fits
-    x = ph.sweep_signal(fs, f1, f2, seconds)
+    x = ph.room.sweep_signal(fs, f1, f2, seconds)
     rec = np.concatenate([x, np.zeros(65536)])
     with pytest.raises(ValueError, match="window around the order-2 arrival"):
-        ph.swept_sine_distortion(rec, fs, f1=f1, f2=f2, seconds=seconds, method="farina", n_harmonics=2,
+        ph.electroacoustics.swept_sine_distortion(
+            rec,
+            fs,
+            f1=f1,
+            f2=f2,
+            seconds=seconds,
+            method="farina",
+            n_harmonics=2,
             ir_length=32768,
         )
 
 
 def test_explicit_ir_length_below_minimum_has_its_own_message() -> None:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
     with pytest.raises(ValueError, match="'ir_length' must be at least"):
-        ph.swept_sine_distortion(x, FS, f1=F1, f2=F2, seconds=SECONDS, ir_length=8)
+        ph.electroacoustics.swept_sine_distortion(
+            x, FS, f1=F1, f2=F2, seconds=SECONDS, ir_length=8
+        )
 
 
 def test_ir_length_explicit_and_windows_centered() -> None:
-    x = ph.synchronized_sweep_signal(FS, F1, F2, SECONDS)
-    res = ph.swept_sine_distortion(
+    x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
+    res = ph.electroacoustics.swept_sine_distortion(
         _polynomial_recording(x), FS, f1=F1, f2=F2, seconds=SECONDS,
         n_harmonics=3, ir_length=2048,
     )

--- a/tests/emission/test_emission_result_plots.py
+++ b/tests/emission/test_emission_result_plots.py
@@ -100,7 +100,7 @@ def test_intensity_bar_width_scales_with_frequency_on_log_axis() -> None:
 
 def test_intensity_without_band_data_raises() -> None:
     p1 = RNG.standard_normal(FS)
-    res = ph.sound_intensity(p1, np.roll(p1, 1), FS, spacing=0.012)
+    res = ph.emission.sound_intensity(p1, np.roll(p1, 1), FS, spacing=0.012)
     assert res.frequency is None
     with pytest.raises(ValueError, match="per-band"):
         res.plot()

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -29,9 +29,9 @@ _PDF_MAGIC = b"%PDF"
 _BANDS = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
 
 
-def _attenuation() -> ph.OutdoorAttenuation:
+def _attenuation() -> ph.environment.OutdoorAttenuation:
     """A porous-ground attenuation over 200 m (a tested clause-7 geometry)."""
-    return ph.outdoor_propagation_attenuation(
+    return ph.environment.outdoor_propagation_attenuation(
         200.0, 2.0, 2.0, _BANDS, 1.0, 1.0, 1.0
     )
 
@@ -41,9 +41,9 @@ def _emission() -> environment.SourceEmission:
     return environment.SourceEmission(sound_power_level=np.full(8, 100.0))
 
 
-def _barrier(method: str = "exact") -> ph.BarrierInsertionLoss:
+def _barrier(method: str = "exact") -> ph.environment.BarrierInsertionLoss:
     """A 4 m thin screen, source 1 m at 50 m, receiver 1.5 m at 100 m."""
-    return ph.barrier_insertion_loss(
+    return ph.environment.barrier_insertion_loss(
         _BANDS, 1.0, 50.0, 4.0, 100.0, 1.5, method=method
     )
 

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -142,12 +142,15 @@ def test_tonal_audibility_plot_smoke_and_export() -> None:
     import phonometry
 
     levels, freqs = _synthetic_tone()
-    res = phonometry.wind_turbine_tonality(levels, freqs)
+    res = phonometry.environment.wind_turbine_tonality(levels, freqs)
     assert res.plot() is not None
     # Caller-supplied plot kwargs must override the defaults, not collide with
     # them (no duplicate-keyword TypeError).
     assert res.plot(lw=2.0, label="spectrum") is not None
-    assert phonometry.apparent_sound_power_level is apparent_sound_power_level
+    assert (
+        phonometry.environment.apparent_sound_power_level
+        is apparent_sound_power_level
+    )
 
 
 def test_two_tone_band_anchors_to_highest_tone_line() -> None:

--- a/tests/filters/test_filters_plot_i18n.py
+++ b/tests/filters/test_filters_plot_i18n.py
@@ -50,7 +50,9 @@ def _add4(a: float, b: float, c: float, d: float) -> float:
 def test_filter_class_es() -> None:
     from phonometry.filters.compliance import filter_class_compliance
 
-    bank = ph.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[500, 2000])
+    bank = ph.filters.OctaveFilterBank(
+        fs=48000, fraction=1, order=6, limits=[500, 2000]
+    )
     res = filter_class_compliance(bank)
     ax = res.plot(language="es")
     assert "Máscara clase" in ax.get_title()
@@ -61,9 +63,9 @@ def test_filter_class_es() -> None:
 
 
 def test_parametric_eq_es_and_bad_language() -> None:
-    eq = ph.ParametricEQ(FS, [
-        ph.EQSection("lowshelf", 100.0, gain_db=4.0),
-        ph.EQSection("peaking", 1000.0, gain_db=-6.0, q=1.5),
+    eq = ph.filters.ParametricEQ(FS, [
+        ph.filters.EQSection("lowshelf", 100.0, gain_db=4.0),
+        ph.filters.EQSection("peaking", 1000.0, gain_db=-6.0, q=1.5),
     ])
     res = eq.response(n_points=64)
     axes = res.plot(language="es")

--- a/tests/filters/test_parametric_eq.py
+++ b/tests/filters/test_parametric_eq.py
@@ -87,7 +87,9 @@ def test_peaking_hand_computed_coefficients() -> None:
         a1/a0 = -1.8612559024730444
         a2/a0 = 0.87731660628506083
     """
-    eq = ph.ParametricEQ(FS, ph.EQSection("peaking", 1000.0, gain_db=6.0, q=0.707))
+    eq = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("peaking", 1000.0, gain_db=6.0, q=0.707)
+    )
     expected = np.array([
         1.0610510792184844,
         -1.8612559024730444,
@@ -116,7 +118,9 @@ def test_peaking_gain_exact_at_f0_and_unity_at_ends(
     2j*(alpha/A)*sin(w0), so H(e^{jw0}) = A^2 = 10^(G/20) exactly. At z=1
     and z=-1 the b and a sums are both 2*(1 -/+ cos w0), so |H| = 1.
     """
-    eq = ph.ParametricEQ(FS, ph.EQSection("peaking", f0, gain_db=gain_db, q=2.0))
+    eq = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("peaking", f0, gain_db=gain_db, q=2.0)
+    )
     at_f0, at_dc, at_nyq = _gain_db_at(eq.sos, [f0, 0.0, FS / 2])
     assert at_f0 == pytest.approx(gain_db, abs=1e-10)
     assert at_dc == pytest.approx(0.0, abs=1e-10)
@@ -131,8 +135,12 @@ def test_shelves_exact_gain_at_ends(gain_db: float) -> None:
     (4(1-cos w0)) = A^2 and H(-1) = 4A(1+cos w0) / (4A(1+cos w0)) = 1;
     the high shelf mirrors them.
     """
-    low = ph.ParametricEQ(FS, ph.EQSection("lowshelf", 500.0, gain_db=gain_db))
-    high = ph.ParametricEQ(FS, ph.EQSection("highshelf", 500.0, gain_db=gain_db))
+    low = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("lowshelf", 500.0, gain_db=gain_db)
+    )
+    high = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("highshelf", 500.0, gain_db=gain_db)
+    )
     low_dc, low_nyq = _gain_db_at(low.sos, [0.0, FS / 2])
     high_dc, high_nyq = _gain_db_at(high.sos, [0.0, FS / 2])
     assert low_dc == pytest.approx(gain_db, abs=1e-10)
@@ -148,8 +156,9 @@ def test_shelf_midpoint_gain_at_f0() -> None:
     A (the square root of the shelf gain A^2), for every S.
     """
     for filter_type in ("lowshelf", "highshelf"):
-        eq = ph.ParametricEQ(
-            FS, ph.EQSection(filter_type, 1000.0, gain_db=8.0, slope=1.0)
+        eq = ph.filters.ParametricEQ(
+            FS,
+            ph.filters.EQSection(filter_type, 1000.0, gain_db=8.0, slope=1.0),
         )
         (at_f0,) = _gain_db_at(eq.sos, [1000.0])
         assert at_f0 == pytest.approx(4.0, abs=1e-10)
@@ -163,8 +172,12 @@ def test_lowpass_highpass_gain_q_at_f0(q: float) -> None:
     corner; the cookbook's bilinear design prewarps so the digital response
     keeps that value exactly at f0.
     """
-    lp = ph.ParametricEQ(FS, ph.EQSection("lowpass", 1000.0, q=q))
-    hp = ph.ParametricEQ(FS, ph.EQSection("highpass", 1000.0, q=q))
+    lp = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("lowpass", 1000.0, q=q)
+    )
+    hp = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("highpass", 1000.0, q=q)
+    )
     q_db = 20 * np.log10(q)
     (lp_f0,) = _gain_db_at(lp.sos, [1000.0])
     (hp_f0,) = _gain_db_at(hp.sos, [1000.0])
@@ -181,24 +194,33 @@ def test_lowpass_highpass_gain_q_at_f0(q: float) -> None:
 def test_bandpass_notch_allpass_anchors() -> None:
     """Band-pass peaks at 0 dB (skirt variant at Q), notch nulls, all-pass is flat."""
     (bp_f0,) = _gain_db_at(
-        ph.ParametricEQ(FS, ph.EQSection("bandpass", 1000.0, q=3.0)).sos, [1000.0]
+        ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection("bandpass", 1000.0, q=3.0)
+        ).sos,
+        [1000.0],
     )
     assert bp_f0 == pytest.approx(0.0, abs=1e-10)
 
     (skirt_f0,) = _gain_db_at(
-        ph.ParametricEQ(FS, ph.EQSection("bandpass_skirt", 1000.0, q=3.0)).sos,
+        ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection("bandpass_skirt", 1000.0, q=3.0)
+        ).sos,
         [1000.0],
     )
     assert skirt_f0 == pytest.approx(20 * np.log10(3.0), abs=1e-10)
 
-    notch = ph.ParametricEQ(FS, ph.EQSection("notch", 1000.0, q=5.0))
+    notch = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("notch", 1000.0, q=5.0)
+    )
     (notch_f0,) = _gain_db_at(notch.sos, [1000.0])
     assert notch_f0 < -250.0
     notch_dc, notch_nyq = _gain_db_at(notch.sos, [0.0, FS / 2])
     assert notch_dc == pytest.approx(0.0, abs=1e-10)
     assert notch_nyq == pytest.approx(0.0, abs=1e-10)
 
-    ap = ph.ParametricEQ(FS, ph.EQSection("allpass", 1000.0, q=0.9))
+    ap = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("allpass", 1000.0, q=0.9)
+    )
     freqs = np.linspace(1.0, FS / 2, 512)
     _, h = signal.sosfreqz(ap.sos, worN=freqs, fs=FS)
     np.testing.assert_allclose(np.abs(h), 1.0, rtol=0.0, atol=1e-12)
@@ -221,7 +243,9 @@ def test_peaking_half_gain_edges_match_q_definition() -> None:
     response alone.
     """
     f0, q, gain_db = 1000.0, 1.5, 6.0
-    eq = ph.ParametricEQ(FS, ph.EQSection("peaking", f0, gain_db=gain_db, q=q))
+    eq = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("peaking", f0, gain_db=gain_db, q=q)
+    )
     w0 = 2 * np.pi * f0 / FS
     alpha = np.sin(w0) / (2 * q)
     half_gain = gain_db / 2
@@ -241,7 +265,9 @@ def test_peaking_half_gain_edges_match_q_definition() -> None:
 def test_peaking_half_gain_bandwidth_matches_q_in_analog_limit() -> None:
     """Far below Nyquist the G/2 dB bandwidth approaches f0/Q."""
     f0, q = 200.0, 2.0  # f0/fs ~ 0.4 %: negligible warping
-    eq = ph.ParametricEQ(FS, ph.EQSection("peaking", f0, gain_db=6.0, q=q))
+    eq = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("peaking", f0, gain_db=6.0, q=q)
+    )
 
     def offset(f: float) -> float:
         return float(_gain_db_at(eq.sos, [f])[0]) - 3.0
@@ -264,11 +290,11 @@ def test_bw_parameterization_reduces_to_q_relation() -> None:
     q = 1.0 / (2 * np.sinh(np.log(2.0) / 2 * bw * w0 / np.sin(w0)))
     for filter_type in ("peaking", "bandpass", "notch"):
         gain = 6.0 if filter_type == "peaking" else 0.0
-        from_bw = ph.ParametricEQ(
-            FS, ph.EQSection(filter_type, f0, gain_db=gain, bw=bw)
+        from_bw = ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection(filter_type, f0, gain_db=gain, bw=bw)
         )
-        from_q = ph.ParametricEQ(
-            FS, ph.EQSection(filter_type, f0, gain_db=gain, q=q)
+        from_q = ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection(filter_type, f0, gain_db=gain, q=q)
         )
         np.testing.assert_allclose(from_bw.sos, from_q.sos, rtol=0.0, atol=1e-15)
 
@@ -279,20 +305,23 @@ def test_slope_parameterization_reduces_to_q_relation() -> None:
     big_a = 10.0 ** (gain_db / 40.0)
     q = 1.0 / np.sqrt((big_a + 1 / big_a) * (1 / slope - 1) + 2)
     for filter_type in ("lowshelf", "highshelf"):
-        from_s = ph.ParametricEQ(
-            FS, ph.EQSection(filter_type, f0, gain_db=gain_db, slope=slope)
+        from_s = ph.filters.ParametricEQ(
+            FS,
+            ph.filters.EQSection(
+                filter_type, f0, gain_db=gain_db, slope=slope
+            ),
         )
-        from_q = ph.ParametricEQ(
-            FS, ph.EQSection(filter_type, f0, gain_db=gain_db, q=q)
+        from_q = ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection(filter_type, f0, gain_db=gain_db, q=q)
         )
         np.testing.assert_allclose(from_s.sos, from_q.sos, rtol=0.0, atol=1e-15)
 
 
 def test_default_q_is_butterworth() -> None:
     """With no q/bw/slope the section designs at Q = 1/sqrt(2) (-3.01 dB)."""
-    eq = ph.ParametricEQ(FS, ph.EQSection("lowpass", 1000.0))
-    explicit = ph.ParametricEQ(
-        FS, ph.EQSection("lowpass", 1000.0, q=1.0 / np.sqrt(2.0))
+    eq = ph.filters.ParametricEQ(FS, ph.filters.EQSection("lowpass", 1000.0))
+    explicit = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("lowpass", 1000.0, q=1.0 / np.sqrt(2.0))
     )
     np.testing.assert_allclose(eq.sos, explicit.sos, rtol=0.0, atol=1e-16)
     (at_f0,) = _gain_db_at(eq.sos, [1000.0])
@@ -313,7 +342,7 @@ def test_bandpass_matches_scipy_iirpeak() -> None:
     0.03 dB across the band here), not coefficient-exact.
     """
     f0, q = 1000.0, 5.0
-    eq = ph.ParametricEQ(FS, ph.EQSection("bandpass", f0, q=q))
+    eq = ph.filters.ParametricEQ(FS, ph.filters.EQSection("bandpass", f0, q=q))
     b, a = signal.iirpeak(f0, q, fs=FS)
     freqs = np.logspace(1, np.log10(FS / 2 * 0.99), 512)
     _, h_eq = signal.sosfreqz(eq.sos, worN=freqs, fs=FS)
@@ -324,7 +353,7 @@ def test_bandpass_matches_scipy_iirpeak() -> None:
 def test_notch_matches_scipy_iirnotch() -> None:
     """Notch magnitude matches scipy.signal.iirnotch (same caveat as iirpeak)."""
     f0, q = 1000.0, 5.0
-    eq = ph.ParametricEQ(FS, ph.EQSection("notch", f0, q=q))
+    eq = ph.filters.ParametricEQ(FS, ph.filters.EQSection("notch", f0, q=q))
     b, a = signal.iirnotch(f0, q, fs=FS)
     freqs = np.logspace(1, np.log10(FS / 2 * 0.99), 512)
     _, h_eq = signal.sosfreqz(eq.sos, worN=freqs, fs=FS)
@@ -337,8 +366,8 @@ def test_butterworth_alignment_matches_scipy_butter() -> None:
     f0 = 1000.0
     freqs = np.logspace(1, np.log10(FS / 2 * 0.99), 512)
     for filter_type, btype in (("lowpass", "low"), ("highpass", "high")):
-        eq = ph.ParametricEQ(
-            FS, ph.EQSection(filter_type, f0, q=1.0 / np.sqrt(2.0))
+        eq = ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection(filter_type, f0, q=1.0 / np.sqrt(2.0))
         )
         sos_ref = signal.butter(2, f0, btype=btype, output="sos", fs=FS)
         _, h_eq = signal.sosfreqz(eq.sos, worN=freqs, fs=FS)
@@ -353,17 +382,17 @@ def test_butterworth_alignment_matches_scipy_butter() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _three_sections() -> list[ph.EQSection]:
+def _three_sections() -> list[ph.filters.EQSection]:
     return [
-        ph.EQSection("lowshelf", 100.0, gain_db=4.0, slope=1.0),
-        ph.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),
-        ph.EQSection("highshelf", 8000.0, gain_db=3.0),
+        ph.filters.EQSection("lowshelf", 100.0, gain_db=4.0, slope=1.0),
+        ph.filters.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),
+        ph.filters.EQSection("highshelf", 8000.0, gain_db=3.0),
     ]
 
 
 def test_cascade_magnitude_is_sum_of_sections() -> None:
     """The cascade magnitude in dB is the sum of the section magnitudes."""
-    res = ph.ParametricEQ(FS, _three_sections()).response(n_points=256)
+    res = ph.filters.ParametricEQ(FS, _three_sections()).response(n_points=256)
     np.testing.assert_allclose(
         res.magnitude_db,
         res.section_magnitude_db.sum(axis=0),
@@ -378,11 +407,14 @@ def test_filter_equals_sosfilt_and_convenience_wrapper() -> None:
     """filter() is the SOS cascade; parametric_eq() is the same one-shot."""
     rng = np.random.default_rng(20260721)
     x = rng.standard_normal(4096)
-    eq = ph.ParametricEQ(FS, _three_sections())
+    eq = ph.filters.ParametricEQ(FS, _three_sections())
     expected = signal.sosfilt(eq.sos, x)
     np.testing.assert_allclose(eq.filter(x), expected, rtol=0.0, atol=0.0)
     np.testing.assert_allclose(
-        ph.parametric_eq(x, FS, sections=_three_sections()), expected, rtol=0.0, atol=0.0
+        ph.filters.parametric_eq(x, FS, sections=_three_sections()),
+        expected,
+        rtol=0.0,
+        atol=0.0,
     )
 
 
@@ -390,8 +422,8 @@ def test_stateful_block_processing_equals_one_shot() -> None:
     """Concatenated stateful blocks equal the single continuous call."""
     rng = np.random.default_rng(7)
     x = rng.standard_normal(8192)
-    one_shot = ph.ParametricEQ(FS, _three_sections()).filter(x)
-    eq = ph.ParametricEQ(FS, _three_sections(), stateful=True)
+    one_shot = ph.filters.ParametricEQ(FS, _three_sections()).filter(x)
+    eq = ph.filters.ParametricEQ(FS, _three_sections(), stateful=True)
     blocks = [eq.filter(x[i : i + 1024]) for i in range(0, len(x), 1024)]
     np.testing.assert_allclose(
         np.concatenate(blocks), one_shot, rtol=0.0, atol=1e-12
@@ -402,14 +434,14 @@ def test_multichannel_filtering() -> None:
     """2D [channels, samples] input filters each channel independently."""
     rng = np.random.default_rng(11)
     x = rng.standard_normal((3, 2048))
-    eq = ph.ParametricEQ(FS, _three_sections())
+    eq = ph.filters.ParametricEQ(FS, _three_sections())
     y = eq.filter(x)
     assert y.shape == x.shape
     for ch in range(3):
         np.testing.assert_allclose(
             y[ch], eq.filter(x[ch]), rtol=0.0, atol=0.0
         )
-    eq_st = ph.ParametricEQ(FS, _three_sections(), stateful=True)
+    eq_st = ph.filters.ParametricEQ(FS, _three_sections(), stateful=True)
     y_blocks = np.concatenate(
         [eq_st.filter(x[:, :1024]), eq_st.filter(x[:, 1024:])], axis=-1
     )
@@ -420,7 +452,9 @@ def test_multichannel_filtering() -> None:
 def test_every_type_designs_and_is_stable(filter_type: str) -> None:
     """Every cookbook type yields a stable, normalized SOS section."""
     gain = 6.0 if filter_type in ("peaking", "lowshelf", "highshelf") else 0.0
-    eq = ph.ParametricEQ(FS, ph.EQSection(filter_type, 1000.0, gain_db=gain))
+    eq = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection(filter_type, 1000.0, gain_db=gain)
+    )
     assert eq.sos.shape == (1, 6)
     assert eq.sos[0, 3] == pytest.approx(1.0, abs=0.0)  # normalized a0
     poles = np.roots(eq.sos[0, 3:])
@@ -434,30 +468,30 @@ def test_every_type_designs_and_is_stable(filter_type: str) -> None:
 
 def test_rejects_unknown_type_and_bad_frequencies() -> None:
     with pytest.raises(ValueError, match="filter_type"):
-        ph.EQSection("bell", 1000.0)  # type: ignore[arg-type]
+        ph.filters.EQSection("bell", 1000.0)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="positive"):
-        ph.EQSection("peaking", 0.0)
-    at_nyquist = ph.EQSection("peaking", FS / 2, gain_db=3.0)
+        ph.filters.EQSection("peaking", 0.0)
+    at_nyquist = ph.filters.EQSection("peaking", FS / 2, gain_db=3.0)
     with pytest.raises(ValueError, match="Nyquist"):
-        ph.ParametricEQ(FS, at_nyquist)
-    section = ph.EQSection("peaking", 1000.0, gain_db=3.0)
+        ph.filters.ParametricEQ(FS, at_nyquist)
+    section = ph.filters.EQSection("peaking", 1000.0, gain_db=3.0)
     with pytest.raises(ValueError, match="positive"):
-        ph.ParametricEQ(0, section)
+        ph.filters.ParametricEQ(0, section)
 
 
 def test_rejects_conflicting_or_misplaced_parameters() -> None:
     with pytest.raises(ValueError, match="only one"):
-        ph.EQSection("peaking", 1000.0, gain_db=3.0, q=1.0, bw=1.0)
+        ph.filters.EQSection("peaking", 1000.0, gain_db=3.0, q=1.0, bw=1.0)
     with pytest.raises(ValueError, match="slope"):
-        ph.EQSection("peaking", 1000.0, gain_db=3.0, slope=1.0)
+        ph.filters.EQSection("peaking", 1000.0, gain_db=3.0, slope=1.0)
     with pytest.raises(ValueError, match="bw"):
-        ph.EQSection("lowshelf", 1000.0, gain_db=3.0, bw=1.0)
+        ph.filters.EQSection("lowshelf", 1000.0, gain_db=3.0, bw=1.0)
     with pytest.raises(ValueError, match="gain_db"):
-        ph.EQSection("notch", 1000.0, gain_db=3.0)
+        ph.filters.EQSection("notch", 1000.0, gain_db=3.0)
     with pytest.raises(ValueError, match="positive"):
-        ph.EQSection("peaking", 1000.0, gain_db=3.0, q=-1.0)
+        ph.filters.EQSection("peaking", 1000.0, gain_db=3.0, q=-1.0)
     with pytest.raises(ValueError, match="at least one"):
-        ph.ParametricEQ(FS, [])
+        ph.filters.ParametricEQ(FS, [])
 
 
 @pytest.mark.parametrize(
@@ -473,7 +507,7 @@ def test_rejects_conflicting_or_misplaced_parameters() -> None:
 )
 def test_rejects_non_finite_parameters(kwargs: dict) -> None:
     with pytest.raises(ValueError, match="finite"):
-        ph.EQSection("peaking", **kwargs)
+        ph.filters.EQSection("peaking", **kwargs)
 
 
 @pytest.mark.parametrize("gain_db", [1e308, -1e308])
@@ -488,7 +522,7 @@ def test_extreme_finite_gain_raises_value_error(
     # zero (then divides by zero in the designers) for huge negative ones;
     # both used to leak raw OverflowError/ZeroDivisionError.
     with pytest.raises(ValueError, match="representable"):
-        ph.EQSection(filter_type, 1000.0, gain_db=gain_db, **kwargs)
+        ph.filters.EQSection(filter_type, 1000.0, gain_db=gain_db, **kwargs)
 
 
 def test_shelf_slope_beyond_gain_bound_raises_informatively() -> None:
@@ -496,30 +530,30 @@ def test_shelf_slope_beyond_gain_bound_raises_informatively() -> None:
     # (A + 1/A)/(A + 1/A - 2) = 8.2869...; beyond it the raw math would
     # fail with a bare "math domain error".
     with pytest.raises(ValueError, match="too steep"):
-        ph.EQSection("lowshelf", 1000.0, gain_db=9.0, slope=12.0)
+        ph.filters.EQSection("lowshelf", 1000.0, gain_db=9.0, slope=12.0)
     # Just below the bound the design succeeds and is strictly stable.
-    section = ph.EQSection("lowshelf", 1000.0, gain_db=9.0, slope=8.0)
-    sos = ph.ParametricEQ(FS, section).sos
+    section = ph.filters.EQSection("lowshelf", 1000.0, gain_db=9.0, slope=8.0)
+    sos = ph.filters.ParametricEQ(FS, section).sos
     assert np.max(np.abs(np.roots(sos[0, 3:]))) < 1.0
     # Gain 0 dB (A = 1): every positive slope is admissible.
-    ph.EQSection("lowshelf", 1000.0, gain_db=0.0, slope=50.0)
+    ph.filters.EQSection("lowshelf", 1000.0, gain_db=0.0, slope=50.0)
 
 
 def test_bw_overflow_near_nyquist_raises_value_error() -> None:
     # The w0/sin(w0) warping factor diverges towards Nyquist: this bw/f0
     # pair used to escape as a raw OverflowError from math.sinh.
-    section = ph.EQSection("notch", 23999.0, bw=1.0)
+    section = ph.filters.EQSection("notch", 23999.0, bw=1.0)
     with pytest.raises(ValueError, match="too wide"):
-        ph.ParametricEQ(FS, section)
+        ph.filters.ParametricEQ(FS, section)
 
 
 def test_bw_marginally_unstable_section_raises_value_error() -> None:
     # Large but finite alpha: the rounded a2 lands exactly at -1.0 (poles
     # on the unit circle) with no arithmetic error to flag it.
     for f0, bw in ((23800.0, 1.0), (23900.0, 6.0)):
-        section = ph.EQSection("notch", f0, bw=bw)
+        section = ph.filters.EQSection("notch", f0, bw=bw)
         with pytest.raises(ValueError, match="not strictly stable"):
-            ph.ParametricEQ(FS, section)
+            ph.filters.ParametricEQ(FS, section)
 
 
 def test_extreme_but_valid_sections_still_design_stably() -> None:
@@ -529,13 +563,17 @@ def test_extreme_but_valid_sections_still_design_stably() -> None:
         ("highpass", 0.01, {"q": 0.001}),
         ("allpass", 12000.0, {"q": 1e-6}),
     ):
-        sos = ph.ParametricEQ(FS, ph.EQSection(filter_type, f0, **kwargs)).sos
+        sos = ph.filters.ParametricEQ(
+            FS, ph.filters.EQSection(filter_type, f0, **kwargs)
+        ).sos
         assert np.all(np.isfinite(sos))
         assert np.max(np.abs(np.roots(sos[0, 3:]))) < 1.0
 
 
 def test_response_grid_validation() -> None:
-    eq = ph.ParametricEQ(FS, ph.EQSection("peaking", 1000.0, gain_db=3.0))
+    eq = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("peaking", 1000.0, gain_db=3.0)
+    )
     with pytest.raises(ValueError, match="n_points"):
         eq.response(n_points=1)
     with pytest.raises(ValueError, match="f_min"):
@@ -552,7 +590,7 @@ def test_response_grid_validation() -> None:
 
 
 def test_plot_two_panel_and_single_axes() -> None:
-    res = ph.ParametricEQ(FS, _three_sections()).response(n_points=128)
+    res = ph.filters.ParametricEQ(FS, _three_sections()).response(n_points=128)
     axes = res.plot()
     assert axes.shape == (2,)
     assert "Audio EQ Cookbook" in axes[0].get_title()
@@ -567,8 +605,8 @@ def test_plot_two_panel_and_single_axes() -> None:
 
 
 def test_plot_rejects_unknown_language() -> None:
-    res = ph.ParametricEQ(
-        FS, ph.EQSection("peaking", 1000.0, gain_db=3.0)
+    res = ph.filters.ParametricEQ(
+        FS, ph.filters.EQSection("peaking", 1000.0, gain_db=3.0)
     ).response(n_points=64)
     with pytest.raises(ValueError, match="language"):
         res.plot(language="xx")

--- a/tests/hearing/test_exposure_result_plots.py
+++ b/tests/hearing/test_exposure_result_plots.py
@@ -49,7 +49,7 @@ def test_exposure_plot_task_bars_and_lex_line() -> None:
 
 def test_exposure_plot_without_tasks_raises() -> None:
     levels = np.full(5, 80.0)
-    res = ph.job_based_exposure(levels, 6.0)
+    res = ph.hearing.job_based_exposure(levels, 6.0)
     assert not res.tasks
     with pytest.raises(ValueError, match="per-task"):
         res.plot()

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -54,7 +54,7 @@ def test_reverse_arrangement_count_bp_worked_example() -> None:
 
 
 def test_example_4_4_accepted_at_5_percent() -> None:
-    res = ph.trend_test(EXAMPLE_4_4)
+    res = ph.metrology.trend_test(EXAMPLE_4_4)
     assert res.statistic == 86
     assert res.bounds == (64, 125)
     assert res.trend_free
@@ -75,12 +75,12 @@ def test_table_a6_alpha_05_percentage_points(
 
 def test_monotonic_sequences_are_rejected() -> None:
     increasing = np.arange(20.0)
-    res = ph.trend_test(increasing)
+    res = ph.metrology.trend_test(increasing)
     assert res.statistic == 0  # no pair with x_i > x_j
     assert not res.trend_free
     assert res.p_value < 1e-9
     decreasing = increasing[::-1]
-    res = ph.trend_test(decreasing)
+    res = ph.metrology.trend_test(decreasing)
     assert res.statistic == 190  # all N(N-1)/2 pairs reversed
     assert not res.trend_free
 
@@ -96,7 +96,7 @@ def test_mahonian_distribution_is_normalized_and_symmetric() -> None:
 def test_large_n_p_value_uses_normal_approximation() -> None:
     rng = np.random.default_rng(11)
     values = rng.standard_normal(150)  # beyond the exact-distribution limit
-    res = ph.trend_test(values)
+    res = ph.metrology.trend_test(values)
     assert 0.0 < res.p_value <= 1.0
     assert res.trend_free
 
@@ -123,11 +123,11 @@ def test_runs_moments_and_pmf_normalization() -> None:
 
 def test_runs_test_rejects_alternation_and_trend() -> None:
     alternating = np.tile([1.0, -1.0], 10)  # r = 20: far too many runs
-    res = ph.trend_test(alternating, method="runs")
+    res = ph.metrology.trend_test(alternating, method="runs")
     assert res.statistic == 20
     assert not res.trend_free
     trending = np.arange(20.0)  # r = 2: one run below, one above the median
-    res = ph.trend_test(trending, method="runs")
+    res = ph.metrology.trend_test(trending, method="runs")
     assert res.statistic == 2
     assert not res.trend_free
     assert res.p_value < 1e-4
@@ -135,7 +135,7 @@ def test_runs_test_rejects_alternation_and_trend() -> None:
 
 def test_runs_test_accepts_random_sequence() -> None:
     rng = np.random.default_rng(3)
-    res = ph.trend_test(rng.standard_normal(40), method="runs")
+    res = ph.metrology.trend_test(rng.standard_normal(40), method="runs")
     assert res.trend_free
     assert res.bounds[0] < res.statistic <= res.bounds[1]
 
@@ -144,28 +144,28 @@ def test_runs_test_discards_median_ties() -> None:
     rng = np.random.default_rng(4)
     values = rng.standard_normal(21)
     values[5] = np.median(values)  # odd length: one exact tie
-    res = ph.trend_test(values, method="runs")
+    res = ph.metrology.trend_test(values, method="runs")
     assert res.n == 20
 
 
 def test_trend_test_validation() -> None:
     short = [1.0] * 9
     with pytest.raises(ValueError, match="at least 10"):
-        ph.trend_test(short)
+        ph.metrology.trend_test(short)
     two_dim = np.ones((5, 4))
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.trend_test(two_dim)
+        ph.metrology.trend_test(two_dim)
     with_nan = np.r_[np.arange(19.0), np.nan]
     with pytest.raises(ValueError, match="finite"):
-        ph.trend_test(with_nan)
+        ph.metrology.trend_test(with_nan)
     good = list(range(12))
     with pytest.raises(ValueError, match="method"):
-        ph.trend_test(good, method="chi2")
+        ph.metrology.trend_test(good, method="chi2")
     with pytest.raises(ValueError, match="alpha"):
-        ph.trend_test(good, alpha=1.5)
+        ph.metrology.trend_test(good, alpha=1.5)
     constant = np.ones(12)
     with pytest.raises(ValueError, match="distinct from the median"):
-        ph.trend_test(constant, method="runs")
+        ph.metrology.trend_test(constant, method="runs")
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +178,7 @@ FS = 8192.0
 def test_stationary_noise_is_accepted() -> None:
     rng = np.random.default_rng(42)
     x = rng.standard_normal(1 << 16)
-    res = ph.stationarity_test(x, FS)
+    res = ph.metrology.stationarity_test(x, FS)
     assert res.stationary
     assert res.n_segments == 20
     assert res.statistic == "mean_square"
@@ -194,23 +194,29 @@ def test_gain_ramp_is_rejected_like_example_10_3() -> None:
     rng = np.random.default_rng(42)
     n = 1 << 16
     x = rng.standard_normal(n) * np.linspace(1.0, 1.2, n)
-    res = ph.stationarity_test(x, FS)
+    res = ph.metrology.stationarity_test(x, FS)
     assert not res.stationary
     assert res.count < res.bounds[0]  # upward trend depresses A
-    runs = ph.stationarity_test(x, FS, method="runs")
+    runs = ph.metrology.stationarity_test(x, FS, method="runs")
     assert not runs.stationary
 
 
 def test_segment_statistics_are_consistent() -> None:
     rng = np.random.default_rng(5)
     x = rng.standard_normal(4000)
-    ms = ph.stationarity_test(x, FS, n_segments=10, statistic="mean_square")
-    rms = ph.stationarity_test(x, FS, n_segments=10, statistic="rms")
+    ms = ph.metrology.stationarity_test(
+        x, FS, n_segments=10, statistic="mean_square"
+    )
+    rms = ph.metrology.stationarity_test(x, FS, n_segments=10, statistic="rms")
     np.testing.assert_allclose(
         rms.segment_values, np.sqrt(ms.segment_values), rtol=1e-12
     )
-    mean = ph.stationarity_test(x, FS, n_segments=10, statistic="mean")
-    var = ph.stationarity_test(x, FS, n_segments=10, statistic="variance")
+    mean = ph.metrology.stationarity_test(
+        x, FS, n_segments=10, statistic="mean"
+    )
+    var = ph.metrology.stationarity_test(
+        x, FS, n_segments=10, statistic="variance"
+    )
     np.testing.assert_allclose(
         var.segment_values,
         ms.segment_values - mean.segment_values**2,
@@ -221,7 +227,7 @@ def test_segment_statistics_are_consistent() -> None:
 def test_stationarity_trailing_samples_are_discarded() -> None:
     rng = np.random.default_rng(6)
     x = rng.standard_normal(1013)  # 1013 = 10 * 101 + 3
-    res = ph.stationarity_test(x, FS, n_segments=10)
+    res = ph.metrology.stationarity_test(x, FS, n_segments=10)
     assert res.segment_duration == pytest.approx(101 / FS)
 
 
@@ -229,13 +235,13 @@ def test_stationarity_validation() -> None:
     rng = np.random.default_rng(7)
     x = rng.standard_normal(2048)
     with pytest.raises(ValueError, match="statistic"):
-        ph.stationarity_test(x, FS, statistic="kurtosis")
+        ph.metrology.stationarity_test(x, FS, statistic="kurtosis")
     with pytest.raises(ValueError, match="n_segments"):
-        ph.stationarity_test(x, FS, n_segments=5)
+        ph.metrology.stationarity_test(x, FS, n_segments=5)
     with pytest.raises(ValueError, match="n_segments"):
-        ph.stationarity_test(x, FS, n_segments=4096)
+        ph.metrology.stationarity_test(x, FS, n_segments=4096)
     with pytest.raises(ValueError, match="fs"):
-        ph.stationarity_test(x, 0.0)
+        ph.metrology.stationarity_test(x, 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -268,7 +274,7 @@ def test_zero_crossing_rate_matches_rice_for_bandpass_noise() -> None:
     fs, n = 20480.0, 1 << 19
     fc, half_band = 1000.0, 200.0
     x = _bandlimited_gaussian(0, fs, n, fc - half_band, fc + half_band)
-    res = ph.level_crossing_rate(x, fs)
+    res = ph.metrology.level_crossing_rate(x, fs)
     n0 = 2.0 * np.sqrt(fc**2 + (2 * half_band) ** 2 / 12.0)
     assert res.zero_crossing_rate == pytest.approx(n0, rel=1e-2)
     assert res.zero_crossing_rate_rice == pytest.approx(n0, rel=1e-2)
@@ -276,7 +282,7 @@ def test_zero_crossing_rate_matches_rice_for_bandpass_noise() -> None:
     # Level dependence, Eq. (5.196): at a = 1 sigma the rate drops by
     # exp(-1/2). The 1-sigma crossing count is about as large as the
     # zero-crossing count, so the same statistical margin applies.
-    res_1s = ph.level_crossing_rate(x, fs, levels=[res.sigma])
+    res_1s = ph.metrology.level_crossing_rate(x, fs, levels=[res.sigma])
     assert res_1s.rates[0] == pytest.approx(n0 * np.exp(-0.5), rel=2e-2)
     assert res_1s.rice_rates[0] == pytest.approx(n0 * np.exp(-0.5), rel=2e-2)
 
@@ -287,7 +293,7 @@ def test_zero_crossing_rate_of_lowpass_noise_example_5_12() -> None:
     fs, n = 20480.0, 1 << 19
     band = 2000.0
     x = _bandlimited_gaussian(1, fs, n, 0.0, band)
-    res = ph.level_crossing_rate(x, fs)
+    res = ph.metrology.level_crossing_rate(x, fs)
     assert res.zero_crossing_rate == pytest.approx(
         2.0 * band / np.sqrt(3.0), rel=1e-2
     )
@@ -298,7 +304,7 @@ def test_sine_crosses_zero_at_twice_its_frequency() -> None:
     fs = 8192.0
     t = np.arange(1 << 16) / fs
     x = np.sin(2.0 * np.pi * 60.0 * t)
-    res = ph.level_crossing_rate(x, fs)
+    res = ph.metrology.level_crossing_rate(x, fs)
     assert res.zero_crossing_rate == pytest.approx(120.0, rel=1e-3)
     assert res.apparent_frequency == pytest.approx(60.0, rel=1e-3)
 
@@ -306,19 +312,19 @@ def test_sine_crosses_zero_at_twice_its_frequency() -> None:
 def test_level_crossing_default_levels_and_validation() -> None:
     rng = np.random.default_rng(8)
     x = rng.standard_normal(4096)
-    res = ph.level_crossing_rate(x, FS)
+    res = ph.metrology.level_crossing_rate(x, FS)
     assert res.levels.size == 13
     assert res.levels[0] == pytest.approx(-3.0 * res.sigma)
     assert res.levels[-1] == pytest.approx(3.0 * res.sigma)
     constant = np.ones(4096)
     with pytest.raises(ValueError, match="constant"):
-        ph.level_crossing_rate(constant, FS)
+        ph.metrology.level_crossing_rate(constant, FS)
     empty_levels: list[float] = []
     with pytest.raises(ValueError, match="levels"):
-        ph.level_crossing_rate(x, FS, levels=empty_levels)
+        ph.metrology.level_crossing_rate(x, FS, levels=empty_levels)
     nan_levels = [0.0, np.nan]
     with pytest.raises(ValueError, match="finite"):
-        ph.level_crossing_rate(x, FS, levels=nan_levels)
+        ph.metrology.level_crossing_rate(x, FS, levels=nan_levels)
 
 
 # ---------------------------------------------------------------------------
@@ -329,7 +335,7 @@ def test_level_crossing_default_levels_and_validation() -> None:
 def test_narrowband_peaks_are_rayleigh_example_5_14() -> None:
     fs, n = 20480.0, 1 << 19
     x = _bandlimited_gaussian(2, fs, n, 950.0, 1050.0)
-    res = ph.peak_statistics(x, fs)
+    res = ph.metrology.peak_statistics(x, fs)
     assert res.irregularity_factor > 0.99
     # Example 5.14: Prob[peak > 4 sigma] = exp(-8) = 0.00033.
     assert res.peak_exceedance(4.0)[0] == pytest.approx(np.exp(-8.0), rel=1e-2)
@@ -345,7 +351,7 @@ def test_wideband_irregularity_factor_of_lowpass_noise() -> None:
     fs, n = 20480.0, 1 << 19
     band = 2000.0
     x = _bandlimited_gaussian(3, fs, n, 0.0, band)
-    res = ph.peak_statistics(x, fs)
+    res = ph.metrology.peak_statistics(x, fs)
     assert res.peak_rate_rice == pytest.approx(
         band * np.sqrt(3.0 / 5.0), rel=1e-2
     )
@@ -381,14 +387,14 @@ def test_peak_exceedance_limits_and_density_consistency() -> None:
 def test_peak_statistics_validation_and_fields() -> None:
     rng = np.random.default_rng(9)
     x = rng.standard_normal(1 << 14)
-    res = ph.peak_statistics(x, FS)
+    res = ph.metrology.peak_statistics(x, FS)
     assert 0.0 < res.irregularity_factor <= 1.0
     assert res.peak_values.size > 0
     assert np.all(np.diff(res.peak_values) >= 0.0)  # sorted
     assert res.duration == pytest.approx((x.size - 1) / FS)
     constant = np.zeros(4096)
     with pytest.raises(ValueError, match="constant"):
-        ph.peak_statistics(constant, FS)
+        ph.metrology.peak_statistics(constant, FS)
 
 
 # ---------------------------------------------------------------------------
@@ -397,7 +403,7 @@ def test_peak_statistics_validation_and_fields() -> None:
 
 
 def test_trend_test_plot_renders_and_returns_axes() -> None:
-    res = ph.trend_test(EXAMPLE_4_4)
+    res = ph.metrology.trend_test(EXAMPLE_4_4)
     ax = res.plot()
     assert "Trend test" in ax.get_title()
     assert ax.get_xlabel() == "Sample index"
@@ -406,7 +412,7 @@ def test_trend_test_plot_renders_and_returns_axes() -> None:
     assert "no trend" in legend
     plt.close("all")
     rng = np.random.default_rng(3)
-    runs = ph.trend_test(rng.standard_normal(40), method="runs")
+    runs = ph.metrology.trend_test(rng.standard_normal(40), method="runs")
     ax = runs.plot()
     legend_texts = [t.get_text() for t in ax.get_legend().get_texts()]
     assert any("Runs $r$ =" in t for t in legend_texts)
@@ -424,7 +430,7 @@ def test_runs_plot_draws_original_classification_median() -> None:
     # median recomputed on the filtered TrendTestResult.values.
     values = np.array([0.0] * 5 + [10.0] * 21 + [100.0] * 15)
     np.random.default_rng(0).shuffle(values)
-    res = ph.trend_test(values, method="runs")
+    res = ph.metrology.trend_test(values, method="runs")
     assert res.median == 10.0
     assert float(np.median(res.values)) == 100.0  # filtered median differs
     ax = res.plot()
@@ -440,29 +446,29 @@ def test_plots_render_and_return_axes() -> None:
     rng = np.random.default_rng(10)
     n = 1 << 14
     x = rng.standard_normal(n) * np.linspace(1.0, 1.3, n)
-    st = ph.stationarity_test(x, FS)
+    st = ph.metrology.stationarity_test(x, FS)
     ax = st.plot()
     assert "Stationarity test" in ax.get_title()
     assert "Reverse arrangements" in ax.get_legend().get_texts()[0].get_text()
     plt.close("all")
-    runs = ph.stationarity_test(x, FS, method="runs")
+    runs = ph.metrology.stationarity_test(x, FS, method="runs")
     ax = runs.plot()
     legend_texts = [t.get_text() for t in ax.get_legend().get_texts()]
     assert any("Runs $r$ =" in t for t in legend_texts)
     assert any("Sequence median" in t for t in legend_texts)
     plt.close("all")
     noise = rng.standard_normal(n)
-    ax = ph.level_crossing_rate(noise, FS).plot()
+    ax = ph.metrology.level_crossing_rate(noise, FS).plot()
     assert "Level-crossing rate" in ax.get_title()
     assert ax.get_yscale() == "log"
     plt.close("all")
-    ax = ph.peak_statistics(noise, FS).plot()
+    ax = ph.metrology.peak_statistics(noise, FS).plot()
     assert "Peak-height distribution" in ax.get_title()
     plt.close("all")
 
 
 def test_peak_plot_without_maxima_raises() -> None:
-    ramp_result = ph.peak_statistics(
+    ramp_result = ph.metrology.peak_statistics(
         np.linspace(0.0, 1.0, 4096) ** 2, FS
     )
     assert ramp_result.peak_values.size == 0

--- a/tests/metrology/test_metrology_plot_i18n.py
+++ b/tests/metrology/test_metrology_plot_i18n.py
@@ -72,7 +72,7 @@ def test_monte_carlo_es() -> None:
 def test_trend_test_es_and_bad_language() -> None:
     values = [5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
               5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0]
-    res = ph.trend_test(values)
+    res = ph.metrology.trend_test(values)
     ax = res.plot(language="es")
     assert "Test de tendencia" in ax.get_title()
     assert ax.get_xlabel() == "Índice de muestra"
@@ -80,7 +80,7 @@ def test_trend_test_es_and_bad_language() -> None:
     assert "Inversiones de orden" in _labels(ax)
     assert "sin tendencia" in _labels(ax)
     plt.close("all")
-    runs = ph.trend_test(RNG.standard_normal(40), method="runs")
+    runs = ph.metrology.trend_test(RNG.standard_normal(40), method="runs")
     ax = runs.plot(language="es")
     assert "Rachas $r$ =" in _labels(ax)
     assert "Mediana de la secuencia" in _labels(ax)
@@ -92,13 +92,13 @@ def test_trend_test_es_and_bad_language() -> None:
 def test_stationarity_test_es_and_bad_language() -> None:
     n = 1 << 14
     x = _white(n) * np.linspace(1.0, 1.3, n)
-    res = ph.stationarity_test(x, FS)
+    res = ph.metrology.stationarity_test(x, FS)
     ax = res.plot(language="es")
     assert "Test de estacionariedad" in ax.get_title()
     assert ax.get_xlabel() == "Índice de segmento"
     assert "Inversiones de orden" in _labels(ax)
     plt.close("all")
-    runs = ph.stationarity_test(x, FS, method="runs")
+    runs = ph.metrology.stationarity_test(x, FS, method="runs")
     ax = runs.plot(language="es")
     assert "Rachas $r$ =" in _labels(ax)
     assert "Mediana de la secuencia" in _labels(ax)
@@ -108,7 +108,7 @@ def test_stationarity_test_es_and_bad_language() -> None:
 
 
 def test_level_crossing_rate_es_and_bad_language() -> None:
-    res = ph.level_crossing_rate(_white(1 << 14), FS)
+    res = ph.metrology.level_crossing_rate(_white(1 << 14), FS)
     ax = res.plot(language="es")
     assert "Tasa de cruces por nivel" in ax.get_title()
     assert ax.get_ylabel() == "Cruces por segundo [1/s]"
@@ -119,7 +119,7 @@ def test_level_crossing_rate_es_and_bad_language() -> None:
 
 
 def test_peak_statistics_es_and_bad_language() -> None:
-    res = ph.peak_statistics(_white(1 << 14), FS)
+    res = ph.metrology.peak_statistics(_white(1 << 14), FS)
     ax = res.plot(language="es")
     assert "Distribución de alturas de pico" in ax.get_title()
     assert "Límite de Rayleigh" in _labels(ax)

--- a/tests/metrology/test_metrology_result_plots.py
+++ b/tests/metrology/test_metrology_result_plots.py
@@ -53,7 +53,7 @@ def test_monte_carlo_plot_histogram_and_interval() -> None:
 
 
 def test_monte_carlo_plot_without_samples_raises() -> None:
-    res = ph.monte_carlo(
+    res = ph.metrology.monte_carlo(
         lambda a, b, c: a + b + c, _MC_QUANTITIES, trials=200, seed=7
     )
     assert res.samples is None

--- a/tests/psychoacoustics/test_loudness_result_plots.py
+++ b/tests/psychoacoustics/test_loudness_result_plots.py
@@ -45,7 +45,7 @@ def test_zwicker_stationary_returns_single_axes_with_specific_curve() -> None:
 
 def test_zwicker_time_varying_returns_two_panels() -> None:
     sig = RNG.standard_normal(FS) * 0.02  # 1 s of noise
-    res = ph.loudness_zwicker(sig, FS, stationary=False)
+    res = ph.psychoacoustics.loudness_zwicker(sig, FS, stationary=False)
     assert res.loudness_vs_time is not None
     axes = res.plot()
     assert isinstance(axes, np.ndarray)
@@ -59,7 +59,9 @@ def test_zwicker_time_varying_returns_two_panels() -> None:
 # Moore-Glasberg loudness (ISO 532-2)
 # --------------------------------------------------------------------------
 def test_moore_glasberg_returns_single_axes_with_specific_curve() -> None:
-    res = ph.loudness_moore_glasberg_from_spectrum([(1000.0, 60.0)])
+    res = ph.psychoacoustics.loudness_moore_glasberg_from_spectrum(
+        [(1000.0, 60.0)]
+    )
     ax = res.plot()
     assert not isinstance(ax, np.ndarray)
     np.testing.assert_allclose(ax.lines[0].get_ydata(), res.specific)

--- a/tests/result_factories.py
+++ b/tests/result_factories.py
@@ -37,113 +37,129 @@ def _exp_ir(seconds: float = 0.8, t60: float = 0.5) -> np.ndarray:
     return decay * RNG.standard_normal(t.size)
 
 
-def _zwicker_stationary() -> ph.ZwickerLoudness:
-    return ph.loudness_zwicker_from_spectrum(np.full(28, 40.0))
+def _zwicker_stationary() -> ph.psychoacoustics.ZwickerLoudness:
+    return ph.psychoacoustics.loudness_zwicker_from_spectrum(np.full(28, 40.0))
 
 
-def _sti() -> ph.STIResult:
-    sig = ph.stipa_signal(fs=FS, seconds=16.0, seed=3)
-    return ph.stipa(sig, FS)
+def _sti() -> ph.speech.STIResult:
+    sig = ph.speech.stipa_signal(fs=FS, seconds=16.0, seed=3)
+    return ph.speech.stipa(sig, FS)
 
 
-def _airborne_rating() -> ph.WeightedRatingResult:
+def _airborne_rating() -> ph.building.WeightedRatingResult:
     measured = np.array(
         [30, 34, 38, 41, 45, 49, 50, 53, 54, 55, 56, 57, 58, 58, 58, 58],
         dtype=float,
     )
-    return ph.weighted_rating(measured)
+    return ph.building.weighted_rating(measured)
 
 
-def _impact_rating() -> ph.ImpactRatingResult:
+def _impact_rating() -> ph.building.ImpactRatingResult:
     measured = np.array(
         [60, 61, 62, 63, 64, 65, 63, 61, 60, 58, 56, 53, 50, 47, 44, 41],
         dtype=float,
     )
-    return ph.weighted_impact_rating(measured)
+    return ph.building.weighted_impact_rating(measured)
 
 
-def _room(limits: list[float] | None) -> ph.RoomAcousticsResult:
-    return ph.room_parameters(_exp_ir(), FS, limits=limits)
+def _room(limits: list[float] | None) -> ph.room.RoomAcousticsResult:
+    return ph.room.room_parameters(_exp_ir(), FS, limits=limits)
 
 
-def _sound_power() -> ph.SoundPowerResult:
+def _sound_power() -> ph.emission.SoundPowerResult:
     freqs = np.array([250.0, 500.0, 1000.0, 2000.0])
     r = 2.0
     s = 2.0 * np.pi * r**2
     lw_bands = np.array([90.0, 92.0, 95.0, 93.0])
     levels = np.tile(lw_bands - 10.0 * np.log10(s), (10, 1))
-    return ph.sound_power_pressure(levels, "hemisphere", radius=r, frequencies=freqs)
+    return ph.emission.sound_power_pressure(
+        levels, "hemisphere", radius=r, frequencies=freqs
+    )
 
 
-def _reverb_power() -> ph.ReverberationSoundPowerResult:
+def _reverb_power() -> ph.emission.ReverberationSoundPowerResult:
     freqs = np.array([250.0, 500.0, 1000.0, 2000.0])
     t60 = np.array([1.6, 1.5, 1.4, 1.1])
     lp = np.tile(np.array([80.0, 82.0, 84.0, 81.0]), (6, 1))
-    return ph.sound_power_reverberation(lp, t60, 200.0, 220.0, freqs)
+    return ph.emission.sound_power_reverberation(lp, t60, 200.0, 220.0, freqs)
 
 
-def _intensity_power_negative() -> ph.SoundPowerIntensityResult:
+def _intensity_power_negative() -> ph.emission.SoundPowerIntensityResult:
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     # band 0 positive net, band 1 all-negative net (external source).
     intensity = np.column_stack([np.full(4, 5.0e-4), np.full(4, -5.0e-5)])
     freqs = np.array([500.0, 1000.0])
-    with pytest.warns(ph.SoundPowerWarning):
-        return ph.sound_power_intensity(intensity, areas, frequencies=freqs)
+    with pytest.warns(ph.emission.SoundPowerWarning):
+        return ph.emission.sound_power_intensity(
+            intensity, areas, frequencies=freqs
+        )
 
 
-def _intensity() -> ph.IntensityResult:
+def _intensity() -> ph.emission.IntensityResult:
     p1 = RNG.standard_normal(FS)
     p2 = np.roll(p1, 1)
-    return ph.sound_intensity(p1, p2, FS, spacing=0.012, fraction=3, limits=[125, 4000])
+    return ph.emission.sound_intensity(
+        p1, p2, FS, spacing=0.012, fraction=3, limits=[125, 4000]
+    )
 
 
-def _open_plan() -> ph.OpenPlanResult:
+def _open_plan() -> ph.room.OpenPlanResult:
     positions = np.array([2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 16.0])
     spl = 57.0 - 7.0 * np.log2(positions / 4.0)
     sti = np.clip(0.9 - 0.055 * positions, 0.0, 1.0)
-    return ph.open_plan_metrics(positions, spl, sti)
+    return ph.room.open_plan_metrics(positions, spl, sti)
 
 
-def _outdoor() -> ph.OutdoorAttenuation:
+def _outdoor() -> ph.environment.OutdoorAttenuation:
     bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
-    barrier = ph.Barrier(source_to_edge=101.0, edge_to_receiver=101.0)
-    return ph.outdoor_propagation_attenuation(
+    barrier = ph.environment.Barrier(
+        source_to_edge=101.0, edge_to_receiver=101.0
+    )
+    return ph.environment.outdoor_propagation_attenuation(
         200.0, 1.5, 1.5, bands, ground_source=1.0, ground_middle=1.0,
         ground_receiver=1.0, barrier=barrier, temperature=15.0,
         relative_humidity=70.0,
     )
 
 
-def _cnossos_road() -> ph.RoadEmissionResult:
-    return ph.road_source_power(
+def _cnossos_road() -> ph.environment.RoadEmissionResult:
+    return ph.environment.road_source_power(
         [
-            ph.RoadTraffic(ph.RoadVehicleCategory.LIGHT, 1200.0, 50.0),
-            ph.RoadTraffic(ph.RoadVehicleCategory.HEAVY, 45.0, 50.0),
+            ph.environment.RoadTraffic(
+                ph.environment.RoadVehicleCategory.LIGHT, 1200.0, 50.0
+            ),
+            ph.environment.RoadTraffic(
+                ph.environment.RoadVehicleCategory.HEAVY, 45.0, 50.0
+            ),
         ],
-        surface=ph.RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
+        surface=ph.environment.RoadSurface.THIN_LAYER_A,
+        temperature=12.0,
+        gradient=3.0,
     )
 
 
-def _porous_medium() -> ph.PorousMediumResult:
+def _porous_medium() -> ph.materials.PorousMediumResult:
     f = np.linspace(400.0, 4000.0, 40)
-    return ph.miki(f, 20000.0)
+    return ph.materials.miki(f, 20000.0)
 
 
-def _layered_absorber() -> ph.LayeredAbsorberResult:
+def _layered_absorber() -> ph.materials.LayeredAbsorberResult:
     f = np.linspace(400.0, 4000.0, 40)
-    med = ph.miki(f, 20000.0)
-    return ph.layered_absorber(f, [ph.PorousLayer(0.05, med)])
+    med = ph.materials.miki(f, 20000.0)
+    return ph.materials.layered_absorber(
+        f, [ph.materials.PorousLayer(0.05, med)]
+    )
 
 
-def _diffuse_absorption() -> ph.DiffuseFieldAbsorptionResult:
+def _diffuse_absorption() -> ph.materials.DiffuseFieldAbsorptionResult:
     f = np.linspace(400.0, 4000.0, 8)
-    med = ph.miki(f, 20000.0)
-    return ph.diffuse_field_absorption(
-        f, [ph.PorousLayer(0.05, med)], quadrature_points=16
+    med = ph.materials.miki(f, 20000.0)
+    return ph.materials.diffuse_field_absorption(
+        f, [ph.materials.PorousLayer(0.05, med)], quadrature_points=16
     )
 
 
-def _impedance_tube() -> ph.ImpedanceTubeResult:
+def _impedance_tube() -> ph.materials.ImpedanceTubeResult:
     f = np.linspace(200.0, 1600.0, 60)
     r_true = 0.6 * np.exp(-f / 1200.0) * np.exp(0.8j)
     k = 2.0 * np.pi * f / 343.2
@@ -152,82 +168,88 @@ def _impedance_tube() -> ph.ImpedanceTubeResult:
     h12 = (np.exp(-1j * k * s) + r_true * phase * np.exp(1j * k * s)) / (
         1.0 + r_true * phase
     )
-    return ph.two_microphone_impedance(
+    return ph.materials.two_microphone_impedance(
         h12, frequency=f, spacing=s, x1=x1, speed_of_sound=343.2,
         characteristic_impedance=407.0,
     )
 
 
 _MC_QUANTITIES = (
-    ph.Quantity(74.0, 0.0, name="Reading"),
-    ph.rectangular(0.0, 0.20, name="Calibration"),
-    ph.Quantity(0.0, 0.35, dof=9, name="Position"),
+    ph.metrology.Quantity(74.0, 0.0, name="Reading"),
+    ph.metrology.rectangular(0.0, 0.20, name="Calibration"),
+    ph.metrology.Quantity(0.0, 0.35, dof=9, name="Position"),
 )
 
 
-def _monte_carlo() -> ph.MonteCarloResult:
-    return ph.monte_carlo(
+def _monte_carlo() -> ph.metrology.MonteCarloResult:
+    return ph.metrology.monte_carlo(
         lambda a, b, c: a + b + c, _MC_QUANTITIES, trials=2000, seed=7,
         keep_samples=True,
     )
 
 
-def _exposure() -> ph.ExposureResult:
+def _exposure() -> ph.hearing.ExposureResult:
     tasks = [
-        ph.Task((86.4, 86.7, 87.0), 2.0, label="grinding"),
-        ph.Task((80.1, 80.9, 80.5), 3.0, label="welding"),
-        ph.Task((75.0, 74.6, 74.9), 3.0, label="assembly"),
+        ph.hearing.Task((86.4, 86.7, 87.0), 2.0, label="grinding"),
+        ph.hearing.Task((80.1, 80.9, 80.5), 3.0, label="welding"),
+        ph.hearing.Task((75.0, 74.6, 74.9), 3.0, label="assembly"),
     ]
-    return ph.task_based_exposure(tasks)
+    return ph.hearing.task_based_exposure(tasks)
 
 
-def _static_airflow() -> ph.StaticAirflowResult:
+def _static_airflow() -> ph.materials.StaticAirflowResult:
     u = np.array([0.2e-3, 0.4e-3, 0.6e-3, 0.8e-3, 1.0e-3])
     dp = 30000.0 * u + 4.0e6 * u**2
-    return ph.static_airflow_resistance(u, dp, area=0.01, thickness=0.05)
+    return ph.materials.static_airflow_resistance(
+        u, dp, area=0.01, thickness=0.05
+    )
 
 
-def _airborne_prediction() -> ph.AirbornePredictionResult:
+def _airborne_prediction() -> ph.building.AirbornePredictionResult:
     paths = []
     for name, rw, k_ff, k_side, lf in (
         ("floor", 49.0, 12.4, 8.9, 4.5),
         ("facade", 42.0, 12.6, 6.7, 2.55),
     ):
-        ff, df, fd = ph.flanking_element(
+        ff, df, fd = ph.building.flanking_element(
             label=name, r_flanking=rw, r_separating=57.0, k_ff=k_ff,
             k_fd=k_side, k_df=k_side, separating_area=11.5, coupling_length=lf,
         )
         paths.extend((ff, df, fd))
-    return ph.predicted_airborne_insulation(r_direct=57.0, flanking_paths=paths)
+    return ph.building.predicted_airborne_insulation(
+        r_direct=57.0, flanking_paths=paths
+    )
 
 
-def _impact_prediction() -> ph.ImpactPredictionResult:
-    return ph.predicted_impact_insulation(
+def _impact_prediction() -> ph.building.ImpactPredictionResult:
+    return ph.building.predicted_impact_insulation(
         ln_w_eq=78.0, delta_l_w=17.0, k_correction=2.0
     )
 
 
-def _airborne_insulation() -> ph.AirborneInsulationResult:
-    return ph.airborne_insulation(
+def _airborne_insulation() -> ph.building.AirborneInsulationResult:
+    return ph.building.airborne_insulation(
         [70.0, 72.0, 74.0], [40.0, 41.0, 42.0], [0.5, 0.5, 0.5],
         area=10.0, volume=50.0,
     )
 
 
-def _impact_insulation() -> ph.ImpactInsulationResult:
-    return ph.impact_insulation([60.0, 61.0, 62.0], [0.5, 0.5, 0.5], volume=50.0)
+def _impact_insulation() -> ph.building.ImpactInsulationResult:
+    return ph.building.impact_insulation(
+        [60.0, 61.0, 62.0], [0.5, 0.5, 0.5], volume=50.0
+    )
 
 
-def _band_uncertainty() -> ph.BandUncertainty:
-    return ph.band_uncertainty("airborne", "B")
+def _band_uncertainty() -> ph.building.BandUncertainty:
+    return ph.building.band_uncertainty("airborne", "B")
 
 
-def _intensity_wide() -> ph.IntensityResult:
+def _intensity_wide() -> ph.emission.IntensityResult:
     """IntensityResult with band centres spanning two decades (100 Hz-10 kHz)
     so the log-axis bar-width scaling can be checked at the extremes."""
     freqs = np.array([100.0, 1000.0, 10000.0])
     n = freqs.size
-    return ph.IntensityResult(
+    return ph.emission.IntensityResult(
         frequency=freqs,
         intensity=np.zeros(n),
         intensity_level=np.full(n, 60.0),
@@ -250,18 +272,18 @@ _ANNEX_C2_FREQS = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500,
                    630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000]
 
 
-def _extended_rating() -> ph.ExtendedWeightedRatingResult:
-    return ph.weighted_rating_extended(
+def _extended_rating() -> ph.building.ExtendedWeightedRatingResult:
+    return ph.building.weighted_rating_extended(
         [18.7, 19.2, 20.0, *_ANNEX_C2_R, 26.8, 29.2], _ANNEX_C2_FREQS
     )
 
 
-def _extended_impact_rating() -> ph.ExtendedImpactRatingResult:
+def _extended_impact_rating() -> ph.building.ExtendedImpactRatingResult:
     li = [55.0, 57.0, 59.0, 62.1, 63.2, 63.5, 66.2, 68.5, 70.0, 71.7, 73.1,
           73.8, 73.5, 73.8, 73.3, 73.1, 73.0, 72.4, 71.2]
     freqs = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500,
              630, 800, 1000, 1250, 1600, 2000, 2500, 3150]
-    return ph.weighted_impact_rating_extended(li, freqs)
+    return ph.building.weighted_impact_rating_extended(li, freqs)
 
 
 _PANEL_BANDS = np.array(
@@ -270,50 +292,54 @@ _PANEL_BANDS = np.array(
 )
 
 
-def _radiation_efficiency() -> ph.RadiationEfficiencyResult:
-    bp = ph.plate_bending_stiffness(6.2e10, 0.006, 0.24)
-    fc = ph.coincidence_frequency(2500.0 * 0.006, bp)
-    return ph.radiation_efficiency(_PANEL_BANDS, 1.5, 1.25, fc)
+def _radiation_efficiency() -> ph.vibration.RadiationEfficiencyResult:
+    bp = ph.vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+    fc = ph.vibration.coincidence_frequency(2500.0 * 0.006, bp)
+    return ph.vibration.radiation_efficiency(_PANEL_BANDS, 1.5, 1.25, fc)
 
 
-def _single_panel() -> ph.SoundReductionResult:
-    bp = ph.plate_bending_stiffness(6.2e10, 0.006, 0.24)
-    fc = ph.coincidence_frequency(15.0, bp)
-    return ph.single_panel_transmission_loss(
+def _single_panel() -> ph.building.SoundReductionResult:
+    bp = ph.vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+    fc = ph.vibration.coincidence_frequency(15.0, bp)
+    return ph.building.single_panel_transmission_loss(
         _PANEL_BANDS, 15.0, critical_frequency=fc, loss_factor=0.024
     )
 
 
-def _double_wall() -> ph.SoundReductionResult:
-    return ph.double_wall_transmission_loss(_PANEL_BANDS, 12.0, 12.0, 0.1)
+def _double_wall() -> ph.building.SoundReductionResult:
+    return ph.building.double_wall_transmission_loss(
+        _PANEL_BANDS, 12.0, 12.0, 0.1
+    )
 
 
-def _slit_aperture() -> ph.ApertureTransmissionResult:
-    return ph.slit_transmission_coefficient(_PANEL_BANDS, 0.002, 0.1)
+def _slit_aperture() -> ph.building.ApertureTransmissionResult:
+    return ph.building.slit_transmission_coefficient(_PANEL_BANDS, 0.002, 0.1)
 
 
-def _modulation() -> ph.ModulationDistortionResult:
+def _modulation() -> ph.electroacoustics.ModulationDistortionResult:
     t = np.arange(FS) / FS
     x = (np.sin(2 * np.pi * 250.0 * t) + 0.25 * np.sin(2 * np.pi * 8000.0 * t)
          + 0.02 * np.sin(2 * np.pi * 8250.0 * t)
          + 0.02 * np.sin(2 * np.pi * 7750.0 * t))
-    return ph.modulation_distortion(x, FS, f_low=250.0, f_high=8000.0)
+    return ph.electroacoustics.modulation_distortion(
+        x, FS, f_low=250.0, f_high=8000.0
+    )
 
 
-def _field_indicators() -> ph.FieldIndicators:
+def _field_indicators() -> ph.emission.FieldIndicators:
     rng = np.random.default_rng(9614)
     lp = 74.0 + rng.normal(0.0, 0.8, (8, 4))
     i_n = 1.0e-5 * (1.0 + rng.normal(0.0, 0.2, (8, 4)))
-    return ph.field_indicators(lp, i_n, [125.0, 250.0, 500.0, 1000.0])
+    return ph.emission.field_indicators(lp, i_n, [125.0, 250.0, 500.0, 1000.0])
 
 
-def _room_with_one_invalid_band() -> ph.RoomAcousticsResult:
+def _room_with_one_invalid_band() -> ph.room.RoomAcousticsResult:
     """A RoomAcousticsResult whose middle band is flagged invalid on every
     decay-time series (built directly so the test is deterministic)."""
     freq = np.array([250.0, 500.0, 1000.0])
     ones = np.ones(3)
     valid = np.array([True, False, True])  # 500 Hz band invalid
-    return ph.RoomAcousticsResult(
+    return ph.room.RoomAcousticsResult(
         frequency=freq,
         edt=ones.copy(),
         t20=ones.copy(),
@@ -330,9 +356,11 @@ def _room_with_one_invalid_band() -> ph.RoomAcousticsResult:
     )
 
 
-def _transfer_matrix() -> tuple[ph.TransferMatrix, np.ndarray, float]:
+def _transfer_matrix() -> tuple[
+    ph.materials.TransferMatrix, np.ndarray, float
+]:
     f = np.linspace(200.0, 1600.0, 40)
     rho_c = 407.0
     k = 2.0 * np.pi * f / 343.2
-    tm = ph.air_layer_transfer_matrix(k, 0.05, rho_c)
+    tm = ph.materials.air_layer_transfer_matrix(k, 0.05, rho_c)
     return tm, f, rho_c

--- a/tests/room/test_room_result_plots.py
+++ b/tests/room/test_room_result_plots.py
@@ -90,21 +90,21 @@ def test_room_acoustics_single_axes_composition() -> None:
 # --------------------------------------------------------------------------
 def test_decay_curve_is_dataclass_and_unpacks_like_tuple() -> None:
     ir = _exp_ir()
-    dc = ph.decay_curve(ir, FS)
-    assert isinstance(dc, ph.DecayCurve)
-    time, level = ph.decay_curve(ir, FS)  # backward-compatible unpacking
+    dc = ph.room.decay_curve(ir, FS)
+    assert isinstance(dc, ph.room.DecayCurve)
+    time, level = ph.room.decay_curve(ir, FS)  # backward-compatible unpacking
     np.testing.assert_array_equal(time, dc.time)
     np.testing.assert_array_equal(level, dc.level)
     assert dc.band is None
 
 
 def test_decay_curve_records_band() -> None:
-    dc = ph.decay_curve(_exp_ir(), FS, band=500.0)
+    dc = ph.room.decay_curve(_exp_ir(), FS, band=500.0)
     assert dc.band == 500.0
 
 
 def test_decay_curve_plot_has_curve_and_fit_overlays() -> None:
-    dc = ph.decay_curve(_exp_ir(seconds=1.0, t60=0.6), FS)
+    dc = ph.room.decay_curve(_exp_ir(seconds=1.0, t60=0.6), FS)
     ax = dc.plot()
     np.testing.assert_allclose(ax.lines[0].get_ydata(), dc.level)
     labels = [ln.get_label() for ln in ax.lines]
@@ -114,7 +114,7 @@ def test_decay_curve_plot_has_curve_and_fit_overlays() -> None:
 
 
 def test_decay_curve_plot_without_fits() -> None:
-    dc = ph.decay_curve(_exp_ir(), FS)
+    dc = ph.room.decay_curve(_exp_ir(), FS)
     ax = dc.plot(fits=False)
     labels = [str(ln.get_label()) for ln in ax.lines]
     assert not any("fit" in lbl for lbl in labels)
@@ -147,7 +147,7 @@ def test_open_plan_plot_line_and_markers() -> None:
 
 
 def test_open_plan_plot_without_regression_raises() -> None:
-    bare = ph.OpenPlanResult(
+    bare = ph.room.OpenPlanResult(
         d2s=float("nan"), lp_as_4m=float("nan"), rd=float("nan"), rp=float("nan")
     )
     with pytest.raises(ValueError, match="regression"):

--- a/tests/signals/test_cepstrum.py
+++ b/tests/signals/test_cepstrum.py
@@ -69,7 +69,7 @@ def _impulse_echo(n: int = N, d: int = DELAY, a: float = ALPHA) -> np.ndarray:
 
 
 def test_power_cepstrum_echo_rahmonics_are_exact() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS, kind="power")
+    res = ph.signals.cepstrum(_impulse_echo(), FS, kind="power")
     assert res.kind == "power"
     for n in (1, 2, 3, 4):
         expected = (-1.0) ** (n + 1) * ALPHA**n / n
@@ -83,14 +83,14 @@ def test_power_cepstrum_echo_rahmonics_are_exact() -> None:
 
 def test_real_cepstrum_is_half_the_power_cepstrum() -> None:
     x = _impulse_echo()
-    real = ph.cepstrum(x, FS, kind="real")
+    real = ph.signals.cepstrum(x, FS, kind="real")
     assert real.cepstrum[DELAY] == pytest.approx(ALPHA / 2.0, abs=1e-12)
     # ...and mirrored onto the negative quefrencies (ln|X| is even).
     assert real.cepstrum[N - DELAY] == pytest.approx(ALPHA / 2.0, abs=1e-12)
 
 
 def test_complex_cepstrum_echo_rahmonics_are_exact() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS, kind="complex")
+    res = ph.signals.cepstrum(_impulse_echo(), FS, kind="complex")
     # delta + a*delta_d with a < 1 is minimum phase: no linear phase removed.
     assert res.linear_phase_samples == 0
     for n in (1, 2, 3):
@@ -103,9 +103,9 @@ def test_complex_cepstrum_echo_rahmonics_are_exact() -> None:
 
 def test_echo_on_broadband_noise_source() -> None:
     """The spike survives a non-trivial source: x = s + a*s(t-t0), circular."""
-    s = ph.noise_signal(FS, N / FS, color="white", seed=20260721)
+    s = ph.signals.noise_signal(FS, N / FS, color="white", seed=20260721)
     x = s + ALPHA * np.roll(s, DELAY)
-    res = ph.cepstrum(x, FS, kind="power")
+    res = ph.signals.cepstrum(x, FS, kind="power")
     # ln X = ln S + ln(1 + a e^{-j theta}) exactly (circular shift), so the
     # echo spike still reads the reflection coefficient; the noise source
     # spreads a small random floor over all quefrencies.
@@ -113,7 +113,7 @@ def test_echo_on_broadband_noise_source() -> None:
 
 
 def test_quefrency_axis_and_shapes() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS)
+    res = ph.signals.cepstrum(_impulse_echo(), FS)
     assert res.quefrencies.size == res.cepstrum.size == res.nfft == N
     assert res.quefrencies[0] == 0.0
     assert res.quefrencies[1] == pytest.approx(1.0 / FS)
@@ -121,7 +121,9 @@ def test_quefrency_axis_and_shapes() -> None:
 
 
 def test_odd_record_pads_to_even_nfft() -> None:
-    res = ph.cepstrum(np.random.default_rng(7).standard_normal(4095), FS)
+    res = ph.signals.cepstrum(
+        np.random.default_rng(7).standard_normal(4095), FS
+    )
     assert res.nfft == 4096
 
 
@@ -142,13 +144,13 @@ def _mixed_phase_delayed() -> np.ndarray:
 
 def test_complex_cepstrum_round_trip_is_exact() -> None:
     x = _mixed_phase_delayed()
-    res = ph.cepstrum(x, FS, kind="complex")
+    res = ph.signals.cepstrum(x, FS, kind="complex")
     assert res.linear_phase_samples != 0  # the delay was detected and removed
     np.testing.assert_allclose(res.invert(), x, atol=1e-12)
 
 
 def test_only_the_complex_cepstrum_inverts() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS, kind="power")
+    res = ph.signals.cepstrum(_impulse_echo(), FS, kind="power")
     with pytest.raises(ValueError, match="invertible"):
         res.invert()
 
@@ -159,16 +161,16 @@ def test_only_the_complex_cepstrum_inverts() -> None:
 
 
 def test_echo_detection_reads_delay_and_reflection_exactly() -> None:
-    res = ph.echo_detection(_impulse_echo(), FS)
+    res = ph.signals.echo_detection(_impulse_echo(), FS)
     assert res.delay_samples == DELAY
     assert res.delay == pytest.approx(DELAY / FS)
     assert res.reflection_coefficient == pytest.approx(ALPHA, abs=1e-12)
 
 
 def test_echo_detection_on_noise_source() -> None:
-    s = ph.noise_signal(FS, N / FS, color="white", seed=42)
+    s = ph.signals.noise_signal(FS, N / FS, color="white", seed=42)
     x = s + 0.25 * np.roll(s, 200)
-    res = ph.echo_detection(x, FS, min_quefrency=0.005)
+    res = ph.signals.echo_detection(x, FS, min_quefrency=0.005)
     assert res.delay_samples == 200
     assert res.reflection_coefficient == pytest.approx(0.25, abs=0.02)
 
@@ -181,16 +183,16 @@ def test_echo_detection_negative_reflection_exact() -> None:
     ``d``. Peak-picking on ``|cepstrum|`` must find the true delay and
     report the signed coefficient.
     """
-    res = ph.echo_detection(_impulse_echo(a=-ALPHA), FS)
+    res = ph.signals.echo_detection(_impulse_echo(a=-ALPHA), FS)
     assert res.delay_samples == DELAY
     assert res.delay == pytest.approx(DELAY / FS)
     assert res.reflection_coefficient == pytest.approx(-ALPHA, abs=1e-12)
 
 
 def test_echo_detection_negative_reflection_on_noise_source() -> None:
-    s = ph.noise_signal(FS, N / FS, color="white", seed=42)
+    s = ph.signals.noise_signal(FS, N / FS, color="white", seed=42)
     x = s - 0.25 * np.roll(s, 200)
-    res = ph.echo_detection(x, FS, min_quefrency=0.005)
+    res = ph.signals.echo_detection(x, FS, min_quefrency=0.005)
     assert res.delay_samples == 200
     assert res.reflection_coefficient == pytest.approx(-0.25, abs=0.02)
 
@@ -210,7 +212,7 @@ def test_echo_detection_off_sample_delay_is_interpolated() -> None:
     ramp = np.exp(-2j * np.pi * np.fft.rfftfreq(N) * true_delay)
     x = s + ALPHA * np.fft.irfft(np.fft.rfft(s) * ramp, N)
 
-    res = ph.echo_detection(x, FS)
+    res = ph.signals.echo_detection(x, FS)
     assert res.delay_samples in (DELAY, DELAY + 1)
     assert res.delay * FS == pytest.approx(true_delay, abs=0.15)
     # Bin splitting: the peak-sample coefficient reads low but keeps sign.
@@ -220,7 +222,7 @@ def test_echo_detection_off_sample_delay_is_interpolated() -> None:
 def test_echo_detection_search_band_is_respected() -> None:
     # Restrict the band away from the true echo: the peak reported must
     # come from inside the band.
-    res = ph.echo_detection(
+    res = ph.signals.echo_detection(
         _impulse_echo(), FS, min_quefrency=400.0 / FS,
         max_quefrency=1000.0 / FS,
     )
@@ -231,9 +233,9 @@ def test_echo_detection_search_band_is_respected() -> None:
 def test_echo_detection_rejects_bad_band() -> None:
     x = _impulse_echo()
     with pytest.raises(ValueError, match="search band"):
-        ph.echo_detection(x, FS, min_quefrency=0.1, max_quefrency=0.05)
+        ph.signals.echo_detection(x, FS, min_quefrency=0.1, max_quefrency=0.05)
     with pytest.raises(ValueError, match="search band"):
-        ph.echo_detection(x, FS, max_quefrency=1.0)
+        ph.signals.echo_detection(x, FS, max_quefrency=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -243,13 +245,17 @@ def test_echo_detection_rejects_bad_band() -> None:
 
 def test_lowpass_lifter_removes_the_echo_ripple() -> None:
     """Below the echo quefrency there is only the flat 0 dB source."""
-    res = ph.lifter(_impulse_echo(), FS, cutoff=(DELAY - 50) / FS, mode="lowpass")
+    res = ph.signals.lifter(
+        _impulse_echo(), FS, cutoff=(DELAY - 50) / FS, mode="lowpass"
+    )
     assert float(np.max(np.abs(res.liftered_db))) < 1e-4
 
 
 def test_highpass_lifter_keeps_the_ripple_extrema() -> None:
     """ln|1 + a e^{-j theta}| swings between ln(1+a) and ln(1-a)."""
-    res = ph.lifter(_impulse_echo(), FS, cutoff=(DELAY - 50) / FS, mode="highpass")
+    res = ph.signals.lifter(
+        _impulse_echo(), FS, cutoff=(DELAY - 50) / FS, mode="highpass"
+    )
     assert float(np.max(res.liftered_db)) == pytest.approx(
         20.0 * np.log10(1.0 + ALPHA), abs=1e-4
     )
@@ -259,9 +265,9 @@ def test_highpass_lifter_keeps_the_ripple_extrema() -> None:
 
 
 def test_lifter_modes_are_exactly_complementary() -> None:
-    x = ph.noise_signal(FS, 0.5, color="pink", seed=3)
-    low = ph.lifter(x, FS, cutoff=0.002, mode="lowpass")
-    high = ph.lifter(x, FS, cutoff=0.002, mode="highpass")
+    x = ph.signals.noise_signal(FS, 0.5, color="pink", seed=3)
+    low = ph.signals.lifter(x, FS, cutoff=0.002, mode="lowpass")
+    high = ph.signals.lifter(x, FS, cutoff=0.002, mode="highpass")
     np.testing.assert_allclose(
         low.liftered_db + high.liftered_db, low.spectrum_db, atol=1e-9
     )
@@ -270,11 +276,11 @@ def test_lifter_modes_are_exactly_complementary() -> None:
 def test_lifter_validates_inputs() -> None:
     x = _impulse_echo()
     with pytest.raises(ValueError, match="mode"):
-        ph.lifter(x, FS, cutoff=0.01, mode="bandpass")
+        ph.signals.lifter(x, FS, cutoff=0.01, mode="bandpass")
     with pytest.raises(ValueError, match="cutoff"):
-        ph.lifter(x, FS, cutoff=10.0)  # beyond nfft/2
+        ph.signals.lifter(x, FS, cutoff=10.0)  # beyond nfft/2
     with pytest.raises(ValueError, match="cutoff"):
-        ph.lifter(x, FS, cutoff=1e-9)  # below one sample
+        ph.signals.lifter(x, FS, cutoff=1e-9)  # below one sample
 
 
 # ---------------------------------------------------------------------------
@@ -285,23 +291,23 @@ def test_lifter_validates_inputs() -> None:
 def test_cepstrum_validates_inputs() -> None:
     x = _impulse_echo()
     with pytest.raises(ValueError, match="kind"):
-        ph.cepstrum(x, FS, kind="cheese")
+        ph.signals.cepstrum(x, FS, kind="cheese")
     with pytest.raises(ValueError, match="nfft"):
-        ph.cepstrum(x, FS, nfft=N - 2)
+        ph.signals.cepstrum(x, FS, nfft=N - 2)
     with pytest.raises(ValueError, match="even"):
-        ph.cepstrum(x, FS, nfft=N + 1)
+        ph.signals.cepstrum(x, FS, nfft=N + 1)
     with pytest.raises(ValueError, match="fs"):
-        ph.cepstrum(x, 0.0)
+        ph.signals.cepstrum(x, 0.0)
     silence = np.zeros(N)
     with pytest.raises(ValueError, match="identically zero"):
-        ph.cepstrum(silence, FS)
+        ph.signals.cepstrum(silence, FS)
 
 
 def test_results_are_frozen() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS)
+    res = ph.signals.cepstrum(_impulse_echo(), FS)
     with pytest.raises(AttributeError):
         res.kind = "real"  # type: ignore[misc]
-    echo = ph.echo_detection(_impulse_echo(), FS)
+    echo = ph.signals.echo_detection(_impulse_echo(), FS)
     with pytest.raises(AttributeError):
         echo.delay = 0.0  # type: ignore[misc]
 
@@ -369,7 +375,7 @@ def test_minimum_phase_refactor_is_bit_exact(oversample: int) -> None:
     """The shared-core refactor changes no output bit on any fixed input."""
     for response in _fixed_responses():
         old = _old_minimum_phase(response, oversample=oversample)
-        new = ph.minimum_phase(response, oversample=oversample)
+        new = ph.signals.minimum_phase(response, oversample=oversample)
         assert old.dtype == new.dtype
         assert old.shape == new.shape
         assert np.array_equal(
@@ -380,7 +386,7 @@ def test_minimum_phase_refactor_is_bit_exact(oversample: int) -> None:
 def test_phase_decomposition_uses_the_shared_core_bit_exactly() -> None:
     response = _fixed_responses()[0]
     old = _old_minimum_phase(response)
-    res = ph.phase_decomposition(response, FS)
+    res = ph.signals.phase_decomposition(response, FS)
     assert np.array_equal(
         old.view(np.float64), res.minimum_phase_response.view(np.float64)
     )
@@ -392,7 +398,7 @@ def test_phase_decomposition_uses_the_shared_core_bit_exactly() -> None:
 
 
 def test_cepstrum_plot_single_axes_and_external_ax() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS)
+    res = ph.signals.cepstrum(_impulse_echo(), FS)
     ax = res.plot()
     assert ax.get_title() != ""
     assert len(ax.lines) == 1
@@ -404,7 +410,7 @@ def test_cepstrum_plot_single_axes_and_external_ax() -> None:
 
 
 def test_echo_detection_plot_marks_the_peak() -> None:
-    res = ph.echo_detection(_impulse_echo(), FS)
+    res = ph.signals.echo_detection(_impulse_echo(), FS)
     ax = res.plot()
     marker = ax.lines[-1]
     assert marker.get_xdata()[0] == pytest.approx(1e3 * res.delay)
@@ -413,7 +419,7 @@ def test_echo_detection_plot_marks_the_peak() -> None:
 
 
 def test_lifter_plot_two_panels_and_external_ax() -> None:
-    res = ph.lifter(_impulse_echo(), FS, cutoff=(DELAY - 50) / FS)
+    res = ph.signals.lifter(_impulse_echo(), FS, cutoff=(DELAY - 50) / FS)
     axes = res.plot()
     assert len(axes) == 2
     _fig, ext = plt.subplots()
@@ -422,7 +428,7 @@ def test_lifter_plot_two_panels_and_external_ax() -> None:
 
 
 def test_plot_rejects_unknown_language() -> None:
-    res = ph.cepstrum(_impulse_echo(), FS)
+    res = ph.signals.cepstrum(_impulse_echo(), FS)
     with pytest.raises(ValueError, match="language"):
         res.plot(language="xx")
     plt.close("all")

--- a/tests/signals/test_correlation.py
+++ b/tests/signals/test_correlation.py
@@ -30,7 +30,9 @@ N = 32768
 
 
 def _white(seed: int, rms: float = 1.0, n: int = N) -> np.ndarray:
-    return ph.noise_signal(FS, n / FS, color="white", rms=rms, seed=seed)
+    return ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=rms, seed=seed
+    )
 
 
 def _bandlimited(seed: int, cutoff: float, n: int = N) -> np.ndarray:
@@ -66,7 +68,9 @@ def test_sine_autocorrelation_closed_form_unbiased() -> None:
     amp, f0 = 2.0, 128.0
     t = np.arange(N) / FS
     x = amp * np.sin(2.0 * np.pi * f0 * t)
-    res = ph.correlation(x, fs=FS, normalization="unbiased", max_lag=0.05)
+    res = ph.signals.correlation(
+        x, fs=FS, normalization="unbiased", max_lag=0.05
+    )
     expected = (amp**2 / 2.0) * np.cos(2.0 * np.pi * f0 * res.lags)
     np.testing.assert_allclose(res.values, expected, atol=5e-3 * amp**2)
 
@@ -74,8 +78,8 @@ def test_sine_autocorrelation_closed_form_unbiased() -> None:
 def test_sine_autocorrelation_biased_tapers_by_one_minus_lag_over_t() -> None:
     """Biased estimate = unbiased × (1-|r|/N) exactly (Eq. 11.95)."""
     x = 3.0 * np.sin(2.0 * np.pi * 100.0 * np.arange(4096) / FS)
-    biased = ph.correlation(x, fs=FS, normalization="biased")
-    unbiased = ph.correlation(x, fs=FS, normalization="unbiased")
+    biased = ph.signals.correlation(x, fs=FS, normalization="biased")
+    unbiased = ph.signals.correlation(x, fs=FS, normalization="unbiased")
     taper = 1.0 - np.abs(biased.lags) * FS / x.size
     np.testing.assert_allclose(biased.values, unbiased.values * taper,
                                rtol=1e-9, atol=1e-12)
@@ -85,7 +89,9 @@ def test_bandlimited_white_noise_autocorrelation_is_sinc() -> None:
     """ρxx(τ) of bandwidth-B white noise = sin(2πBτ)/(2πBτ) (Eq. 8.120)."""
     bandwidth = FS / 5.0
     x = _bandlimited(21, bandwidth)
-    res = ph.correlation(x, fs=FS, normalization="coefficient", max_lag=0.01)
+    res = ph.signals.correlation(
+        x, fs=FS, normalization="coefficient", max_lag=0.01
+    )
     arg = 2.0 * np.pi * bandwidth * res.lags
     expected = np.ones_like(arg)
     nz = arg != 0.0
@@ -96,7 +102,7 @@ def test_bandlimited_white_noise_autocorrelation_is_sinc() -> None:
 
 def test_coefficient_normalization_is_unity_at_zero_lag_and_bounded() -> None:
     x = _white(1)
-    res = ph.correlation(x, fs=FS, normalization="coefficient")
+    res = ph.signals.correlation(x, fs=FS, normalization="coefficient")
     zero = int(np.argmin(np.abs(res.lags)))
     assert res.values[zero] == pytest.approx(1.0, abs=1e-12)
     assert float(np.max(np.abs(res.values))) <= 1.0 + 1e-12
@@ -107,9 +113,11 @@ def test_cross_correlation_peaks_at_the_imposed_delay() -> None:
     """B&P Eq. 5.21: R̂xy peaks at τ0 with ρ ≈ α·σx/σy (Eq. 5.22)."""
     delay = 40
     x = _white(2)
-    noise = ph.noise_signal(FS, N / FS, color="white", rms=0.75, seed=3)
+    noise = ph.signals.noise_signal(
+        FS, N / FS, color="white", rms=0.75, seed=3
+    )
     y = 0.5 * np.roll(x, delay) + noise
-    res = ph.correlation(x, y, FS, normalization="coefficient")
+    res = ph.signals.correlation(x, y, FS, normalization="coefficient")
     peak = int(np.argmax(res.values))
     assert res.lags[peak] == pytest.approx(delay / FS)
     # α·σx/σy = 0.5/sqrt(0.25 + 0.5625)
@@ -121,7 +129,7 @@ def test_cross_correlation_peaks_at_the_imposed_delay() -> None:
 
 def test_correlation_max_lag_restricts_the_axis() -> None:
     x = _white(4, n=4096)
-    res = ph.correlation(x, fs=FS, max_lag=0.02)
+    res = ph.signals.correlation(x, fs=FS, max_lag=0.02)
     m = round(0.02 * FS)
     assert res.lags.size == 2 * m + 1
     assert float(np.max(np.abs(res.lags))) == pytest.approx(m / FS)
@@ -140,7 +148,9 @@ def test_autocorrelation_zero_lag_error_is_one_over_sqrt_bt() -> None:
         # Raw Gaussian noise: noise_signal rescales to an exact RMS, which
         # would remove precisely the zero-lag fluctuation measured here.
         x = np.random.default_rng(100 + seed).standard_normal(n)
-        res = ph.correlation(x, fs=FS, normalization="biased", max_lag=0.002)
+        res = ph.signals.correlation(
+            x, fs=FS, normalization="biased", max_lag=0.002
+        )
         zero = int(np.argmin(np.abs(res.lags)))
         values.append(res.values[zero])
     arr = np.asarray(values)
@@ -151,7 +161,9 @@ def test_autocorrelation_zero_lag_error_is_one_over_sqrt_bt() -> None:
 
 def test_random_error_method_matches_the_closed_form() -> None:
     x = _bandlimited(5, 2000.0)
-    res = ph.correlation(x, fs=FS, normalization="coefficient", max_lag=0.01)
+    res = ph.signals.correlation(
+        x, fs=FS, normalization="coefficient", max_lag=0.01
+    )
     eps = res.random_error(2000.0)
     expected = np.sqrt(1.0 + res.coefficient**-2.0) / np.sqrt(
         2.0 * 2000.0 * res.duration
@@ -167,18 +179,18 @@ def test_random_error_method_matches_the_closed_form() -> None:
 def test_correlation_random_error_reproduces_example_8_5() -> None:
     """B&P Example 8.5: B = 100 Hz, T = 5 s, M/S = N/S = 10 -> ε ≈ 0.35."""
     rho = 1.0 / np.sqrt(11.0 * 11.0)  # S/sqrt((S+M)(S+N)) with S=1, M=N=10
-    eps = ph.correlation_random_error(rho, 100.0, 5.0)
+    eps = ph.signals.correlation_random_error(rho, 100.0, 5.0)
     assert eps == pytest.approx(0.35, abs=0.001)  # book rounds sqrt(122/1000)
 
 
 def test_correlation_random_error_validation() -> None:
-    assert ph.correlation_random_error(0.0, 100.0, 5.0) == np.inf
+    assert ph.signals.correlation_random_error(0.0, 100.0, 5.0) == np.inf
     with pytest.raises(ValueError, match="coefficient"):
-        ph.correlation_random_error(1.5, 100.0, 5.0)
+        ph.signals.correlation_random_error(1.5, 100.0, 5.0)
     with pytest.raises(ValueError, match="signal_bandwidth"):
-        ph.correlation_random_error(0.5, 0.0, 5.0)
+        ph.signals.correlation_random_error(0.5, 0.0, 5.0)
     with pytest.raises(ValueError, match="duration"):
-        ph.correlation_random_error(0.5, 100.0, -1.0)
+        ph.signals.correlation_random_error(0.5, 100.0, -1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +203,7 @@ def test_integer_delay_recovered_by_every_method(method: str) -> None:
     delay = 16
     x = _white(6)
     y = np.roll(x, delay)
-    res = ph.time_delay(x, y, FS, method=method, nperseg=2048)  # type: ignore[arg-type]
+    res = ph.signals.time_delay(x, y, FS, method=method, nperseg=2048)  # type: ignore[arg-type]
     assert res.delay_samples == pytest.approx(delay, abs=1e-3)
     assert res.delay == pytest.approx(delay / FS, rel=1e-4)
     assert res.peak_correlation == pytest.approx(1.0, abs=1e-3)
@@ -202,7 +214,7 @@ def test_integer_delay_recovered_by_every_gcc_weighting(weighting: str) -> None:
     delay = 25
     x = _white(7)
     y = np.roll(x, delay)
-    res = ph.time_delay(
+    res = ph.signals.time_delay(
         x, y, FS, method="gcc", weighting=weighting, nperseg=2048  # type: ignore[arg-type]
     )
     assert res.delay_samples == pytest.approx(delay, abs=1e-3)
@@ -214,7 +226,7 @@ def test_negative_delay_and_sign_convention() -> None:
     """y leading x (y(t) = x(t+|τ0|)) gives a negative delay."""
     x = _white(8)
     y = np.roll(x, -30)
-    res = ph.time_delay(x, y, FS, method="direct")
+    res = ph.signals.time_delay(x, y, FS, method="direct")
     assert res.delay_samples == pytest.approx(-30.0, abs=1e-3)
 
 
@@ -222,7 +234,9 @@ def test_gcc_phat_of_noiseless_delay_is_a_near_delta() -> None:
     """Knapp & Carter Eq. 23: ideal PHAT correlation is δ(τ-D)."""
     x = _white(9)
     y = np.roll(x, 12)
-    res = ph.time_delay(x, y, FS, method="gcc", weighting="phat", nperseg=2048)
+    res = ph.signals.time_delay(
+        x, y, FS, method="gcc", weighting="phat", nperseg=2048
+    )
     curve = np.abs(res.correlation)
     peak = int(np.argmax(curve))
     assert curve[peak] == pytest.approx(1.0)  # normalized to unit peak
@@ -242,12 +256,12 @@ def test_gcc_phat_sharpens_the_peak_of_a_colored_signal() -> None:
     x = np.asarray(sp_signal.lfilter(b, a, _white(10)), dtype=np.float64)
     y = np.roll(x, delay)
 
-    def half_width(res: ph.TimeDelayResult) -> int:
+    def half_width(res: ph.signals.TimeDelayResult) -> int:
         curve = np.abs(res.correlation)
         return int(np.sum(curve > 0.5 * np.max(curve)))
 
-    direct = ph.time_delay(x, y, FS, method="direct")
-    phat = ph.time_delay(x, y, FS, method="gcc", weighting="phat",
+    direct = ph.signals.time_delay(x, y, FS, method="direct")
+    phat = ph.signals.time_delay(x, y, FS, method="gcc", weighting="phat",
                          nperseg=2048)
     assert half_width(phat) < half_width(direct)
     assert phat.delay_samples == pytest.approx(delay, abs=1e-3)
@@ -259,13 +273,17 @@ def test_ml_weighting_suppresses_empty_bands_where_phat_jitters() -> None:
     scales them by γ²/(1-γ²) and stays accurate on a band-limited signal
     observed through noisy sensors."""
     s = _bandlimited(11, 0.4 * FS)
-    noise_a = ph.noise_signal(FS, N / FS, color="white", rms=0.1, seed=311)
-    noise_b = ph.noise_signal(FS, N / FS, color="white", rms=0.1, seed=312)
+    noise_a = ph.signals.noise_signal(
+        FS, N / FS, color="white", rms=0.1, seed=311
+    )
+    noise_b = ph.signals.noise_signal(
+        FS, N / FS, color="white", rms=0.1, seed=312
+    )
     x = s + noise_a
     y = _fractional_delay(s, 12.25) + noise_b
-    ml = ph.time_delay(x, y, FS, method="gcc", weighting="ml",
+    ml = ph.signals.time_delay(x, y, FS, method="gcc", weighting="ml",
                        nperseg=2048, upsample=16)
-    phat = ph.time_delay(x, y, FS, method="gcc", weighting="phat",
+    phat = ph.signals.time_delay(x, y, FS, method="gcc", weighting="phat",
                          nperseg=2048, upsample=16)
     assert ml.delay_samples == pytest.approx(12.25, abs=5e-3)
     assert abs(ml.delay_samples - 12.25) < abs(phat.delay_samples - 12.25)
@@ -281,7 +299,7 @@ def test_fractional_delay_direct_parabolic_accuracy() -> None:
     sample (the parabola only approximates the sinc-shaped peak)."""
     x = _bandlimited(12, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
-    res = ph.time_delay(x, y, FS, method="direct")
+    res = ph.signals.time_delay(x, y, FS, method="direct")
     assert res.delay_samples == pytest.approx(12.25, abs=0.1)
 
 
@@ -290,7 +308,7 @@ def test_fractional_delay_direct_upsampled_accuracy() -> None:
     |err| < 2e-3 samples on the same pair."""
     x = _bandlimited(12, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
-    res = ph.time_delay(x, y, FS, method="direct", upsample=16)
+    res = ph.signals.time_delay(x, y, FS, method="direct", upsample=16)
     assert res.delay_samples == pytest.approx(12.25, abs=2e-3)
 
 
@@ -299,7 +317,7 @@ def test_phase_slope_handles_polarity_inversion() -> None:
     phase to DC keeps the Eq. 5.101b slope unbiased."""
     x = _white(22)
     y = -np.roll(x, 5)
-    res = ph.time_delay(x, y, FS, method="phase", nperseg=2048)
+    res = ph.signals.time_delay(x, y, FS, method="phase", nperseg=2048)
     assert res.delay_samples == pytest.approx(5.0, abs=1e-3)
 
 
@@ -309,7 +327,9 @@ def test_ml_weighting_requires_averaged_coherence() -> None:
     x = _white(23, n=2048)
     y = np.roll(x, 5)
     with pytest.raises(ValueError, match="averaged coherence"):
-        ph.time_delay(x, y, FS, method="gcc", weighting="ml", nperseg=2048)
+        ph.signals.time_delay(
+            x, y, FS, method="gcc", weighting="ml", nperseg=2048
+        )
 
 
 def test_time_delay_rejects_constant_records() -> None:
@@ -317,9 +337,9 @@ def test_time_delay_rejects_constant_records() -> None:
     x = _white(24, n=4096)
     for method in ("direct", "gcc", "phase"):
         with pytest.raises(ValueError, match="constant"):
-            ph.time_delay(flat, x, FS, method=method)  # type: ignore[arg-type]
+            ph.signals.time_delay(flat, x, FS, method=method)  # type: ignore[arg-type]
         with pytest.raises(ValueError, match="constant"):
-            ph.time_delay(x, flat, FS, method=method)  # type: ignore[arg-type]
+            ph.signals.time_delay(x, flat, FS, method=method)  # type: ignore[arg-type]
 
 
 def test_fractional_delay_phase_slope_accuracy() -> None:
@@ -327,14 +347,16 @@ def test_fractional_delay_phase_slope_accuracy() -> None:
     clean fractional delay (the phase of a pure delay is exactly linear)."""
     x = _bandlimited(13, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
-    res = ph.time_delay(x, y, FS, method="phase", nperseg=2048)
+    res = ph.signals.time_delay(x, y, FS, method="phase", nperseg=2048)
     assert res.delay_samples == pytest.approx(12.25, abs=1e-3)
 
 
 def test_interpolation_none_stays_on_the_sample_grid() -> None:
     x = _bandlimited(14, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
-    res = ph.time_delay(x, y, FS, method="direct", interpolation="none")
+    res = ph.signals.time_delay(
+        x, y, FS, method="direct", interpolation="none"
+    )
     assert res.delay_samples == pytest.approx(round(res.delay_samples))
     assert abs(res.delay_samples - 12.25) <= 0.5
 
@@ -354,19 +376,23 @@ def _two_detector_pair(
     """
     s = _bandlimited(2000 + seed, bandwidth, n=n)
     rms = float(np.sqrt(nsr) * np.std(s))
-    m = ph.noise_signal(FS, n / FS, color="white", rms=rms, seed=4000 + seed)
-    nn = ph.noise_signal(FS, n / FS, color="white", rms=rms, seed=6000 + seed)
+    m = ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=rms, seed=4000 + seed
+    )
+    nn = ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=rms, seed=6000 + seed
+    )
     return s + m, np.roll(s, delay) + nn
 
 
 def test_delay_std_fields_follow_the_closed_form() -> None:
     bandwidth = 1000.0
     x, y = _two_detector_pair(1, 50, 3.0, bandwidth)
-    res = ph.time_delay(x, y, FS, method="direct",
+    res = ph.signals.time_delay(x, y, FS, method="direct",
                         signal_bandwidth=bandwidth)
     assert res.delay_std is not None
     assert res.delay_interval is not None
-    eps = ph.correlation_random_error(
+    eps = ph.signals.correlation_random_error(
         abs(res.peak_correlation), bandwidth, N / FS
     )
     expected = (0.75**0.25) * np.sqrt(eps) / (np.pi * bandwidth)
@@ -392,7 +418,7 @@ def test_delay_scatter_is_consistent_with_the_eq_8_129_prediction() -> None:
     predicted = 0.0
     for seed in range(60):
         x, y = _two_detector_pair(seed, 50, 10.0, bandwidth, n=8192)
-        res = ph.time_delay(
+        res = ph.signals.time_delay(
             x, y, FS, method="direct", signal_bandwidth=bandwidth
         )
         delays.append(res.delay)
@@ -405,7 +431,7 @@ def test_delay_scatter_is_consistent_with_the_eq_8_129_prediction() -> None:
 
 def test_no_bandwidth_means_no_error_fields() -> None:
     x = _white(15)
-    res = ph.time_delay(x, np.roll(x, 5), FS, method="direct")
+    res = ph.signals.time_delay(x, np.roll(x, 5), FS, method="direct")
     assert res.delay_std is None
     assert res.delay_interval is None
     assert res.signal_bandwidth is None
@@ -421,26 +447,26 @@ def test_single_ir_subsample_delay_accuracy() -> None:
     hundredths of a sample with the parabola alone, ~1e-3 samples at the
     default upsample=8, below 1e-5 at x32."""
     ir = _bandlimited_pulse(4096, 700.35, 0.15)
-    got = ph.impulse_response_delay(ir, FS) * FS
+    got = ph.signals.impulse_response_delay(ir, FS) * FS
     assert got == pytest.approx(700.35, abs=1e-3)
-    coarse = ph.impulse_response_delay(ir, FS, upsample=1) * FS
+    coarse = ph.signals.impulse_response_delay(ir, FS, upsample=1) * FS
     assert coarse == pytest.approx(700.35, abs=5e-2)
-    fine = ph.impulse_response_delay(ir, FS, upsample=32) * FS
+    fine = ph.signals.impulse_response_delay(ir, FS, upsample=32) * FS
     assert fine == pytest.approx(700.35, abs=1e-5)
 
 
 def test_single_ir_delay_handles_negative_polarity_peaks() -> None:
     ir = -_bandlimited_pulse(4096, 700.35, 0.15)
-    got = ph.impulse_response_delay(ir, FS) * FS
+    got = ph.signals.impulse_response_delay(ir, FS) * FS
     assert got == pytest.approx(700.35, abs=1e-3)
 
 
 def test_ir_pair_delay_and_alignment() -> None:
     reference = _bandlimited_pulse(4096, 600.0, 0.15)
     ir = _bandlimited_pulse(4096, 700.35, 0.15)
-    delay = ph.impulse_response_delay(ir, FS, reference=reference) * FS
+    delay = ph.signals.impulse_response_delay(ir, FS, reference=reference) * FS
     assert delay == pytest.approx(100.35, abs=1e-3)
-    res = ph.align_impulse_responses(ir, reference, FS)
+    res = ph.signals.align_impulse_responses(ir, reference, FS)
     assert res.delay_samples == pytest.approx(100.35, abs=1e-3)
     assert res.delay == pytest.approx(res.delay_samples / FS)
     residual = float(np.max(np.abs(res.aligned - reference)))
@@ -451,7 +477,7 @@ def test_single_ir_delay_near_the_record_start() -> None:
     """A peak close to the boundary keeps a full-size (clamped) upsampling
     window instead of a shrunken one."""
     ir = _bandlimited_pulse(4096, 5.25, 0.15)
-    got = ph.impulse_response_delay(ir, FS) * FS
+    got = ph.signals.impulse_response_delay(ir, FS) * FS
     assert got == pytest.approx(5.25, abs=5e-3)
 
 
@@ -469,7 +495,7 @@ def test_peak_coefficient_guard_for_out_of_record_delays() -> None:
 
 def test_alignment_of_identical_irs_is_a_no_op() -> None:
     reference = _bandlimited_pulse(4096, 600.0, 0.15)
-    res = ph.align_impulse_responses(reference, reference, FS)
+    res = ph.signals.align_impulse_responses(reference, reference, FS)
     assert res.delay_samples == pytest.approx(0.0, abs=1e-9)
     np.testing.assert_allclose(res.aligned, reference, atol=1e-9)
 
@@ -482,16 +508,16 @@ def test_alignment_of_identical_irs_is_a_no_op() -> None:
 def test_correlation_rejects_invalid_inputs() -> None:
     x = _white(16, n=4096)
     with pytest.raises(ValueError, match="same length"):
-        ph.correlation(x, x[:-1], FS)
+        ph.signals.correlation(x, x[:-1], FS)
     with pytest.raises(ValueError, match="normalization"):
-        ph.correlation(x, fs=FS, normalization="raw")  # type: ignore[arg-type]
+        ph.signals.correlation(x, fs=FS, normalization="raw")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="max_lag"):
-        ph.correlation(x, fs=FS, max_lag=10.0)
+        ph.signals.correlation(x, fs=FS, max_lag=10.0)
     with pytest.raises(ValueError, match="max_lag"):
-        ph.correlation(x, fs=FS, max_lag=-1.0)
+        ph.signals.correlation(x, fs=FS, max_lag=-1.0)
     with pytest.raises(ValueError, match="'fs'"):
-        ph.correlation(x, fs=0.0)
-    res = ph.correlation(x, fs=FS)
+        ph.signals.correlation(x, fs=0.0)
+    res = ph.signals.correlation(x, fs=FS)
     with pytest.raises(ValueError, match="signal_bandwidth"):
         res.random_error(0.0)
 
@@ -500,39 +526,41 @@ def test_time_delay_rejects_invalid_inputs() -> None:
     x = _white(17, n=4096)
     y = np.roll(x, 5)
     with pytest.raises(ValueError, match="same length"):
-        ph.time_delay(x, y[:-1], FS)
+        ph.signals.time_delay(x, y[:-1], FS)
     with pytest.raises(ValueError, match="method"):
-        ph.time_delay(x, y, FS, method="fft")  # type: ignore[arg-type]
+        ph.signals.time_delay(x, y, FS, method="fft")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="weighting"):
-        ph.time_delay(x, y, FS, weighting="eckart")  # type: ignore[arg-type]
+        ph.signals.time_delay(x, y, FS, weighting="eckart")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="interpolation"):
-        ph.time_delay(x, y, FS, interpolation="cubic")  # type: ignore[arg-type]
+        ph.signals.time_delay(x, y, FS, interpolation="cubic")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="upsample"):
-        ph.time_delay(x, y, FS, upsample=0)
+        ph.signals.time_delay(x, y, FS, upsample=0)
     with pytest.raises(ValueError, match="max_delay"):
-        ph.time_delay(x, y, FS, method="gcc", nperseg=256, max_delay=1.0)
+        ph.signals.time_delay(
+            x, y, FS, method="gcc", nperseg=256, max_delay=1.0
+        )
     with pytest.raises(ValueError, match="max_delay"):
-        ph.time_delay(x, y, FS, method="direct", max_delay=x.size / FS)
+        ph.signals.time_delay(x, y, FS, method="direct", max_delay=x.size / FS)
     with pytest.raises(ValueError, match="signal_bandwidth"):
-        ph.time_delay(x, y, FS, signal_bandwidth=-100.0)
+        ph.signals.time_delay(x, y, FS, signal_bandwidth=-100.0)
 
 
 def test_ir_utilities_reject_invalid_inputs() -> None:
     ir = _bandlimited_pulse(1024, 300.0, 0.2)
     with pytest.raises(ValueError, match="same length"):
-        ph.align_impulse_responses(ir, ir[:-1], FS)
+        ph.signals.align_impulse_responses(ir, ir[:-1], FS)
     with pytest.raises(ValueError, match="upsample"):
-        ph.impulse_response_delay(ir, FS, upsample=-2)
+        ph.signals.impulse_response_delay(ir, FS, upsample=-2)
     with pytest.raises(ValueError, match="'fs'"):
-        ph.impulse_response_delay(ir, 0.0)
+        ph.signals.impulse_response_delay(ir, 0.0)
 
 
 def test_results_are_frozen() -> None:
     x = _white(18, n=4096)
-    res = ph.correlation(x, fs=FS)
+    res = ph.signals.correlation(x, fs=FS)
     with pytest.raises(AttributeError):
         res.values = res.values * 2.0  # type: ignore[misc]
-    tde = ph.time_delay(x, np.roll(x, 5), FS)
+    tde = ph.signals.time_delay(x, np.roll(x, 5), FS)
     with pytest.raises(AttributeError):
         tde.delay = 0.0  # type: ignore[misc]
 
@@ -541,7 +569,7 @@ def test_max_delay_windows_the_search() -> None:
     delay = 10
     x = _white(19)
     y = np.roll(x, delay)
-    res = ph.time_delay(x, y, FS, method="direct", max_delay=0.01)
+    res = ph.signals.time_delay(x, y, FS, method="direct", max_delay=0.01)
     m = round(0.01 * FS)  # the window rounds to whole samples
     assert float(np.max(np.abs(res.lags))) <= m / FS + 1e-12
     assert res.delay_samples == pytest.approx(delay, abs=1e-3)
@@ -554,7 +582,7 @@ def test_max_delay_windows_the_search() -> None:
 
 def test_correlation_plot_line_and_external_ax() -> None:
     x = _white(20, n=4096)
-    res = ph.correlation(x, fs=FS, max_lag=0.01)
+    res = ph.signals.correlation(x, fs=FS, max_lag=0.01)
     ax = res.plot()
     assert ax.lines
     _fig, ext = plt.subplots()
@@ -565,7 +593,9 @@ def test_correlation_plot_line_and_external_ax() -> None:
 def test_time_delay_plot_marks_the_delay() -> None:
     x = _white(21)
     y = np.roll(x, 12)
-    res = ph.time_delay(x, y, FS, nperseg=2048, signal_bandwidth=FS / 2.0)
+    res = ph.signals.time_delay(
+        x, y, FS, nperseg=2048, signal_bandwidth=FS / 2.0
+    )
     ax = res.plot()
     labels = [str(line.get_label()) for line in ax.lines]
     assert any("tau" in lab for lab in labels)
@@ -577,7 +607,7 @@ def test_time_delay_plot_marks_the_delay() -> None:
 def test_alignment_plot_two_lines() -> None:
     reference = _bandlimited_pulse(4096, 600.0, 0.15)
     ir = _bandlimited_pulse(4096, 700.35, 0.15)
-    res = ph.align_impulse_responses(ir, reference, FS)
+    res = ph.signals.align_impulse_responses(ir, reference, FS)
     ax = res.plot()
     assert len(ax.lines) == 2
     _fig, ext = plt.subplots()

--- a/tests/signals/test_envelope.py
+++ b/tests/signals/test_envelope.py
@@ -45,7 +45,7 @@ def _am(fc: float, fm: float, m: float) -> tuple[np.ndarray, np.ndarray]:
 
 
 def test_pure_tone_has_unit_envelope_and_carrier_frequency() -> None:
-    res = ph.envelope(_tone(1000.0, amp=2.5), FS)
+    res = ph.signals.envelope(_tone(1000.0, amp=2.5), FS)
     np.testing.assert_allclose(res.envelope[INTERIOR], 2.5, atol=1e-9)
     np.testing.assert_allclose(
         res.instantaneous_frequency[INTERIOR], 1000.0, atol=1e-6
@@ -55,7 +55,7 @@ def test_pure_tone_has_unit_envelope_and_carrier_frequency() -> None:
 def test_hilbert_transform_of_cos_is_sin() -> None:
     """Table 13.1: x̃(t) = A(t)·sin(θ(t)) recovers sin(2πf0t) from cos."""
     f0 = 500.0
-    res = ph.envelope(_tone(f0), FS)
+    res = ph.signals.envelope(_tone(f0), FS)
     t = np.arange(N) / FS
     reconstructed = res.envelope * np.sin(res.phase)
     np.testing.assert_allclose(
@@ -68,14 +68,14 @@ def test_hilbert_transform_of_cos_is_sin() -> None:
 def test_am_envelope_is_recovered_exactly() -> None:
     """Eq. 13.27: the envelope of u(t)·cos(2πf0t) is u(t) exactly."""
     x, exact = _am(1000.0, 10.0, 0.5)
-    res = ph.envelope(x, FS)
+    res = ph.signals.envelope(x, FS)
     np.testing.assert_allclose(res.envelope[INTERIOR], exact[INTERIOR],
                                atol=1e-9)
 
 
 def test_instantaneous_phase_of_tone_advances_linearly() -> None:
     f0 = 250.0
-    res = ph.envelope(_tone(f0), FS)
+    res = ph.signals.envelope(_tone(f0), FS)
     slope = float(np.polyfit(res.times[INTERIOR],
                              res.phase[INTERIOR], 1)[0])
     assert slope / (2.0 * np.pi) == pytest.approx(f0, rel=1e-6)
@@ -87,7 +87,7 @@ def test_chirp_instantaneous_frequency_tracks_the_sweep() -> None:
     t = np.arange(N) / FS
     f0, f1 = 200.0, 2000.0
     x = chirp(t, f0=f0, t1=t[-1], f1=f1, method="linear")
-    res = ph.envelope(x, FS)
+    res = ph.signals.envelope(x, FS)
     expected = f0 + (f1 - f0) * t / t[-1]
     np.testing.assert_allclose(
         res.instantaneous_frequency[INTERIOR], expected[INTERIOR], rtol=0.01
@@ -104,7 +104,7 @@ def test_plain_subsampling_matches_the_ecma_internal_convention() -> None:
     from scipy.signal import hilbert
 
     x, _ = _am(1000.0, 10.0, 0.5)
-    res = ph.envelope(x, FS, decimation_factor=32, antialias=False)
+    res = ph.signals.envelope(x, FS, decimation_factor=32, antialias=False)
     np.testing.assert_array_equal(res.envelope, np.abs(hilbert(x))[::32])
     assert res.fs == pytest.approx(FS / 32.0)
     assert res.decimation_factor == 32
@@ -113,7 +113,7 @@ def test_plain_subsampling_matches_the_ecma_internal_convention() -> None:
 
 def test_antialiased_decimation_tracks_the_smooth_envelope() -> None:
     x, exact = _am(1000.0, 10.0, 0.5)
-    res = ph.envelope(x, FS, decimation_factor=16)
+    res = ph.signals.envelope(x, FS, decimation_factor=16)
     exact_dec = exact[::16]
     inner = slice(64, res.envelope.size - 64)
     np.testing.assert_allclose(res.envelope[inner], exact_dec[inner],
@@ -123,12 +123,12 @@ def test_antialiased_decimation_tracks_the_smooth_envelope() -> None:
 
 def test_decimated_outputs_share_one_time_axis() -> None:
     x, _ = _am(2000.0, 20.0, 0.3)
-    res = ph.envelope(x, FS, decimation_factor=8)
+    res = ph.signals.envelope(x, FS, decimation_factor=8)
     assert res.envelope.size == res.phase.size
     assert res.envelope.size == res.instantaneous_frequency.size
     assert res.envelope.size == res.times.size
     # Phase/instantaneous frequency are subsampled from the full rate.
-    full = ph.envelope(x, FS)
+    full = ph.signals.envelope(x, FS)
     np.testing.assert_array_equal(res.phase, full.phase[::8])
     np.testing.assert_array_equal(
         res.instantaneous_frequency, full.instantaneous_frequency[::8]
@@ -137,7 +137,7 @@ def test_decimated_outputs_share_one_time_axis() -> None:
 
 def test_no_decimation_keeps_the_full_rate() -> None:
     x, _ = _am(1000.0, 10.0, 0.5)
-    res = ph.envelope(x, FS)
+    res = ph.signals.envelope(x, FS)
     assert res.fs == FS
     assert res.envelope.size == x.size
     assert res.decimation_factor == 1
@@ -155,28 +155,28 @@ def test_envelope_rejects_invalid_inputs() -> None:
     two_dimensional = np.stack([x, x])
     non_finite = np.full(4096, np.nan)
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.envelope(two_dimensional, FS)
+        ph.signals.envelope(two_dimensional, FS)
     with pytest.raises(ValueError, match="'fs'"):
-        ph.envelope(x, 0.0)
+        ph.signals.envelope(x, 0.0)
     with pytest.raises(ValueError, match="decimation_factor"):
-        ph.envelope(x, FS, decimation_factor=0)
+        ph.signals.envelope(x, FS, decimation_factor=0)
     with pytest.raises(ValueError, match="decimation_factor"):
-        ph.envelope(x, FS, decimation_factor=x.size)
+        ph.signals.envelope(x, FS, decimation_factor=x.size)
     with pytest.raises(ValueError, match="finite"):
-        ph.envelope(non_finite, FS)
+        ph.signals.envelope(non_finite, FS)
 
 
 def test_short_record_antialiased_decimation_is_supported() -> None:
     """scipy's FIR decimator runs through resample_poly, so even the
     32-sample minimum record decimates without a length cushion."""
     x = np.sin(0.3 * np.arange(32))
-    res = ph.envelope(x, FS, decimation_factor=8)
+    res = ph.signals.envelope(x, FS, decimation_factor=8)
     assert res.envelope.size == 4
     assert res.fs == pytest.approx(FS / 8.0)
 
 
 def test_result_is_frozen() -> None:
-    res = ph.envelope(_tone(1000.0), FS)
+    res = ph.signals.envelope(_tone(1000.0), FS)
     with pytest.raises(AttributeError):
         res.envelope = res.envelope * 2.0  # type: ignore[misc]
 
@@ -188,7 +188,7 @@ def test_result_is_frozen() -> None:
 
 def test_envelope_plot_two_panels_and_external_ax() -> None:
     x, _ = _am(1000.0, 10.0, 0.5)
-    res = ph.envelope(x, FS)
+    res = ph.signals.envelope(x, FS)
     axes = res.plot()
     assert len(axes) == 2
     assert len(axes[0].lines) == 2  # signal + envelope
@@ -199,7 +199,7 @@ def test_envelope_plot_two_panels_and_external_ax() -> None:
 
 def test_envelope_plot_with_decimated_result() -> None:
     x, _ = _am(1000.0, 10.0, 0.5)
-    res = ph.envelope(x, FS, decimation_factor=32)
+    res = ph.signals.envelope(x, FS, decimation_factor=32)
     axes = res.plot()
     assert len(axes) == 2
     plt.close("all")
@@ -241,7 +241,7 @@ def _bin(freq: float, nfft: int = ES_N) -> int:
 
 
 def test_envelope_spectrum_magnitude_line_and_mean() -> None:
-    res = ph.envelope_spectrum(_am_signal(), FS)
+    res = ph.signals.envelope_spectrum(_am_signal(), FS)
     assert res.kind == "magnitude"
     assert res.mean_level == pytest.approx(ES_A0, abs=1e-3)
     assert res.amplitude[_bin(ES_FM)] == pytest.approx(ES_A0 * ES_M, rel=1e-3)
@@ -249,7 +249,7 @@ def test_envelope_spectrum_magnitude_line_and_mean() -> None:
 
 
 def test_envelope_spectrum_squared_lines_and_mean() -> None:
-    res = ph.envelope_spectrum(_am_signal(), FS, kind="squared")
+    res = ph.signals.envelope_spectrum(_am_signal(), FS, kind="squared")
     assert res.mean_level == pytest.approx(
         ES_A0**2 * (1.0 + ES_M**2 / 2.0), abs=1e-2
     )
@@ -262,10 +262,10 @@ def test_envelope_spectrum_squared_lines_and_mean() -> None:
 
 
 def test_envelope_spectrum_dc_removal() -> None:
-    res = ph.envelope_spectrum(_am_signal(), FS)
+    res = ph.signals.envelope_spectrum(_am_signal(), FS)
     assert res.remove_dc
     assert res.amplitude[0] == pytest.approx(0.0, abs=1e-6)
-    kept = ph.envelope_spectrum(_am_signal(), FS, remove_dc=False)
+    kept = ph.signals.envelope_spectrum(_am_signal(), FS, remove_dc=False)
     # Without the DC remover the zero-frequency bin carries the mean level
     # (not doubled), up to the taper's slight leakage.
     assert kept.amplitude[0] == pytest.approx(kept.mean_level, rel=5e-3)
@@ -276,14 +276,14 @@ def test_envelope_spectrum_dc_removal() -> None:
 
 
 def test_envelope_spectrum_pure_tone_has_no_lines() -> None:
-    res = ph.envelope_spectrum(_tone(1000.0, amp=1.5), FS)
+    res = ph.signals.envelope_spectrum(_tone(1000.0, amp=1.5), FS)
     assert res.mean_level == pytest.approx(1.5, abs=1e-3)
     # No modulation: nothing anywhere above the Hilbert edge-effect floor.
     assert float(np.max(res.amplitude[1:])) < 1e-2
 
 
 def test_envelope_spectrum_zero_padding() -> None:
-    res = ph.envelope_spectrum(_am_signal(), FS, nfft=2 * ES_N)
+    res = ph.signals.envelope_spectrum(_am_signal(), FS, nfft=2 * ES_N)
     assert res.nfft == 2 * ES_N
     assert res.frequencies.size == ES_N + 1
     assert res.amplitude[_bin(ES_FM, 2 * ES_N)] == pytest.approx(
@@ -305,7 +305,7 @@ def test_envelope_spectrum_off_bin_line_shows_hann_scalloping() -> None:
         ES_A0 * (1.0 + ES_M * np.cos(2.0 * np.pi * fm * t))
         * np.cos(2.0 * np.pi * 1000.0 * t)
     )
-    res = ph.envelope_spectrum(x, FS)
+    res = ph.signals.envelope_spectrum(x, FS)
     peak = float(np.max(res.amplitude[1:]))
     # Hann scalloping at the bin midpoint: |W(1/2)| / |W(0)| ~ 0.8488.
     assert peak == pytest.approx(0.8488 * ES_A0 * ES_M, rel=0.02)
@@ -323,8 +323,8 @@ def test_envelope_spectrum_bandpass_prefilter_isolates_the_carrier() -> None:
     t = np.arange(ES_N) / FS
     x = _am_signal() + 3.0 * np.cos(2.0 * np.pi * 3000.0 * t)
 
-    raw = ph.envelope_spectrum(x, FS)
-    filtered = ph.envelope_spectrum(x, FS, band=(700.0, 1300.0))
+    raw = ph.signals.envelope_spectrum(x, FS)
+    filtered = ph.signals.envelope_spectrum(x, FS, band=(700.0, 1300.0))
 
     assert filtered.band == (700.0, 1300.0)
     assert raw.band is None
@@ -341,28 +341,28 @@ def test_envelope_spectrum_band_validation() -> None:
     x = _am_signal()
     for band in ((0.0, 100.0), (200.0, 100.0), (100.0, FS / 2.0)):
         with pytest.raises(ValueError, match="band"):
-            ph.envelope_spectrum(x, FS, band=band)
+            ph.signals.envelope_spectrum(x, FS, band=band)
     # Malformed shapes: not exactly two numeric edges.
     for bad in ((700.0,), (700.0, 900.0, 1300.0), (700.0, None)):
         with pytest.raises(ValueError, match="pair"):
-            ph.envelope_spectrum(x, FS, band=bad)  # type: ignore[arg-type]
+            ph.signals.envelope_spectrum(x, FS, band=bad)  # type: ignore[arg-type]
     # A record shorter than the zero-phase padding fails informatively.
     with pytest.raises(ValueError, match="too short"):
-        ph.envelope_spectrum(x[:20], FS, band=(700.0, 1300.0))
+        ph.signals.envelope_spectrum(x[:20], FS, band=(700.0, 1300.0))
 
 
 def test_envelope_spectrum_validates_inputs() -> None:
     x = _am_signal()
     with pytest.raises(ValueError, match="kind"):
-        ph.envelope_spectrum(x, FS, kind="log")
+        ph.signals.envelope_spectrum(x, FS, kind="log")
     with pytest.raises(ValueError, match="nfft"):
-        ph.envelope_spectrum(x, FS, nfft=100)
+        ph.signals.envelope_spectrum(x, FS, nfft=100)
     with pytest.raises(ValueError, match="fs"):
-        ph.envelope_spectrum(x, -1.0)
+        ph.signals.envelope_spectrum(x, -1.0)
 
 
 def test_envelope_spectrum_plot_two_panels_and_external_ax() -> None:
-    res = ph.envelope_spectrum(_am_signal(), FS)
+    res = ph.signals.envelope_spectrum(_am_signal(), FS)
     axes = res.plot()
     assert len(axes) == 2
     assert len(axes[0].lines) >= 1  # envelope (+ mean-level rule)

--- a/tests/signals/test_miso.py
+++ b/tests/signals/test_miso.py
@@ -42,7 +42,9 @@ N = 1 << 19
 
 
 def _white(seed: int, rms: float = 1.0, n: int = N) -> np.ndarray:
-    return ph.noise_signal(FS, n / FS, color="white", rms=rms, seed=seed)
+    return ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=rms, seed=seed
+    )
 
 
 def _fir(x: np.ndarray, taps: list[float]) -> np.ndarray:
@@ -110,7 +112,7 @@ def test_conditioned_matrix_is_hermitian_with_positive_diagonal() -> None:
     x1 = _white(1)
     x2 = 0.6 * x1 + _white(2)
     y = _fir(x1, [1.0, 0.4]) + _fir(x2, [0.3, -0.5]) + _white(3, rms=0.3)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     band = _band(res.frequencies)
     # Conditioned residual noise (a genuine autospectrum) stays non-negative.
     assert np.all(res.noise_psd[band] >= 0.0)
@@ -133,7 +135,7 @@ def test_multiple_coherence_equals_snr_over_one_plus_snr() -> None:
     x2 = _white(11)
     noise = _white(12, rms=0.5)
     y = x1 + x2 + noise
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=1024)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=1024)
     band = _band(res.frequencies)
     snr = 2.0 / 0.25
     assert float(np.median(res.multiple_coherence[band])) == pytest.approx(
@@ -145,7 +147,7 @@ def test_multiple_coherence_is_one_for_noiseless_system() -> None:
     x1 = _white(20)
     x2 = _white(21)
     y = _fir(x1, [1.0, 0.5]) + _fir(x2, [0.3, -0.2, 0.1])
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=1024)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=1024)
     band = _band(res.frequencies)
     # No output noise: multiple coherence is 1 within the estimator bias.
     assert float(np.median(res.multiple_coherence[band])) == pytest.approx(
@@ -162,7 +164,7 @@ def test_independent_inputs_partial_equals_ordinary() -> None:
     x1 = _white(30)
     x2 = _white(31)
     y = _fir(x1, [1.0, 0.5, -0.3]) + _fir(x2, [0.2, -0.6, 0.4]) + _white(32, rms=0.3)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     band = _band(res.frequencies)
     for i in (0, 1):
         diff = np.abs(res.partial_coherence[i][band]
@@ -176,7 +178,7 @@ def test_independent_inputs_multiple_equals_sum_of_ordinary() -> None:
     x1 = _white(40)
     x2 = _white(41)
     y = _fir(x1, [1.0, 0.5]) + _fir(x2, [0.2, -0.6, 0.4]) + _white(42, rms=0.3)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     band = _band(res.frequencies)
     diff = res.multiple_coherence[band] - res.ordinary_coherence[:, band].sum(axis=0)
     # Both sides carry the O(q/nd) coherence bias of Section 9.3 (here nd is a
@@ -207,7 +209,7 @@ def test_four_uncorrelated_inputs_general_q_identity() -> None:
         + _fir(x3, [-0.3, 0.5, 0.1])
         + _white(54, rms=0.6)
     )
-    res = ph.miso_coherence([x0, x1, x2, x3], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x0, x1, x2, x3], y, FS, nperseg=2048)
 
     # (a) general q >= 2 no longer raises, and (d) every array carries q = 4.
     assert res.n_inputs == 4
@@ -243,7 +245,7 @@ def test_correlated_input_ordinary_inflated_but_partial_near_zero() -> None:
     x1 = _white(50)
     x2 = 0.8 * x1 + _white(51)
     y = _fir(x1, [1.0, 0.5, -0.3]) + _white(52, rms=0.3)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     band = _band(res.frequencies)
     ordinary_x2 = float(np.median(res.ordinary_coherence[1][band]))
     partial_x2 = float(np.median(res.partial_coherence[1][band]))
@@ -259,7 +261,7 @@ def test_partial_coherence_recovers_true_conditioned_gain() -> None:
     x1 = _white(60)
     x2 = 0.7 * x1 + _white(61)
     y = _fir(x1, [1.0, -0.4, 0.2]) + _white(62, rms=0.2)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     band = _band(res.frequencies)
     share_x1 = res.coherent_output_spectra[0][band]
     share_x2 = res.coherent_output_spectra[1][band]
@@ -277,7 +279,7 @@ def test_output_power_decomposition_is_exact() -> None:
     x3 = _white(72)
     y = (_fir(x1, [1.0, 0.3]) + _fir(x2, [0.4, -0.5])
          + _fir(x3, [0.2, 0.1]) + _white(73, rms=0.3))
-    res = ph.miso_coherence([x1, x2, x3], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2, x3], y, FS, nperseg=2048)
     reconstructed = res.coherent_output_spectra.sum(axis=0) + res.noise_psd
     np.testing.assert_allclose(reconstructed, res.output_psd, rtol=1e-9)
 
@@ -286,7 +288,7 @@ def test_multiple_coherence_equals_sum_of_partials() -> None:
     x1 = _white(80)
     x2 = 0.5 * x1 + _white(81)
     y = _fir(x1, [1.0, 0.3]) + _fir(x2, [0.4, -0.5]) + _white(82, rms=0.3)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     np.testing.assert_allclose(
         res.multiple_coherence, res.partial_coherence.sum(axis=0), atol=1e-12
     )
@@ -324,7 +326,7 @@ def test_near_collinear_inputs_preserve_decomposition() -> None:
     x1 = _white(200)
     x2 = _fir(x1, [1.0, 0.2]) + _white(201, rms=1e-4)
     y = _fir(x1, [0.8, -0.3]) + _fir(x2, [0.1, 0.05]) + _white(202, rms=0.2)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     reconstructed = res.coherent_output_spectra.sum(axis=0) + res.noise_psd
     assert np.all(np.isfinite(res.coherent_output_spectra))
     assert np.all(np.isfinite(res.partial_coherence))
@@ -335,8 +337,12 @@ def test_ordinary_and_multiple_coherence_are_order_invariant() -> None:
     x1 = _white(90)
     x2 = 0.5 * x1 + _white(91)
     y = _fir(x1, [1.0, 0.3]) + _fir(x2, [0.4, -0.5]) + _white(92, rms=0.3)
-    forward = ph.miso_coherence([x1, x2], y, FS, nperseg=2048, order=(0, 1))
-    reverse = ph.miso_coherence([x1, x2], y, FS, nperseg=2048, order=(1, 0))
+    forward = ph.signals.miso_coherence(
+        [x1, x2], y, FS, nperseg=2048, order=(0, 1)
+    )
+    reverse = ph.signals.miso_coherence(
+        [x1, x2], y, FS, nperseg=2048, order=(1, 0)
+    )
     np.testing.assert_allclose(
         forward.ordinary_coherence, reverse.ordinary_coherence, atol=1e-12
     )
@@ -360,7 +366,7 @@ def test_dominant_input_tracks_the_band_with_more_power() -> None:
     hp = sp_signal.butter(4, 2000.0, btype="high", fs=FS, output="sos")
     y = (sp_signal.sosfilt(lp, x1) + sp_signal.sosfilt(hp, x2)
          + _white(102, rms=0.05))
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=2048)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=2048)
     dom = res.dominant_input()
     freqs = res.frequencies
     low = (freqs > 150.0) & (freqs < 400.0)
@@ -379,7 +385,7 @@ def test_multiple_coherence_random_error_matches_bendat_piersol() -> None:
     x2 = _white(111)
     noise = _white(112, rms=0.5)
     y = x1 + x2 + noise
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=1024)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=1024)
     band = _band(res.frequencies)
     gamma2 = float(np.median(res.multiple_coherence[band]))
     eff = res.n_averages - (res.n_inputs - 1)
@@ -399,7 +405,7 @@ def test_plot_returns_two_panels(language: str) -> None:
     x1 = _white(120, n=1 << 17)
     x2 = 0.5 * x1 + _white(121, n=1 << 17)
     y = _fir(x1, [1.0, 0.3]) + _fir(x2, [0.4, -0.5]) + _white(122, rms=0.3, n=1 << 17)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=1024)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=1024)
     axes = res.plot(language=language)
     assert np.asarray(axes).size == 2
     plt.close("all")
@@ -409,7 +415,7 @@ def test_plot_on_given_axis_draws_spectra_panel() -> None:
     x1 = _white(130, n=1 << 17)
     x2 = _white(131, n=1 << 17)
     y = x1 + x2 + _white(132, rms=0.3, n=1 << 17)
-    res = ph.miso_coherence([x1, x2], y, FS, nperseg=1024)
+    res = ph.signals.miso_coherence([x1, x2], y, FS, nperseg=1024)
     _fig, ax = plt.subplots()
     returned = res.plot(ax=ax)
     assert returned is ax
@@ -425,7 +431,7 @@ def test_rejects_single_input() -> None:
     x1 = _white(140, n=1 << 14)
     y = x1.copy()
     with pytest.raises(ValueError, match="at least two"):
-        ph.miso_coherence([x1], y, FS)
+        ph.signals.miso_coherence([x1], y, FS)
 
 
 def test_rejects_mismatched_length() -> None:
@@ -433,7 +439,7 @@ def test_rejects_mismatched_length() -> None:
     x2 = _white(171, n=1 << 13)
     y = _white(172, n=1 << 14)
     with pytest.raises(ValueError, match="same length"):
-        ph.miso_coherence([x1, x2], y, FS)
+        ph.signals.miso_coherence([x1, x2], y, FS)
 
 
 def test_rejects_bad_order() -> None:
@@ -441,7 +447,7 @@ def test_rejects_bad_order() -> None:
     x2 = _white(181, n=1 << 14)
     y = x1 + x2
     with pytest.raises(ValueError, match="permutation"):
-        ph.miso_coherence([x1, x2], y, FS, order=(0, 0))
+        ph.signals.miso_coherence([x1, x2], y, FS, order=(0, 0))
 
 
 def test_accepts_2d_input_array() -> None:
@@ -449,5 +455,5 @@ def test_accepts_2d_input_array() -> None:
     x2 = _white(191, n=1 << 16)
     y = x1 + x2 + _white(192, rms=0.3, n=1 << 16)
     stacked = np.vstack([x1, x2])
-    res = ph.miso_coherence(stacked, y, FS, nperseg=1024)
+    res = ph.signals.miso_coherence(stacked, y, FS, nperseg=1024)
     assert res.n_inputs == 2

--- a/tests/signals/test_multitaper.py
+++ b/tests/signals/test_multitaper.py
@@ -36,7 +36,9 @@ N = 32768
 
 
 def _white(seed: int, rms: float = 1.0, n: int = N) -> np.ndarray:
-    return ph.noise_signal(FS, n / FS, color="white", rms=rms, seed=seed)
+    return ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=rms, seed=seed
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -99,7 +101,9 @@ def test_dpss_eigenvalues_match_pw_section_7_1_pattern() -> None:
 
 
 def test_multitaper_result_eigenvalues_are_the_dpss_ratios() -> None:
-    res = ph.multitaper_psd(_white(30, n=1024), FS, time_half_bandwidth=4.0)
+    res = ph.signals.multitaper_psd(
+        _white(30, n=1024), FS, time_half_bandwidth=4.0
+    )
     assert res.n_tapers == 7
     # P&W print lambda_6 as 0.94: match to half a unit in the last place.
     assert np.allclose(res.eigenvalues, _PW_NW4_N1024[:7], atol=5e-3)
@@ -113,7 +117,7 @@ def test_multitaper_white_noise_density_level() -> None:
     standard error of the mean is below 0.6 %; 3 % is a 5-sigma bound.
     """
     x = _white(31, rms=2.0, n=8192)
-    res = ph.multitaper_psd(x, FS)
+    res = ph.signals.multitaper_psd(x, FS)
     expected = 4.0 / (FS / 2.0)
     assert float(np.mean(res.psd[1:-1])) == pytest.approx(expected, rel=0.03)
 
@@ -121,8 +125,8 @@ def test_multitaper_white_noise_density_level() -> None:
 def test_multitaper_matches_welch_on_the_same_record() -> None:
     """Both estimators are calibrated: same broadband level, either scaling."""
     x = _white(32, n=8192)
-    mt = ph.multitaper_psd(x, FS)
-    welch = ph.power_spectral_density(x, FS, nperseg=1024)
+    mt = ph.signals.multitaper_psd(x, FS)
+    welch = ph.signals.power_spectral_density(x, FS, nperseg=1024)
     assert float(np.mean(mt.psd[1:-1])) == pytest.approx(
         float(np.mean(welch.psd[1:-1])), rel=0.05
     )
@@ -136,7 +140,7 @@ def test_multitaper_density_integrates_to_signal_power_parseval() -> None:
     fraction of a percent on any single record.
     """
     x = _white(33, n=4096)
-    res = ph.multitaper_psd(x, FS, adaptive=False)
+    res = ph.signals.multitaper_psd(x, FS, adaptive=False)
     df = float(res.frequencies[1] - res.frequencies[0])
     assert float(np.sum(res.psd) * df) == pytest.approx(
         float(np.mean(x**2)), rel=5e-3
@@ -149,7 +153,7 @@ def test_multitaper_tone_band_power_recovers_amplitude() -> None:
     t = np.arange(n) / FS
     amp = 3.0
     x = amp * np.sin(2.0 * np.pi * 1024.0 * t)  # exact bin (1024 = 512*df)
-    res = ph.multitaper_psd(x, FS, n_tapers=5, adaptive=False)
+    res = ph.signals.multitaper_psd(x, FS, n_tapers=5, adaptive=False)
     df = float(res.frequencies[1] - res.frequencies[0])
     half_w = res.resolution_bandwidth / 2.0
     band = np.abs(res.frequencies - 1024.0) <= 1.5 * half_w
@@ -167,7 +171,9 @@ def test_multitaper_spectrum_scaling_reads_tone_peak(adaptive: bool) -> None:
     t = np.arange(n) / FS
     amp = 3.0
     x = amp * np.sin(2.0 * np.pi * 1024.0 * t)
-    res = ph.multitaper_psd(x, FS, scaling="spectrum", adaptive=adaptive)
+    res = ph.signals.multitaper_psd(
+        x, FS, scaling="spectrum", adaptive=adaptive
+    )
     peak = int(np.argmax(res.psd))
     assert res.frequencies[peak] == pytest.approx(1024.0)
     assert float(res.psd[peak]) == pytest.approx(amp**2 / 2.0, rel=1e-4)
@@ -185,8 +191,16 @@ def test_multitaper_variance_is_one_kth_of_single_taper() -> None:
     est_mt, est_one = [], []
     for seed in range(120):
         x = _white(600 + seed, n=2048)
-        est_mt.append(ph.multitaper_psd(x, FS, n_tapers=k, adaptive=False).psd[50:900])
-        est_one.append(ph.multitaper_psd(x, FS, n_tapers=1, adaptive=False).psd[50:900])
+        est_mt.append(
+            ph.signals.multitaper_psd(x, FS, n_tapers=k, adaptive=False).psd[
+                50:900
+            ]
+        )
+        est_one.append(
+            ph.signals.multitaper_psd(x, FS, n_tapers=1, adaptive=False).psd[
+                50:900
+            ]
+        )
     rel_var_mt = float(np.mean(
         (np.std(est_mt, axis=0) / np.mean(est_mt, axis=0)) ** 2
     ))
@@ -204,7 +218,7 @@ def test_multitaper_adaptive_weights_uniform_for_white_noise() -> None:
     the departure of the concentrations from unity plus the estimation
     jitter, both far below 0.01 for K = 5, NW = 4.
     """
-    res = ph.multitaper_psd(_white(34, n=4096), FS, n_tapers=5)
+    res = ph.signals.multitaper_psd(_white(34, n=4096), FS, n_tapers=5)
     mean_weights = np.mean(res.weights[:, 1:-1], axis=1)
     assert np.max(np.abs(mean_weights - 0.2)) < 0.01
     lam_flat = res.eigenvalues / float(np.sum(res.eigenvalues))
@@ -213,7 +227,7 @@ def test_multitaper_adaptive_weights_uniform_for_white_noise() -> None:
 
 def test_multitaper_dof_is_2k_for_white_noise() -> None:
     """nu(f) ~ 2K where the adaptive weights are uniform (P&W Eq. 370b)."""
-    res = ph.multitaper_psd(_white(35, n=4096), FS)
+    res = ph.signals.multitaper_psd(_white(35, n=4096), FS)
     interior = res.degrees_of_freedom[1:-1]
     assert float(np.mean(interior)) == pytest.approx(2.0 * res.n_tapers, rel=0.02)
     assert np.all(interior <= 2.0 * res.n_tapers + 1e-9)
@@ -227,7 +241,7 @@ def test_multitaper_chi2_interval_covers_true_density() -> None:
     true_psd = 1.0 / (FS / 2.0)
     hits, total = 0, 0
     for seed in range(150):
-        res = ph.multitaper_psd(_white(800 + seed, n=2048), FS)
+        res = ph.signals.multitaper_psd(_white(800 + seed, n=2048), FS)
         for b in (100, 400, 800):
             hits += int(res.ci_lower[b] <= true_psd <= res.ci_upper[b])
             total += 1
@@ -243,15 +257,17 @@ def test_multitaper_adaptive_dof_drops_where_leakage_would_bias() -> None:
     """
     n = 4096
     t = np.arange(n) / FS
-    rng_x = ph.noise_signal(FS, n / FS, color="white", rms=1e-3, seed=99)
+    rng_x = ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=1e-3, seed=99
+    )
     x = 50.0 * np.sin(2.0 * np.pi * 200.0 * t) + rng_x
-    res = ph.multitaper_psd(x, FS)
+    res = ph.signals.multitaper_psd(x, FS)
     faint = (res.frequencies > 2000.0) & (res.frequencies < 3800.0)
     assert float(np.mean(res.degrees_of_freedom[faint])) < 1.9 * res.n_tapers
 
 
 def test_multitaper_defaults_and_result_fields() -> None:
-    res = ph.multitaper_psd(_white(36, n=1024), FS)
+    res = ph.signals.multitaper_psd(_white(36, n=1024), FS)
     assert res.n_tapers == 7  # 2*NW - 1 for the default NW = 4
     assert res.time_half_bandwidth == 4.0
     assert res.resolution_bandwidth == pytest.approx(2.0 * 4.0 * FS / 1024.0)
@@ -271,28 +287,28 @@ def test_multitaper_rejects_invalid_inputs() -> None:
     x = _white(37, n=1024)
     two_dimensional = np.zeros((4, 256))
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.multitaper_psd(two_dimensional, FS)
+        ph.signals.multitaper_psd(two_dimensional, FS)
     with pytest.raises(ValueError, match="too short"):
-        ph.multitaper_psd(x[:16], FS)
+        ph.signals.multitaper_psd(x[:16], FS)
     with pytest.raises(ValueError, match="positive, finite"):
-        ph.multitaper_psd(x, -1.0)
+        ph.signals.multitaper_psd(x, -1.0)
     with pytest.raises(ValueError, match="time_half_bandwidth"):
-        ph.multitaper_psd(x, FS, time_half_bandwidth=0.5)
+        ph.signals.multitaper_psd(x, FS, time_half_bandwidth=0.5)
     with pytest.raises(ValueError, match="Shannon number"):
-        ph.multitaper_psd(x, FS, n_tapers=9)
+        ph.signals.multitaper_psd(x, FS, n_tapers=9)
     with pytest.raises(ValueError, match="Shannon number"):
-        ph.multitaper_psd(x, FS, n_tapers=0)
+        ph.signals.multitaper_psd(x, FS, n_tapers=0)
     silence = np.zeros(1024)
     with pytest.raises(ValueError, match="identically zero"):
-        ph.multitaper_psd(silence, FS)
+        ph.signals.multitaper_psd(silence, FS)
     with pytest.raises(ValueError, match="scaling"):
-        ph.multitaper_psd(x, FS, scaling="bogus")  # type: ignore[arg-type]
+        ph.signals.multitaper_psd(x, FS, scaling="bogus")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="confidence"):
-        ph.multitaper_psd(x, FS, confidence=1.5)
+        ph.signals.multitaper_psd(x, FS, confidence=1.5)
 
 
 def test_multitaper_plot_line_and_confidence_band() -> None:
-    res = ph.multitaper_psd(_white(38, n=1024), FS)
+    res = ph.signals.multitaper_psd(_white(38, n=1024), FS)
     ax = res.plot()
     assert ax.lines, "expected the density line"
     labels = [str(c.get_label()) for c in ax.collections]

--- a/tests/signals/test_phase.py
+++ b/tests/signals/test_phase.py
@@ -68,14 +68,14 @@ def test_biquad_is_strictly_minimum_phase() -> None:
 def test_minimum_phase_reconstructs_biquad_phase() -> None:
     """On a strictly min-phase response the phase comes back from |H| alone."""
     response = _biquad_response()
-    rec = ph.minimum_phase(response)
+    rec = ph.signals.minimum_phase(response)
     err = np.abs(np.angle(rec) - np.angle(response))
     assert float(np.max(err)) < MINPHASE_TOL_RAD
 
 
 def test_minimum_phase_preserves_magnitude_exactly() -> None:
     response = _biquad_response()
-    rec = ph.minimum_phase(response)
+    rec = ph.signals.minimum_phase(response)
     # |mag * exp(j*phi)| only differs from mag by the 1-ulp rounding of
     # the complex modulus.
     np.testing.assert_allclose(np.abs(rec), np.abs(response), rtol=1e-14)
@@ -84,21 +84,21 @@ def test_minimum_phase_preserves_magnitude_exactly() -> None:
 def test_minimum_phase_ignores_input_phase() -> None:
     """Magnitude array and phase-scrambled response give the same output."""
     response = _biquad_response()
-    from_mag = ph.minimum_phase(np.abs(response))
+    from_mag = ph.signals.minimum_phase(np.abs(response))
     scrambled = response * np.exp(-1j * _digital_grid() * 11.5)
-    from_scrambled = ph.minimum_phase(scrambled)
+    from_scrambled = ph.signals.minimum_phase(scrambled)
     np.testing.assert_allclose(from_mag, from_scrambled, atol=1e-12)
 
 
 def test_minimum_phase_is_idempotent() -> None:
     response = _biquad_response()
-    once = ph.minimum_phase(response)
-    twice = ph.minimum_phase(once)
+    once = ph.signals.minimum_phase(response)
+    twice = ph.signals.minimum_phase(once)
     np.testing.assert_allclose(np.angle(twice), np.angle(once), atol=1e-12)
 
 
 def test_minimum_phase_flat_magnitude_gives_zero_phase() -> None:
-    rec = ph.minimum_phase(np.ones(129))
+    rec = ph.signals.minimum_phase(np.ones(129))
     np.testing.assert_allclose(np.angle(rec), 0.0, atol=1e-12)
     np.testing.assert_allclose(np.abs(rec), 1.0, atol=1e-12)
 
@@ -116,7 +116,7 @@ def test_minimum_phase_oversample_helps_near_circle_zeros() -> None:
     _, response = sp_signal.freqz(b, a, worN=_digital_grid(513))
     err = []
     for oversample in (1, 8):
-        rec = ph.minimum_phase(response, oversample=oversample)
+        rec = ph.signals.minimum_phase(response, oversample=oversample)
         err.append(float(np.max(np.abs(np.angle(rec) - np.angle(response)))))
     assert err[0] > 0.02
     assert err[1] < 0.6 * err[0]
@@ -132,7 +132,7 @@ def test_allpass_group_delay_closed_form() -> None:
     a_coef = 0.5
     omega = _digital_grid()
     _, response = sp_signal.freqz([a_coef, 1.0], [1.0, a_coef], worN=omega)
-    tau = ph.group_delay(response, FS)  # seconds
+    tau = ph.signals.group_delay(response, FS)  # seconds
     expected = (1.0 - a_coef**2) / (
         1.0 + 2.0 * a_coef * np.cos(omega) + a_coef**2
     ) / FS
@@ -144,7 +144,7 @@ def test_allpass_group_delay_closed_form() -> None:
 def test_pure_delay_group_delay_is_constant() -> None:
     delay_samples = 12.25
     response = np.exp(-1j * _digital_grid() * delay_samples)
-    tau = ph.group_delay(response, FS)
+    tau = ph.signals.group_delay(response, FS)
     np.testing.assert_allclose(tau, delay_samples / FS, rtol=1e-9)
 
 
@@ -152,7 +152,7 @@ def test_group_delay_matches_scipy_on_biquad() -> None:
     b, a = _peaking_biquad()
     response = _biquad_response()
     _, tau_ref = sp_signal.group_delay((b, a), w=_digital_grid())
-    tau = ph.group_delay(response, FS) * FS  # to samples
+    tau = ph.signals.group_delay(response, FS) * FS  # to samples
     np.testing.assert_allclose(tau[3:-3], tau_ref[3:-3], atol=1e-3)
 
 
@@ -163,7 +163,7 @@ def test_group_delay_matches_scipy_on_biquad() -> None:
 
 def test_excess_phase_of_minimum_phase_system_is_zero() -> None:
     response = _biquad_response()
-    excess = ph.excess_phase(response)
+    excess = ph.signals.excess_phase(response)
     assert float(np.max(np.abs(excess))) < MINPHASE_TOL_RAD
 
 
@@ -171,7 +171,7 @@ def test_excess_phase_of_delayed_biquad_is_minus_omega_d() -> None:
     delay_samples = 7.25
     omega = _digital_grid()
     delayed = _biquad_response() * np.exp(-1j * omega * delay_samples)
-    excess = ph.excess_phase(delayed)
+    excess = ph.signals.excess_phase(delayed)
     np.testing.assert_allclose(excess, -omega * delay_samples, atol=1e-9)
 
 
@@ -179,7 +179,7 @@ def test_phase_decomposition_bundles_consistently() -> None:
     delay_samples = 7.25
     omega = _digital_grid()
     delayed = _biquad_response() * np.exp(-1j * omega * delay_samples)
-    res = ph.phase_decomposition(delayed, FS)
+    res = ph.signals.phase_decomposition(delayed, FS)
     np.testing.assert_allclose(
         res.excess_phase, res.phase - res.minimum_phase, atol=0.0
     )
@@ -202,7 +202,7 @@ def test_phase_decomposition_bundles_consistently() -> None:
 def test_phase_referenced_to_dc() -> None:
     """The measured phase is unwrapped from a zero-DC reference."""
     response = -1.0 * _biquad_response()  # polarity flip: arg = pi at DC
-    res = ph.phase_decomposition(response, FS)
+    res = ph.signals.phase_decomposition(response, FS)
     assert res.phase[0] == 0.0
 
 
@@ -215,29 +215,29 @@ def test_validation_errors() -> None:
     good = _biquad_response()
     two_dimensional = good.reshape(1, -1)
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.minimum_phase(two_dimensional)
+        ph.signals.minimum_phase(two_dimensional)
     too_short = good[:4]
     with pytest.raises(ValueError, match="at least"):
-        ph.minimum_phase(too_short)
+        ph.signals.minimum_phase(too_short)
     not_finite = np.full(64, np.nan + 0j)
     with pytest.raises(ValueError, match="finite"):
-        ph.minimum_phase(not_finite)
+        ph.signals.minimum_phase(not_finite)
     all_zero = np.zeros(64)
     with pytest.raises(ValueError, match="identically zero"):
-        ph.minimum_phase(all_zero)
+        ph.signals.minimum_phase(all_zero)
     with pytest.raises(ValueError, match="oversample"):
-        ph.minimum_phase(good, oversample=0)
+        ph.signals.minimum_phase(good, oversample=0)
     with pytest.raises(ValueError, match="fs"):
-        ph.group_delay(good, -1.0)
+        ph.signals.group_delay(good, -1.0)
     with pytest.raises(ValueError, match="fs"):
-        ph.phase_decomposition(good, 0.0)
+        ph.signals.phase_decomposition(good, 0.0)
 
 
 def test_magnitude_zeros_are_floored_not_fatal() -> None:
     """A response with an exact zero still returns finite phase."""
     response = _biquad_response()
     response[response.size // 2] = 0.0
-    rec = ph.minimum_phase(response)
+    rec = ph.signals.minimum_phase(response)
     assert np.all(np.isfinite(rec))
 
 
@@ -247,7 +247,7 @@ def test_magnitude_zeros_are_floored_not_fatal() -> None:
 
 
 def test_plot_three_panels_and_external_ax() -> None:
-    res = ph.phase_decomposition(_biquad_response(), FS)
+    res = ph.signals.phase_decomposition(_biquad_response(), FS)
     axes = res.plot()
     assert len(axes) == 3
     plt.close("all")

--- a/tests/signals/test_signal_toolbox.py
+++ b/tests/signals/test_signal_toolbox.py
@@ -51,14 +51,14 @@ _TABLE_AII_BURSTS = [
 @pytest.mark.parametrize(("ms", "cycles"), _TABLE_AII_BURSTS)
 def test_table_aii_burst_sample_counts(ms: int, cycles: int) -> None:
     # 5 kHz tone: 5 periods per ms, 48 samples per ms at 48 kHz.
-    res = ph.tone_burst(FS, 5000.0, cycles)
+    res = ph.signals.tone_burst(FS, 5000.0, cycles)
     assert res.burst_samples == 48 * ms
     assert res.burst_seconds == pytest.approx(ms / 1000.0)
     assert res.signal.size == res.burst_samples
 
 
 def test_burst_starts_at_zero_crossing_positive_going() -> None:
-    res = ph.tone_burst(FS, 5000.0, 25)
+    res = ph.signals.tone_burst(FS, 5000.0, 25)
     assert res.signal[0] == 0.0
     assert res.signal[1] > 0.0
 
@@ -67,7 +67,7 @@ def test_integral_periods_energy_closed_form() -> None:
     # Sum of sin² over an integral number of full periods sampled at an
     # integer number of samples per group of periods is exactly N/2.
     amplitude = 0.8
-    res = ph.tone_burst(FS, 5000.0, 25, amplitude=amplitude)
+    res = ph.signals.tone_burst(FS, 5000.0, 25, amplitude=amplitude)
     n = res.burst_samples
     energy = float(np.sum(res.signal**2))
     assert energy == pytest.approx(amplitude**2 * n / 2.0, rel=1e-12)
@@ -76,7 +76,7 @@ def test_integral_periods_energy_closed_form() -> None:
 
 
 def test_envelope_is_rectangular_gate() -> None:
-    res = ph.tone_burst(
+    res = ph.signals.tone_burst(
         FS, 5000.0, 25, amplitude=2.0, pre_silence=0.01, post_silence=0.02
     )
     n_pre, n_on = round(0.01 * FS), res.burst_samples
@@ -93,7 +93,9 @@ def test_envelope_is_rectangular_gate() -> None:
 def test_repetitive_burst_train_clause_a22() -> None:
     # Clause A2.2: 5 ms bursts of 5 kHz tone; 10 bursts per second gives a
     # 4800-sample period at 48 kHz and a 5 % duty cycle.
-    res = ph.tone_burst(FS, 5000.0, 25, repetitions=3, repetition_rate=10.0)
+    res = ph.signals.tone_burst(
+        FS, 5000.0, 25, repetitions=3, repetition_rate=10.0
+    )
     assert res.burst_samples == 240
     assert res.period_samples == 4800
     assert res.duty_cycle == pytest.approx(0.05)
@@ -109,7 +111,9 @@ def test_repetitive_burst_train_clause_a22() -> None:
 
 @pytest.mark.parametrize("rate", [2.0, 10.0, 100.0])
 def test_table_aiii_repetition_rates_fit(rate: float) -> None:
-    res = ph.tone_burst(FS, 5000.0, 25, repetitions=2, repetition_rate=rate)
+    res = ph.signals.tone_burst(
+        FS, 5000.0, 25, repetitions=2, repetition_rate=rate
+    )
     assert res.period_samples == round(FS / rate)
 
 
@@ -121,7 +125,7 @@ def test_tone_burst_incommensurate_frequency_warns() -> None:
     residual step at the gate edge.
     """
     with pytest.warns(ph.PhonometryWarning, match="incommensurate") as record:
-        res = ph.tone_burst(FS, 997.0, 10)
+        res = ph.signals.tone_burst(FS, 997.0, 10)
     assert res.burst_samples == 481
     # The warning quantifies the exact span and the residual step at the
     # gate edge, sin(2*pi*997*481/48000) ~ -0.058 (a commensurate burst
@@ -142,7 +146,7 @@ def test_tone_burst_invalid_config_raises_before_warning() -> None:
     with _warnings.catch_warnings():
         _warnings.simplefilter("error", ph.PhonometryWarning)
         with pytest.raises(ValueError, match="repetition_rate"):
-            ph.tone_burst(FS, 997.0, 10, repetitions=2)
+            ph.signals.tone_burst(FS, 997.0, 10, repetitions=2)
 
 
 def test_tone_burst_commensurate_frequency_does_not_warn() -> None:
@@ -150,39 +154,41 @@ def test_tone_burst_commensurate_frequency_does_not_warn() -> None:
 
     with _warnings.catch_warnings():
         _warnings.simplefilter("error", ph.PhonometryWarning)
-        res = ph.tone_burst(FS, 5000.0, 25)  # 240 samples exactly
+        res = ph.signals.tone_burst(FS, 5000.0, 25)  # 240 samples exactly
     assert res.burst_samples == 240
 
 
 def test_tone_burst_result_is_frozen() -> None:
-    res = ph.tone_burst(FS, 5000.0, 25)
+    res = ph.signals.tone_burst(FS, 5000.0, 25)
     with pytest.raises(dataclasses.FrozenInstanceError):
         res.cycles = 3  # type: ignore[misc]
 
 
 def test_tone_burst_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="positive integer"):
-        ph.tone_burst(FS, 5000.0, 0)
+        ph.signals.tone_burst(FS, 5000.0, 0)
     with pytest.raises(ValueError, match="Nyquist"):
-        ph.tone_burst(FS, 24000.0, 10)
+        ph.signals.tone_burst(FS, 24000.0, 10)
     with pytest.raises(ValueError, match="repetition_rate"):
-        ph.tone_burst(FS, 5000.0, 25, repetitions=2)
+        ph.signals.tone_burst(FS, 5000.0, 25, repetitions=2)
     with pytest.raises(ValueError, match="does not fit"):
-        ph.tone_burst(FS, 5000.0, 25, repetition_rate=300.0)
+        ph.signals.tone_burst(FS, 5000.0, 25, repetition_rate=300.0)
     with pytest.raises(ValueError, match="non-negative"):
-        ph.tone_burst(FS, 5000.0, 25, pre_silence=-1.0)
+        ph.signals.tone_burst(FS, 5000.0, 25, pre_silence=-1.0)
     with pytest.raises(ValueError, match="positive, finite"):
-        ph.tone_burst(FS, 5000.0, 25, amplitude=0.0)
+        ph.signals.tone_burst(FS, 5000.0, 25, amplitude=0.0)
 
 
 def test_tone_burst_plot_waveform_and_envelope() -> None:
-    res = ph.tone_burst(FS, 5000.0, 25, repetitions=2, repetition_rate=10.0)
+    res = ph.signals.tone_burst(
+        FS, 5000.0, 25, repetitions=2, repetition_rate=10.0
+    )
     ax = res.plot(linewidth=2)
     assert any(line.get_linewidth() == 2.0 for line in ax.lines)
     assert "IEC 60268-1" in ax.get_title()
     assert "10/s" in ax.get_title()
     plt.close("all")
-    ax = ph.tone_burst(FS, 5000.0, 25).plot(color="red")
+    ax = ph.signals.tone_burst(FS, 5000.0, 25).plot(color="red")
     red = plt.matplotlib.colors.to_rgba("red")
     assert any(
         plt.matplotlib.colors.to_rgba(line.get_color()) == red
@@ -211,8 +217,8 @@ def test_designed_filter_meets_its_own_spec(
     # passband flat within δ and stopband below -A dB with δ = 10^(-A/20).
     from scipy import signal as sp_signal
 
-    x = ph.noise_signal(fs, 0.2, seed=5)
-    res = ph.resample_signal(
+    x = ph.signals.noise_signal(fs, 0.2, seed=5)
+    res = ph.signals.resample_signal(
         x, fs, fs_new=fs_new, stopband_attenuation_db=atten, transition_width=tw
     )
     fs_up = res.original_fs * res.up
@@ -233,7 +239,9 @@ def test_resampled_tone_matches_analytic_tone() -> None:
     fs, fs_new, atten = 48000.0, 32000.0, 120.0
     t = np.arange(int(fs * 0.5)) / fs
     tone = np.sin(2.0 * np.pi * 1000.0 * t)
-    res = ph.resample_signal(tone, fs, fs_new=fs_new, stopband_attenuation_db=atten)
+    res = ph.signals.resample_signal(
+        tone, fs, fs_new=fs_new, stopband_attenuation_db=atten
+    )
     t_new = np.arange(res.signal.size) / fs_new
     exact = np.sin(2.0 * np.pi * 1000.0 * t_new)
     edge = res.n_taps // res.up + 1
@@ -242,8 +250,8 @@ def test_resampled_tone_matches_analytic_tone() -> None:
 
 
 def test_rational_ratio_and_output_length() -> None:
-    x = ph.noise_signal(44100.0, 0.1, seed=2)
-    res = ph.resample_signal(x, 44100.0, fs_new=48000.0)
+    x = ph.signals.noise_signal(44100.0, 0.1, seed=2)
+    res = ph.signals.resample_signal(x, 44100.0, fs_new=48000.0)
     assert (res.up, res.down) == (160, 147)
     assert res.signal.size == int(np.ceil(x.size * 160 / 147))
     assert res.fs == 48000.0
@@ -251,34 +259,38 @@ def test_rational_ratio_and_output_length() -> None:
 
 
 def test_identity_ratio_returns_copy_without_filtering() -> None:
-    x = ph.noise_signal(FS, 0.05, seed=3)
-    res = ph.resample_signal(x, FS, fs_new=FS)
+    x = ph.signals.noise_signal(FS, 0.05, seed=3)
+    res = ph.signals.resample_signal(x, FS, fs_new=FS)
     np.testing.assert_array_equal(res.signal, x)
     assert (res.up, res.down) == (1, 1)
     assert res.n_taps == 1
 
 
 def test_irrational_ratio_raises() -> None:
-    x = ph.noise_signal(FS, 0.05, seed=4)
+    x = ph.signals.noise_signal(FS, 0.05, seed=4)
     fs_irrational = FS * np.sqrt(2.0)
     with pytest.raises(ValueError, match="rational"):
-        ph.resample_signal(x, FS, fs_new=fs_irrational)
+        ph.signals.resample_signal(x, FS, fs_new=fs_irrational)
 
 
 def test_resample_invalid_parameters() -> None:
-    x = ph.noise_signal(FS, 0.05, seed=4)
+    x = ph.signals.noise_signal(FS, 0.05, seed=4)
     two_dimensional = np.zeros((4, 4))
     with pytest.raises(ValueError, match="at least 30"):
-        ph.resample_signal(x, FS, fs_new=32000.0, stopband_attenuation_db=10.0)
+        ph.signals.resample_signal(
+            x, FS, fs_new=32000.0, stopband_attenuation_db=10.0
+        )
     with pytest.raises(ValueError, match="transition_width"):
-        ph.resample_signal(x, FS, fs_new=32000.0, transition_width=0.9)
+        ph.signals.resample_signal(x, FS, fs_new=32000.0, transition_width=0.9)
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.resample_signal(two_dimensional, FS, fs_new=32000.0)
+        ph.signals.resample_signal(two_dimensional, FS, fs_new=32000.0)
 
 
 def test_resample_plot_filter_and_edges() -> None:
-    x = ph.noise_signal(FS, 0.2, seed=5)
-    res = ph.resample_signal(x, FS, fs_new=32000.0, stopband_attenuation_db=100.0)
+    x = ph.signals.noise_signal(FS, 0.2, seed=5)
+    res = ph.signals.resample_signal(
+        x, FS, fs_new=32000.0, stopband_attenuation_db=100.0
+    )
     ax = res.plot(linewidth=2)
     # The magnitude trace echoes the requested kwargs.
     assert any(line.get_linewidth() == 2.0 for line in ax.lines)
@@ -306,7 +318,7 @@ def test_circular_delay_of_bin_centered_tone_is_machine_exact() -> None:
     f = k * FS / n
     m = np.arange(n)
     x = np.cos(2.0 * np.pi * f * m / FS + 0.4)
-    y = ph.fractional_delay(x, delay, mode="circular")
+    y = ph.signals.fractional_delay(x, delay, mode="circular")
     exact = np.cos(2.0 * np.pi * f * (m - delay) / FS + 0.4)
     np.testing.assert_allclose(y, exact, atol=1e-11)
 
@@ -321,7 +333,7 @@ def test_phase_slope_is_exactly_minus_2pi_f_d_over_fs() -> None:
     x = np.zeros(n)
     for k in bins:
         x += np.cos(2.0 * np.pi * k * m / n + 0.1 * k)
-    y = ph.fractional_delay(x, delay, mode="circular")
+    y = ph.signals.fractional_delay(x, delay, mode="circular")
     spectrum_x = np.fft.rfft(x)
     spectrum_y = np.fft.rfft(y)
     measured = np.angle(spectrum_y[bins] / spectrum_x[bins])
@@ -332,15 +344,15 @@ def test_phase_slope_is_exactly_minus_2pi_f_d_over_fs() -> None:
 
 
 def test_linear_integer_delay_is_exact_sample_shift() -> None:
-    x = ph.noise_signal(FS, 0.1, seed=7)
-    y = ph.fractional_delay(x, 5.0)
+    x = ph.signals.noise_signal(FS, 0.1, seed=7)
+    y = ph.signals.fractional_delay(x, 5.0)
     expected = np.concatenate([np.zeros(5), x[:-5]])
     np.testing.assert_allclose(y, expected, atol=1e-13)
 
 
 def test_negative_delay_advances() -> None:
-    x = ph.noise_signal(FS, 0.1, seed=8)
-    y = ph.fractional_delay(x, -3.0)
+    x = ph.signals.noise_signal(FS, 0.1, seed=8)
+    y = ph.signals.fractional_delay(x, -3.0)
     expected = np.concatenate([x[3:], np.zeros(3)])
     np.testing.assert_allclose(y, expected, atol=1e-13)
 
@@ -350,32 +362,34 @@ def test_linear_mode_is_bit_identical_to_alignment_kernel() -> None:
     # public function must reproduce it bit for bit (advance = -delay).
     from phonometry.signals.correlation import _fractional_advance
 
-    x = ph.noise_signal(FS, 0.1, seed=9)
+    x = ph.signals.noise_signal(FS, 0.1, seed=9)
     shift = 4.6180339887
     np.testing.assert_array_equal(
-        ph.fractional_delay(x, -shift), _fractional_advance(x, shift)
+        ph.signals.fractional_delay(x, -shift), _fractional_advance(x, shift)
     )
 
 
 def test_circular_roundtrip_recovers_record() -> None:
     # Odd length: the rfft has no Nyquist bin, so the circular ramp is
     # exactly invertible for any record.
-    x = ph.noise_signal(FS, 0.05, seed=10)[:2399]
-    y = ph.fractional_delay(
-        ph.fractional_delay(x, 2.5, mode="circular"), -2.5, mode="circular"
+    x = ph.signals.noise_signal(FS, 0.05, seed=10)[:2399]
+    y = ph.signals.fractional_delay(
+        ph.signals.fractional_delay(x, 2.5, mode="circular"),
+        -2.5,
+        mode="circular",
     )
     np.testing.assert_allclose(y, x, atol=1e-12)
 
 
 def test_fractional_delay_invalid_inputs() -> None:
-    x = ph.noise_signal(FS, 0.05, seed=11)
+    x = ph.signals.noise_signal(FS, 0.05, seed=11)
     full_length = float(x.size)
     two_dimensional = np.zeros((2, 8))
     with pytest.raises(ValueError, match="mode"):
-        ph.fractional_delay(x, 1.0, mode="wrap")  # type: ignore[arg-type]
+        ph.signals.fractional_delay(x, 1.0, mode="wrap")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="magnitude"):
-        ph.fractional_delay(x, full_length)
+        ph.signals.fractional_delay(x, full_length)
     with pytest.raises(ValueError, match="finite"):
-        ph.fractional_delay(x, np.nan)
+        ph.signals.fractional_delay(x, np.nan)
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.fractional_delay(two_dimensional, 1.0)
+        ph.signals.fractional_delay(two_dimensional, 1.0)

--- a/tests/signals/test_signals.py
+++ b/tests/signals/test_signals.py
@@ -28,8 +28,8 @@ _SLOPES = [
 
 def _measured_slope(color: str) -> float:
     """Welch-PSD regression slope in dB per octave over 20 Hz - 20 kHz."""
-    x = ph.noise_signal(FS, 40.0, color=color, seed=3)  # type: ignore[arg-type]
-    res = ph.power_spectral_density(x, FS, nperseg=8192)
+    x = ph.signals.noise_signal(FS, 40.0, color=color, seed=3)  # type: ignore[arg-type]
+    res = ph.signals.power_spectral_density(x, FS, nperseg=8192)
     band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
     slope = np.polyfit(
         np.log2(res.frequencies[band]), 10.0 * np.log10(res.psd[band]), 1
@@ -46,32 +46,32 @@ def test_spectral_slope_matches_exact_power_law(color: str, expected: float) -> 
 
 
 def test_same_seed_is_bit_reproducible() -> None:
-    a = ph.noise_signal(FS, 1.0, color="pink", seed=42)
-    b = ph.noise_signal(FS, 1.0, color="pink", seed=42)
+    a = ph.signals.noise_signal(FS, 1.0, color="pink", seed=42)
+    b = ph.signals.noise_signal(FS, 1.0, color="pink", seed=42)
     np.testing.assert_array_equal(a, b)
 
 
 def test_different_seeds_differ() -> None:
-    a = ph.noise_signal(FS, 1.0, color="pink", seed=1)
-    b = ph.noise_signal(FS, 1.0, color="pink", seed=2)
+    a = ph.signals.noise_signal(FS, 1.0, color="pink", seed=1)
+    b = ph.signals.noise_signal(FS, 1.0, color="pink", seed=2)
     assert not np.array_equal(a, b)
 
 
 def test_rms_is_exact_and_mean_zero() -> None:
     for color in ("white", "pink", "red", "blue", "violet"):
-        x = ph.noise_signal(FS, 2.0, color=color, rms=0.25, seed=5)  # type: ignore[arg-type]
+        x = ph.signals.noise_signal(FS, 2.0, color=color, rms=0.25, seed=5)  # type: ignore[arg-type]
         assert float(np.sqrt(np.mean(x * x))) == pytest.approx(0.25, rel=1e-12)
         assert float(np.mean(x)) == pytest.approx(0.0, abs=1e-12)
 
 
 def test_length_and_dtype() -> None:
-    x = ph.noise_signal(FS, 0.5, seed=1)
+    x = ph.signals.noise_signal(FS, 0.5, seed=1)
     assert x.shape == (24000,)
     assert x.dtype == np.float64
 
 
 def test_white_is_gaussian_like() -> None:
-    x = ph.noise_signal(FS, 10.0, color="white", seed=6)
+    x = ph.signals.noise_signal(FS, 10.0, color="white", seed=6)
     # Kurtosis of a Gaussian is 3; a crude but effective distribution check.
     kurt = float(np.mean(x**4) / np.mean(x**2) ** 2)
     assert kurt == pytest.approx(3.0, abs=0.1)
@@ -79,12 +79,12 @@ def test_white_is_gaussian_like() -> None:
 
 def test_rejects_invalid_arguments() -> None:
     with pytest.raises(ValueError, match="'fs'"):
-        ph.noise_signal(0.0, 1.0)
+        ph.signals.noise_signal(0.0, 1.0)
     with pytest.raises(ValueError, match="'seconds'"):
-        ph.noise_signal(FS, -1.0)
+        ph.signals.noise_signal(FS, -1.0)
     with pytest.raises(ValueError, match="16 samples"):
-        ph.noise_signal(FS, 1e-5)
+        ph.signals.noise_signal(FS, 1e-5)
     with pytest.raises(ValueError, match="'color'"):
-        ph.noise_signal(FS, 1.0, color="brown")  # type: ignore[arg-type]
+        ph.signals.noise_signal(FS, 1.0, color="brown")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="'rms'"):
-        ph.noise_signal(FS, 1.0, rms=0.0)
+        ph.signals.noise_signal(FS, 1.0, rms=0.0)

--- a/tests/signals/test_signals_plot_i18n.py
+++ b/tests/signals/test_signals_plot_i18n.py
@@ -48,7 +48,7 @@ def _add4(a: float, b: float, c: float, d: float) -> float:
 
 
 def test_spectral_density_es_and_bad_language() -> None:
-    res = ph.power_spectral_density(_white(), FS, nperseg=1024)
+    res = ph.signals.power_spectral_density(_white(), FS, nperseg=1024)
     ax = res.plot(language="es")
     assert "Densidad espectral de Welch" in ax.get_title()
     assert ax.get_xlabel() == "Frecuencia [Hz]"
@@ -58,7 +58,7 @@ def test_spectral_density_es_and_bad_language() -> None:
 
 
 def test_multitaper_psd_es_and_bad_language() -> None:
-    res = ph.multitaper_psd(_white(), FS)
+    res = ph.signals.multitaper_psd(_white(), FS)
     ax = res.plot(language="es")
     assert "Densidad multitaper de Thomson" in ax.get_title()
     assert ax.get_xlabel() == "Frecuencia [Hz]"
@@ -71,7 +71,7 @@ def test_multitaper_psd_es_and_bad_language() -> None:
 def test_cross_spectral_density_es() -> None:
     x = _white()
     y = np.roll(x, 17) + 0.1 * _white()
-    axes = ph.cross_spectral_density(x, y, FS).plot(language="es")
+    axes = ph.signals.cross_spectral_density(x, y, FS).plot(language="es")
     assert "Densidad espectral cruzada (Bendat y Piersol)" in _titles(axes)
     assert "Fase [grados]" in _labels(axes)
     plt.close("all")
@@ -80,14 +80,14 @@ def test_cross_spectral_density_es() -> None:
 def test_coherent_output_spectrum_es() -> None:
     x = _white()
     y = np.roll(x, 17) + 0.1 * _white()
-    axes = ph.coherent_output_spectrum(x, y, FS).plot(language="es")
+    axes = ph.signals.coherent_output_spectrum(x, y, FS).plot(language="es")
     assert "Espectro de salida coherente" in _titles(axes)
     assert "SNR espectral [dB]" in _labels(axes)
     plt.close("all")
 
 
 def test_spectrogram_es() -> None:
-    res = ph.spectrogram(_white(8192), FS, nperseg=1024)
+    res = ph.signals.spectrogram(_white(8192), FS, nperseg=1024)
     ax = res.plot(language="es")
     assert "Espectrograma calibrado (Bendat y Piersol 12.6.4.2)" in ax.get_title()
     assert ax.get_xlabel() == "Tiempo [s]"
@@ -98,7 +98,7 @@ def test_spectrogram_es() -> None:
 
 
 def test_zoom_fft_es() -> None:
-    res = ph.zoom_fft(_white(8192), FS, f_min=1000.0, f_max=2000.0)
+    res = ph.signals.zoom_fft(_white(8192), FS, f_min=1000.0, f_max=2000.0)
     ax = res.plot(language="es")
     assert ax.get_title() == "FFT con zoom (Bendat y Piersol 11.5.4)"
     assert ax.get_ylabel() == "Espectro de potencia [dB]"
@@ -108,7 +108,7 @@ def test_zoom_fft_es() -> None:
 
 
 def test_correlation_es() -> None:
-    res = ph.correlation(_white(), fs=FS, max_lag=0.01)
+    res = ph.signals.correlation(_white(), fs=FS, max_lag=0.01)
     ax = res.plot(language="es")
     assert ax.get_title() == "Estimación de autocorrelación (Bendat y Piersol)"
     assert ax.get_xlabel() == "Retardo [s]"
@@ -119,12 +119,14 @@ def test_correlation_es() -> None:
 
 def test_correlation_normalization_label_es() -> None:
     """The normalization word is a table key reached through the result."""
-    res = ph.correlation(_white(), fs=FS, max_lag=0.01, normalization="biased")
+    res = ph.signals.correlation(
+        _white(), fs=FS, max_lag=0.01, normalization="biased"
+    )
     ax = res.plot(language="es")
     assert ax.get_ylabel() == "Correlación (sesgada)"
     plt.close("all")
     # The coefficient normalization has a label of its own, not a template.
-    res = ph.correlation(
+    res = ph.signals.correlation(
         _white(), fs=FS, max_lag=0.01, normalization="coefficient"
     )
     ax = res.plot(language="es")
@@ -135,7 +137,9 @@ def test_correlation_normalization_label_es() -> None:
 def test_time_delay_es() -> None:
     x = _white(8192)
     y = np.roll(x, 12)
-    res = ph.time_delay(x, y, FS, nperseg=2048, signal_bandwidth=FS / 2.0)
+    res = ph.signals.time_delay(
+        x, y, FS, nperseg=2048, signal_bandwidth=FS / 2.0
+    )
     ax = res.plot(language="es")
     assert ax.get_title().startswith("Estimación del retardo temporal")
     plt.close("all")
@@ -144,7 +148,7 @@ def test_time_delay_es() -> None:
 def test_aligned_impulse_response_es() -> None:
     ref = np.zeros(256)
     ref[100] = 1.0
-    res = ph.align_impulse_responses(np.roll(ref, 5), ref, FS)
+    res = ph.signals.align_impulse_responses(np.roll(ref, 5), ref, FS)
     ax = res.plot(language="es")
     assert "Alineación de la respuesta al impulso" in ax.get_title()
     assert "RI de referencia" in _labels(ax)
@@ -154,14 +158,14 @@ def test_aligned_impulse_response_es() -> None:
 
 
 def test_envelope_es() -> None:
-    axes = ph.envelope(_white(), FS).plot(language="es")
+    axes = ph.signals.envelope(_white(), FS).plot(language="es")
     assert "Envolvente de Hilbert (Bendat y Piersol Cap. 13)" in _titles(axes)
     assert "Frecuencia instantánea [Hz]" in _labels(axes)
     plt.close("all")
 
 
 def test_envelope_spectrum_es() -> None:
-    axes = ph.envelope_spectrum(_white(), FS).plot(language="es")
+    axes = ph.signals.envelope_spectrum(_white(), FS).plot(language="es")
     assert "Espectro de la envolvente (Bendat y Piersol 13.3)" in _titles(axes)
     assert "Amplitud de modulación" in _labels(axes)
     assert "Nivel medio" in _labels(axes)
@@ -169,7 +173,7 @@ def test_envelope_spectrum_es() -> None:
 
 
 def test_cepstrum_es() -> None:
-    res = ph.cepstrum(_white(), FS, kind="power")
+    res = ph.signals.cepstrum(_white(), FS, kind="power")
     ax = res.plot(language="es")
     assert "Cepstro de potencia" in _titles(ax)
     assert "Quefrencia [ms]" in _labels(ax)
@@ -181,7 +185,7 @@ def test_cepstrum_es() -> None:
 def test_echo_detection_es() -> None:
     x = np.zeros(4096)
     x[0], x[313] = 1.0, 0.4
-    ax = ph.echo_detection(x, FS).plot(language="es")
+    ax = ph.signals.echo_detection(x, FS).plot(language="es")
     assert "Detección de ecos en el cepstro de potencia" in _titles(ax)
     assert "Banda de búsqueda" in _labels(ax)
     assert any("Eco:" in s and "," in s for s in _labels(ax).split(" || "))
@@ -189,7 +193,9 @@ def test_echo_detection_es() -> None:
 
 
 def test_lifter_es() -> None:
-    axes = ph.lifter(_white(), FS, cutoff=0.002, mode="highpass").plot(language="es")
+    axes = ph.signals.lifter(_white(), FS, cutoff=0.002, mode="highpass").plot(
+        language="es"
+    )
     assert "Liftering a 2 ms (paso alto)" in _titles(axes)
     assert "Lifterado (paso alto)" in _labels(axes)
     plt.close("all")
@@ -197,14 +203,16 @@ def test_lifter_es() -> None:
 
 def test_phase_decomposition_es() -> None:
     resp = np.fft.rfft(np.exp(-np.arange(1024) / 50.0))
-    axes = ph.phase_decomposition(resp, fs=FS).plot(language="es")
+    axes = ph.signals.phase_decomposition(resp, fs=FS).plot(language="es")
     assert "Descomposición fase mínima / pasa-todo" in _titles(axes)
     assert "Fase medida" in _labels(axes)
     plt.close("all")
 
 
 def test_tone_burst_es_and_bad_language() -> None:
-    res = ph.tone_burst(FS, 5000.0, 25, repetitions=2, repetition_rate=10.0)
+    res = ph.signals.tone_burst(
+        FS, 5000.0, 25, repetitions=2, repetition_rate=10.0
+    )
     ax = res.plot(language="es")
     assert "Salva de tono (IEC 60268-1)" in ax.get_title()
     assert ax.get_xlabel() == "Tiempo [s]"
@@ -215,8 +223,8 @@ def test_tone_burst_es_and_bad_language() -> None:
 
 
 def test_resampled_signal_es_and_bad_language() -> None:
-    res = ph.resample_signal(
-        ph.noise_signal(FS, 0.2, seed=5), FS, fs_new=32000.0)
+    res = ph.signals.resample_signal(
+        ph.signals.noise_signal(FS, 0.2, seed=5), FS, fs_new=32000.0)
     ax = res.plot(language="es")
     assert "Remuestreo polifásico" in ax.get_title()
     assert ax.get_xlabel() == "Frecuencia [Hz]"
@@ -228,7 +236,7 @@ def test_resampled_signal_es_and_bad_language() -> None:
 
 
 def test_window_metrics_es_and_bad_language() -> None:
-    res = ph.window_metrics("hann", 1024)
+    res = ph.signals.window_metrics("hann", 1024)
     axes = res.plot(language="es")
     assert "Métricas de la ventana (Harris 1978)" in _titles(axes)
     assert "Pérdida de festoneado" in _labels(axes)
@@ -244,7 +252,7 @@ def test_inverse_filter_es() -> None:
     b, a = sg.butter(2, [100.0, 8000.0], btype="bandpass", fs=float(FS))
     imp = np.zeros(1024)
     imp[0] = 1.0
-    res = ph.regularized_inverse_filter(
+    res = ph.signals.regularized_inverse_filter(
         sg.lfilter(b, a, imp), float(FS), f_range=(200.0, 4000.0)
     )
     ax = res.plot(language="es")

--- a/tests/signals/test_spectra.py
+++ b/tests/signals/test_spectra.py
@@ -33,7 +33,9 @@ N = 32768
 
 
 def _white(seed: int, rms: float = 1.0, n: int = N) -> np.ndarray:
-    return ph.noise_signal(FS, n / FS, color="white", rms=rms, seed=seed)
+    return ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=rms, seed=seed
+    )
 
 
 def _known_snr_pair(seed: int, n: int = N) -> tuple[np.ndarray, np.ndarray, float]:
@@ -44,7 +46,9 @@ def _known_snr_pair(seed: int, n: int = N) -> tuple[np.ndarray, np.ndarray, floa
     ``frequency_response``).
     """
     x = _white(1000 + seed, n=n)
-    noise = ph.noise_signal(FS, n / FS, color="white", rms=0.5, seed=5000 + seed)
+    noise = ph.signals.noise_signal(
+        FS, n / FS, color="white", rms=0.5, seed=5000 + seed
+    )
     return x, 0.8 * x + noise, 0.64 / 0.25
 
 
@@ -55,7 +59,7 @@ def _known_snr_pair(seed: int, n: int = N) -> tuple[np.ndarray, np.ndarray, floa
 
 def test_white_noise_density_level_is_flat_at_sigma2_over_bandwidth() -> None:
     x = _white(1, rms=2.0)
-    res = ph.power_spectral_density(x, FS, nperseg=1024)
+    res = ph.signals.power_spectral_density(x, FS, nperseg=1024)
     band = (res.frequencies > 200.0) & (res.frequencies < 3800.0)
     # Unit-variance-scaled white noise: Gxx = sigma^2 / (fs/2) everywhere.
     expected = 4.0 / (FS / 2.0)
@@ -64,7 +68,7 @@ def test_white_noise_density_level_is_flat_at_sigma2_over_bandwidth() -> None:
 
 def test_boxcar_density_integrates_to_signal_power_parseval() -> None:
     x = _white(2)
-    res = ph.power_spectral_density(
+    res = ph.signals.power_spectral_density(
         x, FS, nperseg=1024, overlap=0.0, window="boxcar"
     )
     df = float(res.frequencies[1] - res.frequencies[0])
@@ -76,7 +80,9 @@ def test_spectrum_scaling_recovers_sine_power() -> None:
     t = np.arange(N) / FS
     amp = 3.0
     x = amp * np.sin(2.0 * np.pi * 400.0 * t)  # 400 Hz = bin 50 of 1024
-    res = ph.power_spectral_density(x, FS, nperseg=1024, scaling="spectrum")
+    res = ph.signals.power_spectral_density(
+        x, FS, nperseg=1024, scaling="spectrum"
+    )
     peak = int(np.argmax(res.psd))
     assert res.frequencies[peak] == pytest.approx(400.0)
     assert float(res.psd[peak]) == pytest.approx(amp**2 / 2.0, rel=1e-6)
@@ -84,8 +90,12 @@ def test_spectrum_scaling_recovers_sine_power() -> None:
 
 def test_density_and_spectrum_scalings_differ_by_enbw() -> None:
     x = _white(3)
-    dens = ph.power_spectral_density(x, FS, nperseg=1024, scaling="density")
-    spec = ph.power_spectral_density(x, FS, nperseg=1024, scaling="spectrum")
+    dens = ph.signals.power_spectral_density(
+        x, FS, nperseg=1024, scaling="density"
+    )
+    spec = ph.signals.power_spectral_density(
+        x, FS, nperseg=1024, scaling="spectrum"
+    )
     ratio = spec.psd[10:-10] / dens.psd[10:-10]
     assert np.allclose(ratio, dens.resolution_bandwidth, rtol=1e-9)
 
@@ -96,7 +106,9 @@ def test_density_and_spectrum_scalings_differ_by_enbw() -> None:
 
 
 def test_no_overlap_averages_equal_segment_count() -> None:
-    res = ph.power_spectral_density(_white(4), FS, nperseg=1024, overlap=0.0)
+    res = ph.signals.power_spectral_density(
+        _white(4), FS, nperseg=1024, overlap=0.0
+    )
     assert res.n_segments == N // 1024
     assert res.n_averages == pytest.approx(res.n_segments)
     assert res.degrees_of_freedom == pytest.approx(2.0 * res.n_segments)
@@ -104,15 +116,19 @@ def test_no_overlap_averages_equal_segment_count() -> None:
 
 
 def test_overlap_increases_segments_but_effective_averages_grow_less() -> None:
-    plain = ph.power_spectral_density(_white(5), FS, nperseg=1024, overlap=0.0)
-    lapped = ph.power_spectral_density(_white(5), FS, nperseg=1024, overlap=0.5)
+    plain = ph.signals.power_spectral_density(
+        _white(5), FS, nperseg=1024, overlap=0.0
+    )
+    lapped = ph.signals.power_spectral_density(
+        _white(5), FS, nperseg=1024, overlap=0.5
+    )
     assert lapped.n_segments == 2 * plain.n_segments - 1
     # Correlated segments: nd grows, but stays below the raw count.
     assert plain.n_averages < lapped.n_averages < lapped.n_segments
 
 
 def test_hann_resolution_bandwidth_is_1_5_bins() -> None:
-    res = ph.power_spectral_density(_white(6), FS, nperseg=1024)
+    res = ph.signals.power_spectral_density(_white(6), FS, nperseg=1024)
     # ENBW of the periodic Hann taper = 1.5 * fs / nperseg.
     assert res.resolution_bandwidth == pytest.approx(1.5 * FS / 1024.0, rel=1e-6)
 
@@ -123,7 +139,7 @@ def test_random_error_matches_monte_carlo(overlap: float) -> None:
     estimates = []
     nd = 0.0
     for seed in range(150):
-        res = ph.power_spectral_density(
+        res = ph.signals.power_spectral_density(
             _white(100 + seed), FS, nperseg=1024, overlap=overlap
         )
         estimates.append(res.psd[50:200])
@@ -138,7 +154,9 @@ def test_chi_square_interval_covers_true_psd_at_stated_confidence() -> None:
     true_psd = 1.0 / (FS / 2.0)
     hits, total = 0, 0
     for seed in range(200):
-        res = ph.power_spectral_density(_white(300 + seed), FS, nperseg=1024)
+        res = ph.signals.power_spectral_density(
+            _white(300 + seed), FS, nperseg=1024
+        )
         for b in (60, 120, 240):
             hits += int(res.ci_lower[b] <= true_psd <= res.ci_upper[b])
             total += 1
@@ -147,14 +165,14 @@ def test_chi_square_interval_covers_true_psd_at_stated_confidence() -> None:
 
 def test_dc_and_nyquist_bins_get_wider_single_component_intervals() -> None:
     """DC/Nyquist carry one real Fourier component: n = nd, not 2·nd."""
-    res = ph.power_spectral_density(_white(8), FS, nperseg=1024)
+    res = ph.signals.power_spectral_density(_white(8), FS, nperseg=1024)
     ratio = res.ci_upper / res.ci_lower
     interior = float(ratio[1])
     assert np.allclose(ratio[1:-1], interior, rtol=1e-9)
     assert float(ratio[0]) > 1.05 * interior
     assert float(ratio[-1]) > 1.05 * interior  # even nperseg -> Nyquist bin
     # Odd segment length: the last bin is not Nyquist and stays interior.
-    odd = ph.power_spectral_density(_white(8), FS, nperseg=1023)
+    odd = ph.signals.power_spectral_density(_white(8), FS, nperseg=1023)
     odd_ratio = odd.ci_upper / odd.ci_lower
     assert float(odd_ratio[-1]) == pytest.approx(float(odd_ratio[1]), rel=1e-9)
     assert float(odd_ratio[0]) > 1.05 * float(odd_ratio[1])
@@ -162,8 +180,12 @@ def test_dc_and_nyquist_bins_get_wider_single_component_intervals() -> None:
 
 def test_confidence_interval_widens_at_higher_confidence() -> None:
     x = _white(7)
-    r90 = ph.power_spectral_density(x, FS, nperseg=1024, confidence=0.90)
-    r99 = ph.power_spectral_density(x, FS, nperseg=1024, confidence=0.99)
+    r90 = ph.signals.power_spectral_density(
+        x, FS, nperseg=1024, confidence=0.90
+    )
+    r99 = ph.signals.power_spectral_density(
+        x, FS, nperseg=1024, confidence=0.99
+    )
     assert np.all(r99.ci_lower <= r90.ci_lower)
     assert np.all(r90.ci_upper <= r99.ci_upper)
     assert np.all(r90.ci_lower < r90.psd)
@@ -172,11 +194,13 @@ def test_confidence_interval_widens_at_higher_confidence() -> None:
 
 def test_resolution_bias_error_closed_form() -> None:
     # Eq. 8.141: εb = -(Be/Br)²/3; quarter-bandwidth analysis -> -1/48.
-    assert ph.resolution_bias_error(1.0, 4.0) == pytest.approx(-1.0 / 48.0)
+    assert ph.signals.resolution_bias_error(1.0, 4.0) == pytest.approx(
+        -1.0 / 48.0
+    )
     with pytest.raises(ValueError, match="resolution_bandwidth"):
-        ph.resolution_bias_error(0.0, 4.0)
+        ph.signals.resolution_bias_error(0.0, 4.0)
     with pytest.raises(ValueError, match="half_power_bandwidth"):
-        ph.resolution_bias_error(1.0, -1.0)
+        ph.signals.resolution_bias_error(1.0, -1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +210,7 @@ def test_resolution_bias_error_closed_form() -> None:
 
 def test_cross_spectrum_of_known_gain_path() -> None:
     x, y, snr = _known_snr_pair(1)
-    res = ph.cross_spectral_density(x, y, FS, nperseg=1024)
+    res = ph.signals.cross_spectral_density(x, y, FS, nperseg=1024)
     band = slice(50, 400)
     # Gxy = H·Gxx with H = 0.8 (uncorrelated noise drops out on average).
     expected = 0.8 / (FS / 2.0)
@@ -204,7 +228,9 @@ def test_cross_spectrum_error_formulas_match_monte_carlo() -> None:
     b = 100
     for seed in range(150):
         x, y, snr = _known_snr_pair(seed)
-        res = ph.cross_spectral_density(x, y, FS, nperseg=1024, overlap=0.0)
+        res = ph.signals.cross_spectral_density(
+            x, y, FS, nperseg=1024, overlap=0.0
+        )
         mags.append(res.magnitude[b])
         phases.append(res.phase[b])
         nd = res.n_averages
@@ -231,7 +257,7 @@ def test_cross_spectrum_phase_slope_measures_pure_delay() -> None:
     delay = 16
     x = _white(8)
     y = np.roll(x, delay)
-    res = ph.cross_spectral_density(x, y, FS, nperseg=2048)
+    res = ph.signals.cross_spectral_density(x, y, FS, nperseg=2048)
     band = (res.frequencies > 100.0) & (res.frequencies < 2000.0)
     slope = np.polyfit(res.frequencies[band], res.phase[band], 1)[0]
     assert slope / (-2.0 * np.pi) * FS == pytest.approx(delay, rel=1e-3)
@@ -241,7 +267,7 @@ def test_cross_spectrum_matches_scipy_csd() -> None:
     x, y, _ = _known_snr_pair(2)
     from scipy import signal as sp_signal
 
-    res = ph.cross_spectral_density(x, y, FS, nperseg=1024)
+    res = ph.signals.cross_spectral_density(x, y, FS, nperseg=1024)
     f, gxy = sp_signal.csd(
         x, y, fs=FS, window="hann", nperseg=1024, noverlap=512, detrend=False
     )
@@ -256,7 +282,7 @@ def test_cross_spectrum_matches_scipy_csd() -> None:
 
 def test_coherent_output_recovers_known_snr_path() -> None:
     x, y, snr = _known_snr_pair(3)
-    res = ph.coherent_output_spectrum(x, y, FS, nperseg=1024)
+    res = ph.signals.coherent_output_spectrum(x, y, FS, nperseg=1024)
     band = slice(50, 400)
     gamma2 = snr / (1.0 + snr)
     assert float(np.median(res.coherence[band])) == pytest.approx(gamma2, abs=0.03)
@@ -276,7 +302,7 @@ def test_coherent_output_recovers_known_snr_path() -> None:
 
 def test_coherent_plus_noise_equals_output_spectrum() -> None:
     x, y, _ = _known_snr_pair(4)
-    res = ph.coherent_output_spectrum(x, y, FS, nperseg=1024)
+    res = ph.signals.coherent_output_spectrum(x, y, FS, nperseg=1024)
     np.testing.assert_allclose(
         res.coherent_psd + res.noise_psd, res.output_psd, rtol=1e-12
     )
@@ -286,9 +312,9 @@ def test_sine_in_noise_coherent_output_at_tone() -> None:
     """γ² at a tone bin follows SNR/(1+SNR) with the in-bin noise power."""
     t = np.arange(N) / FS
     x = np.sqrt(2.0) * np.sin(2.0 * np.pi * 400.0 * t)
-    noise = ph.noise_signal(FS, N / FS, color="white", rms=0.5, seed=9)
+    noise = ph.signals.noise_signal(FS, N / FS, color="white", rms=0.5, seed=9)
     y = x + noise
-    res = ph.coherent_output_spectrum(x, y, FS, nperseg=1024)
+    res = ph.signals.coherent_output_spectrum(x, y, FS, nperseg=1024)
     i = int(np.argmin(np.abs(res.frequencies - 400.0)))
     # Tone power 1.0 against the noise power inside the analysis bandwidth.
     snr = 1.0 / (0.25 / (FS / 2.0) * res.resolution_bandwidth)
@@ -306,7 +332,9 @@ def test_coherent_output_random_error_matches_monte_carlo() -> None:
     b = 100
     for seed in range(150):
         x, y, snr = _known_snr_pair(seed)
-        res = ph.coherent_output_spectrum(x, y, FS, nperseg=1024, overlap=0.0)
+        res = ph.signals.coherent_output_spectrum(
+            x, y, FS, nperseg=1024, overlap=0.0
+        )
         values.append(res.coherent_psd[b])
         nd = res.n_averages
         if seed == 0:
@@ -320,7 +348,7 @@ def test_coherent_output_random_error_matches_monte_carlo() -> None:
 
 def test_noiseless_path_has_unit_coherence_and_tiny_bias() -> None:
     x = _white(10)
-    res = ph.coherent_output_spectrum(x, 2.0 * x, FS, nperseg=1024)
+    res = ph.signals.coherent_output_spectrum(x, 2.0 * x, FS, nperseg=1024)
     band = slice(50, 400)
     assert float(np.min(res.coherence[band])) > 0.999
     # Eq. 9.75: b[γ̂²] ≈ (1-γ²)²/nd -> essentially zero here.
@@ -332,7 +360,7 @@ def test_noiseless_path_has_unit_coherence_and_tiny_bias() -> None:
 
 def test_snr_error_is_sqrt2_over_gamma_sqrt_nd() -> None:
     x, y, _ = _known_snr_pair(5)
-    res = ph.coherent_output_spectrum(x, y, FS, nperseg=1024)
+    res = ph.signals.coherent_output_spectrum(x, y, FS, nperseg=1024)
     gamma = np.sqrt(res.coherence)
     ok = gamma > 0.0
     np.testing.assert_allclose(
@@ -350,14 +378,14 @@ def test_snr_error_is_sqrt2_over_gamma_sqrt_nd() -> None:
 def test_smoothing_leaves_flat_spectrum_exactly_unchanged() -> None:
     f = np.linspace(0.0, 4000.0, 512)
     flat = np.full(512, 3.7)
-    out = ph.fractional_octave_smoothing(f, flat, 3.0)
+    out = ph.signals.fractional_octave_smoothing(f, flat, 3.0)
     np.testing.assert_allclose(out, flat, rtol=0.0, atol=1e-12)
 
 
 def test_smoothing_flat_invariance_in_db_and_amplitude_domains() -> None:
     f = np.linspace(1.0, 4000.0, 512)
     for domain, level in (("db", -12.0), ("amplitude", 0.5)):
-        out = ph.fractional_octave_smoothing(
+        out = ph.signals.fractional_octave_smoothing(
             f, np.full(512, level), 6.0, domain=domain  # type: ignore[arg-type]
         )
         np.testing.assert_allclose(out, np.full(512, level), atol=1e-12)
@@ -371,7 +399,7 @@ def test_smoothed_line_has_third_octave_width_and_conserved_level() -> None:
     f0 = 1000.0
     i0 = int(np.argmin(np.abs(f - f0)))
     power[i0] = 5.0
-    out = ph.fractional_octave_smoothing(f, power, 3.0)
+    out = ph.signals.fractional_octave_smoothing(f, power, 3.0)
     width = f0 * (2.0 ** (1.0 / 6.0) - 2.0 ** (-1.0 / 6.0))
     # Level at the line: the bin's power spread over the kernel width.
     assert float(out[i0]) == pytest.approx(5.0 * df / width, rel=1e-9)
@@ -382,9 +410,11 @@ def test_smoothed_line_has_third_octave_width_and_conserved_level() -> None:
 
 
 def test_smoothing_narrows_variance_of_noisy_spectrum() -> None:
-    res = ph.power_spectral_density(_white(11), FS, nperseg=4096)
+    res = ph.signals.power_spectral_density(_white(11), FS, nperseg=4096)
     band = (res.frequencies > 200.0) & (res.frequencies < 3800.0)
-    smooth = ph.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
+    smooth = ph.signals.fractional_octave_smoothing(
+        res.frequencies, res.psd, 3.0
+    )
     assert float(np.std(smooth[band])) < 0.35 * float(np.std(res.psd[band]))
     # Same mean level: smoothing is power-preserving on average.
     assert float(np.mean(smooth[band])) == pytest.approx(
@@ -395,7 +425,7 @@ def test_smoothing_narrows_variance_of_noisy_spectrum() -> None:
 def test_smoothing_zero_frequency_point_is_copied() -> None:
     f = np.concatenate(([0.0], np.linspace(10.0, 1000.0, 100)))
     v = np.concatenate(([9.0], np.ones(100)))
-    out = ph.fractional_octave_smoothing(f, v, 3.0)
+    out = ph.signals.fractional_octave_smoothing(f, v, 3.0)
     assert out[0] == 9.0
 
 
@@ -431,7 +461,7 @@ def test_smoothing_zero_frequency_point_is_copied() -> None:
 )
 def test_smoothing_rejects_invalid_inputs(kwargs: dict, match: str) -> None:
     with pytest.raises(ValueError, match=match):
-        ph.fractional_octave_smoothing(**kwargs)
+        ph.signals.fractional_octave_smoothing(**kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -444,27 +474,28 @@ def test_psd_rejects_invalid_inputs() -> None:
     two_dimensional = np.stack([x, x])
     non_finite = np.full(4096, np.nan)
     with pytest.raises(ValueError, match="one-dimensional"):
-        ph.power_spectral_density(two_dimensional, FS)
+        ph.signals.power_spectral_density(two_dimensional, FS)
     with pytest.raises(ValueError, match="too short"):
-        ph.power_spectral_density(x[:16], FS)
+        ph.signals.power_spectral_density(x[:16], FS)
     with pytest.raises(ValueError, match="finite"):
-        ph.power_spectral_density(non_finite, FS)
+        ph.signals.power_spectral_density(non_finite, FS)
     with pytest.raises(ValueError, match="'fs'"):
-        ph.power_spectral_density(x, 0.0)
+        ph.signals.power_spectral_density(x, 0.0)
     with pytest.raises(ValueError, match="nperseg"):
-        ph.power_spectral_density(x, FS, nperseg=16)
+        ph.signals.power_spectral_density(x, FS, nperseg=16)
     with pytest.raises(ValueError, match="nperseg"):
-        ph.power_spectral_density(x, FS, nperseg=x.size + 1)
+        ph.signals.power_spectral_density(x, FS, nperseg=x.size + 1)
     with pytest.raises(ValueError, match="overlap"):
-        ph.power_spectral_density(x, FS, overlap=1.0)
+        ph.signals.power_spectral_density(x, FS, overlap=1.0)
     with pytest.raises(ValueError, match="confidence"):
-        ph.power_spectral_density(x, FS, confidence=1.0)
+        ph.signals.power_spectral_density(x, FS, confidence=1.0)
     with pytest.raises(ValueError, match="scaling"):
-        ph.power_spectral_density(x, FS, scaling="power")  # type: ignore[arg-type]
+        ph.signals.power_spectral_density(x, FS, scaling="power")  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
-    "func", [ph.cross_spectral_density, ph.coherent_output_spectrum]
+    "func",
+    [ph.signals.cross_spectral_density, ph.signals.coherent_output_spectrum],
 )
 def test_two_channel_functions_reject_mismatched_lengths(func) -> None:
     x = _white(13)
@@ -473,13 +504,13 @@ def test_two_channel_functions_reject_mismatched_lengths(func) -> None:
 
 
 def test_default_nperseg_targets_4hz_resolution() -> None:
-    res = ph.power_spectral_density(_white(14), FS)
+    res = ph.signals.power_spectral_density(_white(14), FS)
     df = float(res.frequencies[1] - res.frequencies[0])
     assert 2.0 <= df <= 8.0
 
 
 def test_results_are_frozen() -> None:
-    res = ph.power_spectral_density(_white(15), FS, nperseg=1024)
+    res = ph.signals.power_spectral_density(_white(15), FS, nperseg=1024)
     with pytest.raises(AttributeError):
         res.psd = res.psd * 2.0  # type: ignore[misc]
 
@@ -490,7 +521,7 @@ def test_results_are_frozen() -> None:
 
 
 def test_psd_plot_line_and_confidence_band() -> None:
-    res = ph.power_spectral_density(_white(16), FS, nperseg=1024)
+    res = ph.signals.power_spectral_density(_white(16), FS, nperseg=1024)
     ax = res.plot()
     assert ax.lines, "expected the density line"
     labels = [str(c.get_label()) for c in ax.collections]
@@ -502,7 +533,7 @@ def test_psd_plot_line_and_confidence_band() -> None:
 
 def test_csd_plot_three_panels_and_external_ax() -> None:
     x, y, _ = _known_snr_pair(6)
-    res = ph.cross_spectral_density(x, y, FS, nperseg=1024)
+    res = ph.signals.cross_spectral_density(x, y, FS, nperseg=1024)
     axes = res.plot()
     assert len(axes) == 3
     assert axes[2].get_ylim()[1] > 1.0  # coherence panel
@@ -513,7 +544,7 @@ def test_csd_plot_three_panels_and_external_ax() -> None:
 
 def test_coherent_output_plot_two_panels_and_external_ax() -> None:
     x, y, _ = _known_snr_pair(7)
-    res = ph.coherent_output_spectrum(x, y, FS, nperseg=1024)
+    res = ph.signals.coherent_output_spectrum(x, y, FS, nperseg=1024)
     axes = res.plot()
     assert len(axes) == 2
     assert len(axes[0].lines) == 3  # Gyy, Gvv, Gnn

--- a/tests/signals/test_synchronous_average.py
+++ b/tests/signals/test_synchronous_average.py
@@ -111,7 +111,7 @@ def test_mcfadden_node_selection_end_to_end() -> None:
 
     leak_20 = np.max(
         np.abs(
-            ph.time_synchronous_average(
+            ph.signals.time_synchronous_average(
                 signal, FS, period=PERIOD, n_averages=20
             ).period_waveform
             - true_one
@@ -119,7 +119,7 @@ def test_mcfadden_node_selection_end_to_end() -> None:
     )
     leak_32 = np.max(
         np.abs(
-            ph.time_synchronous_average(
+            ph.signals.time_synchronous_average(
                 signal, FS, period=PERIOD, n_averages=32
             ).period_waveform
             - true_one
@@ -138,7 +138,7 @@ def test_exact_recovery_integer_period() -> None:
     """Noiseless periodic signal, integer M, recovered to machine precision."""
     one = _periodic(PERIOD, M, (1.0, 3.0, 5.0))
     signal = _repeat(one, 24)
-    result = ph.time_synchronous_average(signal, FS, period=PERIOD)
+    result = ph.signals.time_synchronous_average(signal, FS, period=PERIOD)
 
     assert result.interpolated is False
     assert result.samples_per_period == M
@@ -149,7 +149,9 @@ def test_exact_recovery_integer_period() -> None:
 
 def test_times_are_the_sampling_grid() -> None:
     one = _periodic(PERIOD, M, (2.0,))
-    result = ph.time_synchronous_average(_repeat(one, 10), FS, period=PERIOD)
+    result = ph.signals.time_synchronous_average(
+        _repeat(one, 10), FS, period=PERIOD
+    )
     assert result.times.size == M
     assert result.times[0] == pytest.approx(0.0, abs=1e-15)
     assert result.times[-1] < PERIOD
@@ -174,7 +176,7 @@ def test_noninteger_period_recovered_within_bound() -> None:
     signal = np.cos(2.0 * np.pi * phase) + 0.4 * np.cos(
         2.0 * np.pi * 2.0 * phase + 0.3
     )
-    result = ph.time_synchronous_average(signal, FS, period=period)
+    result = ph.signals.time_synchronous_average(signal, FS, period=period)
 
     assert result.interpolated is True
     assert np.allclose(result.times, np.arange(m_int) / FS, atol=0.0)
@@ -211,7 +213,9 @@ def test_noninteger_period_samples_on_fs_grid_not_angular_grid() -> None:
             for k, a, p in zip(orders, amps, phases)
         )
 
-    result = ph.time_synchronous_average(wave(t), fs, period=period, n_averages=n_avg)
+    result = ph.signals.time_synchronous_average(
+        wave(t), fs, period=period, n_averages=n_avg
+    )
 
     assert result.interpolated is True
     assert result.samples_per_period == m_int
@@ -237,7 +241,9 @@ def test_noise_reduction_sqrt_n_law() -> None:
     n_avg = 64
     sigma = 1.0
     signal = _repeat(one, n_avg) + rng.standard_normal(n_avg * M) * sigma
-    result = ph.time_synchronous_average(signal, FS, period=PERIOD, n_averages=n_avg)
+    result = ph.signals.time_synchronous_average(
+        signal, FS, period=PERIOD, n_averages=n_avg
+    )
 
     residual_of_average = result.period_waveform - one
     measured = float(np.std(residual_of_average))
@@ -249,7 +255,9 @@ def test_noise_reduction_sqrt_n_law() -> None:
 
 def test_noise_reduction_db_matches_n() -> None:
     one = _periodic(PERIOD, M, (1.0,))
-    result = ph.time_synchronous_average(_repeat(one, 100), FS, period=PERIOD)
+    result = ph.signals.time_synchronous_average(
+        _repeat(one, 100), FS, period=PERIOD
+    )
     assert result.noise_reduction_db == pytest.approx(20.0, abs=1e-9)
     assert result.amplitude_snr_gain == pytest.approx(10.0, abs=1e-9)
 
@@ -261,14 +269,18 @@ def test_noise_reduction_db_matches_n() -> None:
 
 def test_default_n_averages_uses_whole_record() -> None:
     one = _periodic(PERIOD, M, (1.0,))
-    result = ph.time_synchronous_average(_repeat(one, 12), FS, period=PERIOD)
+    result = ph.signals.time_synchronous_average(
+        _repeat(one, 12), FS, period=PERIOD
+    )
     assert result.n_averages == 12
 
 
 def test_requested_n_averages_over_available_raises() -> None:
     signal = _repeat(_periodic(PERIOD, M, (1.0,)), 5)
     with pytest.raises(ValueError, match="exceeds"):
-        ph.time_synchronous_average(signal, FS, period=PERIOD, n_averages=6)
+        ph.signals.time_synchronous_average(
+            signal, FS, period=PERIOD, n_averages=6
+        )
 
 
 @pytest.mark.parametrize(
@@ -281,20 +293,22 @@ def test_requested_n_averages_over_available_raises() -> None:
 def test_invalid_parameters_raise(kwargs: dict, match: str) -> None:
     signal = _repeat(_periodic(PERIOD, M, (1.0,)), 4)
     with pytest.raises(ValueError, match=match):
-        ph.time_synchronous_average(signal, FS, period=PERIOD, **kwargs)
+        ph.signals.time_synchronous_average(
+            signal, FS, period=PERIOD, **kwargs
+        )
 
 
 def test_period_too_short_raises() -> None:
     signal = _repeat(_periodic(PERIOD, M, (1.0,)), 4)
     tiny_period = 1.0 / FS  # spans a single sample
     with pytest.raises(ValueError, match="at least 2 samples"):
-        ph.time_synchronous_average(signal, FS, period=tiny_period)
+        ph.signals.time_synchronous_average(signal, FS, period=tiny_period)
 
 
 def test_record_shorter_than_one_period_raises() -> None:
     short = np.zeros(M // 2, dtype=np.float64)
     with pytest.raises(ValueError, match="shorter than one period"):
-        ph.time_synchronous_average(short, FS, period=PERIOD)
+        ph.signals.time_synchronous_average(short, FS, period=PERIOD)
 
 
 def test_comb_filter_response_validation() -> None:
@@ -318,7 +332,9 @@ def test_comb_filter_response_rejects_overflowing_order() -> None:
 
 def test_plot_returns_axes() -> None:
     one = _periodic(PERIOD, M, (1.0, 3.0))
-    result = ph.time_synchronous_average(_repeat(one, 8), FS, period=PERIOD)
+    result = ph.signals.time_synchronous_average(
+        _repeat(one, 8), FS, period=PERIOD
+    )
 
     axes = result.plot()
     assert axes.shape == (2,)
@@ -331,7 +347,7 @@ def test_plot_returns_axes() -> None:
 
 
 def test_plot_rejects_unknown_language() -> None:
-    result = ph.time_synchronous_average(
+    result = ph.signals.time_synchronous_average(
         _repeat(_periodic(PERIOD, M, (1.0,)), 4), FS, period=PERIOD)
     with pytest.raises(ValueError):
         result.plot(language="fr")

--- a/tests/signals/test_window_metrics.py
+++ b/tests/signals/test_window_metrics.py
@@ -44,7 +44,7 @@ _ENBW_EXACT = [
 
 @pytest.mark.parametrize(("window", "expected"), _ENBW_EXACT)
 def test_enbw_matches_exact_closed_form(window: str, expected: float) -> None:
-    res = ph.window_metrics(window, N)
+    res = ph.signals.window_metrics(window, N)
     assert res.enbw_bins == pytest.approx(expected, rel=1e-12)
 
 
@@ -54,13 +54,13 @@ def test_enbw_matches_exact_closed_form(window: str, expected: float) -> None:
 )
 def test_coherent_gain_exact(window: str, expected: float) -> None:
     # DFT-even cosine sums over full periods leave only the a0 term.
-    res = ph.window_metrics(window, N)
+    res = ph.signals.window_metrics(window, N)
     assert res.coherent_gain == pytest.approx(expected, rel=1e-12)
 
 
 def test_rectangular_scalloping_exact_discrete_form() -> None:
     # |W(1/2)| / |W(0)| = 1 / (N·sin(π/2N)) exactly (Dirichlet kernel).
-    res = ph.window_metrics("boxcar", N)
+    res = ph.signals.window_metrics("boxcar", N)
     exact = 20.0 * np.log10(N * np.sin(np.pi / (2.0 * N)))
     assert res.scalloping_loss_db == pytest.approx(exact, rel=1e-9)
     # Large-N limit: 20·lg(π/2) = 3.9224 dB.
@@ -69,7 +69,7 @@ def test_rectangular_scalloping_exact_discrete_form() -> None:
 
 def test_hann_scalloping_matches_continuous_limit() -> None:
     # W(1/2)/W(0) -> (2/π)/(1 - 1/4) = 8/3π for the continuous Hann kernel.
-    res = ph.window_metrics("hann", N)
+    res = ph.signals.window_metrics("hann", N)
     assert res.scalloping_loss_db == pytest.approx(
         -20.0 * np.log10(8.0 / (3.0 * np.pi)), abs=1e-3
     )
@@ -86,7 +86,7 @@ def test_hann_scalloping_matches_continuous_limit() -> None:
 def test_highest_sidelobe_matches_classic_values(
     window: str, sidelobe_db: float, tol: float
 ) -> None:
-    res = ph.window_metrics(window, N)
+    res = ph.signals.window_metrics(window, N)
     assert res.highest_sidelobe_db == pytest.approx(sidelobe_db, abs=tol)
 
 
@@ -97,18 +97,18 @@ def test_highest_sidelobe_matches_classic_values(
 def test_mainlobe_3db_width_matches_harris_table(
     window: str, width: float
 ) -> None:
-    res = ph.window_metrics(window, N)
+    res = ph.signals.window_metrics(window, N)
     assert res.mainlobe_width_3db_bins == pytest.approx(width, abs=0.01)
 
 
 def test_worst_case_processing_loss() -> None:
     # WCPL = scalloping loss + 10·lg(ENBW): 3.92 dB rectangular (no ENBW
     # term), 3.18 dB Hann (Harris Table 1).
-    rect = ph.window_metrics("boxcar", N)
+    rect = ph.signals.window_metrics("boxcar", N)
     assert rect.worst_case_processing_loss_db == pytest.approx(
         rect.scalloping_loss_db
     )
-    hann = ph.window_metrics("hann", N)
+    hann = ph.signals.window_metrics("hann", N)
     assert hann.worst_case_processing_loss_db == pytest.approx(3.18, abs=0.01)
 
 
@@ -116,16 +116,16 @@ def test_enbw_hz_matches_welch_resolution_bandwidth() -> None:
     # The PSD estimator reports Bₑ = fs·Σw²/(Σw)² per segment; it must be
     # the same number window_metrics reports as ENBW·fs/n.
     fs, nperseg = 48000.0, 2048
-    x = ph.noise_signal(fs, 1.0, seed=6)
-    psd = ph.power_spectral_density(x, fs, nperseg=nperseg)
-    metrics = ph.window_metrics("hann", nperseg)
+    x = ph.signals.noise_signal(fs, 1.0, seed=6)
+    psd = ph.signals.power_spectral_density(x, fs, nperseg=nperseg)
+    metrics = ph.signals.window_metrics("hann", nperseg)
     assert psd.resolution_bandwidth == pytest.approx(
         metrics.enbw_hz(fs), rel=1e-12
     )
 
 
 def test_parametric_windows_are_accepted() -> None:
-    res = ph.window_metrics(("kaiser", 8.6), 512)
+    res = ph.signals.window_metrics(("kaiser", 8.6), 512)
     assert res.enbw_bins > 1.5
     assert res.highest_sidelobe_db < -60.0
     assert res.n == 512
@@ -133,20 +133,20 @@ def test_parametric_windows_are_accepted() -> None:
 
 
 def test_window_metrics_result_is_frozen() -> None:
-    res = ph.window_metrics("hann", N)
+    res = ph.signals.window_metrics("hann", N)
     with pytest.raises(dataclasses.FrozenInstanceError):
         res.enbw_bins = 2.0  # type: ignore[misc]
 
 
 def test_window_metrics_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="Unknown window"):
-        ph.window_metrics("not-a-window", N)
+        ph.signals.window_metrics("not-a-window", N)
     with pytest.raises(ValueError, match="at least 16"):
-        ph.window_metrics("hann", 8)
+        ph.signals.window_metrics("hann", 8)
 
 
 def test_window_metrics_plot_two_panels_and_single_axes() -> None:
-    res = ph.window_metrics("hann", N)
+    res = ph.signals.window_metrics("hann", N)
     axes = res.plot(linewidth=2)
     assert isinstance(axes, np.ndarray)
     assert axes.size == 2

--- a/tests/speech/test_speech_plot_i18n.py
+++ b/tests/speech/test_speech_plot_i18n.py
@@ -37,7 +37,7 @@ def _labels(ax: object) -> str:
 
 def test_standard_speech_spectrum_es_and_bad_language() -> None:
     """The four vocal efforts are table keys reached through the result."""
-    res = ph.standard_speech_spectra()
+    res = ph.speech.standard_speech_spectra()
     ax = res.plot(language="es")
     legend = [t.get_text() for t in ax.get_legend().get_texts()]
     assert legend == ["Normal", "Elevada", "Fuerte", "Grito"]
@@ -59,7 +59,7 @@ def test_standard_speech_spectrum_es_and_bad_language() -> None:
 )
 def test_sii_procedure_es(method: str, label: str) -> None:
     """All four band-importance labels: each is a key of its own."""
-    ax = ph.sii_procedure(method).plot(language="es")
+    ax = ph.speech.sii_procedure(method).plot(language="es")
     assert ax.get_title() == "ANSI S3.5-1997 función de importancia de banda"
     assert ax.get_ylabel() == "Importancia de banda $I_i$"
     assert [t.get_text() for t in ax.get_legend().get_texts()] == [label]
@@ -67,8 +67,8 @@ def test_sii_procedure_es(method: str, label: str) -> None:
 
 
 def test_sii_es() -> None:
-    res = ph.speech_intelligibility_index(
-        ph.standard_speech_spectrum("normal"), [30.0] * 18
+    res = ph.speech.speech_intelligibility_index(
+        ph.speech.standard_speech_spectrum("normal"), [30.0] * 18
     )
     ax = res.plot(language="es")
     text = _labels(ax)
@@ -83,7 +83,7 @@ def test_sti_es() -> None:
     impulse = np.zeros(FS // 2)
     impulse[0] = 1.0
     impulse[2048] = 0.4
-    res = ph.sti_from_impulse_response(impulse, FS)
+    res = ph.speech.sti_from_impulse_response(impulse, FS)
     ax = res.plot(language="es")
     text = _labels(ax)
     assert "Índice de transferencia de modulación MTI" in text
@@ -96,7 +96,7 @@ def test_sti_es() -> None:
 def test_stoi_es() -> None:
     clean = RNG.standard_normal(FS)
     degraded = clean + 0.2 * RNG.standard_normal(FS)
-    res = ph.stoi(clean, degraded, FS)
+    res = ph.speech.stoi(clean, degraded, FS)
     ax = res.plot(language="es")
     text = _labels(ax)
     assert "Correlación" in text
@@ -104,7 +104,7 @@ def test_stoi_es() -> None:
 
 def test_sti_with_a_non_octave_band_set_es() -> None:
     """A result whose MTI is not the seven octave bands gets a plain axis."""
-    res = ph.STIResult(
+    res = ph.speech.STIResult(
         sti=0.62,
         mti=np.linspace(0.4, 0.8, 5),
         mtf=np.zeros((5, 14)),

--- a/tests/test_api_docs_generator.py
+++ b/tests/test_api_docs_generator.py
@@ -64,7 +64,7 @@ def test_section_labels_are_bilingual() -> None:
 
 
 def test_parse_docstring_on_real_docstring() -> None:
-    doc = inspect.getdoc(phonometry.leq)
+    doc = inspect.getdoc(phonometry.signals.leq)
     assert doc is not None
     parsed = gad.parse_docstring(doc)
     assert not parsed.issues
@@ -79,7 +79,7 @@ def test_parse_docstring_on_real_docstring() -> None:
 
 
 def test_parse_docstring_ivar_and_raises() -> None:
-    doc = inspect.getdoc(phonometry.UncertaintyResult)
+    doc = inspect.getdoc(phonometry.metrology.UncertaintyResult)
     assert doc is not None
     parsed = gad.parse_docstring(doc)
     assert not parsed.issues

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,7 +41,9 @@ def test_octave_filter_basic() -> None:
     y = 100 * np.sum([np.sin(2 * np.pi * f * t) for f in freqs], axis=0)
 
     # 1. Filter and get only SPL spectrum
-    spl, freq = phonometry.octave_filter(y, fs=fs, fraction=3, order=6, limits=[12, 20000])
+    spl, freq = phonometry.filters.octave_filter(
+        y, fs=fs, fraction=3, order=6, limits=[12, 20000]
+    )
 
     assert len(spl) == len(freq)
     assert len(freq) > 0
@@ -71,7 +73,7 @@ def test_octave_filter_sigbands() -> None:
     y = np.sin(2 * np.pi * 1000 * t)
 
     # 2. Filter and get signals in time-domain bands
-    _, freq, xb = phonometry.octave_filter(
+    _, freq, xb = phonometry.filters.octave_filter(
         y, fs=fs, fraction=1, order=6, limits=[500, 2000], sigbands=True
     )
 
@@ -91,7 +93,9 @@ def test_detrend_acts_on_the_input_once_not_per_band() -> None:
     t = np.arange(2 * fs) / fs
     y = np.sin(2 * np.pi * 1000 * t) + 5.0  # 1 kHz tone riding a DC offset
 
-    bank = phonometry.OctaveFilterBank(fs=fs, fraction=1, limits=[12, 20000])
+    bank = phonometry.filters.OctaveFilterBank(
+        fs=fs, fraction=1, limits=[12, 20000]
+    )
     spl_on, _, bands_on = bank.filter(y, sigbands=True, detrend=True)
     spl_off, _, bands_off = bank.filter(y, sigbands=True, detrend=False)
 
@@ -118,11 +122,13 @@ def test_octave_filter_reuses_cached_bank(monkeypatch) -> None:
     monkeypatch.setattr(OctaveFilterBank, "__init__", counting_init)
 
     x = np.random.default_rng(0).standard_normal(4800)
-    phonometry.octave_filter(x, 48000, fraction=3)
-    phonometry.octave_filter(x, 48000, fraction=3)
+    phonometry.filters.octave_filter(x, 48000, fraction=3)
+    phonometry.filters.octave_filter(x, 48000, fraction=3)
     assert calls["n"] == 1
 
-    phonometry.octave_filter(x, 48000, fraction=1)  # different params -> new bank
+    phonometry.filters.octave_filter(
+        x, 48000, fraction=1
+    )  # different params -> new bank
     assert calls["n"] == 2
     phonometry.filters.core._cached_filter_bank.cache_clear()
 
@@ -131,8 +137,8 @@ def test_octave_filter_cached_results_identical() -> None:
     """The cached bank must return bit-identical results across calls."""
     phonometry.filters.core._cached_filter_bank.cache_clear()
     x = np.random.default_rng(1).standard_normal(4800)
-    spl1, f1 = phonometry.octave_filter(x, 48000, fraction=3)
-    spl2, f2 = phonometry.octave_filter(x, 48000, fraction=3)
+    spl1, f1 = phonometry.filters.octave_filter(x, 48000, fraction=3)
+    spl2, f2 = phonometry.filters.octave_filter(x, 48000, fraction=3)
     np.testing.assert_array_equal(spl1, spl2)
     assert f1 == f2
 
@@ -141,8 +147,8 @@ def test_octave_filter_freq_list_is_mutation_safe() -> None:
     """Mutating the returned freq list must not corrupt the cached bank."""
     phonometry.filters.core._cached_filter_bank.cache_clear()
     x = np.random.default_rng(2).standard_normal(4800)
-    _, freq1 = phonometry.octave_filter(x, 48000, fraction=1)
+    _, freq1 = phonometry.filters.octave_filter(x, 48000, fraction=1)
     freq1[0] = -999.0  # caller mutates the returned list
-    _, freq2 = phonometry.octave_filter(x, 48000, fraction=1)
+    _, freq2 = phonometry.filters.octave_filter(x, 48000, fraction=1)
     assert freq2[0] != -999.0
     phonometry.filters.core._cached_filter_bank.cache_clear()

--- a/tests/test_device_geometry_plots.py
+++ b/tests/test_device_geometry_plots.py
@@ -35,13 +35,13 @@ def _close_figures():
 # ---------------------------------------------------------------------------
 def test_silencer_results_retain_geometry_and_draw() -> None:
     cases = (
-        pm.expansion_chamber(FREQ, 0.3, 0.03, 0.005),
-        pm.extended_tube_chamber(
+        pm.noise_control.expansion_chamber(FREQ, 0.3, 0.03, 0.005),
+        pm.noise_control.extended_tube_chamber(
             FREQ, 0.3, 0.03, 0.005, inlet_extension=0.075,
             outlet_extension=0.05,
         ),
-        pm.helmholtz_resonator(FREQ, 0.01, 0.001, 0.05, 0.002),
-        pm.quarter_wave_resonator(FREQ, 0.01, 0.4, 0.003),
+        pm.noise_control.helmholtz_resonator(FREQ, 0.01, 0.001, 0.05, 0.002),
+        pm.noise_control.quarter_wave_resonator(FREQ, 0.01, 0.4, 0.003),
     )
     for result in cases:
         assert result.geometry is not None
@@ -53,7 +53,7 @@ def test_silencer_results_retain_geometry_and_draw() -> None:
 
 
 def test_silencer_hand_built_refuses() -> None:
-    result = pm.expansion_chamber(FREQ, 0.3, 0.03, 0.005)
+    result = pm.noise_control.expansion_chamber(FREQ, 0.3, 0.03, 0.005)
     import dataclasses
 
     bare = dataclasses.replace(result, geometry=None)
@@ -66,12 +66,12 @@ def test_silencer_hand_built_refuses() -> None:
 CHAIN_FREQ = np.linspace(20.0, 500.0, 481)
 
 
-def _chain(branch_length: float = 0.686) -> pm.SilencerChain:
+def _chain(branch_length: float = 0.686) -> pm.noise_control.SilencerChain:
     """A duct-shunt-duct-chamber-duct chain with one quarter-wave branch."""
     from phonometry.noise_control.silencers import quarter_wave_impedance
 
     return (
-        pm.SilencerChain(CHAIN_FREQ)
+        pm.noise_control.SilencerChain(CHAIN_FREQ)
         .duct(0.15, 0.0314)
         .shunt(
             quarter_wave_impedance(CHAIN_FREQ, branch_length, 0.00785),
@@ -134,7 +134,7 @@ def test_silencer_chain_result_and_language() -> None:
 
 def test_silencer_chain_numbers_unlabelled_branches() -> None:
     ax = (
-        pm.SilencerChain(FREQ)
+        pm.noise_control.SilencerChain(FREQ)
         .shunt(1.0e4)
         .duct(0.4, 0.02)
         .shunt(1.0e4)
@@ -146,38 +146,40 @@ def test_silencer_chain_numbers_unlabelled_branches() -> None:
 
 
 def test_silencer_chain_without_a_duct_refuses_to_draw() -> None:
-    chain = pm.SilencerChain(FREQ).shunt(1.0e4)
+    chain = pm.noise_control.SilencerChain(FREQ).shunt(1.0e4)
     with pytest.raises(ValueError, match="no duct of positive length"):
         chain.plot_geometry()
     # A zero-length duct is the identity matrix: nothing acoustically, and
     # nothing to draw either.
-    flat = pm.SilencerChain(FREQ).duct(0.0, 0.02)
+    flat = pm.noise_control.SilencerChain(FREQ).duct(0.0, 0.02)
     with pytest.raises(ValueError, match="no duct of positive length"):
         flat.plot_geometry()
 
 
 def test_silencer_free_function_validation() -> None:
     with pytest.raises(ValueError, match="Unknown silencer kind"):
-        pm.plot_silencer_geometry("muffler")
+        pm.noise_control.plot_silencer_geometry("muffler")
     with pytest.raises(ValueError, match="chamber_area"):
-        pm.plot_silencer_geometry(
+        pm.noise_control.plot_silencer_geometry(
             "expansion chamber", length=0.3, chamber_area=0.004,
             pipe_area=0.005,
         )
     with pytest.raises(ValueError, match="must not exceed"):
-        pm.plot_silencer_geometry(
+        pm.noise_control.plot_silencer_geometry(
             "extended-tube chamber", length=0.1, chamber_area=0.03,
             pipe_area=0.005, inlet_extension=0.08, outlet_extension=0.08,
         )
     with pytest.raises(ValueError, match="needs"):
-        pm.plot_silencer_geometry("Helmholtz resonator", duct_area=0.01)
+        pm.noise_control.plot_silencer_geometry(
+            "Helmholtz resonator", duct_area=0.01
+        )
 
 
 # ---------------------------------------------------------------------------
 # Image-source plan.
 # ---------------------------------------------------------------------------
 def test_image_source_plan_draws_and_caps_order() -> None:
-    res = pm.image_source_rir(
+    res = pm.room.image_source_rir(
         (5.0, 4.0, 3.0), (1.5, 1.2, 1.5), (3.5, 2.8, 1.2), 0.3,
         fs=8000, max_order=4,
     )
@@ -193,11 +195,11 @@ def test_image_source_plan_draws_and_caps_order() -> None:
 # Barrier section.
 # ---------------------------------------------------------------------------
 def test_barrier_result_retains_geometry_and_draws() -> None:
-    res = pm.barrier_insertion_loss(FREQ, 1.5, 5.0, 3.0, 20.0, 1.5)
+    res = pm.environment.barrier_insertion_loss(FREQ, 1.5, 5.0, 3.0, 20.0, 1.5)
     assert res.barrier_height == pytest.approx(3.0)
     assert res.thickness is None
     assert res.plot_geometry() is not None
-    thick = pm.barrier_insertion_loss(
+    thick = pm.environment.barrier_insertion_loss(
         FREQ, 1.5, 5.0, 3.0, 20.0, 1.5, thickness=0.4
     )
     assert thick.thickness == pytest.approx(0.4)
@@ -206,7 +208,7 @@ def test_barrier_result_retains_geometry_and_draws() -> None:
 
 def test_barrier_free_function_validation() -> None:
     with pytest.raises(ValueError, match="receiver_distance"):
-        pm.plot_barrier_geometry(
+        pm.environment.plot_barrier_geometry(
             source_height=1.5, barrier_distance=5.0, barrier_height=3.0,
             receiver_distance=4.0, receiver_height=1.5,
         )
@@ -216,39 +218,41 @@ def test_barrier_free_function_validation() -> None:
 # Microphone positions (3-D).
 # ---------------------------------------------------------------------------
 def test_microphone_positions_hemisphere_and_sphere() -> None:
-    pos = pm.measurement_positions("hemisphere", radius=2.0)
-    ax = pm.plot_microphone_positions(pos, radius=2.0)
+    pos = pm.emission.measurement_positions("hemisphere", radius=2.0)
+    ax = pm.emission.plot_microphone_positions(pos, radius=2.0)
     assert ax.name == "3d"
-    sphere = pm.precision_positions("sphere", radius=1.0, count=20)
-    ax = pm.plot_microphone_positions(sphere)
+    sphere = pm.emission.precision_positions("sphere", radius=1.0, count=20)
+    ax = pm.emission.plot_microphone_positions(sphere)
     assert ax.name == "3d"
     bad = np.zeros((3, 2))
     with pytest.raises(ValueError, match="shape"):
-        pm.plot_microphone_positions(bad)
+        pm.emission.plot_microphone_positions(bad)
     with pytest.raises(ValueError, match="radius"):
-        pm.plot_microphone_positions(pos, radius=-1.0)
+        pm.emission.plot_microphone_positions(pos, radius=-1.0)
 
 
 # ---------------------------------------------------------------------------
 # Wall aperture.
 # ---------------------------------------------------------------------------
 def test_aperture_results_retain_geometry_and_draw() -> None:
-    slit = pm.slit_transmission_coefficient(FREQ, 0.003, 0.1)
+    slit = pm.building.slit_transmission_coefficient(FREQ, 0.003, 0.1)
     assert slit.width == pytest.approx(0.003)
     assert slit.depth == pytest.approx(0.1)
     assert slit.plot_geometry() is not None
-    hole = pm.circular_aperture_transmission_coefficient(FREQ, 0.005, 0.1)
+    hole = pm.building.circular_aperture_transmission_coefficient(
+        FREQ, 0.005, 0.1
+    )
     assert hole.radius == pytest.approx(0.005)
     assert hole.plot_geometry() is not None
 
 
 def test_aperture_validation() -> None:
     with pytest.raises(ValueError, match="exactly one"):
-        pm.plot_aperture_geometry(0.1)
+        pm.building.plot_aperture_geometry(0.1)
     with pytest.raises(ValueError, match="exactly one"):
-        pm.plot_aperture_geometry(0.1, width=0.003, radius=0.005)
+        pm.building.plot_aperture_geometry(0.1, width=0.003, radius=0.005)
     with pytest.raises(ValueError, match="depth"):
-        pm.plot_aperture_geometry(0.0, width=0.003)
+        pm.building.plot_aperture_geometry(0.0, width=0.003)
 
 
 # ---------------------------------------------------------------------------
@@ -256,30 +260,30 @@ def test_aperture_validation() -> None:
 # ---------------------------------------------------------------------------
 def test_piston_geometry_with_and_without_lobe() -> None:
     angles = np.linspace(-np.pi / 2, np.pi / 2, 91)
-    with_lobe = pm.radiating_piston(
+    with_lobe = pm.electroacoustics.radiating_piston(
         0.1, np.array([500.0, 4000.0]), angles=angles
     )
     ax = with_lobe.plot_geometry()
     assert ax.get_legend() is not None
-    without = pm.radiating_piston(0.1, np.array([500.0]))
+    without = pm.electroacoustics.radiating_piston(0.1, np.array([500.0]))
     ax = without.plot_geometry()
     assert ax.get_legend() is None
     with pytest.raises(ValueError, match="radius"):
-        pm.plot_piston_geometry(0.0)
+        pm.electroacoustics.plot_piston_geometry(0.0)
     with pytest.raises(ValueError, match="together"):
-        pm.plot_piston_geometry(0.1, angles=angles)
+        pm.electroacoustics.plot_piston_geometry(0.1, angles=angles)
 
 
 # ---------------------------------------------------------------------------
 # Plenum.
 # ---------------------------------------------------------------------------
 def test_plenum_geometry_draws_and_validates() -> None:
-    ax = pm.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
+    ax = pm.noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
     assert ax.get_aspect() == 1.0
     with pytest.raises(ValueError, match="positive"):
-        pm.plot_plenum_geometry(0.0, 1.2, 6.0)
+        pm.noise_control.plot_plenum_geometry(0.0, 1.2, 6.0)
     with pytest.raises(ValueError, match="angle"):
-        pm.plot_plenum_geometry(0.09, 1.2, 6.0, angle=2.0)
+        pm.noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=2.0)
 
 
 # ---------------------------------------------------------------------------
@@ -314,16 +318,16 @@ def test_fdtd_domain_preview() -> None:
 
 def test_device_geometry_language_validation() -> None:
     with pytest.raises(ValueError, match="Unknown language"):
-        pm.plot_plenum_geometry(0.09, 1.2, 6.0, language="fr")
+        pm.noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, language="fr")
     with pytest.raises(ValueError, match="Unknown language"):
-        pm.plot_barrier_geometry(
+        pm.environment.plot_barrier_geometry(
             source_height=1.5, barrier_distance=5.0, barrier_height=3.0,
             receiver_distance=20.0, receiver_height=1.5, language="pt",
         )
 
 
 def test_device_geometry_spanish_labels() -> None:
-    res = pm.barrier_insertion_loss(FREQ, 1.5, 5.0, 3.0, 20.0, 1.5)
+    res = pm.environment.barrier_insertion_loss(FREQ, 1.5, 5.0, 3.0, 20.0, 1.5)
     ax = res.plot_geometry(language="es")
     texts = " ".join(t.get_text() for t in ax.texts) + " " + " ".join(
         t.get_text() for t in ax.get_legend().get_texts()

--- a/tests/test_multichannel_rejection.py
+++ b/tests/test_multichannel_rejection.py
@@ -19,10 +19,10 @@ _STEREO = np.zeros((2, 4800))
 @pytest.mark.parametrize(
     "analyze",
     [
-        ph.loudness_ecma,
-        ph.tonality_ecma,
-        ph.roughness_ecma,
-        ph.loudness_moore_glasberg,
+        ph.psychoacoustics.loudness_ecma,
+        ph.psychoacoustics.tonality_ecma,
+        ph.psychoacoustics.roughness_ecma,
+        ph.psychoacoustics.loudness_moore_glasberg,
     ],
     ids=["loudness_ecma", "tonality_ecma", "roughness_ecma", "moore_glasberg"],
 )

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -134,9 +134,18 @@ _KWARG_PLOT_CASES = [
     ("reverb_power", _reverb_power, "bar"),
     ("intensity_power", _intensity_power_negative, "bar"),
     ("intensity", _intensity, "line"),
-    ("decay_curve", lambda: ph.decay_curve(_exp_ir(seconds=1.0, t60=0.6), FS), "line"),
-    ("facade", lambda: ph.facade_insulation(
-        [70.0, 72.0, 74.0], [40.0, 41.0, 42.0], [0.5, 0.5, 0.5]), "line"),
+    (
+        "decay_curve",
+        lambda: ph.room.decay_curve(_exp_ir(seconds=1.0, t60=0.6), FS),
+        "line",
+    ),
+    (
+        "facade",
+        lambda: ph.building.facade_insulation(
+            [70.0, 72.0, 74.0], [40.0, 41.0, 42.0], [0.5, 0.5, 0.5]
+        ),
+        "line",
+    ),
     ("open_plan", _open_plan, "line"),
     ("outdoor", _outdoor, "line"),
     ("cnossos_road", _cnossos_road, "bar"),

--- a/tests/test_secondary_geometry_plots.py
+++ b/tests/test_secondary_geometry_plots.py
@@ -31,51 +31,53 @@ def _close_figures():
 
 def test_facade_result_retains_elements_and_draws() -> None:
     elements = [
-        pm.FacadeElement("Masonry wall", area=6.0, r=[50.0] * 5),
-        pm.FacadeElement("Window", area=1.5, r=[30.0] * 5),
+        pm.building.FacadeElement("Masonry wall", area=6.0, r=[50.0] * 5),
+        pm.building.FacadeElement("Window", area=1.5, r=[30.0] * 5),
     ]
-    res = pm.facade_sound_reduction(
+    res = pm.building.facade_sound_reduction(
         elements, area=7.5, volume=30.0, frequencies=FREQ
     )
     assert res.elements == tuple(elements)
     assert res.plot_geometry() is not None
     with pytest.raises(ValueError, match="at least one"):
-        pm.plot_facade_elements([])
+        pm.building.plot_facade_elements([])
 
 
 def test_double_wall_result_retains_geometry_and_draws() -> None:
-    res = pm.double_wall_transmission_loss(FREQ, 8.8, 8.8, 0.1)
+    res = pm.building.double_wall_transmission_loss(FREQ, 8.8, 8.8, 0.1)
     assert res.gap == pytest.approx(0.1)
     assert res.plot_geometry() is not None
-    single = pm.single_panel_transmission_loss(
+    single = pm.building.single_panel_transmission_loss(
         FREQ, 10.0, critical_frequency=1200.0
     )
     with pytest.raises(ValueError, match="does not retain"):
         single.plot_geometry()
     with pytest.raises(ValueError, match="positive"):
-        pm.plot_double_wall_geometry(0.0, 8.8, 0.1)
+        pm.building.plot_double_wall_geometry(0.0, 8.8, 0.1)
 
 
 def test_junction_result_retains_thicknesses_and_draws() -> None:
-    res = pm.junction_transmission(
+    res = pm.vibration.junction_transmission(
         "T1", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0
     )
     assert res.thickness1 == pytest.approx(0.14)
     assert res.plot_geometry() is not None
     for junction in ("L", "T1", "T2", "X"):
-        assert pm.plot_junction_geometry(junction, 0.14, 0.2) is not None
+        assert (
+            pm.building.plot_junction_geometry(junction, 0.14, 0.2) is not None
+        )
     with pytest.raises(ValueError, match="junction"):
-        pm.plot_junction_geometry("Y", 0.14, 0.2)
+        pm.building.plot_junction_geometry("Y", 0.14, 0.2)
 
 
 def test_insitu_setup_defaults_and_retention() -> None:
-    assert pm.plot_insitu_geometry() is not None
+    assert pm.materials.plot_insitu_geometry() is not None
     with pytest.raises(ValueError, match="mic_height"):
-        pm.plot_insitu_geometry(source_height=0.2, mic_height=0.25)
+        pm.materials.plot_insitu_geometry(source_height=0.2, mic_height=0.25)
     fs = 48000
     impulse = np.zeros(2048)
     impulse[100] = 1.0
-    res = pm.insitu_absorption_spectrum(
+    res = pm.materials.insitu_absorption_spectrum(
         impulse, 0.4 * impulse, fs, source_height=1.25, mic_height=0.25
     )
     assert res.source_height == pytest.approx(1.25)
@@ -83,28 +85,28 @@ def test_insitu_setup_defaults_and_retention() -> None:
 
 
 def test_dynamic_stiffness_rig_draws_and_validates() -> None:
-    assert pm.plot_dynamic_stiffness_rig() is not None
+    assert pm.materials.plot_dynamic_stiffness_rig() is not None
     with pytest.raises(ValueError, match="positive"):
-        pm.plot_dynamic_stiffness_rig(load_mass=0.0)
+        pm.materials.plot_dynamic_stiffness_rig(load_mass=0.0)
 
 
 def test_goniometer_microphone_count() -> None:
-    ax = pm.plot_goniometer_geometry()
+    ax = pm.materials.plot_goniometer_geometry()
     counts = [len(c.get_offsets()) for c in ax.collections]
     assert 37 in counts
     with pytest.raises(ValueError, match="angular_step"):
-        pm.plot_goniometer_geometry(angular_step=0.0)
+        pm.materials.plot_goniometer_geometry(angular_step=0.0)
 
 
 def test_plate_geometry_from_result() -> None:
-    res = pm.radiation_efficiency(FREQ, 1.2, 0.8, 1000.0)
+    res = pm.vibration.radiation_efficiency(FREQ, 1.2, 0.8, 1000.0)
     assert res.plot_geometry() is not None
     with pytest.raises(ValueError, match="positive"):
-        pm.plot_plate_geometry(0.0, 0.8)
+        pm.vibration.plot_plate_geometry(0.0, 0.8)
 
 
 def test_open_plan_result_retains_positions_and_draws() -> None:
-    res = pm.open_plan_metrics(
+    res = pm.room.open_plan_metrics(
         [2.0, 4.0, 6.0, 8.0, 12.0],
         [55.0, 51.0, 48.0, 46.0, 43.0],
         [0.9, 0.72, 0.6, 0.5, 0.35],
@@ -112,7 +114,7 @@ def test_open_plan_result_retains_positions_and_draws() -> None:
     assert res.positions_m is not None
     assert res.plot_geometry() is not None
     with pytest.raises(ValueError, match="at least two"):
-        pm.plot_open_plan_geometry([3.0])
+        pm.room.plot_open_plan_geometry([3.0])
 
 
 def test_intensity_result_retains_spacing_and_draws() -> None:
@@ -120,18 +122,18 @@ def test_intensity_result_retains_spacing_and_draws() -> None:
     t = np.arange(fs // 4) / fs
     p1 = np.sin(2.0 * np.pi * 500.0 * t)
     p2 = np.sin(2.0 * np.pi * 500.0 * t - 0.05)
-    res = pm.sound_intensity(p1, p2, fs, spacing=0.012)
+    res = pm.emission.sound_intensity(p1, p2, fs, spacing=0.012)
     assert res.spacing == pytest.approx(0.012)
     assert res.plot_geometry() is not None
-    assert pm.plot_pp_probe_geometry() is not None
+    assert pm.emission.plot_pp_probe_geometry() is not None
     with pytest.raises(ValueError, match="spacing"):
-        pm.plot_pp_probe_geometry(0.0)
+        pm.emission.plot_pp_probe_geometry(0.0)
 
 
 def test_secondary_geometry_spanish_labels() -> None:
-    ax = pm.plot_dynamic_stiffness_rig(language="es")
+    ax = pm.materials.plot_dynamic_stiffness_rig(language="es")
     texts = " ".join(t.get_text() for t in ax.texts) + ax.get_title()
     assert "Probeta" in texts
     assert "Banco de rigidez dinámica" in ax.get_title()
     with pytest.raises(ValueError, match="Unknown language"):
-        pm.plot_goniometer_geometry(language="ca")
+        pm.materials.plot_goniometer_geometry(language="ca")


### PR DESCRIPTION
Follows #592, which moved the flat `from phonometry import` imports. This is
the same change in the other form the tree uses:

```diff
 import phonometry as ph
-res = ph.room_parameters(ir, fs)
+res = ph.room.room_parameters(ir, fs)
```

## Why it was missed

The first pass looked at import statements, and this form has nothing wrong
with its import: `import phonometry as ph` is exactly right and stays. What
moved is the call site.

Nothing could tell until the top level actually stopped re-exporting. `ph.leq`
resolves happily while the shortcut is there, so no gate had an opinion; the
type checker found all of it in minutes on a tree with the shortcut removed,
which is how this came to light. Seventy-eight files and about sixteen hundred
call sites, the conformance runner and the report-fiche scripts being most of
it.

## Verification

`ruff check .` and `mypy src scripts stub/src` clean. No behaviour touched:
`ph.signals.leq` and `ph.leq` are the same function object.

The figure package was checked rather than assumed. Every one of its
forty-six modules was compared against its committed version after erasing
the package spelling on both sides, so `ph.signals.leq(x)` and `ph.leq(x)`
reduce to the same thing while a call to a *different* function would still
show. None differ, and the clip fingerprints are unmoved, so the freshness
gate passes without a re-stamp.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Route package-root imports through their owning phonometry subpackages throughout the repository while preserving behavior and public function identity.

Enhancements:
- Update tests, conformance checks, benchmarks, figure generators, and report scripts to access public APIs through their owning package modules instead of top-level re-exports.
- Align result and model type references with their package namespaces across the codebase.

Tests:
- Revise the test suite and conformance tooling to validate the package-qualified API paths without changing numerical behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated benchmark, reporting, conformance, and test workflows to use organized domain-specific API namespaces.
  - Improved consistency across aircraft, environmental, building, materials, signals, psychoacoustics, and other analysis areas.
  - Preserved existing calculations, expected results, validation behavior, and report outputs.
- **Tests**
  - Updated coverage for namespaced APIs while retaining existing assertions and behavior checks.
  - Expanded plot-test separation for clearer validation of rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->