### PR TITLE
Run the checks on a pull request whatever branch it targets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,8 +39,12 @@ on:
       - ".zenodo.json"
       - ".github/workflows/docs.yml"
   pull_request:
-    branches: ["main"]
-    # Deliberately the same set as the push trigger above, spelled out because
+    # No base-branch filter: a pull request stacked on another branch has to
+    # build the site too, and it is the one most likely to break it. See the
+    # note in python-app.yml; the `push` trigger above stays on main, so
+    # nothing runs twice.
+    #
+    # The paths below are deliberately the same set as the push trigger, spelled out because
     # GitHub Actions does not resolve YAML anchors. Keep the two lists in step:
     # a path that deploys on push but is not validated here would be exactly the
     # blind spot this trigger exists to close.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,8 +3,19 @@ name: Python CI
 on:
   push:
     branches: [ "master", "main" ]
+  # No base-branch filter, deliberately. A pull request that targets another
+  # branch is the bottom half of a stack, and it is the half that still has to
+  # be reviewed and merged: with `branches` set to main it arrived with four
+  # checks instead of the thirty this workflow runs, and the gates only spoke
+  # once it was already at the front of the queue.
+  #
+  # This does not double any run. The `push` trigger above is limited to the
+  # two trunk branches, so a commit on a working branch fires `pull_request`
+  # alone and a commit on main fires `push` alone. The two jobs that care which
+  # one it was, `sonar` and `pr-comment`, key on `github.event_name` rather
+  # than on the base, so they behave for a stacked pull request exactly as they
+  # do for any other.
   pull_request:
-    branches: [ "master", "main" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Both workflows filtered `pull_request` by base branch, so a pull request stacked
on another branch got four checks instead of the thirty this repository runs.
That is the half of a stack that still has to be reviewed and merged, and it
arrived with every gate silent: they only spoke once it reached the front of the
queue and GitHub retargeted it at main, which is the last moment anything can be
learned from them. #591 and #592 both spent their review with four checks for
this reason.

```diff
   pull_request:
-    branches: [ "master", "main" ]
```

## Nothing runs twice

Checked before making the change, because a doubled matrix here is expensive:

- `push` stays limited to `master` and `main` in both workflows. A commit on a
  working branch therefore fires `pull_request` alone; a commit on main fires
  `push` alone. One run per commit either way, exactly as now.
- The only workflow with an unfiltered `push` is `joss-paper.yml`, which has no
  `pull_request` trigger at all, so there is no overlap to create.
- The two jobs that care which event fired, `sonar` and `pr-comment`, key on
  `github.event_name` rather than on the base branch, so a stacked pull request
  gets the same treatment as any other.

## What is not changed

`docs.yml` keeps its `paths` filter. That is a different question and still the
right one: the site is rebuilt when something the site is built from changes,
and the comment saying to keep the two path lists in step still applies.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated GitHub Actions workflows (docs.yml and python-app.yml) to remove base-branch filters on pull requests, enabling CI for stacked pull requests.</li>
<li>Refactored phonometry API calls in scripts/bench.py to use top-level functions instead of submodule-specific calls (e.g., ph.noise_contour instead of ph.aircraft.noise_contour).</li>
<li>Extensive refactoring across conformance scripts and reports to update API usage and potentially improve modularity.</li>
<li>Updated numerous test files to reflect API changes and ensure continued coverage.</li>
</ul></div>