### PR TITLE
Let a caller name the curve instead of colliding with our label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A caller can name a curve. `label` is an ordinary matplotlib keyword and
+  arrives through `**kwargs` like `color` or `linewidth`, but fifty-five
+  renderers also passed one by name in the same call, so `result.plot(label=
+  "mine")` raised `TypeError: got multiple values for keyword argument
+  'label'` instead of drawing a labelled curve. Six of the thirty-two result
+  types the plotting contract covers failed outright; the rest were one
+  argument away from it.
+
+  They use `kwargs.setdefault("label", ...)` now, which is what the same
+  renderers already do for `color` and `marker`: the caller's label wins and
+  the generated one still appears when there is none. Two renderers draw one
+  bar per item, each with its own name, and take a copy of the keywords per
+  bar rather than one default before the loop, which would have put the first
+  item's label on all of them.
+
+  The plotting contract test now checks `label` alongside `color`, through the
+  legend rather than the artist: `ax.bar` puts the label on the container it
+  returns, not on each rectangle, so reading `ax.patches` would have missed it
+  on every bar renderer and let this back in.
+
 - `plot_excitation` is exported by `phonometry.room`, the package that owns it.
   It was the one of the twenty-four plotting helpers that no domain published:
   it is defined in the private `_plot.room`, the top level re-exported it, and

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -278,7 +278,8 @@ def plot_sound_reduction(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("markersize", 3)
-    ax.semilogx(freq, r, label=_t("predicted $R$", language), **kwargs)
+    kwargs.setdefault("label", _t("predicted $R$", language))
+    ax.semilogx(freq, r, **kwargs)
     if result.critical_frequency is not None:
         symbol = "$f_{c1}$" if result.critical_frequency_upper is not None else "$f_\\mathrm{c}$"
         ax.axvline(
@@ -341,7 +342,8 @@ def plot_aperture_transmission(
     freq = np.asarray(result.frequencies, dtype=np.float64)
     r = np.asarray(result.transmission_loss, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.semilogx(freq, r, label=f"{result.kind} {_t('aperture $R$', language)}", **kwargs)
+    kwargs.setdefault("label", f"{result.kind} {_t('aperture $R$', language)}")
+    ax.semilogx(freq, r, **kwargs)
     ax.axhline(0.0, color=_C_MUTED, ls=":", lw=0.9)
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
     ax.set_xlabel(_t(_FREQ_LABEL, language))
@@ -854,7 +856,8 @@ def plot_installed_structure_borne(
                 label=_t("paths", language) if k == 0 else None)
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 2.2)
-    ax.plot(x, total, label=_t(r"total $L_\mathrm{n,s}$", language), **kwargs)
+    kwargs.setdefault("label", _t(r"total $L_\mathrm{n,s}$", language))
+    ax.plot(x, total, **kwargs)
     ax.set_ylabel(_t(r"Normalised SPL $L_\mathrm{n,s}$ [dB]", language))
     ax.set_title(_t("EN 12354-5 installed structure-borne sound", language))
     ax.legend(loc="best", fontsize="small")
@@ -994,14 +997,20 @@ def _plot_path_shares(
     bottom = np.zeros(positions.size, dtype=np.float64)
     for colour, k in zip(palette, named):
         share = 100.0 * fractions[k]
+        # A copy per bar, not one `setdefault` before the loop: this renderer
+        # draws one bar per transmission path and each carries its own name,
+        # so a single default would put the first path's label on all of them.
+        path_kwargs = dict(kwargs)
+        path_kwargs.setdefault("label", labels[k])
         ax.bar(positions, share, bottom=bottom, width=0.85, color=colour,
-               edgecolor="none", zorder=0, label=labels[k], **kwargs)
+               edgecolor="none", zorder=0, **path_kwargs)
         bottom = bottom + share
     if pooled:
         share = 100.0 * fractions[pooled].sum(axis=0)
+        pooled_kwargs = dict(kwargs)
+        pooled_kwargs.setdefault("label", _t("other paths", language))
         ax.bar(positions, share, bottom=bottom, width=0.85, color=_C_MUTED,
-               edgecolor="none", zorder=0, label=_t("other paths", language),
-               **kwargs)
+               edgecolor="none", zorder=0, **pooled_kwargs)
     ax.set_ylabel(_t(_SHARE_LABEL, language))
     ax.set_ylim(0.0, 100.0)
     ax.set_title(title)
@@ -1096,7 +1105,8 @@ def plot_in_situ_element(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("ms", 4)
-    ax.plot(freqs, result.sound_reduction_index, label=r"$R_\mathrm{situ}$", **kwargs)
+    kwargs.setdefault("label", r"$R_\mathrm{situ}$")
+    ax.plot(freqs, result.sound_reduction_index, **kwargs)
     ax.plot(freqs, result.impact_level, color=_C_SECONDARY, marker="s", ms=4,
             label=r"$L_\mathrm{n,situ}$")
     ax.set_xscale("log")
@@ -1411,7 +1421,8 @@ def _plot_shaded_band_pair(
             label=_t(reference_label, language))
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
-    ax.plot(positions, curve, "-", label=_t(curve_label, language), **kwargs)
+    kwargs.setdefault("label", _t(curve_label, language))
+    ax.plot(positions, curve, "-", **kwargs)
     ax.fill_between(
         positions, reference, curve,
         color=theme_fill(_C_SECONDARY, ax), lw=0, zorder=0,
@@ -1451,7 +1462,8 @@ def plot_heavy_impact_source(
             label=_t("nominal $L_{FE}$", language))
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
-    ax.plot(positions, result.measured, "-", label=_t("measured $L_{FE}$", language),
+    kwargs.setdefault("label", _t("measured $L_{FE}$", language))
+    ax.plot(positions, result.measured, "-",
             **kwargs)
     failing = ~result.within_tolerance
     if bool(np.any(failing)):
@@ -1523,8 +1535,9 @@ def plot_a_weighted_maximum_impact(
     ax = ax if ax is not None else _new_axes()
     positions = _band_axis(ax, result.frequencies, language=language)
     kwargs.setdefault("color", _C_PRIMARY)
+    kwargs.setdefault("label", _t("A-weighted contribution", language))
     ax.bar(positions, result.corrected, width=0.7, zorder=2,
-           label=_t("A-weighted contribution", language), **kwargs)
+           **kwargs)
     ax.plot(positions, result.levels, "s--", color=_C_REFERENCE, lw=1.2, zorder=3,
             label=_t(r"$X_\mathrm{i,Fmax}$ (unweighted)", language))
     ax.axhline(result.rating, color=_C_SECONDARY, ls="-", lw=1.6, zorder=4,
@@ -1633,8 +1646,9 @@ def plot_wall_tie_coupling(
     ax.loglog(freq, result.rigid_coupling_loss_factor, "--", color=_C_REFERENCE,
               lw=1.2, label=_t("rigid connection ($Y_\\mathrm{c}$ = 0)", language))
     kwargs.setdefault("color", _C_PRIMARY)
+    kwargs.setdefault("label", _t("resilient tie array", language))
     ax.loglog(freq, result.coupling_loss_factor,
-              label=_t("resilient tie array", language), **kwargs)
+              **kwargs)
     ax.fill_between(
         freq, result.coupling_loss_factor, result.rigid_coupling_loss_factor,
         color=theme_fill(_C_TERTIARY, ax), lw=0, zorder=0,
@@ -1679,7 +1693,8 @@ def _plot_improvement_spectrum(
     kwargs.setdefault("color", colour)
     kwargs.setdefault("ls", style)
     # The caller may name the curve; do not hand matplotlib two labels.
-    ax.plot(freqs, values, label=kwargs.pop("label", _t(label, language)), **kwargs)
+    kwargs.setdefault("label", kwargs.pop("label", _t(label, language)))
+    ax.plot(freqs, values, **kwargs)
     for values, label, colour, style in rest:
         ax.plot(freqs, values, color=colour, ls=style, label=_t(label, language))
     if marker_frequency is not None:
@@ -1716,8 +1731,8 @@ def plot_tapping_force(
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
+    kwargs.setdefault("label", kwargs.pop("label", _t("force spectrum $|F_n|$", language)))
     ax.plot(freqs, result.peak_force,
-            label=kwargs.pop("label", _t("force spectrum $|F_n|$", language)),
             **kwargs)
     ax.axhline(result.upper_limit, color=_C_REFERENCE, ls="--", lw=1.2,
                label=r"$|F_n|_\mathrm{upper}$")
@@ -1841,7 +1856,8 @@ def plot_lining_improvement(
     ]
     curves = np.asarray(ratings, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.plot(sweep, curves[:, 0], label=kwargs.pop("label", r"$\Delta R_\mathrm{w}$"), **kwargs)
+    kwargs.setdefault("label", kwargs.pop("label", r"$\Delta R_\mathrm{w}$"))
+    ax.plot(sweep, curves[:, 0], **kwargs)
     ax.plot(sweep, curves[:, 1], color=_C_SECONDARY, ls="--", label=r"$\Delta R_\mathrm{A}$")
     ax.plot(sweep, curves[:, 2], color=_C_TERTIARY, ls="-.", label=r"$\Delta R_\mathrm{A,tr}$")
     ax.plot([result.resonance_frequency], [result.delta_rw], marker="o", ms=8,

--- a/src/phonometry/_plot/environment.py
+++ b/src/phonometry/_plot/environment.py
@@ -261,7 +261,8 @@ def plot_impulse_prominence(
 
     kwargs.setdefault("color", _C_PRIMARY_LIGHT)
     kwargs.setdefault("zorder", 3)
-    ax.scatter(per, impulse_adjustment(per), label=_t("Impulses", language), **kwargs)
+    kwargs.setdefault("label", _t("Impulses", language))
+    ax.scatter(per, impulse_adjustment(per), **kwargs)
     ax.scatter([result.prominence], [result.adjustment], color=_C_REFERENCE,
                zorder=4, s=90, marker="*",
                label=f"{_t('Governing', language)}  $P$ = {format_number(result.prominence, language, decimals=2)},  "
@@ -303,9 +304,10 @@ def plot_tonal_adjustment(
     kwargs.setdefault("zorder", 4)
     kwargs.setdefault("s", 90)
     kwargs.setdefault("marker", "*")
+    kwargs.setdefault("label", rf"$\Delta L_\mathrm{{ta}}$ = {format_number(result.audibility, language)} dB,  "
+                     rf"$K_\mathrm{{t}}$ = {format_number(result.adjustment, language)} dB")
     ax.scatter([result.audibility], [result.adjustment],
-               label=rf"$\Delta L_\mathrm{{ta}}$ = {format_number(result.audibility, language)} dB,  "
-                     rf"$K_\mathrm{{t}}$ = {format_number(result.adjustment, language)} dB", **kwargs)
+               **kwargs)
     ax.set_xlabel(_t("Tonal audibility $\\Delta L_\\mathrm{ta}$ [dB]", language))
     ax.set_ylabel(_t("Tonal adjustment $K_\\mathrm{t}$ [dB]", language))
     ax.set_title(_t("ISO 1996-2 tonal adjustment", language))

--- a/src/phonometry/_plot/geometry/electroacoustics.py
+++ b/src/phonometry/_plot/geometry/electroacoustics.py
@@ -283,8 +283,9 @@ def plot_sound_reinforcement_geometry(
     kwargs.setdefault("color", _C_SECONDARY)
     kwargs.setdefault("linewidth", 1.4)
     kwargs.setdefault("linestyle", "--")
+    kwargs.setdefault("label", _t("Feedback path", language))
     ax.plot([h_xy[0], m_xy[0]], [h_xy[1], 0.62], zorder=4,
-            label=_t("Feedback path", language), **kwargs)
+            **kwargs)
 
     for (x0, y0), (x1, y1), value, dy in (
         (t_xy, (m_xy[0], 0.5), d_tm, 0.16),

--- a/src/phonometry/_plot/hearing.py
+++ b/src/phonometry/_plot/hearing.py
@@ -90,7 +90,8 @@ def plot_age_threshold(
 
     _fractile_band(ax, freqs, median, sl, su, color=_C_PRIMARY, language=language)
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.plot(freqs, median, "o-", label=_t("Median", language), **kwargs)
+    kwargs.setdefault("label", _t("Median", language))
+    ax.plot(freqs, median, "o-", **kwargs)
     if abs(result.fractile - 0.5) > 1e-9:
         ax.plot(freqs, np.asarray(result.threshold, dtype=np.float64), "s--",
                 color=_C_REFERENCE, label=_t(_FRACTILE_LABEL, language).format(
@@ -133,7 +134,8 @@ def plot_nipts(
         language=language,
     )
     kwargs.setdefault("color", _C_SECONDARY)
-    ax.plot(freqs, median, "o-", label=_t("Median $N_{50}$", language), **kwargs)
+    kwargs.setdefault("label", _t("Median $N_{50}$", language))
+    ax.plot(freqs, median, "o-", **kwargs)
     if abs(result.fractile - 0.5) > 1e-9:
         ax.plot(freqs, np.asarray(result.value, dtype=np.float64), "s--",
                 color=_C_REFERENCE, label=_t(_FRACTILE_LABEL, language).format(
@@ -176,8 +178,9 @@ def plot_htlan(
     ax.plot(freqs, np.asarray(result.nipts, dtype=np.float64), "^-",
             color=_C_SECONDARY, label=_t("Noise (NIPTS)", language))
     kwargs.setdefault("color", _C_REFERENCE)
+    kwargs.setdefault("label", _t("Age + noise (HTLAN)", language))
     ax.plot(freqs, np.asarray(result.threshold, dtype=np.float64), "s--",
-            label=_t("Age + noise (HTLAN)", language), **kwargs)
+            **kwargs)
     _freq_axis(ax, freqs, language=language)
     ax.set_xlabel(_t(_FREQ_LABEL, language))
     ax.set_ylabel(_t("Hearing threshold level [dB]", language))

--- a/src/phonometry/_plot/materials.py
+++ b/src/phonometry/_plot/materials.py
@@ -318,7 +318,8 @@ def plot_scattering_report(
     )
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.plot(positions, s, ms=4, zorder=3, label=r"$s$", **kwargs)
+    kwargs.setdefault("label", r"$s$")
+    ax.plot(positions, s, ms=4, zorder=3, **kwargs)
     ax.set_ylabel(_t("Coefficient", language))
     top = max(1.05, float(np.nanmax(s)) * 1.05) if s.size else 1.05
     ax.set_ylim(0.0, top)
@@ -366,7 +367,8 @@ def plot_diffusion_report(
         )
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.plot(positions, d, ms=4, zorder=3, label=r"$d$", **kwargs)
+    kwargs.setdefault("label", r"$d$")
+    ax.plot(positions, d, ms=4, zorder=3, **kwargs)
     ax.set_ylabel(_t("Coefficient", language))
     ax.set_ylim(0.0, 1.05)
     ax.set_title(
@@ -472,10 +474,10 @@ def plot_dynamic_stiffness(
     kwargs.setdefault("color", _C_REFERENCE)
     kwargs.setdefault("zorder", 5)
     kwargs.setdefault("s", 80)
-    ax.scatter([s_mn], [result.natural_frequency],
-               label=(rf"$s^{{\prime}}$ = {format_number(s_mn, language, decimals=2)} MN/m³,  "
+    kwargs.setdefault("label", rf"$s^{{\prime}}$ = {format_number(s_mn, language, decimals=2)} MN/m³,  "
                       f"$f_0$ = "
-                      f"{format_number(result.natural_frequency, language, decimals=1)} Hz"),
+                      f"{format_number(result.natural_frequency, language, decimals=1)} Hz")
+    ax.scatter([s_mn], [result.natural_frequency],
                **kwargs)
     ax.set_xscale("log")
     ax.set_xlabel(_t(r"Dynamic stiffness per unit area $s^{\prime}$ [MN/m³]", language))
@@ -668,12 +670,12 @@ def _absorption_reflection_axes(
     reflection-factor magnitude as a muted dashed companion, then adds the
     legend. Used by the layered-absorber and slit-resonator predictions.
     """
+    kwargs.setdefault("label", _t(r"Absorption $\alpha(\theta)$", language))
     ax = _absorption_spectrum_axes(
         ax,
         freqs,
         alpha,
         title=title,
-        label=_t(r"Absorption $\alpha(\theta)$", language),
         language=language,
         **kwargs,
     )
@@ -880,12 +882,12 @@ def plot_diffuse_field_absorption(
                  f"{format_number(float(limit_deg), language, decimals=0)}°)")
     else:
         title = f"Random-incidence absorption (Paris integral to {limit_deg:.0f}°)"
+    kwargs.setdefault("label", _t(r"Absorption $\alpha_{\mathrm{dif}}$", language))
     ax = _absorption_spectrum_axes(
         ax,
         np.asarray(result.frequency, dtype=np.float64),
         np.asarray(result.absorption, dtype=np.float64),
         title=title,
-        label=_t(r"Absorption $\alpha_{\mathrm{dif}}$", language),
         language=language,
         **kwargs,
     )
@@ -1013,12 +1015,12 @@ def plot_metadiffuser_absorption(
     :return: The axes.
     """
     freqs = np.asarray(result.frequency, dtype=np.float64)
+    kwargs.setdefault("label", _t("Panel average", language))
     ax = _absorption_spectrum_axes(
         ax,
         freqs,
         np.asarray(result.absorption, dtype=np.float64),
         title=_t("Metadiffuser per-well absorption", language),
-        label=_t("Panel average", language),
         language=language,
         **kwargs,
     )

--- a/src/phonometry/_plot/metrology.py
+++ b/src/phonometry/_plot/metrology.py
@@ -250,7 +250,8 @@ def plot_trend_test(
     kwargs.setdefault("lw", 1.2)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("ms", 4.5)
-    ax.plot(index, result.values, label=label, **kwargs)
+    kwargs.setdefault("label", label)
+    ax.plot(index, result.values, **kwargs)
     if result.method == "runs" and result.median is not None:
         # The runs test classifies each value against the median of the
         # *original* sequence (before values equal to it were discarded),
@@ -296,7 +297,8 @@ def plot_stationarity_test(
     kwargs.setdefault("lw", 1.2)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("ms", 4.5)
-    ax.plot(index, result.segment_values, label=label, **kwargs)
+    kwargs.setdefault("label", label)
+    ax.plot(index, result.segment_values, **kwargs)
     if result.method == "runs":
         _draw_sequence_median(
             ax, float(np.median(result.segment_values)), language
@@ -336,9 +338,10 @@ def plot_level_crossing_rate(
     )
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("ms", 6.0)
+    kwargs.setdefault("label", _t("Measured rate", language))
     ax.plot(
         result.levels, result.rates, "o",
-        label=_t("Measured rate", language), **kwargs,
+        **kwargs,
     )
     ax.set_yscale("log")
     ax.set_xlabel(_t("Level $a$ [signal units]", language))
@@ -393,9 +396,10 @@ def plot_peak_statistics(
     )
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 1.2)
+    kwargs.setdefault("label", _t("Empirical peak exceedance", language))
     ax.plot(
         peaks, exceedance, drawstyle="steps-post",
-        label=_t("Empirical peak exceedance", language), **kwargs,
+        **kwargs,
     )
     floor = max(1.0 / peaks.size, 1e-6)
     ax.set_yscale("log")

--- a/src/phonometry/_plot/psychoacoustics.py
+++ b/src/phonometry/_plot/psychoacoustics.py
@@ -219,7 +219,8 @@ def plot_zwicker_loudness_time(
     time = np.asarray(result.time, dtype=np.float64)
     lvt = np.asarray(result.loudness_vs_time, dtype=np.float64)
     kwargs.setdefault("color", _C_TERTIARY)
-    ax_time.plot(time, lvt, label="$N(t)$", **kwargs)
+    kwargs.setdefault("label", "$N(t)$")
+    ax_time.plot(time, lvt, **kwargs)
     if result.n5 is not None:
         ax_time.axhline(
             result.n5, color=_C_REFERENCE, ls="--", lw=1,
@@ -362,7 +363,8 @@ def plot_moore_glasberg_time_loudness(
             label=_t("Short-term loudness", language))
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 1.8)
-    ax.plot(time, ltl, label=_t("Long-term loudness", language), **kwargs)
+    kwargs.setdefault("label", _t("Long-term loudness", language))
+    ax.plot(time, ltl, **kwargs)
     ax.axhline(result.n_max, color=_C_REFERENCE, ls="--", lw=1.0, alpha=0.7)
     ax.set_xlabel(_t(_AXIS_TIME, language))
     ax.set_ylabel(_t("Loudness [sone]", language))
@@ -723,8 +725,9 @@ def plot_tone_assessment(
     kwargs.setdefault("linestyle", "none")
     kwargs.setdefault("markersize", 9)
     kwargs.setdefault("color", _C_PRIMARY)
+    kwargs.setdefault("label", _t("assessed tone", language))
     ax.plot([ft], [ratio], markeredgecolor=_C_EDGE, zorder=4,
-            label=_t("assessed tone", language), **kwargs)
+            **kwargs)
     ax.annotate(
         _t("margin {m} dB", language).format(
             m=format_number(ratio - criterion, language, decimals=1),
@@ -859,9 +862,10 @@ def plot_tone_audibility_levels(
         )
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("linestyle", "none")
+    kwargs.setdefault("label", _t(r"tone level $L_{p\mathrm{t}}$", language))
     ax.plot(
         freqs, lt, color=_C_PRIMARY, markeredgecolor=_C_EDGE, zorder=4,
-        label=_t(r"tone level $L_{p\mathrm{t}}$", language), **kwargs,
+        **kwargs,
     )
     ax.plot(
         [freqs[decisive]], [lt[decisive]], marker="o", linestyle="none",

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -510,13 +510,13 @@ def plot_reverberation_models(
         ("Arau-Puchades", result.arau_puchades, _C_PRIMARY, "o", 2.4),
     )
     for label, curve, color, marker, lw in styles:
+        kwargs.setdefault("label", label)
         ax.plot(
             freq,
             np.asarray(curve, dtype=np.float64),
             color=color,
             marker=marker,
             lw=lw,
-            label=label,
             **kwargs,
         )
     _freq_axis(ax, freq, language=language)
@@ -748,8 +748,9 @@ def plot_image_source_reflectogram(
         cbar.set_label(_t("Reflection order", language))
     ax.vlines(ms[order0], -120.0, level[order0], color=_C_PRIMARY, lw=1.6,
               zorder=4)
+    kwargs.setdefault("label", _t("Direct sound", language))
     ax.plot(ms[order0], level[order0], "o", color=_C_PRIMARY, ms=7, zorder=5,
-            label=_t("Direct sound", language), **kwargs)
+            **kwargs)
 
     lx, ly, lz = result.dimensions
     # A bare ``:g`` never reaches the locale pass (``localize_axes`` reformats
@@ -805,8 +806,9 @@ def plot_steady_field(
             color=_C_TERTIARY, ls=":", lw=1.4, label=_t("Reverberant field", language))
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 2.4)
+    kwargs.setdefault("label", _t("Total", language))
     ax.plot(r, np.asarray(result.total, dtype=np.float64),
-            label=_t("Total", language), **kwargs)
+            **kwargs)
     ax.axvline(result.critical_distance, color=_C_REFERENCE, ls="-.", lw=1.2,
                label=rf"$r_\mathrm{{c}}$ = "
                      f"{format_number(result.critical_distance, language, decimals=2)} m")
@@ -973,8 +975,9 @@ def plot_room_modes(
         if not np.any(mask):
             continue
         row = rows[kind]
+        kwargs.setdefault("label", _t(kind, language))
         ladder.vlines(freqs[mask], row - 0.35, row + 0.35, color=colors[kind],
-                      lw=1.2, label=_t(kind, language), **kwargs)
+                      lw=1.2, **kwargs)
     ladder.set_ylim(0.4, 4.1)
     order = ("oblique", "tangential", "axial")
     ladder.set_yticks([rows[k] for k in order])
@@ -1042,10 +1045,10 @@ def plot_crowd_noise(
     levels = np.asarray(result.levels, dtype=np.float64)
     palette = (_C_PRIMARY, _C_SECONDARY, _C_TERTIARY, _C_QUATERNARY, _C_MUTED)
     for row, (area, curve) in enumerate(zip(result.absorption_areas, levels)):
+        kwargs.setdefault("label", _t(_ABSORPTION_AREA_LABEL, language).format(
+                value=format_number(float(area), language, decimals=0)))
         ax.plot(
             n, curve, color=palette[row % len(palette)], lw=1.8,
-            label=_t(_ABSORPTION_AREA_LABEL, language).format(
-                value=format_number(float(area), language, decimals=0)),
             **kwargs,
         )
     ax.axhline(

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -510,14 +510,17 @@ def plot_reverberation_models(
         ("Arau-Puchades", result.arau_puchades, _C_PRIMARY, "o", 2.4),
     )
     for label, curve, color, marker, lw in styles:
-        kwargs.setdefault("label", label)
+        # A copy per curve: `setdefault` mutates, so one before the loop would
+        # give every model the first one's name.
+        model_kwargs = dict(kwargs)
+        model_kwargs.setdefault("label", label)
         ax.plot(
             freq,
             np.asarray(curve, dtype=np.float64),
             color=color,
             marker=marker,
             lw=lw,
-            **kwargs,
+            **model_kwargs,
         )
     _freq_axis(ax, freq, language=language)
     ax.set_ylabel(_t(_REVERBERATION_TIME_LABEL, language))
@@ -975,9 +978,10 @@ def plot_room_modes(
         if not np.any(mask):
             continue
         row = rows[kind]
-        kwargs.setdefault("label", _t(kind, language))
+        kind_kwargs = dict(kwargs)
+        kind_kwargs.setdefault("label", _t(kind, language))
         ladder.vlines(freqs[mask], row - 0.35, row + 0.35, color=colors[kind],
-                      lw=1.2, **kwargs)
+                      lw=1.2, **kind_kwargs)
     ladder.set_ylim(0.4, 4.1)
     order = ("oblique", "tangential", "axial")
     ladder.set_yticks([rows[k] for k in order])
@@ -1045,11 +1049,12 @@ def plot_crowd_noise(
     levels = np.asarray(result.levels, dtype=np.float64)
     palette = (_C_PRIMARY, _C_SECONDARY, _C_TERTIARY, _C_QUATERNARY, _C_MUTED)
     for row, (area, curve) in enumerate(zip(result.absorption_areas, levels)):
-        kwargs.setdefault("label", _t(_ABSORPTION_AREA_LABEL, language).format(
+        area_kwargs = dict(kwargs)
+        area_kwargs.setdefault("label", _t(_ABSORPTION_AREA_LABEL, language).format(
                 value=format_number(float(area), language, decimals=0)))
         ax.plot(
             n, curve, color=palette[row % len(palette)], lw=1.8,
-            **kwargs,
+            **area_kwargs,
         )
     ax.axhline(
         result.signal_level, color=_C_EDGE, ls="--", lw=1.3,

--- a/src/phonometry/_plot/signals.py
+++ b/src/phonometry/_plot/signals.py
@@ -1026,8 +1026,9 @@ def plot_resampled_signal(
     kwargs.setdefault("color", _C_PRIMARY)
     if "lw" not in kwargs and "linewidth" not in kwargs:
         kwargs["lw"] = 1.2
+    kwargs.setdefault("label", _t("Anti-alias filter $|H(f)|$", language))
     ax.semilogx(freqs[view], mag_db[view],
-                label=_t("Anti-alias filter $|H(f)|$", language), **kwargs)
+                **kwargs)
     ax.axvline(result.passband_edge_hz, color=_C_TERTIARY, linestyle="--",
                lw=1.2, label=_t("Passband edge", language))
     ax.axvline(result.stopband_edge_hz, color=_C_SECONDARY, linestyle="--",
@@ -1360,9 +1361,10 @@ def plot_inverse_filter(
     color = kwargs.pop("color", _C_PRIMARY)
     f1, f2 = result.f_range
 
+    kwargs.setdefault("label", _t("Measured response $|H|$", language))
     ax.semilogx(
         freqs[pos], 20.0 * np.log10(np.maximum(h_mag[pos], tiny) / peak),
-        color=color, lw=1.2, label=_t("Measured response $|H|$", language),
+        color=color, lw=1.2,
         **kwargs,
     )
     ax.semilogx(
@@ -1409,10 +1411,10 @@ def plot_synchronous_average(
     def _waveform(axw: Axes) -> None:
         kwargs.setdefault("color", _C_PRIMARY)
         kwargs.setdefault("lw", 1.6)
+        kwargs.setdefault("label", _t("Averaged periodic waveform ($N$ = {n})", language,
+                     n=result.n_averages))
         axw.plot(
             1e3 * result.times, result.period_waveform,
-            label=_t("Averaged periodic waveform ($N$ = {n})", language,
-                     n=result.n_averages),
             **kwargs,
         )
         axw.set_xlabel(_t("Time [ms]", language))

--- a/src/phonometry/_plot/simulation.py
+++ b/src/phonometry/_plot/simulation.py
@@ -88,7 +88,8 @@ def _render_probe_lines(
     from .._i18n import localize_axes
 
     for trace, label in zip(traces, labels, strict=True):
-        ax.plot(t_ms, trace, label=label, **kwargs)
+        kwargs.setdefault("label", label)
+        ax.plot(t_ms, trace, **kwargs)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     ax.set_title(title)

--- a/src/phonometry/_plot/simulation.py
+++ b/src/phonometry/_plot/simulation.py
@@ -88,8 +88,9 @@ def _render_probe_lines(
     from .._i18n import localize_axes
 
     for trace, label in zip(traces, labels, strict=True):
-        kwargs.setdefault("label", label)
-        ax.plot(t_ms, trace, **kwargs)
+        trace_kwargs = dict(kwargs)
+        trace_kwargs.setdefault("label", label)
+        ax.plot(t_ms, trace, **trace_kwargs)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     ax.set_title(title)

--- a/src/phonometry/_plot/speech.py
+++ b/src/phonometry/_plot/speech.py
@@ -197,8 +197,9 @@ def plot_sii(
     # keep the zero bars rather than dividing 0/0 into NaN.
     peak = float(contribution.max()) if contribution.size else 0.0
     scaled = contribution / peak if peak > 0.0 else contribution
+    kwargs.setdefault("label", _t(r"Importance-weighted $I_i\,A_i$ (scaled)", language))
     ax.bar(positions, scaled, width=0.5,
-           label=_t(r"Importance-weighted $I_i\,A_i$ (scaled)", language), **kwargs)
+           **kwargs)
     ax.set_ylabel(_t("Band audibility", language))
     ax.set_ylim(0.0, 1.0)
     ax.set_title(_t(_SII_TITLE, language).format(

--- a/src/phonometry/_plot/underwater.py
+++ b/src/phonometry/_plot/underwater.py
@@ -621,8 +621,9 @@ def plot_eigenrays(
         if np.any(direct):
             ax.vlines(t[direct], base, loss[direct], color=_C_PRIMARY, lw=1.4,
                       zorder=4)
+            kwargs.setdefault("label", _t("Refracted or direct", language))
             ax.plot(t[direct], loss[direct], "o", color=_C_PRIMARY, ms=6,
-                    zorder=5, label=_t("Refracted or direct", language),
+                    zorder=5,
                     **kwargs)
         ax.set_ylim(base, float(loss.min()) - 3.0)
         ax.legend(loc=_LEGEND_LOWER_RIGHT, fontsize="small")

--- a/src/phonometry/_plot/vibration.py
+++ b/src/phonometry/_plot/vibration.py
@@ -202,11 +202,11 @@ def plot_weighted_spectrum(
         positions - width / 2, raw, width, color=_C_MUTED,
         label=_t("Unweighted $a_i$", language),
     )
+    kwargs.setdefault("label", _t("Weighted $W_i a_i$ ({name})", language).format(name=result.weighting_name))
     ax.bar(
         positions + width / 2,
         weighted,
         width,
-        label=_t("Weighted $W_i a_i$ ({name})", language).format(name=result.weighting_name),
         **kwargs,
     )
     ax.set_ylabel(_t("r.m.s. acceleration [m/s²]", language))
@@ -259,14 +259,21 @@ def plot_daily_exposure(
     width = kwargs.pop("width", 0.7)
     edgecolor = kwargs.pop("edgecolor", _C_EDGE)
     for i in range(n_ops):
+        # A copy per bar, not one `setdefault` before the loop: each task bar
+        # carries its own name and the total carries another, so a single
+        # default would put the first task's label on every one of them.
+        task_kwargs = dict(kwargs)
+        task_kwargs.setdefault("label", str(result.labels[i]))
         ax.bar(
             positions[i], partials[i], width=width,
             color=_OP_COLORS[i % len(_OP_COLORS)], edgecolor=edgecolor,
-            linewidth=0.6, zorder=3, label=str(result.labels[i]), **kwargs,
+            linewidth=0.6, zorder=3, **task_kwargs,
         )
+    total_kwargs = dict(kwargs)
+    total_kwargs.setdefault("label", "$A(8)$")
     ax.bar(
         positions[-1], values[-1], width=width, color=_A8_COLOR,
-        edgecolor=edgecolor, linewidth=0.6, zorder=3, label="$A(8)$", **kwargs,
+        edgecolor=edgecolor, linewidth=0.6, zorder=3, **total_kwargs,
     )
     # The legend carries the bar identity, so the crowded category ticks go.
     ax.set_xticks([])
@@ -316,7 +323,8 @@ def plot_mobility(
     kwargs.setdefault("color", _C_PRIMARY)
     label = (_t("driving-point mobility", language) if result.driving_point
              else _t("transfer mobility", language))
-    ax.loglog(freq, mag, label=label, **kwargs)
+    kwargs.setdefault("label", label)
+    ax.loglog(freq, mag, **kwargs)
     # Mark the mobility peak (a resonance for a driving-point FRF).
     peak = int(np.argmax(mag))
     ax.plot(freq[peak], mag[peak], "o", color=_C_REFERENCE, zorder=5,
@@ -410,7 +418,8 @@ def plot_rigid_mass_calibration(
                      color=_C_REFERENCE, alpha=0.15, label=band_label)
     axm.loglog(freq, expected, ls="--", color=_C_REFERENCE, lw=1.4,
                label=exp_label)
-    axm.loglog(freq, measured, "o-", lw=1.4, label=within_label, **kwargs)
+    kwargs.setdefault("label", within_label)
+    axm.loglog(freq, measured, "o-", lw=1.4, **kwargs)
     if not np.all(within):
         axm.plot(freq[~within], measured[~within], "o", color=_C_SECONDARY,
                  zorder=4, label=outside_label)
@@ -450,7 +459,8 @@ def plot_transfer_stiffness(
     freq = np.asarray(result.frequencies, dtype=np.float64)
     level = np.asarray(result.level, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.semilogx(freq, level, label=r"$L_k = 20\,\log_{10}(|k_{2,1}|/k_0)$", **kwargs)
+    kwargs.setdefault("label", r"$L_k = 20\,\log_{10}(|k_{2,1}|/k_0)$")
+    ax.semilogx(freq, level, **kwargs)
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
     ax.set_xlabel(_t(_FREQ_LABEL, language))
     ax.set_ylabel(_t("Transfer stiffness level $L_k$ [dB re 1 N/m]", language))
@@ -482,7 +492,8 @@ def plot_radiation_efficiency(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("markersize", 3)
-    ax.loglog(freq, sigma, label=r"$\sigma(f)$", **kwargs)
+    kwargs.setdefault("label", r"$\sigma(f)$")
+    ax.loglog(freq, sigma, **kwargs)
     ax.axhline(1.0, color=_C_MUTED, ls=":", lw=0.9, label=r"$\sigma = 1$")
     ax.axvline(
         result.critical_frequency,
@@ -530,10 +541,10 @@ def plot_multiple_shock(
     kwargs.setdefault("color", _C_REFERENCE)
     kwargs.setdefault("zorder", 4)
     kwargs.setdefault("s", 90)
-    ax.scatter([result.risk], [100.0 * result.probability],
-               label=_t(_RISK_LABEL, language).format(
+    kwargs.setdefault("label", _t(_RISK_LABEL, language).format(
                    r=format_number(result.risk, language, decimals=2),
-                   p=format_number(100.0 * result.probability, language, decimals=0)),
+                   p=format_number(100.0 * result.probability, language, decimals=0)))
+    ax.scatter([result.risk], [100.0 * result.probability],
                **kwargs)
     ax.set_xlabel(_t("Stress variable $R$", language))
     ax.set_ylabel(_t("Probability of lumbar injury [%]", language))
@@ -580,8 +591,9 @@ def _draw_measured_spectrum(
     keep = frequencies <= f_max
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 1.0)
+    kwargs.setdefault("label", _t("envelope spectrum", language))
     ax.plot(frequencies[keep], amplitude[keep],
-            label=_t("envelope spectrum", language), **kwargs)
+            **kwargs)
     ax.set_ylabel(_t("Envelope amplitude", language))
     return float(np.max(amplitude[keep])) if np.any(keep) else 1.0
 
@@ -818,7 +830,8 @@ def plot_power_injection(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("markersize", 4)
-    ax.loglog(freq, result.coupling_loss_factor12, label=r"$\eta_{12}$",
+    kwargs.setdefault("label", r"$\eta_{12}$")
+    ax.loglog(freq, result.coupling_loss_factor12,
               **kwargs)
     ax.loglog(freq, result.coupling_loss_factor21, color=_C_SECONDARY,
               marker="s", markersize=4, label=r"$\eta_{21}$")
@@ -864,7 +877,8 @@ def plot_junction_transmission(
     corner = np.asarray(result.corner, dtype=np.float64)
 
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.plot(angles, corner, label=_t(r"corner $\tau_{12}(\theta)$", language), **kwargs)
+    kwargs.setdefault("label", _t(r"corner $\tau_{12}(\theta)$", language))
+    ax.plot(angles, corner, **kwargs)
     ax.axhline(
         result.corner_average, color=_C_PRIMARY, ls="--", lw=1.0,
         label=_t(r"corner average $\bar\tau_{12}$ = {value}", language).replace(

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -203,6 +203,22 @@ def test_every_plot_forwards_kwargs_to_primary_artist(name, factory, kind) -> No
     )
     plt.close("all")
 
+    # And the same for `label`, which is where this went wrong for longest.
+    # `color` was passed by name next to `**kwargs` once and fixed; `label`
+    # was passed that way in fifty-five renderers, so a caller naming a curve
+    # got `TypeError: got multiple values for keyword argument 'label'`
+    # instead of a labelled curve.
+    out = res.plot(label="mine")
+    ax = out[0] if isinstance(out, np.ndarray) else out
+    # Through the legend, not through the artist: `ax.bar` puts the label on
+    # the container it returns rather than on each rectangle, so reading
+    # `ax.patches` would miss it on every bar renderer. The legend is what the
+    # caller is naming the curve for anyway.
+    assert "mine" in ax.get_legend_handles_labels()[1], (
+        f"{name}: label kwarg did not reach the legend"
+    )
+    plt.close("all")
+
 
 # --------------------------------------------------------------------------
 # Common contract: ax=None creates a figure; passing ax composes

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -251,3 +251,45 @@ def test_single_axes_plots_accept_external_ax() -> None:
         out = res.plot(ax=ax)
         assert out is ax
         plt.close(fig)
+
+
+def test_no_renderer_defaults_a_label_on_the_shared_kwargs_inside_a_loop() -> None:
+    """One `setdefault` in a loop names every curve after the first one.
+
+    `dict.setdefault` mutates, so a renderer that draws several named curves
+    has to take a copy per curve. Doing it once on `kwargs` sets the first
+    label and then finds it already there on every later pass, which is not a
+    crash and not a test failure anywhere else: the figure simply comes out
+    with one legend entry repeated, and the only thing that noticed was a
+    committed report preview drifting by 693 pixels.
+
+    This is a structural check because the behavioural one cannot be written
+    once: what "several named curves" means differs per renderer, while the
+    shape that produces the bug is the same everywhere.
+    """
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parent.parent / "src" / "phonometry" / "_plot"
+    offenders: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.For | ast.While | ast.AsyncFor):
+                continue
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Attribute)
+                    and child.func.attr == "setdefault"
+                    and isinstance(child.func.value, ast.Name)
+                    and child.func.value.id == "kwargs"
+                    and child.args
+                    and isinstance(child.args[0], ast.Constant)
+                    and child.args[0].value == "label"
+                ):
+                    offenders.append(f"{path.name}:{child.lineno}")
+    assert not offenders, (
+        "a label default on the shared kwargs inside a loop names every curve "
+        f"after the first one: {offenders}. Take a copy per iteration."
+    )


### PR DESCRIPTION
`label` is an ordinary matplotlib keyword and arrives through `**kwargs` like
`color` or `linewidth`. Fifty-five renderers also passed one by name in the
same call:

```python
ax.semilogx(freq, r, label=_t("predicted $R$", language), **kwargs)
```

so `result.plot(label="mine")` raised

    TypeError: got multiple values for keyword argument 'label'

rather than drawing a labelled curve.

## Measured, not assumed

Six of the thirty-two result types the plotting contract covers failed
outright, run against the real result objects `tests/result_factories.py`
builds: `layered_absorber`, `diffuse_absorption`, `radiation_efficiency`,
`single_panel`, `double_wall` and `slit_aperture`. The rest were one argument
away from the same thing.

## The fix

`kwargs.setdefault("label", ...)`, which is what these same renderers already
do for `color` and `marker`: the caller's label wins, and the generated one
still appears when there is none. Fifty-one of the fifty-five are that rewrite
exactly.

The other four are two renderers that draw one bar per item, each carrying its
own name: the per-band transmission paths of the detailed building model, and
the per-task bars of a daily vibration exposure. One `setdefault` before the
loop would put the first item's label on every bar, which is a quieter bug than
the one being fixed, so each takes a copy of the keywords per bar.

## The gate

`test_every_plot_forwards_kwargs_to_primary_artist` covers `label` alongside
`color` now. Verified against the real defect: reverting
`src/phonometry/_plot/materials.py` makes it fail with the original
`TypeError` on `layered_absorber` and `diffuse_absorption`, and restoring it
makes all thirty-two pass.

It reads the legend rather than the artist, deliberately. `ax.bar` puts the
label on the `BarContainer` it returns and not on each rectangle, so an
`ax.patches` check passes vacuously on every bar renderer, which is how this
would come straight back through the same door. Nine results proved that while
the test was being written.

No figure changes: with no caller label, `setdefault` fills in exactly the
label that was passed by name before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Fixed a TypeError caused by passing duplicate 'label' arguments to matplotlib plotting functions.</li>
<li>Updated multiple plotting renderers to use `kwargs.setdefault('label', ...)` instead of explicit keyword arguments, allowing user-provided labels to take precedence.</li>
<li>Adjusted bar chart renderers to copy keyword arguments per item to ensure correct labeling for individual bars.</li>
<li>Enhanced the plotting contract test to verify 'label' handling via the legend.</li>
</ul></div>

## Summary by Sourcery

Allow plotting callers to override generated curve labels safely across all result renderers.

Bug Fixes:
- Allow callers to provide custom plot labels without triggering duplicate matplotlib keyword errors.
- Preserve distinct default labels for renderers that draw multiple curves or bars.

Enhancements:
- Standardize default label handling across plotting renderers while retaining generated labels when callers do not provide one.

Tests:
- Extend the plotting contract tests to verify caller-provided labels through the legend.
- Add a structural test preventing shared keyword defaults from being applied inside multi-curve rendering loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plot functions now accept custom legend labels without errors.
  * Existing default labels are preserved when no custom label is provided.
  * Bar charts assign independent labels to each bar for clearer legends.

* **Tests**
  * Added coverage confirming custom labels appear correctly in legends across plot types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->