### PR TITLE
Reach every function through the package that owns it, in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Every example in the documentation reaches a function through the package
+  that owns it: `from phonometry import building` and then
+  `building.single_panel_transmission_loss(...)`, in both languages in step.
+  Two thirds of the pages already led with that form; the remaining third
+  imported the function flat off the top level, and the two forms sat side by
+  side on the same page.
+
+  Reading the domain at each call site is the point. A page that computes a
+  panel's transmission loss from its bending stiffness now says out loud that
+  `plate_bending_stiffness` and `coincidence_frequency` come from `vibration`
+  while `single_panel_transmission_loss` comes from `building`, which the flat
+  form hid. It is also what the published guidance recommends, and it settles
+  a collision the pages were already paying for by hand: `envelope`,
+  `spectrogram`, `coherence`, `group_delay`, `minimum_phase` and `zoom_fft`
+  all exist in `scipy.signal` under the same spelling, which is why several
+  pages import the other side as `from scipy import signal as sp_signal`.
+
 - The transforms whose output is itself a pressure record return a `Signal`
   when they are given one, instead of a bare array. A chain of them used to
   lose the rate and the calibration at the first step and the caller rebuilt

--- a/docs/aircraft/aircraft-noise.md
+++ b/docs/aircraft/aircraft-noise.md
@@ -136,10 +136,10 @@ EPNL result and is not an official State noise certificate; it does not
 reproduce any TCDSN.
 
 ```python
-from phonometry import effective_perceived_noise_level, ReportMetadata
+from phonometry import ReportMetadata, aircraft
 
 # spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
-res = effective_perceived_noise_level(spectra, dt=0.5)
+res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 res.report(
     "epnl_fiche.pdf",
     metadata=ReportMetadata(

--- a/docs/aircraft/anp-fleet.md
+++ b/docs/aircraft/anp-fleet.md
@@ -20,9 +20,9 @@ table yourself.
 Point it at a directory to read any other ANP CSV export instead.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 print(len(db.aircraft_ids))          # 155 aircraft types
 ac = db.aircraft("747100")
 print(ac.description)                # Boeing 747-100 / JT9DBD
@@ -53,9 +53,9 @@ tabulated nodes the Doc 29 interpolation is logarithmic in distance and linear
 in power.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-curves = load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
+curves = aircraft.load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
 print(curves.powers)                       # [10000. 14000. 19000. 23000.] lb
 print(curves.level(19000.0, [304.8, 1000.0, 3000.0]))
 ```
@@ -77,9 +77,9 @@ the level, while distance sets the shape.
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 curves = ac.npd_curves("D", "SEL")
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -116,9 +116,9 @@ only for arrivals. Asking for one that does not exist raises a `KeyError` naming
 the stage lengths that do, which is how to discover them:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for identifier, operation, stage in (("A320-232", "D", 1), ("747100", "D", 9)):
     try:
         db.profile(identifier, operation, stage)
@@ -133,9 +133,9 @@ substitute trajectory. NPD curves, on the other hand, are tabulated for every
 aircraft in the database.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-profile = load_anp_database().aircraft("747100").profile("D", stage_length=1)
+profile = aircraft.load_anp_database().aircraft("747100").profile("D", stage_length=1)
 print(profile.profile_id, profile.stage_length, profile.path.shape)
 profile.plot()
 ```
@@ -153,9 +153,9 @@ after them fixes the slant distance at every receiver, so it decides the contour
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -178,9 +178,9 @@ over a ground grid, each wiring the NPD curves and the default profile into the
 functions the airport-noise page builds by hand.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 flyover = ac.event_level([3000.0, 500.0, 0.0], "D")
 print(round(float(flyover.level), 1))     # 100.4 dB
 ```
@@ -200,9 +200,9 @@ weather correction.
 
 ```python
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-contour = load_anp_database().aircraft("747100").noise_contour(
+contour = aircraft.load_anp_database().aircraft("747100").noise_contour(
     "D",
     x=np.linspace(-2000.0, 12000.0, 40),
     y=np.linspace(-3000.0, 3000.0, 30),

--- a/docs/aircraft/rotorcraft-noise.md
+++ b/docs/aircraft/rotorcraft-noise.md
@@ -410,11 +410,11 @@ the CNOSSOS-EU scheme the guidance adopts). The ground effect is not
 evaluated separately in that regime.
 
 ```python
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = [63.0, 250.0, 1000.0, 4000.0]
-diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
-diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
+aircraft.diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
+aircraft.diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```
 
 <picture>
@@ -428,11 +428,11 @@ diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = np.array([63.0, 250.0, 1000.0, 4000.0])
 delta = np.linspace(-0.4, 1.5, 441)
-ld = np.array([diffraction_attenuation(bands, float(d), edge_height=2.5)
+ld = np.array([aircraft.diffraction_attenuation(bands, float(d), edge_height=2.5)
               for d in delta])
 
 fig, ax = plt.subplots(figsize=(9, 6))

--- a/docs/buildings/design/detailed-prediction.md
+++ b/docs/buildings/design/detailed-prediction.md
@@ -101,35 +101,31 @@ model. Eight defects of those printed tables are recorded in
 
 ```python
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 
 # Annex E junctions (unrounded): floor-to-external-wall rigid T, external wall
 # in-line across it, floor-to-internal-wall rigid cross, internal wall in-line.
-k_floor_ext = junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
-k_ext_ext = junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
-k_floor_int = junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
-k_int_int = junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_ext_ext = building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
+k_int_int = building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
 print(round(k_floor_ext, 1), round(k_ext_ext, 1))     # 6.4 11.2  (Table L.5)
 print(round(k_floor_int, 1), round(k_int_int, 1))     # 8.8 11.0  (Table L.6)
 
 # The floor's perimeter: it butts into an external wall above and below at each
 # of its two external edges, and crosses the internal walls at the other two.
-a_at_ext = perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
-a_at_int = perimeter_absorption_coefficient(
-    [76.8, 128.4, 128.4], [junction_vibration_reduction(
+a_at_ext = building.perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
+a_at_int = building.perimeter_absorption_coefficient(
+    [76.8, 128.4, 128.4], [building.junction_vibration_reduction(
         "rigid_cross", "through", 360.0 / 484.0), k_floor_int, k_floor_int])
 floor_perimeter = 9.0 * (a_at_ext + a_at_int)         # 2.659 m (Formula C.4)
 
-floor = HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
-                           floor_perimeter, 2200.0, 3800.0)
-el = in_situ_element(floor, bands)
+floor = building.HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
+                                    floor_perimeter, 2200.0, 3800.0)
+el = building.in_situ_element(floor, bands)
 print(np.round(el.total_loss_factor[[0, 10]], 4))     # [0.0831 0.029 ]  Table L.3
 print(np.round(el.sound_reduction_index[[0, 10]], 1)) # [31.8 54.9]      Table L.3
 print(np.round(el.impact_level[[0, 10]], 1))          # [57.3 63.6]      Table G.3
@@ -142,13 +138,13 @@ Every printed column of Tables L.2, L.3, L.4, G.3 and G.4 comes back within
 ```python
 # The floating floor: 35 mm screed, m' = 73,5 kg/m2 on s' = 8 MN/m3.
 f0 = 160.0 * np.sqrt(8.0 / 73.5)                      # 52.8 Hz (Formula C.2)
-delta = floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
+delta = building.floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
 
-wall = in_situ_element(HomogeneousElement(
+wall = building.in_situ_element(building.HomogeneousElement(
     "ext1", 11.0, 4.0, 2.75, 219.0, 92.6, 0.0125, 2.375, 600.0, 1900.0), bands)
 
 # Path D1 (Df: separating floor -> external wall 1), Table L.4.
-d1 = airborne_flanking_path(
+d1 = building.airborne_flanking_path(
     label="D1", kind="Df", element_i=el, element_j=wall,
     vibration_reduction_index=k_floor_ext, coupling_length=4.0,
     separating_area=20.0, delta_r_i=delta)
@@ -161,9 +157,9 @@ index per band, its energy split and the ISO 717-1 rating in one call:
 ```python
 # `paths` holds the twelve flanking paths of the four elements, built the
 # way `d1` was above; the code block under the figure builds all of them.
-res = detailed_airborne_prediction(
-    bands, direct_index=direct_reduction_index(el.sound_reduction_index,
-                                               delta_r_source=delta),
+res = building.detailed_airborne_prediction(
+    bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
+                                                        delta_r_source=delta),
     flanking_paths=paths)
 print(np.round(res.r_prime[[0, 10]], 1))   # [28.8 55.9]   Table L.1 total
 print(res.rating.rating, res.dominant[0])  # 57 'Dd'
@@ -185,26 +181,22 @@ the result there. The single number $R'_\mathrm{w} = 57$ dB says none of that.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 k = {
-    "floor-ext": junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
-    "ext-ext": junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
-    "floor-floor": junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
-    "floor-int": junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
-    "int-int": junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
-    "int-ext": junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
-    "extT-ext": junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
-    "corner": junction_vibration_reduction("corner", "corner", 1.0),
-    "int-int-x": junction_vibration_reduction("rigid_cross", "through", 1.0),
+    "floor-ext": building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
+    "ext-ext": building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
+    "floor-floor": building.junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
+    "floor-int": building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
+    "int-int": building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
+    "int-ext": building.junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
+    "extT-ext": building.junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
+    "corner": building.junction_vibration_reduction("corner", "corner", 1.0),
+    "int-int-x": building.junction_vibration_reduction("rigid_cross", "through", 1.0),
 }
-a = perimeter_absorption_coefficient
+a = building.perimeter_absorption_coefficient
 floor_sum = 9.0 * (a([92.6, 92.6], [k["floor-ext"]] * 2)
                    + a([76.8, 128.4, 128.4],
                        [k["floor-floor"], k["floor-int"], k["floor-int"]]))
@@ -224,10 +216,10 @@ specs = {
     "int2": (13.75, 5.0, 2.75, 360.0, 128.4, 0.01,
              10.0 * int_top + 2.75 * int_side, 1800.0, 2500.0),
 }
-situ = {name: in_situ_element(HomogeneousElement(name, *spec), bands)
+situ = {name: building.in_situ_element(building.HomogeneousElement(name, *spec), bands)
         for name, spec in specs.items()}
-delta = floating_floor_improvement(bands,
-                                   resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
+delta = building.floating_floor_improvement(bands,
+                                            resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
 
 paths = []
 for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
@@ -236,21 +228,21 @@ for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
     cross = k["floor-ext"] if name.startswith("ext") else k["floor-int"]
     through = k["ext-ext"] if name.startswith("ext") else k["int-int"]
     paths += [
-        airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
-                               element_j=wall, vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0,
-                               delta_r_i=delta),
-        airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
-                               element_j=situ["floor"], vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0),
-        airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
-                               element_j=wall, vibration_reduction_index=through,
-                               coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=wall, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
+                                        element_j=wall, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
     ]
-res = detailed_airborne_prediction(
+res = building.detailed_airborne_prediction(
     bands,
-    direct_index=direct_reduction_index(situ["floor"].sound_reduction_index,
-                                        delta_r_source=delta),
+    direct_index=building.direct_reduction_index(situ["floor"].sound_reduction_index,
+                                                 delta_r_source=delta),
     flanking_paths=paths)
 
 # One line — the per-band path contributions with R' overlaid:
@@ -263,19 +255,18 @@ plt.show()
 The impact side of the same building runs on the same `situ` dictionary:
 
 ```python
-from phonometry import (detailed_impact_prediction, direct_impact_level,
-                        impact_flanking_path)
+from phonometry import building
 
-direct = direct_impact_level(situ["floor"].impact_level, delta_l=delta)
+direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
-    impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
-                         vibration_reduction_index=(
+    building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
+                                  vibration_reduction_index=(
                              k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
-                         coupling_length=lij, delta_l=delta)
+                                  coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
 ]
-imp = detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
+imp = building.detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
 print(np.round(imp.l_prime_n[[3, 10]], 1))     # [54.  35.9]   Table G.1 total
 print(imp.rating.rating, imp.rating.ci)        # 41 2           printed 41,0 (2)
 ```
@@ -305,25 +296,22 @@ $\overline{D}_{v,ij,\mathrm{n}}$ and Part 2 Formula (13) from a measured normali
 flanking impact level $L_\mathrm{n,f}$.
 
 ```python
-from phonometry import (flanking_impact_level_from_flanking_level,
-                        flanking_reduction_index_from_flanking_level,
-                        flanking_reduction_index_from_normalized_difference,
-                        resonant_sound_reduction_index)
+from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
-r_star = resonant_sound_reduction_index(r_wall_leaf, bands,
-                                        critical_frequency=2200.0)   # +8 dB below fc
-r_ff = flanking_reduction_index_from_normalized_difference(
+r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
+                                                 critical_frequency=2200.0)   # +8 dB below fc
+r_ff = building.flanking_reduction_index_from_normalized_difference(
     index_i=r_star, index_j=r_star, normalized_velocity_level_difference=dv_n,
     separating_area=20.0, coupling_length=4.0)                        # Table L.11
 
 # ISO 12354-1 L.2.2: a measured junction between two timber frame walls.
-r13 = flanking_reduction_index_from_flanking_level(
+r13 = building.flanking_reduction_index_from_flanking_level(
     dnf_13, separating_area=10.44, coupling_length=2.41,
     laboratory_coupling_length=2.5)                                   # Table L.15
 
 # ISO 12354-2 Formula (13): the impact twin, from a measured Ln,f.
-ln_13 = flanking_impact_level_from_flanking_level(
+ln_13 = building.flanking_impact_level_from_flanking_level(
     lnf_13, area=20.0, laboratory_area=10.0,
     coupling_length=4.0, laboratory_coupling_length=4.5)
 ```

--- a/docs/buildings/design/installed-structure-borne.md
+++ b/docs/buildings/design/installed-structure-borne.md
@@ -221,7 +221,7 @@ optional `phonometry[report]` extra (reportlab), plus matplotlib for the plot.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, installed_source_prediction
+from phonometry import ReportMetadata, building
 
 bands = np.array([63, 125, 250, 500, 1000, 2000], float)
 lwc = np.array([84.4, 82.5, 69.9, 67.6, 61.6, 49.9])   # characteristic power [dB]
@@ -234,7 +234,7 @@ paths = [
      "flanking_reduction_index": np.array([37.0, 41.2, 35.9, 37.7, 49, 57.8]),
      "element_area": 12.8},
 ]
-res = installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
+res = building.installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
 res.report(
     "installed_structure_borne.pdf",
     metadata=ReportMetadata(

--- a/docs/buildings/design/panel-sound-insulation.md
+++ b/docs/buildings/design/panel-sound-insulation.md
@@ -48,21 +48,18 @@ plasterboard leaf puts $f_\mathrm{c}$ near 2.6 kHz and rates $R_\mathrm{w} = 27$
 
 ```python
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006                                 # 15 kg/m2
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
-fc = coincidence_frequency(mass, bp)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
+fc = vibration.coincidence_frequency(mass, bp)
 print(round(fc))                                      # 2107 Hz (Hopkins declares ~2079)
 
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 print(round(res.rating().rating))                     # 32  ->  Rw = 32 dB (catalogue 6 mm glass)
 
 res.plot()   # predicted R(f) with the critical frequency marked (needs matplotlib)
@@ -84,19 +81,16 @@ $R_\mathrm{w} = 32$ dB of 6 mm glass.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(mass, bp)
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(mass, bp)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 w = res.rating()
 
 # One line each — the predicted R(f), or the rated curve vs the reference:
@@ -183,18 +177,18 @@ what it claims to be: an estimate, not the dip.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import plateau_transmission_loss, single_panel_transmission_loss
+from phonometry import building
 
 # 6 mm float glass: Norton Table 3.1 gives 2.47 kg/m2 per mm, a 27 dB
 # coincidence plateau and B/A = 10; its critical frequency is 2033 Hz.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000], dtype=float)
-quick = plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
-                                  field_correction=5.5)
-physical = single_panel_transmission_loss(bands, 2.47 * 6.0,
-                                          critical_frequency=2033.0,
-                                          loss_factor=0.02)
+quick = building.plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
+                                           field_correction=5.5)
+physical = building.single_panel_transmission_loss(bands, 2.47 * 6.0,
+                                                   critical_frequency=2033.0,
+                                                   loss_factor=0.02)
 
 print(round(quick.plateau_start), round(quick.plateau_end))   # 374 3742
 print(quick.plateau_height)                                   # 27.0
@@ -213,11 +207,11 @@ problem 3.11 exactly, band for band, in the two regions the construction fixes
 analytically.
 
 ```python
-from phonometry import plateau_transmission_loss
+from phonometry import building
 
 octaves = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
-res = plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
-                                air_density=1.21)
+res = building.plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
+                                         air_density=1.21)
 print(res.transmission_loss.round(1))
 # [35.8 37.  37.  43.3 53.3 63.3 73.3]
 ```
@@ -297,20 +291,16 @@ supported orthotropic plate (Vigran Eq. 3.113 = Bies Eq. 7.27, after Hearmon
 valid above roughly $1.5f_{1,1}$.
 
 ```python
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_plate_resonance, plate_bending_stiffness,
-)
+from phonometry import building, vibration
 
 # Vigran's worked example: a 1 m x 1 m steel sheet 1 mm thick, E = 210 GPa,
 # nu = 0.3, m'' = 7.8 kg/m2, corrugated into a sinusoid 20 mm deep
 # (amplitude H = 10 mm) at a 100 mm pitch.
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, b_xz = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, b_xz = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
 print(round(flat_b, 1), round(b_x, 1), round(b_z))     # 19.2 17.5 2202
 print(round(mass, 2))                                  # 8.52 kg/m2 (+9 %)
 
@@ -320,14 +310,14 @@ flat = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": 7.8,
 corr = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": mass,
         "bending_stiffness_x": b_x, "bending_stiffness_z": b_z,
         "bending_stiffness_xz": b_xz}
-print(round(orthotropic_plate_resonance(1, 1, **flat), 1),
-      round(orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
-print(round(orthotropic_plate_resonance(1, 1, **corr), 1),
-      round(orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
+print(round(building.orthotropic_plate_resonance(1, 1, **flat), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
+print(round(building.orthotropic_plate_resonance(1, 1, **corr), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
 
 # The same sheet, flat and corrugated, in the coincidence picture:
-print(round(coincidence_frequency(7.8, flat_b)))               # 11925 Hz
-print([round(f) for f in orthotropic_critical_frequencies(mass, b_x, b_z)])
+print(round(vibration.coincidence_frequency(7.8, flat_b)))               # 11925 Hz
+print([round(f) for f in building.orthotropic_critical_frequencies(mass, b_x, b_z)])
 # [1165, 13064]
 ```
 
@@ -351,33 +341,28 @@ the corrugated sheet gives away up to 13 dB, and $R_\mathrm{w}$ falls from 28 dB
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_transmission_loss, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000, 12500, 16000], dtype=float)
 eta = 0.011
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, _ = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, _ = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
-fc1, fc2 = orthotropic_critical_frequencies(mass, b_x, b_z)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
+fc1, fc2 = building.orthotropic_critical_frequencies(mass, b_x, b_z)
 
-flat = single_panel_transmission_loss(
-    bands, 7.8, critical_frequency=coincidence_frequency(7.8, flat_b),
+flat = building.single_panel_transmission_loss(
+    bands, 7.8, critical_frequency=vibration.coincidence_frequency(7.8, flat_b),
     loss_factor=eta,
 )
-corrugated = orthotropic_transmission_loss(
+corrugated = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     loss_factor=eta,
 )
-heckl = orthotropic_transmission_loss(
+heckl = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     method="heckl",
 )
@@ -422,21 +407,21 @@ add, boosted by the cavity, until $f_\mathrm{l} = c_0/(2\pi d)$ where the boost 
 at 6 dB (Eq. 7.64). A porous fill lowers $f_0$.
 
 ```python
-from phonometry import double_wall_transmission_loss, mass_spring_mass_resonance
-from phonometry import mass_law_transmission_loss, miki
+from phonometry import building
+from phonometry import materials
 
 # Two 12 kg/m2 leaves, 75 mm air gap.
-f0 = mass_spring_mass_resonance(12.0, 12.0, 0.075)
+f0 = building.mass_spring_mass_resonance(12.0, 12.0, 0.075)
 print(round(f0))                                          # 89 Hz
 
 # Below f0 the double wall equals the mass law of the total mass 24 kg/m2:
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
 print(round(float(dw.transmission_loss[0]), 1),
-      round(float(mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
+      round(float(building.mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
 
 # A mineral-wool fill (a materials porous model) lowers the resonance:
-fill = miki([f0], 7000.0)
-print(round(mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
+fill = materials.miki([f0], 7000.0)
+print(round(building.mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
 
 dw.plot()   # double-wall R(f) with the mass-spring-mass resonance marked (needs matplotlib)
 ```
@@ -458,11 +443,11 @@ double-wall curve sits.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import mass_spring_mass_resonance, plot_double_wall_geometry
+from phonometry import building
 
 # Two 8.8 kg/m2 plasterboard leaves on a 100 mm cavity.
-f0 = mass_spring_mass_resonance(8.8, 8.8, 0.1)
-plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
+f0 = building.mass_spring_mass_resonance(8.8, 8.8, 0.1)
+building.plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
 plt.show()
 
 # A double-wall prediction retains its geometry and redraws it:
@@ -511,25 +496,20 @@ Hall & Hopkins (2001).
 | Vertical-twist tie (proprietary) | 100 | 43.4 |
 
 ```python
-from phonometry import (
-    double_wall_transmission_loss,
-    mass_spring_mass_resonance,
-    wall_tie_stiffness,
-    wall_tie_stiffness_per_area,
-)
+from phonometry import building
 
-print(wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
+print(building.wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
 
 # Hopkins Fig. 4.35: two 140 kg/m2 leaves across an empty 75 mm cavity.
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
 
 # Add 2.5 ties per m2 of s_75mm = 2 MN/m: the resonance nearly doubles.
-ties = wall_tie_stiffness_per_area(2.5, 2.0e6)
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075,
-                                       tie_stiffness_per_area=ties)))  # 50 Hz
+ties = building.wall_tie_stiffness_per_area(2.5, 2.0e6)
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075,
+                                                tie_stiffness_per_area=ties)))  # 50 Hz
 
-dw = double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
-                                   tie_stiffness_per_area=ties)
+dw = building.double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
+                                            tie_stiffness_per_area=ties)
 ```
 
 **The tie as a point connection (Hopkins Eqs. 4.84 to 4.88).** Each tie
@@ -555,11 +535,11 @@ differently.
 
 ```python
 import numpy as np
-from phonometry import plate_bending_stiffness, wall_tie_coupling_loss_factor
+from phonometry import building, vibration
 
 freq = np.logspace(np.log10(50.0), np.log10(5000.0), 60)
-b1 = plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
-res = wall_tie_coupling_loss_factor(
+b1 = vibration.plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
+res = building.wall_tie_coupling_loss_factor(
     freq, 150.0, 170.0, b1, b1, ties_per_area=2.5, tie="butterfly"
 )
 print(res.coupling_loss_factor[0], res.rigid_coupling_loss_factor[0])
@@ -594,17 +574,14 @@ so a bare opening of relative area $S_\mathrm{a}/S$ caps the composite at $10\lo
 a 1 % opening can never do better than 20 dB, whatever the wall.
 
 ```python
-from phonometry import (
-    composite_transmission_loss, slit_transmission_coefficient,
-    slit_resonance_frequencies,
-)
+from phonometry import building
 
 # A 2 mm x 100 mm-deep slit: transmission peaks at the depth's half-wavelength
 # resonances.
-print(slit_resonance_frequencies(0.1, 0.002, orders=2).round().tolist())   # [~1500, ~3100]
+print(building.slit_resonance_frequencies(0.1, 0.002, orders=2).round().tolist())   # [~1500, ~3100]
 
 # A wall of Rw = 50 dB with 1 % of its area open as a slit is capped:
-print(round(float(composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
+print(round(float(building.composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
 ```
 
 The leak that undoes a heavy wall is almost invisible, and `.plot_geometry()`
@@ -623,10 +600,10 @@ resonances near 1.5 and 3.1 kHz rather than as a simple open area.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import slit_transmission_coefficient
+from phonometry import building
 
 f = np.geomspace(100.0, 5000.0, 200)
-result = slit_transmission_coefficient(f, 0.002, 0.1)
+result = building.slit_transmission_coefficient(f, 0.002, 0.1)
 
 # One line: the wall section with the slit to scale.
 result.plot_geometry()
@@ -662,16 +639,16 @@ radiates weakly; above it $\sigma \to 1$ (Leppington/Maidanik, Eqs 2.227-2.230):
 $\sigma = (1 - f_\mathrm{c}/f)^{-1/2}$ for $f > f_\mathrm{c}$.
 
 ```python
-from phonometry import radiation_efficiency, sound_power_from_vibration
+from phonometry import emission, vibration
 
 # The 6 mm glass pane (1.5 x 1.25 m) of the single-panel example above.
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 print(sig.radiation_efficiency[bands == 2000].round(2))    # ~2.5 (peak at coincidence)
 
 # Feed the prediction straight into ISO 7849 as the radiation factor:
-lw = sound_power_from_vibration(velocity_level=80.0, area=1.875,
-                                radiation_factor=sig.radiation_efficiency,
-                                frequencies=bands)
+lw = emission.sound_power_from_vibration(velocity_level=80.0, area=1.875,
+                                         radiation_factor=sig.radiation_efficiency,
+                                         frequencies=bands)
 
 sig.plot()   # sigma(f) with the coincidence peak (needs matplotlib)
 ```
@@ -687,11 +664,11 @@ $\omega^{-1/2}$). They supply the receiver mobility EN 12354-5 needs when no
 measurement exists.
 
 ```python
-from phonometry import infinite_plate_impedance, infinite_beam_mobility, injected_power
+from phonometry import vibration
 
-z_plate = infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
+z_plate = vibration.infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
 print(round(z_plate))                                 # real, frequency independent
-w = injected_power(force=10.0, mobility=1.0 / z_plate)
+w = vibration.injected_power(force=10.0, mobility=1.0 / z_plate)
 print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' m''))
 ```
 
@@ -701,37 +678,32 @@ print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' 
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (
-    coincidence_frequency, composite_transmission_loss,
-    double_wall_transmission_loss, mass_law_transmission_loss,
-    mass_spring_mass_resonance, plate_bending_stiffness,
-    radiation_efficiency, single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000], dtype=float)
 fig, ax = plt.subplots(2, 2, figsize=(12, 9))
 
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(15.0, bp)
-ml = mass_law_transmission_loss(bands, 15.0, incidence="field")
-sp = single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(15.0, bp)
+ml = building.mass_law_transmission_loss(bands, 15.0, incidence="field")
+sp = building.single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
 ax[0, 0].semilogx(bands, ml, "--", label="field-incidence mass law")
 ax[0, 0].semilogx(bands, sp.transmission_loss, "-o", ms=3, label="single panel R (Sharp)")
 ax[0, 0].axvline(fc, ls=":", color="r"); ax[0, 0].set_title("Single panel")
 
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
-ax[0, 1].semilogx(bands, mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+ax[0, 1].semilogx(bands, building.mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
 ax[0, 1].semilogx(bands, dw.transmission_loss, "-o", ms=3, label="double wall")
-ax[0, 1].axvline(mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
+ax[0, 1].axvline(building.mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
 ax[0, 1].set_title("Double wall")
 
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 ax[1, 0].loglog(bands, sig.radiation_efficiency, "-o", ms=3, label=r"$\sigma(f)$")
 ax[1, 0].axhline(1.0, ls=":"); ax[1, 0].set_title("Radiation efficiency")
 
 wall = sp.transmission_loss
-comp = [float(composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
+comp = [float(building.composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
 ax[1, 1].semilogx(bands, wall, "-o", ms=3, label="solid wall")
 ax[1, 1].semilogx(bands, comp, "-s", ms=3, label="wall + 1 % slit")
 ax[1, 1].axhline(20.0, ls=":"); ax[1, 1].set_title("Composite with aperture")

--- a/docs/buildings/design/resilient-layers.md
+++ b/docs/buildings/design/resilient-layers.md
@@ -54,21 +54,18 @@ the floor, caps the injected power.
 
 ```python
 import numpy as np
-from phonometry import (
-    hammer_impact_velocity, infinite_plate_impedance, plate_bending_stiffness,
-    plate_contact_stiffness, tapping_force_spectrum,
-)
+from phonometry import building, vibration
 
-print(round(hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
+print(round(building.hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
 
 # A 140 mm cast in-situ concrete slab: 2200 kg/m3, cL = 3800 m/s, nu = 0.2.
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-k = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+k = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 freqs = np.array([100, 200, 400, 800, 1600, 3150], dtype=float)
-res = tapping_force_spectrum(freqs, k, z)
+res = building.tapping_force_spectrum(freqs, k, z)
 res.over_critical            # False: the hammer rebounds off concrete
 round(res.cut_off_frequency)  # 6948 Hz, above the building acoustics range
 res.peak_force               # |Fn| per band, within 1 dB of res.upper_limit
@@ -112,23 +109,20 @@ carries the nulls where they belong.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    covering_contact_stiffness, covering_improvement, infinite_plate_impedance,
-    plate_bending_stiffness, plate_contact_stiffness,
-)
+from phonometry import building, vibration
 
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14          # 140 mm concrete slab
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-plate = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+plate = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0])
 
 d = 0.005
 for label, modulus_over_thickness in (("PVC", 1.5e11), ("backed vinyl", 2.8e8)):
-    res = covering_improvement(
-        bands, covering_contact_stiffness(modulus_over_thickness * d, d),
+    res = building.covering_improvement(
+        bands, building.covering_contact_stiffness(modulus_over_thickness * d, d),
         plate, z)
     plt.semilogx(bands, res.improvement, marker="o",
                  label=f"{label}: fco = {res.cut_off_frequency:.0f} Hz")
@@ -140,13 +134,13 @@ plt.show()
 </details>
 
 ```python
-from phonometry import covering_contact_stiffness, covering_improvement
+from phonometry import building
 
 # Covering No. 2 of Hopkins Fig. 4.64: E/d = 2.8e8 N/m3, a vinyl or carpet
 # with a resilient backing, 5 mm thick on the same 140 mm slab.
 d = 0.005
-covering = covering_contact_stiffness(2.8e8 * d, d)
-res = covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
+covering = building.covering_contact_stiffness(2.8e8 * d, d)
+res = building.covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
 round(res.cut_off_frequency)        # 100 Hz
 round(res.bare_cut_off_frequency)   # 6948 Hz, the bare slab's own cut-off
 res.improvement                     # 3.2, 17.0, 33.3, 43.0 dB, band values
@@ -189,16 +183,14 @@ applies is a question about damping, not about the layer:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-)
+from phonometry import building
 
 # The worked floating floor of ISO 12354-2:2017 Annex G.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
 freqs = np.logspace(np.log10(40.0), np.log10(5000.0), 400)
 for model, kwargs in (("en12354", {}), ("cremer", {}),
                       ("cremer_hammer", {"limiting_frequency": 521.0})):
-    res = floating_floor_improvement_spectrum(
+    res = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=f0, model=model, **kwargs)
     plt.semilogx(freqs, res.improvement, label=model)
 plt.axvline(f0, ls=":")
@@ -209,19 +201,15 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    combined_dynamic_stiffness, double_floating_floor_resonances,
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-    weighted_floating_floor_improvement,
-)
+from phonometry import building
 
 # 35 mm screed, m' = 73.5 kg/m2, on a resilient layer of s' = 8 MN/m3.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)
 round(f0, 1)                                                    # 52.8 Hz
 
 bands = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
          800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0]
-res = floating_floor_improvement_spectrum(
+res = building.floating_floor_improvement_spectrum(
     bands, resonance_frequency=f0, mass_per_area=73.5, dynamic_stiffness=8.0e6)
 res.improvement          # 0.0, 2.3, 5.4, 8.3, 11.2 ... 59.3 dB
 round(res.delta_lw, 1)   # 32.2 dB, the Formula (C.4) weighted improvement
@@ -229,12 +217,12 @@ res.plot()
 
 # Two resilient layers act as springs in series (Formula C.6), which drops the
 # resonance by sqrt(2) and buys about 4.5 dB everywhere above it.
-round(floating_floor_resonance_frequency(
-    combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
+round(building.floating_floor_resonance_frequency(
+    building.combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
 
 # One floating floor on top of another has two resonances instead of one; the
 # adverse dip disappears, but the steep rise only starts above the higher.
-double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
+building.double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
 ```
 
 The weighted single numbers come straight from the same two inputs, so a
@@ -252,10 +240,10 @@ Vér's two-subsystem SEA model turns into a 30 dB per decade rise rather than
 it.
 
 ```python
-from phonometry import resilient_mount_improvement
+from phonometry import building
 
 # 50 mm concrete walking surface on 4 mounts per m2 of 2 MN/m stiffness.
-resilient_mount_improvement(
+building.resilient_mount_improvement(
     [125.0, 250.0, 500.0, 1000.0], impedance=3.8e5, mass_per_area=115.0,
     loss_factor=0.02, mount_stiffness=2.0e6, mount_density=4.0)
 ```
@@ -289,30 +277,27 @@ to gain. From 200 Hz upwards it costs: 1 dB at 200 Hz falling to 10 dB from
 the range of interest is therefore the entire design brief.
 
 ```python
-from phonometry import (
-    lining_improvement, lining_improvement_in_situ, lining_resonance_frequency,
-    weighted_lining_improvement,
-)
+from phonometry import building
 
 # A 9.5 mm plasterboard laminated with 32 mm EPS (s' = 65 MN/m3), bonded with
 # adhesive dabs to a 100 mm aircrete block wall of 51 kg/m2.
-f0 = lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
+f0 = building.lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
 round(f0)                                       # 542 Hz: squarely in the way
-round(weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
+round(building.weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
 
 # The same lining on studs over a 100 mm mineral-wool-filled cavity.
-f0 = lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
+f0 = building.lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
 round(f0, 1)                                     # 70.8 Hz
-round(weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
+round(building.weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
 
 # External thermal insulation systems have their own Annex D fits.
-res = lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
+res = building.lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
 res.delta_rw, res.delta_ra, res.delta_ratr               # (10.5, 8.0, 9.7) dB
-lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
+building.lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
 res.plot()   # the Annex D ratings against fo, with this system marked
 
 # A laboratory rating transfers to the field through Formula (D.8).
-round(lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
+round(building.lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
 ```
 
 ## What is anchored on a published number, and what is not

--- a/docs/buildings/design/structure-borne-power.md
+++ b/docs/buildings/design/structure-borne-power.md
@@ -202,11 +202,11 @@ plus matplotlib for the spectrum.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, reception_plate_power
+from phonometry import ReportMetadata, building
 
 freqs = np.array([125, 250, 500, 1000, 2000, 4000], float)
 lv = np.array([88.0, 90, 86, 82, 78, 73])   # spatial mean plate velocity level [dB]
-res = reception_plate_power(
+res = building.reception_plate_power(
     lv, freqs, mass_per_area=25.0, area=1.2, reverberation_time=0.3,
 )
 res.report(

--- a/docs/buildings/insulation/flanking-lab.md
+++ b/docs/buildings/insulation/flanking-lab.md
@@ -205,29 +205,26 @@ $R_\mathrm{cl,p} = R_\mathrm{cl} + 10\log_{10}(H_\mathrm{S}/L_\mathrm{S})$ (Eq. 
 ceiling path be added to the direct path as transmission factors.
 
 ```python
-from phonometry import (
-    partition_referenced_reduction_index,
-    plenum_flanking_reduction_index,
-)
+from phonometry import building
 
 freqs = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0]   # 9.5 mm plasterboard
 
 # Vigran's example geometry: LS = LR = 4.75 m, plenum 0.43 m, reflecting walls.
-res = plenum_flanking_reduction_index(
+res = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, frequency=freqs
 )
 print(round(res.geometry_term, 1))    # 10.4 dB charged against RS + RR
 res.plot()                            # Rcl against the two ceilings
 
 # A lined plenum attenuates the sideways path (Eq. (9.18) instead of (9.20)):
-damped = plenum_flanking_reduction_index(
+damped = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43,
     attenuation_source=[0.5] * 7, attenuation_receiving=[0.5] * 7,
 )
 
 # Referred to the partition instead of the ceiling (Eq. (9.13)):
-print(partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
+print(building.partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
 ```
 
 **The measured quantity.** A ceiling is not rated by $R_\mathrm{cl}$ but by the
@@ -250,25 +247,21 @@ deficiency exceeds 8 dB (clauses 5.3 and 5.4), and reads the rating off the
 shifted contour at 500 Hz (clause 5.5).
 
 ```python
-from phonometry import (
-    ceiling_attenuation_class,
-    normalized_ceiling_attenuation,
-    weighted_rating,
-)
+from phonometry import building
 
 # ASTM E1414 normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
-dnc = normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
+dnc = building.normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
        41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9]
-res = ceiling_attenuation_class(dnc)
+res = building.ceiling_attenuation_class(dnc)
 print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34, 27.0, 7.0
 res.plot()                                                  # Dn,c vs the contour
 
 # The ISO single number of the same spectrum, shifted to A0 = 10 m2:
 iso = [v - 0.79 for v in dnc]
-print(weighted_rating(iso).rating)                          # Dn,c,w
+print(building.weighted_rating(iso).rating)                          # Dn,c,w
 ```
 
 ## ISO 10848 flanking-transmission reports (`.report()`)

--- a/docs/buildings/insulation/heavy-impact-sources.md
+++ b/docs/buildings/insulation/heavy-impact-sources.md
@@ -54,22 +54,17 @@ less into the top one, which is why the two sources are not interchangeable and
 why a floor can pass one and fail the other.
 
 ```python
-from phonometry import (
-    check_heavy_impact_source,
-    heavy_impact_source_limits,
-    heavy_impact_source_specification,
-    impact_force_exposure_level,
-)
+from phonometry import building
 
-spec = heavy_impact_source_specification("rubber_ball")
+spec = building.heavy_impact_source_specification("rubber_ball")
 print(spec.drop_height, spec.effective_mass)      # 1.0 m, 2.5 kg
 print(spec.contact_time, spec.contact_time_tolerance)   # 0.02 s +/- 0.002 s
 
-freqs, lower, upper = heavy_impact_source_limits("bang_machine")
+freqs, lower, upper = building.heavy_impact_source_limits("bang_machine")
 print(list(zip(freqs, lower, upper))[0])          # (31.5, 46.0, 48.0)
 
 # A calibration run: five measured octave-band LFE against the printed table.
-check = check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9])
+check = building.check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9])
 print(check.passed, list(check.within_tolerance))
 check.plot()   # measured LFE over the tolerance band (needs matplotlib)
 ```
@@ -84,7 +79,7 @@ any single band value and must not be compared with the table above.
 
 ```python
 import numpy as np
-from phonometry import OctaveFilterBank, impact_force_exposure_level
+from phonometry import building, filters
 
 fs = 48_000
 t = np.arange(0.0, 0.020, 1.0 / fs)          # the 20 ms contact time
@@ -92,12 +87,12 @@ force = 1500.0 * np.sin(np.pi * t / 0.020)   # a single-peak half-sine pulse
 
 # Broadband, i.e. the whole pulse energy: 10 lg(Fp^2 t / 2) = 43.5 dB.
 # Not a band value, and not comparable with the table above.
-print(round(impact_force_exposure_level(force, fs), 2))
+print(round(building.impact_force_exposure_level(force, fs), 2))
 
 # The five octave-band values the specification is actually written in.
-bank = OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
+bank = filters.OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
 _, freqs, bands = bank.filter(force, sigbands=True, calculate_level=False)
-lfe = [impact_force_exposure_level(b, fs) for b in bands]
+lfe = [building.impact_force_exposure_level(b, fs) for b in bands]
 print([round(v, 1) for v in lfe])   # [-1.4, 14.0, 22.1, 20.2, 17.1]
 
 # Those five go to the conformance check; this synthetic half-sine is not a
@@ -139,23 +134,19 @@ its value is $1/e$. When $T = T_0$ the bracket collapses to 1 and the whole
 correction reduces to the volume term, as it must.
 
 ```python
-from phonometry import (
-    fast_reverberation_correction,
-    heavy_impact_octave_levels,
-    standardized_maximum_impact_level,
-)
+from phonometry import building
 
 freqs = [63.0, 125.0, 250.0, 500.0]
 li_fmax = [65.3, 64.5, 58.0, 55.8]           # energy-averaged over ball positions
 t = [1.43, 3.70, 3.10, 2.38]                 # receiving-room reverberation time
 
-res = standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
+res = building.standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
 print(res.volume_term)                        # 10 lg(41.4/50) = -0.8 dB
-print(fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
+print(building.fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
 res.plot()   # measured and standardized spectra (needs matplotlib)
 
 # One-third-octave measurements combine into octaves with Formula (20):
-print(heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
+print(building.heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
 ```
 
 ## The single number is an A-weighted sum, not a shifted curve
@@ -179,10 +170,10 @@ The worked example of Table D.4 is reproduced exactly, including the
 deliberately unrounded intermediate the standard prints:
 
 ```python
-from phonometry import a_weighted_maximum_impact_level
+from phonometry import building
 
 # ISO 717-2:2020 Table D.4: a field measurement in octave bands.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 print(list(res.corrected))   # 39.1, 48.3, 49.3, 52.6 dB
 print(res.unrounded)         # 55.350667... dB
 print(res.rating)            # 55 dB

--- a/docs/buildings/insulation/spanish-building-code.md
+++ b/docs/buildings/insulation/spanish-building-code.md
@@ -134,7 +134,7 @@ $C_{\mathrm{tr},100-5000}$ are both $-5$, so the $D_{2\mathrm{m,nT,Atr}}$ that D
 requires happens not to discriminate between the two readings at all.
 
 ```python
-from phonometry import building, weighted_rating_extended
+from phonometry import building
 
 d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
           38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5, 39.4, 41.5]
@@ -142,7 +142,7 @@ d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
 direct = building.d2m_nt_atr(d2m_nt)
 direct.intermediate, direct.reported   # 32.8 dBA -> 33 dBA
 
-iso = weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
+iso = building.weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
 iso.rating, iso.ctr_100_5000           # 38 dB, -5 dB -> 33 dBA, the same figure
 iso.c, iso.c_100_5000                  # -2 and -1: core range versus enlarged range
 ```

--- a/docs/buildings/rooms/enclosed-space-absorption.md
+++ b/docs/buildings/rooms/enclosed-space-absorption.md
@@ -190,10 +190,7 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import (
-    enclosed_space_reverberation, hard_object_absorption, object_fraction,
-    ReportMetadata,
-)
+from phonometry import ReportMetadata, room
 
 surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (20.0, [0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.55]),  # carpeted floor
@@ -201,10 +198,10 @@ surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (45.0, [0.02, 0.02, 0.03, 0.04, 0.05, 0.05, 0.05]),  # painted-plaster walls
 ]
 volumes = [0.5, 0.8, 0.3]                      # furniture, m^3
-result = enclosed_space_reverberation(
+result = room.enclosed_space_reverberation(
     surfaces, 50.0,
-    objects=hard_object_absorption(volumes),
-    object_fraction=object_fraction(volumes, 50.0),
+    objects=room.hard_object_absorption(volumes),
+    object_fraction=room.object_fraction(volumes, 50.0),
     air_condition="20C_50-70",
 )
 result.report(

--- a/docs/buildings/rooms/reverberation-prediction.md
+++ b/docs/buildings/rooms/reverberation-prediction.md
@@ -309,9 +309,9 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import reverberation_time_models, ReportMetadata
+from phonometry import ReportMetadata, room
 
-result = reverberation_time_models(
+result = room.reverberation_time_models(
     (8.0, 5.0, 3.0),                       # a shoebox room, one treated wall pair
     ([0.10, 0.15, 0.30, 0.45, 0.55, 0.60], # treated wall pair, per octave band
      [0.08, 0.10, 0.12, 0.15, 0.18, 0.20], # side walls

--- a/docs/buildings/rooms/room-impulse-response.md
+++ b/docs/buildings/rooms/room-impulse-response.md
@@ -108,15 +108,14 @@ sequence, visible as the near-constant magnitude on the right.
 
 ```python
 from phonometry import room
-from phonometry import plot_excitation
 
 fs = 48000
 sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)   # ESS excitation
 mls = room.mls_signal(12).astype(float)             # length 2**12 - 1
 
 # One-liner: waveform + spectrogram (sweep), sequence + flat spectrum (MLS)
-plot_excitation(sweep, fs, kind="sweep")
-plot_excitation(mls, fs, kind="mls")
+room.plot_excitation(sweep, fs, kind="sweep")
+room.plot_excitation(mls, fs, kind="mls")
 
 # By hand: the sweep spectrogram and the MLS magnitude spectrum
 import numpy as np

--- a/docs/devices/electroacoustics/loudspeakers.md
+++ b/docs/devices/electroacoustics/loudspeakers.md
@@ -72,10 +72,10 @@ $ka\sin\theta = 3.8317$.
 
 ```python
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.1, frequencies=np.geomspace(20, 20000, 200),
-                       angles=np.linspace(0.0, np.pi / 2, 91))
+res = electroacoustics.radiating_piston(radius=0.1, frequencies=np.geomspace(20, 20000, 200),
+                                        angles=np.linspace(0.0, np.pi / 2, 91))
 print(round(res.radiation_mass, 4))               # 8 rho a^3 / 3, kg
 print(round(float(res.directivity_index[0]), 2))  # 3.01 dB half-space limit
 res.plot()                                         # R1 and X1 vs ka
@@ -96,9 +96,9 @@ reactance dies away.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
 res.plot()   # normalized R1 and X1 against ka
 plt.show()
 ```
@@ -121,9 +121,9 @@ classic polar beam pattern. Several $ka$ are shown as one family, so the main
 lobe narrowing and the side lobes appearing read at a glance:
 
 ```python
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-pattern = piston_directivity_pattern([3.0, 8.0, 16.0])
+pattern = electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0])
 print(pattern.directivity_db.shape)  # (3, 361): one row per ka
 pattern.plot()                       # polar beam pattern in dB (needs matplotlib)
 ```
@@ -135,9 +135,9 @@ pattern.plot()                       # polar beam pattern in dB (needs matplotli
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
+electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
 plt.show()
 ```
 
@@ -161,10 +161,10 @@ first side lobes have appeared.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
-                       angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
+res = electroacoustics.radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
+                                        angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
 
 # One line: the piston in its baffle with the lobe of the highest frequency.
 res.plot_geometry()
@@ -192,25 +192,22 @@ computed from the response rather than merely repeated:
 
 ```python
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, ReportMetadata, loudspeaker_characteristics,
-    radiating_piston,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(np.geomspace(20, 20000, 260),
                6.6 + 24 * np.exp(-(np.log2(np.geomspace(20, 20000, 260) / 52.0) ** 2) / 0.12)),
     distortion=(np.geomspace(50, 5000, 140),
                 0.3 + 2.6 * np.exp(-(np.log2(np.geomspace(50, 5000, 140) / 70.0) ** 2) / 0.45)),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -256,15 +253,15 @@ result.plot(quantity="directivity")  # polar response on the 25 dB circle
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
-                                     sensitivity_band=(200.0, 4000.0))
+result = electroacoustics.loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
+                                                      sensitivity_band=(200.0, 4000.0))
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -279,13 +276,13 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 fz = np.geomspace(20, 20000, 260)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(fz, 6.6 + 24 * np.exp(-(np.log2(fz / 52.0) ** 2) / 0.12)),
 )
@@ -303,13 +300,13 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 thd_f = np.geomspace(50, 5000, 140)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distortion=(thd_f, 0.3 + 2.6 * np.exp(-(np.log2(thd_f / 70.0) ** 2) / 0.45)),
 )
@@ -327,18 +324,16 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, loudspeaker_characteristics, radiating_piston,
-)
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )

--- a/docs/devices/electroacoustics/microphones.md
+++ b/docs/devices/electroacoustics/microphones.md
@@ -114,10 +114,7 @@ standard's own definitions rather than merely repeated:
 
 ```python
 import numpy as np
-from phonometry import (
-    MicrophoneDirectivity, MicrophoneElectrical, MicrophoneNoise,
-    MicrophoneOverload, ReportMetadata, microphone_characteristics,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
@@ -128,19 +125,19 @@ angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,          # 12.5 mV/Pa at 1 kHz
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
-    noise=MicrophoneNoise(                             # A-weighted, V
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    noise=electroacoustics.MicrophoneNoise(                             # A-weighted, V
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(np.linspace(100, 140, 81),
                     0.5 * 10 ** ((np.linspace(100, 140, 81) - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
-    electrical=MicrophoneElectrical(
+    electrical=electroacoustics.MicrophoneElectrical(
         rated_impedance=150.0, minimum_load_impedance=1000.0,
         powering="Phantom P48 (IEC 61938)", supply_current_ma=3.1,
     ),
@@ -189,14 +186,14 @@ result.plot(quantity="distortion")   # THD vs sound pressure level
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
 response -= 10 * np.log10(1 + (freqs / 19000.0) ** 8)   # high-frequency roll-off
 response += 2.0 * np.exp(-(np.log2(freqs / 9000.0) ** 2) / 0.3)  # presence region
 
-result = microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
+result = electroacoustics.microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -211,16 +208,16 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneDirectivity, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
 )
 result.plot(quantity="directivity")
 plt.show()
@@ -236,15 +233,15 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneNoise, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    noise=MicrophoneNoise(
+    noise=electroacoustics.MicrophoneNoise(
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
@@ -263,15 +260,15 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneOverload, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 spl_axis = np.linspace(100, 140, 81)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(spl_axis, 0.5 * 10 ** ((spl_axis - 130.0) * 0.08)),
         thd_percent=0.5,
     ),

--- a/docs/devices/electroacoustics/swept-sine-distortion.md
+++ b/docs/devices/electroacoustics/swept-sine-distortion.md
@@ -52,12 +52,12 @@ their fixed advances.
 
 ```python
 import numpy as np
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
-x = synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
 res.thd, res.thd_frequencies
@@ -74,14 +74,14 @@ res.plot()                # |Hn| magnitudes + THD(f)
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)             # 3 kHz post-filter
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 h1 = 1.0 + 3.0 * a3 / 4.0                              # Chebyshev gain
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -159,10 +159,10 @@ be ignored; the band of every $H_n$ is also capped at $f_2$ by the inverse
 filter.
 
 ```python
-from phonometry import sweep_signal, swept_sine_distortion
+from phonometry import electroacoustics, room
 
-x = sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
+x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
 
@@ -191,16 +191,14 @@ all-pass parts:
 
 ```python
 import numpy as np
-from phonometry import (
-    excess_phase, group_delay, minimum_phase, phase_decomposition,
-)
+from phonometry import signals
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
-h_min = minimum_phase(np.abs(H))       # phase from the magnitude alone
-tau_g = group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
-phi_x = excess_phase(H)                # unwrap(arg H) - phi_min
+h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone
+tau_g = signals.group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
+phi_x = signals.excess_phase(H)                # unwrap(arg H) - phi_min
 
-res = phase_decomposition(H, fs)       # everything on one axis
+res = signals.phase_decomposition(H, fs)       # everything on one axis
 res.excess_group_delay                 # the all-pass part, in seconds
 res.plot()                             # magnitude, phases, group delays
 ```
@@ -219,7 +217,7 @@ excess group delay reads the latency directly as a flat 2.5 ms line.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import phase_decomposition
+from phonometry import signals
 
 fs = 48000.0
 delay = int(0.0025 * fs)                      # a 2.5 ms processing latency
@@ -232,7 +230,7 @@ imp = np.zeros(16384)
 imp[delay] = 1.0
 ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
-res = phase_decomposition(np.fft.rfft(ir), fs)
+res = signals.phase_decomposition(np.fft.rfft(ir), fs)
 res.plot()   # |H|, the three phases and the group delays
 plt.show()
 ```

--- a/docs/devices/emission/sound-power-pressure.md
+++ b/docs/devices/emission/sound-power-pressure.md
@@ -223,11 +223,11 @@ surface integral.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import measurement_positions, plot_microphone_positions
+from phonometry import emission
 
 # The 10 ISO 3744 Annex B microphones on a 2 m hemisphere.
-plot_microphone_positions(measurement_positions("hemisphere", radius=2.0),
-                          radius=2.0)
+emission.plot_microphone_positions(emission.measurement_positions("hemisphere", radius=2.0),
+                                   radius=2.0)
 plt.show()
 ```
 

--- a/docs/devices/noise-control/duct-path.md
+++ b/docs/devices/noise-control/duct-path.md
@@ -33,20 +33,20 @@ level leaving it. `DuctElement` carries exactly the two spectra an element
 owns, and `duct_path` walks them:
 
 ```python
-from phonometry import DuctElement, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 
-path = duct_path(
+path = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined",
-                    attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
-                    self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
-                    self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined",
+                                  attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
+                                  self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
+                                  self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
     ],
     source_label="Fan, centrifugal FC, 5000 cfm, 2 in w.g.",
 )
@@ -99,21 +99,18 @@ logarithmic terms take the same values as the foot-pound form in cfm and
 inches of water gauge.
 
 ```python
-from phonometry import (
-    blade_passing_frequency, fan_casing_attenuation,
-    fan_efficiency_correction, fan_sound_power,
-)
+from phonometry import noise_control
 
 CFM, IN_WG = 0.0004719474432, 249.0
 
-fan = fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
-                      fan_type="forward_curved", relative_efficiency=80.0)
+fan = noise_control.fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
+                                    fan_type="forward_curved", relative_efficiency=80.0)
 print([round(float(v)) for v in fan.values])
 # [99, 99, 89, 84, 82, 77, 72, 67]
 
-print(fan_efficiency_correction(80.0))          # 6.0 dB off the peak
-print(blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
-print(fan_casing_attenuation().values)          # what the housing holds back
+print(noise_control.fan_efficiency_correction(80.0))          # 6.0 dB off the peak
+print(noise_control.blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
+print(noise_control.fan_casing_attenuation().values)          # what the housing holds back
 # [ 0.  0.  5. 10. 15. 20. 22. 25.]
 fan.plot()                                      # the band spectrum, one line
 ```
@@ -158,17 +155,15 @@ for 25 mm to 52 mm linings and clipped at 40 dB per run because flanking
 takes over beyond that.
 
 ```python
-from phonometry import (
-    lined_rectangular_duct_attenuation, unlined_rectangular_duct_attenuation,
-)
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
-bare = unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
-lined = lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
-                                           1 * IN, include_unlined=True)
+bare = noise_control.unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
+lined = noise_control.lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
+                                                         1 * IN, include_unlined=True)
 print(np.round(bare.values, 1))    # [1.1 0.7 0.5 0.2 0.2 0.2 0.2 0.2]
 print(np.round(lined.values, 1))   # [ 1.3  1.3  2.5  6.7 12.8 10.6  9.7  9. ]
 ```
@@ -196,12 +191,12 @@ branch area does not match the feeder, and a 25 per cent branch therefore
 costs 6 dB.
 
 ```python
-from phonometry import elbow_insertion_loss, split_loss
+from phonometry import noise_control
 
 IN = 0.0254
 area = 36 * IN * 24 * IN
-print(round(split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
-print(elbow_insertion_loss(
+print(round(noise_control.split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
+print(noise_control.elbow_insertion_loss(
     [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
     24 * IN, bend_type="round").values)          # [0. 1. 2. 3. 3. 3. 3. 3.]
 ```
@@ -224,15 +219,15 @@ the impedance transition, and a manufacturer's diffuser rating already
 contains whatever is left of it.
 
 ```python
-from phonometry import end_reflection_loss, equivalent_diameter
+from phonometry import noise_control
 import numpy as np
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0]
-print(np.round(end_reflection_loss(bands, 0.30, method="bies").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="bies").values, 1))
 # [12.  7.  3.  1.  0.  0.]
-print(np.round(end_reflection_loss(bands, 0.30, method="long").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="long").values, 1))
 # [12.7  7.7  3.7  1.3  0.4  0.1]
-print(round(equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
+print(round(noise_control.equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
 ```
 
 **Silencers and plenums.** A parallel-splitter attenuator reduces, in Bies
@@ -243,17 +238,17 @@ chamber (Bies Eq. (8.275)), whose reverberant term uses the plenum
 [room constant](../../buildings/rooms/room-image-sources.md).
 
 ```python
-from phonometry import plenum_attenuation, splitter_silencer_insertion_loss
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
-sil = splitter_silencer_insertion_loss(
+sil = noise_control.splitter_silencer_insertion_loss(
     None, height=24 * IN, length=5 * FT,
     airway_widths=[0.10] * 5, splitter_thickness=0.10,
 )
 print(np.round(sil.values, 1))
 # [ 5.8  8.6 14.1 28.2 34.5 33.5 18.4 12.1]
-print(round(plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
+print(round(noise_control.plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
 ```
 
 Read that estimate for what it is. The 5 ft unit Long's return path
@@ -281,14 +276,14 @@ is the whole message: the fifth-and-a-half power of the airway velocity
 means that *doubling the face velocity of a silencer adds about 17 dB*.
 
 ```python
-from phonometry import silencer_self_noise
+from phonometry import noise_control
 import numpy as np
 
 IN = 0.0254
-slow = silencer_self_noise(None, airway_velocity=10.0, passages=5,
-                           height=24 * IN)
-fast = silencer_self_noise(None, airway_velocity=20.0, passages=5,
-                           height=24 * IN)
+slow = noise_control.silencer_self_noise(None, airway_velocity=10.0, passages=5,
+                                         height=24 * IN)
+fast = noise_control.silencer_self_noise(None, airway_velocity=20.0, passages=5,
+                                         height=24 * IN)
 print(np.round(slow.values, 1))
 # [40.8 40.8 38.8 36.8 31.8 26.8 21.8 16.8]
 print(round(float(fast.values[0] - slow.values[0]), 1))     # 16.6 dB
@@ -313,15 +308,15 @@ function $C_D = -11.82 - 0.15 A - 1.13 A^2$ ($-5.82$ for a round device)
 about the peak band $f_\mathrm{P} = 48.8\,U_\mathrm{G}$.
 
 ```python
-from phonometry import diffuser_sound_power
+from phonometry import noise_control
 import numpy as np
 
 IN, CFM, IN_WG = 0.0254, 0.0004719474432, 249.0
 
 # The supply diffuser of Long's worked sheet: 24 x 24 in, 312 cfm, 0.05 in pd.
-print(np.round(diffuser_sound_power(None, (24 * IN) ** 2,
-                                    volume_flow=312 * CFM,
-                                    pressure_drop=0.05 * IN_WG).values, 1))
+print(np.round(noise_control.diffuser_sound_power(None, (24 * IN) ** 2,
+                                                  volume_flow=312 * CFM,
+                                                  pressure_drop=0.05 * IN_WG).values, 1))
 # [ 33.4  32.4  29.1  23.6  15.9   5.9  -6.4 -21. ]
 # Long Table 14.9 prints 33/32/29/23/15/4/0/0 for that row.
 ```
@@ -336,12 +331,12 @@ penalty for throttling a balancing damper, which is where a great many
 finished installations fail.
 
 ```python
-from phonometry import air_terminal_damper_correction, air_terminal_velocity_limit
+from phonometry import noise_control
 
-print(air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
-print(air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
-print(air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
-print(air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
+print(noise_control.air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
+print(noise_control.air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
+print(noise_control.air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
+print(noise_control.air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
 ```
 
 Fifteen decibels in the neck against two decibels 1.5 m back in the duct,
@@ -359,12 +354,12 @@ every other loss, with $Q = 2$ by default for a diffuser flush in a
 ceiling.
 
 ```python
-from phonometry import room_constant, room_effect
+from phonometry import noise_control, room
 
 # The 20 x 20 x 8 ft room of Long's worked sheet, drywall and carpet.
 area = 2 * 6.10 * 6.10 + 4 * 6.10 * 2.44        # 134.0 m2
-r_const = room_constant(area, 0.15)             # 23.6 m2
-print(round(float(room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
+r_const = room.room_constant(area, 0.15)             # 23.6 m2
+print(round(float(noise_control.room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
 ```
 
 Long's sheet prints 5 to 7 dB for that room across the bands, so a single
@@ -391,54 +386,54 @@ silencers and the terminal devices, which is what a real sheet uses.
 
 ```python
 import numpy as np
-from phonometry import DuctElement, combine_duct_paths, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 source = "Fan, centrifugal FC, 5000 cfm, 2 in w.g."
 
-supply = duct_path(
+supply = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    [7, 12, 16, 28, 35, 35, 28, 17],
-                    [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
-        DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
-                    [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
-        DuctElement("Split, 25 per cent", 6.0, code="5"),
-        DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
-                    [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
-        DuctElement("Flexible duct, 12 in, 6 ft",
-                    [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
-        DuctElement("Rectangular diffuser, 312 cfm", None,
-                    [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  [7, 12, 16, 28, 35, 35, 28, 17],
+                                  [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
+                                  [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
+        noise_control.DuctElement("Split, 25 per cent", 6.0, code="5"),
+        noise_control.DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
+                                  [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
+        noise_control.DuctElement("Flexible duct, 12 in, 6 ft",
+                                  [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
+        noise_control.DuctElement("Rectangular diffuser, 312 cfm", None,
+                                  [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
     ],
     room_effect=[6, 6, 5, 5, 6, 7, 6, 6],
     source_label=source, target=30.0, label="Supply",
 )
 
-ret = duct_path(
+ret = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
-        DuctElement("Silencer, 5 ft, low-frequency type",
-                    [16, 21, 35, 41, 41, 28, 21, 15],
-                    [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
-        DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
-                    [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
-        DuctElement("Plenum, 800 sq ft, 50 per cent lined",
-                    [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
-        DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
-                    [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 5 ft, low-frequency type",
+                                  [16, 21, 35, 41, 41, 28, 21, 15],
+                                  [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
+                                  [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
+        noise_control.DuctElement("Plenum, 800 sq ft, 50 per cent lined",
+                                  [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
+        noise_control.DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
+                                  [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
     ],
     room_effect=[9, 8, 6, 8, 8, 8, 9, 10],
     source_label=source, target=30.0, label="Return",
 )
 
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 print(np.round(supply.received_level, 0))    # Long: 52 42 30 18  9 -2 -2 -1
 print(np.round(ret.received_level, 0))       # Long: 52 41 27 25 23 25 22 12
 print(np.round(total.received_level, 0))     # Long: 55 45 32 26 23 25 22 12
@@ -469,7 +464,7 @@ nothing at all: the return already sets the answer everywhere except at
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import combine_duct_paths
+from phonometry import noise_control
 
 # `supply` and `ret` are the two DuctPathResult objects built above.
 
@@ -478,7 +473,7 @@ supply.plot()
 plt.show()
 
 # The concept figure: both paths, their energy sum and the criterion.
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 total.plot()
 plt.gca().set_ylim(-6.0, 62.0)
 plt.show()
@@ -577,18 +572,18 @@ $k_x = -M\kappa_{pq}/\sqrt{1 - M^2}$.
 
 ```python
 import numpy as np
-from phonometry import plane_wave_limit, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.2: a 0.65 x 0.4 m air-conditioning duct at 15 m/s.
-modes = rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
+modes = noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
 print(modes.modes[:3])                          # ((1, 0), (0, 1), (1, 1))
 print(np.round(modes.cut_on[:3], 1))            # [263.6 428.3 502.9] Hz
 print(np.round(modes.cut_on_no_flow[:3], 1))    # [263.8 428.8 503.4] Hz
 print(round(modes.plane_wave_limit, 1))         # 263.6 Hz
 
 IN = 0.0254
-print(round(plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
-print(round(plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
+print(round(noise_control.plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
+print(round(noise_control.plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
 ```
 
 Those ventilation numbers are blunt: in that duct plane waves are the whole
@@ -628,11 +623,11 @@ rung.
 
 ```python
 import numpy as np
-from phonometry import circular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.1: a 254 mm circular duct carrying steam at 200 m/s.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 print(steam.modes)
 # ((1, 0), (2, 0), (0, 1), (3, 0), (4, 0), (1, 1))
 print(np.round(steam.cut_on_no_flow, 1))
@@ -658,16 +653,16 @@ at the frequency at which it appears.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import circular_duct_cut_on, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # One line for one duct: the cut-on ladder with the plane-wave band shaded.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 steam.plot()
 plt.show()
 
 # The ventilation duct of problem 7.2, where the flow shift is negligible.
-rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
+noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
 plt.show()
 ```
 
@@ -682,17 +677,17 @@ they describe the plane-wave mode alone, which a measurement will not.
 
 ```python
 import warnings
-from phonometry import DuctElement, PlaneWaveWarning, duct_path
+from phonometry import noise_control
 
 IN = 0.0254
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
-    duct_path(bands, [90.0] * 8, [DuctElement("Straight run", 3.0)],
-              section={"width": 36 * IN, "height": 24 * IN},
-              flow_velocity=6.0, label="Supply")
-print(caught[0].category is PlaneWaveWarning)
+    noise_control.duct_path(bands, [90.0] * 8, [noise_control.DuctElement("Straight run", 3.0)],
+                            section={"width": 36 * IN, "height": 24 * IN},
+                            flow_velocity=6.0, label="Supply")
+print(caught[0].category is noise_control.PlaneWaveWarning)
 print(str(caught[0].message))
 # Supply: 6 of 8 frequencies are above the first duct cut-on frequency
 # (188 Hz), where higher-order modes propagate and the plane-wave result

--- a/docs/devices/noise-control/noise-control.md
+++ b/docs/devices/noise-control/noise-control.md
@@ -106,10 +106,10 @@ numbers has the same predicted attenuation.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import plot_plenum_geometry
+from phonometry import noise_control
 
 # The r, S_out and S_w that Wells' formula actually uses, drawn exactly.
-plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
+noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
 plt.show()
 ```
 
@@ -184,12 +184,12 @@ interior absorption.
 
 ```python
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
-enc = enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
-                               internal_absorption=0.3, frequencies=bands)
+enc = noise_control.enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
+                                             internal_absorption=0.3, frequencies=bands)
 print(np.round(enc.insertion_loss, 1))          # net IL = R - C per band
 enc.plot()
 ```
@@ -207,13 +207,13 @@ together with the panels, not as an afterthought.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
 
-enc = enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
-                               internal_absorption=0.3, frequencies=bands)
+enc = noise_control.enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
+                                             internal_absorption=0.3, frequencies=bands)
 
 # One line — panel R, interior correction C and the net IL = R - C:
 enc.plot()
@@ -258,14 +258,14 @@ insertion loss.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, enclosure_insertion_loss
+from phonometry import ReportMetadata, noise_control
 
 octaves = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 sheet_steel_R = np.array([18.0, 22.0, 28.0, 33.0, 38.0, 42.0, 45.0])
 
-case = enclosure_insertion_loss(sheet_steel_R, external_area=24.0,
-                                internal_area=30.0, internal_absorption=0.30,
-                                frequencies=octaves)
+case = noise_control.enclosure_insertion_loss(sheet_steel_R, external_area=24.0,
+                                              internal_area=30.0, internal_absorption=0.30,
+                                              frequencies=octaves)
 case.report(
     "enclosure.pdf",
     metadata=ReportMetadata(

--- a/docs/devices/noise-control/room-to-room.md
+++ b/docs/devices/noise-control/room-to-room.md
@@ -65,14 +65,12 @@ speaking into the same 8 m x 9 m x 3 m receiving room through the same
 
 ```python
 import numpy as np
-from phonometry import (
-    SourceRoom, equivalent_absorption_area, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 
 # Receiving room 8 x 9 x 3 m: walls 102 m2, floor and ceiling 72 m2 each.
-receiving = equivalent_absorption_area([
+receiving = room.equivalent_absorption_area([
     (102.0, [0.04, 0.04, 0.09, 0.15, 0.17, 0.23]),   # walls
     (72.0,  [0.02, 0.06, 0.14, 0.37, 0.60, 0.66]),   # floor
     (72.0,  [0.30, 0.20, 0.15, 0.05, 0.05, 0.05]),   # ceiling
@@ -86,9 +84,9 @@ partitions = {
     "Double brick, 50 mm cavity":      [37, 41, 48, 60, 61, 61],
 }
 for name, tl in partitions.items():
-    res = room_to_room_transmission(
+    res = noise_control.room_to_room_transmission(
         bands, tl, 8.0 * 3.0, receiving,
-        source=SourceRoom(level=90.0), label=name,
+        source=noise_control.SourceRoom(level=90.0), label=name,
     )
     print(f"{name:32s} {np.round(res.noise_reduction, 1)}")
 # Two 13 mm wallboards, 64 mm gap  [18.5 26.8 38.  47.8 47.3 43.9]
@@ -132,10 +130,7 @@ $10\log_{10} 4 = 6.02\ \text{dB}$, and without it the printed answers come out
 6 dB low.
 
 ```python
-from phonometry import (
-    DesignCriterion, SourceRoom, equivalent_absorption_area, mean_absorption,
-    room_constant, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [0.07, 0.20, 0.40, 0.52, 0.60, 0.67]      # absorbent ceiling
@@ -149,18 +144,18 @@ plant = [(80.0, [0.01, 0.01, 0.015, 0.02, 0.02, 0.02]),
 operator = [(25.0, [0.08, 0.24, 0.57, 0.69, 0.71, 0.73]),
             (25.0, ceiling), (60.0, walls)]
 
-chain = room_to_room_transmission(
+chain = noise_control.room_to_room_transmission(
     bands,
     [39.0, 42.0, 50.0, 58.0, 63.0, 67.0],       # TL of the separating wall
     5.0 * 3.0,                                  # the wall is 5 m x 3 m
-    equivalent_absorption_area(operator),
-    source=SourceRoom(
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(
         power_level=[105.0, 103.0, 98.0, 108.0, 107.0, 109.0],
-        room_constant=room_constant(268.0, mean_absorption(plant)),
+        room_constant=room.room_constant(268.0, room.mean_absorption(plant)),
         directivity=4.0,                        # floor-wall intersection
         model="constant_volume",                # the conservative bound
     ),
-    criterion=DesignCriterion(target=45.0),
+    criterion=noise_control.DesignCriterion(target=45.0),
     label="Plant room to operator room",
 )
 
@@ -276,7 +271,7 @@ $\text{TL} = \text{IL} + 10\log_{10}(S_\mathrm{E} / R_\mathrm{i})$, which is
 
 ```python
 import numpy as np
-from phonometry import enclosure_required_transmission_loss, mean_absorption
+from phonometry import noise_control, room
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 wool = [0.10, 0.20, 0.45, 0.65, 0.75, 0.80, 0.80, 0.80]   # 50 mm blanket
@@ -293,11 +288,11 @@ radiating = 2 * (2.5 * 2.5) + 2 * (3.5 * 2.5) + 2.5 * 3.5
 machine = 2 * (1.5 * 1.5) + 2 * (2.5 * 1.5) + 1.5 * 2.5
 bare_floor = 2.5 * 3.5 - 1.5 * 2.5
 
-required = enclosure_required_transmission_loss(
+required = noise_control.enclosure_required_transmission_loss(
     lp1 - nc45,
     radiating,
     radiating + bare_floor + machine,
-    mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
+    room.mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
     frequencies=bands,
     model="norton",
 )
@@ -358,11 +353,11 @@ transmission loss rather than get lost:
 
 ```python
 # The chain of section 3 again, with 3 dB allowed for flanking and leaks.
-honest = room_to_room_transmission(
+honest = noise_control.room_to_room_transmission(
     bands, [39.0, 42.0, 50.0, 58.0, 63.0, 67.0], 15.0,
-    equivalent_absorption_area(operator),
-    source=SourceRoom(level=chain.source_level),
-    criterion=DesignCriterion(target=45.0, flanking_penalty=3.0),
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(level=chain.source_level),
+    criterion=noise_control.DesignCriterion(target=45.0, flanking_penalty=3.0),
 )
 print(np.round(honest.received_level, 1))
 # [75.4 63.4 44.4 44.  36.9 33.7]      every band 3 dB worse

--- a/docs/devices/noise-control/silencers.md
+++ b/docs/devices/noise-control/silencers.md
@@ -78,10 +78,10 @@ exactly.
 
 ```python
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 print(round(res.transmission_loss.max(), 2))   # 6.55 dB peak (m = 4)
 res.plot()                                      # TL (and IL) vs frequency
 ```
@@ -102,18 +102,18 @@ circular diameters $d = 2\sqrt{S/\pi}$ of the 0.04 and 0.01 m² cross-sections.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber, plot_silencer_geometry
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 
 # One line: the dimensioned cross-section of the chamber just computed.
 res.plot_geometry()
 plt.show()
 
 # The same drawing without a result, from the free function:
-plot_silencer_geometry("expansion chamber", length=0.3,
-                       chamber_area=0.04, pipe_area=0.01)
+noise_control.plot_silencer_geometry("expansion chamber", length=0.3,
+                                     chamber_area=0.04, pipe_area=0.01)
 plt.show()
 ```
 
@@ -144,26 +144,24 @@ with `duct_matrix`, `shunt_matrix`, `cascade`, `transmission_loss` and
 
 ```python
 import numpy as np
-from phonometry import (
-    helmholtz_resonator, quarter_wave_resonator, extended_tube_chamber,
-)
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
 
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 print(round(float(hr.resonances[0]), 1))       # tuning frequency, Hz
 hr.plot()   # TL spike at the tuning frequency (needs matplotlib)
 
-qw = quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
-                            speed_of_sound=343.24)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
+                                          speed_of_sound=343.24)
 print(round(float(qw.resonances[0]), 1))        # 56.6 Hz (Bies Example 8.1)
 
 # Each extension is a quarter-wave stub, so its own length picks the trough
 # it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
 # second trough, and L/2 = 0.2 m would take the first one at c/2L.
-et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
-                           inlet_extension=0.1)
+et = noise_control.extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
+                                         inlet_extension=0.1)
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_side_branch_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_side_branch.svg" alt="Transmission loss of a Helmholtz resonator and a closed quarter-wave tube on the same 10 cm2 duct: each side branch produces a sharp spike at its own tuning frequency, near 120 Hz for the Helmholtz volume and near 285 Hz for the 0.3 m tube, and is transparent elsewhere" width="88%"></picture>
@@ -178,12 +176,12 @@ firing frequency or a fan blade-passing tone rather than used broadband.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator, quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line for one device: TL vs frequency with the resonance marked.
 hr.plot()
@@ -236,11 +234,11 @@ its target.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 
 # One line: the side branch drawn to scale, cavity as its equal-volume cube.
 hr.plot_geometry()
@@ -265,10 +263,10 @@ area only sets how strongly the stub loads the duct.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line: the closed 0.3 m tube on its duct, to scale.
 qw.plot_geometry()
@@ -311,7 +309,7 @@ all, because an impedance is not a shape.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import SilencerChain
+from phonometry import noise_control
 from phonometry.noise_control import helmholtz_impedance, quarter_wave_impedance
 
 freqs = np.linspace(20.0, 500.0, 481)
@@ -319,7 +317,7 @@ s_duct = np.pi * 0.100**2               # nominal 200 mm duct
 s_shell = np.pi * 0.200**2              # nominal 400 mm shell
 
 chain = (
-    SilencerChain(freqs)
+    noise_control.SilencerChain(freqs)
     .duct(0.10, s_duct)
     .shunt(quarter_wave_impedance(freqs, 343.0 / (4.0 * 125.0), np.pi * 0.050**2),
            label="Quarter-wave stub")
@@ -351,11 +349,11 @@ embedded figure, matplotlib (`pip install "phonometry[report,plot]"`), and
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, expansion_chamber
+from phonometry import ReportMetadata, noise_control
 
 # A 0.5 m chamber of area ratio m = 8, at the octave-band centres.
 freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-res = expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
 res.report(
     "silencer_fiche.pdf",
     metadata=ReportMetadata(

--- a/docs/environment/propagation/atmospheric-refraction.md
+++ b/docs/environment/propagation/atmospheric-refraction.md
@@ -45,35 +45,30 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    atmospheric_ray_paths,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 c0 = 340.0
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
 zs = 2.0
 fig, axes = plt.subplots(2, 1, figsize=(11, 8.2), sharex=True)
 
-rays = atmospheric_ray_paths(profile, source_height=zs,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=3000)
+rays = environment.atmospheric_ray_paths(profile, source_height=zs,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=3000)
 for i in range(rays.heights.shape[0]):
     axes[0].plot(rays.ranges[i], rays.heights[i], color="#1f77b4", lw=0.8, alpha=0.7)
 axes[0].plot([0.0], [zs], "o", color="#d62728", label="Source")
 grad = (profile.speed_at(10.0) - c0) / 10.0
-x_sh = shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
+x_sh = environment.shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
 axes[0].axvline(x_sh, color="#d62728", ls="--", label="Shadow-zone boundary")
 axes[0].set(ylabel="Height [m]", ylim=(0, 40), title="Sound rays (upward refraction)")
 axes[0].legend()
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(400.0, profile, source_height=zs,
-                                        flow_resistivity=200e3,
-                                        max_range=600.0, max_height=40.0)
+    pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=zs,
+                                                    flow_resistivity=200e3,
+                                                    max_range=600.0, max_height=40.0)
 img = axes[1].imshow(pe.relative_level, cmap="RdBu_r", vmin=-30, vmax=6,
                      aspect="auto", origin="lower", interpolation="bilinear",
                      extent=(pe.ranges[0], pe.ranges[-1], pe.heights[0], pe.heights[-1]))
@@ -110,9 +105,9 @@ the receiver (favourable propagation); a negative gradient bends them **up** and
 opens an acoustic **shadow** near the ground.
 
 ```python
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
 profile.speed_at(10.0)   # effective sound speed 10 m above the ground
 profile.plot()           # c_eff(z) with height on the vertical axis
 ```
@@ -124,11 +119,11 @@ profile.plot()           # c_eff(z) with height on the vertical axis
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
 # The two canonical surface layers of Salomons Eq. 4.5 over grassland.
-down = log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
-up = log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
+down = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
+up = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
 ax = down.plot(color="#1f77b4")
 up.plot(ax=ax, color="#d62728")
 plt.show()
@@ -146,12 +141,12 @@ travel times and the number of ground reflections.
 
 ```python
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0)
 rays.plot()   # curved ray fan with the acoustic shadow near the ground
 ```
 
@@ -168,13 +163,13 @@ the surface instead of losing it upward.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
 # Downward refraction: the favourable-propagation mirror of the shadow case.
-profile = log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=600)
+profile = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=600)
 rays.plot()   # shallow rays return to the ground and bounce on down-range
 plt.show()
 ```
@@ -235,12 +230,12 @@ $\Delta L(z, r) = 20\log_{10}(|p| R_1)$ (dB re free field, Salomons Eq. 3.6) ove
 the whole range-height plane.
 
 ```python
-from phonometry import atmospheric_parabolic_equation, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
-pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                    flow_resistivity=200e3,  # grassland
-                                    max_range=600.0, max_height=40.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                flow_resistivity=200e3,  # grassland
+                                                max_range=600.0, max_height=40.0)
 pe.level_at_height(2.0)   # relative level vs range at 2 m
 pe.plot()                 # the range-height relative-level field
 ```
@@ -259,31 +254,26 @@ import warnings
 
 import matplotlib.pyplot as plt
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    linear_sound_speed_profile,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 cases = [
-    (log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
-    (linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
-    (log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
+    (environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
+    (environment.linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
+    (environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
 ]
 fig, ax = plt.subplots(figsize=(11, 6.2))
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     for profile, label in cases:
-        pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                            flow_resistivity=200e3,
-                                            max_range=600.0, max_height=40.0)
+        pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                        flow_resistivity=200e3,
+                                                        max_range=600.0, max_height=40.0)
         ax.plot(pe.ranges, pe.level_at_height(2.0), label=label)
 # The closed-form boundary of the equivalent linear upward gradient (its
 # 10 m mean), the dotted line of the figure.
 up = cases[2][0]
 grad = float(up.speed_at(10.0) - 340.0) / 10.0
-ax.axvline(shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
+ax.axvline(environment.shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
            color="k", ls=":", label="Shadow-zone boundary")
 ax.set(xlabel="Range [m]", ylabel="Level re free field [dB]", ylim=(-40, 10))
 ax.legend()

--- a/docs/environment/propagation/ground-barriers.md
+++ b/docs/environment/propagation/ground-barriers.md
@@ -55,14 +55,14 @@ $$
 
 ```python
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 
 # Grassland (effective flow resistivity sigma = 200 kPa.s/m^2), source 1 m and
 # receiver 1.5 m high, 50 m apart. The impedance comes from the Delany-Bazley
 # porous model of phonometry.materials (a semi-infinite ground).
-res = ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
+res = environment.ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
 print(res.excess_attenuation)     # the ground dip (dB re free field)
 print(res.reflection_coefficient) # complex Q per band
 res.plot()                        # excess attenuation vs frequency
@@ -88,7 +88,7 @@ it enters the Weyl-Van der Pol formulas.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 4000.0, 400)
 grounds = [
@@ -99,7 +99,7 @@ grounds = [
 ]
 fig, ax = plt.subplots(figsize=(11, 6.4))
 for label, sigma, color in grounds:
-    res = ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
+    res = environment.ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
     ax.plot(freqs, res.excess_attenuation, color=color, label=label)
 ax.axhline(6.0, color="k", ls=":", label="Hard-ground limit (+6 dB)")
 ax.axhline(0.0, color="k", lw=0.8)
@@ -165,13 +165,13 @@ the 4 m screen of the snippets, they differ by just 0.15 m.
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier.svg" alt="Section of the barrier geometry: a loudspeaker source 1 m above the ground, a thin 4 m screen at 50 m and a microphone receiver 1.5 m high at 100 m, the blocked direct path of 100.00 m drawn dashed through the screen and the diffracted path bent over the edge in two segments A = 50.09 m and B = 50.06 m, with the resulting path difference of 0.15 m giving a Fresnel number of 0.44 and a Kurze-Anderson insertion loss of 10.0 dB at 500 Hz, rising to 15.5 dB at 2 kHz" width="92%"></picture>
 
 ```python
-from phonometry import barrier_insertion_loss, kurze_anderson_attenuation
+from phonometry import environment
 
-kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
+environment.kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
 
 # A 4 m barrier 50 m from a 1 m source, receiver 1.5 m high at 100 m.
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="kurze_anderson")
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="kurze_anderson")
 il.plot()                           # insertion loss vs frequency
 ```
 
@@ -200,8 +200,8 @@ coefficient per image path; the model is coherent and reciprocal but not a full
 boundary-element solution.
 
 ```python
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="exact", ground_flow_resistivity=2e5)
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="exact", ground_flow_resistivity=2e5)
 il.ground        # True: the four-path coherent ground model was applied
 il.plot()
 ```
@@ -221,16 +221,16 @@ interfere destructively.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 # The 4 m barrier of the snippets above, on a fine frequency grid.
 freqs = np.geomspace(50.0, 5000.0, 240)
-il_ka = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="kurze_anderson")
-il_ex = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact")
-il_gr = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact", ground_flow_resistivity=2e5)
+il_ka = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="kurze_anderson")
+il_ex = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact")
+il_gr = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact", ground_flow_resistivity=2e5)
 fig, ax = plt.subplots(figsize=(11, 6.4))
 ax.semilogx(freqs, il_ka.insertion_loss, "--", label="Kurze-Anderson (thin screen)")
 ax.semilogx(freqs, il_ex.insertion_loss, label="Exact rigid half-plane")
@@ -262,10 +262,10 @@ thin-screen methods above key on.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 5000.0, 240)
-il = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+il = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 
 # One line: the section to scale, with the path-length difference annotated.
 il.plot_geometry()

--- a/docs/environment/propagation/outdoor-propagation.md
+++ b/docs/environment/propagation/outdoor-propagation.md
@@ -536,18 +536,13 @@ level supplied through the metadata `requirement` then adds a PASS/FAIL verdict
 
 ```python
 import numpy as np
-from phonometry import (
-    Barrier,
-    ReportMetadata,
-    SourceEmission,
-    outdoor_propagation_attenuation,
-)
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 lw = np.array([95, 100, 103, 105, 104, 101, 95, 88], dtype=float)
-result = outdoor_propagation_attenuation(
+result = environment.outdoor_propagation_attenuation(
     200.0, 4.0, 2.0, freqs, 1.0, 1.0, 1.0,
-    barrier=Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
+    barrier=environment.Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
     temperature=10.0, relative_humidity=70.0,
 )
 result.report(
@@ -557,7 +552,7 @@ result.report(
         test_room="Nearest dwelling facade",
         requirement=50.0,  # maximum acceptable A-weighted downwind level
     ),
-    source_emission=SourceEmission(sound_power_level=lw),
+    source_emission=environment.SourceEmission(sound_power_level=lw),
 )
 ```
 
@@ -578,10 +573,10 @@ adds a PASS/FAIL verdict (a higher insertion loss is better).
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, barrier_insertion_loss
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
-result = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+result = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 result.report(
     "barrier_insertion_loss.pdf",
     metadata=ReportMetadata(

--- a/docs/environment/sources/cnossos-rail-emission.md
+++ b/docs/environment/sources/cnossos-rail-emission.md
@@ -78,29 +78,23 @@ starts to matter.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    BrakeType, ContactFilter, RailRoughnessClass, RailwayTrack, RailwayVehicle,
-    RollingStock, TrackTransferClass, TractionVehicle, WheelDiameter,
-    aerodynamic_sound_power, contact_filter, impact_roughness_single,
-    rail_roughness, railway_source_power, track_transfer, traction_sound_power,
-    wheel_roughness, wheel_transfer,
-)
+from phonometry import environment
 
-stock = RollingStock(
+stock = environment.RollingStock(
     axles=4,
-    wheel_roughness=wheel_roughness(BrakeType.NON_TREAD),
-    contact_filter=contact_filter(ContactFilter.LOAD_50_DIAMETER_920),
-    wheel_transfer=wheel_transfer(WheelDiameter.MM_920),
-    traction=traction_sound_power(TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
-    aerodynamic=aerodynamic_sound_power(),
+    wheel_roughness=environment.wheel_roughness(environment.BrakeType.NON_TREAD),
+    contact_filter=environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920),
+    wheel_transfer=environment.wheel_transfer(environment.WheelDiameter.MM_920),
+    traction=environment.traction_sound_power(environment.TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
+    aerodynamic=environment.aerodynamic_sound_power(),
 )
-track = RailwayTrack(
-    rail_roughness=rail_roughness(RailRoughnessClass.NORMAL),
-    track_transfer=track_transfer(TrackTransferClass.MONOBLOCK_MEDIUM),
-    impact_roughness=impact_roughness_single(),
+track = environment.RailwayTrack(
+    rail_roughness=environment.rail_roughness(environment.RailRoughnessClass.NORMAL),
+    track_transfer=environment.track_transfer(environment.TrackTransferClass.MONOBLOCK_MEDIUM),
+    impact_roughness=environment.impact_roughness_single(),
 )
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
 )
 result.plot()
 plt.show()
@@ -162,24 +156,20 @@ rough ones.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    RAILWAY_THIRD_OCTAVE_BANDS, BrakeType, ContactFilter, RailRoughnessClass,
-    contact_filter, rail_roughness, roughness_to_frequency,
-    total_effective_roughness, wheel_roughness,
-)
+from phonometry import environment
 
-rail = rail_roughness(RailRoughnessClass.NORMAL)
-wheel = wheel_roughness(BrakeType.NON_TREAD)
-filt = contact_filter(ContactFilter.LOAD_50_DIAMETER_920)
+rail = environment.rail_roughness(environment.RailRoughnessClass.NORMAL)
+wheel = environment.wheel_roughness(environment.BrakeType.NON_TREAD)
+filt = environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920)
 
 fig, ax = plt.subplots()
 for speed in (60.0, 160.0, 300.0):
-    total = total_effective_roughness(
-        roughness_to_frequency(rail[1], rail[0], speed),
-        roughness_to_frequency(wheel[1], wheel[0], speed),
-        roughness_to_frequency(filt[1], filt[0], speed),
+    total = environment.total_effective_roughness(
+        environment.roughness_to_frequency(rail[1], rail[0], speed),
+        environment.roughness_to_frequency(wheel[1], wheel[0], speed),
+        environment.roughness_to_frequency(filt[1], filt[0], speed),
     )
-    ax.semilogx(RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
+    ax.semilogx(environment.RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
 ax.legend()
 plt.show()
 ```
@@ -201,10 +191,10 @@ worked example. Two readings are shipped, and the default is the one that
 reproduces the Commission's own reference source module:
 
 ```python
-from phonometry import RoughnessInterpolation
+from phonometry import environment
 
-RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
-RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
+environment.RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
+environment.RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
 ```
 
 They differ by up to about 1 dB on a steep part of a spectrum. This is the
@@ -248,12 +238,12 @@ the 2015 one:
 | Tram | curve or switch turnout with $R \le 200\ \text{m}$ | 5 dB |
 
 ```python
-from phonometry import curve_squeal_excess
+from phonometry import environment
 
-curve_squeal_excess(280.0)                       # 8.0 dB
-curve_squeal_excess(450.0)                       # 5.0 dB
-curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
-curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
+environment.curve_squeal_excess(280.0)                       # 8.0 dB
+environment.curve_squeal_excess(450.0)                       # 5.0 dB
+environment.curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
+environment.curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
 ```
 
 The 2015 text read "8 dB for R < 300 m and 5 dB for 300 m < R < 500 m", which
@@ -310,10 +300,10 @@ available, because comparing with a study computed before 2021 needs the old
 one:
 
 ```python
-from phonometry import DirectivityEdition, vertical_directivity
+from phonometry import environment
 
-vertical_directivity(-30.0)                                        # zeros
-vertical_directivity(-30.0, edition=DirectivityEdition.ORIGINAL_2015)  # positive
+environment.vertical_directivity(-30.0)                                        # zeros
+environment.vertical_directivity(-30.0, edition=environment.DirectivityEdition.ORIGINAL_2015)  # positive
 ```
 
 At source B, only the aerodynamic source is directional, $10\log_{10}(\cos^2\psi)$
@@ -345,11 +335,11 @@ bridge term is added to it. It sits at source A and is omni-directional, which
 the amendment states explicitly.
 
 ```python
-from phonometry import BridgeType, RailwayTrack, bridge_transfer
+from phonometry import environment
 
-RailwayTrack(
+environment.RailwayTrack(
     rail_roughness=..., track_transfer=...,
-    bridge_transfer=bridge_transfer(BridgeType.PLUS_10_DBA),
+    bridge_transfer=environment.bridge_transfer(environment.BridgeType.PLUS_10_DBA),
 )
 ```
 

--- a/docs/environment/sources/cnossos-road-emission.md
+++ b/docs/environment/sources/cnossos-road-emission.md
@@ -68,19 +68,17 @@ governs.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    JunctionType, RoadSurface, RoadTraffic, RoadVehicleCategory, road_source_power,
-)
+from phonometry import environment
 
 traffic = [
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1200.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 45.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1200.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 45.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
 ]
-result = road_source_power(
-    traffic, surface=RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
-    junction_distance=60.0, junction_type=JunctionType.CROSSING,
+result = environment.road_source_power(
+    traffic, surface=environment.RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
+    junction_distance=60.0, junction_type=environment.JunctionType.CROSSING,
 )
 result.plot()
 plt.show()
@@ -147,20 +145,17 @@ from about 60 km/h, which is why a lorry is still an engine at urban speeds.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    CNOSSOS_A_WEIGHTING, road_propulsion_noise, road_rolling_noise,
-    road_vehicle_sound_power,
-)
+from phonometry import environment
 
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 speeds = np.linspace(20.0, 130.0, 221)
 fig, ax = plt.subplots()
 for category, name in [("1", "Light vehicles (1)"), ("3", "Heavy vehicles (3)")]:
-    rolling = [a_weighted(road_rolling_noise(category, v)) for v in speeds]
-    propulsion = [a_weighted(road_propulsion_noise(category, v)) for v in speeds]
-    total = [a_weighted(road_vehicle_sound_power(category, v)) for v in speeds]
+    rolling = [a_weighted(environment.road_rolling_noise(category, v)) for v in speeds]
+    propulsion = [a_weighted(environment.road_propulsion_noise(category, v)) for v in speeds]
+    total = [a_weighted(environment.road_vehicle_sound_power(category, v)) for v in speeds]
     ax.plot(speeds, total, lw=2.4, label=f"{name} - total")
     ax.plot(speeds, rolling, ls="--", lw=1.2, label=f"{name} - rolling")
     ax.plot(speeds, propulsion, ls=":", lw=1.2, label=f"{name} - propulsion")
@@ -208,9 +203,9 @@ down onto it, but a rough texture only generates tyre noise, and tyre noise is
 already the rolling term.
 
 ```python
-from phonometry import RoadSurface, road_surface_coefficients
+from phonometry import environment
 
-row = road_surface_coefficients(RoadSurface.TWO_LAYER_ZOAB_FINE)
+row = environment.road_surface_coefficients(environment.RoadSurface.TWO_LAYER_ZOAB_FINE)
 row.speed_range          # (80.0, 130.0) km/h, the printed validity range
 row.alpha["1"]           # alpha per octave band for light vehicles
 row.beta["1"]            # -0.1, the speed coefficient
@@ -234,19 +229,16 @@ $dL$ simply carries $L'_{W,\mathrm{eq,line},i} + 10\log_{10}(dL)$, which is
 arithmetic and is offered as such.
 
 ```python
-from phonometry import (
-    PropagationGeometry, RoadTraffic, RoadVehicleCategory,
-    line_source_segment_power, predicted_receiver_level, road_source_power,
-)
+from phonometry import environment
 
-result = road_source_power([
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 90.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 120.0, 80.0),
+result = environment.road_source_power([
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 90.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 120.0, 80.0),
 ])
-segment = line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
-levels = predicted_receiver_level(
+segment = environment.line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
+levels = environment.predicted_receiver_level(
     segment,
-    PropagationGeometry(100.0, result.source_height, 4.0),
+    environment.PropagationGeometry(100.0, result.source_height, 4.0),
     frequencies=result.frequencies,
 )
 ```
@@ -262,9 +254,9 @@ For the A-weighted total, use the octave-band weighting the Directive itself
 prints in 2.5.5 as amended, rather than recomputing it:
 
 ```python
-from phonometry import CNOSSOS_A_WEIGHTING
+from phonometry import environment
 
-CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
+environment.CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
 result.a_weighted_line_power
 ```
 
@@ -278,13 +270,13 @@ and the 2021 one). Both coefficient objects can be replaced:
 ```python
 import dataclasses
 
-from phonometry import ROAD_COEFFICIENTS
+from phonometry import environment
 
 # One measured national row for light vehicles, the rest of Appendix F as published.
 national = dataclasses.replace(
-    ROAD_COEFFICIENTS,
+    environment.ROAD_COEFFICIENTS,
     rolling_a={
-        **ROAD_COEFFICIENTS.rolling_a,
+        **environment.ROAD_COEFFICIENTS.rolling_a,
         "1": (83.4, 89.0, 88.1, 93.6, 100.4, 96.9, 87.0, 76.5),
     },
 )

--- a/docs/materials/absorbers/metamaterial-absorbers.md
+++ b/docs/materials/absorbers/metamaterial-absorbers.md
@@ -48,18 +48,16 @@ reflection at zero.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 
 f = np.array([300.0])
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -89,19 +87,17 @@ $\mathrm{Re}(Z)\cos\theta = Z_0$ and $\mathrm{Im}(Z) = 0$ hold.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 print(round(design.absorption, 4))          # ~1.0 (perfect absorption)
 
 f = np.linspace(150.0, 500.0, 700)
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -124,9 +120,9 @@ the cavity length to place the resonance.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator
+from phonometry import materials
 
-resonator = HelmholtzResonator(
+resonator = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
@@ -148,13 +144,13 @@ mechanism.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator, critical_coupling_design, materials
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 
@@ -181,20 +177,18 @@ deep; detuning the slit height drops the peak below one.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
 a, d, f0 = 3.0e-2, 5.0e-2, 300.0
-base = HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
-design = critical_coupling_design(f0, base, lattice_step=a, period=d)
+base = materials.HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
+design = materials.critical_coupling_design(f0, base, lattice_step=a, period=d)
 h0 = design.slit_height
 
 f = np.linspace(150.0, 500.0, 700)
 fig, ax = plt.subplots()
 for factor, label in [(1.0, "critically coupled"),
                       (0.6, "narrow slit"), (1.7, "wide slit")]:
-    res = slit_helmholtz_absorber(
+    res = materials.slit_helmholtz_absorber(
         f, design.resonator, slit_height=factor * h0,
         lattice_step=a, period=d,
     )
@@ -225,16 +219,14 @@ everything about why the panel can be thin:
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
-res = slit_helmholtz_absorber(
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+res = materials.slit_helmholtz_absorber(
     np.array([300.0]), design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )

--- a/docs/materials/absorbers/porous-absorbers.md
+++ b/docs/materials/absorbers/porous-absorbers.md
@@ -177,23 +177,20 @@ and the limp one settles on $\rho_\mathrm{t}/\rho_0 = 25.9$.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PorousLayer, decoupling_frequency, johnson_champoux_allard,
-    layered_absorber, limp_frame, limp_frame_applicable,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 11.2: soft fibrous layer, 50 mm.
 f = np.linspace(1.0, 2000.0, 800)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     f, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 
-print(round(decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
+print(round(materials.decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
 # 127.4
 print(round(float(limp.effective_density[0].real), 1))     # 31.2 = rho_t
-print(limp_frame_applicable(20e3), limp_frame_applicable(25e3))  # True False
+print(materials.limp_frame_applicable(20e3), materials.limp_frame_applicable(25e3))  # True False
 
 limp.plot()   # normalised Zc and k of the corrected medium
 plt.show()
@@ -226,18 +223,16 @@ slightly higher one either side of 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PorousLayer, johnson_champoux_allard, layered_absorber, limp_frame,
-)
+from phonometry import materials
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 1000], dtype=float)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     bands, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 for medium in (rigid, limp):
-    print(layered_absorber(bands, [PorousLayer(0.05, medium)]).absorption.round(2))
+    print(materials.layered_absorber(bands, [materials.PorousLayer(0.05, medium)]).absorption.round(2))
 # [0.07 0.11 0.17 0.24 0.32 0.43 0.54 0.64 0.88]   rigid frame
 # [0.04 0.08 0.15 0.24 0.36 0.48 0.61 0.71 0.91]   limp frame
 ```
@@ -325,31 +320,28 @@ imaginary part that the book measures and plots in its Fig. 6.10.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, biot_waves, frame_elastic_coefficient,
-    frame_quarter_wave_resonance, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 6.1: glass wool "Domisol Coffrage", 100 mm, glued.
 f = np.linspace(200.0, 1500.0, 1301)
 shear = 2.2e6 * (1 + 0.1j)          # 220 N/cm2, loss factor 0.1
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     f, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 
-print(frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
-print(round(frame_quarter_wave_resonance(
+print(materials.frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
+print(round(materials.frame_quarter_wave_resonance(
     0.10, shear_modulus=shear, poisson_ratio=0.0, frame_density=130.0), 1))
 # 459.9
 
-waves = biot_waves(med, porosity=0.94, tortuosity=1.06,
-                   frame_density=130.0, shear_modulus=shear)
+waves = materials.biot_waves(med, porosity=0.94, tortuosity=1.06,
+                             frame_density=130.0, shear_modulus=shear)
 print(round(float(abs(waves.airborne_velocity_ratio[800])), 1))     # 42.4
 print(np.round(waves.frame_borne_velocity_ratio[-1], 3))  # (0.811+0.473j)
 
-biot = layered_absorber(f, [PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
-rigid = layered_absorber(f, [PorousLayer(0.10, med)])
+biot = materials.layered_absorber(f, [materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
+rigid = materials.layered_absorber(f, [materials.PorousLayer(0.10, med)])
 
 fig, ax = plt.subplots()
 for res, style in ((rigid, "--"), (biot, "-")):
@@ -384,19 +376,17 @@ sharpest; on third-octave centres the largest shift is the 0.12 at 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 bands = np.array([250, 315, 400, 500, 630, 800, 1000], dtype=float)
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     bands, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 shear = 2.2e6 * (1 + 0.1j)
-for layer in (PorousLayer(0.10, med),
-              PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
-    print(layered_absorber(bands, [layer]).absorption.round(2))
+for layer in (materials.PorousLayer(0.10, med),
+              materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
+    print(materials.layered_absorber(bands, [layer]).absorption.round(2))
 # [0.55 0.58 0.62 0.65 0.69 0.74 0.78]   rigid frame
 # [0.53 0.56 0.61 0.77 0.71 0.74 0.78]   Biot poroelastic
 ```

--- a/docs/materials/diffusers/metadiffusers.md
+++ b/docs/materials/diffusers/metadiffusers.md
@@ -76,12 +76,7 @@ five-well sequence six times (`periods=6`, a 2.1 m panel):
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    metadiffuser_polar_response,
-    metadiffuser_reflection,
-)
+from phonometry import materials
 
 # The published quadratic-residue metadiffuser: five slits with two
 # resonators each in a 35 cm x 2 cm panel (7 cm pitch), tuned to mimic a
@@ -95,21 +90,21 @@ rows = [  # slit h, neck l_n, cavity l_c, neck w_n, cavity w_c  [mm]
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 f = np.arange(1800.0, 2601.0, 5.0)
-panel = metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
 alpha1 = panel.well_absorption[0]
 print(round(float(alpha1.max()), 2), int(f[alpha1.argmax()]))  # 0.99 2305
 
 # Far-field comparison: the five-well sequence repeated six times (2.1 m).
-polar = metadiffuser_polar_response(2000.0, wells, depth=0.02,
-                                    period=0.07, periods=6)
+polar = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02,
+                                              period=0.07, periods=6)
 print(round(polar.coefficient, 2))                             # 0.32
 ```
 
@@ -120,12 +115,7 @@ print(round(polar.coefficient, 2))                             # 0.32
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    materials,
-    metadiffuser_polar_response,
-)
+from phonometry import materials
 
 mm = 1e-3
 rows = [
@@ -136,17 +126,17 @@ rows = [
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 # The metadiffuser panel and the QRD it was tuned to at 2 kHz, both with
 # six repetitions of the period (2.1 m panels).
-meta = metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
-                                   periods=6)
+meta = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
+                                             periods=6)
 sequence = np.roll(materials.quadratic_residue_sequence(5), -1)
 depths = sequence * (343.0 / 500.0) / (2 * 5)
 qrd = materials.predict_diffuser_polar_response(
@@ -186,11 +176,11 @@ few degrees of the QRD targets while keeping $|R_n|$ near one:
 
 ```python
 import numpy as np
-from phonometry import materials, metadiffuser_reflection
+from phonometry import materials
 
 # wells: the five published slits from the example above.
-panel = metadiffuser_reflection(np.array([2000.0]), wells,
-                                depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(np.array([2000.0]), wells,
+                                          depth=0.02, period=0.07)
 phases = np.degrees(np.angle(panel.reflection[:, 0]))
 print(np.round(np.abs(panel.reflection[:, 0]), 2))  # [0.97 1.   1.   0.97 0.98]
 print(np.round(phases))                             # [ 75. -71. -71.  74.   2.]

--- a/docs/perception/speech/objective-intelligibility.md
+++ b/docs/perception/speech/objective-intelligibility.md
@@ -52,7 +52,7 @@ Section II):
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 16000
 rng = np.random.default_rng(0)
@@ -61,9 +61,9 @@ clean = rng.standard_normal(3 * fs)          # stand-in for a speech waveform
 noise = rng.standard_normal(3 * fs)
 degraded = clean + 0.56 * noise
 
-d = stoi(clean, degraded, fs)
+d = speech.stoi(clean, degraded, fs)
 print(round(d.value, 3))              # a scalar in roughly [0, 1]
-print(stoi(clean, clean, fs).value)   # 1.0  (a signal against itself)
+print(speech.stoi(clean, clean, fs).value)   # 1.0  (a signal against itself)
 ```
 
 Everything up to the 384 ms segments is shared; the two measures only part
@@ -84,7 +84,7 @@ is the average of those intermediate correlations over all bands and segments
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(1)
@@ -92,7 +92,7 @@ clean = rng.standard_normal(3 * fs)
 # Higher SNR gives a higher STOI: the relation is monotonic.
 for snr_db in (-10, 0, 10, 20):
     g = 10.0 ** (-snr_db / 20.0)
-    print(snr_db, round(stoi(clean, clean + g * rng.standard_normal(clean.size), fs).value, 3))
+    print(snr_db, round(speech.stoi(clean, clean + g * rng.standard_normal(clean.size), fs).value, 3))
 ```
 
 The `STOIResult` carries the per-band mean correlation (`band_scores`) and the
@@ -110,7 +110,7 @@ bites, which the single number cannot.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.signal import butter, lfilter
-from phonometry import stoi
+from phonometry import speech
 
 # Speech-like material: band-limited noise with a 3.5 Hz syllabic envelope,
 # in a flat masker at 0 dB SNR.
@@ -122,7 +122,7 @@ carrier = lfilter(b, a, rng.standard_normal(t.size))
 clean = carrier * (0.15 + 0.85 * np.abs(np.sin(2 * np.pi * 3.5 * t)) ** 2)
 masker = rng.standard_normal(clean.size)
 gain = np.sqrt(np.mean(clean ** 2)) / np.sqrt(np.mean(masker ** 2))
-res = stoi(clean, clean + gain * masker, fs)
+res = speech.stoi(clean, clean + gain * masker, fs)
 print(round(res.value, 3))    # 0.727
 
 # One line: the per-band intermediate correlation behind the index.
@@ -162,9 +162,9 @@ audible, is credited for the speech glimpsed there, which STOI's per-band
 average largely misses.
 
 ```python
-from phonometry import stoi
+from phonometry import speech
 
-estoi = stoi(clean, degraded, fs, extended=True)
+estoi = speech.stoi(clean, degraded, fs, extended=True)
 print(round(estoi.value, 3))
 ```
 
@@ -176,7 +176,7 @@ print(round(estoi.value, 3))
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(20)
@@ -198,7 +198,7 @@ def curve(masker, extended):
     out = []
     for snr in snrs:
         g = p_clean / (p_m * 10.0 ** (snr / 20.0))
-        out.append(stoi(clean, clean + g * masker, fs, extended=extended).value)
+        out.append(speech.stoi(clean, clean + g * masker, fs, extended=extended).value)
     return out
 
 fig, (a, b) = plt.subplots(1, 2, figsize=(12, 5), sharey=True)

--- a/docs/perception/speech/speech-intelligibility.md
+++ b/docs/perception/speech/speech-intelligibility.md
@@ -342,18 +342,18 @@ and so sums to 0.9996.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import SII_METHODS, sii_procedure
+from phonometry import speech
 
 # One line: each procedure's own .plot() steps its Ii over its band limits.
 fig, ax = plt.subplots(figsize=(10, 6))
-for method in SII_METHODS:
-    sii_procedure(method).plot(ax=ax, linewidth=1.8)
+for method in speech.SII_METHODS:
+    speech.sii_procedure(method).plot(ax=ax, linewidth=1.8)
 plt.show()
 
 # By hand, mirroring what SIIProcedure.plot() draws:
 fig, ax = plt.subplots()
-for method in SII_METHODS:
-    proc = sii_procedure(method)
+for method in speech.SII_METHODS:
+    proc = speech.sii_procedure(method)
     ii = proc.band_importance
     ax.plot(proc.band_edges, np.append(ii, ii[-1]), drawstyle="steps-post",
             label=method)

--- a/docs/signals/filters/filter-banks.md
+++ b/docs/signals/filters/filter-banks.md
@@ -169,16 +169,16 @@ all-pass has unit magnitude everywhere (only the phase turns).
 
 ```python
 import numpy as np
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 rng = np.random.default_rng(1)
 x = rng.standard_normal(fs)                 # one second of noise
 
-eq = ParametricEQ(fs, [
-    EQSection("lowshelf", 100.0, gain_db=4.0),
-    EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
-    EQSection("highshelf", 8000.0, gain_db=3.0),
+eq = filters.ParametricEQ(fs, [
+    filters.EQSection("lowshelf", 100.0, gain_db=4.0),
+    filters.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
+    filters.EQSection("highshelf", 8000.0, gain_db=3.0),
 ])
 y = eq.filter(x)              # apply the cascade
 res = eq.response()           # frozen result carrying the SOS cascade
@@ -195,21 +195,21 @@ For block processing pass `stateful=True` (the same convention as
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 family = [
-    EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
-    EQSection("lowshelf", 125.0, gain_db=6.0),
-    EQSection("highshelf", 4000.0, gain_db=-6.0),
-    EQSection("lowpass", 10000.0),
-    EQSection("highpass", 50.0),
-    EQSection("bandpass", 500.0, q=2.0),
-    EQSection("notch", 2000.0, q=6.0),
+    filters.EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
+    filters.EQSection("lowshelf", 125.0, gain_db=6.0),
+    filters.EQSection("highshelf", 4000.0, gain_db=-6.0),
+    filters.EQSection("lowpass", 10000.0),
+    filters.EQSection("highpass", 50.0),
+    filters.EQSection("bandpass", 500.0, q=2.0),
+    filters.EQSection("notch", 2000.0, q=6.0),
 ]
 fig, ax = plt.subplots(figsize=(10, 6))
 for section in family:
-    res = ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
+    res = filters.ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
     ax.semilogx(res.frequencies, res.magnitude_db,
                 label=f"{section.filter_type} @ {section.f0:g} Hz")
 ax.set(xlim=(20, 20000), ylim=(-27, 9),

--- a/docs/signals/filters/filter-compliance.md
+++ b/docs/signals/filters/filter-compliance.md
@@ -220,10 +220,10 @@ Spanish fiche (translated fixed strings and a comma decimal separator), e.g.
 `result.report("iec61260_es.pdf", language="es")`.
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # overall_class == 1
 result.plot()   # the worst-margin band on its class corridor
 
 result.report(
@@ -250,8 +250,8 @@ ANSI S1.11-2004 mask, which keeps the stricter **class 0** that the 2014 edition
 dropped; the default order-6 Butterworth bank can then be certified to class 0:
 
 ```python
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
-result = filter_class_compliance(bank, edition="1995")   # overall_class == 0
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
+result = filters.filter_class_compliance(bank, edition="1995")   # overall_class == 0
 result.plot()   # the class-0 corridor of the 1995 edition
 result.report(
     "iec61260_1995.pdf",

--- a/docs/signals/metrology/compliance-verification.md
+++ b/docs/signals/metrology/compliance-verification.md
@@ -85,10 +85,10 @@ class; `intensity_class_compliance` does the same for the IEC 61043
 residual-index verdict:
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank_11 = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank_11)   # result.overall_class == 1
+bank_11 = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank_11)   # result.overall_class == 1
 result.report(
     "iec61260.pdf",
     metadata=ReportMetadata(

--- a/docs/signals/metrology/data-qualification.md
+++ b/docs/signals/metrology/data-qualification.md
@@ -40,12 +40,12 @@ suite pins. The book's Example 4.4 (twenty observations, $A = 86$, accepted
 between 64 and 125) runs verbatim:
 
 ```python
-from phonometry import trend_test
+from phonometry import metrology
 
 values = [5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
           5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0]
 
-res = trend_test(values)                  # B&P Example 4.4
+res = metrology.trend_test(values)                  # B&P Example 4.4
 print(res.statistic, res.bounds)          # 86, (64, 125)
 print(res.trend_free, round(res.p_value, 3))   # True, 0.586
 res.plot()
@@ -59,14 +59,14 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 example = np.array([5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
                     5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0])
 drifting = example + np.linspace(0.0, 4.0, example.size)   # rising drift
 
-res_flat = trend_test(example)
-res_drift = trend_test(drifting)
+res_flat = metrology.trend_test(example)
+res_drift = metrology.trend_test(drifting)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, example.size + 1)
@@ -103,17 +103,17 @@ while the same noise without the drift passes:
 
 ```python
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 noise = np.random.default_rng(42).standard_normal(n)
 
-res = stationarity_test(noise, fs)        # 20 segments, mean squares
+res = metrology.stationarity_test(noise, fs)        # 20 segments, mean squares
 print(res.stationary, res.count, res.bounds)   # True, 91, (64, 125)
 
 drifting = noise * np.linspace(1.0, 1.2, n)    # +20 % gain ramp
-res = stationarity_test(drifting, fs)
+res = metrology.stationarity_test(drifting, fs)
 print(res.stationary, res.count)          # False, 7  (upward trend -> low A)
 res.plot()
 ```
@@ -126,15 +126,15 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 steady = np.random.default_rng(42).standard_normal(n)
 ramp = np.random.default_rng(42).standard_normal(n) * np.linspace(1.0, 1.2, n)
 
-res_steady = stationarity_test(steady, fs)
-res_ramp = stationarity_test(ramp, fs)
+res_steady = metrology.stationarity_test(steady, fs)
+res_ramp = metrology.stationarity_test(ramp, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, res_steady.n_segments + 1)
@@ -176,15 +176,15 @@ acceptance region at $\alpha = 0.05$ is the classical $(6, 15]$:
 
 ```python
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
-res = trend_test(rng.standard_normal(40), method="runs")
+res = metrology.trend_test(rng.standard_normal(40), method="runs")
 print(res.statistic, res.bounds, res.trend_free)
 res.plot()   # the sequence about its median with the runs verdict
 
 alternating = np.tile([1.0, -1.0], 10)   # 20 runs: rejected the other way
-print(trend_test(alternating, method="runs").trend_free)   # False
+print(metrology.trend_test(alternating, method="runs").trend_free)   # False
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test.svg" alt="Two panels of sequences classified about their median, points above in blue and below in red. Left: forty Gaussian observations with twenty runs inside the acceptance region from fourteen to twenty-seven, verdict trend-free. Right: a strictly alternating twenty-value sequence also giving twenty runs, but against the acceptance region from six to fifteen for twenty values, verdict rejected for too-rapid alternation" width="92%"></picture>
@@ -200,19 +200,19 @@ too *many* runs is as non-random as too few.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
 sequences = [rng.standard_normal(40), np.tile([1.0, -1.0], 10)]
 
 # One line per sequence — the tested values with the verdict:
-trend_test(sequences[0], method="runs").plot()
+metrology.trend_test(sequences[0], method="runs").plot()
 plt.show()
 
 # Both verdicts side by side, classified about the median:
 fig, axes = plt.subplots(1, 2, figsize=(11, 4.5))
 for ax, seq in zip(axes, sequences):
-    res = trend_test(seq, method="runs")
+    res = metrology.trend_test(seq, method="runs")
     idx = np.arange(1, seq.size + 1)
     median = np.median(seq)
     above = seq > median
@@ -260,13 +260,13 @@ the Rice curve next to them, taking the moments from the record's own
 
 ```python
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # a 60 Hz sine ...
 
-res = level_crossing_rate(x, fs)
+res = metrology.level_crossing_rate(x, fs)
 print(round(res.zero_crossing_rate, 1))   # ... has 120 zeros per second
 print(round(res.apparent_frequency, 1))   # 60.0
 res.plot()
@@ -280,7 +280,7 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 20480.0
 n = 1 << 19
@@ -290,7 +290,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[(freqs < 800.0) | (freqs > 1200.0)] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
+res = metrology.level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.levels, res.rice_rates, label="Rice (Eq. 5.196)")
@@ -333,13 +333,13 @@ available as `peak_exceedance()` / `peak_density()` on the result:
 
 ```python
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # narrowband: r is essentially 1
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 print(round(res.irregularity_factor, 3))       # 0.997
 print(res.peak_exceedance(4.0))                # exp(-8): about 1 in 3000
 res.plot()   # empirical exceedance against the Rice mixture (figure below)
@@ -353,7 +353,7 @@ res.plot()   # empirical exceedance against the Rice mixture (figure below)
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 from phonometry.metrology.data_qualification import _rice_peak_exceedance
 
 fs = 20480.0
@@ -364,7 +364,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[freqs > 2000.0] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 peaks = res.peak_values
 empirical = 1.0 - np.arange(1, peaks.size + 1) / peaks.size
 z = np.linspace(-2.5, 4.5, 400)

--- a/docs/signals/spectra/cepstrum-echoes.md
+++ b/docs/signals/spectra/cepstrum-echoes.md
@@ -42,13 +42,13 @@ computes the three standard variants over the quefrency axis:
 
 ```python
 import numpy as np
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(1)
 x = rng.standard_normal(4096)
 
-res = cepstrum(x, fs, kind="power")
+res = signals.cepstrum(x, fs, kind="power")
 print(res.quefrencies[:3], res.cepstrum.shape)   # quefrency axis, in s
 res.plot()
 ```
@@ -68,7 +68,7 @@ wavelet concentrates below 2 ms.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited source wavelet plus one reflection at 8 ms (a = 0.5)
@@ -78,13 +78,13 @@ s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
 # One line per variant — each CepstrumResult draws itself:
-cepstrum(x, fs, kind="power").plot()
+signals.cepstrum(x, fs, kind="power").plot()
 plt.show()
 
 # The three variants overlaid by hand on one quefrency axis:
 fig, ax = plt.subplots()
 for kind, style in (("power", "-"), ("real", "--"), ("complex", ":")):
-    res = cepstrum(x, fs, kind=kind)
+    res = signals.cepstrum(x, fs, kind=kind)
     q_ms = 1e3 * res.quefrencies
     mask = (q_ms > 0.5) & (q_ms <= 20.0)
     ax.plot(q_ms[mask], res.cepstrum[mask], style, label=f"{kind} cepstrum")
@@ -133,14 +133,14 @@ delay still lands on it, but the reported coefficient underestimates $|a|$
 
 ```python
 import numpy as np
-from phonometry import echo_detection
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(2)
 s = rng.standard_normal(12000)               # broadband source
 x = s + 0.5 * np.roll(s, 384)                # echo: 8 ms, a = 0.5
 
-res = echo_detection(x, fs, min_quefrency=0.002)
+res = signals.echo_detection(x, fs, min_quefrency=0.002)
 print(res.delay, res.reflection_coefficient)  # 0.008 s, ~0.5
 res.plot()
 ```
@@ -154,7 +154,7 @@ res.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import echo_detection, noise_signal
+from phonometry import signals
 
 fs = 48000.0
 n = 12000
@@ -163,9 +163,9 @@ impulse[0] = 1.0
 b, a = sp_signal.butter(2, [0.004, 0.9], btype="bandpass")
 direct = sp_signal.lfilter(b, a, impulse)              # broadband click
 ir = direct + 0.5 * np.roll(direct, int(0.008 * fs))   # echo at 8 ms
-ir += noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
+ir += signals.noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
 
-res = echo_detection(ir, fs, min_quefrency=0.002)
+res = signals.echo_detection(ir, fs, min_quefrency=0.002)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 half = res.nfft // 2 + 1
@@ -200,15 +200,15 @@ exactly complementary in dB, because the split is linear in the log domain:
 
 ```python
 import numpy as np
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(3)
 s = rng.standard_normal(12000)
 x = s + 0.5 * np.roll(s, 384)                # the same 8 ms echo
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
-high = lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
 print(np.allclose(low.liftered_db + high.liftered_db, low.spectrum_db))
 low.plot()
 ```
@@ -227,7 +227,7 @@ $20\log_{10}(1 \pm a) = +3.5$ and $-6.0$ dB.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited wavelet carrying a pure 8 ms echo (a = 0.5), so the
@@ -237,8 +237,8 @@ s = np.zeros(4096)
 s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")
-high = lifter(x, fs, cutoff=0.004, mode="highpass")
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")
 
 # One line — the cepstrum with the cutoff and the two log spectra:
 low.plot()
@@ -280,14 +280,14 @@ removes and stores in `linear_phase_samples`:
 ```python
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 x = np.zeros(2048)
 b, a = sp_signal.butter(2, 0.3)
 x[37:293] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 
-res = cepstrum(x, fs, kind="complex")
+res = signals.cepstrum(x, fs, kind="complex")
 print(res.linear_phase_samples)              # negative: a bulk delay removed
 print(np.max(np.abs(res.invert() - x)))      # ~1e-14
 res.plot()   # the complex cepstrum against quefrency (as in the figure above)
@@ -333,13 +333,13 @@ on an analysis bin the closed forms are:
 
 ```python
 import numpy as np
-from phonometry import envelope_spectrum
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(4 * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 k = int(round(25.0 * res.nfft / fs))
 print(res.mean_level, res.amplitude[k])      # ~1.0 and ~0.4
 res.plot()
@@ -353,15 +353,15 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope_spectrum, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 seconds = 4.0
 t = np.arange(int(seconds * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
-x += noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.frequencies, res.amplitude, lw=1.4, label="Envelope spectrum")

--- a/docs/signals/spectra/correlation-delay.md
+++ b/docs/signals/spectra/correlation-delay.md
@@ -32,9 +32,9 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 
 ```python
 import numpy as np
-from phonometry import correlation
+from phonometry import signals
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
 res.plot()
@@ -54,23 +54,23 @@ there (bottom).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import correlation, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 delay = 102                                  # 12.45 ms
-x = noise_signal(fs, 2.0, seed=4)
-interference = noise_signal(fs, 2.0, rms=0.5, seed=5)
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
 y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 
 # One line — the correlation estimate against the lag in seconds:
 res.plot()
 plt.show()
 
 # The three normalizations by hand, from the same records:
-biased = correlation(x, y, fs, normalization="biased")
-unbiased = correlation(x, y, fs, normalization="unbiased")
+biased = signals.correlation(x, y, fs, normalization="biased")
+unbiased = signals.correlation(x, y, fs, normalization="unbiased")
 
 fig, (ax_c, ax_n) = plt.subplots(2, 1)
 ax_c.plot(1e3 * res.lags, res.values, label="coefficient")
@@ -153,18 +153,18 @@ attaches to each:
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import noise_signal, time_delay
+from phonometry import signals
 
 fs = 8192.0
 delay = 20  # samples
 b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
-s = sp_signal.lfilter(b, a, noise_signal(fs, 4.0, color="white", seed=10))
-x = s + noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
-y = np.roll(s, delay) + noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
-direct = time_delay(x, y, fs, method="direct", max_delay=0.01)
-phat = time_delay(x, y, fs, method="gcc", weighting="phat",
-                  nperseg=2048, max_delay=0.01)
+direct = signals.time_delay(x, y, fs, method="direct", max_delay=0.01)
+phat = signals.time_delay(x, y, fs, method="gcc", weighting="phat",
+                          nperseg=2048, max_delay=0.01)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(1e3 * direct.lags,
@@ -199,10 +199,10 @@ $$
 $$
 
 ```python
-from phonometry import time_delay
+from phonometry import signals
 
-res = time_delay(x, y, fs, method="gcc", weighting="ml",
-                 nperseg=2048, upsample=16, signal_bandwidth=1000.0)
+res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
+                         nperseg=2048, upsample=16, signal_bandwidth=1000.0)
 print(res.delay, res.delay_samples)     # seconds and fractional samples
 print(res.delay_std, res.delay_interval)  # Eq. 8.129 sigma, +/-2 sigma
 res.plot()                              # correlation with the delay marked
@@ -224,12 +224,12 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
-from phonometry import align_impulse_responses, impulse_response_delay
+from phonometry import signals
 
-t_arrival = impulse_response_delay(ir, fs)              # seconds from t = 0
-dt = impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
+t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
-res = align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
+res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
 res.plot()                                     # reference vs aligned overlay
 ```
 
@@ -246,17 +246,17 @@ back onto its reference: the band-limited shift removes the estimated
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import align_impulse_responses, fractional_delay
+from phonometry import signals
 
 fs = 48000.0
 t = np.arange(int(0.03 * fs)) / fs
 rng = np.random.default_rng(6)
 # Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
 ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
-ir_b = fractional_delay(ir_a, 7.37)[: ir_a.size]
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
 ir_b += 0.005 * rng.standard_normal(ir_a.size)
 
-res = align_impulse_responses(ir_b, ir_a, fs)
+res = signals.align_impulse_responses(ir_b, ir_a, fs)
 
 # One line — reference and aligned IR overlaid:
 res.plot()
@@ -302,13 +302,13 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
-from phonometry import envelope
+from phonometry import signals
 
-res = envelope(x, fs)
+res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)
 res.plot()               # signal + envelope, instantaneous frequency
 
-slow = envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
+slow = signals.envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope.svg" alt="Two panels for a decaying 250 hertz mode in light noise. Top: the oscillating signal with the smooth exponential Hilbert envelope tracing its decay above and below. Bottom: the instantaneous frequency staying on the dashed 250 hertz carrier line while the mode is strong and jittering increasingly as the signal decays into the noise floor" width="86%"></picture>
@@ -324,7 +324,7 @@ noise floor (bottom, ×8 anti-aliased decimation).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(0.4 * fs)) / fs
@@ -332,7 +332,7 @@ rng = np.random.default_rng(7)
 x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 x += 0.001 * rng.standard_normal(t.size)
 
-res = envelope(x, fs, decimation_factor=8)
+res = signals.envelope(x, fs, decimation_factor=8)
 
 # One line — signal + envelope and the instantaneous frequency:
 res.plot()

--- a/docs/signals/spectra/miso-coherence.md
+++ b/docs/signals/spectra/miso-coherence.md
@@ -21,19 +21,19 @@ correlated inputs and one output.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import miso_coherence, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 # Input 1 drives a low-frequency path; input 2 = 0.7*x1 + independent noise
 # drives a high-frequency path, so input 2 is correlated with input 1.
-x1 = noise_signal(fs, 32.0, color="white", seed=1)
-x2 = 0.7 * x1 + noise_signal(fs, 32.0, color="white", seed=2)
+x1 = signals.noise_signal(fs, 32.0, color="white", seed=1)
+x2 = 0.7 * x1 + signals.noise_signal(fs, 32.0, color="white", seed=2)
 low = signal.butter(4, 400.0, fs=fs, output="sos")
 high = signal.butter(4, 1500.0, btype="high", fs=fs, output="sos")
-noise = noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
+noise = signals.noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
 y = signal.sosfilt(low, x1) + signal.sosfilt(high, x2) + noise
 
-res = miso_coherence([x1, x2], y, fs, nperseg=2048)
+res = signals.miso_coherence([x1, x2], y, fs, nperseg=2048)
 f = res.frequencies
 band = (f >= 20.0) & (f <= 4000.0)
 
@@ -102,7 +102,7 @@ to the multiple coherence (Eq. 7.116) and reduce exactly to the ordinary
 coherences when the inputs are mutually uncorrelated (Eq. 7.117).
 
 ```python
-res = miso_coherence([x1, x2], y, fs)
+res = signals.miso_coherence([x1, x2], y, fs)
 res.ordinary_coherence   # shape (q, F): each input on its own
 res.multiple_coherence   # shape (F,):  all inputs jointly
 res.partial_coherence    # shape (q, F): conditioned on the preceding inputs
@@ -165,7 +165,7 @@ Bendat & Piersol (Section 7.2.4) recommend ordering the inputs by descending
 ordinary coherence with the output. Pass `order` to choose:
 
 ```python
-res = miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
+res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order
 ```

--- a/docs/signals/spectra/spectral-analysis.md
+++ b/docs/signals/spectra/spectral-analysis.md
@@ -56,9 +56,9 @@ has a single real Fourier component, so those bins carry half the degrees of
 freedom and a correspondingly wider interval.
 
 ```python
-from phonometry import power_spectral_density
+from phonometry import signals
 
-res = power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
+res = signals.power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -76,9 +76,9 @@ $$
 $$
 
 ```python
-from phonometry import resolution_bias_error
+from phonometry import signals
 
-eps_b = resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
+eps_b = signals.resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
 ```
 
 Narrow $B_\mathrm{e}$ (long segments) suppresses the bias but leaves fewer averages and
@@ -94,18 +94,14 @@ visible.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    fractional_octave_smoothing,
-    noise_signal,
-    power_spectral_density,
-)
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 20.0, color="pink", seed=11)
-res = power_spectral_density(x, fs, nperseg=4096)
+x = signals.noise_signal(fs, 20.0, color="pink", seed=11)
+res = signals.power_spectral_density(x, fs, nperseg=4096)
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
-smooth = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
+smooth = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.fill_between(freqs, 10 * np.log10(res.ci_lower[band]),
@@ -146,9 +142,9 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
-from phonometry import cross_spectral_density
+from phonometry import signals
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
 ```
@@ -167,16 +163,16 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import cross_spectral_density, noise_signal
+from phonometry import signals
 
 fs = 8000.0
 tau = 0.002                                   # 2 ms = 16 samples
 delay = int(tau * fs)
-x = noise_signal(fs, 8.0, seed=8)
-noise = noise_signal(fs, 8.0, rms=0.3, seed=9)
+x = signals.noise_signal(fs, 8.0, seed=8)
+noise = signals.noise_signal(fs, 8.0, rms=0.3, seed=9)
 y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 
 # One line — magnitude, phase with its ±sigma band and coherence:
 res.plot()
@@ -233,14 +229,14 @@ synthetic signal:
 
 ```python
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 at every frequency
 
-res = coherent_output_spectrum(x, y, fs)
+res = signals.coherent_output_spectrum(x, y, fs)
 print(np.median(res.coherence))          # -> SNR/(1+SNR) = 0.719
 print(np.median(res.snr_db))             # -> 10·lg(2.56) = 4.1 dB
 res.plot()                               # Gyy, Gvv, Gnn and the SNR panel
@@ -259,14 +255,14 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 per band
 
-res = coherent_output_spectrum(x, y, fs, nperseg=2048)
+res = signals.coherent_output_spectrum(x, y, fs, nperseg=2048)
 
 # One line — the three spectra and the SNR panel:
 res.plot()
@@ -310,12 +306,12 @@ squared first, dB levels converted and back), so band power is conserved
 rather than amplitude, and a flat spectrum passes through exactly unchanged.
 
 ```python
-from phonometry import fractional_octave_smoothing
+from phonometry import signals
 
-smooth_psd = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
-smooth_mag = fractional_octave_smoothing(freqs, np.abs(response), 6.0,
-                                         domain="amplitude")  # an FRF |H|
-smooth_db = fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
+smooth_psd = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
+smooth_mag = signals.fractional_octave_smoothing(freqs, np.abs(response), 6.0,
+                                                 domain="amplitude")  # an FRF |H|
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -344,10 +340,10 @@ seed reproduces the same record bit for bit.
 | `violet` | +2 | +6.02 dB/octave |
 
 ```python
-from phonometry import noise_signal
+from phonometry import signals
 
-pink = noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
-white = noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
+pink = signals.noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
+white = signals.noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
 ```
 
 Measured over three decades (20 Hz – 20 kHz) with the estimator of section 1,
@@ -378,9 +374,9 @@ it:
   resolution.
 
 ```python
-from phonometry import window_metrics
+from phonometry import signals
 
-m = window_metrics("hann", 2048)
+m = signals.window_metrics("hann", 2048)
 print(m.enbw_bins)              # 1.5, exactly
 print(m.scalloping_loss_db)     # 1.42 dB
 print(m.highest_sidelobe_db)    # -31.5 dB
@@ -433,9 +429,9 @@ taper count is $K = 2NW - 1$, all tapers with near-unity concentration.
 Larger $NW$ admits more tapers (lower variance) at the cost of resolution.
 
 ```python
-from phonometry import multitaper_psd
+from phonometry import signals
 
-res = multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band
@@ -479,12 +475,12 @@ precision, which is the anchor oracle of the test suite.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import multitaper_psd, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
-single = multitaper_psd(x, fs, n_tapers=1, adaptive=False)
-res = multitaper_psd(x, fs)                              # NW = 4, K = 7
+x = signals.noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
+single = signals.multitaper_psd(x, fs, n_tapers=1, adaptive=False)
+res = signals.multitaper_psd(x, fs)                              # NW = 4, K = 7
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
 

--- a/docs/signals/spectra/synchronous-averaging.md
+++ b/docs/signals/spectra/synchronous-averaging.md
@@ -21,11 +21,7 @@ Signal Processing 1(1), 1987, 83-95).
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    comb_filter_response,
-    noise_signal,
-    time_synchronous_average,
-)
+from phonometry import signals
 
 fs = 8192.0
 period = 1.0 / 32.0        # one revolution: 256 samples at this rate
@@ -36,8 +32,8 @@ periodic = (
     + 0.5 * np.cos(2.0 * np.pi * 3.0 * phase + 0.4)
     - 0.3 * np.cos(2.0 * np.pi * 6.0 * phase)
 )
-recording = periodic + noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
-res = time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
+recording = periodic + signals.noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
 
 fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(11, 4.6))
 t_ms = 1e3 * res.times
@@ -49,9 +45,9 @@ ax0.set_xlabel("Time [ms]"); ax0.set_ylabel("Amplitude"); ax0.legend()
 
 orders = np.linspace(31.0, 33.0, 4000)
 freqs = orders / period
-ax1.plot(orders, comb_filter_response(freqs, period, 32), color="#2ca02c",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 32), color="#2ca02c",
          label="N = 32 (power of two)")
-ax1.plot(orders, comb_filter_response(freqs, period, 20), color="#1f77b4",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 20), color="#1f77b4",
          label="N = 20 (node on 32.05)")
 ax1.axvline(32.05, color="#d62728", ls=":", label="Interfering tone")
 ax1.set_xlabel("Frequency [orders]"); ax1.set_ylabel("Comb filter magnitude")
@@ -98,12 +94,12 @@ every $j$ that is not a multiple of $N$, where the response is exactly zero.
 
 ```python
 import numpy as np
-from phonometry import comb_filter_response
+from phonometry import signals
 
 period = 1.0 / 32.0
-comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
-comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
-comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
+signals.comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
+signals.comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
+signals.comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
 ```
 
 `SynchronousAverageResult` carries the response over the first few harmonics
@@ -120,7 +116,7 @@ That is a power reduction of $10\log_{10} N$ dB, reported as
 `amplitude_snr_gain`:
 
 ```python
-res = time_synchronous_average(recording, fs, period=period, n_averages=100)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=100)
 res.noise_reduction_db      # 20.0 dB = 10*log10(100)
 res.amplitude_snr_gain      # 10.0   = sqrt(100)
 res.plot()                  # averaged waveform + the comb it applied
@@ -139,7 +135,7 @@ the ideal $\sigma/\sqrt{N}$ line as the number of averaged periods grows from
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import time_synchronous_average
+from phonometry import signals
 
 fs = 8192.0
 samples = 256
@@ -154,8 +150,8 @@ recording = np.tile(true, 128) + rng.standard_normal(128 * samples)
 counts = [1, 2, 4, 8, 16, 32, 64, 128]
 errors = []
 for n in counts:
-    res = time_synchronous_average(recording[:n * samples], fs, period=period,
-                                   n_averages=n)
+    res = signals.time_synchronous_average(recording[:n * samples], fs, period=period,
+                                           n_averages=n)
     errors.append(np.sqrt(np.mean((res.period_waveform - true) ** 2)))
 
 # One line — the averaged waveform and the comb filter it applied:
@@ -205,8 +201,8 @@ average confirms it:
 phase = np.arange(41 * 256) / 256
 recording = np.cos(2 * np.pi * 8.0 * phase) + 0.7 * np.cos(2 * np.pi * 32.05 * phase)
 
-leak_20 = time_synchronous_average(recording, fs, period=period, n_averages=20)
-leak_32 = time_synchronous_average(recording, fs, period=period, n_averages=32)
+leak_20 = signals.time_synchronous_average(recording, fs, period=period, n_averages=20)
+leak_32 = signals.time_synchronous_average(recording, fs, period=period, n_averages=32)
 # leak_20.period_waveform matches the clean 8th-order tone; leak_32 does not
 ```
 
@@ -229,7 +225,7 @@ fs = 8192.0
 period = 1.0 / 31.7                       # fs * period is not an integer
 t = np.arange(int(40 * period * fs)) / fs
 recording = np.cos(2.0 * np.pi * t / period)  # one cycle per revolution
-res = time_synchronous_average(recording, fs, period=period)
+res = signals.time_synchronous_average(recording, fs, period=period)
 res.interpolated                          # True: fractional-delay alignment
 res.samples_per_period                    # integer samples of one period
 ```

--- a/docs/signals/spectra/system-measurement.md
+++ b/docs/signals/spectra/system-measurement.md
@@ -48,10 +48,10 @@ comes back to machine precision, a closed-form identity the tests and the
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 
 # Simulated measurement: play each code periodically and record one
 # steady-state period of a room-like band-pass system.
@@ -60,7 +60,7 @@ length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 print(ir.method, ir.size)                   # golay 16384
 ir.plot()
 ```
@@ -78,16 +78,16 @@ complementary correlations land on the true response to machine precision
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 b, a = signal.butter(2, [200.0, 2000.0], btype="bandpass", fs=fs)
 length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 
 # One line — the recovered impulse response:
 ir.plot()
@@ -147,10 +147,10 @@ details; `target` is `"pink"` (the classical room-measurement emphasis,
 default), `"white"`, or any `(frequencies_hz, magnitude_db)` pair:
 
 ```python
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-sweep = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+sweep = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 print(round(sweep.crest_factor_db, 1))      # 4.2 (dB; the ideal is 3.02)
 sweep.plot()
 ```
@@ -164,10 +164,10 @@ sweep.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-res = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+res = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 x = np.asarray(res)
 
 nperseg = 8192   # 75 % overlap: 50 % would ripple ~2 dB on a sweep
@@ -212,20 +212,20 @@ for the [spectral method](../../buildings/rooms/room-acoustics.md) of
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import impulse_response, shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
 freqs = np.array([50.0, 200.0, 1000.0, 8000.0])
 emphasis = np.array([12.0, 6.0, 0.0, 0.0])   # LF boost against rumble
-sweep = shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
-                            target=(freqs, emphasis))
+sweep = room.shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
+                                 target=(freqs, emphasis))
 
 # Simulated measurement of a known system (replace with play/record):
 b, a = signal.butter(2, [200.0, 4000.0], btype="bandpass", fs=fs)
 excitation = np.concatenate([np.asarray(sweep), np.zeros(fs)])
 recorded = signal.lfilter(b, a, excitation)
 
-ir = impulse_response(recorded, excitation, fs, length=fs)
+ir = room.impulse_response(recorded, excitation, fs, length=fs)
 ir.plot()
 ```
 
@@ -260,7 +260,7 @@ of a mixed-phase response causal
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 # A loudspeaker-like measured response (replace with a measured IR).
@@ -269,7 +269,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 print(round(inv.flatness_db, 5))    # 1e-05 (dB: in-band deviation from 0 dB)
 print(round(inv.max_gain_db, 1))    # -6.0 (dB: capped out-of-band boost)
 inv.plot()
@@ -284,7 +284,7 @@ inv.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -292,7 +292,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-res = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+res = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 f = res.frequencies[1:]
 h_mag = np.abs(res.response_spectrum)[1:]
 inv_mag = np.abs(res.spectrum)[1:]
@@ -327,17 +327,16 @@ rate rides along:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import (impulse_response, regularized_inverse_filter,
-                        sweep_signal)
+from phonometry import room, signals
 
 fs = 48000
-sweep = sweep_signal(fs, 50.0, 20000.0, 1.0)
+sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)
 excitation = np.concatenate([sweep, np.zeros(fs // 2)])
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
 recorded = signal.lfilter(b, a, excitation)     # play/record in reality
 
-ir = impulse_response(recorded, excitation, fs)  # any front end works
-inv = regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
+ir = room.impulse_response(recorded, excitation, fs)  # any front end works
+inv = signals.regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
 flat_recording = inv.apply(recorded)             # delay already removed
 inv.plot()   # measured, inverse and equalized magnitudes (figure above)
 ```
@@ -354,7 +353,7 @@ post-processing:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter, shaped_sweep_signal
+from phonometry import room, signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -362,12 +361,12 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)                    # the measured response
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 target_db = 20.0 * np.log10(
     np.abs(inv.spectrum[1:]) * np.abs(inv.response_spectrum).max()
 )
-sweep = shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
-                            target=(inv.frequencies[1:], target_db))
+sweep = room.shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
+                                 target=(inv.frequencies[1:], target_db))
 sweep.plot()   # waveform and spectrum against the inverted-response target
 ```
 

--- a/docs/signals/spectra/test-signals.md
+++ b/docs/signals/spectra/test-signals.md
@@ -27,14 +27,14 @@ single burst or as the repetitive train of Clause A2.2 in which each burst
 occupies one full repetition period:
 
 ```python
-from phonometry import tone_burst
+from phonometry import signals
 
 # One 5 ms burst of 5 kHz tone (25 full periods), as in Table AII.
-single = tone_burst(48000, 5000, 25)
+single = signals.tone_burst(48000, 5000, 25)
 print(single.burst_samples)         # 240 samples = 5 ms at 48 kHz
 
 # Clause A2.2: 5 ms bursts at 10 bursts per second.
-train = tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
+train = signals.tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
 print(train.period_samples, train.duty_cycle)   # 4800, 0.05
 train.plot()                        # waveform with the gating envelope
 ```
@@ -54,11 +54,11 @@ the generator is verified.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import tone_burst
+from phonometry import signals
 
 fs = 48000.0
-single = tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
-train = tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
+single = signals.tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
+train = signals.tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
 
 fig, axes = plt.subplots(2, 1, figsize=(10, 6.4))
 t_ms = 1e3 * np.arange(single.signal.size) / single.fs
@@ -105,10 +105,10 @@ numbers the caller controls:
   bound $\delta = 10^{-A/20}$.
 
 ```python
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 print(res.up, res.down)                  # 160, 147
 print(res.n_taps, res.passband_edge_hz)  # designed FIR, 20947.5 Hz
 res.plot()   # the delivered anti-alias filter against its design spec
@@ -128,10 +128,10 @@ it, flat within the same ripple bound.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 
 # res is the ResampledSignalResult computed in the example above.
 # One line — the delivered anti-alias filter against its design spec:
@@ -194,10 +194,10 @@ boundary conventions cover the two use cases:
 
 ```python
 import numpy as np
-from phonometry import fractional_delay
+from phonometry import signals
 
-y = fractional_delay(x, 0.37)                    # 0.37 samples later
-z = fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
+y = signals.fractional_delay(x, 0.37)                    # 0.37 samples later
+z = signals.fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
 ```
 
 One subtlety worth knowing: a real record of even length cannot carry a

--- a/docs/signals/spectra/time-frequency.md
+++ b/docs/signals/spectra/time-frequency.md
@@ -41,9 +41,9 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
-from phonometry import spectrogram
+from phonometry import signals
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)
 print(res.time_resolution)         # T_B = nperseg/fs, in s
 print(res.resolution_bandwidth)    # Be of the tapered segment, in Hz
@@ -70,7 +70,7 @@ tool for the stationary background.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import noise_signal, spectrogram
+from phonometry import signals
 
 fs = 16000.0
 t = np.arange(int(4.0 * fs)) / fs
@@ -85,10 +85,10 @@ n_imp = int(0.06 * fs)                              # impact at t = 2.5 s
 x[int(2.5 * fs):int(2.5 * fs) + n_imp] += 0.4 * (
     rng.standard_normal(n_imp) * np.exp(-np.arange(n_imp) / (0.012 * fs))
 )
-x += noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
-                  rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
+x += signals.noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
+                          rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 level = 10.0 * np.log10(res.power / p_ref**2)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -128,9 +128,9 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
-from phonometry import zoom_fft
+from phonometry import signals
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
 print(res.bin_spacing)                   # fs/N by default
 print(res.resolution_bandwidth)          # Be of the tapered record
 peak = res.amplitude.argmax()
@@ -154,7 +154,7 @@ only a longer record separates closer tones.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import zoom_fft
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
@@ -166,7 +166,7 @@ coarse = 2.0 * np.abs(np.fft.rfft(x[:1024] * w)) / np.sum(w)
 coarse_f = np.fft.rfftfreq(1024, 1.0 / fs)
 band = (coarse_f >= 950.0) & (coarse_f <= 1050.0)
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(coarse_f[band], 20.0 * np.log10(coarse[band]), "o--",

--- a/docs/simulation/fdtd-simulation.md
+++ b/docs/simulation/fdtd-simulation.md
@@ -309,8 +309,7 @@ few degrees.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (HelmholtzResonator, MetadiffuserWell,
-                        metadiffuser_polar_response, simulation)
+from phonometry import materials, simulation
 
 c0, dx, f0, pitch = 343.0, 0.0005, 2000.0, 0.07
 rows = [(14.7, 13.0, 16.4, 6.2, 9.0), (30.9, 9.1, 4.3, 3.5, 9.0),
@@ -357,12 +356,12 @@ pattern = simulation.far_field_from_contour(
     origin=((lat + face / 2.0) * dx, r_face * dx))
 levels = 20 * np.log10(np.abs(pattern) / np.abs(pattern).max())
 
-wells = [MetadiffuserWell(h * 1e-3,
-                          (HelmholtzResonator(ln * 1e-3, wn * 1e-3,
-                                              lc * 1e-3, wc * 1e-3),) * 2)
+wells = [materials.MetadiffuserWell(h * 1e-3,
+                                    (materials.HelmholtzResonator(ln * 1e-3, wn * 1e-3,
+                                                        lc * 1e-3, wc * 1e-3),) * 2)
          for h, ln, lc, wn, wc in rows]
-model = metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
-                                    angles=angles, periods=1)
+model = materials.metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
+                                              angles=angles, periods=1)
 ax = model.plot(color="#1f77b4", marker="", linestyle="--",
                 label="TMM + Fraunhofer model")
 ax.plot(np.radians(angles), levels, color="#d62728", lw=2.2,

--- a/docs/vibration/machinery/machine-diagnostics.md
+++ b/docs/vibration/machinery/machine-diagnostics.md
@@ -27,12 +27,12 @@ BSF. That is the diagnosis: a spall on the outer race.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import bearing_fault_frequencies, envelope_spectrum, noise_signal
+from phonometry import signals, vibration
 
 # The bearing: 15 rollers on a 34 mm pitch diameter, 6 mm rollers,
 # 12.96 degrees contact angle, shaft at 2000 r/min.
-faults = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
-                                   contact_angle_deg=12.96)
+faults = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
+                                             contact_angle_deg=12.96)
 bpfo, shaft = faults["BPFO"], faults.shaft_rate    # 207.0 Hz, 33.33 Hz
 
 # A spalled outer race: one impact per BPFO period, each ringing a 3 kHz
@@ -47,11 +47,11 @@ tau = np.arange(int(0.004 * fs)) / fs
 ring = np.exp(-tau / 6.0e-4) * np.sin(2.0 * np.pi * 3000.0 * tau)
 x = np.convolve(impacts, ring)[: t.size] * 0.6
 x += 0.35 * np.sin(2.0 * np.pi * shaft * t)          # residual unbalance
-x += noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
 
 # Band-pass the resonance the impacts ring, envelope it, transform it,
 # and let the result draw its own lines on top.
-spectrum = envelope_spectrum(x, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(x, fs, band=(2000.0, 4000.0))
 faults.within(1.0, 5.0 * bpfo).plot(spectrum=spectrum)
 plt.show()
 ```
@@ -82,9 +82,9 @@ errors instantly: $\text{BPFO} + \text{BPFI} = Z f_\mathrm{s}$ always, and
 $\text{BPFO} = Z \times \text{FTF}$ whenever the outer race is stationary.
 
 ```python
-from phonometry import bearing_fault_frequencies
+from phonometry import vibration
 
-res = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
+res = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
 print(round(res["BPFO"], 1), round(res["BPFI"], 1))   # 207.0 293.0
 print(round(res["BPFO"] + res["BPFI"], 1))            # 500.0 = 15 x 33.33
 print(res.as_dict())
@@ -110,10 +110,10 @@ flat sidebands spaced by the shaft rate, while distributed wear raises tall
 sideband groups and lifts the higher mesh harmonics.
 
 ```python
-from phonometry import gear_mesh_frequencies
+from phonometry import vibration
 
 # A 28-tooth pinion on a 1500 r/min shaft, with two sideband orders.
-res = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+res = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 print(round(res["GMF"], 1))            # 700.0
 print(round(res["GMF+1x"], 1))         # 725.0  (GMF + one shaft order)
 print(res.harmonics("GMF", 3))         # [ 700. 1400. 2100.]
@@ -139,10 +139,10 @@ $n = 1, 2, \ldots$. Dynamic eccentricity dresses the dominant slot harmonic
 with sidebands at $\pm$ the shaft rate and $\pm$ the slip frequency.
 
 ```python
-from phonometry import induction_motor_frequencies
+from phonometry import vibration
 
 # Sixty rotor bars, six magnetic poles, 3600 r/min, no slip.
-res = induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
+res = vibration.induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
 print(round(res["1x"]), round(res["2x"]),
       round(res["2fe"]), round(res["fsh"]))     # 60 120 360 3600
 ```
@@ -175,10 +175,10 @@ count reached from a different harmonic is a different pattern turning at a
 different speed.
 
 ```python
-from phonometry import blade_pass_frequencies
+from phonometry import vibration
 
 # Six blades, four vanes, 3500 r/min.
-res = blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
+res = vibration.blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
 print(round(res["BPF"]))          # 350
 print(round(res["lobe n=1 m=2"]), round(res["lobe n=1 m=10"]))    # 175 35
 ```
@@ -211,24 +211,19 @@ harmonic or sideband family onto a single quefrency spike, which is the fastest
 way to tell *which* periodicity dominates when several are superimposed.
 
 ```python
-from phonometry import (
-    bearing_fault_frequencies,
-    combine_fault_lines,
-    envelope_spectrum,
-    gear_mesh_frequencies,
-)
+from phonometry import signals, vibration
 
 record, fs = x, 20000.0          # the housing record and its sample rate
 shaft_rpm = 2000.0               # from the tacho, not from the nameplate
 
 # The bearing's own lines, the mesh family of the pinion it supports, and the
 # shaft harmonics. Put them all on one axes.
-bearing = bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
-                                    contact_angle_deg=12.96)
-gear = gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
-lines = combine_fault_lines(bearing, gear)
+bearing = vibration.bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
+                                              contact_angle_deg=12.96)
+gear = vibration.gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
+lines = vibration.combine_fault_lines(bearing, gear)
 
-spectrum = envelope_spectrum(record, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(record, fs, band=(2000.0, 4000.0))
 lines.within(1.0, 1600.0).plot(spectrum=spectrum)
 ```
 

--- a/docs/vibration/structural/junction-transmission.md
+++ b/docs/vibration/structural/junction-transmission.md
@@ -32,10 +32,10 @@ continuous 200 mm wall.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # A 140 mm concrete floor meeting a 200 mm wall at a T-junction.
-res = junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
+res = vibration.junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
 res.plot_geometry()
 plt.show()
 ```
@@ -49,10 +49,10 @@ plt.show()
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # X-junction between a 100 mm and a 200 mm concrete plate (cL = 3200 m/s).
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 res.plot()  # tau(theta) for the corner and straight paths, with averages
 plt.show()
 ```
@@ -84,9 +84,9 @@ cut-off angle $\theta_\text{co} = \arcsin\chi$; $\psi$ is the ratio of their
 bending-moment mobilities. For **identical plates** both are 1.
 
 ```python
-from phonometry import junction_wave_parameters
+from phonometry import vibration
 
-chi, psi = junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+chi, psi = vibration.junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 #  -> (sqrt(0.5), 4.0)
 ```
 
@@ -128,14 +128,11 @@ plates 2 and 4 identical.
 
 ```python
 import numpy as np
-from phonometry import (
-    corner_transmission_coefficient,
-    straight_transmission_coefficient,
-)
+from phonometry import vibration
 
 theta = np.radians(np.linspace(0.0, 90.0, 91))
-tau12 = corner_transmission_coefficient(theta, chi, psi, "X")
-tau13 = straight_transmission_coefficient(theta, chi, psi, "X")
+tau12 = vibration.corner_transmission_coefficient(theta, chi, psi, "X")
+tau13 = vibration.straight_transmission_coefficient(theta, chi, psi, "X")
 ```
 
 The clip below runs this experiment in the time domain with the library's 2D
@@ -170,10 +167,10 @@ first-principles oracle:
 * in-line junction: $\tau_{12}(0°) = 1$ (a continuous plate transmits fully).
 
 ```python
-from phonometry import angular_average_transmission_coefficient
+from phonometry import vibration
 
-angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
-angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
 ```
 
 The two directions obey the SEA consistency relationship (Eq. 5.7),
@@ -205,14 +202,13 @@ X-junction ($f_\mathrm{c} \approx 203\ \text{Hz}$),
 $K_{ij} = 10\log_{10} 12 + 5\log_{10}(203/1000) \approx 7.3\ \text{dB}$.
 
 ```python
-from phonometry import (coupling_loss_factor, junction_transmission,
-                        wave_vibration_reduction_index)
+from phonometry import vibration
 
-eta = coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
-                           junction_length=4.0, frequency=500.0, plate_area=10.0)
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
-kij = wave_vibration_reduction_index(res.corner_average,
-                                     res.critical_frequency2)  # 7.33 dB
+eta = vibration.coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
+                                     junction_length=4.0, frequency=500.0, plate_area=10.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
+kij = vibration.wave_vibration_reduction_index(res.corner_average,
+                                               res.critical_frequency2)  # 7.33 dB
 kij = res.corner_reduction_index  # the same, precomputed on the result
 
 res.plot()   # tau(theta) for this junction's corner and straight paths (needs matplotlib)
@@ -239,7 +235,7 @@ perpendicular plates increasingly pin the junction line:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import junction_transmission, wave_vibration_reduction_index
+from phonometry import vibration
 
 # Concrete plates (cL = 3200 m/s, rho = 2400 kg/m3): plate 1 fixed at
 # 100 mm, plate 2 swept from 50 mm to 400 mm.
@@ -248,7 +244,7 @@ ratios = np.linspace(0.5, 4.0, 36)
 kij_corner = []
 for ratio in ratios:
     h2 = h1 * float(ratio)
-    res = junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
+    res = vibration.junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
     kij_corner.append(res.corner_reduction_index)
 
 fig, ax = plt.subplots()
@@ -271,10 +267,10 @@ the top: its corner path gives $K_{12} = 9.8\ \text{dB}$. Handing that to
 junction's three flanking paths and their effect on the apparent rating:
 
 ```python
-from phonometry import building, junction_transmission
+from phonometry import building, vibration
 
 # The 100 mm / 200 mm concrete X-junction of the opening figure:
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 k12 = res.corner_reduction_index                     # 9.8 dB (corner path)
 
 # Feed it to the EN 12354-1 simplified model as this junction's Kij:
@@ -353,15 +349,7 @@ model to be trustworthy.*
 import math
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coupling_loss_factor,
-    cylindrical_shell_modal_density,
-    flat_plate_modal_density,
-    plate_bending_stiffness,
-    point_connection_coupling_loss_factor,
-    power_injection_clf,
-    right_angle_transmission_coefficient,
-)
+from phonometry import vibration
 from phonometry.vibration.structural.point_mobility import plate_bending_wave_speed
 
 rho, nu, young = 2700.0, 0.33, 7.1e10                 # aluminium
@@ -371,13 +359,13 @@ bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0])
 # Predicted: a 3 mm x 2.5 m x 1.2 m plate meeting a 5.5 mm x 2.0 m x 1.2 m
 # plate at right angles along the 1.2 m edge, welded and then bolted.
 h1, h2, area1, length = 0.003, 0.0055, 2.5 * 1.2, 1.2
-tau = right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
-                                           wave_speed1=cl, wave_speed2=cl)
-cb = plate_bending_wave_speed(bands, plate_bending_stiffness(young, h1, nu),
+tau = vibration.right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
+                                                     wave_speed1=cl, wave_speed2=cl)
+cb = plate_bending_wave_speed(bands, vibration.plate_bending_stiffness(young, h1, nu),
                               rho * h1)
-welded = [float(coupling_loss_factor(tau, 2.0 * c, length, f, area1))
+welded = [float(vibration.coupling_loss_factor(tau, 2.0 * c, length, f, area1))
           for c, f in zip(cb, bands, strict=True)]
-bolted = point_connection_coupling_loss_factor(
+bolted = vibration.point_connection_coupling_loss_factor(
     bands, 12, thickness1=h1, thickness2=h2, surface_density1=rho * h1,
     surface_density2=rho * h2, wave_speed1=cl, wave_speed2=cl,
     plate_area1=area1)
@@ -387,11 +375,11 @@ bolted = point_connection_coupling_loss_factor(
 t_p, t_c, radius = 0.005, 0.003, 0.75
 area_c = 2.0 * math.pi * radius * 2.0
 area_p = 3.5 * 3.0 - math.pi * radius**2
-sea = power_injection_clf(
+sea = vibration.power_injection_clf(
     500.0, rho * t_p * area_p * 0.0272**2, rho * t_c * area_c * 0.0132**2,
     4.4e-3, 2.4e-3,
-    flat_plate_modal_density(area_p, t_p, cl),
-    float(cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
+    vibration.flat_plate_modal_density(area_p, t_p, cl),
+    float(vibration.cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
 
 print(f"{float(sea.coupling_loss_factor12[0]):.2e}")   # 4.26e-04
 print(f"{float(sea.coupling_loss_factor21[0]):.2e}")   # 3.91e-04

--- a/docs/vibration/structural/transfer-stiffness.md
+++ b/docs/vibration/structural/transfer-stiffness.md
@@ -232,13 +232,13 @@ $L_k(f)$ spectrum, so it needs both the report and plot extras
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, TransferStiffnessResult, transfer_stiffness_direct
+from phonometry import ReportMetadata, vibration
 
 freqs = np.array([20, 31.5, 50, 80, 125, 200, 315, 500, 800, 1250, 2000], dtype=float)
 k21 = 1e6 + 1j * (2 * np.pi * freqs) * 80.0     # Kelvin-Voigt element k + jwc
 u1 = 1e-6 + 0j
-k = transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
-res = TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
+k = vibration.transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
+res = vibration.TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
 res.report(
     "transfer_stiffness.pdf",
     metadata=ReportMetadata(

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -682,10 +682,10 @@ EPNL result and is not an official State noise certificate; it does not
 reproduce any TCDSN.
 
 ```python
-from phonometry import effective_perceived_noise_level, ReportMetadata
+from phonometry import ReportMetadata, aircraft
 
 # spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
-res = effective_perceived_noise_level(spectra, dt=0.5)
+res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 res.report(
     "epnl_fiche.pdf",
     metadata=ReportMetadata(
@@ -1169,9 +1169,9 @@ table yourself.
 Point it at a directory to read any other ANP CSV export instead.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 print(len(db.aircraft_ids))          # 155 aircraft types
 ac = db.aircraft("747100")
 print(ac.description)                # Boeing 747-100 / JT9DBD
@@ -1202,9 +1202,9 @@ tabulated nodes the Doc 29 interpolation is logarithmic in distance and linear
 in power.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-curves = load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
+curves = aircraft.load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
 print(curves.powers)                       # [10000. 14000. 19000. 23000.] lb
 print(curves.level(19000.0, [304.8, 1000.0, 3000.0]))
 ```
@@ -1226,9 +1226,9 @@ the level, while distance sets the shape.
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 curves = ac.npd_curves("D", "SEL")
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -1265,9 +1265,9 @@ only for arrivals. Asking for one that does not exist raises a `KeyError` naming
 the stage lengths that do, which is how to discover them:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for identifier, operation, stage in (("A320-232", "D", 1), ("747100", "D", 9)):
     try:
         db.profile(identifier, operation, stage)
@@ -1282,9 +1282,9 @@ substitute trajectory. NPD curves, on the other hand, are tabulated for every
 aircraft in the database.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-profile = load_anp_database().aircraft("747100").profile("D", stage_length=1)
+profile = aircraft.load_anp_database().aircraft("747100").profile("D", stage_length=1)
 print(profile.profile_id, profile.stage_length, profile.path.shape)
 profile.plot()
 ```
@@ -1302,9 +1302,9 @@ after them fixes the slant distance at every receiver, so it decides the contour
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -1327,9 +1327,9 @@ over a ground grid, each wiring the NPD curves and the default profile into the
 functions the airport-noise page builds by hand.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 flyover = ac.event_level([3000.0, 500.0, 0.0], "D")
 print(round(float(flyover.level), 1))     # 100.4 dB
 ```
@@ -1349,9 +1349,9 @@ weather correction.
 
 ```python
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-contour = load_anp_database().aircraft("747100").noise_contour(
+contour = aircraft.load_anp_database().aircraft("747100").noise_contour(
     "D",
     x=np.linspace(-2000.0, 12000.0, 40),
     y=np.linspace(-3000.0, 3000.0, 30),
@@ -1948,11 +1948,11 @@ the CNOSSOS-EU scheme the guidance adopts). The ground effect is not
 evaluated separately in that regime.
 
 ```python
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = [63.0, 250.0, 1000.0, 4000.0]
-diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
-diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
+aircraft.diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
+aircraft.diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```
 
 <picture>
@@ -1966,11 +1966,11 @@ diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = np.array([63.0, 250.0, 1000.0, 4000.0])
 delta = np.linspace(-0.4, 1.5, 441)
-ld = np.array([diffraction_attenuation(bands, float(d), edge_height=2.5)
+ld = np.array([aircraft.diffraction_attenuation(bands, float(d), edge_height=2.5)
               for d in delta])
 
 fig, ax = plt.subplots(figsize=(9, 6))
@@ -2281,35 +2281,31 @@ model. Eight defects of those printed tables are recorded in
 
 ```python
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 
 # Annex E junctions (unrounded): floor-to-external-wall rigid T, external wall
 # in-line across it, floor-to-internal-wall rigid cross, internal wall in-line.
-k_floor_ext = junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
-k_ext_ext = junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
-k_floor_int = junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
-k_int_int = junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_ext_ext = building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
+k_int_int = building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
 print(round(k_floor_ext, 1), round(k_ext_ext, 1))     # 6.4 11.2  (Table L.5)
 print(round(k_floor_int, 1), round(k_int_int, 1))     # 8.8 11.0  (Table L.6)
 
 # The floor's perimeter: it butts into an external wall above and below at each
 # of its two external edges, and crosses the internal walls at the other two.
-a_at_ext = perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
-a_at_int = perimeter_absorption_coefficient(
-    [76.8, 128.4, 128.4], [junction_vibration_reduction(
+a_at_ext = building.perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
+a_at_int = building.perimeter_absorption_coefficient(
+    [76.8, 128.4, 128.4], [building.junction_vibration_reduction(
         "rigid_cross", "through", 360.0 / 484.0), k_floor_int, k_floor_int])
 floor_perimeter = 9.0 * (a_at_ext + a_at_int)         # 2.659 m (Formula C.4)
 
-floor = HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
-                           floor_perimeter, 2200.0, 3800.0)
-el = in_situ_element(floor, bands)
+floor = building.HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
+                                    floor_perimeter, 2200.0, 3800.0)
+el = building.in_situ_element(floor, bands)
 print(np.round(el.total_loss_factor[[0, 10]], 4))     # [0.0831 0.029 ]  Table L.3
 print(np.round(el.sound_reduction_index[[0, 10]], 1)) # [31.8 54.9]      Table L.3
 print(np.round(el.impact_level[[0, 10]], 1))          # [57.3 63.6]      Table G.3
@@ -2322,13 +2318,13 @@ Every printed column of Tables L.2, L.3, L.4, G.3 and G.4 comes back within
 ```python
 # The floating floor: 35 mm screed, m' = 73,5 kg/m2 on s' = 8 MN/m3.
 f0 = 160.0 * np.sqrt(8.0 / 73.5)                      # 52.8 Hz (Formula C.2)
-delta = floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
+delta = building.floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
 
-wall = in_situ_element(HomogeneousElement(
+wall = building.in_situ_element(building.HomogeneousElement(
     "ext1", 11.0, 4.0, 2.75, 219.0, 92.6, 0.0125, 2.375, 600.0, 1900.0), bands)
 
 # Path D1 (Df: separating floor -> external wall 1), Table L.4.
-d1 = airborne_flanking_path(
+d1 = building.airborne_flanking_path(
     label="D1", kind="Df", element_i=el, element_j=wall,
     vibration_reduction_index=k_floor_ext, coupling_length=4.0,
     separating_area=20.0, delta_r_i=delta)
@@ -2341,9 +2337,9 @@ index per band, its energy split and the ISO 717-1 rating in one call:
 ```python
 # `paths` holds the twelve flanking paths of the four elements, built the
 # way `d1` was above; the code block under the figure builds all of them.
-res = detailed_airborne_prediction(
-    bands, direct_index=direct_reduction_index(el.sound_reduction_index,
-                                               delta_r_source=delta),
+res = building.detailed_airborne_prediction(
+    bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
+                                                        delta_r_source=delta),
     flanking_paths=paths)
 print(np.round(res.r_prime[[0, 10]], 1))   # [28.8 55.9]   Table L.1 total
 print(res.rating.rating, res.dominant[0])  # 57 'Dd'
@@ -2365,26 +2361,22 @@ the result there. The single number $R'_\mathrm{w} = 57$ dB says none of that.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 k = {
-    "floor-ext": junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
-    "ext-ext": junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
-    "floor-floor": junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
-    "floor-int": junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
-    "int-int": junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
-    "int-ext": junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
-    "extT-ext": junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
-    "corner": junction_vibration_reduction("corner", "corner", 1.0),
-    "int-int-x": junction_vibration_reduction("rigid_cross", "through", 1.0),
+    "floor-ext": building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
+    "ext-ext": building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
+    "floor-floor": building.junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
+    "floor-int": building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
+    "int-int": building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
+    "int-ext": building.junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
+    "extT-ext": building.junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
+    "corner": building.junction_vibration_reduction("corner", "corner", 1.0),
+    "int-int-x": building.junction_vibration_reduction("rigid_cross", "through", 1.0),
 }
-a = perimeter_absorption_coefficient
+a = building.perimeter_absorption_coefficient
 floor_sum = 9.0 * (a([92.6, 92.6], [k["floor-ext"]] * 2)
                    + a([76.8, 128.4, 128.4],
                        [k["floor-floor"], k["floor-int"], k["floor-int"]]))
@@ -2404,10 +2396,10 @@ specs = {
     "int2": (13.75, 5.0, 2.75, 360.0, 128.4, 0.01,
              10.0 * int_top + 2.75 * int_side, 1800.0, 2500.0),
 }
-situ = {name: in_situ_element(HomogeneousElement(name, *spec), bands)
+situ = {name: building.in_situ_element(building.HomogeneousElement(name, *spec), bands)
         for name, spec in specs.items()}
-delta = floating_floor_improvement(bands,
-                                   resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
+delta = building.floating_floor_improvement(bands,
+                                            resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
 
 paths = []
 for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
@@ -2416,21 +2408,21 @@ for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
     cross = k["floor-ext"] if name.startswith("ext") else k["floor-int"]
     through = k["ext-ext"] if name.startswith("ext") else k["int-int"]
     paths += [
-        airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
-                               element_j=wall, vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0,
-                               delta_r_i=delta),
-        airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
-                               element_j=situ["floor"], vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0),
-        airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
-                               element_j=wall, vibration_reduction_index=through,
-                               coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=wall, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
+                                        element_j=wall, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
     ]
-res = detailed_airborne_prediction(
+res = building.detailed_airborne_prediction(
     bands,
-    direct_index=direct_reduction_index(situ["floor"].sound_reduction_index,
-                                        delta_r_source=delta),
+    direct_index=building.direct_reduction_index(situ["floor"].sound_reduction_index,
+                                                 delta_r_source=delta),
     flanking_paths=paths)
 
 # One line — the per-band path contributions with R' overlaid:
@@ -2443,19 +2435,18 @@ plt.show()
 The impact side of the same building runs on the same `situ` dictionary:
 
 ```python
-from phonometry import (detailed_impact_prediction, direct_impact_level,
-                        impact_flanking_path)
+from phonometry import building
 
-direct = direct_impact_level(situ["floor"].impact_level, delta_l=delta)
+direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
-    impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
-                         vibration_reduction_index=(
+    building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
+                                  vibration_reduction_index=(
                              k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
-                         coupling_length=lij, delta_l=delta)
+                                  coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
 ]
-imp = detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
+imp = building.detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
 print(np.round(imp.l_prime_n[[3, 10]], 1))     # [54.  35.9]   Table G.1 total
 print(imp.rating.rating, imp.rating.ci)        # 41 2           printed 41,0 (2)
 ```
@@ -2485,25 +2476,22 @@ $\overline{D}_{v,ij,\mathrm{n}}$ and Part 2 Formula (13) from a measured normali
 flanking impact level $L_\mathrm{n,f}$.
 
 ```python
-from phonometry import (flanking_impact_level_from_flanking_level,
-                        flanking_reduction_index_from_flanking_level,
-                        flanking_reduction_index_from_normalized_difference,
-                        resonant_sound_reduction_index)
+from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
-r_star = resonant_sound_reduction_index(r_wall_leaf, bands,
-                                        critical_frequency=2200.0)   # +8 dB below fc
-r_ff = flanking_reduction_index_from_normalized_difference(
+r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
+                                                 critical_frequency=2200.0)   # +8 dB below fc
+r_ff = building.flanking_reduction_index_from_normalized_difference(
     index_i=r_star, index_j=r_star, normalized_velocity_level_difference=dv_n,
     separating_area=20.0, coupling_length=4.0)                        # Table L.11
 
 # ISO 12354-1 L.2.2: a measured junction between two timber frame walls.
-r13 = flanking_reduction_index_from_flanking_level(
+r13 = building.flanking_reduction_index_from_flanking_level(
     dnf_13, separating_area=10.44, coupling_length=2.41,
     laboratory_coupling_length=2.5)                                   # Table L.15
 
 # ISO 12354-2 Formula (13): the impact twin, from a measured Ln,f.
-ln_13 = flanking_impact_level_from_flanking_level(
+ln_13 = building.flanking_impact_level_from_flanking_level(
     lnf_13, area=20.0, laboratory_area=10.0,
     coupling_length=4.0, laboratory_coupling_length=4.5)
 ```
@@ -3303,7 +3291,7 @@ optional `phonometry[report]` extra (reportlab), plus matplotlib for the plot.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, installed_source_prediction
+from phonometry import ReportMetadata, building
 
 bands = np.array([63, 125, 250, 500, 1000, 2000], float)
 lwc = np.array([84.4, 82.5, 69.9, 67.6, 61.6, 49.9])   # characteristic power [dB]
@@ -3316,7 +3304,7 @@ paths = [
      "flanking_reduction_index": np.array([37.0, 41.2, 35.9, 37.7, 49, 57.8]),
      "element_area": 12.8},
 ]
-res = installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
+res = building.installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
 res.report(
     "installed_structure_borne.pdf",
     metadata=ReportMetadata(
@@ -3821,21 +3809,18 @@ plasterboard leaf puts $f_\mathrm{c}$ near 2.6 kHz and rates $R_\mathrm{w} = 27$
 
 ```python
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006                                 # 15 kg/m2
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
-fc = coincidence_frequency(mass, bp)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
+fc = vibration.coincidence_frequency(mass, bp)
 print(round(fc))                                      # 2107 Hz (Hopkins declares ~2079)
 
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 print(round(res.rating().rating))                     # 32  ->  Rw = 32 dB (catalogue 6 mm glass)
 
 res.plot()   # predicted R(f) with the critical frequency marked (needs matplotlib)
@@ -3857,19 +3842,16 @@ $R_\mathrm{w} = 32$ dB of 6 mm glass.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(mass, bp)
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(mass, bp)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 w = res.rating()
 
 # One line each — the predicted R(f), or the rated curve vs the reference:
@@ -3956,18 +3938,18 @@ what it claims to be: an estimate, not the dip.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import plateau_transmission_loss, single_panel_transmission_loss
+from phonometry import building
 
 # 6 mm float glass: Norton Table 3.1 gives 2.47 kg/m2 per mm, a 27 dB
 # coincidence plateau and B/A = 10; its critical frequency is 2033 Hz.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000], dtype=float)
-quick = plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
-                                  field_correction=5.5)
-physical = single_panel_transmission_loss(bands, 2.47 * 6.0,
-                                          critical_frequency=2033.0,
-                                          loss_factor=0.02)
+quick = building.plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
+                                           field_correction=5.5)
+physical = building.single_panel_transmission_loss(bands, 2.47 * 6.0,
+                                                   critical_frequency=2033.0,
+                                                   loss_factor=0.02)
 
 print(round(quick.plateau_start), round(quick.plateau_end))   # 374 3742
 print(quick.plateau_height)                                   # 27.0
@@ -3986,11 +3968,11 @@ problem 3.11 exactly, band for band, in the two regions the construction fixes
 analytically.
 
 ```python
-from phonometry import plateau_transmission_loss
+from phonometry import building
 
 octaves = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
-res = plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
-                                air_density=1.21)
+res = building.plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
+                                         air_density=1.21)
 print(res.transmission_loss.round(1))
 # [35.8 37.  37.  43.3 53.3 63.3 73.3]
 ```
@@ -4070,20 +4052,16 @@ supported orthotropic plate (Vigran Eq. 3.113 = Bies Eq. 7.27, after Hearmon
 valid above roughly $1.5f_{1,1}$.
 
 ```python
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_plate_resonance, plate_bending_stiffness,
-)
+from phonometry import building, vibration
 
 # Vigran's worked example: a 1 m x 1 m steel sheet 1 mm thick, E = 210 GPa,
 # nu = 0.3, m'' = 7.8 kg/m2, corrugated into a sinusoid 20 mm deep
 # (amplitude H = 10 mm) at a 100 mm pitch.
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, b_xz = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, b_xz = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
 print(round(flat_b, 1), round(b_x, 1), round(b_z))     # 19.2 17.5 2202
 print(round(mass, 2))                                  # 8.52 kg/m2 (+9 %)
 
@@ -4093,14 +4071,14 @@ flat = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": 7.8,
 corr = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": mass,
         "bending_stiffness_x": b_x, "bending_stiffness_z": b_z,
         "bending_stiffness_xz": b_xz}
-print(round(orthotropic_plate_resonance(1, 1, **flat), 1),
-      round(orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
-print(round(orthotropic_plate_resonance(1, 1, **corr), 1),
-      round(orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
+print(round(building.orthotropic_plate_resonance(1, 1, **flat), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
+print(round(building.orthotropic_plate_resonance(1, 1, **corr), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
 
 # The same sheet, flat and corrugated, in the coincidence picture:
-print(round(coincidence_frequency(7.8, flat_b)))               # 11925 Hz
-print([round(f) for f in orthotropic_critical_frequencies(mass, b_x, b_z)])
+print(round(vibration.coincidence_frequency(7.8, flat_b)))               # 11925 Hz
+print([round(f) for f in building.orthotropic_critical_frequencies(mass, b_x, b_z)])
 # [1165, 13064]
 ```
 
@@ -4124,33 +4102,28 @@ the corrugated sheet gives away up to 13 dB, and $R_\mathrm{w}$ falls from 28 dB
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_transmission_loss, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000, 12500, 16000], dtype=float)
 eta = 0.011
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, _ = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, _ = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
-fc1, fc2 = orthotropic_critical_frequencies(mass, b_x, b_z)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
+fc1, fc2 = building.orthotropic_critical_frequencies(mass, b_x, b_z)
 
-flat = single_panel_transmission_loss(
-    bands, 7.8, critical_frequency=coincidence_frequency(7.8, flat_b),
+flat = building.single_panel_transmission_loss(
+    bands, 7.8, critical_frequency=vibration.coincidence_frequency(7.8, flat_b),
     loss_factor=eta,
 )
-corrugated = orthotropic_transmission_loss(
+corrugated = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     loss_factor=eta,
 )
-heckl = orthotropic_transmission_loss(
+heckl = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     method="heckl",
 )
@@ -4195,21 +4168,21 @@ add, boosted by the cavity, until $f_\mathrm{l} = c_0/(2\pi d)$ where the boost 
 at 6 dB (Eq. 7.64). A porous fill lowers $f_0$.
 
 ```python
-from phonometry import double_wall_transmission_loss, mass_spring_mass_resonance
-from phonometry import mass_law_transmission_loss, miki
+from phonometry import building
+from phonometry import materials
 
 # Two 12 kg/m2 leaves, 75 mm air gap.
-f0 = mass_spring_mass_resonance(12.0, 12.0, 0.075)
+f0 = building.mass_spring_mass_resonance(12.0, 12.0, 0.075)
 print(round(f0))                                          # 89 Hz
 
 # Below f0 the double wall equals the mass law of the total mass 24 kg/m2:
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
 print(round(float(dw.transmission_loss[0]), 1),
-      round(float(mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
+      round(float(building.mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
 
 # A mineral-wool fill (a materials porous model) lowers the resonance:
-fill = miki([f0], 7000.0)
-print(round(mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
+fill = materials.miki([f0], 7000.0)
+print(round(building.mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
 
 dw.plot()   # double-wall R(f) with the mass-spring-mass resonance marked (needs matplotlib)
 ```
@@ -4231,11 +4204,11 @@ double-wall curve sits.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import mass_spring_mass_resonance, plot_double_wall_geometry
+from phonometry import building
 
 # Two 8.8 kg/m2 plasterboard leaves on a 100 mm cavity.
-f0 = mass_spring_mass_resonance(8.8, 8.8, 0.1)
-plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
+f0 = building.mass_spring_mass_resonance(8.8, 8.8, 0.1)
+building.plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
 plt.show()
 
 # A double-wall prediction retains its geometry and redraws it:
@@ -4284,25 +4257,20 @@ Hall & Hopkins (2001).
 | Vertical-twist tie (proprietary) | 100 | 43.4 |
 
 ```python
-from phonometry import (
-    double_wall_transmission_loss,
-    mass_spring_mass_resonance,
-    wall_tie_stiffness,
-    wall_tie_stiffness_per_area,
-)
+from phonometry import building
 
-print(wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
+print(building.wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
 
 # Hopkins Fig. 4.35: two 140 kg/m2 leaves across an empty 75 mm cavity.
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
 
 # Add 2.5 ties per m2 of s_75mm = 2 MN/m: the resonance nearly doubles.
-ties = wall_tie_stiffness_per_area(2.5, 2.0e6)
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075,
-                                       tie_stiffness_per_area=ties)))  # 50 Hz
+ties = building.wall_tie_stiffness_per_area(2.5, 2.0e6)
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075,
+                                                tie_stiffness_per_area=ties)))  # 50 Hz
 
-dw = double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
-                                   tie_stiffness_per_area=ties)
+dw = building.double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
+                                            tie_stiffness_per_area=ties)
 ```
 
 **The tie as a point connection (Hopkins Eqs. 4.84 to 4.88).** Each tie
@@ -4328,11 +4296,11 @@ differently.
 
 ```python
 import numpy as np
-from phonometry import plate_bending_stiffness, wall_tie_coupling_loss_factor
+from phonometry import building, vibration
 
 freq = np.logspace(np.log10(50.0), np.log10(5000.0), 60)
-b1 = plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
-res = wall_tie_coupling_loss_factor(
+b1 = vibration.plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
+res = building.wall_tie_coupling_loss_factor(
     freq, 150.0, 170.0, b1, b1, ties_per_area=2.5, tie="butterfly"
 )
 print(res.coupling_loss_factor[0], res.rigid_coupling_loss_factor[0])
@@ -4367,17 +4335,14 @@ so a bare opening of relative area $S_\mathrm{a}/S$ caps the composite at $10\lo
 a 1 % opening can never do better than 20 dB, whatever the wall.
 
 ```python
-from phonometry import (
-    composite_transmission_loss, slit_transmission_coefficient,
-    slit_resonance_frequencies,
-)
+from phonometry import building
 
 # A 2 mm x 100 mm-deep slit: transmission peaks at the depth's half-wavelength
 # resonances.
-print(slit_resonance_frequencies(0.1, 0.002, orders=2).round().tolist())   # [~1500, ~3100]
+print(building.slit_resonance_frequencies(0.1, 0.002, orders=2).round().tolist())   # [~1500, ~3100]
 
 # A wall of Rw = 50 dB with 1 % of its area open as a slit is capped:
-print(round(float(composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
+print(round(float(building.composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
 ```
 
 The leak that undoes a heavy wall is almost invisible, and `.plot_geometry()`
@@ -4396,10 +4361,10 @@ resonances near 1.5 and 3.1 kHz rather than as a simple open area.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import slit_transmission_coefficient
+from phonometry import building
 
 f = np.geomspace(100.0, 5000.0, 200)
-result = slit_transmission_coefficient(f, 0.002, 0.1)
+result = building.slit_transmission_coefficient(f, 0.002, 0.1)
 
 # One line: the wall section with the slit to scale.
 result.plot_geometry()
@@ -4435,16 +4400,16 @@ radiates weakly; above it $\sigma \to 1$ (Leppington/Maidanik, Eqs 2.227-2.230):
 $\sigma = (1 - f_\mathrm{c}/f)^{-1/2}$ for $f > f_\mathrm{c}$.
 
 ```python
-from phonometry import radiation_efficiency, sound_power_from_vibration
+from phonometry import emission, vibration
 
 # The 6 mm glass pane (1.5 x 1.25 m) of the single-panel example above.
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 print(sig.radiation_efficiency[bands == 2000].round(2))    # ~2.5 (peak at coincidence)
 
 # Feed the prediction straight into ISO 7849 as the radiation factor:
-lw = sound_power_from_vibration(velocity_level=80.0, area=1.875,
-                                radiation_factor=sig.radiation_efficiency,
-                                frequencies=bands)
+lw = emission.sound_power_from_vibration(velocity_level=80.0, area=1.875,
+                                         radiation_factor=sig.radiation_efficiency,
+                                         frequencies=bands)
 
 sig.plot()   # sigma(f) with the coincidence peak (needs matplotlib)
 ```
@@ -4460,11 +4425,11 @@ $\omega^{-1/2}$). They supply the receiver mobility EN 12354-5 needs when no
 measurement exists.
 
 ```python
-from phonometry import infinite_plate_impedance, infinite_beam_mobility, injected_power
+from phonometry import vibration
 
-z_plate = infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
+z_plate = vibration.infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
 print(round(z_plate))                                 # real, frequency independent
-w = injected_power(force=10.0, mobility=1.0 / z_plate)
+w = vibration.injected_power(force=10.0, mobility=1.0 / z_plate)
 print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' m''))
 ```
 
@@ -4474,37 +4439,32 @@ print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' 
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (
-    coincidence_frequency, composite_transmission_loss,
-    double_wall_transmission_loss, mass_law_transmission_loss,
-    mass_spring_mass_resonance, plate_bending_stiffness,
-    radiation_efficiency, single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000], dtype=float)
 fig, ax = plt.subplots(2, 2, figsize=(12, 9))
 
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(15.0, bp)
-ml = mass_law_transmission_loss(bands, 15.0, incidence="field")
-sp = single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(15.0, bp)
+ml = building.mass_law_transmission_loss(bands, 15.0, incidence="field")
+sp = building.single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
 ax[0, 0].semilogx(bands, ml, "--", label="field-incidence mass law")
 ax[0, 0].semilogx(bands, sp.transmission_loss, "-o", ms=3, label="single panel R (Sharp)")
 ax[0, 0].axvline(fc, ls=":", color="r"); ax[0, 0].set_title("Single panel")
 
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
-ax[0, 1].semilogx(bands, mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+ax[0, 1].semilogx(bands, building.mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
 ax[0, 1].semilogx(bands, dw.transmission_loss, "-o", ms=3, label="double wall")
-ax[0, 1].axvline(mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
+ax[0, 1].axvline(building.mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
 ax[0, 1].set_title("Double wall")
 
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 ax[1, 0].loglog(bands, sig.radiation_efficiency, "-o", ms=3, label=r"$\sigma(f)$")
 ax[1, 0].axhline(1.0, ls=":"); ax[1, 0].set_title("Radiation efficiency")
 
 wall = sp.transmission_loss
-comp = [float(composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
+comp = [float(building.composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
 ax[1, 1].semilogx(bands, wall, "-o", ms=3, label="solid wall")
 ax[1, 1].semilogx(bands, comp, "-s", ms=3, label="wall + 1 % slit")
 ax[1, 1].axhline(20.0, ls=":"); ax[1, 1].set_title("Composite with aperture")
@@ -4696,21 +4656,18 @@ the floor, caps the injected power.
 
 ```python
 import numpy as np
-from phonometry import (
-    hammer_impact_velocity, infinite_plate_impedance, plate_bending_stiffness,
-    plate_contact_stiffness, tapping_force_spectrum,
-)
+from phonometry import building, vibration
 
-print(round(hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
+print(round(building.hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
 
 # A 140 mm cast in-situ concrete slab: 2200 kg/m3, cL = 3800 m/s, nu = 0.2.
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-k = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+k = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 freqs = np.array([100, 200, 400, 800, 1600, 3150], dtype=float)
-res = tapping_force_spectrum(freqs, k, z)
+res = building.tapping_force_spectrum(freqs, k, z)
 res.over_critical            # False: the hammer rebounds off concrete
 round(res.cut_off_frequency)  # 6948 Hz, above the building acoustics range
 res.peak_force               # |Fn| per band, within 1 dB of res.upper_limit
@@ -4754,23 +4711,20 @@ carries the nulls where they belong.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    covering_contact_stiffness, covering_improvement, infinite_plate_impedance,
-    plate_bending_stiffness, plate_contact_stiffness,
-)
+from phonometry import building, vibration
 
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14          # 140 mm concrete slab
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-plate = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+plate = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0])
 
 d = 0.005
 for label, modulus_over_thickness in (("PVC", 1.5e11), ("backed vinyl", 2.8e8)):
-    res = covering_improvement(
-        bands, covering_contact_stiffness(modulus_over_thickness * d, d),
+    res = building.covering_improvement(
+        bands, building.covering_contact_stiffness(modulus_over_thickness * d, d),
         plate, z)
     plt.semilogx(bands, res.improvement, marker="o",
                  label=f"{label}: fco = {res.cut_off_frequency:.0f} Hz")
@@ -4782,13 +4736,13 @@ plt.show()
 </details>
 
 ```python
-from phonometry import covering_contact_stiffness, covering_improvement
+from phonometry import building
 
 # Covering No. 2 of Hopkins Fig. 4.64: E/d = 2.8e8 N/m3, a vinyl or carpet
 # with a resilient backing, 5 mm thick on the same 140 mm slab.
 d = 0.005
-covering = covering_contact_stiffness(2.8e8 * d, d)
-res = covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
+covering = building.covering_contact_stiffness(2.8e8 * d, d)
+res = building.covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
 round(res.cut_off_frequency)        # 100 Hz
 round(res.bare_cut_off_frequency)   # 6948 Hz, the bare slab's own cut-off
 res.improvement                     # 3.2, 17.0, 33.3, 43.0 dB, band values
@@ -4831,16 +4785,14 @@ applies is a question about damping, not about the layer:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-)
+from phonometry import building
 
 # The worked floating floor of ISO 12354-2:2017 Annex G.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
 freqs = np.logspace(np.log10(40.0), np.log10(5000.0), 400)
 for model, kwargs in (("en12354", {}), ("cremer", {}),
                       ("cremer_hammer", {"limiting_frequency": 521.0})):
-    res = floating_floor_improvement_spectrum(
+    res = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=f0, model=model, **kwargs)
     plt.semilogx(freqs, res.improvement, label=model)
 plt.axvline(f0, ls=":")
@@ -4851,19 +4803,15 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    combined_dynamic_stiffness, double_floating_floor_resonances,
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-    weighted_floating_floor_improvement,
-)
+from phonometry import building
 
 # 35 mm screed, m' = 73.5 kg/m2, on a resilient layer of s' = 8 MN/m3.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)
 round(f0, 1)                                                    # 52.8 Hz
 
 bands = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
          800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0]
-res = floating_floor_improvement_spectrum(
+res = building.floating_floor_improvement_spectrum(
     bands, resonance_frequency=f0, mass_per_area=73.5, dynamic_stiffness=8.0e6)
 res.improvement          # 0.0, 2.3, 5.4, 8.3, 11.2 ... 59.3 dB
 round(res.delta_lw, 1)   # 32.2 dB, the Formula (C.4) weighted improvement
@@ -4871,12 +4819,12 @@ res.plot()
 
 # Two resilient layers act as springs in series (Formula C.6), which drops the
 # resonance by sqrt(2) and buys about 4.5 dB everywhere above it.
-round(floating_floor_resonance_frequency(
-    combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
+round(building.floating_floor_resonance_frequency(
+    building.combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
 
 # One floating floor on top of another has two resonances instead of one; the
 # adverse dip disappears, but the steep rise only starts above the higher.
-double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
+building.double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
 ```
 
 The weighted single numbers come straight from the same two inputs, so a
@@ -4894,10 +4842,10 @@ Vér's two-subsystem SEA model turns into a 30 dB per decade rise rather than
 it.
 
 ```python
-from phonometry import resilient_mount_improvement
+from phonometry import building
 
 # 50 mm concrete walking surface on 4 mounts per m2 of 2 MN/m stiffness.
-resilient_mount_improvement(
+building.resilient_mount_improvement(
     [125.0, 250.0, 500.0, 1000.0], impedance=3.8e5, mass_per_area=115.0,
     loss_factor=0.02, mount_stiffness=2.0e6, mount_density=4.0)
 ```
@@ -4931,30 +4879,27 @@ to gain. From 200 Hz upwards it costs: 1 dB at 200 Hz falling to 10 dB from
 the range of interest is therefore the entire design brief.
 
 ```python
-from phonometry import (
-    lining_improvement, lining_improvement_in_situ, lining_resonance_frequency,
-    weighted_lining_improvement,
-)
+from phonometry import building
 
 # A 9.5 mm plasterboard laminated with 32 mm EPS (s' = 65 MN/m3), bonded with
 # adhesive dabs to a 100 mm aircrete block wall of 51 kg/m2.
-f0 = lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
+f0 = building.lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
 round(f0)                                       # 542 Hz: squarely in the way
-round(weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
+round(building.weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
 
 # The same lining on studs over a 100 mm mineral-wool-filled cavity.
-f0 = lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
+f0 = building.lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
 round(f0, 1)                                     # 70.8 Hz
-round(weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
+round(building.weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
 
 # External thermal insulation systems have their own Annex D fits.
-res = lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
+res = building.lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
 res.delta_rw, res.delta_ra, res.delta_ratr               # (10.5, 8.0, 9.7) dB
-lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
+building.lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
 res.plot()   # the Annex D ratings against fo, with this system marked
 
 # A laboratory rating transfers to the field through Formula (D.8).
-round(lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
+round(building.lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
 ```
 
 ## What is anchored on a published number, and what is not
@@ -5287,11 +5232,11 @@ plus matplotlib for the spectrum.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, reception_plate_power
+from phonometry import ReportMetadata, building
 
 freqs = np.array([125, 250, 500, 1000, 2000, 4000], float)
 lv = np.array([88.0, 90, 86, 82, 78, 73])   # spatial mean plate velocity level [dB]
-res = reception_plate_power(
+res = building.reception_plate_power(
     lv, freqs, mass_per_area=25.0, area=1.2, reverberation_time=0.3,
 )
 res.report(
@@ -6320,29 +6265,26 @@ $R_\mathrm{cl,p} = R_\mathrm{cl} + 10\log_{10}(H_\mathrm{S}/L_\mathrm{S})$ (Eq. 
 ceiling path be added to the direct path as transmission factors.
 
 ```python
-from phonometry import (
-    partition_referenced_reduction_index,
-    plenum_flanking_reduction_index,
-)
+from phonometry import building
 
 freqs = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0]   # 9.5 mm plasterboard
 
 # Vigran's example geometry: LS = LR = 4.75 m, plenum 0.43 m, reflecting walls.
-res = plenum_flanking_reduction_index(
+res = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, frequency=freqs
 )
 print(round(res.geometry_term, 1))    # 10.4 dB charged against RS + RR
 res.plot()                            # Rcl against the two ceilings
 
 # A lined plenum attenuates the sideways path (Eq. (9.18) instead of (9.20)):
-damped = plenum_flanking_reduction_index(
+damped = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43,
     attenuation_source=[0.5] * 7, attenuation_receiving=[0.5] * 7,
 )
 
 # Referred to the partition instead of the ceiling (Eq. (9.13)):
-print(partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
+print(building.partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
 ```
 
 **The measured quantity.** A ceiling is not rated by $R_\mathrm{cl}$ but by the
@@ -6365,25 +6307,21 @@ deficiency exceeds 8 dB (clauses 5.3 and 5.4), and reads the rating off the
 shifted contour at 500 Hz (clause 5.5).
 
 ```python
-from phonometry import (
-    ceiling_attenuation_class,
-    normalized_ceiling_attenuation,
-    weighted_rating,
-)
+from phonometry import building
 
 # ASTM E1414 normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
-dnc = normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
+dnc = building.normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
        41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9]
-res = ceiling_attenuation_class(dnc)
+res = building.ceiling_attenuation_class(dnc)
 print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34, 27.0, 7.0
 res.plot()                                                  # Dn,c vs the contour
 
 # The ISO single number of the same spectrum, shifted to A0 = 10 m2:
 iso = [v - 0.79 for v in dnc]
-print(weighted_rating(iso).rating)                          # Dn,c,w
+print(building.weighted_rating(iso).rating)                          # Dn,c,w
 ```
 
 ## ISO 10848 flanking-transmission reports (`.report()`)
@@ -6602,22 +6540,17 @@ less into the top one, which is why the two sources are not interchangeable and
 why a floor can pass one and fail the other.
 
 ```python
-from phonometry import (
-    check_heavy_impact_source,
-    heavy_impact_source_limits,
-    heavy_impact_source_specification,
-    impact_force_exposure_level,
-)
+from phonometry import building
 
-spec = heavy_impact_source_specification("rubber_ball")
+spec = building.heavy_impact_source_specification("rubber_ball")
 print(spec.drop_height, spec.effective_mass)      # 1.0 m, 2.5 kg
 print(spec.contact_time, spec.contact_time_tolerance)   # 0.02 s +/- 0.002 s
 
-freqs, lower, upper = heavy_impact_source_limits("bang_machine")
+freqs, lower, upper = building.heavy_impact_source_limits("bang_machine")
 print(list(zip(freqs, lower, upper))[0])          # (31.5, 46.0, 48.0)
 
 # A calibration run: five measured octave-band LFE against the printed table.
-check = check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9])
+check = building.check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9])
 print(check.passed, list(check.within_tolerance))
 check.plot()   # measured LFE over the tolerance band (needs matplotlib)
 ```
@@ -6632,7 +6565,7 @@ any single band value and must not be compared with the table above.
 
 ```python
 import numpy as np
-from phonometry import OctaveFilterBank, impact_force_exposure_level
+from phonometry import building, filters
 
 fs = 48_000
 t = np.arange(0.0, 0.020, 1.0 / fs)          # the 20 ms contact time
@@ -6640,12 +6573,12 @@ force = 1500.0 * np.sin(np.pi * t / 0.020)   # a single-peak half-sine pulse
 
 # Broadband, i.e. the whole pulse energy: 10 lg(Fp^2 t / 2) = 43.5 dB.
 # Not a band value, and not comparable with the table above.
-print(round(impact_force_exposure_level(force, fs), 2))
+print(round(building.impact_force_exposure_level(force, fs), 2))
 
 # The five octave-band values the specification is actually written in.
-bank = OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
+bank = filters.OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
 _, freqs, bands = bank.filter(force, sigbands=True, calculate_level=False)
-lfe = [impact_force_exposure_level(b, fs) for b in bands]
+lfe = [building.impact_force_exposure_level(b, fs) for b in bands]
 print([round(v, 1) for v in lfe])   # [-1.4, 14.0, 22.1, 20.2, 17.1]
 
 # Those five go to the conformance check; this synthetic half-sine is not a
@@ -6687,23 +6620,19 @@ its value is $1/e$. When $T = T_0$ the bracket collapses to 1 and the whole
 correction reduces to the volume term, as it must.
 
 ```python
-from phonometry import (
-    fast_reverberation_correction,
-    heavy_impact_octave_levels,
-    standardized_maximum_impact_level,
-)
+from phonometry import building
 
 freqs = [63.0, 125.0, 250.0, 500.0]
 li_fmax = [65.3, 64.5, 58.0, 55.8]           # energy-averaged over ball positions
 t = [1.43, 3.70, 3.10, 2.38]                 # receiving-room reverberation time
 
-res = standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
+res = building.standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
 print(res.volume_term)                        # 10 lg(41.4/50) = -0.8 dB
-print(fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
+print(building.fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
 res.plot()   # measured and standardized spectra (needs matplotlib)
 
 # One-third-octave measurements combine into octaves with Formula (20):
-print(heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
+print(building.heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
 ```
 
 ## The single number is an A-weighted sum, not a shifted curve
@@ -6727,10 +6656,10 @@ The worked example of Table D.4 is reproduced exactly, including the
 deliberately unrounded intermediate the standard prints:
 
 ```python
-from phonometry import a_weighted_maximum_impact_level
+from phonometry import building
 
 # ISO 717-2:2020 Table D.4: a field measurement in octave bands.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 print(list(res.corrected))   # 39.1, 48.3, 49.3, 52.6 dB
 print(res.unrounded)         # 55.350667... dB
 print(res.rating)            # 55 dB
@@ -8936,7 +8865,7 @@ $C_{\mathrm{tr},100-5000}$ are both $-5$, so the $D_{2\mathrm{m,nT,Atr}}$ that D
 requires happens not to discriminate between the two readings at all.
 
 ```python
-from phonometry import building, weighted_rating_extended
+from phonometry import building
 
 d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
           38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5, 39.4, 41.5]
@@ -8944,7 +8873,7 @@ d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
 direct = building.d2m_nt_atr(d2m_nt)
 direct.intermediate, direct.reported   # 32.8 dBA -> 33 dBA
 
-iso = weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
+iso = building.weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
 iso.rating, iso.ctr_100_5000           # 38 dB, -5 dB -> 33 dBA, the same figure
 iso.c, iso.c_100_5000                  # -2 and -1: core range versus enlarged range
 ```
@@ -9326,10 +9255,7 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import (
-    enclosed_space_reverberation, hard_object_absorption, object_fraction,
-    ReportMetadata,
-)
+from phonometry import ReportMetadata, room
 
 surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (20.0, [0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.55]),  # carpeted floor
@@ -9337,10 +9263,10 @@ surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (45.0, [0.02, 0.02, 0.03, 0.04, 0.05, 0.05, 0.05]),  # painted-plaster walls
 ]
 volumes = [0.5, 0.8, 0.3]                      # furniture, m^3
-result = enclosed_space_reverberation(
+result = room.enclosed_space_reverberation(
     surfaces, 50.0,
-    objects=hard_object_absorption(volumes),
-    object_fraction=object_fraction(volumes, 50.0),
+    objects=room.hard_object_absorption(volumes),
+    object_fraction=room.object_fraction(volumes, 50.0),
     air_condition="20C_50-70",
 )
 result.report(
@@ -10231,9 +10157,9 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import reverberation_time_models, ReportMetadata
+from phonometry import ReportMetadata, room
 
-result = reverberation_time_models(
+result = room.reverberation_time_models(
     (8.0, 5.0, 3.0),                       # a shoebox room, one treated wall pair
     ([0.10, 0.15, 0.30, 0.45, 0.55, 0.60], # treated wall pair, per octave band
      [0.08, 0.10, 0.12, 0.15, 0.18, 0.20], # side walls
@@ -11401,15 +11327,14 @@ sequence, visible as the near-constant magnitude on the right.
 
 ```python
 from phonometry import room
-from phonometry import plot_excitation
 
 fs = 48000
 sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)   # ESS excitation
 mls = room.mls_signal(12).astype(float)             # length 2**12 - 1
 
 # One-liner: waveform + spectrogram (sweep), sequence + flat spectrum (MLS)
-plot_excitation(sweep, fs, kind="sweep")
-plot_excitation(mls, fs, kind="mls")
+room.plot_excitation(sweep, fs, kind="sweep")
+room.plot_excitation(mls, fs, kind="mls")
 
 # By hand: the sweep spectrogram and the MLS magnitude spectrum
 import numpy as np
@@ -13032,10 +12957,10 @@ $ka\sin\theta = 3.8317$.
 
 ```python
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.1, frequencies=np.geomspace(20, 20000, 200),
-                       angles=np.linspace(0.0, np.pi / 2, 91))
+res = electroacoustics.radiating_piston(radius=0.1, frequencies=np.geomspace(20, 20000, 200),
+                                        angles=np.linspace(0.0, np.pi / 2, 91))
 print(round(res.radiation_mass, 4))               # 8 rho a^3 / 3, kg
 print(round(float(res.directivity_index[0]), 2))  # 3.01 dB half-space limit
 res.plot()                                         # R1 and X1 vs ka
@@ -13056,9 +12981,9 @@ reactance dies away.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
 res.plot()   # normalized R1 and X1 against ka
 plt.show()
 ```
@@ -13081,9 +13006,9 @@ classic polar beam pattern. Several $ka$ are shown as one family, so the main
 lobe narrowing and the side lobes appearing read at a glance:
 
 ```python
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-pattern = piston_directivity_pattern([3.0, 8.0, 16.0])
+pattern = electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0])
 print(pattern.directivity_db.shape)  # (3, 361): one row per ka
 pattern.plot()                       # polar beam pattern in dB (needs matplotlib)
 ```
@@ -13095,9 +13020,9 @@ pattern.plot()                       # polar beam pattern in dB (needs matplotli
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
+electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
 plt.show()
 ```
 
@@ -13121,10 +13046,10 @@ first side lobes have appeared.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
-                       angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
+res = electroacoustics.radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
+                                        angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
 
 # One line: the piston in its baffle with the lobe of the highest frequency.
 res.plot_geometry()
@@ -13152,25 +13077,22 @@ computed from the response rather than merely repeated:
 
 ```python
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, ReportMetadata, loudspeaker_characteristics,
-    radiating_piston,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(np.geomspace(20, 20000, 260),
                6.6 + 24 * np.exp(-(np.log2(np.geomspace(20, 20000, 260) / 52.0) ** 2) / 0.12)),
     distortion=(np.geomspace(50, 5000, 140),
                 0.3 + 2.6 * np.exp(-(np.log2(np.geomspace(50, 5000, 140) / 70.0) ** 2) / 0.45)),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -13216,15 +13138,15 @@ result.plot(quantity="directivity")  # polar response on the 25 dB circle
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
-                                     sensitivity_band=(200.0, 4000.0))
+result = electroacoustics.loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
+                                                      sensitivity_band=(200.0, 4000.0))
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -13239,13 +13161,13 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 fz = np.geomspace(20, 20000, 260)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(fz, 6.6 + 24 * np.exp(-(np.log2(fz / 52.0) ** 2) / 0.12)),
 )
@@ -13263,13 +13185,13 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 thd_f = np.geomspace(50, 5000, 140)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distortion=(thd_f, 0.3 + 2.6 * np.exp(-(np.log2(thd_f / 70.0) ** 2) / 0.45)),
 )
@@ -13287,18 +13209,16 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, loudspeaker_characteristics, radiating_piston,
-)
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -13583,10 +13503,7 @@ standard's own definitions rather than merely repeated:
 
 ```python
 import numpy as np
-from phonometry import (
-    MicrophoneDirectivity, MicrophoneElectrical, MicrophoneNoise,
-    MicrophoneOverload, ReportMetadata, microphone_characteristics,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
@@ -13597,19 +13514,19 @@ angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,          # 12.5 mV/Pa at 1 kHz
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
-    noise=MicrophoneNoise(                             # A-weighted, V
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    noise=electroacoustics.MicrophoneNoise(                             # A-weighted, V
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(np.linspace(100, 140, 81),
                     0.5 * 10 ** ((np.linspace(100, 140, 81) - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
-    electrical=MicrophoneElectrical(
+    electrical=electroacoustics.MicrophoneElectrical(
         rated_impedance=150.0, minimum_load_impedance=1000.0,
         powering="Phantom P48 (IEC 61938)", supply_current_ma=3.1,
     ),
@@ -13658,14 +13575,14 @@ result.plot(quantity="distortion")   # THD vs sound pressure level
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
 response -= 10 * np.log10(1 + (freqs / 19000.0) ** 8)   # high-frequency roll-off
 response += 2.0 * np.exp(-(np.log2(freqs / 9000.0) ** 2) / 0.3)  # presence region
 
-result = microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
+result = electroacoustics.microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -13680,16 +13597,16 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneDirectivity, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
 )
 result.plot(quantity="directivity")
 plt.show()
@@ -13705,15 +13622,15 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneNoise, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    noise=MicrophoneNoise(
+    noise=electroacoustics.MicrophoneNoise(
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
@@ -13732,15 +13649,15 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneOverload, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 spl_axis = np.linspace(100, 140, 81)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(spl_axis, 0.5 * 10 ** ((spl_axis - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
@@ -13866,12 +13783,12 @@ their fixed advances.
 
 ```python
 import numpy as np
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
-x = synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
 res.thd, res.thd_frequencies
@@ -13888,14 +13805,14 @@ res.plot()                # |Hn| magnitudes + THD(f)
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)             # 3 kHz post-filter
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 h1 = 1.0 + 3.0 * a3 / 4.0                              # Chebyshev gain
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -13973,10 +13890,10 @@ be ignored; the band of every $H_n$ is also capped at $f_2$ by the inverse
 filter.
 
 ```python
-from phonometry import sweep_signal, swept_sine_distortion
+from phonometry import electroacoustics, room
 
-x = sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
+x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
 
@@ -14005,16 +13922,14 @@ all-pass parts:
 
 ```python
 import numpy as np
-from phonometry import (
-    excess_phase, group_delay, minimum_phase, phase_decomposition,
-)
+from phonometry import signals
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
-h_min = minimum_phase(np.abs(H))       # phase from the magnitude alone
-tau_g = group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
-phi_x = excess_phase(H)                # unwrap(arg H) - phi_min
+h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone
+tau_g = signals.group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
+phi_x = signals.excess_phase(H)                # unwrap(arg H) - phi_min
 
-res = phase_decomposition(H, fs)       # everything on one axis
+res = signals.phase_decomposition(H, fs)       # everything on one axis
 res.excess_group_delay                 # the all-pass part, in seconds
 res.plot()                             # magnitude, phases, group delays
 ```
@@ -14033,7 +13948,7 @@ excess group delay reads the latency directly as a flat 2.5 ms line.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import phase_decomposition
+from phonometry import signals
 
 fs = 48000.0
 delay = int(0.0025 * fs)                      # a 2.5 ms processing latency
@@ -14046,7 +13961,7 @@ imp = np.zeros(16384)
 imp[delay] = 1.0
 ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
-res = phase_decomposition(np.fft.rfft(ir), fs)
+res = signals.phase_decomposition(np.fft.rfft(ir), fs)
 res.plot()   # |H|, the three phases and the group delays
 plt.show()
 ```
@@ -15510,11 +15425,11 @@ surface integral.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import measurement_positions, plot_microphone_positions
+from phonometry import emission
 
 # The 10 ISO 3744 Annex B microphones on a 2 m hemisphere.
-plot_microphone_positions(measurement_positions("hemisphere", radius=2.0),
-                          radius=2.0)
+emission.plot_microphone_positions(emission.measurement_positions("hemisphere", radius=2.0),
+                                   radius=2.0)
 plt.show()
 ```
 
@@ -16967,20 +16882,20 @@ level leaving it. `DuctElement` carries exactly the two spectra an element
 owns, and `duct_path` walks them:
 
 ```python
-from phonometry import DuctElement, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 
-path = duct_path(
+path = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined",
-                    attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
-                    self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
-                    self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined",
+                                  attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
+                                  self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
+                                  self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
     ],
     source_label="Fan, centrifugal FC, 5000 cfm, 2 in w.g.",
 )
@@ -17033,21 +16948,18 @@ logarithmic terms take the same values as the foot-pound form in cfm and
 inches of water gauge.
 
 ```python
-from phonometry import (
-    blade_passing_frequency, fan_casing_attenuation,
-    fan_efficiency_correction, fan_sound_power,
-)
+from phonometry import noise_control
 
 CFM, IN_WG = 0.0004719474432, 249.0
 
-fan = fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
-                      fan_type="forward_curved", relative_efficiency=80.0)
+fan = noise_control.fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
+                                    fan_type="forward_curved", relative_efficiency=80.0)
 print([round(float(v)) for v in fan.values])
 # [99, 99, 89, 84, 82, 77, 72, 67]
 
-print(fan_efficiency_correction(80.0))          # 6.0 dB off the peak
-print(blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
-print(fan_casing_attenuation().values)          # what the housing holds back
+print(noise_control.fan_efficiency_correction(80.0))          # 6.0 dB off the peak
+print(noise_control.blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
+print(noise_control.fan_casing_attenuation().values)          # what the housing holds back
 # [ 0.  0.  5. 10. 15. 20. 22. 25.]
 fan.plot()                                      # the band spectrum, one line
 ```
@@ -17092,17 +17004,15 @@ for 25 mm to 52 mm linings and clipped at 40 dB per run because flanking
 takes over beyond that.
 
 ```python
-from phonometry import (
-    lined_rectangular_duct_attenuation, unlined_rectangular_duct_attenuation,
-)
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
-bare = unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
-lined = lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
-                                           1 * IN, include_unlined=True)
+bare = noise_control.unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
+lined = noise_control.lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
+                                                         1 * IN, include_unlined=True)
 print(np.round(bare.values, 1))    # [1.1 0.7 0.5 0.2 0.2 0.2 0.2 0.2]
 print(np.round(lined.values, 1))   # [ 1.3  1.3  2.5  6.7 12.8 10.6  9.7  9. ]
 ```
@@ -17130,12 +17040,12 @@ branch area does not match the feeder, and a 25 per cent branch therefore
 costs 6 dB.
 
 ```python
-from phonometry import elbow_insertion_loss, split_loss
+from phonometry import noise_control
 
 IN = 0.0254
 area = 36 * IN * 24 * IN
-print(round(split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
-print(elbow_insertion_loss(
+print(round(noise_control.split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
+print(noise_control.elbow_insertion_loss(
     [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
     24 * IN, bend_type="round").values)          # [0. 1. 2. 3. 3. 3. 3. 3.]
 ```
@@ -17158,15 +17068,15 @@ the impedance transition, and a manufacturer's diffuser rating already
 contains whatever is left of it.
 
 ```python
-from phonometry import end_reflection_loss, equivalent_diameter
+from phonometry import noise_control
 import numpy as np
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0]
-print(np.round(end_reflection_loss(bands, 0.30, method="bies").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="bies").values, 1))
 # [12.  7.  3.  1.  0.  0.]
-print(np.round(end_reflection_loss(bands, 0.30, method="long").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="long").values, 1))
 # [12.7  7.7  3.7  1.3  0.4  0.1]
-print(round(equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
+print(round(noise_control.equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
 ```
 
 **Silencers and plenums.** A parallel-splitter attenuator reduces, in Bies
@@ -17177,17 +17087,17 @@ chamber (Bies Eq. (8.275)), whose reverberant term uses the plenum
 [room constant](https://jmrplens.github.io/phonometry/buildings/rooms/room-image-sources/).
 
 ```python
-from phonometry import plenum_attenuation, splitter_silencer_insertion_loss
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
-sil = splitter_silencer_insertion_loss(
+sil = noise_control.splitter_silencer_insertion_loss(
     None, height=24 * IN, length=5 * FT,
     airway_widths=[0.10] * 5, splitter_thickness=0.10,
 )
 print(np.round(sil.values, 1))
 # [ 5.8  8.6 14.1 28.2 34.5 33.5 18.4 12.1]
-print(round(plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
+print(round(noise_control.plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
 ```
 
 Read that estimate for what it is. The 5 ft unit Long's return path
@@ -17215,14 +17125,14 @@ is the whole message: the fifth-and-a-half power of the airway velocity
 means that *doubling the face velocity of a silencer adds about 17 dB*.
 
 ```python
-from phonometry import silencer_self_noise
+from phonometry import noise_control
 import numpy as np
 
 IN = 0.0254
-slow = silencer_self_noise(None, airway_velocity=10.0, passages=5,
-                           height=24 * IN)
-fast = silencer_self_noise(None, airway_velocity=20.0, passages=5,
-                           height=24 * IN)
+slow = noise_control.silencer_self_noise(None, airway_velocity=10.0, passages=5,
+                                         height=24 * IN)
+fast = noise_control.silencer_self_noise(None, airway_velocity=20.0, passages=5,
+                                         height=24 * IN)
 print(np.round(slow.values, 1))
 # [40.8 40.8 38.8 36.8 31.8 26.8 21.8 16.8]
 print(round(float(fast.values[0] - slow.values[0]), 1))     # 16.6 dB
@@ -17247,15 +17157,15 @@ function $C_D = -11.82 - 0.15 A - 1.13 A^2$ ($-5.82$ for a round device)
 about the peak band $f_\mathrm{P} = 48.8\,U_\mathrm{G}$.
 
 ```python
-from phonometry import diffuser_sound_power
+from phonometry import noise_control
 import numpy as np
 
 IN, CFM, IN_WG = 0.0254, 0.0004719474432, 249.0
 
 # The supply diffuser of Long's worked sheet: 24 x 24 in, 312 cfm, 0.05 in pd.
-print(np.round(diffuser_sound_power(None, (24 * IN) ** 2,
-                                    volume_flow=312 * CFM,
-                                    pressure_drop=0.05 * IN_WG).values, 1))
+print(np.round(noise_control.diffuser_sound_power(None, (24 * IN) ** 2,
+                                                  volume_flow=312 * CFM,
+                                                  pressure_drop=0.05 * IN_WG).values, 1))
 # [ 33.4  32.4  29.1  23.6  15.9   5.9  -6.4 -21. ]
 # Long Table 14.9 prints 33/32/29/23/15/4/0/0 for that row.
 ```
@@ -17270,12 +17180,12 @@ penalty for throttling a balancing damper, which is where a great many
 finished installations fail.
 
 ```python
-from phonometry import air_terminal_damper_correction, air_terminal_velocity_limit
+from phonometry import noise_control
 
-print(air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
-print(air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
-print(air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
-print(air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
+print(noise_control.air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
+print(noise_control.air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
+print(noise_control.air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
+print(noise_control.air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
 ```
 
 Fifteen decibels in the neck against two decibels 1.5 m back in the duct,
@@ -17293,12 +17203,12 @@ every other loss, with $Q = 2$ by default for a diffuser flush in a
 ceiling.
 
 ```python
-from phonometry import room_constant, room_effect
+from phonometry import noise_control, room
 
 # The 20 x 20 x 8 ft room of Long's worked sheet, drywall and carpet.
 area = 2 * 6.10 * 6.10 + 4 * 6.10 * 2.44        # 134.0 m2
-r_const = room_constant(area, 0.15)             # 23.6 m2
-print(round(float(room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
+r_const = room.room_constant(area, 0.15)             # 23.6 m2
+print(round(float(noise_control.room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
 ```
 
 Long's sheet prints 5 to 7 dB for that room across the bands, so a single
@@ -17325,54 +17235,54 @@ silencers and the terminal devices, which is what a real sheet uses.
 
 ```python
 import numpy as np
-from phonometry import DuctElement, combine_duct_paths, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 source = "Fan, centrifugal FC, 5000 cfm, 2 in w.g."
 
-supply = duct_path(
+supply = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    [7, 12, 16, 28, 35, 35, 28, 17],
-                    [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
-        DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
-                    [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
-        DuctElement("Split, 25 per cent", 6.0, code="5"),
-        DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
-                    [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
-        DuctElement("Flexible duct, 12 in, 6 ft",
-                    [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
-        DuctElement("Rectangular diffuser, 312 cfm", None,
-                    [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  [7, 12, 16, 28, 35, 35, 28, 17],
+                                  [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
+                                  [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
+        noise_control.DuctElement("Split, 25 per cent", 6.0, code="5"),
+        noise_control.DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
+                                  [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
+        noise_control.DuctElement("Flexible duct, 12 in, 6 ft",
+                                  [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
+        noise_control.DuctElement("Rectangular diffuser, 312 cfm", None,
+                                  [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
     ],
     room_effect=[6, 6, 5, 5, 6, 7, 6, 6],
     source_label=source, target=30.0, label="Supply",
 )
 
-ret = duct_path(
+ret = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
-        DuctElement("Silencer, 5 ft, low-frequency type",
-                    [16, 21, 35, 41, 41, 28, 21, 15],
-                    [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
-        DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
-                    [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
-        DuctElement("Plenum, 800 sq ft, 50 per cent lined",
-                    [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
-        DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
-                    [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 5 ft, low-frequency type",
+                                  [16, 21, 35, 41, 41, 28, 21, 15],
+                                  [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
+                                  [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
+        noise_control.DuctElement("Plenum, 800 sq ft, 50 per cent lined",
+                                  [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
+        noise_control.DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
+                                  [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
     ],
     room_effect=[9, 8, 6, 8, 8, 8, 9, 10],
     source_label=source, target=30.0, label="Return",
 )
 
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 print(np.round(supply.received_level, 0))    # Long: 52 42 30 18  9 -2 -2 -1
 print(np.round(ret.received_level, 0))       # Long: 52 41 27 25 23 25 22 12
 print(np.round(total.received_level, 0))     # Long: 55 45 32 26 23 25 22 12
@@ -17403,7 +17313,7 @@ nothing at all: the return already sets the answer everywhere except at
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import combine_duct_paths
+from phonometry import noise_control
 
 # `supply` and `ret` are the two DuctPathResult objects built above.
 
@@ -17412,7 +17322,7 @@ supply.plot()
 plt.show()
 
 # The concept figure: both paths, their energy sum and the criterion.
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 total.plot()
 plt.gca().set_ylim(-6.0, 62.0)
 plt.show()
@@ -17511,18 +17421,18 @@ $k_x = -M\kappa_{pq}/\sqrt{1 - M^2}$.
 
 ```python
 import numpy as np
-from phonometry import plane_wave_limit, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.2: a 0.65 x 0.4 m air-conditioning duct at 15 m/s.
-modes = rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
+modes = noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
 print(modes.modes[:3])                          # ((1, 0), (0, 1), (1, 1))
 print(np.round(modes.cut_on[:3], 1))            # [263.6 428.3 502.9] Hz
 print(np.round(modes.cut_on_no_flow[:3], 1))    # [263.8 428.8 503.4] Hz
 print(round(modes.plane_wave_limit, 1))         # 263.6 Hz
 
 IN = 0.0254
-print(round(plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
-print(round(plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
+print(round(noise_control.plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
+print(round(noise_control.plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
 ```
 
 Those ventilation numbers are blunt: in that duct plane waves are the whole
@@ -17562,11 +17472,11 @@ rung.
 
 ```python
 import numpy as np
-from phonometry import circular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.1: a 254 mm circular duct carrying steam at 200 m/s.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 print(steam.modes)
 # ((1, 0), (2, 0), (0, 1), (3, 0), (4, 0), (1, 1))
 print(np.round(steam.cut_on_no_flow, 1))
@@ -17592,16 +17502,16 @@ at the frequency at which it appears.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import circular_duct_cut_on, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # One line for one duct: the cut-on ladder with the plane-wave band shaded.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 steam.plot()
 plt.show()
 
 # The ventilation duct of problem 7.2, where the flow shift is negligible.
-rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
+noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
 plt.show()
 ```
 
@@ -17616,17 +17526,17 @@ they describe the plane-wave mode alone, which a measurement will not.
 
 ```python
 import warnings
-from phonometry import DuctElement, PlaneWaveWarning, duct_path
+from phonometry import noise_control
 
 IN = 0.0254
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
-    duct_path(bands, [90.0] * 8, [DuctElement("Straight run", 3.0)],
-              section={"width": 36 * IN, "height": 24 * IN},
-              flow_velocity=6.0, label="Supply")
-print(caught[0].category is PlaneWaveWarning)
+    noise_control.duct_path(bands, [90.0] * 8, [noise_control.DuctElement("Straight run", 3.0)],
+                            section={"width": 36 * IN, "height": 24 * IN},
+                            flow_velocity=6.0, label="Supply")
+print(caught[0].category is noise_control.PlaneWaveWarning)
 print(str(caught[0].message))
 # Supply: 6 of 8 frequencies are above the first duct cut-on frequency
 # (188 Hz), where higher-order modes propagate and the plane-wave result
@@ -17934,10 +17844,10 @@ numbers has the same predicted attenuation.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import plot_plenum_geometry
+from phonometry import noise_control
 
 # The r, S_out and S_w that Wells' formula actually uses, drawn exactly.
-plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
+noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
 plt.show()
 ```
 
@@ -18012,12 +17922,12 @@ interior absorption.
 
 ```python
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
-enc = enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
-                               internal_absorption=0.3, frequencies=bands)
+enc = noise_control.enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
+                                             internal_absorption=0.3, frequencies=bands)
 print(np.round(enc.insertion_loss, 1))          # net IL = R - C per band
 enc.plot()
 ```
@@ -18035,13 +17945,13 @@ together with the panels, not as an afterthought.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
 
-enc = enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
-                               internal_absorption=0.3, frequencies=bands)
+enc = noise_control.enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
+                                             internal_absorption=0.3, frequencies=bands)
 
 # One line — panel R, interior correction C and the net IL = R - C:
 enc.plot()
@@ -18086,14 +17996,14 @@ insertion loss.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, enclosure_insertion_loss
+from phonometry import ReportMetadata, noise_control
 
 octaves = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 sheet_steel_R = np.array([18.0, 22.0, 28.0, 33.0, 38.0, 42.0, 45.0])
 
-case = enclosure_insertion_loss(sheet_steel_R, external_area=24.0,
-                                internal_area=30.0, internal_absorption=0.30,
-                                frequencies=octaves)
+case = noise_control.enclosure_insertion_loss(sheet_steel_R, external_area=24.0,
+                                              internal_area=30.0, internal_absorption=0.30,
+                                              frequencies=octaves)
 case.report(
     "enclosure.pdf",
     metadata=ReportMetadata(
@@ -18246,14 +18156,12 @@ speaking into the same 8 m x 9 m x 3 m receiving room through the same
 
 ```python
 import numpy as np
-from phonometry import (
-    SourceRoom, equivalent_absorption_area, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 
 # Receiving room 8 x 9 x 3 m: walls 102 m2, floor and ceiling 72 m2 each.
-receiving = equivalent_absorption_area([
+receiving = room.equivalent_absorption_area([
     (102.0, [0.04, 0.04, 0.09, 0.15, 0.17, 0.23]),   # walls
     (72.0,  [0.02, 0.06, 0.14, 0.37, 0.60, 0.66]),   # floor
     (72.0,  [0.30, 0.20, 0.15, 0.05, 0.05, 0.05]),   # ceiling
@@ -18267,9 +18175,9 @@ partitions = {
     "Double brick, 50 mm cavity":      [37, 41, 48, 60, 61, 61],
 }
 for name, tl in partitions.items():
-    res = room_to_room_transmission(
+    res = noise_control.room_to_room_transmission(
         bands, tl, 8.0 * 3.0, receiving,
-        source=SourceRoom(level=90.0), label=name,
+        source=noise_control.SourceRoom(level=90.0), label=name,
     )
     print(f"{name:32s} {np.round(res.noise_reduction, 1)}")
 # Two 13 mm wallboards, 64 mm gap  [18.5 26.8 38.  47.8 47.3 43.9]
@@ -18313,10 +18221,7 @@ $10\log_{10} 4 = 6.02\ \text{dB}$, and without it the printed answers come out
 6 dB low.
 
 ```python
-from phonometry import (
-    DesignCriterion, SourceRoom, equivalent_absorption_area, mean_absorption,
-    room_constant, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [0.07, 0.20, 0.40, 0.52, 0.60, 0.67]      # absorbent ceiling
@@ -18330,18 +18235,18 @@ plant = [(80.0, [0.01, 0.01, 0.015, 0.02, 0.02, 0.02]),
 operator = [(25.0, [0.08, 0.24, 0.57, 0.69, 0.71, 0.73]),
             (25.0, ceiling), (60.0, walls)]
 
-chain = room_to_room_transmission(
+chain = noise_control.room_to_room_transmission(
     bands,
     [39.0, 42.0, 50.0, 58.0, 63.0, 67.0],       # TL of the separating wall
     5.0 * 3.0,                                  # the wall is 5 m x 3 m
-    equivalent_absorption_area(operator),
-    source=SourceRoom(
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(
         power_level=[105.0, 103.0, 98.0, 108.0, 107.0, 109.0],
-        room_constant=room_constant(268.0, mean_absorption(plant)),
+        room_constant=room.room_constant(268.0, room.mean_absorption(plant)),
         directivity=4.0,                        # floor-wall intersection
         model="constant_volume",                # the conservative bound
     ),
-    criterion=DesignCriterion(target=45.0),
+    criterion=noise_control.DesignCriterion(target=45.0),
     label="Plant room to operator room",
 )
 
@@ -18457,7 +18362,7 @@ $\text{TL} = \text{IL} + 10\log_{10}(S_\mathrm{E} / R_\mathrm{i})$, which is
 
 ```python
 import numpy as np
-from phonometry import enclosure_required_transmission_loss, mean_absorption
+from phonometry import noise_control, room
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 wool = [0.10, 0.20, 0.45, 0.65, 0.75, 0.80, 0.80, 0.80]   # 50 mm blanket
@@ -18474,11 +18379,11 @@ radiating = 2 * (2.5 * 2.5) + 2 * (3.5 * 2.5) + 2.5 * 3.5
 machine = 2 * (1.5 * 1.5) + 2 * (2.5 * 1.5) + 1.5 * 2.5
 bare_floor = 2.5 * 3.5 - 1.5 * 2.5
 
-required = enclosure_required_transmission_loss(
+required = noise_control.enclosure_required_transmission_loss(
     lp1 - nc45,
     radiating,
     radiating + bare_floor + machine,
-    mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
+    room.mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
     frequencies=bands,
     model="norton",
 )
@@ -18539,11 +18444,11 @@ transmission loss rather than get lost:
 
 ```python
 # The chain of section 3 again, with 3 dB allowed for flanking and leaks.
-honest = room_to_room_transmission(
+honest = noise_control.room_to_room_transmission(
     bands, [39.0, 42.0, 50.0, 58.0, 63.0, 67.0], 15.0,
-    equivalent_absorption_area(operator),
-    source=SourceRoom(level=chain.source_level),
-    criterion=DesignCriterion(target=45.0, flanking_penalty=3.0),
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(level=chain.source_level),
+    criterion=noise_control.DesignCriterion(target=45.0, flanking_penalty=3.0),
 )
 print(np.round(honest.received_level, 1))
 # [75.4 63.4 44.4 44.  36.9 33.7]      every band 3 dB worse
@@ -18711,10 +18616,10 @@ exactly.
 
 ```python
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 print(round(res.transmission_loss.max(), 2))   # 6.55 dB peak (m = 4)
 res.plot()                                      # TL (and IL) vs frequency
 ```
@@ -18735,18 +18640,18 @@ circular diameters $d = 2\sqrt{S/\pi}$ of the 0.04 and 0.01 m² cross-sections.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber, plot_silencer_geometry
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 
 # One line: the dimensioned cross-section of the chamber just computed.
 res.plot_geometry()
 plt.show()
 
 # The same drawing without a result, from the free function:
-plot_silencer_geometry("expansion chamber", length=0.3,
-                       chamber_area=0.04, pipe_area=0.01)
+noise_control.plot_silencer_geometry("expansion chamber", length=0.3,
+                                     chamber_area=0.04, pipe_area=0.01)
 plt.show()
 ```
 
@@ -18777,26 +18682,24 @@ with `duct_matrix`, `shunt_matrix`, `cascade`, `transmission_loss` and
 
 ```python
 import numpy as np
-from phonometry import (
-    helmholtz_resonator, quarter_wave_resonator, extended_tube_chamber,
-)
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
 
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 print(round(float(hr.resonances[0]), 1))       # tuning frequency, Hz
 hr.plot()   # TL spike at the tuning frequency (needs matplotlib)
 
-qw = quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
-                            speed_of_sound=343.24)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
+                                          speed_of_sound=343.24)
 print(round(float(qw.resonances[0]), 1))        # 56.6 Hz (Bies Example 8.1)
 
 # Each extension is a quarter-wave stub, so its own length picks the trough
 # it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
 # second trough, and L/2 = 0.2 m would take the first one at c/2L.
-et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
-                           inlet_extension=0.1)
+et = noise_control.extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
+                                         inlet_extension=0.1)
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_side_branch_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_side_branch.svg" alt="Transmission loss of a Helmholtz resonator and a closed quarter-wave tube on the same 10 cm2 duct: each side branch produces a sharp spike at its own tuning frequency, near 120 Hz for the Helmholtz volume and near 285 Hz for the 0.3 m tube, and is transparent elsewhere" width="88%"></picture>
@@ -18811,12 +18714,12 @@ firing frequency or a fan blade-passing tone rather than used broadband.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator, quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line for one device: TL vs frequency with the resonance marked.
 hr.plot()
@@ -18869,11 +18772,11 @@ its target.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 
 # One line: the side branch drawn to scale, cavity as its equal-volume cube.
 hr.plot_geometry()
@@ -18898,10 +18801,10 @@ area only sets how strongly the stub loads the duct.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line: the closed 0.3 m tube on its duct, to scale.
 qw.plot_geometry()
@@ -18944,7 +18847,7 @@ all, because an impedance is not a shape.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import SilencerChain
+from phonometry import noise_control
 from phonometry.noise_control import helmholtz_impedance, quarter_wave_impedance
 
 freqs = np.linspace(20.0, 500.0, 481)
@@ -18952,7 +18855,7 @@ s_duct = np.pi * 0.100**2               # nominal 200 mm duct
 s_shell = np.pi * 0.200**2              # nominal 400 mm shell
 
 chain = (
-    SilencerChain(freqs)
+    noise_control.SilencerChain(freqs)
     .duct(0.10, s_duct)
     .shunt(quarter_wave_impedance(freqs, 343.0 / (4.0 * 125.0), np.pi * 0.050**2),
            label="Quarter-wave stub")
@@ -18984,11 +18887,11 @@ embedded figure, matplotlib (`pip install "phonometry[report,plot]"`), and
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, expansion_chamber
+from phonometry import ReportMetadata, noise_control
 
 # A 0.5 m chamber of area ratio m = 8, at the octave-band centres.
 freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-res = expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
 res.report(
     "silencer_fiche.pdf",
     metadata=ReportMetadata(
@@ -20333,35 +20236,30 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    atmospheric_ray_paths,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 c0 = 340.0
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
 zs = 2.0
 fig, axes = plt.subplots(2, 1, figsize=(11, 8.2), sharex=True)
 
-rays = atmospheric_ray_paths(profile, source_height=zs,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=3000)
+rays = environment.atmospheric_ray_paths(profile, source_height=zs,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=3000)
 for i in range(rays.heights.shape[0]):
     axes[0].plot(rays.ranges[i], rays.heights[i], color="#1f77b4", lw=0.8, alpha=0.7)
 axes[0].plot([0.0], [zs], "o", color="#d62728", label="Source")
 grad = (profile.speed_at(10.0) - c0) / 10.0
-x_sh = shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
+x_sh = environment.shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
 axes[0].axvline(x_sh, color="#d62728", ls="--", label="Shadow-zone boundary")
 axes[0].set(ylabel="Height [m]", ylim=(0, 40), title="Sound rays (upward refraction)")
 axes[0].legend()
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(400.0, profile, source_height=zs,
-                                        flow_resistivity=200e3,
-                                        max_range=600.0, max_height=40.0)
+    pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=zs,
+                                                    flow_resistivity=200e3,
+                                                    max_range=600.0, max_height=40.0)
 img = axes[1].imshow(pe.relative_level, cmap="RdBu_r", vmin=-30, vmax=6,
                      aspect="auto", origin="lower", interpolation="bilinear",
                      extent=(pe.ranges[0], pe.ranges[-1], pe.heights[0], pe.heights[-1]))
@@ -20398,9 +20296,9 @@ the receiver (favourable propagation); a negative gradient bends them **up** and
 opens an acoustic **shadow** near the ground.
 
 ```python
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
 profile.speed_at(10.0)   # effective sound speed 10 m above the ground
 profile.plot()           # c_eff(z) with height on the vertical axis
 ```
@@ -20412,11 +20310,11 @@ profile.plot()           # c_eff(z) with height on the vertical axis
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
 # The two canonical surface layers of Salomons Eq. 4.5 over grassland.
-down = log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
-up = log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
+down = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
+up = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
 ax = down.plot(color="#1f77b4")
 up.plot(ax=ax, color="#d62728")
 plt.show()
@@ -20434,12 +20332,12 @@ travel times and the number of ground reflections.
 
 ```python
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0)
 rays.plot()   # curved ray fan with the acoustic shadow near the ground
 ```
 
@@ -20456,13 +20354,13 @@ the surface instead of losing it upward.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
 # Downward refraction: the favourable-propagation mirror of the shadow case.
-profile = log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=600)
+profile = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=600)
 rays.plot()   # shallow rays return to the ground and bounce on down-range
 plt.show()
 ```
@@ -20523,12 +20421,12 @@ $\Delta L(z, r) = 20\log_{10}(|p| R_1)$ (dB re free field, Salomons Eq. 3.6) ove
 the whole range-height plane.
 
 ```python
-from phonometry import atmospheric_parabolic_equation, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
-pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                    flow_resistivity=200e3,  # grassland
-                                    max_range=600.0, max_height=40.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                flow_resistivity=200e3,  # grassland
+                                                max_range=600.0, max_height=40.0)
 pe.level_at_height(2.0)   # relative level vs range at 2 m
 pe.plot()                 # the range-height relative-level field
 ```
@@ -20547,31 +20445,26 @@ import warnings
 
 import matplotlib.pyplot as plt
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    linear_sound_speed_profile,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 cases = [
-    (log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
-    (linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
-    (log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
+    (environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
+    (environment.linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
+    (environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
 ]
 fig, ax = plt.subplots(figsize=(11, 6.2))
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     for profile, label in cases:
-        pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                            flow_resistivity=200e3,
-                                            max_range=600.0, max_height=40.0)
+        pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                        flow_resistivity=200e3,
+                                                        max_range=600.0, max_height=40.0)
         ax.plot(pe.ranges, pe.level_at_height(2.0), label=label)
 # The closed-form boundary of the equivalent linear upward gradient (its
 # 10 m mean), the dotted line of the figure.
 up = cases[2][0]
 grad = float(up.speed_at(10.0) - 340.0) / 10.0
-ax.axvline(shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
+ax.axvline(environment.shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
            color="k", ls=":", label="Shadow-zone boundary")
 ax.set(xlabel="Range [m]", ylabel="Level re free field [dB]", ylim=(-40, 10))
 ax.legend()
@@ -20718,14 +20611,14 @@ $$
 
 ```python
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 
 # Grassland (effective flow resistivity sigma = 200 kPa.s/m^2), source 1 m and
 # receiver 1.5 m high, 50 m apart. The impedance comes from the Delany-Bazley
 # porous model of phonometry.materials (a semi-infinite ground).
-res = ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
+res = environment.ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
 print(res.excess_attenuation)     # the ground dip (dB re free field)
 print(res.reflection_coefficient) # complex Q per band
 res.plot()                        # excess attenuation vs frequency
@@ -20751,7 +20644,7 @@ it enters the Weyl-Van der Pol formulas.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 4000.0, 400)
 grounds = [
@@ -20762,7 +20655,7 @@ grounds = [
 ]
 fig, ax = plt.subplots(figsize=(11, 6.4))
 for label, sigma, color in grounds:
-    res = ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
+    res = environment.ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
     ax.plot(freqs, res.excess_attenuation, color=color, label=label)
 ax.axhline(6.0, color="k", ls=":", label="Hard-ground limit (+6 dB)")
 ax.axhline(0.0, color="k", lw=0.8)
@@ -20828,13 +20721,13 @@ the 4 m screen of the snippets, they differ by just 0.15 m.
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier.svg" alt="Section of the barrier geometry: a loudspeaker source 1 m above the ground, a thin 4 m screen at 50 m and a microphone receiver 1.5 m high at 100 m, the blocked direct path of 100.00 m drawn dashed through the screen and the diffracted path bent over the edge in two segments A = 50.09 m and B = 50.06 m, with the resulting path difference of 0.15 m giving a Fresnel number of 0.44 and a Kurze-Anderson insertion loss of 10.0 dB at 500 Hz, rising to 15.5 dB at 2 kHz" width="92%"></picture>
 
 ```python
-from phonometry import barrier_insertion_loss, kurze_anderson_attenuation
+from phonometry import environment
 
-kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
+environment.kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
 
 # A 4 m barrier 50 m from a 1 m source, receiver 1.5 m high at 100 m.
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="kurze_anderson")
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="kurze_anderson")
 il.plot()                           # insertion loss vs frequency
 ```
 
@@ -20863,8 +20756,8 @@ coefficient per image path; the model is coherent and reciprocal but not a full
 boundary-element solution.
 
 ```python
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="exact", ground_flow_resistivity=2e5)
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="exact", ground_flow_resistivity=2e5)
 il.ground        # True: the four-path coherent ground model was applied
 il.plot()
 ```
@@ -20884,16 +20777,16 @@ interfere destructively.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 # The 4 m barrier of the snippets above, on a fine frequency grid.
 freqs = np.geomspace(50.0, 5000.0, 240)
-il_ka = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="kurze_anderson")
-il_ex = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact")
-il_gr = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact", ground_flow_resistivity=2e5)
+il_ka = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="kurze_anderson")
+il_ex = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact")
+il_gr = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact", ground_flow_resistivity=2e5)
 fig, ax = plt.subplots(figsize=(11, 6.4))
 ax.semilogx(freqs, il_ka.insertion_loss, "--", label="Kurze-Anderson (thin screen)")
 ax.semilogx(freqs, il_ex.insertion_loss, label="Exact rigid half-plane")
@@ -20925,10 +20818,10 @@ thin-screen methods above key on.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 5000.0, 240)
-il = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+il = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 
 # One line: the section to scale, with the path-length difference annotated.
 il.plot_geometry()
@@ -21651,18 +21544,13 @@ level supplied through the metadata `requirement` then adds a PASS/FAIL verdict
 
 ```python
 import numpy as np
-from phonometry import (
-    Barrier,
-    ReportMetadata,
-    SourceEmission,
-    outdoor_propagation_attenuation,
-)
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 lw = np.array([95, 100, 103, 105, 104, 101, 95, 88], dtype=float)
-result = outdoor_propagation_attenuation(
+result = environment.outdoor_propagation_attenuation(
     200.0, 4.0, 2.0, freqs, 1.0, 1.0, 1.0,
-    barrier=Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
+    barrier=environment.Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
     temperature=10.0, relative_humidity=70.0,
 )
 result.report(
@@ -21672,7 +21560,7 @@ result.report(
         test_room="Nearest dwelling facade",
         requirement=50.0,  # maximum acceptable A-weighted downwind level
     ),
-    source_emission=SourceEmission(sound_power_level=lw),
+    source_emission=environment.SourceEmission(sound_power_level=lw),
 )
 ```
 
@@ -21693,10 +21581,10 @@ adds a PASS/FAIL verdict (a higher insertion loss is better).
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, barrier_insertion_loss
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
-result = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+result = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 result.report(
     "barrier_insertion_loss.pdf",
     metadata=ReportMetadata(
@@ -21861,29 +21749,23 @@ starts to matter.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    BrakeType, ContactFilter, RailRoughnessClass, RailwayTrack, RailwayVehicle,
-    RollingStock, TrackTransferClass, TractionVehicle, WheelDiameter,
-    aerodynamic_sound_power, contact_filter, impact_roughness_single,
-    rail_roughness, railway_source_power, track_transfer, traction_sound_power,
-    wheel_roughness, wheel_transfer,
-)
+from phonometry import environment
 
-stock = RollingStock(
+stock = environment.RollingStock(
     axles=4,
-    wheel_roughness=wheel_roughness(BrakeType.NON_TREAD),
-    contact_filter=contact_filter(ContactFilter.LOAD_50_DIAMETER_920),
-    wheel_transfer=wheel_transfer(WheelDiameter.MM_920),
-    traction=traction_sound_power(TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
-    aerodynamic=aerodynamic_sound_power(),
+    wheel_roughness=environment.wheel_roughness(environment.BrakeType.NON_TREAD),
+    contact_filter=environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920),
+    wheel_transfer=environment.wheel_transfer(environment.WheelDiameter.MM_920),
+    traction=environment.traction_sound_power(environment.TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
+    aerodynamic=environment.aerodynamic_sound_power(),
 )
-track = RailwayTrack(
-    rail_roughness=rail_roughness(RailRoughnessClass.NORMAL),
-    track_transfer=track_transfer(TrackTransferClass.MONOBLOCK_MEDIUM),
-    impact_roughness=impact_roughness_single(),
+track = environment.RailwayTrack(
+    rail_roughness=environment.rail_roughness(environment.RailRoughnessClass.NORMAL),
+    track_transfer=environment.track_transfer(environment.TrackTransferClass.MONOBLOCK_MEDIUM),
+    impact_roughness=environment.impact_roughness_single(),
 )
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
 )
 result.plot()
 plt.show()
@@ -21945,24 +21827,20 @@ rough ones.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    RAILWAY_THIRD_OCTAVE_BANDS, BrakeType, ContactFilter, RailRoughnessClass,
-    contact_filter, rail_roughness, roughness_to_frequency,
-    total_effective_roughness, wheel_roughness,
-)
+from phonometry import environment
 
-rail = rail_roughness(RailRoughnessClass.NORMAL)
-wheel = wheel_roughness(BrakeType.NON_TREAD)
-filt = contact_filter(ContactFilter.LOAD_50_DIAMETER_920)
+rail = environment.rail_roughness(environment.RailRoughnessClass.NORMAL)
+wheel = environment.wheel_roughness(environment.BrakeType.NON_TREAD)
+filt = environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920)
 
 fig, ax = plt.subplots()
 for speed in (60.0, 160.0, 300.0):
-    total = total_effective_roughness(
-        roughness_to_frequency(rail[1], rail[0], speed),
-        roughness_to_frequency(wheel[1], wheel[0], speed),
-        roughness_to_frequency(filt[1], filt[0], speed),
+    total = environment.total_effective_roughness(
+        environment.roughness_to_frequency(rail[1], rail[0], speed),
+        environment.roughness_to_frequency(wheel[1], wheel[0], speed),
+        environment.roughness_to_frequency(filt[1], filt[0], speed),
     )
-    ax.semilogx(RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
+    ax.semilogx(environment.RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
 ax.legend()
 plt.show()
 ```
@@ -21984,10 +21862,10 @@ worked example. Two readings are shipped, and the default is the one that
 reproduces the Commission's own reference source module:
 
 ```python
-from phonometry import RoughnessInterpolation
+from phonometry import environment
 
-RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
-RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
+environment.RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
+environment.RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
 ```
 
 They differ by up to about 1 dB on a steep part of a spectrum. This is the
@@ -22031,12 +21909,12 @@ the 2015 one:
 | Tram | curve or switch turnout with $R \le 200\ \text{m}$ | 5 dB |
 
 ```python
-from phonometry import curve_squeal_excess
+from phonometry import environment
 
-curve_squeal_excess(280.0)                       # 8.0 dB
-curve_squeal_excess(450.0)                       # 5.0 dB
-curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
-curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
+environment.curve_squeal_excess(280.0)                       # 8.0 dB
+environment.curve_squeal_excess(450.0)                       # 5.0 dB
+environment.curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
+environment.curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
 ```
 
 The 2015 text read "8 dB for R < 300 m and 5 dB for 300 m < R < 500 m", which
@@ -22093,10 +21971,10 @@ available, because comparing with a study computed before 2021 needs the old
 one:
 
 ```python
-from phonometry import DirectivityEdition, vertical_directivity
+from phonometry import environment
 
-vertical_directivity(-30.0)                                        # zeros
-vertical_directivity(-30.0, edition=DirectivityEdition.ORIGINAL_2015)  # positive
+environment.vertical_directivity(-30.0)                                        # zeros
+environment.vertical_directivity(-30.0, edition=environment.DirectivityEdition.ORIGINAL_2015)  # positive
 ```
 
 At source B, only the aerodynamic source is directional, $10\log_{10}(\cos^2\psi)$
@@ -22128,11 +22006,11 @@ bridge term is added to it. It sits at source A and is omni-directional, which
 the amendment states explicitly.
 
 ```python
-from phonometry import BridgeType, RailwayTrack, bridge_transfer
+from phonometry import environment
 
-RailwayTrack(
+environment.RailwayTrack(
     rail_roughness=..., track_transfer=...,
-    bridge_transfer=bridge_transfer(BridgeType.PLUS_10_DBA),
+    bridge_transfer=environment.bridge_transfer(environment.BridgeType.PLUS_10_DBA),
 )
 ```
 
@@ -22332,19 +22210,17 @@ governs.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    JunctionType, RoadSurface, RoadTraffic, RoadVehicleCategory, road_source_power,
-)
+from phonometry import environment
 
 traffic = [
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1200.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 45.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1200.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 45.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
 ]
-result = road_source_power(
-    traffic, surface=RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
-    junction_distance=60.0, junction_type=JunctionType.CROSSING,
+result = environment.road_source_power(
+    traffic, surface=environment.RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
+    junction_distance=60.0, junction_type=environment.JunctionType.CROSSING,
 )
 result.plot()
 plt.show()
@@ -22411,20 +22287,17 @@ from about 60 km/h, which is why a lorry is still an engine at urban speeds.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    CNOSSOS_A_WEIGHTING, road_propulsion_noise, road_rolling_noise,
-    road_vehicle_sound_power,
-)
+from phonometry import environment
 
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 speeds = np.linspace(20.0, 130.0, 221)
 fig, ax = plt.subplots()
 for category, name in [("1", "Light vehicles (1)"), ("3", "Heavy vehicles (3)")]:
-    rolling = [a_weighted(road_rolling_noise(category, v)) for v in speeds]
-    propulsion = [a_weighted(road_propulsion_noise(category, v)) for v in speeds]
-    total = [a_weighted(road_vehicle_sound_power(category, v)) for v in speeds]
+    rolling = [a_weighted(environment.road_rolling_noise(category, v)) for v in speeds]
+    propulsion = [a_weighted(environment.road_propulsion_noise(category, v)) for v in speeds]
+    total = [a_weighted(environment.road_vehicle_sound_power(category, v)) for v in speeds]
     ax.plot(speeds, total, lw=2.4, label=f"{name} - total")
     ax.plot(speeds, rolling, ls="--", lw=1.2, label=f"{name} - rolling")
     ax.plot(speeds, propulsion, ls=":", lw=1.2, label=f"{name} - propulsion")
@@ -22472,9 +22345,9 @@ down onto it, but a rough texture only generates tyre noise, and tyre noise is
 already the rolling term.
 
 ```python
-from phonometry import RoadSurface, road_surface_coefficients
+from phonometry import environment
 
-row = road_surface_coefficients(RoadSurface.TWO_LAYER_ZOAB_FINE)
+row = environment.road_surface_coefficients(environment.RoadSurface.TWO_LAYER_ZOAB_FINE)
 row.speed_range          # (80.0, 130.0) km/h, the printed validity range
 row.alpha["1"]           # alpha per octave band for light vehicles
 row.beta["1"]            # -0.1, the speed coefficient
@@ -22498,19 +22371,16 @@ $dL$ simply carries $L'_{W,\mathrm{eq,line},i} + 10\log_{10}(dL)$, which is
 arithmetic and is offered as such.
 
 ```python
-from phonometry import (
-    PropagationGeometry, RoadTraffic, RoadVehicleCategory,
-    line_source_segment_power, predicted_receiver_level, road_source_power,
-)
+from phonometry import environment
 
-result = road_source_power([
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 90.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 120.0, 80.0),
+result = environment.road_source_power([
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 90.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 120.0, 80.0),
 ])
-segment = line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
-levels = predicted_receiver_level(
+segment = environment.line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
+levels = environment.predicted_receiver_level(
     segment,
-    PropagationGeometry(100.0, result.source_height, 4.0),
+    environment.PropagationGeometry(100.0, result.source_height, 4.0),
     frequencies=result.frequencies,
 )
 ```
@@ -22526,9 +22396,9 @@ For the A-weighted total, use the octave-band weighting the Directive itself
 prints in 2.5.5 as amended, rather than recomputing it:
 
 ```python
-from phonometry import CNOSSOS_A_WEIGHTING
+from phonometry import environment
 
-CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
+environment.CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
 result.a_weighted_line_power
 ```
 
@@ -22542,13 +22412,13 @@ and the 2021 one). Both coefficient objects can be replaced:
 ```python
 import dataclasses
 
-from phonometry import ROAD_COEFFICIENTS
+from phonometry import environment
 
 # One measured national row for light vehicles, the rest of Appendix F as published.
 national = dataclasses.replace(
-    ROAD_COEFFICIENTS,
+    environment.ROAD_COEFFICIENTS,
     rolling_a={
-        **ROAD_COEFFICIENTS.rolling_a,
+        **environment.ROAD_COEFFICIENTS.rolling_a,
         "1": (83.4, 89.0, 88.1, 93.6, 100.4, 96.9, 87.0, 76.5),
     },
 )
@@ -25251,18 +25121,16 @@ reflection at zero.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 
 f = np.array([300.0])
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -25292,19 +25160,17 @@ $\mathrm{Re}(Z)\cos\theta = Z_0$ and $\mathrm{Im}(Z) = 0$ hold.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 print(round(design.absorption, 4))          # ~1.0 (perfect absorption)
 
 f = np.linspace(150.0, 500.0, 700)
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -25327,9 +25193,9 @@ the cavity length to place the resonance.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator
+from phonometry import materials
 
-resonator = HelmholtzResonator(
+resonator = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
@@ -25351,13 +25217,13 @@ mechanism.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator, critical_coupling_design, materials
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 
@@ -25384,20 +25250,18 @@ deep; detuning the slit height drops the peak below one.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
 a, d, f0 = 3.0e-2, 5.0e-2, 300.0
-base = HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
-design = critical_coupling_design(f0, base, lattice_step=a, period=d)
+base = materials.HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
+design = materials.critical_coupling_design(f0, base, lattice_step=a, period=d)
 h0 = design.slit_height
 
 f = np.linspace(150.0, 500.0, 700)
 fig, ax = plt.subplots()
 for factor, label in [(1.0, "critically coupled"),
                       (0.6, "narrow slit"), (1.7, "wide slit")]:
-    res = slit_helmholtz_absorber(
+    res = materials.slit_helmholtz_absorber(
         f, design.resonator, slit_height=factor * h0,
         lattice_step=a, period=d,
     )
@@ -25428,16 +25292,14 @@ everything about why the panel can be thin:
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
-res = slit_helmholtz_absorber(
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+res = materials.slit_helmholtz_absorber(
     np.array([300.0]), design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -25752,23 +25614,20 @@ and the limp one settles on $\rho_\mathrm{t}/\rho_0 = 25.9$.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PorousLayer, decoupling_frequency, johnson_champoux_allard,
-    layered_absorber, limp_frame, limp_frame_applicable,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 11.2: soft fibrous layer, 50 mm.
 f = np.linspace(1.0, 2000.0, 800)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     f, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 
-print(round(decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
+print(round(materials.decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
 # 127.4
 print(round(float(limp.effective_density[0].real), 1))     # 31.2 = rho_t
-print(limp_frame_applicable(20e3), limp_frame_applicable(25e3))  # True False
+print(materials.limp_frame_applicable(20e3), materials.limp_frame_applicable(25e3))  # True False
 
 limp.plot()   # normalised Zc and k of the corrected medium
 plt.show()
@@ -25801,18 +25660,16 @@ slightly higher one either side of 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PorousLayer, johnson_champoux_allard, layered_absorber, limp_frame,
-)
+from phonometry import materials
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 1000], dtype=float)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     bands, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 for medium in (rigid, limp):
-    print(layered_absorber(bands, [PorousLayer(0.05, medium)]).absorption.round(2))
+    print(materials.layered_absorber(bands, [materials.PorousLayer(0.05, medium)]).absorption.round(2))
 # [0.07 0.11 0.17 0.24 0.32 0.43 0.54 0.64 0.88]   rigid frame
 # [0.04 0.08 0.15 0.24 0.36 0.48 0.61 0.71 0.91]   limp frame
 ```
@@ -25900,31 +25757,28 @@ imaginary part that the book measures and plots in its Fig. 6.10.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, biot_waves, frame_elastic_coefficient,
-    frame_quarter_wave_resonance, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 6.1: glass wool "Domisol Coffrage", 100 mm, glued.
 f = np.linspace(200.0, 1500.0, 1301)
 shear = 2.2e6 * (1 + 0.1j)          # 220 N/cm2, loss factor 0.1
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     f, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 
-print(frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
-print(round(frame_quarter_wave_resonance(
+print(materials.frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
+print(round(materials.frame_quarter_wave_resonance(
     0.10, shear_modulus=shear, poisson_ratio=0.0, frame_density=130.0), 1))
 # 459.9
 
-waves = biot_waves(med, porosity=0.94, tortuosity=1.06,
-                   frame_density=130.0, shear_modulus=shear)
+waves = materials.biot_waves(med, porosity=0.94, tortuosity=1.06,
+                             frame_density=130.0, shear_modulus=shear)
 print(round(float(abs(waves.airborne_velocity_ratio[800])), 1))     # 42.4
 print(np.round(waves.frame_borne_velocity_ratio[-1], 3))  # (0.811+0.473j)
 
-biot = layered_absorber(f, [PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
-rigid = layered_absorber(f, [PorousLayer(0.10, med)])
+biot = materials.layered_absorber(f, [materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
+rigid = materials.layered_absorber(f, [materials.PorousLayer(0.10, med)])
 
 fig, ax = plt.subplots()
 for res, style in ((rigid, "--"), (biot, "-")):
@@ -25959,19 +25813,17 @@ sharpest; on third-octave centres the largest shift is the 0.12 at 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 bands = np.array([250, 315, 400, 500, 630, 800, 1000], dtype=float)
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     bands, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 shear = 2.2e6 * (1 + 0.1j)
-for layer in (PorousLayer(0.10, med),
-              PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
-    print(layered_absorber(bands, [layer]).absorption.round(2))
+for layer in (materials.PorousLayer(0.10, med),
+              materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
+    print(materials.layered_absorber(bands, [layer]).absorption.round(2))
 # [0.55 0.58 0.62 0.65 0.69 0.74 0.78]   rigid frame
 # [0.53 0.56 0.61 0.77 0.71 0.74 0.78]   Biot poroelastic
 ```
@@ -27265,12 +27117,7 @@ five-well sequence six times (`periods=6`, a 2.1 m panel):
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    metadiffuser_polar_response,
-    metadiffuser_reflection,
-)
+from phonometry import materials
 
 # The published quadratic-residue metadiffuser: five slits with two
 # resonators each in a 35 cm x 2 cm panel (7 cm pitch), tuned to mimic a
@@ -27284,21 +27131,21 @@ rows = [  # slit h, neck l_n, cavity l_c, neck w_n, cavity w_c  [mm]
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 f = np.arange(1800.0, 2601.0, 5.0)
-panel = metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
 alpha1 = panel.well_absorption[0]
 print(round(float(alpha1.max()), 2), int(f[alpha1.argmax()]))  # 0.99 2305
 
 # Far-field comparison: the five-well sequence repeated six times (2.1 m).
-polar = metadiffuser_polar_response(2000.0, wells, depth=0.02,
-                                    period=0.07, periods=6)
+polar = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02,
+                                              period=0.07, periods=6)
 print(round(polar.coefficient, 2))                             # 0.32
 ```
 
@@ -27309,12 +27156,7 @@ print(round(polar.coefficient, 2))                             # 0.32
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    materials,
-    metadiffuser_polar_response,
-)
+from phonometry import materials
 
 mm = 1e-3
 rows = [
@@ -27325,17 +27167,17 @@ rows = [
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 # The metadiffuser panel and the QRD it was tuned to at 2 kHz, both with
 # six repetitions of the period (2.1 m panels).
-meta = metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
-                                   periods=6)
+meta = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
+                                             periods=6)
 sequence = np.roll(materials.quadratic_residue_sequence(5), -1)
 depths = sequence * (343.0 / 500.0) / (2 * 5)
 qrd = materials.predict_diffuser_polar_response(
@@ -27375,11 +27217,11 @@ few degrees of the QRD targets while keeping $|R_n|$ near one:
 
 ```python
 import numpy as np
-from phonometry import materials, metadiffuser_reflection
+from phonometry import materials
 
 # wells: the five published slits from the example above.
-panel = metadiffuser_reflection(np.array([2000.0]), wells,
-                                depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(np.array([2000.0]), wells,
+                                          depth=0.02, period=0.07)
 phases = np.degrees(np.angle(panel.reflection[:, 0]))
 print(np.round(np.abs(panel.reflection[:, 0]), 2))  # [0.97 1.   1.   0.97 0.98]
 print(np.round(phases))                             # [ 75. -71. -71.  74.   2.]
@@ -31827,7 +31669,7 @@ Section II):
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 16000
 rng = np.random.default_rng(0)
@@ -31836,9 +31678,9 @@ clean = rng.standard_normal(3 * fs)          # stand-in for a speech waveform
 noise = rng.standard_normal(3 * fs)
 degraded = clean + 0.56 * noise
 
-d = stoi(clean, degraded, fs)
+d = speech.stoi(clean, degraded, fs)
 print(round(d.value, 3))              # a scalar in roughly [0, 1]
-print(stoi(clean, clean, fs).value)   # 1.0  (a signal against itself)
+print(speech.stoi(clean, clean, fs).value)   # 1.0  (a signal against itself)
 ```
 
 Everything up to the 384 ms segments is shared; the two measures only part
@@ -31859,7 +31701,7 @@ is the average of those intermediate correlations over all bands and segments
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(1)
@@ -31867,7 +31709,7 @@ clean = rng.standard_normal(3 * fs)
 # Higher SNR gives a higher STOI: the relation is monotonic.
 for snr_db in (-10, 0, 10, 20):
     g = 10.0 ** (-snr_db / 20.0)
-    print(snr_db, round(stoi(clean, clean + g * rng.standard_normal(clean.size), fs).value, 3))
+    print(snr_db, round(speech.stoi(clean, clean + g * rng.standard_normal(clean.size), fs).value, 3))
 ```
 
 The `STOIResult` carries the per-band mean correlation (`band_scores`) and the
@@ -31885,7 +31727,7 @@ bites, which the single number cannot.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.signal import butter, lfilter
-from phonometry import stoi
+from phonometry import speech
 
 # Speech-like material: band-limited noise with a 3.5 Hz syllabic envelope,
 # in a flat masker at 0 dB SNR.
@@ -31897,7 +31739,7 @@ carrier = lfilter(b, a, rng.standard_normal(t.size))
 clean = carrier * (0.15 + 0.85 * np.abs(np.sin(2 * np.pi * 3.5 * t)) ** 2)
 masker = rng.standard_normal(clean.size)
 gain = np.sqrt(np.mean(clean ** 2)) / np.sqrt(np.mean(masker ** 2))
-res = stoi(clean, clean + gain * masker, fs)
+res = speech.stoi(clean, clean + gain * masker, fs)
 print(round(res.value, 3))    # 0.727
 
 # One line: the per-band intermediate correlation behind the index.
@@ -31937,9 +31779,9 @@ audible, is credited for the speech glimpsed there, which STOI's per-band
 average largely misses.
 
 ```python
-from phonometry import stoi
+from phonometry import speech
 
-estoi = stoi(clean, degraded, fs, extended=True)
+estoi = speech.stoi(clean, degraded, fs, extended=True)
 print(round(estoi.value, 3))
 ```
 
@@ -31951,7 +31793,7 @@ print(round(estoi.value, 3))
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(20)
@@ -31973,7 +31815,7 @@ def curve(masker, extended):
     out = []
     for snr in snrs:
         g = p_clean / (p_m * 10.0 ** (snr / 20.0))
-        out.append(stoi(clean, clean + g * masker, fs, extended=extended).value)
+        out.append(speech.stoi(clean, clean + g * masker, fs, extended=extended).value)
     return out
 
 fig, (a, b) = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
@@ -32415,18 +32257,18 @@ and so sums to 0.9996.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import SII_METHODS, sii_procedure
+from phonometry import speech
 
 # One line: each procedure's own .plot() steps its Ii over its band limits.
 fig, ax = plt.subplots(figsize=(10, 6))
-for method in SII_METHODS:
-    sii_procedure(method).plot(ax=ax, linewidth=1.8)
+for method in speech.SII_METHODS:
+    speech.sii_procedure(method).plot(ax=ax, linewidth=1.8)
 plt.show()
 
 # By hand, mirroring what SIIProcedure.plot() draws:
 fig, ax = plt.subplots()
-for method in SII_METHODS:
-    proc = sii_procedure(method)
+for method in speech.SII_METHODS:
+    proc = speech.sii_procedure(method)
     ii = proc.band_importance
     ax.plot(proc.band_edges, np.append(ii, ii[-1]), drawstyle="steps-post",
             label=method)
@@ -38620,16 +38462,16 @@ all-pass has unit magnitude everywhere (only the phase turns).
 
 ```python
 import numpy as np
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 rng = np.random.default_rng(1)
 x = rng.standard_normal(fs)                 # one second of noise
 
-eq = ParametricEQ(fs, [
-    EQSection("lowshelf", 100.0, gain_db=4.0),
-    EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
-    EQSection("highshelf", 8000.0, gain_db=3.0),
+eq = filters.ParametricEQ(fs, [
+    filters.EQSection("lowshelf", 100.0, gain_db=4.0),
+    filters.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
+    filters.EQSection("highshelf", 8000.0, gain_db=3.0),
 ])
 y = eq.filter(x)              # apply the cascade
 res = eq.response()           # frozen result carrying the SOS cascade
@@ -38646,21 +38488,21 @@ For block processing pass `stateful=True` (the same convention as
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 family = [
-    EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
-    EQSection("lowshelf", 125.0, gain_db=6.0),
-    EQSection("highshelf", 4000.0, gain_db=-6.0),
-    EQSection("lowpass", 10000.0),
-    EQSection("highpass", 50.0),
-    EQSection("bandpass", 500.0, q=2.0),
-    EQSection("notch", 2000.0, q=6.0),
+    filters.EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
+    filters.EQSection("lowshelf", 125.0, gain_db=6.0),
+    filters.EQSection("highshelf", 4000.0, gain_db=-6.0),
+    filters.EQSection("lowpass", 10000.0),
+    filters.EQSection("highpass", 50.0),
+    filters.EQSection("bandpass", 500.0, q=2.0),
+    filters.EQSection("notch", 2000.0, q=6.0),
 ]
 fig, ax = plt.subplots(figsize=(10, 6))
 for section in family:
-    res = ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
+    res = filters.ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
     ax.semilogx(res.frequencies, res.magnitude_db,
                 label=f"{section.filter_type} @ {section.f0:g} Hz")
 ax.set(xlim=(20, 20000), ylim=(-27, 9),
@@ -39133,10 +38975,10 @@ Spanish fiche (translated fixed strings and a comma decimal separator), e.g.
 `result.report("iec61260_es.pdf", language="es")`.
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # overall_class == 1
 result.plot()   # the worst-margin band on its class corridor
 
 result.report(
@@ -39163,8 +39005,8 @@ ANSI S1.11-2004 mask, which keeps the stricter **class 0** that the 2014 edition
 dropped; the default order-6 Butterworth bank can then be certified to class 0:
 
 ```python
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
-result = filter_class_compliance(bank, edition="1995")   # overall_class == 0
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
+result = filters.filter_class_compliance(bank, edition="1995")   # overall_class == 0
 result.plot()   # the class-0 corridor of the 1995 edition
 result.report(
     "iec61260_1995.pdf",
@@ -42229,10 +42071,10 @@ class; `intensity_class_compliance` does the same for the IEC 61043
 residual-index verdict:
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank_11 = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank_11)   # result.overall_class == 1
+bank_11 = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank_11)   # result.overall_class == 1
 result.report(
     "iec61260.pdf",
     metadata=ReportMetadata(
@@ -42364,12 +42206,12 @@ suite pins. The book's Example 4.4 (twenty observations, $A = 86$, accepted
 between 64 and 125) runs verbatim:
 
 ```python
-from phonometry import trend_test
+from phonometry import metrology
 
 values = [5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
           5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0]
 
-res = trend_test(values)                  # B&P Example 4.4
+res = metrology.trend_test(values)                  # B&P Example 4.4
 print(res.statistic, res.bounds)          # 86, (64, 125)
 print(res.trend_free, round(res.p_value, 3))   # True, 0.586
 res.plot()
@@ -42383,14 +42225,14 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 example = np.array([5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
                     5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0])
 drifting = example + np.linspace(0.0, 4.0, example.size)   # rising drift
 
-res_flat = trend_test(example)
-res_drift = trend_test(drifting)
+res_flat = metrology.trend_test(example)
+res_drift = metrology.trend_test(drifting)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, example.size + 1)
@@ -42427,17 +42269,17 @@ while the same noise without the drift passes:
 
 ```python
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 noise = np.random.default_rng(42).standard_normal(n)
 
-res = stationarity_test(noise, fs)        # 20 segments, mean squares
+res = metrology.stationarity_test(noise, fs)        # 20 segments, mean squares
 print(res.stationary, res.count, res.bounds)   # True, 91, (64, 125)
 
 drifting = noise * np.linspace(1.0, 1.2, n)    # +20 % gain ramp
-res = stationarity_test(drifting, fs)
+res = metrology.stationarity_test(drifting, fs)
 print(res.stationary, res.count)          # False, 7  (upward trend -> low A)
 res.plot()
 ```
@@ -42450,15 +42292,15 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 steady = np.random.default_rng(42).standard_normal(n)
 ramp = np.random.default_rng(42).standard_normal(n) * np.linspace(1.0, 1.2, n)
 
-res_steady = stationarity_test(steady, fs)
-res_ramp = stationarity_test(ramp, fs)
+res_steady = metrology.stationarity_test(steady, fs)
+res_ramp = metrology.stationarity_test(ramp, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, res_steady.n_segments + 1)
@@ -42500,15 +42342,15 @@ acceptance region at $\alpha = 0.05$ is the classical $(6, 15]$:
 
 ```python
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
-res = trend_test(rng.standard_normal(40), method="runs")
+res = metrology.trend_test(rng.standard_normal(40), method="runs")
 print(res.statistic, res.bounds, res.trend_free)
 res.plot()   # the sequence about its median with the runs verdict
 
 alternating = np.tile([1.0, -1.0], 10)   # 20 runs: rejected the other way
-print(trend_test(alternating, method="runs").trend_free)   # False
+print(metrology.trend_test(alternating, method="runs").trend_free)   # False
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test.svg" alt="Two panels of sequences classified about their median, points above in blue and below in red. Left: forty Gaussian observations with twenty runs inside the acceptance region from fourteen to twenty-seven, verdict trend-free. Right: a strictly alternating twenty-value sequence also giving twenty runs, but against the acceptance region from six to fifteen for twenty values, verdict rejected for too-rapid alternation" width="92%"></picture>
@@ -42524,19 +42366,19 @@ too *many* runs is as non-random as too few.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
 sequences = [rng.standard_normal(40), np.tile([1.0, -1.0], 10)]
 
 # One line per sequence — the tested values with the verdict:
-trend_test(sequences[0], method="runs").plot()
+metrology.trend_test(sequences[0], method="runs").plot()
 plt.show()
 
 # Both verdicts side by side, classified about the median:
 fig, axes = plt.subplots(1, 2, figsize=(11, 4.5))
 for ax, seq in zip(axes, sequences):
-    res = trend_test(seq, method="runs")
+    res = metrology.trend_test(seq, method="runs")
     idx = np.arange(1, seq.size + 1)
     median = np.median(seq)
     above = seq > median
@@ -42584,13 +42426,13 @@ the Rice curve next to them, taking the moments from the record's own
 
 ```python
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # a 60 Hz sine ...
 
-res = level_crossing_rate(x, fs)
+res = metrology.level_crossing_rate(x, fs)
 print(round(res.zero_crossing_rate, 1))   # ... has 120 zeros per second
 print(round(res.apparent_frequency, 1))   # 60.0
 res.plot()
@@ -42604,7 +42446,7 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 20480.0
 n = 1 << 19
@@ -42614,7 +42456,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[(freqs < 800.0) | (freqs > 1200.0)] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
+res = metrology.level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.levels, res.rice_rates, label="Rice (Eq. 5.196)")
@@ -42657,13 +42499,13 @@ available as `peak_exceedance()` / `peak_density()` on the result:
 
 ```python
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # narrowband: r is essentially 1
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 print(round(res.irregularity_factor, 3))       # 0.997
 print(res.peak_exceedance(4.0))                # exp(-8): about 1 in 3000
 res.plot()   # empirical exceedance against the Rice mixture (figure below)
@@ -42677,7 +42519,7 @@ res.plot()   # empirical exceedance against the Rice mixture (figure below)
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 from phonometry.metrology.data_qualification import _rice_peak_exceedance
 
 fs = 20480.0
@@ -42688,7 +42530,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[freqs > 2000.0] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 peaks = res.peak_values
 empirical = 1.0 - np.arange(1, peaks.size + 1) / peaks.size
 z = np.linspace(-2.5, 4.5, 400)
@@ -43452,13 +43294,13 @@ computes the three standard variants over the quefrency axis:
 
 ```python
 import numpy as np
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(1)
 x = rng.standard_normal(4096)
 
-res = cepstrum(x, fs, kind="power")
+res = signals.cepstrum(x, fs, kind="power")
 print(res.quefrencies[:3], res.cepstrum.shape)   # quefrency axis, in s
 res.plot()
 ```
@@ -43478,7 +43320,7 @@ wavelet concentrates below 2 ms.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited source wavelet plus one reflection at 8 ms (a = 0.5)
@@ -43488,13 +43330,13 @@ s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
 # One line per variant — each CepstrumResult draws itself:
-cepstrum(x, fs, kind="power").plot()
+signals.cepstrum(x, fs, kind="power").plot()
 plt.show()
 
 # The three variants overlaid by hand on one quefrency axis:
 fig, ax = plt.subplots()
 for kind, style in (("power", "-"), ("real", "--"), ("complex", ":")):
-    res = cepstrum(x, fs, kind=kind)
+    res = signals.cepstrum(x, fs, kind=kind)
     q_ms = 1e3 * res.quefrencies
     mask = (q_ms > 0.5) & (q_ms <= 20.0)
     ax.plot(q_ms[mask], res.cepstrum[mask], style, label=f"{kind} cepstrum")
@@ -43543,14 +43385,14 @@ delay still lands on it, but the reported coefficient underestimates $|a|$
 
 ```python
 import numpy as np
-from phonometry import echo_detection
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(2)
 s = rng.standard_normal(12000)               # broadband source
 x = s + 0.5 * np.roll(s, 384)                # echo: 8 ms, a = 0.5
 
-res = echo_detection(x, fs, min_quefrency=0.002)
+res = signals.echo_detection(x, fs, min_quefrency=0.002)
 print(res.delay, res.reflection_coefficient)  # 0.008 s, ~0.5
 res.plot()
 ```
@@ -43564,7 +43406,7 @@ res.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import echo_detection, noise_signal
+from phonometry import signals
 
 fs = 48000.0
 n = 12000
@@ -43573,9 +43415,9 @@ impulse[0] = 1.0
 b, a = sp_signal.butter(2, [0.004, 0.9], btype="bandpass")
 direct = sp_signal.lfilter(b, a, impulse)              # broadband click
 ir = direct + 0.5 * np.roll(direct, int(0.008 * fs))   # echo at 8 ms
-ir += noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
+ir += signals.noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
 
-res = echo_detection(ir, fs, min_quefrency=0.002)
+res = signals.echo_detection(ir, fs, min_quefrency=0.002)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 half = res.nfft // 2 + 1
@@ -43610,15 +43452,15 @@ exactly complementary in dB, because the split is linear in the log domain:
 
 ```python
 import numpy as np
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(3)
 s = rng.standard_normal(12000)
 x = s + 0.5 * np.roll(s, 384)                # the same 8 ms echo
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
-high = lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
 print(np.allclose(low.liftered_db + high.liftered_db, low.spectrum_db))
 low.plot()
 ```
@@ -43637,7 +43479,7 @@ $20\log_{10}(1 \pm a) = +3.5$ and $-6.0$ dB.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited wavelet carrying a pure 8 ms echo (a = 0.5), so the
@@ -43647,8 +43489,8 @@ s = np.zeros(4096)
 s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")
-high = lifter(x, fs, cutoff=0.004, mode="highpass")
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")
 
 # One line — the cepstrum with the cutoff and the two log spectra:
 low.plot()
@@ -43690,14 +43532,14 @@ removes and stores in `linear_phase_samples`:
 ```python
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 x = np.zeros(2048)
 b, a = sp_signal.butter(2, 0.3)
 x[37:293] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 
-res = cepstrum(x, fs, kind="complex")
+res = signals.cepstrum(x, fs, kind="complex")
 print(res.linear_phase_samples)              # negative: a bulk delay removed
 print(np.max(np.abs(res.invert() - x)))      # ~1e-14
 res.plot()   # the complex cepstrum against quefrency (as in the figure above)
@@ -43743,13 +43585,13 @@ on an analysis bin the closed forms are:
 
 ```python
 import numpy as np
-from phonometry import envelope_spectrum
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(4 * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 k = int(round(25.0 * res.nfft / fs))
 print(res.mean_level, res.amplitude[k])      # ~1.0 and ~0.4
 res.plot()
@@ -43763,15 +43605,15 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope_spectrum, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 seconds = 4.0
 t = np.arange(int(seconds * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
-x += noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.frequencies, res.amplitude, lw=1.4, label="Envelope spectrum")
@@ -43889,9 +43731,9 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 
 ```python
 import numpy as np
-from phonometry import correlation
+from phonometry import signals
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
 res.plot()
@@ -43911,23 +43753,23 @@ there (bottom).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import correlation, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 delay = 102                                  # 12.45 ms
-x = noise_signal(fs, 2.0, seed=4)
-interference = noise_signal(fs, 2.0, rms=0.5, seed=5)
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
 y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 
 # One line — the correlation estimate against the lag in seconds:
 res.plot()
 plt.show()
 
 # The three normalizations by hand, from the same records:
-biased = correlation(x, y, fs, normalization="biased")
-unbiased = correlation(x, y, fs, normalization="unbiased")
+biased = signals.correlation(x, y, fs, normalization="biased")
+unbiased = signals.correlation(x, y, fs, normalization="unbiased")
 
 fig, (ax_c, ax_n) = plt.subplots(2, 1)
 ax_c.plot(1e3 * res.lags, res.values, label="coefficient")
@@ -44010,18 +43852,18 @@ attaches to each:
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import noise_signal, time_delay
+from phonometry import signals
 
 fs = 8192.0
 delay = 20  # samples
 b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
-s = sp_signal.lfilter(b, a, noise_signal(fs, 4.0, color="white", seed=10))
-x = s + noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
-y = np.roll(s, delay) + noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
-direct = time_delay(x, y, fs, method="direct", max_delay=0.01)
-phat = time_delay(x, y, fs, method="gcc", weighting="phat",
-                  nperseg=2048, max_delay=0.01)
+direct = signals.time_delay(x, y, fs, method="direct", max_delay=0.01)
+phat = signals.time_delay(x, y, fs, method="gcc", weighting="phat",
+                          nperseg=2048, max_delay=0.01)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(1e3 * direct.lags,
@@ -44056,10 +43898,10 @@ $$
 $$
 
 ```python
-from phonometry import time_delay
+from phonometry import signals
 
-res = time_delay(x, y, fs, method="gcc", weighting="ml",
-                 nperseg=2048, upsample=16, signal_bandwidth=1000.0)
+res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
+                         nperseg=2048, upsample=16, signal_bandwidth=1000.0)
 print(res.delay, res.delay_samples)     # seconds and fractional samples
 print(res.delay_std, res.delay_interval)  # Eq. 8.129 sigma, +/-2 sigma
 res.plot()                              # correlation with the delay marked
@@ -44081,12 +43923,12 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
-from phonometry import align_impulse_responses, impulse_response_delay
+from phonometry import signals
 
-t_arrival = impulse_response_delay(ir, fs)              # seconds from t = 0
-dt = impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
+t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
-res = align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
+res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
 res.plot()                                     # reference vs aligned overlay
 ```
 
@@ -44103,17 +43945,17 @@ back onto its reference: the band-limited shift removes the estimated
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import align_impulse_responses, fractional_delay
+from phonometry import signals
 
 fs = 48000.0
 t = np.arange(int(0.03 * fs)) / fs
 rng = np.random.default_rng(6)
 # Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
 ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
-ir_b = fractional_delay(ir_a, 7.37)[: ir_a.size]
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
 ir_b += 0.005 * rng.standard_normal(ir_a.size)
 
-res = align_impulse_responses(ir_b, ir_a, fs)
+res = signals.align_impulse_responses(ir_b, ir_a, fs)
 
 # One line — reference and aligned IR overlaid:
 res.plot()
@@ -44159,13 +44001,13 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
-from phonometry import envelope
+from phonometry import signals
 
-res = envelope(x, fs)
+res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)
 res.plot()               # signal + envelope, instantaneous frequency
 
-slow = envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
+slow = signals.envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope.svg" alt="Two panels for a decaying 250 hertz mode in light noise. Top: the oscillating signal with the smooth exponential Hilbert envelope tracing its decay above and below. Bottom: the instantaneous frequency staying on the dashed 250 hertz carrier line while the mode is strong and jittering increasingly as the signal decays into the noise floor" width="86%"></picture>
@@ -44181,7 +44023,7 @@ noise floor (bottom, ×8 anti-aliased decimation).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(0.4 * fs)) / fs
@@ -44189,7 +44031,7 @@ rng = np.random.default_rng(7)
 x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 x += 0.001 * rng.standard_normal(t.size)
 
-res = envelope(x, fs, decimation_factor=8)
+res = signals.envelope(x, fs, decimation_factor=8)
 
 # One line — signal + envelope and the instantaneous frequency:
 res.plot()
@@ -44492,19 +44334,19 @@ correlated inputs and one output.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import miso_coherence, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 # Input 1 drives a low-frequency path; input 2 = 0.7*x1 + independent noise
 # drives a high-frequency path, so input 2 is correlated with input 1.
-x1 = noise_signal(fs, 32.0, color="white", seed=1)
-x2 = 0.7 * x1 + noise_signal(fs, 32.0, color="white", seed=2)
+x1 = signals.noise_signal(fs, 32.0, color="white", seed=1)
+x2 = 0.7 * x1 + signals.noise_signal(fs, 32.0, color="white", seed=2)
 low = signal.butter(4, 400.0, fs=fs, output="sos")
 high = signal.butter(4, 1500.0, btype="high", fs=fs, output="sos")
-noise = noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
+noise = signals.noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
 y = signal.sosfilt(low, x1) + signal.sosfilt(high, x2) + noise
 
-res = miso_coherence([x1, x2], y, fs, nperseg=2048)
+res = signals.miso_coherence([x1, x2], y, fs, nperseg=2048)
 f = res.frequencies
 band = (f >= 20.0) & (f <= 4000.0)
 
@@ -44573,7 +44415,7 @@ to the multiple coherence (Eq. 7.116) and reduce exactly to the ordinary
 coherences when the inputs are mutually uncorrelated (Eq. 7.117).
 
 ```python
-res = miso_coherence([x1, x2], y, fs)
+res = signals.miso_coherence([x1, x2], y, fs)
 res.ordinary_coherence   # shape (q, F): each input on its own
 res.multiple_coherence   # shape (F,):  all inputs jointly
 res.partial_coherence    # shape (q, F): conditioned on the preceding inputs
@@ -44636,7 +44478,7 @@ Bendat & Piersol (Section 7.2.4) recommend ordering the inputs by descending
 ordinary coherence with the output. Pass `order` to choose:
 
 ```python
-res = miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
+res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order
 ```
@@ -44755,9 +44597,9 @@ has a single real Fourier component, so those bins carry half the degrees of
 freedom and a correspondingly wider interval.
 
 ```python
-from phonometry import power_spectral_density
+from phonometry import signals
 
-res = power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
+res = signals.power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -44775,9 +44617,9 @@ $$
 $$
 
 ```python
-from phonometry import resolution_bias_error
+from phonometry import signals
 
-eps_b = resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
+eps_b = signals.resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
 ```
 
 Narrow $B_\mathrm{e}$ (long segments) suppresses the bias but leaves fewer averages and
@@ -44793,18 +44635,14 @@ visible.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    fractional_octave_smoothing,
-    noise_signal,
-    power_spectral_density,
-)
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 20.0, color="pink", seed=11)
-res = power_spectral_density(x, fs, nperseg=4096)
+x = signals.noise_signal(fs, 20.0, color="pink", seed=11)
+res = signals.power_spectral_density(x, fs, nperseg=4096)
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
-smooth = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
+smooth = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.fill_between(freqs, 10 * np.log10(res.ci_lower[band]),
@@ -44845,9 +44683,9 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
-from phonometry import cross_spectral_density
+from phonometry import signals
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
 ```
@@ -44866,16 +44704,16 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import cross_spectral_density, noise_signal
+from phonometry import signals
 
 fs = 8000.0
 tau = 0.002                                   # 2 ms = 16 samples
 delay = int(tau * fs)
-x = noise_signal(fs, 8.0, seed=8)
-noise = noise_signal(fs, 8.0, rms=0.3, seed=9)
+x = signals.noise_signal(fs, 8.0, seed=8)
+noise = signals.noise_signal(fs, 8.0, rms=0.3, seed=9)
 y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 
 # One line — magnitude, phase with its ±sigma band and coherence:
 res.plot()
@@ -44932,14 +44770,14 @@ synthetic signal:
 
 ```python
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 at every frequency
 
-res = coherent_output_spectrum(x, y, fs)
+res = signals.coherent_output_spectrum(x, y, fs)
 print(np.median(res.coherence))          # -> SNR/(1+SNR) = 0.719
 print(np.median(res.snr_db))             # -> 10·lg(2.56) = 4.1 dB
 res.plot()                               # Gyy, Gvv, Gnn and the SNR panel
@@ -44958,14 +44796,14 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 per band
 
-res = coherent_output_spectrum(x, y, fs, nperseg=2048)
+res = signals.coherent_output_spectrum(x, y, fs, nperseg=2048)
 
 # One line — the three spectra and the SNR panel:
 res.plot()
@@ -45009,12 +44847,12 @@ squared first, dB levels converted and back), so band power is conserved
 rather than amplitude, and a flat spectrum passes through exactly unchanged.
 
 ```python
-from phonometry import fractional_octave_smoothing
+from phonometry import signals
 
-smooth_psd = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
-smooth_mag = fractional_octave_smoothing(freqs, np.abs(response), 6.0,
-                                         domain="amplitude")  # an FRF |H|
-smooth_db = fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
+smooth_psd = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
+smooth_mag = signals.fractional_octave_smoothing(freqs, np.abs(response), 6.0,
+                                                 domain="amplitude")  # an FRF |H|
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -45043,10 +44881,10 @@ seed reproduces the same record bit for bit.
 | `violet` | +2 | +6.02 dB/octave |
 
 ```python
-from phonometry import noise_signal
+from phonometry import signals
 
-pink = noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
-white = noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
+pink = signals.noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
+white = signals.noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
 ```
 
 Measured over three decades (20 Hz – 20 kHz) with the estimator of section 1,
@@ -45077,9 +44915,9 @@ it:
   resolution.
 
 ```python
-from phonometry import window_metrics
+from phonometry import signals
 
-m = window_metrics("hann", 2048)
+m = signals.window_metrics("hann", 2048)
 print(m.enbw_bins)              # 1.5, exactly
 print(m.scalloping_loss_db)     # 1.42 dB
 print(m.highest_sidelobe_db)    # -31.5 dB
@@ -45132,9 +44970,9 @@ taper count is $K = 2NW - 1$, all tapers with near-unity concentration.
 Larger $NW$ admits more tapers (lower variance) at the cost of resolution.
 
 ```python
-from phonometry import multitaper_psd
+from phonometry import signals
 
-res = multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band
@@ -45178,12 +45016,12 @@ precision, which is the anchor oracle of the test suite.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import multitaper_psd, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
-single = multitaper_psd(x, fs, n_tapers=1, adaptive=False)
-res = multitaper_psd(x, fs)                              # NW = 4, K = 7
+x = signals.noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
+single = signals.multitaper_psd(x, fs, n_tapers=1, adaptive=False)
+res = signals.multitaper_psd(x, fs)                              # NW = 4, K = 7
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
 
@@ -45309,11 +45147,7 @@ Signal Processing 1(1), 1987, 83-95).
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    comb_filter_response,
-    noise_signal,
-    time_synchronous_average,
-)
+from phonometry import signals
 
 fs = 8192.0
 period = 1.0 / 32.0        # one revolution: 256 samples at this rate
@@ -45324,8 +45158,8 @@ periodic = (
     + 0.5 * np.cos(2.0 * np.pi * 3.0 * phase + 0.4)
     - 0.3 * np.cos(2.0 * np.pi * 6.0 * phase)
 )
-recording = periodic + noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
-res = time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
+recording = periodic + signals.noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
 
 fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(11, 4.6))
 t_ms = 1e3 * res.times
@@ -45337,9 +45171,9 @@ ax0.set_xlabel("Time [ms]"); ax0.set_ylabel("Amplitude"); ax0.legend()
 
 orders = np.linspace(31.0, 33.0, 4000)
 freqs = orders / period
-ax1.plot(orders, comb_filter_response(freqs, period, 32), color="#2ca02c",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 32), color="#2ca02c",
          label="N = 32 (power of two)")
-ax1.plot(orders, comb_filter_response(freqs, period, 20), color="#1f77b4",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 20), color="#1f77b4",
          label="N = 20 (node on 32.05)")
 ax1.axvline(32.05, color="#d62728", ls=":", label="Interfering tone")
 ax1.set_xlabel("Frequency [orders]"); ax1.set_ylabel("Comb filter magnitude")
@@ -45386,12 +45220,12 @@ every $j$ that is not a multiple of $N$, where the response is exactly zero.
 
 ```python
 import numpy as np
-from phonometry import comb_filter_response
+from phonometry import signals
 
 period = 1.0 / 32.0
-comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
-comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
-comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
+signals.comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
+signals.comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
+signals.comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
 ```
 
 `SynchronousAverageResult` carries the response over the first few harmonics
@@ -45408,7 +45242,7 @@ That is a power reduction of $10\log_{10} N$ dB, reported as
 `amplitude_snr_gain`:
 
 ```python
-res = time_synchronous_average(recording, fs, period=period, n_averages=100)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=100)
 res.noise_reduction_db      # 20.0 dB = 10*log10(100)
 res.amplitude_snr_gain      # 10.0   = sqrt(100)
 res.plot()                  # averaged waveform + the comb it applied
@@ -45427,7 +45261,7 @@ the ideal $\sigma/\sqrt{N}$ line as the number of averaged periods grows from
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import time_synchronous_average
+from phonometry import signals
 
 fs = 8192.0
 samples = 256
@@ -45442,8 +45276,8 @@ recording = np.tile(true, 128) + rng.standard_normal(128 * samples)
 counts = [1, 2, 4, 8, 16, 32, 64, 128]
 errors = []
 for n in counts:
-    res = time_synchronous_average(recording[:n * samples], fs, period=period,
-                                   n_averages=n)
+    res = signals.time_synchronous_average(recording[:n * samples], fs, period=period,
+                                           n_averages=n)
     errors.append(np.sqrt(np.mean((res.period_waveform - true) ** 2)))
 
 # One line — the averaged waveform and the comb filter it applied:
@@ -45493,8 +45327,8 @@ average confirms it:
 phase = np.arange(41 * 256) / 256
 recording = np.cos(2 * np.pi * 8.0 * phase) + 0.7 * np.cos(2 * np.pi * 32.05 * phase)
 
-leak_20 = time_synchronous_average(recording, fs, period=period, n_averages=20)
-leak_32 = time_synchronous_average(recording, fs, period=period, n_averages=32)
+leak_20 = signals.time_synchronous_average(recording, fs, period=period, n_averages=20)
+leak_32 = signals.time_synchronous_average(recording, fs, period=period, n_averages=32)
 # leak_20.period_waveform matches the clean 8th-order tone; leak_32 does not
 ```
 
@@ -45517,7 +45351,7 @@ fs = 8192.0
 period = 1.0 / 31.7                       # fs * period is not an integer
 t = np.arange(int(40 * period * fs)) / fs
 recording = np.cos(2.0 * np.pi * t / period)  # one cycle per revolution
-res = time_synchronous_average(recording, fs, period=period)
+res = signals.time_synchronous_average(recording, fs, period=period)
 res.interpolated                          # True: fractional-delay alignment
 res.samples_per_period                    # integer samples of one period
 ```
@@ -45646,10 +45480,10 @@ comes back to machine precision, a closed-form identity the tests and the
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 
 # Simulated measurement: play each code periodically and record one
 # steady-state period of a room-like band-pass system.
@@ -45658,7 +45492,7 @@ length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 print(ir.method, ir.size)                   # golay 16384
 ir.plot()
 ```
@@ -45676,16 +45510,16 @@ complementary correlations land on the true response to machine precision
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 b, a = signal.butter(2, [200.0, 2000.0], btype="bandpass", fs=fs)
 length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 
 # One line — the recovered impulse response:
 ir.plot()
@@ -45745,10 +45579,10 @@ details; `target` is `"pink"` (the classical room-measurement emphasis,
 default), `"white"`, or any `(frequencies_hz, magnitude_db)` pair:
 
 ```python
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-sweep = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+sweep = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 print(round(sweep.crest_factor_db, 1))      # 4.2 (dB; the ideal is 3.02)
 sweep.plot()
 ```
@@ -45762,10 +45596,10 @@ sweep.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-res = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+res = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 x = np.asarray(res)
 
 nperseg = 8192   # 75 % overlap: 50 % would ripple ~2 dB on a sweep
@@ -45810,20 +45644,20 @@ for the [spectral method](https://jmrplens.github.io/phonometry/buildings/rooms/
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import impulse_response, shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
 freqs = np.array([50.0, 200.0, 1000.0, 8000.0])
 emphasis = np.array([12.0, 6.0, 0.0, 0.0])   # LF boost against rumble
-sweep = shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
-                            target=(freqs, emphasis))
+sweep = room.shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
+                                 target=(freqs, emphasis))
 
 # Simulated measurement of a known system (replace with play/record):
 b, a = signal.butter(2, [200.0, 4000.0], btype="bandpass", fs=fs)
 excitation = np.concatenate([np.asarray(sweep), np.zeros(fs)])
 recorded = signal.lfilter(b, a, excitation)
 
-ir = impulse_response(recorded, excitation, fs, length=fs)
+ir = room.impulse_response(recorded, excitation, fs, length=fs)
 ir.plot()
 ```
 
@@ -45858,7 +45692,7 @@ of a mixed-phase response causal
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 # A loudspeaker-like measured response (replace with a measured IR).
@@ -45867,7 +45701,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 print(round(inv.flatness_db, 5))    # 1e-05 (dB: in-band deviation from 0 dB)
 print(round(inv.max_gain_db, 1))    # -6.0 (dB: capped out-of-band boost)
 inv.plot()
@@ -45882,7 +45716,7 @@ inv.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -45890,7 +45724,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-res = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+res = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 f = res.frequencies[1:]
 h_mag = np.abs(res.response_spectrum)[1:]
 inv_mag = np.abs(res.spectrum)[1:]
@@ -45925,17 +45759,16 @@ rate rides along:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import (impulse_response, regularized_inverse_filter,
-                        sweep_signal)
+from phonometry import room, signals
 
 fs = 48000
-sweep = sweep_signal(fs, 50.0, 20000.0, 1.0)
+sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)
 excitation = np.concatenate([sweep, np.zeros(fs // 2)])
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
 recorded = signal.lfilter(b, a, excitation)     # play/record in reality
 
-ir = impulse_response(recorded, excitation, fs)  # any front end works
-inv = regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
+ir = room.impulse_response(recorded, excitation, fs)  # any front end works
+inv = signals.regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
 flat_recording = inv.apply(recorded)             # delay already removed
 inv.plot()   # measured, inverse and equalized magnitudes (figure above)
 ```
@@ -45952,7 +45785,7 @@ post-processing:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter, shaped_sweep_signal
+from phonometry import room, signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -45960,12 +45793,12 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)                    # the measured response
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 target_db = 20.0 * np.log10(
     np.abs(inv.spectrum[1:]) * np.abs(inv.response_spectrum).max()
 )
-sweep = shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
-                            target=(inv.frequencies[1:], target_db))
+sweep = room.shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
+                                 target=(inv.frequencies[1:], target_db))
 sweep.plot()   # waveform and spectrum against the inverted-response target
 ```
 
@@ -46062,14 +45895,14 @@ single burst or as the repetitive train of Clause A2.2 in which each burst
 occupies one full repetition period:
 
 ```python
-from phonometry import tone_burst
+from phonometry import signals
 
 # One 5 ms burst of 5 kHz tone (25 full periods), as in Table AII.
-single = tone_burst(48000, 5000, 25)
+single = signals.tone_burst(48000, 5000, 25)
 print(single.burst_samples)         # 240 samples = 5 ms at 48 kHz
 
 # Clause A2.2: 5 ms bursts at 10 bursts per second.
-train = tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
+train = signals.tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
 print(train.period_samples, train.duty_cycle)   # 4800, 0.05
 train.plot()                        # waveform with the gating envelope
 ```
@@ -46089,11 +45922,11 @@ the generator is verified.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import tone_burst
+from phonometry import signals
 
 fs = 48000.0
-single = tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
-train = tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
+single = signals.tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
+train = signals.tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
 
 fig, axes = plt.subplots(2, 1, figsize=(10, 6.4))
 t_ms = 1e3 * np.arange(single.signal.size) / single.fs
@@ -46140,10 +45973,10 @@ numbers the caller controls:
   bound $\delta = 10^{-A/20}$.
 
 ```python
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 print(res.up, res.down)                  # 160, 147
 print(res.n_taps, res.passband_edge_hz)  # designed FIR, 20947.5 Hz
 res.plot()   # the delivered anti-alias filter against its design spec
@@ -46163,10 +45996,10 @@ it, flat within the same ripple bound.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 
 # res is the ResampledSignalResult computed in the example above.
 # One line — the delivered anti-alias filter against its design spec:
@@ -46229,10 +46062,10 @@ boundary conventions cover the two use cases:
 
 ```python
 import numpy as np
-from phonometry import fractional_delay
+from phonometry import signals
 
-y = fractional_delay(x, 0.37)                    # 0.37 samples later
-z = fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
+y = signals.fractional_delay(x, 0.37)                    # 0.37 samples later
+z = signals.fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
 ```
 
 One subtlety worth knowing: a real record of even length cannot carry a
@@ -46347,9 +46180,9 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
-from phonometry import spectrogram
+from phonometry import signals
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)
 print(res.time_resolution)         # T_B = nperseg/fs, in s
 print(res.resolution_bandwidth)    # Be of the tapered segment, in Hz
@@ -46376,7 +46209,7 @@ tool for the stationary background.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import noise_signal, spectrogram
+from phonometry import signals
 
 fs = 16000.0
 t = np.arange(int(4.0 * fs)) / fs
@@ -46391,10 +46224,10 @@ n_imp = int(0.06 * fs)                              # impact at t = 2.5 s
 x[int(2.5 * fs):int(2.5 * fs) + n_imp] += 0.4 * (
     rng.standard_normal(n_imp) * np.exp(-np.arange(n_imp) / (0.012 * fs))
 )
-x += noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
-                  rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
+x += signals.noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
+                          rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 level = 10.0 * np.log10(res.power / p_ref**2)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -46434,9 +46267,9 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
-from phonometry import zoom_fft
+from phonometry import signals
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
 print(res.bin_spacing)                   # fs/N by default
 print(res.resolution_bandwidth)          # Be of the tapered record
 peak = res.amplitude.argmax()
@@ -46460,7 +46293,7 @@ only a longer record separates closer tones.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import zoom_fft
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
@@ -46472,7 +46305,7 @@ coarse = 2.0 * np.abs(np.fft.rfft(x[:1024] * w)) / np.sum(w)
 coarse_f = np.fft.rfftfreq(1024, 1.0 / fs)
 band = (coarse_f >= 950.0) & (coarse_f <= 1050.0)
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(coarse_f[band], 20.0 * np.log10(coarse[band]), "o--",
@@ -47376,8 +47209,7 @@ few degrees.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (HelmholtzResonator, MetadiffuserWell,
-                        metadiffuser_polar_response, simulation)
+from phonometry import materials, simulation
 
 c0, dx, f0, pitch = 343.0, 0.0005, 2000.0, 0.07
 rows = [(14.7, 13.0, 16.4, 6.2, 9.0), (30.9, 9.1, 4.3, 3.5, 9.0),
@@ -47424,12 +47256,12 @@ pattern = simulation.far_field_from_contour(
     origin=((lat + face / 2.0) * dx, r_face * dx))
 levels = 20 * np.log10(np.abs(pattern) / np.abs(pattern).max())
 
-wells = [MetadiffuserWell(h * 1e-3,
-                          (HelmholtzResonator(ln * 1e-3, wn * 1e-3,
-                                              lc * 1e-3, wc * 1e-3),) * 2)
+wells = [materials.MetadiffuserWell(h * 1e-3,
+                                    (materials.HelmholtzResonator(ln * 1e-3, wn * 1e-3,
+                                                        lc * 1e-3, wc * 1e-3),) * 2)
          for h, ln, lc, wn, wc in rows]
-model = metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
-                                    angles=angles, periods=1)
+model = materials.metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
+                                              angles=angles, periods=1)
 ax = model.plot(color="#1f77b4", marker="", linestyle="--",
                 label="TMM + Fraunhofer model")
 ax.plot(np.radians(angles), levels, color="#d62728", lw=2.2,
@@ -51842,12 +51674,12 @@ BSF. That is the diagnosis: a spall on the outer race.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import bearing_fault_frequencies, envelope_spectrum, noise_signal
+from phonometry import signals, vibration
 
 # The bearing: 15 rollers on a 34 mm pitch diameter, 6 mm rollers,
 # 12.96 degrees contact angle, shaft at 2000 r/min.
-faults = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
-                                   contact_angle_deg=12.96)
+faults = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
+                                             contact_angle_deg=12.96)
 bpfo, shaft = faults["BPFO"], faults.shaft_rate    # 207.0 Hz, 33.33 Hz
 
 # A spalled outer race: one impact per BPFO period, each ringing a 3 kHz
@@ -51862,11 +51694,11 @@ tau = np.arange(int(0.004 * fs)) / fs
 ring = np.exp(-tau / 6.0e-4) * np.sin(2.0 * np.pi * 3000.0 * tau)
 x = np.convolve(impacts, ring)[: t.size] * 0.6
 x += 0.35 * np.sin(2.0 * np.pi * shaft * t)          # residual unbalance
-x += noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
 
 # Band-pass the resonance the impacts ring, envelope it, transform it,
 # and let the result draw its own lines on top.
-spectrum = envelope_spectrum(x, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(x, fs, band=(2000.0, 4000.0))
 faults.within(1.0, 5.0 * bpfo).plot(spectrum=spectrum)
 plt.show()
 ```
@@ -51897,9 +51729,9 @@ errors instantly: $\text{BPFO} + \text{BPFI} = Z f_\mathrm{s}$ always, and
 $\text{BPFO} = Z \times \text{FTF}$ whenever the outer race is stationary.
 
 ```python
-from phonometry import bearing_fault_frequencies
+from phonometry import vibration
 
-res = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
+res = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
 print(round(res["BPFO"], 1), round(res["BPFI"], 1))   # 207.0 293.0
 print(round(res["BPFO"] + res["BPFI"], 1))            # 500.0 = 15 x 33.33
 print(res.as_dict())
@@ -51925,10 +51757,10 @@ flat sidebands spaced by the shaft rate, while distributed wear raises tall
 sideband groups and lifts the higher mesh harmonics.
 
 ```python
-from phonometry import gear_mesh_frequencies
+from phonometry import vibration
 
 # A 28-tooth pinion on a 1500 r/min shaft, with two sideband orders.
-res = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+res = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 print(round(res["GMF"], 1))            # 700.0
 print(round(res["GMF+1x"], 1))         # 725.0  (GMF + one shaft order)
 print(res.harmonics("GMF", 3))         # [ 700. 1400. 2100.]
@@ -51954,10 +51786,10 @@ $n = 1, 2, \ldots$. Dynamic eccentricity dresses the dominant slot harmonic
 with sidebands at $\pm$ the shaft rate and $\pm$ the slip frequency.
 
 ```python
-from phonometry import induction_motor_frequencies
+from phonometry import vibration
 
 # Sixty rotor bars, six magnetic poles, 3600 r/min, no slip.
-res = induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
+res = vibration.induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
 print(round(res["1x"]), round(res["2x"]),
       round(res["2fe"]), round(res["fsh"]))     # 60 120 360 3600
 ```
@@ -51990,10 +51822,10 @@ count reached from a different harmonic is a different pattern turning at a
 different speed.
 
 ```python
-from phonometry import blade_pass_frequencies
+from phonometry import vibration
 
 # Six blades, four vanes, 3500 r/min.
-res = blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
+res = vibration.blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
 print(round(res["BPF"]))          # 350
 print(round(res["lobe n=1 m=2"]), round(res["lobe n=1 m=10"]))    # 175 35
 ```
@@ -52026,24 +51858,19 @@ harmonic or sideband family onto a single quefrency spike, which is the fastest
 way to tell *which* periodicity dominates when several are superimposed.
 
 ```python
-from phonometry import (
-    bearing_fault_frequencies,
-    combine_fault_lines,
-    envelope_spectrum,
-    gear_mesh_frequencies,
-)
+from phonometry import signals, vibration
 
 record, fs = x, 20000.0          # the housing record and its sample rate
 shaft_rpm = 2000.0               # from the tacho, not from the nameplate
 
 # The bearing's own lines, the mesh family of the pinion it supports, and the
 # shaft harmonics. Put them all on one axes.
-bearing = bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
-                                    contact_angle_deg=12.96)
-gear = gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
-lines = combine_fault_lines(bearing, gear)
+bearing = vibration.bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
+                                              contact_angle_deg=12.96)
+gear = vibration.gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
+lines = vibration.combine_fault_lines(bearing, gear)
 
-spectrum = envelope_spectrum(record, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(record, fs, band=(2000.0, 4000.0))
 lines.within(1.0, 1600.0).plot(spectrum=spectrum)
 ```
 
@@ -52230,10 +52057,10 @@ continuous 200 mm wall.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # A 140 mm concrete floor meeting a 200 mm wall at a T-junction.
-res = junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
+res = vibration.junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
 res.plot_geometry()
 plt.show()
 ```
@@ -52247,10 +52074,10 @@ plt.show()
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # X-junction between a 100 mm and a 200 mm concrete plate (cL = 3200 m/s).
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 res.plot()  # tau(theta) for the corner and straight paths, with averages
 plt.show()
 ```
@@ -52282,9 +52109,9 @@ cut-off angle $\theta_\text{co} = \arcsin\chi$; $\psi$ is the ratio of their
 bending-moment mobilities. For **identical plates** both are 1.
 
 ```python
-from phonometry import junction_wave_parameters
+from phonometry import vibration
 
-chi, psi = junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+chi, psi = vibration.junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 #  -> (sqrt(0.5), 4.0)
 ```
 
@@ -52326,14 +52153,11 @@ plates 2 and 4 identical.
 
 ```python
 import numpy as np
-from phonometry import (
-    corner_transmission_coefficient,
-    straight_transmission_coefficient,
-)
+from phonometry import vibration
 
 theta = np.radians(np.linspace(0.0, 90.0, 91))
-tau12 = corner_transmission_coefficient(theta, chi, psi, "X")
-tau13 = straight_transmission_coefficient(theta, chi, psi, "X")
+tau12 = vibration.corner_transmission_coefficient(theta, chi, psi, "X")
+tau13 = vibration.straight_transmission_coefficient(theta, chi, psi, "X")
 ```
 
 The clip below runs this experiment in the time domain with the library's 2D
@@ -52368,10 +52192,10 @@ first-principles oracle:
 * in-line junction: $\tau_{12}(0°) = 1$ (a continuous plate transmits fully).
 
 ```python
-from phonometry import angular_average_transmission_coefficient
+from phonometry import vibration
 
-angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
-angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
 ```
 
 The two directions obey the SEA consistency relationship (Eq. 5.7),
@@ -52403,14 +52227,13 @@ X-junction ($f_\mathrm{c} \approx 203\ \text{Hz}$),
 $K_{ij} = 10\log_{10} 12 + 5\log_{10}(203/1000) \approx 7.3\ \text{dB}$.
 
 ```python
-from phonometry import (coupling_loss_factor, junction_transmission,
-                        wave_vibration_reduction_index)
+from phonometry import vibration
 
-eta = coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
-                           junction_length=4.0, frequency=500.0, plate_area=10.0)
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
-kij = wave_vibration_reduction_index(res.corner_average,
-                                     res.critical_frequency2)  # 7.33 dB
+eta = vibration.coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
+                                     junction_length=4.0, frequency=500.0, plate_area=10.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
+kij = vibration.wave_vibration_reduction_index(res.corner_average,
+                                               res.critical_frequency2)  # 7.33 dB
 kij = res.corner_reduction_index  # the same, precomputed on the result
 
 res.plot()   # tau(theta) for this junction's corner and straight paths (needs matplotlib)
@@ -52437,7 +52260,7 @@ perpendicular plates increasingly pin the junction line:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import junction_transmission, wave_vibration_reduction_index
+from phonometry import vibration
 
 # Concrete plates (cL = 3200 m/s, rho = 2400 kg/m3): plate 1 fixed at
 # 100 mm, plate 2 swept from 50 mm to 400 mm.
@@ -52446,7 +52269,7 @@ ratios = np.linspace(0.5, 4.0, 36)
 kij_corner = []
 for ratio in ratios:
     h2 = h1 * float(ratio)
-    res = junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
+    res = vibration.junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
     kij_corner.append(res.corner_reduction_index)
 
 fig, ax = plt.subplots()
@@ -52469,10 +52292,10 @@ the top: its corner path gives $K_{12} = 9.8\ \text{dB}$. Handing that to
 junction's three flanking paths and their effect on the apparent rating:
 
 ```python
-from phonometry import building, junction_transmission
+from phonometry import building, vibration
 
 # The 100 mm / 200 mm concrete X-junction of the opening figure:
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 k12 = res.corner_reduction_index                     # 9.8 dB (corner path)
 
 # Feed it to the EN 12354-1 simplified model as this junction's Kij:
@@ -52551,15 +52374,7 @@ model to be trustworthy.*
 import math
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coupling_loss_factor,
-    cylindrical_shell_modal_density,
-    flat_plate_modal_density,
-    plate_bending_stiffness,
-    point_connection_coupling_loss_factor,
-    power_injection_clf,
-    right_angle_transmission_coefficient,
-)
+from phonometry import vibration
 from phonometry.vibration.structural.point_mobility import plate_bending_wave_speed
 
 rho, nu, young = 2700.0, 0.33, 7.1e10                 # aluminium
@@ -52569,13 +52384,13 @@ bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0])
 # Predicted: a 3 mm x 2.5 m x 1.2 m plate meeting a 5.5 mm x 2.0 m x 1.2 m
 # plate at right angles along the 1.2 m edge, welded and then bolted.
 h1, h2, area1, length = 0.003, 0.0055, 2.5 * 1.2, 1.2
-tau = right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
-                                           wave_speed1=cl, wave_speed2=cl)
-cb = plate_bending_wave_speed(bands, plate_bending_stiffness(young, h1, nu),
+tau = vibration.right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
+                                                     wave_speed1=cl, wave_speed2=cl)
+cb = plate_bending_wave_speed(bands, vibration.plate_bending_stiffness(young, h1, nu),
                               rho * h1)
-welded = [float(coupling_loss_factor(tau, 2.0 * c, length, f, area1))
+welded = [float(vibration.coupling_loss_factor(tau, 2.0 * c, length, f, area1))
           for c, f in zip(cb, bands, strict=True)]
-bolted = point_connection_coupling_loss_factor(
+bolted = vibration.point_connection_coupling_loss_factor(
     bands, 12, thickness1=h1, thickness2=h2, surface_density1=rho * h1,
     surface_density2=rho * h2, wave_speed1=cl, wave_speed2=cl,
     plate_area1=area1)
@@ -52585,11 +52400,11 @@ bolted = point_connection_coupling_loss_factor(
 t_p, t_c, radius = 0.005, 0.003, 0.75
 area_c = 2.0 * math.pi * radius * 2.0
 area_p = 3.5 * 3.0 - math.pi * radius**2
-sea = power_injection_clf(
+sea = vibration.power_injection_clf(
     500.0, rho * t_p * area_p * 0.0272**2, rho * t_c * area_c * 0.0132**2,
     4.4e-3, 2.4e-3,
-    flat_plate_modal_density(area_p, t_p, cl),
-    float(cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
+    vibration.flat_plate_modal_density(area_p, t_p, cl),
+    float(vibration.cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
 
 print(f"{float(sea.coupling_loss_factor12[0]):.2e}")   # 4.26e-04
 print(f"{float(sea.coupling_loss_factor21[0]):.2e}")   # 3.91e-04
@@ -53289,13 +53104,13 @@ $L_k(f)$ spectrum, so it needs both the report and plot extras
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, TransferStiffnessResult, transfer_stiffness_direct
+from phonometry import ReportMetadata, vibration
 
 freqs = np.array([20, 31.5, 50, 80, 125, 200, 315, 500, 800, 1250, 2000], dtype=float)
 k21 = 1e6 + 1j * (2 * np.pi * freqs) * 80.0     # Kelvin-Voigt element k + jwc
 u1 = 1e-6 + 0j
-k = transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
-res = TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
+k = vibration.transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
+res = vibration.TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
 res.report(
     "transfer_stiffness.pdf",
     metadata=ReportMetadata(

--- a/site/public/llms/llms-aircraft.txt
+++ b/site/public/llms/llms-aircraft.txt
@@ -270,10 +270,10 @@ EPNL result and is not an official State noise certificate; it does not
 reproduce any TCDSN.
 
 ```python
-from phonometry import effective_perceived_noise_level, ReportMetadata
+from phonometry import ReportMetadata, aircraft
 
 # spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
-res = effective_perceived_noise_level(spectra, dt=0.5)
+res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 res.report(
     "epnl_fiche.pdf",
     metadata=ReportMetadata(
@@ -757,9 +757,9 @@ table yourself.
 Point it at a directory to read any other ANP CSV export instead.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 print(len(db.aircraft_ids))          # 155 aircraft types
 ac = db.aircraft("747100")
 print(ac.description)                # Boeing 747-100 / JT9DBD
@@ -790,9 +790,9 @@ tabulated nodes the Doc 29 interpolation is logarithmic in distance and linear
 in power.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-curves = load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
+curves = aircraft.load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
 print(curves.powers)                       # [10000. 14000. 19000. 23000.] lb
 print(curves.level(19000.0, [304.8, 1000.0, 3000.0]))
 ```
@@ -814,9 +814,9 @@ the level, while distance sets the shape.
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 curves = ac.npd_curves("D", "SEL")
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -853,9 +853,9 @@ only for arrivals. Asking for one that does not exist raises a `KeyError` naming
 the stage lengths that do, which is how to discover them:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for identifier, operation, stage in (("A320-232", "D", 1), ("747100", "D", 9)):
     try:
         db.profile(identifier, operation, stage)
@@ -870,9 +870,9 @@ substitute trajectory. NPD curves, on the other hand, are tabulated for every
 aircraft in the database.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-profile = load_anp_database().aircraft("747100").profile("D", stage_length=1)
+profile = aircraft.load_anp_database().aircraft("747100").profile("D", stage_length=1)
 print(profile.profile_id, profile.stage_length, profile.path.shape)
 profile.plot()
 ```
@@ -890,9 +890,9 @@ after them fixes the slant distance at every receiver, so it decides the contour
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -915,9 +915,9 @@ over a ground grid, each wiring the NPD curves and the default profile into the
 functions the airport-noise page builds by hand.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 flyover = ac.event_level([3000.0, 500.0, 0.0], "D")
 print(round(float(flyover.level), 1))     # 100.4 dB
 ```
@@ -937,9 +937,9 @@ weather correction.
 
 ```python
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-contour = load_anp_database().aircraft("747100").noise_contour(
+contour = aircraft.load_anp_database().aircraft("747100").noise_contour(
     "D",
     x=np.linspace(-2000.0, 12000.0, 40),
     y=np.linspace(-3000.0, 3000.0, 30),
@@ -1409,11 +1409,11 @@ the CNOSSOS-EU scheme the guidance adopts). The ground effect is not
 evaluated separately in that regime.
 
 ```python
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = [63.0, 250.0, 1000.0, 4000.0]
-diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
-diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
+aircraft.diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
+aircraft.diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```
 
 <picture>
@@ -1427,11 +1427,11 @@ diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = np.array([63.0, 250.0, 1000.0, 4000.0])
 delta = np.linspace(-0.4, 1.5, 441)
-ld = np.array([diffraction_attenuation(bands, float(d), edge_height=2.5)
+ld = np.array([aircraft.diffraction_attenuation(bands, float(d), edge_height=2.5)
               for d in delta])
 
 fig, ax = plt.subplots(figsize=(9, 6))

--- a/site/public/llms/llms-buildings-design.txt
+++ b/site/public/llms/llms-buildings-design.txt
@@ -674,35 +674,31 @@ model. Eight defects of those printed tables are recorded in
 
 ```python
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 
 # Annex E junctions (unrounded): floor-to-external-wall rigid T, external wall
 # in-line across it, floor-to-internal-wall rigid cross, internal wall in-line.
-k_floor_ext = junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
-k_ext_ext = junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
-k_floor_int = junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
-k_int_int = junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_ext_ext = building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
+k_int_int = building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
 print(round(k_floor_ext, 1), round(k_ext_ext, 1))     # 6.4 11.2  (Table L.5)
 print(round(k_floor_int, 1), round(k_int_int, 1))     # 8.8 11.0  (Table L.6)
 
 # The floor's perimeter: it butts into an external wall above and below at each
 # of its two external edges, and crosses the internal walls at the other two.
-a_at_ext = perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
-a_at_int = perimeter_absorption_coefficient(
-    [76.8, 128.4, 128.4], [junction_vibration_reduction(
+a_at_ext = building.perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
+a_at_int = building.perimeter_absorption_coefficient(
+    [76.8, 128.4, 128.4], [building.junction_vibration_reduction(
         "rigid_cross", "through", 360.0 / 484.0), k_floor_int, k_floor_int])
 floor_perimeter = 9.0 * (a_at_ext + a_at_int)         # 2.659 m (Formula C.4)
 
-floor = HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
-                           floor_perimeter, 2200.0, 3800.0)
-el = in_situ_element(floor, bands)
+floor = building.HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
+                                    floor_perimeter, 2200.0, 3800.0)
+el = building.in_situ_element(floor, bands)
 print(np.round(el.total_loss_factor[[0, 10]], 4))     # [0.0831 0.029 ]  Table L.3
 print(np.round(el.sound_reduction_index[[0, 10]], 1)) # [31.8 54.9]      Table L.3
 print(np.round(el.impact_level[[0, 10]], 1))          # [57.3 63.6]      Table G.3
@@ -715,13 +711,13 @@ Every printed column of Tables L.2, L.3, L.4, G.3 and G.4 comes back within
 ```python
 # The floating floor: 35 mm screed, m' = 73,5 kg/m2 on s' = 8 MN/m3.
 f0 = 160.0 * np.sqrt(8.0 / 73.5)                      # 52.8 Hz (Formula C.2)
-delta = floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
+delta = building.floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
 
-wall = in_situ_element(HomogeneousElement(
+wall = building.in_situ_element(building.HomogeneousElement(
     "ext1", 11.0, 4.0, 2.75, 219.0, 92.6, 0.0125, 2.375, 600.0, 1900.0), bands)
 
 # Path D1 (Df: separating floor -> external wall 1), Table L.4.
-d1 = airborne_flanking_path(
+d1 = building.airborne_flanking_path(
     label="D1", kind="Df", element_i=el, element_j=wall,
     vibration_reduction_index=k_floor_ext, coupling_length=4.0,
     separating_area=20.0, delta_r_i=delta)
@@ -734,9 +730,9 @@ index per band, its energy split and the ISO 717-1 rating in one call:
 ```python
 # `paths` holds the twelve flanking paths of the four elements, built the
 # way `d1` was above; the code block under the figure builds all of them.
-res = detailed_airborne_prediction(
-    bands, direct_index=direct_reduction_index(el.sound_reduction_index,
-                                               delta_r_source=delta),
+res = building.detailed_airborne_prediction(
+    bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
+                                                        delta_r_source=delta),
     flanking_paths=paths)
 print(np.round(res.r_prime[[0, 10]], 1))   # [28.8 55.9]   Table L.1 total
 print(res.rating.rating, res.dominant[0])  # 57 'Dd'
@@ -758,26 +754,22 @@ the result there. The single number $R'_\mathrm{w} = 57$ dB says none of that.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 k = {
-    "floor-ext": junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
-    "ext-ext": junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
-    "floor-floor": junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
-    "floor-int": junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
-    "int-int": junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
-    "int-ext": junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
-    "extT-ext": junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
-    "corner": junction_vibration_reduction("corner", "corner", 1.0),
-    "int-int-x": junction_vibration_reduction("rigid_cross", "through", 1.0),
+    "floor-ext": building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
+    "ext-ext": building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
+    "floor-floor": building.junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
+    "floor-int": building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
+    "int-int": building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
+    "int-ext": building.junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
+    "extT-ext": building.junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
+    "corner": building.junction_vibration_reduction("corner", "corner", 1.0),
+    "int-int-x": building.junction_vibration_reduction("rigid_cross", "through", 1.0),
 }
-a = perimeter_absorption_coefficient
+a = building.perimeter_absorption_coefficient
 floor_sum = 9.0 * (a([92.6, 92.6], [k["floor-ext"]] * 2)
                    + a([76.8, 128.4, 128.4],
                        [k["floor-floor"], k["floor-int"], k["floor-int"]]))
@@ -797,10 +789,10 @@ specs = {
     "int2": (13.75, 5.0, 2.75, 360.0, 128.4, 0.01,
              10.0 * int_top + 2.75 * int_side, 1800.0, 2500.0),
 }
-situ = {name: in_situ_element(HomogeneousElement(name, *spec), bands)
+situ = {name: building.in_situ_element(building.HomogeneousElement(name, *spec), bands)
         for name, spec in specs.items()}
-delta = floating_floor_improvement(bands,
-                                   resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
+delta = building.floating_floor_improvement(bands,
+                                            resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
 
 paths = []
 for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
@@ -809,21 +801,21 @@ for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
     cross = k["floor-ext"] if name.startswith("ext") else k["floor-int"]
     through = k["ext-ext"] if name.startswith("ext") else k["int-int"]
     paths += [
-        airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
-                               element_j=wall, vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0,
-                               delta_r_i=delta),
-        airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
-                               element_j=situ["floor"], vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0),
-        airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
-                               element_j=wall, vibration_reduction_index=through,
-                               coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=wall, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
+                                        element_j=wall, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
     ]
-res = detailed_airborne_prediction(
+res = building.detailed_airborne_prediction(
     bands,
-    direct_index=direct_reduction_index(situ["floor"].sound_reduction_index,
-                                        delta_r_source=delta),
+    direct_index=building.direct_reduction_index(situ["floor"].sound_reduction_index,
+                                                 delta_r_source=delta),
     flanking_paths=paths)
 
 # One line — the per-band path contributions with R' overlaid:
@@ -836,19 +828,18 @@ plt.show()
 The impact side of the same building runs on the same `situ` dictionary:
 
 ```python
-from phonometry import (detailed_impact_prediction, direct_impact_level,
-                        impact_flanking_path)
+from phonometry import building
 
-direct = direct_impact_level(situ["floor"].impact_level, delta_l=delta)
+direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
-    impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
-                         vibration_reduction_index=(
+    building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
+                                  vibration_reduction_index=(
                              k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
-                         coupling_length=lij, delta_l=delta)
+                                  coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
 ]
-imp = detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
+imp = building.detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
 print(np.round(imp.l_prime_n[[3, 10]], 1))     # [54.  35.9]   Table G.1 total
 print(imp.rating.rating, imp.rating.ci)        # 41 2           printed 41,0 (2)
 ```
@@ -878,25 +869,22 @@ $\overline{D}_{v,ij,\mathrm{n}}$ and Part 2 Formula (13) from a measured normali
 flanking impact level $L_\mathrm{n,f}$.
 
 ```python
-from phonometry import (flanking_impact_level_from_flanking_level,
-                        flanking_reduction_index_from_flanking_level,
-                        flanking_reduction_index_from_normalized_difference,
-                        resonant_sound_reduction_index)
+from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
-r_star = resonant_sound_reduction_index(r_wall_leaf, bands,
-                                        critical_frequency=2200.0)   # +8 dB below fc
-r_ff = flanking_reduction_index_from_normalized_difference(
+r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
+                                                 critical_frequency=2200.0)   # +8 dB below fc
+r_ff = building.flanking_reduction_index_from_normalized_difference(
     index_i=r_star, index_j=r_star, normalized_velocity_level_difference=dv_n,
     separating_area=20.0, coupling_length=4.0)                        # Table L.11
 
 # ISO 12354-1 L.2.2: a measured junction between two timber frame walls.
-r13 = flanking_reduction_index_from_flanking_level(
+r13 = building.flanking_reduction_index_from_flanking_level(
     dnf_13, separating_area=10.44, coupling_length=2.41,
     laboratory_coupling_length=2.5)                                   # Table L.15
 
 # ISO 12354-2 Formula (13): the impact twin, from a measured Ln,f.
-ln_13 = flanking_impact_level_from_flanking_level(
+ln_13 = building.flanking_impact_level_from_flanking_level(
     lnf_13, area=20.0, laboratory_area=10.0,
     coupling_length=4.0, laboratory_coupling_length=4.5)
 ```
@@ -1065,21 +1053,18 @@ plasterboard leaf puts $f_\mathrm{c}$ near 2.6 kHz and rates $R_\mathrm{w} = 27$
 
 ```python
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006                                 # 15 kg/m2
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
-fc = coincidence_frequency(mass, bp)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
+fc = vibration.coincidence_frequency(mass, bp)
 print(round(fc))                                      # 2107 Hz (Hopkins declares ~2079)
 
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 print(round(res.rating().rating))                     # 32  ->  Rw = 32 dB (catalogue 6 mm glass)
 
 res.plot()   # predicted R(f) with the critical frequency marked (needs matplotlib)
@@ -1101,19 +1086,16 @@ $R_\mathrm{w} = 32$ dB of 6 mm glass.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(mass, bp)
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(mass, bp)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 w = res.rating()
 
 # One line each — the predicted R(f), or the rated curve vs the reference:
@@ -1200,18 +1182,18 @@ what it claims to be: an estimate, not the dip.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import plateau_transmission_loss, single_panel_transmission_loss
+from phonometry import building
 
 # 6 mm float glass: Norton Table 3.1 gives 2.47 kg/m2 per mm, a 27 dB
 # coincidence plateau and B/A = 10; its critical frequency is 2033 Hz.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000], dtype=float)
-quick = plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
-                                  field_correction=5.5)
-physical = single_panel_transmission_loss(bands, 2.47 * 6.0,
-                                          critical_frequency=2033.0,
-                                          loss_factor=0.02)
+quick = building.plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
+                                           field_correction=5.5)
+physical = building.single_panel_transmission_loss(bands, 2.47 * 6.0,
+                                                   critical_frequency=2033.0,
+                                                   loss_factor=0.02)
 
 print(round(quick.plateau_start), round(quick.plateau_end))   # 374 3742
 print(quick.plateau_height)                                   # 27.0
@@ -1230,11 +1212,11 @@ problem 3.11 exactly, band for band, in the two regions the construction fixes
 analytically.
 
 ```python
-from phonometry import plateau_transmission_loss
+from phonometry import building
 
 octaves = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
-res = plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
-                                air_density=1.21)
+res = building.plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
+                                         air_density=1.21)
 print(res.transmission_loss.round(1))
 # [35.8 37.  37.  43.3 53.3 63.3 73.3]
 ```
@@ -1314,20 +1296,16 @@ supported orthotropic plate (Vigran Eq. 3.113 = Bies Eq. 7.27, after Hearmon
 valid above roughly $1.5f_{1,1}$.
 
 ```python
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_plate_resonance, plate_bending_stiffness,
-)
+from phonometry import building, vibration
 
 # Vigran's worked example: a 1 m x 1 m steel sheet 1 mm thick, E = 210 GPa,
 # nu = 0.3, m'' = 7.8 kg/m2, corrugated into a sinusoid 20 mm deep
 # (amplitude H = 10 mm) at a 100 mm pitch.
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, b_xz = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, b_xz = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
 print(round(flat_b, 1), round(b_x, 1), round(b_z))     # 19.2 17.5 2202
 print(round(mass, 2))                                  # 8.52 kg/m2 (+9 %)
 
@@ -1337,14 +1315,14 @@ flat = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": 7.8,
 corr = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": mass,
         "bending_stiffness_x": b_x, "bending_stiffness_z": b_z,
         "bending_stiffness_xz": b_xz}
-print(round(orthotropic_plate_resonance(1, 1, **flat), 1),
-      round(orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
-print(round(orthotropic_plate_resonance(1, 1, **corr), 1),
-      round(orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
+print(round(building.orthotropic_plate_resonance(1, 1, **flat), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
+print(round(building.orthotropic_plate_resonance(1, 1, **corr), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
 
 # The same sheet, flat and corrugated, in the coincidence picture:
-print(round(coincidence_frequency(7.8, flat_b)))               # 11925 Hz
-print([round(f) for f in orthotropic_critical_frequencies(mass, b_x, b_z)])
+print(round(vibration.coincidence_frequency(7.8, flat_b)))               # 11925 Hz
+print([round(f) for f in building.orthotropic_critical_frequencies(mass, b_x, b_z)])
 # [1165, 13064]
 ```
 
@@ -1368,33 +1346,28 @@ the corrugated sheet gives away up to 13 dB, and $R_\mathrm{w}$ falls from 28 dB
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_transmission_loss, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000, 12500, 16000], dtype=float)
 eta = 0.011
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, _ = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, _ = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
-fc1, fc2 = orthotropic_critical_frequencies(mass, b_x, b_z)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
+fc1, fc2 = building.orthotropic_critical_frequencies(mass, b_x, b_z)
 
-flat = single_panel_transmission_loss(
-    bands, 7.8, critical_frequency=coincidence_frequency(7.8, flat_b),
+flat = building.single_panel_transmission_loss(
+    bands, 7.8, critical_frequency=vibration.coincidence_frequency(7.8, flat_b),
     loss_factor=eta,
 )
-corrugated = orthotropic_transmission_loss(
+corrugated = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     loss_factor=eta,
 )
-heckl = orthotropic_transmission_loss(
+heckl = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     method="heckl",
 )
@@ -1439,21 +1412,21 @@ add, boosted by the cavity, until $f_\mathrm{l} = c_0/(2\pi d)$ where the boost 
 at 6 dB (Eq. 7.64). A porous fill lowers $f_0$.
 
 ```python
-from phonometry import double_wall_transmission_loss, mass_spring_mass_resonance
-from phonometry import mass_law_transmission_loss, miki
+from phonometry import building
+from phonometry import materials
 
 # Two 12 kg/m2 leaves, 75 mm air gap.
-f0 = mass_spring_mass_resonance(12.0, 12.0, 0.075)
+f0 = building.mass_spring_mass_resonance(12.0, 12.0, 0.075)
 print(round(f0))                                          # 89 Hz
 
 # Below f0 the double wall equals the mass law of the total mass 24 kg/m2:
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
 print(round(float(dw.transmission_loss[0]), 1),
-      round(float(mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
+      round(float(building.mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
 
 # A mineral-wool fill (a materials porous model) lowers the resonance:
-fill = miki([f0], 7000.0)
-print(round(mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
+fill = materials.miki([f0], 7000.0)
+print(round(building.mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
 
 dw.plot()   # double-wall R(f) with the mass-spring-mass resonance marked (needs matplotlib)
 ```
@@ -1475,11 +1448,11 @@ double-wall curve sits.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import mass_spring_mass_resonance, plot_double_wall_geometry
+from phonometry import building
 
 # Two 8.8 kg/m2 plasterboard leaves on a 100 mm cavity.
-f0 = mass_spring_mass_resonance(8.8, 8.8, 0.1)
-plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
+f0 = building.mass_spring_mass_resonance(8.8, 8.8, 0.1)
+building.plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
 plt.show()
 
 # A double-wall prediction retains its geometry and redraws it:
@@ -1528,25 +1501,20 @@ Hall & Hopkins (2001).
 | Vertical-twist tie (proprietary) | 100 | 43.4 |
 
 ```python
-from phonometry import (
-    double_wall_transmission_loss,
-    mass_spring_mass_resonance,
-    wall_tie_stiffness,
-    wall_tie_stiffness_per_area,
-)
+from phonometry import building
 
-print(wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
+print(building.wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
 
 # Hopkins Fig. 4.35: two 140 kg/m2 leaves across an empty 75 mm cavity.
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
 
 # Add 2.5 ties per m2 of s_75mm = 2 MN/m: the resonance nearly doubles.
-ties = wall_tie_stiffness_per_area(2.5, 2.0e6)
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075,
-                                       tie_stiffness_per_area=ties)))  # 50 Hz
+ties = building.wall_tie_stiffness_per_area(2.5, 2.0e6)
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075,
+                                                tie_stiffness_per_area=ties)))  # 50 Hz
 
-dw = double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
-                                   tie_stiffness_per_area=ties)
+dw = building.double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
+                                            tie_stiffness_per_area=ties)
 ```
 
 **The tie as a point connection (Hopkins Eqs. 4.84 to 4.88).** Each tie
@@ -1572,11 +1540,11 @@ differently.
 
 ```python
 import numpy as np
-from phonometry import plate_bending_stiffness, wall_tie_coupling_loss_factor
+from phonometry import building, vibration
 
 freq = np.logspace(np.log10(50.0), np.log10(5000.0), 60)
-b1 = plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
-res = wall_tie_coupling_loss_factor(
+b1 = vibration.plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
+res = building.wall_tie_coupling_loss_factor(
     freq, 150.0, 170.0, b1, b1, ties_per_area=2.5, tie="butterfly"
 )
 print(res.coupling_loss_factor[0], res.rigid_coupling_loss_factor[0])
@@ -1611,17 +1579,14 @@ so a bare opening of relative area $S_\mathrm{a}/S$ caps the composite at $10\lo
 a 1 % opening can never do better than 20 dB, whatever the wall.
 
 ```python
-from phonometry import (
-    composite_transmission_loss, slit_transmission_coefficient,
-    slit_resonance_frequencies,
-)
+from phonometry import building
 
 # A 2 mm x 100 mm-deep slit: transmission peaks at the depth's half-wavelength
 # resonances.
-print(slit_resonance_frequencies(0.1, 0.002, orders=2).round().tolist())   # [~1500, ~3100]
+print(building.slit_resonance_frequencies(0.1, 0.002, orders=2).round().tolist())   # [~1500, ~3100]
 
 # A wall of Rw = 50 dB with 1 % of its area open as a slit is capped:
-print(round(float(composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
+print(round(float(building.composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
 ```
 
 The leak that undoes a heavy wall is almost invisible, and `.plot_geometry()`
@@ -1640,10 +1605,10 @@ resonances near 1.5 and 3.1 kHz rather than as a simple open area.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import slit_transmission_coefficient
+from phonometry import building
 
 f = np.geomspace(100.0, 5000.0, 200)
-result = slit_transmission_coefficient(f, 0.002, 0.1)
+result = building.slit_transmission_coefficient(f, 0.002, 0.1)
 
 # One line: the wall section with the slit to scale.
 result.plot_geometry()
@@ -1679,16 +1644,16 @@ radiates weakly; above it $\sigma \to 1$ (Leppington/Maidanik, Eqs 2.227-2.230):
 $\sigma = (1 - f_\mathrm{c}/f)^{-1/2}$ for $f > f_\mathrm{c}$.
 
 ```python
-from phonometry import radiation_efficiency, sound_power_from_vibration
+from phonometry import emission, vibration
 
 # The 6 mm glass pane (1.5 x 1.25 m) of the single-panel example above.
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 print(sig.radiation_efficiency[bands == 2000].round(2))    # ~2.5 (peak at coincidence)
 
 # Feed the prediction straight into ISO 7849 as the radiation factor:
-lw = sound_power_from_vibration(velocity_level=80.0, area=1.875,
-                                radiation_factor=sig.radiation_efficiency,
-                                frequencies=bands)
+lw = emission.sound_power_from_vibration(velocity_level=80.0, area=1.875,
+                                         radiation_factor=sig.radiation_efficiency,
+                                         frequencies=bands)
 
 sig.plot()   # sigma(f) with the coincidence peak (needs matplotlib)
 ```
@@ -1704,11 +1669,11 @@ $\omega^{-1/2}$). They supply the receiver mobility EN 12354-5 needs when no
 measurement exists.
 
 ```python
-from phonometry import infinite_plate_impedance, infinite_beam_mobility, injected_power
+from phonometry import vibration
 
-z_plate = infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
+z_plate = vibration.infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
 print(round(z_plate))                                 # real, frequency independent
-w = injected_power(force=10.0, mobility=1.0 / z_plate)
+w = vibration.injected_power(force=10.0, mobility=1.0 / z_plate)
 print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' m''))
 ```
 
@@ -1718,37 +1683,32 @@ print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' 
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (
-    coincidence_frequency, composite_transmission_loss,
-    double_wall_transmission_loss, mass_law_transmission_loss,
-    mass_spring_mass_resonance, plate_bending_stiffness,
-    radiation_efficiency, single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000], dtype=float)
 fig, ax = plt.subplots(2, 2, figsize=(12, 9))
 
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(15.0, bp)
-ml = mass_law_transmission_loss(bands, 15.0, incidence="field")
-sp = single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(15.0, bp)
+ml = building.mass_law_transmission_loss(bands, 15.0, incidence="field")
+sp = building.single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
 ax[0, 0].semilogx(bands, ml, "--", label="field-incidence mass law")
 ax[0, 0].semilogx(bands, sp.transmission_loss, "-o", ms=3, label="single panel R (Sharp)")
 ax[0, 0].axvline(fc, ls=":", color="r"); ax[0, 0].set_title("Single panel")
 
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
-ax[0, 1].semilogx(bands, mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+ax[0, 1].semilogx(bands, building.mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
 ax[0, 1].semilogx(bands, dw.transmission_loss, "-o", ms=3, label="double wall")
-ax[0, 1].axvline(mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
+ax[0, 1].axvline(building.mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
 ax[0, 1].set_title("Double wall")
 
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 ax[1, 0].loglog(bands, sig.radiation_efficiency, "-o", ms=3, label=r"$\sigma(f)$")
 ax[1, 0].axhline(1.0, ls=":"); ax[1, 0].set_title("Radiation efficiency")
 
 wall = sp.transmission_loss
-comp = [float(composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
+comp = [float(building.composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
 ax[1, 1].semilogx(bands, wall, "-o", ms=3, label="solid wall")
 ax[1, 1].semilogx(bands, comp, "-s", ms=3, label="wall + 1 % slit")
 ax[1, 1].axhline(20.0, ls=":"); ax[1, 1].set_title("Composite with aperture")
@@ -2213,21 +2173,18 @@ the floor, caps the injected power.
 
 ```python
 import numpy as np
-from phonometry import (
-    hammer_impact_velocity, infinite_plate_impedance, plate_bending_stiffness,
-    plate_contact_stiffness, tapping_force_spectrum,
-)
+from phonometry import building, vibration
 
-print(round(hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
+print(round(building.hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
 
 # A 140 mm cast in-situ concrete slab: 2200 kg/m3, cL = 3800 m/s, nu = 0.2.
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-k = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+k = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 freqs = np.array([100, 200, 400, 800, 1600, 3150], dtype=float)
-res = tapping_force_spectrum(freqs, k, z)
+res = building.tapping_force_spectrum(freqs, k, z)
 res.over_critical            # False: the hammer rebounds off concrete
 round(res.cut_off_frequency)  # 6948 Hz, above the building acoustics range
 res.peak_force               # |Fn| per band, within 1 dB of res.upper_limit
@@ -2271,23 +2228,20 @@ carries the nulls where they belong.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    covering_contact_stiffness, covering_improvement, infinite_plate_impedance,
-    plate_bending_stiffness, plate_contact_stiffness,
-)
+from phonometry import building, vibration
 
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14          # 140 mm concrete slab
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-plate = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+plate = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0])
 
 d = 0.005
 for label, modulus_over_thickness in (("PVC", 1.5e11), ("backed vinyl", 2.8e8)):
-    res = covering_improvement(
-        bands, covering_contact_stiffness(modulus_over_thickness * d, d),
+    res = building.covering_improvement(
+        bands, building.covering_contact_stiffness(modulus_over_thickness * d, d),
         plate, z)
     plt.semilogx(bands, res.improvement, marker="o",
                  label=f"{label}: fco = {res.cut_off_frequency:.0f} Hz")
@@ -2299,13 +2253,13 @@ plt.show()
 </details>
 
 ```python
-from phonometry import covering_contact_stiffness, covering_improvement
+from phonometry import building
 
 # Covering No. 2 of Hopkins Fig. 4.64: E/d = 2.8e8 N/m3, a vinyl or carpet
 # with a resilient backing, 5 mm thick on the same 140 mm slab.
 d = 0.005
-covering = covering_contact_stiffness(2.8e8 * d, d)
-res = covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
+covering = building.covering_contact_stiffness(2.8e8 * d, d)
+res = building.covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
 round(res.cut_off_frequency)        # 100 Hz
 round(res.bare_cut_off_frequency)   # 6948 Hz, the bare slab's own cut-off
 res.improvement                     # 3.2, 17.0, 33.3, 43.0 dB, band values
@@ -2348,16 +2302,14 @@ applies is a question about damping, not about the layer:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-)
+from phonometry import building
 
 # The worked floating floor of ISO 12354-2:2017 Annex G.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
 freqs = np.logspace(np.log10(40.0), np.log10(5000.0), 400)
 for model, kwargs in (("en12354", {}), ("cremer", {}),
                       ("cremer_hammer", {"limiting_frequency": 521.0})):
-    res = floating_floor_improvement_spectrum(
+    res = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=f0, model=model, **kwargs)
     plt.semilogx(freqs, res.improvement, label=model)
 plt.axvline(f0, ls=":")
@@ -2368,19 +2320,15 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    combined_dynamic_stiffness, double_floating_floor_resonances,
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-    weighted_floating_floor_improvement,
-)
+from phonometry import building
 
 # 35 mm screed, m' = 73.5 kg/m2, on a resilient layer of s' = 8 MN/m3.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)
 round(f0, 1)                                                    # 52.8 Hz
 
 bands = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
          800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0]
-res = floating_floor_improvement_spectrum(
+res = building.floating_floor_improvement_spectrum(
     bands, resonance_frequency=f0, mass_per_area=73.5, dynamic_stiffness=8.0e6)
 res.improvement          # 0.0, 2.3, 5.4, 8.3, 11.2 ... 59.3 dB
 round(res.delta_lw, 1)   # 32.2 dB, the Formula (C.4) weighted improvement
@@ -2388,12 +2336,12 @@ res.plot()
 
 # Two resilient layers act as springs in series (Formula C.6), which drops the
 # resonance by sqrt(2) and buys about 4.5 dB everywhere above it.
-round(floating_floor_resonance_frequency(
-    combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
+round(building.floating_floor_resonance_frequency(
+    building.combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
 
 # One floating floor on top of another has two resonances instead of one; the
 # adverse dip disappears, but the steep rise only starts above the higher.
-double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
+building.double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
 ```
 
 The weighted single numbers come straight from the same two inputs, so a
@@ -2411,10 +2359,10 @@ Vér's two-subsystem SEA model turns into a 30 dB per decade rise rather than
 it.
 
 ```python
-from phonometry import resilient_mount_improvement
+from phonometry import building
 
 # 50 mm concrete walking surface on 4 mounts per m2 of 2 MN/m stiffness.
-resilient_mount_improvement(
+building.resilient_mount_improvement(
     [125.0, 250.0, 500.0, 1000.0], impedance=3.8e5, mass_per_area=115.0,
     loss_factor=0.02, mount_stiffness=2.0e6, mount_density=4.0)
 ```
@@ -2448,30 +2396,27 @@ to gain. From 200 Hz upwards it costs: 1 dB at 200 Hz falling to 10 dB from
 the range of interest is therefore the entire design brief.
 
 ```python
-from phonometry import (
-    lining_improvement, lining_improvement_in_situ, lining_resonance_frequency,
-    weighted_lining_improvement,
-)
+from phonometry import building
 
 # A 9.5 mm plasterboard laminated with 32 mm EPS (s' = 65 MN/m3), bonded with
 # adhesive dabs to a 100 mm aircrete block wall of 51 kg/m2.
-f0 = lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
+f0 = building.lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
 round(f0)                                       # 542 Hz: squarely in the way
-round(weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
+round(building.weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
 
 # The same lining on studs over a 100 mm mineral-wool-filled cavity.
-f0 = lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
+f0 = building.lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
 round(f0, 1)                                     # 70.8 Hz
-round(weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
+round(building.weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
 
 # External thermal insulation systems have their own Annex D fits.
-res = lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
+res = building.lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
 res.delta_rw, res.delta_ra, res.delta_ratr               # (10.5, 8.0, 9.7) dB
-lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
+building.lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
 res.plot()   # the Annex D ratings against fo, with this system marked
 
 # A laboratory rating transfers to the field through Formula (D.8).
-round(lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
+round(building.lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
 ```
 
 ## What is anchored on a published number, and what is not
@@ -2804,11 +2749,11 @@ plus matplotlib for the spectrum.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, reception_plate_power
+from phonometry import ReportMetadata, building
 
 freqs = np.array([125, 250, 500, 1000, 2000, 4000], float)
 lv = np.array([88.0, 90, 86, 82, 78, 73])   # spatial mean plate velocity level [dB]
-res = reception_plate_power(
+res = building.reception_plate_power(
     lv, freqs, mass_per_area=25.0, area=1.2, reverberation_time=0.3,
 )
 res.report(
@@ -3097,7 +3042,7 @@ optional `phonometry[report]` extra (reportlab), plus matplotlib for the plot.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, installed_source_prediction
+from phonometry import ReportMetadata, building
 
 bands = np.array([63, 125, 250, 500, 1000, 2000], float)
 lwc = np.array([84.4, 82.5, 69.9, 67.6, 61.6, 49.9])   # characteristic power [dB]
@@ -3110,7 +3055,7 @@ paths = [
      "flanking_reduction_index": np.array([37.0, 41.2, 35.9, 37.7, 49, 57.8]),
      "element_area": 12.8},
 ]
-res = installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
+res = building.installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
 res.report(
     "installed_structure_borne.pdf",
     metadata=ReportMetadata(

--- a/site/public/llms/llms-buildings-insulation-ratings.txt
+++ b/site/public/llms/llms-buildings-insulation-ratings.txt
@@ -1195,7 +1195,7 @@ $C_{\mathrm{tr},100-5000}$ are both $-5$, so the $D_{2\mathrm{m,nT,Atr}}$ that D
 requires happens not to discriminate between the two readings at all.
 
 ```python
-from phonometry import building, weighted_rating_extended
+from phonometry import building
 
 d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
           38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5, 39.4, 41.5]
@@ -1203,7 +1203,7 @@ d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
 direct = building.d2m_nt_atr(d2m_nt)
 direct.intermediate, direct.reported   # 32.8 dBA -> 33 dBA
 
-iso = weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
+iso = building.weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
 iso.rating, iso.ctr_100_5000           # 38 dB, -5 dB -> 33 dBA, the same figure
 iso.c, iso.c_100_5000                  # -2 and -1: core range versus enlarged range
 ```

--- a/site/public/llms/llms-buildings-insulation.txt
+++ b/site/public/llms/llms-buildings-insulation.txt
@@ -1000,29 +1000,26 @@ $R_\mathrm{cl,p} = R_\mathrm{cl} + 10\log_{10}(H_\mathrm{S}/L_\mathrm{S})$ (Eq. 
 ceiling path be added to the direct path as transmission factors.
 
 ```python
-from phonometry import (
-    partition_referenced_reduction_index,
-    plenum_flanking_reduction_index,
-)
+from phonometry import building
 
 freqs = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0]   # 9.5 mm plasterboard
 
 # Vigran's example geometry: LS = LR = 4.75 m, plenum 0.43 m, reflecting walls.
-res = plenum_flanking_reduction_index(
+res = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, frequency=freqs
 )
 print(round(res.geometry_term, 1))    # 10.4 dB charged against RS + RR
 res.plot()                            # Rcl against the two ceilings
 
 # A lined plenum attenuates the sideways path (Eq. (9.18) instead of (9.20)):
-damped = plenum_flanking_reduction_index(
+damped = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43,
     attenuation_source=[0.5] * 7, attenuation_receiving=[0.5] * 7,
 )
 
 # Referred to the partition instead of the ceiling (Eq. (9.13)):
-print(partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
+print(building.partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
 ```
 
 **The measured quantity.** A ceiling is not rated by $R_\mathrm{cl}$ but by the
@@ -1045,25 +1042,21 @@ deficiency exceeds 8 dB (clauses 5.3 and 5.4), and reads the rating off the
 shifted contour at 500 Hz (clause 5.5).
 
 ```python
-from phonometry import (
-    ceiling_attenuation_class,
-    normalized_ceiling_attenuation,
-    weighted_rating,
-)
+from phonometry import building
 
 # ASTM E1414 normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
-dnc = normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
+dnc = building.normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
        41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9]
-res = ceiling_attenuation_class(dnc)
+res = building.ceiling_attenuation_class(dnc)
 print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34, 27.0, 7.0
 res.plot()                                                  # Dn,c vs the contour
 
 # The ISO single number of the same spectrum, shifted to A0 = 10 m2:
 iso = [v - 0.79 for v in dnc]
-print(weighted_rating(iso).rating)                          # Dn,c,w
+print(building.weighted_rating(iso).rating)                          # Dn,c,w
 ```
 
 ## ISO 10848 flanking-transmission reports (`.report()`)
@@ -1765,22 +1758,17 @@ less into the top one, which is why the two sources are not interchangeable and
 why a floor can pass one and fail the other.
 
 ```python
-from phonometry import (
-    check_heavy_impact_source,
-    heavy_impact_source_limits,
-    heavy_impact_source_specification,
-    impact_force_exposure_level,
-)
+from phonometry import building
 
-spec = heavy_impact_source_specification("rubber_ball")
+spec = building.heavy_impact_source_specification("rubber_ball")
 print(spec.drop_height, spec.effective_mass)      # 1.0 m, 2.5 kg
 print(spec.contact_time, spec.contact_time_tolerance)   # 0.02 s +/- 0.002 s
 
-freqs, lower, upper = heavy_impact_source_limits("bang_machine")
+freqs, lower, upper = building.heavy_impact_source_limits("bang_machine")
 print(list(zip(freqs, lower, upper))[0])          # (31.5, 46.0, 48.0)
 
 # A calibration run: five measured octave-band LFE against the printed table.
-check = check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9])
+check = building.check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9])
 print(check.passed, list(check.within_tolerance))
 check.plot()   # measured LFE over the tolerance band (needs matplotlib)
 ```
@@ -1795,7 +1783,7 @@ any single band value and must not be compared with the table above.
 
 ```python
 import numpy as np
-from phonometry import OctaveFilterBank, impact_force_exposure_level
+from phonometry import building, filters
 
 fs = 48_000
 t = np.arange(0.0, 0.020, 1.0 / fs)          # the 20 ms contact time
@@ -1803,12 +1791,12 @@ force = 1500.0 * np.sin(np.pi * t / 0.020)   # a single-peak half-sine pulse
 
 # Broadband, i.e. the whole pulse energy: 10 lg(Fp^2 t / 2) = 43.5 dB.
 # Not a band value, and not comparable with the table above.
-print(round(impact_force_exposure_level(force, fs), 2))
+print(round(building.impact_force_exposure_level(force, fs), 2))
 
 # The five octave-band values the specification is actually written in.
-bank = OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
+bank = filters.OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
 _, freqs, bands = bank.filter(force, sigbands=True, calculate_level=False)
-lfe = [impact_force_exposure_level(b, fs) for b in bands]
+lfe = [building.impact_force_exposure_level(b, fs) for b in bands]
 print([round(v, 1) for v in lfe])   # [-1.4, 14.0, 22.1, 20.2, 17.1]
 
 # Those five go to the conformance check; this synthetic half-sine is not a
@@ -1850,23 +1838,19 @@ its value is $1/e$. When $T = T_0$ the bracket collapses to 1 and the whole
 correction reduces to the volume term, as it must.
 
 ```python
-from phonometry import (
-    fast_reverberation_correction,
-    heavy_impact_octave_levels,
-    standardized_maximum_impact_level,
-)
+from phonometry import building
 
 freqs = [63.0, 125.0, 250.0, 500.0]
 li_fmax = [65.3, 64.5, 58.0, 55.8]           # energy-averaged over ball positions
 t = [1.43, 3.70, 3.10, 2.38]                 # receiving-room reverberation time
 
-res = standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
+res = building.standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
 print(res.volume_term)                        # 10 lg(41.4/50) = -0.8 dB
-print(fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
+print(building.fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
 res.plot()   # measured and standardized spectra (needs matplotlib)
 
 # One-third-octave measurements combine into octaves with Formula (20):
-print(heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
+print(building.heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
 ```
 
 ## The single number is an A-weighted sum, not a shifted curve
@@ -1890,10 +1874,10 @@ The worked example of Table D.4 is reproduced exactly, including the
 deliberately unrounded intermediate the standard prints:
 
 ```python
-from phonometry import a_weighted_maximum_impact_level
+from phonometry import building
 
 # ISO 717-2:2020 Table D.4: a field measurement in octave bands.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 print(list(res.corrected))   # 39.1, 48.3, 49.3, 52.6 dB
 print(res.unrounded)         # 55.350667... dB
 print(res.rating)            # 55 dB

--- a/site/public/llms/llms-buildings-rooms.txt
+++ b/site/public/llms/llms-buildings-rooms.txt
@@ -246,15 +246,14 @@ sequence, visible as the near-constant magnitude on the right.
 
 ```python
 from phonometry import room
-from phonometry import plot_excitation
 
 fs = 48000
 sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)   # ESS excitation
 mls = room.mls_signal(12).astype(float)             # length 2**12 - 1
 
 # One-liner: waveform + spectrogram (sweep), sequence + flat spectrum (MLS)
-plot_excitation(sweep, fs, kind="sweep")
-plot_excitation(mls, fs, kind="mls")
+room.plot_excitation(sweep, fs, kind="sweep")
+room.plot_excitation(mls, fs, kind="mls")
 
 # By hand: the sweep spectrogram and the MLS magnitude spectrum
 import numpy as np
@@ -2425,9 +2424,9 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import reverberation_time_models, ReportMetadata
+from phonometry import ReportMetadata, room
 
-result = reverberation_time_models(
+result = room.reverberation_time_models(
     (8.0, 5.0, 3.0),                       # a shoebox room, one treated wall pair
     ([0.10, 0.15, 0.30, 0.45, 0.55, 0.60], # treated wall pair, per octave band
      [0.08, 0.10, 0.12, 0.15, 0.18, 0.20], # side walls
@@ -2719,10 +2718,7 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import (
-    enclosed_space_reverberation, hard_object_absorption, object_fraction,
-    ReportMetadata,
-)
+from phonometry import ReportMetadata, room
 
 surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (20.0, [0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.55]),  # carpeted floor
@@ -2730,10 +2726,10 @@ surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (45.0, [0.02, 0.02, 0.03, 0.04, 0.05, 0.05, 0.05]),  # painted-plaster walls
 ]
 volumes = [0.5, 0.8, 0.3]                      # furniture, m^3
-result = enclosed_space_reverberation(
+result = room.enclosed_space_reverberation(
     surfaces, 50.0,
-    objects=hard_object_absorption(volumes),
-    object_fraction=object_fraction(volumes, 50.0),
+    objects=room.hard_object_absorption(volumes),
+    object_fraction=room.object_fraction(volumes, 50.0),
     air_condition="20C_50-70",
 )
 result.report(

--- a/site/public/llms/llms-devices-electroacoustics.txt
+++ b/site/public/llms/llms-devices-electroacoustics.txt
@@ -549,10 +549,10 @@ $ka\sin\theta = 3.8317$.
 
 ```python
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.1, frequencies=np.geomspace(20, 20000, 200),
-                       angles=np.linspace(0.0, np.pi / 2, 91))
+res = electroacoustics.radiating_piston(radius=0.1, frequencies=np.geomspace(20, 20000, 200),
+                                        angles=np.linspace(0.0, np.pi / 2, 91))
 print(round(res.radiation_mass, 4))               # 8 rho a^3 / 3, kg
 print(round(float(res.directivity_index[0]), 2))  # 3.01 dB half-space limit
 res.plot()                                         # R1 and X1 vs ka
@@ -573,9 +573,9 @@ reactance dies away.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
 res.plot()   # normalized R1 and X1 against ka
 plt.show()
 ```
@@ -598,9 +598,9 @@ classic polar beam pattern. Several $ka$ are shown as one family, so the main
 lobe narrowing and the side lobes appearing read at a glance:
 
 ```python
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-pattern = piston_directivity_pattern([3.0, 8.0, 16.0])
+pattern = electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0])
 print(pattern.directivity_db.shape)  # (3, 361): one row per ka
 pattern.plot()                       # polar beam pattern in dB (needs matplotlib)
 ```
@@ -612,9 +612,9 @@ pattern.plot()                       # polar beam pattern in dB (needs matplotli
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
+electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
 plt.show()
 ```
 
@@ -638,10 +638,10 @@ first side lobes have appeared.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
-                       angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
+res = electroacoustics.radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
+                                        angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
 
 # One line: the piston in its baffle with the lobe of the highest frequency.
 res.plot_geometry()
@@ -669,25 +669,22 @@ computed from the response rather than merely repeated:
 
 ```python
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, ReportMetadata, loudspeaker_characteristics,
-    radiating_piston,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(np.geomspace(20, 20000, 260),
                6.6 + 24 * np.exp(-(np.log2(np.geomspace(20, 20000, 260) / 52.0) ** 2) / 0.12)),
     distortion=(np.geomspace(50, 5000, 140),
                 0.3 + 2.6 * np.exp(-(np.log2(np.geomspace(50, 5000, 140) / 70.0) ** 2) / 0.45)),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -733,15 +730,15 @@ result.plot(quantity="directivity")  # polar response on the 25 dB circle
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
-                                     sensitivity_band=(200.0, 4000.0))
+result = electroacoustics.loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
+                                                      sensitivity_band=(200.0, 4000.0))
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -756,13 +753,13 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 fz = np.geomspace(20, 20000, 260)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(fz, 6.6 + 24 * np.exp(-(np.log2(fz / 52.0) ** 2) / 0.12)),
 )
@@ -780,13 +777,13 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 thd_f = np.geomspace(50, 5000, 140)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distortion=(thd_f, 0.3 + 2.6 * np.exp(-(np.log2(thd_f / 70.0) ** 2) / 0.45)),
 )
@@ -804,18 +801,16 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, loudspeaker_characteristics, radiating_piston,
-)
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -1100,10 +1095,7 @@ standard's own definitions rather than merely repeated:
 
 ```python
 import numpy as np
-from phonometry import (
-    MicrophoneDirectivity, MicrophoneElectrical, MicrophoneNoise,
-    MicrophoneOverload, ReportMetadata, microphone_characteristics,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
@@ -1114,19 +1106,19 @@ angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,          # 12.5 mV/Pa at 1 kHz
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
-    noise=MicrophoneNoise(                             # A-weighted, V
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    noise=electroacoustics.MicrophoneNoise(                             # A-weighted, V
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(np.linspace(100, 140, 81),
                     0.5 * 10 ** ((np.linspace(100, 140, 81) - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
-    electrical=MicrophoneElectrical(
+    electrical=electroacoustics.MicrophoneElectrical(
         rated_impedance=150.0, minimum_load_impedance=1000.0,
         powering="Phantom P48 (IEC 61938)", supply_current_ma=3.1,
     ),
@@ -1175,14 +1167,14 @@ result.plot(quantity="distortion")   # THD vs sound pressure level
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
 response -= 10 * np.log10(1 + (freqs / 19000.0) ** 8)   # high-frequency roll-off
 response += 2.0 * np.exp(-(np.log2(freqs / 9000.0) ** 2) / 0.3)  # presence region
 
-result = microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
+result = electroacoustics.microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -1197,16 +1189,16 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneDirectivity, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
 )
 result.plot(quantity="directivity")
 plt.show()
@@ -1222,15 +1214,15 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneNoise, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    noise=MicrophoneNoise(
+    noise=electroacoustics.MicrophoneNoise(
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
@@ -1249,15 +1241,15 @@ plt.show()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneOverload, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 spl_axis = np.linspace(100, 140, 81)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(spl_axis, 0.5 * 10 ** ((spl_axis - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
@@ -1383,12 +1375,12 @@ their fixed advances.
 
 ```python
 import numpy as np
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
-x = synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
 res.thd, res.thd_frequencies
@@ -1405,14 +1397,14 @@ res.plot()                # |Hn| magnitudes + THD(f)
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)             # 3 kHz post-filter
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 h1 = 1.0 + 3.0 * a3 / 4.0                              # Chebyshev gain
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -1490,10 +1482,10 @@ be ignored; the band of every $H_n$ is also capped at $f_2$ by the inverse
 filter.
 
 ```python
-from phonometry import sweep_signal, swept_sine_distortion
+from phonometry import electroacoustics, room
 
-x = sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
+x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
 
@@ -1522,16 +1514,14 @@ all-pass parts:
 
 ```python
 import numpy as np
-from phonometry import (
-    excess_phase, group_delay, minimum_phase, phase_decomposition,
-)
+from phonometry import signals
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
-h_min = minimum_phase(np.abs(H))       # phase from the magnitude alone
-tau_g = group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
-phi_x = excess_phase(H)                # unwrap(arg H) - phi_min
+h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone
+tau_g = signals.group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
+phi_x = signals.excess_phase(H)                # unwrap(arg H) - phi_min
 
-res = phase_decomposition(H, fs)       # everything on one axis
+res = signals.phase_decomposition(H, fs)       # everything on one axis
 res.excess_group_delay                 # the all-pass part, in seconds
 res.plot()                             # magnitude, phases, group delays
 ```
@@ -1550,7 +1540,7 @@ excess group delay reads the latency directly as a flat 2.5 ms line.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import phase_decomposition
+from phonometry import signals
 
 fs = 48000.0
 delay = int(0.0025 * fs)                      # a 2.5 ms processing latency
@@ -1563,7 +1553,7 @@ imp = np.zeros(16384)
 imp[delay] = 1.0
 ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
-res = phase_decomposition(np.fft.rfft(ir), fs)
+res = signals.phase_decomposition(np.fft.rfft(ir), fs)
 res.plot()   # |H|, the three phases and the group delays
 plt.show()
 ```

--- a/site/public/llms/llms-devices-emission.txt
+++ b/site/public/llms/llms-devices-emission.txt
@@ -637,11 +637,11 @@ surface integral.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import measurement_positions, plot_microphone_positions
+from phonometry import emission
 
 # The 10 ISO 3744 Annex B microphones on a 2 m hemisphere.
-plot_microphone_positions(measurement_positions("hemisphere", radius=2.0),
-                          radius=2.0)
+emission.plot_microphone_positions(emission.measurement_positions("hemisphere", radius=2.0),
+                                   radius=2.0)
 plt.show()
 ```
 

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -141,20 +141,20 @@ level leaving it. `DuctElement` carries exactly the two spectra an element
 owns, and `duct_path` walks them:
 
 ```python
-from phonometry import DuctElement, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 
-path = duct_path(
+path = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined",
-                    attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
-                    self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
-                    self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined",
+                                  attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
+                                  self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
+                                  self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
     ],
     source_label="Fan, centrifugal FC, 5000 cfm, 2 in w.g.",
 )
@@ -207,21 +207,18 @@ logarithmic terms take the same values as the foot-pound form in cfm and
 inches of water gauge.
 
 ```python
-from phonometry import (
-    blade_passing_frequency, fan_casing_attenuation,
-    fan_efficiency_correction, fan_sound_power,
-)
+from phonometry import noise_control
 
 CFM, IN_WG = 0.0004719474432, 249.0
 
-fan = fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
-                      fan_type="forward_curved", relative_efficiency=80.0)
+fan = noise_control.fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
+                                    fan_type="forward_curved", relative_efficiency=80.0)
 print([round(float(v)) for v in fan.values])
 # [99, 99, 89, 84, 82, 77, 72, 67]
 
-print(fan_efficiency_correction(80.0))          # 6.0 dB off the peak
-print(blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
-print(fan_casing_attenuation().values)          # what the housing holds back
+print(noise_control.fan_efficiency_correction(80.0))          # 6.0 dB off the peak
+print(noise_control.blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
+print(noise_control.fan_casing_attenuation().values)          # what the housing holds back
 # [ 0.  0.  5. 10. 15. 20. 22. 25.]
 fan.plot()                                      # the band spectrum, one line
 ```
@@ -266,17 +263,15 @@ for 25 mm to 52 mm linings and clipped at 40 dB per run because flanking
 takes over beyond that.
 
 ```python
-from phonometry import (
-    lined_rectangular_duct_attenuation, unlined_rectangular_duct_attenuation,
-)
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
-bare = unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
-lined = lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
-                                           1 * IN, include_unlined=True)
+bare = noise_control.unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
+lined = noise_control.lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
+                                                         1 * IN, include_unlined=True)
 print(np.round(bare.values, 1))    # [1.1 0.7 0.5 0.2 0.2 0.2 0.2 0.2]
 print(np.round(lined.values, 1))   # [ 1.3  1.3  2.5  6.7 12.8 10.6  9.7  9. ]
 ```
@@ -304,12 +299,12 @@ branch area does not match the feeder, and a 25 per cent branch therefore
 costs 6 dB.
 
 ```python
-from phonometry import elbow_insertion_loss, split_loss
+from phonometry import noise_control
 
 IN = 0.0254
 area = 36 * IN * 24 * IN
-print(round(split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
-print(elbow_insertion_loss(
+print(round(noise_control.split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
+print(noise_control.elbow_insertion_loss(
     [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
     24 * IN, bend_type="round").values)          # [0. 1. 2. 3. 3. 3. 3. 3.]
 ```
@@ -332,15 +327,15 @@ the impedance transition, and a manufacturer's diffuser rating already
 contains whatever is left of it.
 
 ```python
-from phonometry import end_reflection_loss, equivalent_diameter
+from phonometry import noise_control
 import numpy as np
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0]
-print(np.round(end_reflection_loss(bands, 0.30, method="bies").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="bies").values, 1))
 # [12.  7.  3.  1.  0.  0.]
-print(np.round(end_reflection_loss(bands, 0.30, method="long").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="long").values, 1))
 # [12.7  7.7  3.7  1.3  0.4  0.1]
-print(round(equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
+print(round(noise_control.equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
 ```
 
 **Silencers and plenums.** A parallel-splitter attenuator reduces, in Bies
@@ -351,17 +346,17 @@ chamber (Bies Eq. (8.275)), whose reverberant term uses the plenum
 [room constant](https://jmrplens.github.io/phonometry/buildings/rooms/room-image-sources/).
 
 ```python
-from phonometry import plenum_attenuation, splitter_silencer_insertion_loss
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
-sil = splitter_silencer_insertion_loss(
+sil = noise_control.splitter_silencer_insertion_loss(
     None, height=24 * IN, length=5 * FT,
     airway_widths=[0.10] * 5, splitter_thickness=0.10,
 )
 print(np.round(sil.values, 1))
 # [ 5.8  8.6 14.1 28.2 34.5 33.5 18.4 12.1]
-print(round(plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
+print(round(noise_control.plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
 ```
 
 Read that estimate for what it is. The 5 ft unit Long's return path
@@ -389,14 +384,14 @@ is the whole message: the fifth-and-a-half power of the airway velocity
 means that *doubling the face velocity of a silencer adds about 17 dB*.
 
 ```python
-from phonometry import silencer_self_noise
+from phonometry import noise_control
 import numpy as np
 
 IN = 0.0254
-slow = silencer_self_noise(None, airway_velocity=10.0, passages=5,
-                           height=24 * IN)
-fast = silencer_self_noise(None, airway_velocity=20.0, passages=5,
-                           height=24 * IN)
+slow = noise_control.silencer_self_noise(None, airway_velocity=10.0, passages=5,
+                                         height=24 * IN)
+fast = noise_control.silencer_self_noise(None, airway_velocity=20.0, passages=5,
+                                         height=24 * IN)
 print(np.round(slow.values, 1))
 # [40.8 40.8 38.8 36.8 31.8 26.8 21.8 16.8]
 print(round(float(fast.values[0] - slow.values[0]), 1))     # 16.6 dB
@@ -421,15 +416,15 @@ function $C_D = -11.82 - 0.15 A - 1.13 A^2$ ($-5.82$ for a round device)
 about the peak band $f_\mathrm{P} = 48.8\,U_\mathrm{G}$.
 
 ```python
-from phonometry import diffuser_sound_power
+from phonometry import noise_control
 import numpy as np
 
 IN, CFM, IN_WG = 0.0254, 0.0004719474432, 249.0
 
 # The supply diffuser of Long's worked sheet: 24 x 24 in, 312 cfm, 0.05 in pd.
-print(np.round(diffuser_sound_power(None, (24 * IN) ** 2,
-                                    volume_flow=312 * CFM,
-                                    pressure_drop=0.05 * IN_WG).values, 1))
+print(np.round(noise_control.diffuser_sound_power(None, (24 * IN) ** 2,
+                                                  volume_flow=312 * CFM,
+                                                  pressure_drop=0.05 * IN_WG).values, 1))
 # [ 33.4  32.4  29.1  23.6  15.9   5.9  -6.4 -21. ]
 # Long Table 14.9 prints 33/32/29/23/15/4/0/0 for that row.
 ```
@@ -444,12 +439,12 @@ penalty for throttling a balancing damper, which is where a great many
 finished installations fail.
 
 ```python
-from phonometry import air_terminal_damper_correction, air_terminal_velocity_limit
+from phonometry import noise_control
 
-print(air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
-print(air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
-print(air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
-print(air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
+print(noise_control.air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
+print(noise_control.air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
+print(noise_control.air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
+print(noise_control.air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
 ```
 
 Fifteen decibels in the neck against two decibels 1.5 m back in the duct,
@@ -467,12 +462,12 @@ every other loss, with $Q = 2$ by default for a diffuser flush in a
 ceiling.
 
 ```python
-from phonometry import room_constant, room_effect
+from phonometry import noise_control, room
 
 # The 20 x 20 x 8 ft room of Long's worked sheet, drywall and carpet.
 area = 2 * 6.10 * 6.10 + 4 * 6.10 * 2.44        # 134.0 m2
-r_const = room_constant(area, 0.15)             # 23.6 m2
-print(round(float(room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
+r_const = room.room_constant(area, 0.15)             # 23.6 m2
+print(round(float(noise_control.room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
 ```
 
 Long's sheet prints 5 to 7 dB for that room across the bands, so a single
@@ -499,54 +494,54 @@ silencers and the terminal devices, which is what a real sheet uses.
 
 ```python
 import numpy as np
-from phonometry import DuctElement, combine_duct_paths, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 source = "Fan, centrifugal FC, 5000 cfm, 2 in w.g."
 
-supply = duct_path(
+supply = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    [7, 12, 16, 28, 35, 35, 28, 17],
-                    [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
-        DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
-                    [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
-        DuctElement("Split, 25 per cent", 6.0, code="5"),
-        DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
-                    [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
-        DuctElement("Flexible duct, 12 in, 6 ft",
-                    [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
-        DuctElement("Rectangular diffuser, 312 cfm", None,
-                    [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  [7, 12, 16, 28, 35, 35, 28, 17],
+                                  [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
+                                  [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
+        noise_control.DuctElement("Split, 25 per cent", 6.0, code="5"),
+        noise_control.DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
+                                  [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
+        noise_control.DuctElement("Flexible duct, 12 in, 6 ft",
+                                  [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
+        noise_control.DuctElement("Rectangular diffuser, 312 cfm", None,
+                                  [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
     ],
     room_effect=[6, 6, 5, 5, 6, 7, 6, 6],
     source_label=source, target=30.0, label="Supply",
 )
 
-ret = duct_path(
+ret = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
-        DuctElement("Silencer, 5 ft, low-frequency type",
-                    [16, 21, 35, 41, 41, 28, 21, 15],
-                    [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
-        DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
-                    [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
-        DuctElement("Plenum, 800 sq ft, 50 per cent lined",
-                    [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
-        DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
-                    [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 5 ft, low-frequency type",
+                                  [16, 21, 35, 41, 41, 28, 21, 15],
+                                  [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
+                                  [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
+        noise_control.DuctElement("Plenum, 800 sq ft, 50 per cent lined",
+                                  [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
+        noise_control.DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
+                                  [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
     ],
     room_effect=[9, 8, 6, 8, 8, 8, 9, 10],
     source_label=source, target=30.0, label="Return",
 )
 
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 print(np.round(supply.received_level, 0))    # Long: 52 42 30 18  9 -2 -2 -1
 print(np.round(ret.received_level, 0))       # Long: 52 41 27 25 23 25 22 12
 print(np.round(total.received_level, 0))     # Long: 55 45 32 26 23 25 22 12
@@ -577,7 +572,7 @@ nothing at all: the return already sets the answer everywhere except at
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import combine_duct_paths
+from phonometry import noise_control
 
 # `supply` and `ret` are the two DuctPathResult objects built above.
 
@@ -586,7 +581,7 @@ supply.plot()
 plt.show()
 
 # The concept figure: both paths, their energy sum and the criterion.
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 total.plot()
 plt.gca().set_ylim(-6.0, 62.0)
 plt.show()
@@ -685,18 +680,18 @@ $k_x = -M\kappa_{pq}/\sqrt{1 - M^2}$.
 
 ```python
 import numpy as np
-from phonometry import plane_wave_limit, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.2: a 0.65 x 0.4 m air-conditioning duct at 15 m/s.
-modes = rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
+modes = noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
 print(modes.modes[:3])                          # ((1, 0), (0, 1), (1, 1))
 print(np.round(modes.cut_on[:3], 1))            # [263.6 428.3 502.9] Hz
 print(np.round(modes.cut_on_no_flow[:3], 1))    # [263.8 428.8 503.4] Hz
 print(round(modes.plane_wave_limit, 1))         # 263.6 Hz
 
 IN = 0.0254
-print(round(plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
-print(round(plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
+print(round(noise_control.plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
+print(round(noise_control.plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
 ```
 
 Those ventilation numbers are blunt: in that duct plane waves are the whole
@@ -736,11 +731,11 @@ rung.
 
 ```python
 import numpy as np
-from phonometry import circular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.1: a 254 mm circular duct carrying steam at 200 m/s.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 print(steam.modes)
 # ((1, 0), (2, 0), (0, 1), (3, 0), (4, 0), (1, 1))
 print(np.round(steam.cut_on_no_flow, 1))
@@ -766,16 +761,16 @@ at the frequency at which it appears.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import circular_duct_cut_on, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # One line for one duct: the cut-on ladder with the plane-wave band shaded.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 steam.plot()
 plt.show()
 
 # The ventilation duct of problem 7.2, where the flow shift is negligible.
-rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
+noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
 plt.show()
 ```
 
@@ -790,17 +785,17 @@ they describe the plane-wave mode alone, which a measurement will not.
 
 ```python
 import warnings
-from phonometry import DuctElement, PlaneWaveWarning, duct_path
+from phonometry import noise_control
 
 IN = 0.0254
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
-    duct_path(bands, [90.0] * 8, [DuctElement("Straight run", 3.0)],
-              section={"width": 36 * IN, "height": 24 * IN},
-              flow_velocity=6.0, label="Supply")
-print(caught[0].category is PlaneWaveWarning)
+    noise_control.duct_path(bands, [90.0] * 8, [noise_control.DuctElement("Straight run", 3.0)],
+                            section={"width": 36 * IN, "height": 24 * IN},
+                            flow_velocity=6.0, label="Supply")
+print(caught[0].category is noise_control.PlaneWaveWarning)
 print(str(caught[0].message))
 # Supply: 6 of 8 frequencies are above the first duct cut-on frequency
 # (188 Hz), where higher-order modes propagate and the plane-wave result
@@ -966,14 +961,12 @@ speaking into the same 8 m x 9 m x 3 m receiving room through the same
 
 ```python
 import numpy as np
-from phonometry import (
-    SourceRoom, equivalent_absorption_area, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 
 # Receiving room 8 x 9 x 3 m: walls 102 m2, floor and ceiling 72 m2 each.
-receiving = equivalent_absorption_area([
+receiving = room.equivalent_absorption_area([
     (102.0, [0.04, 0.04, 0.09, 0.15, 0.17, 0.23]),   # walls
     (72.0,  [0.02, 0.06, 0.14, 0.37, 0.60, 0.66]),   # floor
     (72.0,  [0.30, 0.20, 0.15, 0.05, 0.05, 0.05]),   # ceiling
@@ -987,9 +980,9 @@ partitions = {
     "Double brick, 50 mm cavity":      [37, 41, 48, 60, 61, 61],
 }
 for name, tl in partitions.items():
-    res = room_to_room_transmission(
+    res = noise_control.room_to_room_transmission(
         bands, tl, 8.0 * 3.0, receiving,
-        source=SourceRoom(level=90.0), label=name,
+        source=noise_control.SourceRoom(level=90.0), label=name,
     )
     print(f"{name:32s} {np.round(res.noise_reduction, 1)}")
 # Two 13 mm wallboards, 64 mm gap  [18.5 26.8 38.  47.8 47.3 43.9]
@@ -1033,10 +1026,7 @@ $10\log_{10} 4 = 6.02\ \text{dB}$, and without it the printed answers come out
 6 dB low.
 
 ```python
-from phonometry import (
-    DesignCriterion, SourceRoom, equivalent_absorption_area, mean_absorption,
-    room_constant, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [0.07, 0.20, 0.40, 0.52, 0.60, 0.67]      # absorbent ceiling
@@ -1050,18 +1040,18 @@ plant = [(80.0, [0.01, 0.01, 0.015, 0.02, 0.02, 0.02]),
 operator = [(25.0, [0.08, 0.24, 0.57, 0.69, 0.71, 0.73]),
             (25.0, ceiling), (60.0, walls)]
 
-chain = room_to_room_transmission(
+chain = noise_control.room_to_room_transmission(
     bands,
     [39.0, 42.0, 50.0, 58.0, 63.0, 67.0],       # TL of the separating wall
     5.0 * 3.0,                                  # the wall is 5 m x 3 m
-    equivalent_absorption_area(operator),
-    source=SourceRoom(
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(
         power_level=[105.0, 103.0, 98.0, 108.0, 107.0, 109.0],
-        room_constant=room_constant(268.0, mean_absorption(plant)),
+        room_constant=room.room_constant(268.0, room.mean_absorption(plant)),
         directivity=4.0,                        # floor-wall intersection
         model="constant_volume",                # the conservative bound
     ),
-    criterion=DesignCriterion(target=45.0),
+    criterion=noise_control.DesignCriterion(target=45.0),
     label="Plant room to operator room",
 )
 
@@ -1177,7 +1167,7 @@ $\text{TL} = \text{IL} + 10\log_{10}(S_\mathrm{E} / R_\mathrm{i})$, which is
 
 ```python
 import numpy as np
-from phonometry import enclosure_required_transmission_loss, mean_absorption
+from phonometry import noise_control, room
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 wool = [0.10, 0.20, 0.45, 0.65, 0.75, 0.80, 0.80, 0.80]   # 50 mm blanket
@@ -1194,11 +1184,11 @@ radiating = 2 * (2.5 * 2.5) + 2 * (3.5 * 2.5) + 2.5 * 3.5
 machine = 2 * (1.5 * 1.5) + 2 * (2.5 * 1.5) + 1.5 * 2.5
 bare_floor = 2.5 * 3.5 - 1.5 * 2.5
 
-required = enclosure_required_transmission_loss(
+required = noise_control.enclosure_required_transmission_loss(
     lp1 - nc45,
     radiating,
     radiating + bare_floor + machine,
-    mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
+    room.mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
     frequencies=bands,
     model="norton",
 )
@@ -1259,11 +1249,11 @@ transmission loss rather than get lost:
 
 ```python
 # The chain of section 3 again, with 3 dB allowed for flanking and leaks.
-honest = room_to_room_transmission(
+honest = noise_control.room_to_room_transmission(
     bands, [39.0, 42.0, 50.0, 58.0, 63.0, 67.0], 15.0,
-    equivalent_absorption_area(operator),
-    source=SourceRoom(level=chain.source_level),
-    criterion=DesignCriterion(target=45.0, flanking_penalty=3.0),
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(level=chain.source_level),
+    criterion=noise_control.DesignCriterion(target=45.0, flanking_penalty=3.0),
 )
 print(np.round(honest.received_level, 1))
 # [75.4 63.4 44.4 44.  36.9 33.7]      every band 3 dB worse
@@ -1431,10 +1421,10 @@ exactly.
 
 ```python
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 print(round(res.transmission_loss.max(), 2))   # 6.55 dB peak (m = 4)
 res.plot()                                      # TL (and IL) vs frequency
 ```
@@ -1455,18 +1445,18 @@ circular diameters $d = 2\sqrt{S/\pi}$ of the 0.04 and 0.01 m² cross-sections.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber, plot_silencer_geometry
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 
 # One line: the dimensioned cross-section of the chamber just computed.
 res.plot_geometry()
 plt.show()
 
 # The same drawing without a result, from the free function:
-plot_silencer_geometry("expansion chamber", length=0.3,
-                       chamber_area=0.04, pipe_area=0.01)
+noise_control.plot_silencer_geometry("expansion chamber", length=0.3,
+                                     chamber_area=0.04, pipe_area=0.01)
 plt.show()
 ```
 
@@ -1497,26 +1487,24 @@ with `duct_matrix`, `shunt_matrix`, `cascade`, `transmission_loss` and
 
 ```python
 import numpy as np
-from phonometry import (
-    helmholtz_resonator, quarter_wave_resonator, extended_tube_chamber,
-)
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
 
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 print(round(float(hr.resonances[0]), 1))       # tuning frequency, Hz
 hr.plot()   # TL spike at the tuning frequency (needs matplotlib)
 
-qw = quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
-                            speed_of_sound=343.24)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
+                                          speed_of_sound=343.24)
 print(round(float(qw.resonances[0]), 1))        # 56.6 Hz (Bies Example 8.1)
 
 # Each extension is a quarter-wave stub, so its own length picks the trough
 # it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
 # second trough, and L/2 = 0.2 m would take the first one at c/2L.
-et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
-                           inlet_extension=0.1)
+et = noise_control.extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
+                                         inlet_extension=0.1)
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_side_branch_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_side_branch.svg" alt="Transmission loss of a Helmholtz resonator and a closed quarter-wave tube on the same 10 cm2 duct: each side branch produces a sharp spike at its own tuning frequency, near 120 Hz for the Helmholtz volume and near 285 Hz for the 0.3 m tube, and is transparent elsewhere" width="88%"></picture>
@@ -1531,12 +1519,12 @@ firing frequency or a fan blade-passing tone rather than used broadband.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator, quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line for one device: TL vs frequency with the resonance marked.
 hr.plot()
@@ -1589,11 +1577,11 @@ its target.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 
 # One line: the side branch drawn to scale, cavity as its equal-volume cube.
 hr.plot_geometry()
@@ -1618,10 +1606,10 @@ area only sets how strongly the stub loads the duct.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line: the closed 0.3 m tube on its duct, to scale.
 qw.plot_geometry()
@@ -1664,7 +1652,7 @@ all, because an impedance is not a shape.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import SilencerChain
+from phonometry import noise_control
 from phonometry.noise_control import helmholtz_impedance, quarter_wave_impedance
 
 freqs = np.linspace(20.0, 500.0, 481)
@@ -1672,7 +1660,7 @@ s_duct = np.pi * 0.100**2               # nominal 200 mm duct
 s_shell = np.pi * 0.200**2              # nominal 400 mm shell
 
 chain = (
-    SilencerChain(freqs)
+    noise_control.SilencerChain(freqs)
     .duct(0.10, s_duct)
     .shunt(quarter_wave_impedance(freqs, 343.0 / (4.0 * 125.0), np.pi * 0.050**2),
            label="Quarter-wave stub")
@@ -1704,11 +1692,11 @@ embedded figure, matplotlib (`pip install "phonometry[report,plot]"`), and
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, expansion_chamber
+from phonometry import ReportMetadata, noise_control
 
 # A 0.5 m chamber of area ratio m = 8, at the octave-band centres.
 freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-res = expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
 res.report(
     "silencer_fiche.pdf",
     metadata=ReportMetadata(
@@ -1971,10 +1959,10 @@ numbers has the same predicted attenuation.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import plot_plenum_geometry
+from phonometry import noise_control
 
 # The r, S_out and S_w that Wells' formula actually uses, drawn exactly.
-plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
+noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
 plt.show()
 ```
 
@@ -2049,12 +2037,12 @@ interior absorption.
 
 ```python
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
-enc = enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
-                               internal_absorption=0.3, frequencies=bands)
+enc = noise_control.enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
+                                             internal_absorption=0.3, frequencies=bands)
 print(np.round(enc.insertion_loss, 1))          # net IL = R - C per band
 enc.plot()
 ```
@@ -2072,13 +2060,13 @@ together with the panels, not as an afterthought.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
 
-enc = enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
-                               internal_absorption=0.3, frequencies=bands)
+enc = noise_control.enclosure_insertion_loss(panel_R, external_area=6.0, internal_area=5.0,
+                                             internal_absorption=0.3, frequencies=bands)
 
 # One line — panel R, interior correction C and the net IL = R - C:
 enc.plot()
@@ -2123,14 +2111,14 @@ insertion loss.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, enclosure_insertion_loss
+from phonometry import ReportMetadata, noise_control
 
 octaves = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 sheet_steel_R = np.array([18.0, 22.0, 28.0, 33.0, 38.0, 42.0, 45.0])
 
-case = enclosure_insertion_loss(sheet_steel_R, external_area=24.0,
-                                internal_area=30.0, internal_absorption=0.30,
-                                frequencies=octaves)
+case = noise_control.enclosure_insertion_loss(sheet_steel_R, external_area=24.0,
+                                              internal_area=30.0, internal_absorption=0.30,
+                                              frequencies=octaves)
 case.report(
     "enclosure.pdf",
     metadata=ReportMetadata(

--- a/site/public/llms/llms-environment-propagation.txt
+++ b/site/public/llms/llms-environment-propagation.txt
@@ -650,18 +650,13 @@ level supplied through the metadata `requirement` then adds a PASS/FAIL verdict
 
 ```python
 import numpy as np
-from phonometry import (
-    Barrier,
-    ReportMetadata,
-    SourceEmission,
-    outdoor_propagation_attenuation,
-)
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 lw = np.array([95, 100, 103, 105, 104, 101, 95, 88], dtype=float)
-result = outdoor_propagation_attenuation(
+result = environment.outdoor_propagation_attenuation(
     200.0, 4.0, 2.0, freqs, 1.0, 1.0, 1.0,
-    barrier=Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
+    barrier=environment.Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
     temperature=10.0, relative_humidity=70.0,
 )
 result.report(
@@ -671,7 +666,7 @@ result.report(
         test_room="Nearest dwelling facade",
         requirement=50.0,  # maximum acceptable A-weighted downwind level
     ),
-    source_emission=SourceEmission(sound_power_level=lw),
+    source_emission=environment.SourceEmission(sound_power_level=lw),
 )
 ```
 
@@ -692,10 +687,10 @@ adds a PASS/FAIL verdict (a higher insertion loss is better).
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, barrier_insertion_loss
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
-result = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+result = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 result.report(
     "barrier_insertion_loss.pdf",
     metadata=ReportMetadata(
@@ -837,14 +832,14 @@ $$
 
 ```python
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 
 # Grassland (effective flow resistivity sigma = 200 kPa.s/m^2), source 1 m and
 # receiver 1.5 m high, 50 m apart. The impedance comes from the Delany-Bazley
 # porous model of phonometry.materials (a semi-infinite ground).
-res = ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
+res = environment.ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
 print(res.excess_attenuation)     # the ground dip (dB re free field)
 print(res.reflection_coefficient) # complex Q per band
 res.plot()                        # excess attenuation vs frequency
@@ -870,7 +865,7 @@ it enters the Weyl-Van der Pol formulas.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 4000.0, 400)
 grounds = [
@@ -881,7 +876,7 @@ grounds = [
 ]
 fig, ax = plt.subplots(figsize=(11, 6.4))
 for label, sigma, color in grounds:
-    res = ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
+    res = environment.ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
     ax.plot(freqs, res.excess_attenuation, color=color, label=label)
 ax.axhline(6.0, color="k", ls=":", label="Hard-ground limit (+6 dB)")
 ax.axhline(0.0, color="k", lw=0.8)
@@ -947,13 +942,13 @@ the 4 m screen of the snippets, they differ by just 0.15 m.
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier.svg" alt="Section of the barrier geometry: a loudspeaker source 1 m above the ground, a thin 4 m screen at 50 m and a microphone receiver 1.5 m high at 100 m, the blocked direct path of 100.00 m drawn dashed through the screen and the diffracted path bent over the edge in two segments A = 50.09 m and B = 50.06 m, with the resulting path difference of 0.15 m giving a Fresnel number of 0.44 and a Kurze-Anderson insertion loss of 10.0 dB at 500 Hz, rising to 15.5 dB at 2 kHz" width="92%"></picture>
 
 ```python
-from phonometry import barrier_insertion_loss, kurze_anderson_attenuation
+from phonometry import environment
 
-kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
+environment.kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
 
 # A 4 m barrier 50 m from a 1 m source, receiver 1.5 m high at 100 m.
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="kurze_anderson")
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="kurze_anderson")
 il.plot()                           # insertion loss vs frequency
 ```
 
@@ -982,8 +977,8 @@ coefficient per image path; the model is coherent and reciprocal but not a full
 boundary-element solution.
 
 ```python
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="exact", ground_flow_resistivity=2e5)
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="exact", ground_flow_resistivity=2e5)
 il.ground        # True: the four-path coherent ground model was applied
 il.plot()
 ```
@@ -1003,16 +998,16 @@ interfere destructively.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 # The 4 m barrier of the snippets above, on a fine frequency grid.
 freqs = np.geomspace(50.0, 5000.0, 240)
-il_ka = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="kurze_anderson")
-il_ex = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact")
-il_gr = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact", ground_flow_resistivity=2e5)
+il_ka = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="kurze_anderson")
+il_ex = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact")
+il_gr = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact", ground_flow_resistivity=2e5)
 fig, ax = plt.subplots(figsize=(11, 6.4))
 ax.semilogx(freqs, il_ka.insertion_loss, "--", label="Kurze-Anderson (thin screen)")
 ax.semilogx(freqs, il_ex.insertion_loss, label="Exact rigid half-plane")
@@ -1044,10 +1039,10 @@ thin-screen methods above key on.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 5000.0, 240)
-il = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+il = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 
 # One line: the section to scale, with the path-length difference annotated.
 il.plot_geometry()
@@ -1172,35 +1167,30 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    atmospheric_ray_paths,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 c0 = 340.0
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
 zs = 2.0
 fig, axes = plt.subplots(2, 1, figsize=(11, 8.2), sharex=True)
 
-rays = atmospheric_ray_paths(profile, source_height=zs,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=3000)
+rays = environment.atmospheric_ray_paths(profile, source_height=zs,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=3000)
 for i in range(rays.heights.shape[0]):
     axes[0].plot(rays.ranges[i], rays.heights[i], color="#1f77b4", lw=0.8, alpha=0.7)
 axes[0].plot([0.0], [zs], "o", color="#d62728", label="Source")
 grad = (profile.speed_at(10.0) - c0) / 10.0
-x_sh = shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
+x_sh = environment.shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
 axes[0].axvline(x_sh, color="#d62728", ls="--", label="Shadow-zone boundary")
 axes[0].set(ylabel="Height [m]", ylim=(0, 40), title="Sound rays (upward refraction)")
 axes[0].legend()
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(400.0, profile, source_height=zs,
-                                        flow_resistivity=200e3,
-                                        max_range=600.0, max_height=40.0)
+    pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=zs,
+                                                    flow_resistivity=200e3,
+                                                    max_range=600.0, max_height=40.0)
 img = axes[1].imshow(pe.relative_level, cmap="RdBu_r", vmin=-30, vmax=6,
                      aspect="auto", origin="lower", interpolation="bilinear",
                      extent=(pe.ranges[0], pe.ranges[-1], pe.heights[0], pe.heights[-1]))
@@ -1237,9 +1227,9 @@ the receiver (favourable propagation); a negative gradient bends them **up** and
 opens an acoustic **shadow** near the ground.
 
 ```python
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
 profile.speed_at(10.0)   # effective sound speed 10 m above the ground
 profile.plot()           # c_eff(z) with height on the vertical axis
 ```
@@ -1251,11 +1241,11 @@ profile.plot()           # c_eff(z) with height on the vertical axis
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
 # The two canonical surface layers of Salomons Eq. 4.5 over grassland.
-down = log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
-up = log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
+down = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
+up = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
 ax = down.plot(color="#1f77b4")
 up.plot(ax=ax, color="#d62728")
 plt.show()
@@ -1273,12 +1263,12 @@ travel times and the number of ground reflections.
 
 ```python
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0)
 rays.plot()   # curved ray fan with the acoustic shadow near the ground
 ```
 
@@ -1295,13 +1285,13 @@ the surface instead of losing it upward.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
 # Downward refraction: the favourable-propagation mirror of the shadow case.
-profile = log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=600)
+profile = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=600)
 rays.plot()   # shallow rays return to the ground and bounce on down-range
 plt.show()
 ```
@@ -1362,12 +1352,12 @@ $\Delta L(z, r) = 20\log_{10}(|p| R_1)$ (dB re free field, Salomons Eq. 3.6) ove
 the whole range-height plane.
 
 ```python
-from phonometry import atmospheric_parabolic_equation, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
-pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                    flow_resistivity=200e3,  # grassland
-                                    max_range=600.0, max_height=40.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                flow_resistivity=200e3,  # grassland
+                                                max_range=600.0, max_height=40.0)
 pe.level_at_height(2.0)   # relative level vs range at 2 m
 pe.plot()                 # the range-height relative-level field
 ```
@@ -1386,31 +1376,26 @@ import warnings
 
 import matplotlib.pyplot as plt
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    linear_sound_speed_profile,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 cases = [
-    (log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
-    (linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
-    (log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
+    (environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
+    (environment.linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
+    (environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
 ]
 fig, ax = plt.subplots(figsize=(11, 6.2))
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     for profile, label in cases:
-        pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                            flow_resistivity=200e3,
-                                            max_range=600.0, max_height=40.0)
+        pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                        flow_resistivity=200e3,
+                                                        max_range=600.0, max_height=40.0)
         ax.plot(pe.ranges, pe.level_at_height(2.0), label=label)
 # The closed-form boundary of the equivalent linear upward gradient (its
 # 10 m mean), the dotted line of the figure.
 up = cases[2][0]
 grad = float(up.speed_at(10.0) - 340.0) / 10.0
-ax.axvline(shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
+ax.axvline(environment.shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
            color="k", ls=":", label="Shadow-zone boundary")
 ax.set(xlabel="Range [m]", ylabel="Level re free field [dB]", ylim=(-40, 10))
 ax.legend()

--- a/site/public/llms/llms-environment-sources.txt
+++ b/site/public/llms/llms-environment-sources.txt
@@ -173,19 +173,17 @@ governs.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    JunctionType, RoadSurface, RoadTraffic, RoadVehicleCategory, road_source_power,
-)
+from phonometry import environment
 
 traffic = [
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1200.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 45.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1200.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 45.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
 ]
-result = road_source_power(
-    traffic, surface=RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
-    junction_distance=60.0, junction_type=JunctionType.CROSSING,
+result = environment.road_source_power(
+    traffic, surface=environment.RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
+    junction_distance=60.0, junction_type=environment.JunctionType.CROSSING,
 )
 result.plot()
 plt.show()
@@ -252,20 +250,17 @@ from about 60 km/h, which is why a lorry is still an engine at urban speeds.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    CNOSSOS_A_WEIGHTING, road_propulsion_noise, road_rolling_noise,
-    road_vehicle_sound_power,
-)
+from phonometry import environment
 
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 speeds = np.linspace(20.0, 130.0, 221)
 fig, ax = plt.subplots()
 for category, name in [("1", "Light vehicles (1)"), ("3", "Heavy vehicles (3)")]:
-    rolling = [a_weighted(road_rolling_noise(category, v)) for v in speeds]
-    propulsion = [a_weighted(road_propulsion_noise(category, v)) for v in speeds]
-    total = [a_weighted(road_vehicle_sound_power(category, v)) for v in speeds]
+    rolling = [a_weighted(environment.road_rolling_noise(category, v)) for v in speeds]
+    propulsion = [a_weighted(environment.road_propulsion_noise(category, v)) for v in speeds]
+    total = [a_weighted(environment.road_vehicle_sound_power(category, v)) for v in speeds]
     ax.plot(speeds, total, lw=2.4, label=f"{name} - total")
     ax.plot(speeds, rolling, ls="--", lw=1.2, label=f"{name} - rolling")
     ax.plot(speeds, propulsion, ls=":", lw=1.2, label=f"{name} - propulsion")
@@ -313,9 +308,9 @@ down onto it, but a rough texture only generates tyre noise, and tyre noise is
 already the rolling term.
 
 ```python
-from phonometry import RoadSurface, road_surface_coefficients
+from phonometry import environment
 
-row = road_surface_coefficients(RoadSurface.TWO_LAYER_ZOAB_FINE)
+row = environment.road_surface_coefficients(environment.RoadSurface.TWO_LAYER_ZOAB_FINE)
 row.speed_range          # (80.0, 130.0) km/h, the printed validity range
 row.alpha["1"]           # alpha per octave band for light vehicles
 row.beta["1"]            # -0.1, the speed coefficient
@@ -339,19 +334,16 @@ $dL$ simply carries $L'_{W,\mathrm{eq,line},i} + 10\log_{10}(dL)$, which is
 arithmetic and is offered as such.
 
 ```python
-from phonometry import (
-    PropagationGeometry, RoadTraffic, RoadVehicleCategory,
-    line_source_segment_power, predicted_receiver_level, road_source_power,
-)
+from phonometry import environment
 
-result = road_source_power([
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 90.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 120.0, 80.0),
+result = environment.road_source_power([
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 90.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 120.0, 80.0),
 ])
-segment = line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
-levels = predicted_receiver_level(
+segment = environment.line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
+levels = environment.predicted_receiver_level(
     segment,
-    PropagationGeometry(100.0, result.source_height, 4.0),
+    environment.PropagationGeometry(100.0, result.source_height, 4.0),
     frequencies=result.frequencies,
 )
 ```
@@ -367,9 +359,9 @@ For the A-weighted total, use the octave-band weighting the Directive itself
 prints in 2.5.5 as amended, rather than recomputing it:
 
 ```python
-from phonometry import CNOSSOS_A_WEIGHTING
+from phonometry import environment
 
-CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
+environment.CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
 result.a_weighted_line_power
 ```
 
@@ -383,13 +375,13 @@ and the 2021 one). Both coefficient objects can be replaced:
 ```python
 import dataclasses
 
-from phonometry import ROAD_COEFFICIENTS
+from phonometry import environment
 
 # One measured national row for light vehicles, the rest of Appendix F as published.
 national = dataclasses.replace(
-    ROAD_COEFFICIENTS,
+    environment.ROAD_COEFFICIENTS,
     rolling_a={
-        **ROAD_COEFFICIENTS.rolling_a,
+        **environment.ROAD_COEFFICIENTS.rolling_a,
         "1": (83.4, 89.0, 88.1, 93.6, 100.4, 96.9, 87.0, 76.5),
     },
 )
@@ -552,29 +544,23 @@ starts to matter.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    BrakeType, ContactFilter, RailRoughnessClass, RailwayTrack, RailwayVehicle,
-    RollingStock, TrackTransferClass, TractionVehicle, WheelDiameter,
-    aerodynamic_sound_power, contact_filter, impact_roughness_single,
-    rail_roughness, railway_source_power, track_transfer, traction_sound_power,
-    wheel_roughness, wheel_transfer,
-)
+from phonometry import environment
 
-stock = RollingStock(
+stock = environment.RollingStock(
     axles=4,
-    wheel_roughness=wheel_roughness(BrakeType.NON_TREAD),
-    contact_filter=contact_filter(ContactFilter.LOAD_50_DIAMETER_920),
-    wheel_transfer=wheel_transfer(WheelDiameter.MM_920),
-    traction=traction_sound_power(TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
-    aerodynamic=aerodynamic_sound_power(),
+    wheel_roughness=environment.wheel_roughness(environment.BrakeType.NON_TREAD),
+    contact_filter=environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920),
+    wheel_transfer=environment.wheel_transfer(environment.WheelDiameter.MM_920),
+    traction=environment.traction_sound_power(environment.TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
+    aerodynamic=environment.aerodynamic_sound_power(),
 )
-track = RailwayTrack(
-    rail_roughness=rail_roughness(RailRoughnessClass.NORMAL),
-    track_transfer=track_transfer(TrackTransferClass.MONOBLOCK_MEDIUM),
-    impact_roughness=impact_roughness_single(),
+track = environment.RailwayTrack(
+    rail_roughness=environment.rail_roughness(environment.RailRoughnessClass.NORMAL),
+    track_transfer=environment.track_transfer(environment.TrackTransferClass.MONOBLOCK_MEDIUM),
+    impact_roughness=environment.impact_roughness_single(),
 )
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
 )
 result.plot()
 plt.show()
@@ -636,24 +622,20 @@ rough ones.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    RAILWAY_THIRD_OCTAVE_BANDS, BrakeType, ContactFilter, RailRoughnessClass,
-    contact_filter, rail_roughness, roughness_to_frequency,
-    total_effective_roughness, wheel_roughness,
-)
+from phonometry import environment
 
-rail = rail_roughness(RailRoughnessClass.NORMAL)
-wheel = wheel_roughness(BrakeType.NON_TREAD)
-filt = contact_filter(ContactFilter.LOAD_50_DIAMETER_920)
+rail = environment.rail_roughness(environment.RailRoughnessClass.NORMAL)
+wheel = environment.wheel_roughness(environment.BrakeType.NON_TREAD)
+filt = environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920)
 
 fig, ax = plt.subplots()
 for speed in (60.0, 160.0, 300.0):
-    total = total_effective_roughness(
-        roughness_to_frequency(rail[1], rail[0], speed),
-        roughness_to_frequency(wheel[1], wheel[0], speed),
-        roughness_to_frequency(filt[1], filt[0], speed),
+    total = environment.total_effective_roughness(
+        environment.roughness_to_frequency(rail[1], rail[0], speed),
+        environment.roughness_to_frequency(wheel[1], wheel[0], speed),
+        environment.roughness_to_frequency(filt[1], filt[0], speed),
     )
-    ax.semilogx(RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
+    ax.semilogx(environment.RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
 ax.legend()
 plt.show()
 ```
@@ -675,10 +657,10 @@ worked example. Two readings are shipped, and the default is the one that
 reproduces the Commission's own reference source module:
 
 ```python
-from phonometry import RoughnessInterpolation
+from phonometry import environment
 
-RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
-RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
+environment.RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
+environment.RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
 ```
 
 They differ by up to about 1 dB on a steep part of a spectrum. This is the
@@ -722,12 +704,12 @@ the 2015 one:
 | Tram | curve or switch turnout with $R \le 200\ \text{m}$ | 5 dB |
 
 ```python
-from phonometry import curve_squeal_excess
+from phonometry import environment
 
-curve_squeal_excess(280.0)                       # 8.0 dB
-curve_squeal_excess(450.0)                       # 5.0 dB
-curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
-curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
+environment.curve_squeal_excess(280.0)                       # 8.0 dB
+environment.curve_squeal_excess(450.0)                       # 5.0 dB
+environment.curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
+environment.curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
 ```
 
 The 2015 text read "8 dB for R < 300 m and 5 dB for 300 m < R < 500 m", which
@@ -784,10 +766,10 @@ available, because comparing with a study computed before 2021 needs the old
 one:
 
 ```python
-from phonometry import DirectivityEdition, vertical_directivity
+from phonometry import environment
 
-vertical_directivity(-30.0)                                        # zeros
-vertical_directivity(-30.0, edition=DirectivityEdition.ORIGINAL_2015)  # positive
+environment.vertical_directivity(-30.0)                                        # zeros
+environment.vertical_directivity(-30.0, edition=environment.DirectivityEdition.ORIGINAL_2015)  # positive
 ```
 
 At source B, only the aerodynamic source is directional, $10\log_{10}(\cos^2\psi)$
@@ -819,11 +801,11 @@ bridge term is added to it. It sits at source A and is omni-directional, which
 the amendment states explicitly.
 
 ```python
-from phonometry import BridgeType, RailwayTrack, bridge_transfer
+from phonometry import environment
 
-RailwayTrack(
+environment.RailwayTrack(
     rail_roughness=..., track_transfer=...,
-    bridge_transfer=bridge_transfer(BridgeType.PLUS_10_DBA),
+    bridge_transfer=environment.bridge_transfer(environment.BridgeType.PLUS_10_DBA),
 )
 ```
 

--- a/site/public/llms/llms-materials-absorbers.txt
+++ b/site/public/llms/llms-materials-absorbers.txt
@@ -1772,23 +1772,20 @@ and the limp one settles on $\rho_\mathrm{t}/\rho_0 = 25.9$.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PorousLayer, decoupling_frequency, johnson_champoux_allard,
-    layered_absorber, limp_frame, limp_frame_applicable,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 11.2: soft fibrous layer, 50 mm.
 f = np.linspace(1.0, 2000.0, 800)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     f, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 
-print(round(decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
+print(round(materials.decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
 # 127.4
 print(round(float(limp.effective_density[0].real), 1))     # 31.2 = rho_t
-print(limp_frame_applicable(20e3), limp_frame_applicable(25e3))  # True False
+print(materials.limp_frame_applicable(20e3), materials.limp_frame_applicable(25e3))  # True False
 
 limp.plot()   # normalised Zc and k of the corrected medium
 plt.show()
@@ -1821,18 +1818,16 @@ slightly higher one either side of 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PorousLayer, johnson_champoux_allard, layered_absorber, limp_frame,
-)
+from phonometry import materials
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 1000], dtype=float)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     bands, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 for medium in (rigid, limp):
-    print(layered_absorber(bands, [PorousLayer(0.05, medium)]).absorption.round(2))
+    print(materials.layered_absorber(bands, [materials.PorousLayer(0.05, medium)]).absorption.round(2))
 # [0.07 0.11 0.17 0.24 0.32 0.43 0.54 0.64 0.88]   rigid frame
 # [0.04 0.08 0.15 0.24 0.36 0.48 0.61 0.71 0.91]   limp frame
 ```
@@ -1920,31 +1915,28 @@ imaginary part that the book measures and plots in its Fig. 6.10.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, biot_waves, frame_elastic_coefficient,
-    frame_quarter_wave_resonance, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 6.1: glass wool "Domisol Coffrage", 100 mm, glued.
 f = np.linspace(200.0, 1500.0, 1301)
 shear = 2.2e6 * (1 + 0.1j)          # 220 N/cm2, loss factor 0.1
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     f, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 
-print(frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
-print(round(frame_quarter_wave_resonance(
+print(materials.frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
+print(round(materials.frame_quarter_wave_resonance(
     0.10, shear_modulus=shear, poisson_ratio=0.0, frame_density=130.0), 1))
 # 459.9
 
-waves = biot_waves(med, porosity=0.94, tortuosity=1.06,
-                   frame_density=130.0, shear_modulus=shear)
+waves = materials.biot_waves(med, porosity=0.94, tortuosity=1.06,
+                             frame_density=130.0, shear_modulus=shear)
 print(round(float(abs(waves.airborne_velocity_ratio[800])), 1))     # 42.4
 print(np.round(waves.frame_borne_velocity_ratio[-1], 3))  # (0.811+0.473j)
 
-biot = layered_absorber(f, [PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
-rigid = layered_absorber(f, [PorousLayer(0.10, med)])
+biot = materials.layered_absorber(f, [materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
+rigid = materials.layered_absorber(f, [materials.PorousLayer(0.10, med)])
 
 fig, ax = plt.subplots()
 for res, style in ((rigid, "--"), (biot, "-")):
@@ -1979,19 +1971,17 @@ sharpest; on third-octave centres the largest shift is the 0.12 at 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 bands = np.array([250, 315, 400, 500, 630, 800, 1000], dtype=float)
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     bands, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 shear = 2.2e6 * (1 + 0.1j)
-for layer in (PorousLayer(0.10, med),
-              PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
-    print(layered_absorber(bands, [layer]).absorption.round(2))
+for layer in (materials.PorousLayer(0.10, med),
+              materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
+    print(materials.layered_absorber(bands, [layer]).absorption.round(2))
 # [0.55 0.58 0.62 0.65 0.69 0.74 0.78]   rigid frame
 # [0.53 0.56 0.61 0.77 0.71 0.74 0.78]   Biot poroelastic
 ```
@@ -2510,18 +2500,16 @@ reflection at zero.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 
 f = np.array([300.0])
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -2551,19 +2539,17 @@ $\mathrm{Re}(Z)\cos\theta = Z_0$ and $\mathrm{Im}(Z) = 0$ hold.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 print(round(design.absorption, 4))          # ~1.0 (perfect absorption)
 
 f = np.linspace(150.0, 500.0, 700)
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -2586,9 +2572,9 @@ the cavity length to place the resonance.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator
+from phonometry import materials
 
-resonator = HelmholtzResonator(
+resonator = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
@@ -2610,13 +2596,13 @@ mechanism.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator, critical_coupling_design, materials
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 
@@ -2643,20 +2629,18 @@ deep; detuning the slit height drops the peak below one.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
 a, d, f0 = 3.0e-2, 5.0e-2, 300.0
-base = HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
-design = critical_coupling_design(f0, base, lattice_step=a, period=d)
+base = materials.HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
+design = materials.critical_coupling_design(f0, base, lattice_step=a, period=d)
 h0 = design.slit_height
 
 f = np.linspace(150.0, 500.0, 700)
 fig, ax = plt.subplots()
 for factor, label in [(1.0, "critically coupled"),
                       (0.6, "narrow slit"), (1.7, "wide slit")]:
-    res = slit_helmholtz_absorber(
+    res = materials.slit_helmholtz_absorber(
         f, design.resonator, slit_height=factor * h0,
         lattice_step=a, period=d,
     )
@@ -2687,16 +2671,14 @@ everything about why the panel can be thin:
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
-res = slit_helmholtz_absorber(
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+res = materials.slit_helmholtz_absorber(
     np.array([300.0]), design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )

--- a/site/public/llms/llms-materials-diffusers.txt
+++ b/site/public/llms/llms-materials-diffusers.txt
@@ -830,12 +830,7 @@ five-well sequence six times (`periods=6`, a 2.1 m panel):
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    metadiffuser_polar_response,
-    metadiffuser_reflection,
-)
+from phonometry import materials
 
 # The published quadratic-residue metadiffuser: five slits with two
 # resonators each in a 35 cm x 2 cm panel (7 cm pitch), tuned to mimic a
@@ -849,21 +844,21 @@ rows = [  # slit h, neck l_n, cavity l_c, neck w_n, cavity w_c  [mm]
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 f = np.arange(1800.0, 2601.0, 5.0)
-panel = metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
 alpha1 = panel.well_absorption[0]
 print(round(float(alpha1.max()), 2), int(f[alpha1.argmax()]))  # 0.99 2305
 
 # Far-field comparison: the five-well sequence repeated six times (2.1 m).
-polar = metadiffuser_polar_response(2000.0, wells, depth=0.02,
-                                    period=0.07, periods=6)
+polar = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02,
+                                              period=0.07, periods=6)
 print(round(polar.coefficient, 2))                             # 0.32
 ```
 
@@ -874,12 +869,7 @@ print(round(polar.coefficient, 2))                             # 0.32
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    materials,
-    metadiffuser_polar_response,
-)
+from phonometry import materials
 
 mm = 1e-3
 rows = [
@@ -890,17 +880,17 @@ rows = [
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 # The metadiffuser panel and the QRD it was tuned to at 2 kHz, both with
 # six repetitions of the period (2.1 m panels).
-meta = metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
-                                   periods=6)
+meta = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
+                                             periods=6)
 sequence = np.roll(materials.quadratic_residue_sequence(5), -1)
 depths = sequence * (343.0 / 500.0) / (2 * 5)
 qrd = materials.predict_diffuser_polar_response(
@@ -940,11 +930,11 @@ few degrees of the QRD targets while keeping $|R_n|$ near one:
 
 ```python
 import numpy as np
-from phonometry import materials, metadiffuser_reflection
+from phonometry import materials
 
 # wells: the five published slits from the example above.
-panel = metadiffuser_reflection(np.array([2000.0]), wells,
-                                depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(np.array([2000.0]), wells,
+                                          depth=0.02, period=0.07)
 phases = np.degrees(np.angle(panel.reflection[:, 0]))
 print(np.round(np.abs(panel.reflection[:, 0]), 2))  # [0.97 1.   1.   0.97 0.98]
 print(np.round(phases))                             # [ 75. -71. -71.  74.   2.]

--- a/site/public/llms/llms-perception-speech.txt
+++ b/site/public/llms/llms-perception-speech.txt
@@ -760,18 +760,18 @@ and so sums to 0.9996.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import SII_METHODS, sii_procedure
+from phonometry import speech
 
 # One line: each procedure's own .plot() steps its Ii over its band limits.
 fig, ax = plt.subplots(figsize=(10, 6))
-for method in SII_METHODS:
-    sii_procedure(method).plot(ax=ax, linewidth=1.8)
+for method in speech.SII_METHODS:
+    speech.sii_procedure(method).plot(ax=ax, linewidth=1.8)
 plt.show()
 
 # By hand, mirroring what SIIProcedure.plot() draws:
 fig, ax = plt.subplots()
-for method in SII_METHODS:
-    proc = sii_procedure(method)
+for method in speech.SII_METHODS:
+    proc = speech.sii_procedure(method)
     ii = proc.band_importance
     ax.plot(proc.band_edges, np.append(ii, ii[-1]), drawstyle="steps-post",
             label=method)
@@ -1055,7 +1055,7 @@ Section II):
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 16000
 rng = np.random.default_rng(0)
@@ -1064,9 +1064,9 @@ clean = rng.standard_normal(3 * fs)          # stand-in for a speech waveform
 noise = rng.standard_normal(3 * fs)
 degraded = clean + 0.56 * noise
 
-d = stoi(clean, degraded, fs)
+d = speech.stoi(clean, degraded, fs)
 print(round(d.value, 3))              # a scalar in roughly [0, 1]
-print(stoi(clean, clean, fs).value)   # 1.0  (a signal against itself)
+print(speech.stoi(clean, clean, fs).value)   # 1.0  (a signal against itself)
 ```
 
 Everything up to the 384 ms segments is shared; the two measures only part
@@ -1087,7 +1087,7 @@ is the average of those intermediate correlations over all bands and segments
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(1)
@@ -1095,7 +1095,7 @@ clean = rng.standard_normal(3 * fs)
 # Higher SNR gives a higher STOI: the relation is monotonic.
 for snr_db in (-10, 0, 10, 20):
     g = 10.0 ** (-snr_db / 20.0)
-    print(snr_db, round(stoi(clean, clean + g * rng.standard_normal(clean.size), fs).value, 3))
+    print(snr_db, round(speech.stoi(clean, clean + g * rng.standard_normal(clean.size), fs).value, 3))
 ```
 
 The `STOIResult` carries the per-band mean correlation (`band_scores`) and the
@@ -1113,7 +1113,7 @@ bites, which the single number cannot.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.signal import butter, lfilter
-from phonometry import stoi
+from phonometry import speech
 
 # Speech-like material: band-limited noise with a 3.5 Hz syllabic envelope,
 # in a flat masker at 0 dB SNR.
@@ -1125,7 +1125,7 @@ carrier = lfilter(b, a, rng.standard_normal(t.size))
 clean = carrier * (0.15 + 0.85 * np.abs(np.sin(2 * np.pi * 3.5 * t)) ** 2)
 masker = rng.standard_normal(clean.size)
 gain = np.sqrt(np.mean(clean ** 2)) / np.sqrt(np.mean(masker ** 2))
-res = stoi(clean, clean + gain * masker, fs)
+res = speech.stoi(clean, clean + gain * masker, fs)
 print(round(res.value, 3))    # 0.727
 
 # One line: the per-band intermediate correlation behind the index.
@@ -1165,9 +1165,9 @@ audible, is credited for the speech glimpsed there, which STOI's per-band
 average largely misses.
 
 ```python
-from phonometry import stoi
+from phonometry import speech
 
-estoi = stoi(clean, degraded, fs, extended=True)
+estoi = speech.stoi(clean, degraded, fs, extended=True)
 print(round(estoi.value, 3))
 ```
 
@@ -1179,7 +1179,7 @@ print(round(estoi.value, 3))
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(20)
@@ -1201,7 +1201,7 @@ def curve(masker, extended):
     out = []
     for snr in snrs:
         g = p_clean / (p_m * 10.0 ** (snr / 20.0))
-        out.append(stoi(clean, clean + g * masker, fs, extended=extended).value)
+        out.append(speech.stoi(clean, clean + g * masker, fs, extended=extended).value)
     return out
 
 fig, (a, b) = plt.subplots(1, 2, figsize=(12, 5), sharey=True)

--- a/site/public/llms/llms-signals-filters.txt
+++ b/site/public/llms/llms-signals-filters.txt
@@ -261,16 +261,16 @@ all-pass has unit magnitude everywhere (only the phase turns).
 
 ```python
 import numpy as np
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 rng = np.random.default_rng(1)
 x = rng.standard_normal(fs)                 # one second of noise
 
-eq = ParametricEQ(fs, [
-    EQSection("lowshelf", 100.0, gain_db=4.0),
-    EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
-    EQSection("highshelf", 8000.0, gain_db=3.0),
+eq = filters.ParametricEQ(fs, [
+    filters.EQSection("lowshelf", 100.0, gain_db=4.0),
+    filters.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
+    filters.EQSection("highshelf", 8000.0, gain_db=3.0),
 ])
 y = eq.filter(x)              # apply the cascade
 res = eq.response()           # frozen result carrying the SOS cascade
@@ -287,21 +287,21 @@ For block processing pass `stateful=True` (the same convention as
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 family = [
-    EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
-    EQSection("lowshelf", 125.0, gain_db=6.0),
-    EQSection("highshelf", 4000.0, gain_db=-6.0),
-    EQSection("lowpass", 10000.0),
-    EQSection("highpass", 50.0),
-    EQSection("bandpass", 500.0, q=2.0),
-    EQSection("notch", 2000.0, q=6.0),
+    filters.EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
+    filters.EQSection("lowshelf", 125.0, gain_db=6.0),
+    filters.EQSection("highshelf", 4000.0, gain_db=-6.0),
+    filters.EQSection("lowpass", 10000.0),
+    filters.EQSection("highpass", 50.0),
+    filters.EQSection("bandpass", 500.0, q=2.0),
+    filters.EQSection("notch", 2000.0, q=6.0),
 ]
 fig, ax = plt.subplots(figsize=(10, 6))
 for section in family:
-    res = ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
+    res = filters.ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
     ax.semilogx(res.frequencies, res.magnitude_db,
                 label=f"{section.filter_type} @ {section.f0:g} Hz")
 ax.set(xlim=(20, 20000), ylim=(-27, 9),
@@ -1191,10 +1191,10 @@ Spanish fiche (translated fixed strings and a comma decimal separator), e.g.
 `result.report("iec61260_es.pdf", language="es")`.
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # overall_class == 1
 result.plot()   # the worst-margin band on its class corridor
 
 result.report(
@@ -1221,8 +1221,8 @@ ANSI S1.11-2004 mask, which keeps the stricter **class 0** that the 2014 edition
 dropped; the default order-6 Butterworth bank can then be certified to class 0:
 
 ```python
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
-result = filter_class_compliance(bank, edition="1995")   # overall_class == 0
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
+result = filters.filter_class_compliance(bank, edition="1995")   # overall_class == 0
 result.plot()   # the class-0 corridor of the 1995 edition
 result.report(
     "iec61260_1995.pdf",

--- a/site/public/llms/llms-signals-metrology.txt
+++ b/site/public/llms/llms-signals-metrology.txt
@@ -789,10 +789,10 @@ class; `intensity_class_compliance` does the same for the IEC 61043
 residual-index verdict:
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank_11 = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank_11)   # result.overall_class == 1
+bank_11 = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank_11)   # result.overall_class == 1
 result.report(
     "iec61260.pdf",
     metadata=ReportMetadata(
@@ -924,12 +924,12 @@ suite pins. The book's Example 4.4 (twenty observations, $A = 86$, accepted
 between 64 and 125) runs verbatim:
 
 ```python
-from phonometry import trend_test
+from phonometry import metrology
 
 values = [5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
           5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0]
 
-res = trend_test(values)                  # B&P Example 4.4
+res = metrology.trend_test(values)                  # B&P Example 4.4
 print(res.statistic, res.bounds)          # 86, (64, 125)
 print(res.trend_free, round(res.p_value, 3))   # True, 0.586
 res.plot()
@@ -943,14 +943,14 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 example = np.array([5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
                     5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0])
 drifting = example + np.linspace(0.0, 4.0, example.size)   # rising drift
 
-res_flat = trend_test(example)
-res_drift = trend_test(drifting)
+res_flat = metrology.trend_test(example)
+res_drift = metrology.trend_test(drifting)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, example.size + 1)
@@ -987,17 +987,17 @@ while the same noise without the drift passes:
 
 ```python
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 noise = np.random.default_rng(42).standard_normal(n)
 
-res = stationarity_test(noise, fs)        # 20 segments, mean squares
+res = metrology.stationarity_test(noise, fs)        # 20 segments, mean squares
 print(res.stationary, res.count, res.bounds)   # True, 91, (64, 125)
 
 drifting = noise * np.linspace(1.0, 1.2, n)    # +20 % gain ramp
-res = stationarity_test(drifting, fs)
+res = metrology.stationarity_test(drifting, fs)
 print(res.stationary, res.count)          # False, 7  (upward trend -> low A)
 res.plot()
 ```
@@ -1010,15 +1010,15 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 steady = np.random.default_rng(42).standard_normal(n)
 ramp = np.random.default_rng(42).standard_normal(n) * np.linspace(1.0, 1.2, n)
 
-res_steady = stationarity_test(steady, fs)
-res_ramp = stationarity_test(ramp, fs)
+res_steady = metrology.stationarity_test(steady, fs)
+res_ramp = metrology.stationarity_test(ramp, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, res_steady.n_segments + 1)
@@ -1060,15 +1060,15 @@ acceptance region at $\alpha = 0.05$ is the classical $(6, 15]$:
 
 ```python
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
-res = trend_test(rng.standard_normal(40), method="runs")
+res = metrology.trend_test(rng.standard_normal(40), method="runs")
 print(res.statistic, res.bounds, res.trend_free)
 res.plot()   # the sequence about its median with the runs verdict
 
 alternating = np.tile([1.0, -1.0], 10)   # 20 runs: rejected the other way
-print(trend_test(alternating, method="runs").trend_free)   # False
+print(metrology.trend_test(alternating, method="runs").trend_free)   # False
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test.svg" alt="Two panels of sequences classified about their median, points above in blue and below in red. Left: forty Gaussian observations with twenty runs inside the acceptance region from fourteen to twenty-seven, verdict trend-free. Right: a strictly alternating twenty-value sequence also giving twenty runs, but against the acceptance region from six to fifteen for twenty values, verdict rejected for too-rapid alternation" width="92%"></picture>
@@ -1084,19 +1084,19 @@ too *many* runs is as non-random as too few.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
 sequences = [rng.standard_normal(40), np.tile([1.0, -1.0], 10)]
 
 # One line per sequence — the tested values with the verdict:
-trend_test(sequences[0], method="runs").plot()
+metrology.trend_test(sequences[0], method="runs").plot()
 plt.show()
 
 # Both verdicts side by side, classified about the median:
 fig, axes = plt.subplots(1, 2, figsize=(11, 4.5))
 for ax, seq in zip(axes, sequences):
-    res = trend_test(seq, method="runs")
+    res = metrology.trend_test(seq, method="runs")
     idx = np.arange(1, seq.size + 1)
     median = np.median(seq)
     above = seq > median
@@ -1144,13 +1144,13 @@ the Rice curve next to them, taking the moments from the record's own
 
 ```python
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # a 60 Hz sine ...
 
-res = level_crossing_rate(x, fs)
+res = metrology.level_crossing_rate(x, fs)
 print(round(res.zero_crossing_rate, 1))   # ... has 120 zeros per second
 print(round(res.apparent_frequency, 1))   # 60.0
 res.plot()
@@ -1164,7 +1164,7 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 20480.0
 n = 1 << 19
@@ -1174,7 +1174,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[(freqs < 800.0) | (freqs > 1200.0)] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
+res = metrology.level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.levels, res.rice_rates, label="Rice (Eq. 5.196)")
@@ -1217,13 +1217,13 @@ available as `peak_exceedance()` / `peak_density()` on the result:
 
 ```python
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # narrowband: r is essentially 1
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 print(round(res.irregularity_factor, 3))       # 0.997
 print(res.peak_exceedance(4.0))                # exp(-8): about 1 in 3000
 res.plot()   # empirical exceedance against the Rice mixture (figure below)
@@ -1237,7 +1237,7 @@ res.plot()   # empirical exceedance against the Rice mixture (figure below)
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 from phonometry.metrology.data_qualification import _rice_peak_exceedance
 
 fs = 20480.0
@@ -1248,7 +1248,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[freqs > 2000.0] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 peaks = res.peak_values
 empirical = 1.0 - np.arange(1, peaks.size + 1) / peaks.size
 z = np.linspace(-2.5, 4.5, 400)

--- a/site/public/llms/llms-signals-spectra.txt
+++ b/site/public/llms/llms-signals-spectra.txt
@@ -249,9 +249,9 @@ has a single real Fourier component, so those bins carry half the degrees of
 freedom and a correspondingly wider interval.
 
 ```python
-from phonometry import power_spectral_density
+from phonometry import signals
 
-res = power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
+res = signals.power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -269,9 +269,9 @@ $$
 $$
 
 ```python
-from phonometry import resolution_bias_error
+from phonometry import signals
 
-eps_b = resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
+eps_b = signals.resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
 ```
 
 Narrow $B_\mathrm{e}$ (long segments) suppresses the bias but leaves fewer averages and
@@ -287,18 +287,14 @@ visible.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    fractional_octave_smoothing,
-    noise_signal,
-    power_spectral_density,
-)
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 20.0, color="pink", seed=11)
-res = power_spectral_density(x, fs, nperseg=4096)
+x = signals.noise_signal(fs, 20.0, color="pink", seed=11)
+res = signals.power_spectral_density(x, fs, nperseg=4096)
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
-smooth = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
+smooth = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.fill_between(freqs, 10 * np.log10(res.ci_lower[band]),
@@ -339,9 +335,9 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
-from phonometry import cross_spectral_density
+from phonometry import signals
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
 ```
@@ -360,16 +356,16 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import cross_spectral_density, noise_signal
+from phonometry import signals
 
 fs = 8000.0
 tau = 0.002                                   # 2 ms = 16 samples
 delay = int(tau * fs)
-x = noise_signal(fs, 8.0, seed=8)
-noise = noise_signal(fs, 8.0, rms=0.3, seed=9)
+x = signals.noise_signal(fs, 8.0, seed=8)
+noise = signals.noise_signal(fs, 8.0, rms=0.3, seed=9)
 y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 
 # One line — magnitude, phase with its ±sigma band and coherence:
 res.plot()
@@ -426,14 +422,14 @@ synthetic signal:
 
 ```python
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 at every frequency
 
-res = coherent_output_spectrum(x, y, fs)
+res = signals.coherent_output_spectrum(x, y, fs)
 print(np.median(res.coherence))          # -> SNR/(1+SNR) = 0.719
 print(np.median(res.snr_db))             # -> 10·lg(2.56) = 4.1 dB
 res.plot()                               # Gyy, Gvv, Gnn and the SNR panel
@@ -452,14 +448,14 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 per band
 
-res = coherent_output_spectrum(x, y, fs, nperseg=2048)
+res = signals.coherent_output_spectrum(x, y, fs, nperseg=2048)
 
 # One line — the three spectra and the SNR panel:
 res.plot()
@@ -503,12 +499,12 @@ squared first, dB levels converted and back), so band power is conserved
 rather than amplitude, and a flat spectrum passes through exactly unchanged.
 
 ```python
-from phonometry import fractional_octave_smoothing
+from phonometry import signals
 
-smooth_psd = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
-smooth_mag = fractional_octave_smoothing(freqs, np.abs(response), 6.0,
-                                         domain="amplitude")  # an FRF |H|
-smooth_db = fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
+smooth_psd = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
+smooth_mag = signals.fractional_octave_smoothing(freqs, np.abs(response), 6.0,
+                                                 domain="amplitude")  # an FRF |H|
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -537,10 +533,10 @@ seed reproduces the same record bit for bit.
 | `violet` | +2 | +6.02 dB/octave |
 
 ```python
-from phonometry import noise_signal
+from phonometry import signals
 
-pink = noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
-white = noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
+pink = signals.noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
+white = signals.noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
 ```
 
 Measured over three decades (20 Hz – 20 kHz) with the estimator of section 1,
@@ -571,9 +567,9 @@ it:
   resolution.
 
 ```python
-from phonometry import window_metrics
+from phonometry import signals
 
-m = window_metrics("hann", 2048)
+m = signals.window_metrics("hann", 2048)
 print(m.enbw_bins)              # 1.5, exactly
 print(m.scalloping_loss_db)     # 1.42 dB
 print(m.highest_sidelobe_db)    # -31.5 dB
@@ -626,9 +622,9 @@ taper count is $K = 2NW - 1$, all tapers with near-unity concentration.
 Larger $NW$ admits more tapers (lower variance) at the cost of resolution.
 
 ```python
-from phonometry import multitaper_psd
+from phonometry import signals
 
-res = multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band
@@ -672,12 +668,12 @@ precision, which is the anchor oracle of the test suite.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import multitaper_psd, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
-single = multitaper_psd(x, fs, n_tapers=1, adaptive=False)
-res = multitaper_psd(x, fs)                              # NW = 4, K = 7
+x = signals.noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
+single = signals.multitaper_psd(x, fs, n_tapers=1, adaptive=False)
+res = signals.multitaper_psd(x, fs)                              # NW = 4, K = 7
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
 
@@ -803,19 +799,19 @@ correlated inputs and one output.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import miso_coherence, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 # Input 1 drives a low-frequency path; input 2 = 0.7*x1 + independent noise
 # drives a high-frequency path, so input 2 is correlated with input 1.
-x1 = noise_signal(fs, 32.0, color="white", seed=1)
-x2 = 0.7 * x1 + noise_signal(fs, 32.0, color="white", seed=2)
+x1 = signals.noise_signal(fs, 32.0, color="white", seed=1)
+x2 = 0.7 * x1 + signals.noise_signal(fs, 32.0, color="white", seed=2)
 low = signal.butter(4, 400.0, fs=fs, output="sos")
 high = signal.butter(4, 1500.0, btype="high", fs=fs, output="sos")
-noise = noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
+noise = signals.noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
 y = signal.sosfilt(low, x1) + signal.sosfilt(high, x2) + noise
 
-res = miso_coherence([x1, x2], y, fs, nperseg=2048)
+res = signals.miso_coherence([x1, x2], y, fs, nperseg=2048)
 f = res.frequencies
 band = (f >= 20.0) & (f <= 4000.0)
 
@@ -884,7 +880,7 @@ to the multiple coherence (Eq. 7.116) and reduce exactly to the ordinary
 coherences when the inputs are mutually uncorrelated (Eq. 7.117).
 
 ```python
-res = miso_coherence([x1, x2], y, fs)
+res = signals.miso_coherence([x1, x2], y, fs)
 res.ordinary_coherence   # shape (q, F): each input on its own
 res.multiple_coherence   # shape (F,):  all inputs jointly
 res.partial_coherence    # shape (q, F): conditioned on the preceding inputs
@@ -947,7 +943,7 @@ Bendat & Piersol (Section 7.2.4) recommend ordering the inputs by descending
 ordinary coherence with the output. Pass `order` to choose:
 
 ```python
-res = miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
+res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order
 ```
@@ -1051,9 +1047,9 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
-from phonometry import spectrogram
+from phonometry import signals
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)
 print(res.time_resolution)         # T_B = nperseg/fs, in s
 print(res.resolution_bandwidth)    # Be of the tapered segment, in Hz
@@ -1080,7 +1076,7 @@ tool for the stationary background.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import noise_signal, spectrogram
+from phonometry import signals
 
 fs = 16000.0
 t = np.arange(int(4.0 * fs)) / fs
@@ -1095,10 +1091,10 @@ n_imp = int(0.06 * fs)                              # impact at t = 2.5 s
 x[int(2.5 * fs):int(2.5 * fs) + n_imp] += 0.4 * (
     rng.standard_normal(n_imp) * np.exp(-np.arange(n_imp) / (0.012 * fs))
 )
-x += noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
-                  rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
+x += signals.noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
+                          rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 level = 10.0 * np.log10(res.power / p_ref**2)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -1138,9 +1134,9 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
-from phonometry import zoom_fft
+from phonometry import signals
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
 print(res.bin_spacing)                   # fs/N by default
 print(res.resolution_bandwidth)          # Be of the tapered record
 peak = res.amplitude.argmax()
@@ -1164,7 +1160,7 @@ only a longer record separates closer tones.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import zoom_fft
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
@@ -1176,7 +1172,7 @@ coarse = 2.0 * np.abs(np.fft.rfft(x[:1024] * w)) / np.sum(w)
 coarse_f = np.fft.rfftfreq(1024, 1.0 / fs)
 band = (coarse_f >= 950.0) & (coarse_f <= 1050.0)
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(coarse_f[band], 20.0 * np.log10(coarse[band]), "o--",
@@ -1298,13 +1294,13 @@ computes the three standard variants over the quefrency axis:
 
 ```python
 import numpy as np
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(1)
 x = rng.standard_normal(4096)
 
-res = cepstrum(x, fs, kind="power")
+res = signals.cepstrum(x, fs, kind="power")
 print(res.quefrencies[:3], res.cepstrum.shape)   # quefrency axis, in s
 res.plot()
 ```
@@ -1324,7 +1320,7 @@ wavelet concentrates below 2 ms.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited source wavelet plus one reflection at 8 ms (a = 0.5)
@@ -1334,13 +1330,13 @@ s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
 # One line per variant — each CepstrumResult draws itself:
-cepstrum(x, fs, kind="power").plot()
+signals.cepstrum(x, fs, kind="power").plot()
 plt.show()
 
 # The three variants overlaid by hand on one quefrency axis:
 fig, ax = plt.subplots()
 for kind, style in (("power", "-"), ("real", "--"), ("complex", ":")):
-    res = cepstrum(x, fs, kind=kind)
+    res = signals.cepstrum(x, fs, kind=kind)
     q_ms = 1e3 * res.quefrencies
     mask = (q_ms > 0.5) & (q_ms <= 20.0)
     ax.plot(q_ms[mask], res.cepstrum[mask], style, label=f"{kind} cepstrum")
@@ -1389,14 +1385,14 @@ delay still lands on it, but the reported coefficient underestimates $|a|$
 
 ```python
 import numpy as np
-from phonometry import echo_detection
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(2)
 s = rng.standard_normal(12000)               # broadband source
 x = s + 0.5 * np.roll(s, 384)                # echo: 8 ms, a = 0.5
 
-res = echo_detection(x, fs, min_quefrency=0.002)
+res = signals.echo_detection(x, fs, min_quefrency=0.002)
 print(res.delay, res.reflection_coefficient)  # 0.008 s, ~0.5
 res.plot()
 ```
@@ -1410,7 +1406,7 @@ res.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import echo_detection, noise_signal
+from phonometry import signals
 
 fs = 48000.0
 n = 12000
@@ -1419,9 +1415,9 @@ impulse[0] = 1.0
 b, a = sp_signal.butter(2, [0.004, 0.9], btype="bandpass")
 direct = sp_signal.lfilter(b, a, impulse)              # broadband click
 ir = direct + 0.5 * np.roll(direct, int(0.008 * fs))   # echo at 8 ms
-ir += noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
+ir += signals.noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
 
-res = echo_detection(ir, fs, min_quefrency=0.002)
+res = signals.echo_detection(ir, fs, min_quefrency=0.002)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 half = res.nfft // 2 + 1
@@ -1456,15 +1452,15 @@ exactly complementary in dB, because the split is linear in the log domain:
 
 ```python
 import numpy as np
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(3)
 s = rng.standard_normal(12000)
 x = s + 0.5 * np.roll(s, 384)                # the same 8 ms echo
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
-high = lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
 print(np.allclose(low.liftered_db + high.liftered_db, low.spectrum_db))
 low.plot()
 ```
@@ -1483,7 +1479,7 @@ $20\log_{10}(1 \pm a) = +3.5$ and $-6.0$ dB.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited wavelet carrying a pure 8 ms echo (a = 0.5), so the
@@ -1493,8 +1489,8 @@ s = np.zeros(4096)
 s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")
-high = lifter(x, fs, cutoff=0.004, mode="highpass")
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")
 
 # One line — the cepstrum with the cutoff and the two log spectra:
 low.plot()
@@ -1536,14 +1532,14 @@ removes and stores in `linear_phase_samples`:
 ```python
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 x = np.zeros(2048)
 b, a = sp_signal.butter(2, 0.3)
 x[37:293] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 
-res = cepstrum(x, fs, kind="complex")
+res = signals.cepstrum(x, fs, kind="complex")
 print(res.linear_phase_samples)              # negative: a bulk delay removed
 print(np.max(np.abs(res.invert() - x)))      # ~1e-14
 res.plot()   # the complex cepstrum against quefrency (as in the figure above)
@@ -1589,13 +1585,13 @@ on an analysis bin the closed forms are:
 
 ```python
 import numpy as np
-from phonometry import envelope_spectrum
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(4 * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 k = int(round(25.0 * res.nfft / fs))
 print(res.mean_level, res.amplitude[k])      # ~1.0 and ~0.4
 res.plot()
@@ -1609,15 +1605,15 @@ res.plot()
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope_spectrum, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 seconds = 4.0
 t = np.arange(int(seconds * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
-x += noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.frequencies, res.amplitude, lw=1.4, label="Envelope spectrum")
@@ -1724,11 +1720,7 @@ Signal Processing 1(1), 1987, 83-95).
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    comb_filter_response,
-    noise_signal,
-    time_synchronous_average,
-)
+from phonometry import signals
 
 fs = 8192.0
 period = 1.0 / 32.0        # one revolution: 256 samples at this rate
@@ -1739,8 +1731,8 @@ periodic = (
     + 0.5 * np.cos(2.0 * np.pi * 3.0 * phase + 0.4)
     - 0.3 * np.cos(2.0 * np.pi * 6.0 * phase)
 )
-recording = periodic + noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
-res = time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
+recording = periodic + signals.noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
 
 fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(11, 4.6))
 t_ms = 1e3 * res.times
@@ -1752,9 +1744,9 @@ ax0.set_xlabel("Time [ms]"); ax0.set_ylabel("Amplitude"); ax0.legend()
 
 orders = np.linspace(31.0, 33.0, 4000)
 freqs = orders / period
-ax1.plot(orders, comb_filter_response(freqs, period, 32), color="#2ca02c",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 32), color="#2ca02c",
          label="N = 32 (power of two)")
-ax1.plot(orders, comb_filter_response(freqs, period, 20), color="#1f77b4",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 20), color="#1f77b4",
          label="N = 20 (node on 32.05)")
 ax1.axvline(32.05, color="#d62728", ls=":", label="Interfering tone")
 ax1.set_xlabel("Frequency [orders]"); ax1.set_ylabel("Comb filter magnitude")
@@ -1801,12 +1793,12 @@ every $j$ that is not a multiple of $N$, where the response is exactly zero.
 
 ```python
 import numpy as np
-from phonometry import comb_filter_response
+from phonometry import signals
 
 period = 1.0 / 32.0
-comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
-comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
-comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
+signals.comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
+signals.comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
+signals.comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
 ```
 
 `SynchronousAverageResult` carries the response over the first few harmonics
@@ -1823,7 +1815,7 @@ That is a power reduction of $10\log_{10} N$ dB, reported as
 `amplitude_snr_gain`:
 
 ```python
-res = time_synchronous_average(recording, fs, period=period, n_averages=100)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=100)
 res.noise_reduction_db      # 20.0 dB = 10*log10(100)
 res.amplitude_snr_gain      # 10.0   = sqrt(100)
 res.plot()                  # averaged waveform + the comb it applied
@@ -1842,7 +1834,7 @@ the ideal $\sigma/\sqrt{N}$ line as the number of averaged periods grows from
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import time_synchronous_average
+from phonometry import signals
 
 fs = 8192.0
 samples = 256
@@ -1857,8 +1849,8 @@ recording = np.tile(true, 128) + rng.standard_normal(128 * samples)
 counts = [1, 2, 4, 8, 16, 32, 64, 128]
 errors = []
 for n in counts:
-    res = time_synchronous_average(recording[:n * samples], fs, period=period,
-                                   n_averages=n)
+    res = signals.time_synchronous_average(recording[:n * samples], fs, period=period,
+                                           n_averages=n)
     errors.append(np.sqrt(np.mean((res.period_waveform - true) ** 2)))
 
 # One line — the averaged waveform and the comb filter it applied:
@@ -1908,8 +1900,8 @@ average confirms it:
 phase = np.arange(41 * 256) / 256
 recording = np.cos(2 * np.pi * 8.0 * phase) + 0.7 * np.cos(2 * np.pi * 32.05 * phase)
 
-leak_20 = time_synchronous_average(recording, fs, period=period, n_averages=20)
-leak_32 = time_synchronous_average(recording, fs, period=period, n_averages=32)
+leak_20 = signals.time_synchronous_average(recording, fs, period=period, n_averages=20)
+leak_32 = signals.time_synchronous_average(recording, fs, period=period, n_averages=32)
 # leak_20.period_waveform matches the clean 8th-order tone; leak_32 does not
 ```
 
@@ -1932,7 +1924,7 @@ fs = 8192.0
 period = 1.0 / 31.7                       # fs * period is not an integer
 t = np.arange(int(40 * period * fs)) / fs
 recording = np.cos(2.0 * np.pi * t / period)  # one cycle per revolution
-res = time_synchronous_average(recording, fs, period=period)
+res = signals.time_synchronous_average(recording, fs, period=period)
 res.interpolated                          # True: fractional-delay alignment
 res.samples_per_period                    # integer samples of one period
 ```
@@ -2045,9 +2037,9 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 
 ```python
 import numpy as np
-from phonometry import correlation
+from phonometry import signals
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
 res.plot()
@@ -2067,23 +2059,23 @@ there (bottom).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import correlation, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 delay = 102                                  # 12.45 ms
-x = noise_signal(fs, 2.0, seed=4)
-interference = noise_signal(fs, 2.0, rms=0.5, seed=5)
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
 y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 
 # One line — the correlation estimate against the lag in seconds:
 res.plot()
 plt.show()
 
 # The three normalizations by hand, from the same records:
-biased = correlation(x, y, fs, normalization="biased")
-unbiased = correlation(x, y, fs, normalization="unbiased")
+biased = signals.correlation(x, y, fs, normalization="biased")
+unbiased = signals.correlation(x, y, fs, normalization="unbiased")
 
 fig, (ax_c, ax_n) = plt.subplots(2, 1)
 ax_c.plot(1e3 * res.lags, res.values, label="coefficient")
@@ -2166,18 +2158,18 @@ attaches to each:
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import noise_signal, time_delay
+from phonometry import signals
 
 fs = 8192.0
 delay = 20  # samples
 b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
-s = sp_signal.lfilter(b, a, noise_signal(fs, 4.0, color="white", seed=10))
-x = s + noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
-y = np.roll(s, delay) + noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
-direct = time_delay(x, y, fs, method="direct", max_delay=0.01)
-phat = time_delay(x, y, fs, method="gcc", weighting="phat",
-                  nperseg=2048, max_delay=0.01)
+direct = signals.time_delay(x, y, fs, method="direct", max_delay=0.01)
+phat = signals.time_delay(x, y, fs, method="gcc", weighting="phat",
+                          nperseg=2048, max_delay=0.01)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(1e3 * direct.lags,
@@ -2212,10 +2204,10 @@ $$
 $$
 
 ```python
-from phonometry import time_delay
+from phonometry import signals
 
-res = time_delay(x, y, fs, method="gcc", weighting="ml",
-                 nperseg=2048, upsample=16, signal_bandwidth=1000.0)
+res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
+                         nperseg=2048, upsample=16, signal_bandwidth=1000.0)
 print(res.delay, res.delay_samples)     # seconds and fractional samples
 print(res.delay_std, res.delay_interval)  # Eq. 8.129 sigma, +/-2 sigma
 res.plot()                              # correlation with the delay marked
@@ -2237,12 +2229,12 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
-from phonometry import align_impulse_responses, impulse_response_delay
+from phonometry import signals
 
-t_arrival = impulse_response_delay(ir, fs)              # seconds from t = 0
-dt = impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
+t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
-res = align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
+res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
 res.plot()                                     # reference vs aligned overlay
 ```
 
@@ -2259,17 +2251,17 @@ back onto its reference: the band-limited shift removes the estimated
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import align_impulse_responses, fractional_delay
+from phonometry import signals
 
 fs = 48000.0
 t = np.arange(int(0.03 * fs)) / fs
 rng = np.random.default_rng(6)
 # Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
 ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
-ir_b = fractional_delay(ir_a, 7.37)[: ir_a.size]
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
 ir_b += 0.005 * rng.standard_normal(ir_a.size)
 
-res = align_impulse_responses(ir_b, ir_a, fs)
+res = signals.align_impulse_responses(ir_b, ir_a, fs)
 
 # One line — reference and aligned IR overlaid:
 res.plot()
@@ -2315,13 +2307,13 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
-from phonometry import envelope
+from phonometry import signals
 
-res = envelope(x, fs)
+res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)
 res.plot()               # signal + envelope, instantaneous frequency
 
-slow = envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
+slow = signals.envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope.svg" alt="Two panels for a decaying 250 hertz mode in light noise. Top: the oscillating signal with the smooth exponential Hilbert envelope tracing its decay above and below. Bottom: the instantaneous frequency staying on the dashed 250 hertz carrier line while the mode is strong and jittering increasingly as the signal decays into the noise floor" width="86%"></picture>
@@ -2337,7 +2329,7 @@ noise floor (bottom, ×8 anti-aliased decimation).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(0.4 * fs)) / fs
@@ -2345,7 +2337,7 @@ rng = np.random.default_rng(7)
 x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 x += 0.001 * rng.standard_normal(t.size)
 
-res = envelope(x, fs, decimation_factor=8)
+res = signals.envelope(x, fs, decimation_factor=8)
 
 # One line — signal + envelope and the instantaneous frequency:
 res.plot()
@@ -2468,14 +2460,14 @@ single burst or as the repetitive train of Clause A2.2 in which each burst
 occupies one full repetition period:
 
 ```python
-from phonometry import tone_burst
+from phonometry import signals
 
 # One 5 ms burst of 5 kHz tone (25 full periods), as in Table AII.
-single = tone_burst(48000, 5000, 25)
+single = signals.tone_burst(48000, 5000, 25)
 print(single.burst_samples)         # 240 samples = 5 ms at 48 kHz
 
 # Clause A2.2: 5 ms bursts at 10 bursts per second.
-train = tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
+train = signals.tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
 print(train.period_samples, train.duty_cycle)   # 4800, 0.05
 train.plot()                        # waveform with the gating envelope
 ```
@@ -2495,11 +2487,11 @@ the generator is verified.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import tone_burst
+from phonometry import signals
 
 fs = 48000.0
-single = tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
-train = tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
+single = signals.tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
+train = signals.tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
 
 fig, axes = plt.subplots(2, 1, figsize=(10, 6.4))
 t_ms = 1e3 * np.arange(single.signal.size) / single.fs
@@ -2546,10 +2538,10 @@ numbers the caller controls:
   bound $\delta = 10^{-A/20}$.
 
 ```python
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 print(res.up, res.down)                  # 160, 147
 print(res.n_taps, res.passband_edge_hz)  # designed FIR, 20947.5 Hz
 res.plot()   # the delivered anti-alias filter against its design spec
@@ -2569,10 +2561,10 @@ it, flat within the same ripple bound.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 
 # res is the ResampledSignalResult computed in the example above.
 # One line — the delivered anti-alias filter against its design spec:
@@ -2635,10 +2627,10 @@ boundary conventions cover the two use cases:
 
 ```python
 import numpy as np
-from phonometry import fractional_delay
+from phonometry import signals
 
-y = fractional_delay(x, 0.37)                    # 0.37 samples later
-z = fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
+y = signals.fractional_delay(x, 0.37)                    # 0.37 samples later
+z = signals.fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
 ```
 
 One subtlety worth knowing: a real record of even length cannot carry a
@@ -2760,10 +2752,10 @@ comes back to machine precision, a closed-form identity the tests and the
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 
 # Simulated measurement: play each code periodically and record one
 # steady-state period of a room-like band-pass system.
@@ -2772,7 +2764,7 @@ length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 print(ir.method, ir.size)                   # golay 16384
 ir.plot()
 ```
@@ -2790,16 +2782,16 @@ complementary correlations land on the true response to machine precision
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 b, a = signal.butter(2, [200.0, 2000.0], btype="bandpass", fs=fs)
 length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 
 # One line — the recovered impulse response:
 ir.plot()
@@ -2859,10 +2851,10 @@ details; `target` is `"pink"` (the classical room-measurement emphasis,
 default), `"white"`, or any `(frequencies_hz, magnitude_db)` pair:
 
 ```python
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-sweep = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+sweep = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 print(round(sweep.crest_factor_db, 1))      # 4.2 (dB; the ideal is 3.02)
 sweep.plot()
 ```
@@ -2876,10 +2868,10 @@ sweep.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-res = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+res = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 x = np.asarray(res)
 
 nperseg = 8192   # 75 % overlap: 50 % would ripple ~2 dB on a sweep
@@ -2924,20 +2916,20 @@ for the [spectral method](https://jmrplens.github.io/phonometry/buildings/rooms/
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import impulse_response, shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
 freqs = np.array([50.0, 200.0, 1000.0, 8000.0])
 emphasis = np.array([12.0, 6.0, 0.0, 0.0])   # LF boost against rumble
-sweep = shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
-                            target=(freqs, emphasis))
+sweep = room.shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
+                                 target=(freqs, emphasis))
 
 # Simulated measurement of a known system (replace with play/record):
 b, a = signal.butter(2, [200.0, 4000.0], btype="bandpass", fs=fs)
 excitation = np.concatenate([np.asarray(sweep), np.zeros(fs)])
 recorded = signal.lfilter(b, a, excitation)
 
-ir = impulse_response(recorded, excitation, fs, length=fs)
+ir = room.impulse_response(recorded, excitation, fs, length=fs)
 ir.plot()
 ```
 
@@ -2972,7 +2964,7 @@ of a mixed-phase response causal
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 # A loudspeaker-like measured response (replace with a measured IR).
@@ -2981,7 +2973,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 print(round(inv.flatness_db, 5))    # 1e-05 (dB: in-band deviation from 0 dB)
 print(round(inv.max_gain_db, 1))    # -6.0 (dB: capped out-of-band boost)
 inv.plot()
@@ -2996,7 +2988,7 @@ inv.plot()
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -3004,7 +2996,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-res = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+res = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 f = res.frequencies[1:]
 h_mag = np.abs(res.response_spectrum)[1:]
 inv_mag = np.abs(res.spectrum)[1:]
@@ -3039,17 +3031,16 @@ rate rides along:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import (impulse_response, regularized_inverse_filter,
-                        sweep_signal)
+from phonometry import room, signals
 
 fs = 48000
-sweep = sweep_signal(fs, 50.0, 20000.0, 1.0)
+sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)
 excitation = np.concatenate([sweep, np.zeros(fs // 2)])
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
 recorded = signal.lfilter(b, a, excitation)     # play/record in reality
 
-ir = impulse_response(recorded, excitation, fs)  # any front end works
-inv = regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
+ir = room.impulse_response(recorded, excitation, fs)  # any front end works
+inv = signals.regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
 flat_recording = inv.apply(recorded)             # delay already removed
 inv.plot()   # measured, inverse and equalized magnitudes (figure above)
 ```
@@ -3066,7 +3057,7 @@ post-processing:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter, shaped_sweep_signal
+from phonometry import room, signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -3074,12 +3065,12 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)                    # the measured response
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 target_db = 20.0 * np.log10(
     np.abs(inv.spectrum[1:]) * np.abs(inv.response_spectrum).max()
 )
-sweep = shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
-                            target=(inv.frequencies[1:], target_db))
+sweep = room.shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
+                                 target=(inv.frequencies[1:], target_db))
 sweep.plot()   # waveform and spectrum against the inverted-response target
 ```
 

--- a/site/public/llms/llms-simulation.txt
+++ b/site/public/llms/llms-simulation.txt
@@ -981,8 +981,7 @@ few degrees.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (HelmholtzResonator, MetadiffuserWell,
-                        metadiffuser_polar_response, simulation)
+from phonometry import materials, simulation
 
 c0, dx, f0, pitch = 343.0, 0.0005, 2000.0, 0.07
 rows = [(14.7, 13.0, 16.4, 6.2, 9.0), (30.9, 9.1, 4.3, 3.5, 9.0),
@@ -1029,12 +1028,12 @@ pattern = simulation.far_field_from_contour(
     origin=((lat + face / 2.0) * dx, r_face * dx))
 levels = 20 * np.log10(np.abs(pattern) / np.abs(pattern).max())
 
-wells = [MetadiffuserWell(h * 1e-3,
-                          (HelmholtzResonator(ln * 1e-3, wn * 1e-3,
-                                              lc * 1e-3, wc * 1e-3),) * 2)
+wells = [materials.MetadiffuserWell(h * 1e-3,
+                                    (materials.HelmholtzResonator(ln * 1e-3, wn * 1e-3,
+                                                        lc * 1e-3, wc * 1e-3),) * 2)
          for h, ln, lc, wn, wc in rows]
-model = metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
-                                    angles=angles, periods=1)
+model = materials.metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
+                                              angles=angles, periods=1)
 ax = model.plot(color="#1f77b4", marker="", linestyle="--",
                 label="TMM + Fraunhofer model")
 ax.plot(np.radians(angles), levels, color="#d62728", lw=2.2,

--- a/site/public/llms/llms-vibration-machinery.txt
+++ b/site/public/llms/llms-vibration-machinery.txt
@@ -111,12 +111,12 @@ BSF. That is the diagnosis: a spall on the outer race.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import bearing_fault_frequencies, envelope_spectrum, noise_signal
+from phonometry import signals, vibration
 
 # The bearing: 15 rollers on a 34 mm pitch diameter, 6 mm rollers,
 # 12.96 degrees contact angle, shaft at 2000 r/min.
-faults = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
-                                   contact_angle_deg=12.96)
+faults = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
+                                             contact_angle_deg=12.96)
 bpfo, shaft = faults["BPFO"], faults.shaft_rate    # 207.0 Hz, 33.33 Hz
 
 # A spalled outer race: one impact per BPFO period, each ringing a 3 kHz
@@ -131,11 +131,11 @@ tau = np.arange(int(0.004 * fs)) / fs
 ring = np.exp(-tau / 6.0e-4) * np.sin(2.0 * np.pi * 3000.0 * tau)
 x = np.convolve(impacts, ring)[: t.size] * 0.6
 x += 0.35 * np.sin(2.0 * np.pi * shaft * t)          # residual unbalance
-x += noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
 
 # Band-pass the resonance the impacts ring, envelope it, transform it,
 # and let the result draw its own lines on top.
-spectrum = envelope_spectrum(x, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(x, fs, band=(2000.0, 4000.0))
 faults.within(1.0, 5.0 * bpfo).plot(spectrum=spectrum)
 plt.show()
 ```
@@ -166,9 +166,9 @@ errors instantly: $\text{BPFO} + \text{BPFI} = Z f_\mathrm{s}$ always, and
 $\text{BPFO} = Z \times \text{FTF}$ whenever the outer race is stationary.
 
 ```python
-from phonometry import bearing_fault_frequencies
+from phonometry import vibration
 
-res = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
+res = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
 print(round(res["BPFO"], 1), round(res["BPFI"], 1))   # 207.0 293.0
 print(round(res["BPFO"] + res["BPFI"], 1))            # 500.0 = 15 x 33.33
 print(res.as_dict())
@@ -194,10 +194,10 @@ flat sidebands spaced by the shaft rate, while distributed wear raises tall
 sideband groups and lifts the higher mesh harmonics.
 
 ```python
-from phonometry import gear_mesh_frequencies
+from phonometry import vibration
 
 # A 28-tooth pinion on a 1500 r/min shaft, with two sideband orders.
-res = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+res = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 print(round(res["GMF"], 1))            # 700.0
 print(round(res["GMF+1x"], 1))         # 725.0  (GMF + one shaft order)
 print(res.harmonics("GMF", 3))         # [ 700. 1400. 2100.]
@@ -223,10 +223,10 @@ $n = 1, 2, \ldots$. Dynamic eccentricity dresses the dominant slot harmonic
 with sidebands at $\pm$ the shaft rate and $\pm$ the slip frequency.
 
 ```python
-from phonometry import induction_motor_frequencies
+from phonometry import vibration
 
 # Sixty rotor bars, six magnetic poles, 3600 r/min, no slip.
-res = induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
+res = vibration.induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
 print(round(res["1x"]), round(res["2x"]),
       round(res["2fe"]), round(res["fsh"]))     # 60 120 360 3600
 ```
@@ -259,10 +259,10 @@ count reached from a different harmonic is a different pattern turning at a
 different speed.
 
 ```python
-from phonometry import blade_pass_frequencies
+from phonometry import vibration
 
 # Six blades, four vanes, 3500 r/min.
-res = blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
+res = vibration.blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
 print(round(res["BPF"]))          # 350
 print(round(res["lobe n=1 m=2"]), round(res["lobe n=1 m=10"]))    # 175 35
 ```
@@ -295,24 +295,19 @@ harmonic or sideband family onto a single quefrency spike, which is the fastest
 way to tell *which* periodicity dominates when several are superimposed.
 
 ```python
-from phonometry import (
-    bearing_fault_frequencies,
-    combine_fault_lines,
-    envelope_spectrum,
-    gear_mesh_frequencies,
-)
+from phonometry import signals, vibration
 
 record, fs = x, 20000.0          # the housing record and its sample rate
 shaft_rpm = 2000.0               # from the tacho, not from the nameplate
 
 # The bearing's own lines, the mesh family of the pinion it supports, and the
 # shaft harmonics. Put them all on one axes.
-bearing = bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
-                                    contact_angle_deg=12.96)
-gear = gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
-lines = combine_fault_lines(bearing, gear)
+bearing = vibration.bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
+                                              contact_angle_deg=12.96)
+gear = vibration.gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
+lines = vibration.combine_fault_lines(bearing, gear)
 
-spectrum = envelope_spectrum(record, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(record, fs, band=(2000.0, 4000.0))
 lines.within(1.0, 1600.0).plot(spectrum=spectrum)
 ```
 

--- a/site/public/llms/llms-vibration-structural.txt
+++ b/site/public/llms/llms-vibration-structural.txt
@@ -508,10 +508,10 @@ continuous 200 mm wall.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # A 140 mm concrete floor meeting a 200 mm wall at a T-junction.
-res = junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
+res = vibration.junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
 res.plot_geometry()
 plt.show()
 ```
@@ -525,10 +525,10 @@ plt.show()
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # X-junction between a 100 mm and a 200 mm concrete plate (cL = 3200 m/s).
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 res.plot()  # tau(theta) for the corner and straight paths, with averages
 plt.show()
 ```
@@ -560,9 +560,9 @@ cut-off angle $\theta_\text{co} = \arcsin\chi$; $\psi$ is the ratio of their
 bending-moment mobilities. For **identical plates** both are 1.
 
 ```python
-from phonometry import junction_wave_parameters
+from phonometry import vibration
 
-chi, psi = junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+chi, psi = vibration.junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 #  -> (sqrt(0.5), 4.0)
 ```
 
@@ -604,14 +604,11 @@ plates 2 and 4 identical.
 
 ```python
 import numpy as np
-from phonometry import (
-    corner_transmission_coefficient,
-    straight_transmission_coefficient,
-)
+from phonometry import vibration
 
 theta = np.radians(np.linspace(0.0, 90.0, 91))
-tau12 = corner_transmission_coefficient(theta, chi, psi, "X")
-tau13 = straight_transmission_coefficient(theta, chi, psi, "X")
+tau12 = vibration.corner_transmission_coefficient(theta, chi, psi, "X")
+tau13 = vibration.straight_transmission_coefficient(theta, chi, psi, "X")
 ```
 
 The clip below runs this experiment in the time domain with the library's 2D
@@ -646,10 +643,10 @@ first-principles oracle:
 * in-line junction: $\tau_{12}(0°) = 1$ (a continuous plate transmits fully).
 
 ```python
-from phonometry import angular_average_transmission_coefficient
+from phonometry import vibration
 
-angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
-angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
 ```
 
 The two directions obey the SEA consistency relationship (Eq. 5.7),
@@ -681,14 +678,13 @@ X-junction ($f_\mathrm{c} \approx 203\ \text{Hz}$),
 $K_{ij} = 10\log_{10} 12 + 5\log_{10}(203/1000) \approx 7.3\ \text{dB}$.
 
 ```python
-from phonometry import (coupling_loss_factor, junction_transmission,
-                        wave_vibration_reduction_index)
+from phonometry import vibration
 
-eta = coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
-                           junction_length=4.0, frequency=500.0, plate_area=10.0)
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
-kij = wave_vibration_reduction_index(res.corner_average,
-                                     res.critical_frequency2)  # 7.33 dB
+eta = vibration.coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
+                                     junction_length=4.0, frequency=500.0, plate_area=10.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
+kij = vibration.wave_vibration_reduction_index(res.corner_average,
+                                               res.critical_frequency2)  # 7.33 dB
 kij = res.corner_reduction_index  # the same, precomputed on the result
 
 res.plot()   # tau(theta) for this junction's corner and straight paths (needs matplotlib)
@@ -715,7 +711,7 @@ perpendicular plates increasingly pin the junction line:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import junction_transmission, wave_vibration_reduction_index
+from phonometry import vibration
 
 # Concrete plates (cL = 3200 m/s, rho = 2400 kg/m3): plate 1 fixed at
 # 100 mm, plate 2 swept from 50 mm to 400 mm.
@@ -724,7 +720,7 @@ ratios = np.linspace(0.5, 4.0, 36)
 kij_corner = []
 for ratio in ratios:
     h2 = h1 * float(ratio)
-    res = junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
+    res = vibration.junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
     kij_corner.append(res.corner_reduction_index)
 
 fig, ax = plt.subplots()
@@ -747,10 +743,10 @@ the top: its corner path gives $K_{12} = 9.8\ \text{dB}$. Handing that to
 junction's three flanking paths and their effect on the apparent rating:
 
 ```python
-from phonometry import building, junction_transmission
+from phonometry import building, vibration
 
 # The 100 mm / 200 mm concrete X-junction of the opening figure:
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 k12 = res.corner_reduction_index                     # 9.8 dB (corner path)
 
 # Feed it to the EN 12354-1 simplified model as this junction's Kij:
@@ -829,15 +825,7 @@ model to be trustworthy.*
 import math
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coupling_loss_factor,
-    cylindrical_shell_modal_density,
-    flat_plate_modal_density,
-    plate_bending_stiffness,
-    point_connection_coupling_loss_factor,
-    power_injection_clf,
-    right_angle_transmission_coefficient,
-)
+from phonometry import vibration
 from phonometry.vibration.structural.point_mobility import plate_bending_wave_speed
 
 rho, nu, young = 2700.0, 0.33, 7.1e10                 # aluminium
@@ -847,13 +835,13 @@ bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0])
 # Predicted: a 3 mm x 2.5 m x 1.2 m plate meeting a 5.5 mm x 2.0 m x 1.2 m
 # plate at right angles along the 1.2 m edge, welded and then bolted.
 h1, h2, area1, length = 0.003, 0.0055, 2.5 * 1.2, 1.2
-tau = right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
-                                           wave_speed1=cl, wave_speed2=cl)
-cb = plate_bending_wave_speed(bands, plate_bending_stiffness(young, h1, nu),
+tau = vibration.right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
+                                                     wave_speed1=cl, wave_speed2=cl)
+cb = plate_bending_wave_speed(bands, vibration.plate_bending_stiffness(young, h1, nu),
                               rho * h1)
-welded = [float(coupling_loss_factor(tau, 2.0 * c, length, f, area1))
+welded = [float(vibration.coupling_loss_factor(tau, 2.0 * c, length, f, area1))
           for c, f in zip(cb, bands, strict=True)]
-bolted = point_connection_coupling_loss_factor(
+bolted = vibration.point_connection_coupling_loss_factor(
     bands, 12, thickness1=h1, thickness2=h2, surface_density1=rho * h1,
     surface_density2=rho * h2, wave_speed1=cl, wave_speed2=cl,
     plate_area1=area1)
@@ -863,11 +851,11 @@ bolted = point_connection_coupling_loss_factor(
 t_p, t_c, radius = 0.005, 0.003, 0.75
 area_c = 2.0 * math.pi * radius * 2.0
 area_p = 3.5 * 3.0 - math.pi * radius**2
-sea = power_injection_clf(
+sea = vibration.power_injection_clf(
     500.0, rho * t_p * area_p * 0.0272**2, rho * t_c * area_c * 0.0132**2,
     4.4e-3, 2.4e-3,
-    flat_plate_modal_density(area_p, t_p, cl),
-    float(cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
+    vibration.flat_plate_modal_density(area_p, t_p, cl),
+    float(vibration.cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
 
 print(f"{float(sea.coupling_loss_factor12[0]):.2e}")   # 4.26e-04
 print(f"{float(sea.coupling_loss_factor21[0]):.2e}")   # 3.91e-04
@@ -1199,13 +1187,13 @@ $L_k(f)$ spectrum, so it needs both the report and plot extras
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, TransferStiffnessResult, transfer_stiffness_direct
+from phonometry import ReportMetadata, vibration
 
 freqs = np.array([20, 31.5, 50, 80, 125, 200, 315, 500, 800, 1250, 2000], dtype=float)
 k21 = 1e6 + 1j * (2 * np.pi * freqs) * 80.0     # Kelvin-Voigt element k + jwc
 u1 = 1e-6 + 0j
-k = transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
-res = TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
+k = vibration.transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
+res = vibration.TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
 res.report(
     "transfer_stiffness.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/aircraft/aircraft-noise.mdx
+++ b/site/src/content/docs/aircraft/aircraft-noise.mdx
@@ -307,10 +307,10 @@ EPNL result and is not an official State noise certificate; it does not
 reproduce any TCDSN.
 
 ```python
-from phonometry import effective_perceived_noise_level, ReportMetadata
+from phonometry import ReportMetadata, aircraft
 
 # spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
-res = effective_perceived_noise_level(spectra, dt=0.5)
+res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 res.report(
     "epnl_fiche.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/aircraft/anp-fleet.mdx
+++ b/site/src/content/docs/aircraft/anp-fleet.mdx
@@ -40,9 +40,9 @@ writing a table yourself.
 Point it at a directory to read any other ANP CSV export instead.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 print(len(db.aircraft_ids))          # 155 aircraft types
 ac = db.aircraft("747100")
 print(ac.description)                # Boeing 747-100 / JT9DBD
@@ -82,9 +82,9 @@ variant: `A320-232` is the IAE-engined A320 and `747100` the JT9D-engined
 747-100. Search the descriptions to find yours rather than guessing the string:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for aid in db.aircraft_ids:
     rec = db.aircraft(aid)
     if "A320" in rec.description:
@@ -132,9 +132,9 @@ asserts anything — everything between them is Doc 29 interpolation.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 curves = ac.npd_curves("D", "SEL")
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -150,18 +150,18 @@ plt.show()
 </details>
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-load_anp_database().aircraft("747100").npd_curves("D", "SEL").plot()
+aircraft.load_anp_database().aircraft("747100").npd_curves("D", "SEL").plot()
 ```
 
 To read a single value rather than draw the family, `level` interpolates at any
 power and distance:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-curves = load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
+curves = aircraft.load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
 print(curves.powers)                       # [10000. 14000. 19000. 23000.] lb
 print(curves.level(19000.0, [304.8, 1000.0, 3000.0]))
 ```
@@ -192,9 +192,9 @@ footprint is longer and wider.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -210,9 +210,9 @@ plt.show()
 </details>
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-load_anp_database().aircraft("747100").profile("D", stage_length=1).plot()
+aircraft.load_anp_database().aircraft("747100").profile("D", stage_length=1).plot()
 ```
 
 The **stage length** selects the trip-distance bin: a longer stage means more
@@ -237,9 +237,9 @@ for one that does not exist raises a `KeyError` naming the stage lengths that
 do, which is also how to discover the bins an aircraft actually ships:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for identifier, operation, stage in (("A320-232", "D", 1), ("747100", "D", 9)):
     try:
         db.profile(identifier, operation, stage)
@@ -288,9 +288,9 @@ atmosphere they were reduced to, and the chain offers no humidity-dependent band
 correction, so a hot dry aerodrome is not modelled by passing its temperature.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 flyover = ac.event_level([3000.0, 500.0, 0.0], "D")
 print(round(float(flyover.level), 1))     # 100.4 dB
 ```
@@ -302,9 +302,9 @@ lateral attenuation switches on as the elevation angle falls below 50°.
 
 ```python
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 contour = ac.noise_contour(
     "D",
     x=np.linspace(-2000.0, 12000.0, 40),
@@ -335,9 +335,9 @@ calculation at one point and at 1 200 of them.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 x = np.linspace(-2000.0, 12000.0, 40)
 y = np.linspace(-3000.0, 3000.0, 30)

--- a/site/src/content/docs/aircraft/rotorcraft-noise.mdx
+++ b/site/src/content/docs/aircraft/rotorcraft-noise.mdx
@@ -824,11 +824,11 @@ and only pay for a full elevation model if that section turns out to be
 screened.
 
 ```python
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = [63.0, 250.0, 1000.0, 4000.0]
-diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
-diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
+aircraft.diffraction_attenuation(bands, 0.0, edge_height=2.5)   # grazing incidence
+aircraft.diffraction_attenuation(bands, 1.0, edge_height=2.5)   # 1 m into the shadow
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_insertion_loss.svg" alt="Diffraction attenuation against path difference for four bands from 63 Hz to 4 kHz, over a 2.5 m edge: every curve is zero left of its own band-dependent threshold near the line of sight, the three bands with C_h = 1 cross about 4.8 dB at grazing incidence while 63 Hz crosses at 3.0 dB, and only the 4 kHz curve reaches the 25 dB cap within the plotted range" width="82%" />
@@ -848,11 +848,11 @@ with wavelength alone.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bands = np.array([63.0, 250.0, 1000.0, 4000.0])
 delta = np.linspace(-0.4, 1.5, 441)
-ld = np.array([diffraction_attenuation(bands, float(d), edge_height=2.5)
+ld = np.array([aircraft.diffraction_attenuation(bands, float(d), edge_height=2.5)
               for d in delta])
 
 fig, ax = plt.subplots(figsize=(9, 6))

--- a/site/src/content/docs/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/buildings/design/detailed-prediction.mdx
@@ -253,35 +253,31 @@ direct path plus three per flanking element, $1 + 4\times3$.
 
 ```python
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 
 # Annex E junctions (unrounded): floor-to-external-wall rigid T, external wall
 # in-line across it, floor-to-internal-wall rigid cross, internal wall in-line.
-k_floor_ext = junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
-k_ext_ext = junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
-k_floor_int = junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
-k_int_int = junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_ext_ext = building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
+k_int_int = building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
 print(round(k_floor_ext, 1), round(k_ext_ext, 1))     # 6.4 11.2  (Table L.5)
 print(round(k_floor_int, 1), round(k_int_int, 1))     # 8.8 11.0  (Table L.6)
 
 # The floor's perimeter: it butts into an external wall above and below at each
 # of its two external edges, and crosses the internal walls at the other two.
-a_at_ext = perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
-a_at_int = perimeter_absorption_coefficient(
-    [76.8, 128.4, 128.4], [junction_vibration_reduction(
+a_at_ext = building.perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
+a_at_int = building.perimeter_absorption_coefficient(
+    [76.8, 128.4, 128.4], [building.junction_vibration_reduction(
         "rigid_cross", "through", 360.0 / 484.0), k_floor_int, k_floor_int])
 floor_perimeter = 9.0 * (a_at_ext + a_at_int)         # 2.659 m (Formula C.4)
 
-floor = HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
-                           floor_perimeter, 2200.0, 3800.0)
-el = in_situ_element(floor, bands)
+floor = building.HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
+                                    floor_perimeter, 2200.0, 3800.0)
+el = building.in_situ_element(floor, bands)
 print(np.round(el.total_loss_factor[[0, 10]], 4))     # [0.0831 0.029 ]  Table L.3
 print(np.round(el.sound_reduction_index[[0, 10]], 1)) # [31.8 54.9]      Table L.3
 print(np.round(el.impact_level[[0, 10]], 1))          # [57.3 63.6]      Table G.3
@@ -294,13 +290,13 @@ Every printed column of Tables L.2, L.3, L.4, G.3 and G.4 comes back within
 ```python
 # The floating floor: 35 mm screed, m' = 73,5 kg/m2 on s' = 8 MN/m3.
 f0 = 160.0 * np.sqrt(8.0 / 73.5)                      # 52.8 Hz (Formula C.2)
-delta = floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
+delta = building.floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
 
-wall = in_situ_element(HomogeneousElement(
+wall = building.in_situ_element(building.HomogeneousElement(
     "ext1", 11.0, 4.0, 2.75, 219.0, 92.6, 0.0125, 2.375, 600.0, 1900.0), bands)
 
 # Path D1 (Df: separating floor -> external wall 1), Table L.4.
-d1 = airborne_flanking_path(
+d1 = building.airborne_flanking_path(
     label="D1", kind="Df", element_i=el, element_j=wall,
     vibration_reduction_index=k_floor_ext, coupling_length=4.0,
     separating_area=20.0, delta_r_i=delta)
@@ -313,9 +309,9 @@ index per band, its energy split and the ISO 717-1 rating in one call:
 ```python
 # `paths` holds the twelve flanking paths of the four elements, built the
 # way `d1` was above; the code block under the figure builds all of them.
-res = detailed_airborne_prediction(
-    bands, direct_index=direct_reduction_index(el.sound_reduction_index,
-                                               delta_r_source=delta),
+res = building.detailed_airborne_prediction(
+    bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
+                                                        delta_r_source=delta),
     flanking_paths=paths)
 print(np.round(res.r_prime[[0, 10]], 1))   # [28.8 55.9]   Table L.1 total
 print(res.rating.rating, res.dominant[0])  # 57 'Dd'
@@ -337,26 +333,22 @@ the result there. The single number $R'_\mathrm{w} = 57$ dB says none of that.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 k = {
-    "floor-ext": junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
-    "ext-ext": junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
-    "floor-floor": junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
-    "floor-int": junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
-    "int-int": junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
-    "int-ext": junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
-    "extT-ext": junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
-    "corner": junction_vibration_reduction("corner", "corner", 1.0),
-    "int-int-x": junction_vibration_reduction("rigid_cross", "through", 1.0),
+    "floor-ext": building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
+    "ext-ext": building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
+    "floor-floor": building.junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
+    "floor-int": building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
+    "int-int": building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
+    "int-ext": building.junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
+    "extT-ext": building.junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
+    "corner": building.junction_vibration_reduction("corner", "corner", 1.0),
+    "int-int-x": building.junction_vibration_reduction("rigid_cross", "through", 1.0),
 }
-a = perimeter_absorption_coefficient
+a = building.perimeter_absorption_coefficient
 floor_sum = 9.0 * (a([92.6, 92.6], [k["floor-ext"]] * 2)
                    + a([76.8, 128.4, 128.4],
                        [k["floor-floor"], k["floor-int"], k["floor-int"]]))
@@ -376,10 +368,10 @@ specs = {
     "int2": (13.75, 5.0, 2.75, 360.0, 128.4, 0.01,
              10.0 * int_top + 2.75 * int_side, 1800.0, 2500.0),
 }
-situ = {name: in_situ_element(HomogeneousElement(name, *spec), bands)
+situ = {name: building.in_situ_element(building.HomogeneousElement(name, *spec), bands)
         for name, spec in specs.items()}
-delta = floating_floor_improvement(bands,
-                                   resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
+delta = building.floating_floor_improvement(bands,
+                                            resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
 
 paths = []
 for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
@@ -388,21 +380,21 @@ for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
     cross = k["floor-ext"] if name.startswith("ext") else k["floor-int"]
     through = k["ext-ext"] if name.startswith("ext") else k["int-int"]
     paths += [
-        airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
-                               element_j=wall, vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0,
-                               delta_r_i=delta),
-        airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
-                               element_j=situ["floor"], vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0),
-        airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
-                               element_j=wall, vibration_reduction_index=through,
-                               coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=wall, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
+                                        element_j=wall, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
     ]
-res = detailed_airborne_prediction(
+res = building.detailed_airborne_prediction(
     bands,
-    direct_index=direct_reduction_index(situ["floor"].sound_reduction_index,
-                                        delta_r_source=delta),
+    direct_index=building.direct_reduction_index(situ["floor"].sound_reduction_index,
+                                                 delta_r_source=delta),
     flanking_paths=paths)
 
 # One line — the per-band path contributions with R' overlaid:
@@ -415,19 +407,18 @@ plt.show()
 The impact side of the same building runs on the same `situ` dictionary:
 
 ```python
-from phonometry import (detailed_impact_prediction, direct_impact_level,
-                        impact_flanking_path)
+from phonometry import building
 
-direct = direct_impact_level(situ["floor"].impact_level, delta_l=delta)
+direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
-    impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
-                         vibration_reduction_index=(
+    building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
+                                  vibration_reduction_index=(
                              k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
-                         coupling_length=lij, delta_l=delta)
+                                  coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
 ]
-imp = detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
+imp = building.detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
 print(np.round(imp.l_prime_n[[3, 10]], 1))     # [54.  35.9]   Table G.1 total
 print(imp.rating.rating, imp.rating.ci)        # 41 2           printed 41,0 (2)
 ```
@@ -503,10 +494,7 @@ re-scales by both area and coupling length. The block below is an excerpt: it
 starts from those four arrays.
 
 ```python
-from phonometry import (flanking_impact_level_from_flanking_level,
-                        flanking_reduction_index_from_flanking_level,
-                        flanking_reduction_index_from_normalized_difference,
-                        resonant_sound_reduction_index)
+from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
 r_wall_leaf = ...   # measured R of the inner leaf per band, dB (ISO 10140-2)
@@ -514,19 +502,19 @@ dv_n = ...          # normalized junction velocity level difference, dB (ISO 108
 dnf_13 = ...        # laboratory normalized flanking level difference Dn,f, dB
 lnf_13 = ...        # laboratory normalized flanking impact level Ln,f, dB
 
-r_star = resonant_sound_reduction_index(r_wall_leaf, bands,
-                                        critical_frequency=2200.0)   # +8 dB below fc
-r_ff = flanking_reduction_index_from_normalized_difference(
+r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
+                                                 critical_frequency=2200.0)   # +8 dB below fc
+r_ff = building.flanking_reduction_index_from_normalized_difference(
     index_i=r_star, index_j=r_star, normalized_velocity_level_difference=dv_n,
     separating_area=20.0, coupling_length=4.0)                        # Table L.11
 
 # ISO 12354-1 L.2.2: a measured junction between two timber frame walls.
-r13 = flanking_reduction_index_from_flanking_level(
+r13 = building.flanking_reduction_index_from_flanking_level(
     dnf_13, separating_area=10.44, coupling_length=2.41,
     laboratory_coupling_length=2.5)                                   # Table L.15
 
 # ISO 12354-2 Formula (13): the impact twin, from a measured Ln,f.
-ln_13 = flanking_impact_level_from_flanking_level(
+ln_13 = building.flanking_impact_level_from_flanking_level(
     lnf_13, area=20.0, laboratory_area=10.0,
     coupling_length=4.0, laboratory_coupling_length=4.5)
 ```

--- a/site/src/content/docs/buildings/design/installed-structure-borne.mdx
+++ b/site/src/content/docs/buildings/design/installed-structure-borne.mdx
@@ -576,7 +576,7 @@ example's spectrum the two differ by about 15 dB.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, installed_source_prediction
+from phonometry import ReportMetadata, building
 
 bands = np.array([63, 125, 250, 500, 1000, 2000], float)
 lwc = np.array([84.4, 82.5, 69.9, 67.6, 61.6, 49.9])   # characteristic power [dB]
@@ -589,7 +589,7 @@ paths = [
      "flanking_reduction_index": np.array([37.0, 41.2, 35.9, 37.7, 49, 57.8]),
      "element_area": 12.8},
 ]
-res = installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
+res = building.installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
 
 res.report(
     "installed_structure_borne.pdf",

--- a/site/src/content/docs/buildings/design/panel-sound-insulation.mdx
+++ b/site/src/content/docs/buildings/design/panel-sound-insulation.mdx
@@ -111,37 +111,32 @@ matter what the wall is worth.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (
-    coincidence_frequency, composite_transmission_loss,
-    double_wall_transmission_loss, mass_law_transmission_loss,
-    mass_spring_mass_resonance, plate_bending_stiffness,
-    radiation_efficiency, single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000], dtype=float)
 fig, ax = plt.subplots(2, 2, figsize=(12, 9))
 
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(15.0, bp)
-ml = mass_law_transmission_loss(bands, 15.0, incidence="field")
-sp = single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(15.0, bp)
+ml = building.mass_law_transmission_loss(bands, 15.0, incidence="field")
+sp = building.single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
 ax[0, 0].semilogx(bands, ml, "--", label="field-incidence mass law")
 ax[0, 0].semilogx(bands, sp.transmission_loss, "-o", ms=3, label="single panel R (Sharp)")
 ax[0, 0].axvline(fc, ls=":", color="r"); ax[0, 0].set_title("Single panel")
 
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
-ax[0, 1].semilogx(bands, mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+ax[0, 1].semilogx(bands, building.mass_law_transmission_loss(bands, 24.0), "--", label="single leaf")
 ax[0, 1].semilogx(bands, dw.transmission_loss, "-o", ms=3, label="double wall")
-ax[0, 1].axvline(mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
+ax[0, 1].axvline(building.mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
 ax[0, 1].set_title("Double wall")
 
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 ax[1, 0].loglog(bands, sig.radiation_efficiency, "-o", ms=3, label=r"$\sigma(f)$")
 ax[1, 0].axhline(1.0, ls=":"); ax[1, 0].set_title("Radiation efficiency")
 
 wall = sp.transmission_loss
-comp = [float(composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
+comp = [float(building.composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
 ax[1, 1].semilogx(bands, wall, "-o", ms=3, label="solid wall")
 ax[1, 1].semilogx(bands, comp, "-s", ms=3, label="wall + 1 % slit")
 ax[1, 1].axhline(20.0, ls=":"); ax[1, 1].set_title("Composite with aperture")
@@ -195,21 +190,18 @@ plasterboard leaf puts $f_\mathrm{c}$ near 2.6 kHz and rates $R_\mathrm{w} = 27$
 
 ```python
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006                                 # 15 kg/m2
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
-fc = coincidence_frequency(mass, bp)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
+fc = vibration.coincidence_frequency(mass, bp)
 print(round(fc))                                      # 2107 Hz (Hopkins declares ~2079)
 
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 print(round(res.rating().rating))                     # 32  ->  Rw = 32 dB (catalogue 6 mm glass)
 
 res.plot()   # predicted R(f) with the critical frequency marked (needs matplotlib)
@@ -248,19 +240,16 @@ $R_\mathrm{w} = 32$ dB of 6 mm glass.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # 6 mm float glass: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(mass, bp)
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(mass, bp)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 w = res.rating()
 
 # One line each — the predicted R(f), or the rated curve vs the reference:
@@ -349,18 +338,18 @@ what it claims to be: an estimate, not the dip.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import plateau_transmission_loss, single_panel_transmission_loss
+from phonometry import building
 
 # 6 mm float glass: Norton Table 3.1 gives 2.47 kg/m2 per mm, a 27 dB
 # coincidence plateau and B/A = 10; its critical frequency is 2033 Hz.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000], dtype=float)
-quick = plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
-                                  field_correction=5.5)
-physical = single_panel_transmission_loss(bands, 2.47 * 6.0,
-                                          critical_frequency=2033.0,
-                                          loss_factor=0.02)
+quick = building.plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
+                                           field_correction=5.5)
+physical = building.single_panel_transmission_loss(bands, 2.47 * 6.0,
+                                                   critical_frequency=2033.0,
+                                                   loss_factor=0.02)
 
 print(round(quick.plateau_start), round(quick.plateau_end))   # 374 3742
 print(quick.plateau_height)                                   # 27.0
@@ -378,11 +367,11 @@ problem 3.11 exactly, band for band, in the two regions the construction fixes
 analytically.
 
 ```python
-from phonometry import plateau_transmission_loss
+from phonometry import building
 
 octaves = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
-res = plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
-                                air_density=1.21)
+res = building.plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
+                                         air_density=1.21)
 print(res.transmission_loss.round(1))
 # [35.8 37.  37.  43.3 53.3 63.3 73.3]
 ```
@@ -462,20 +451,16 @@ supported orthotropic plate (Vigran Eq. 3.113 = Bies Eq. 7.27, after Hearmon
 valid above roughly $1.5f_{1,1}$.
 
 ```python
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_plate_resonance, plate_bending_stiffness,
-)
+from phonometry import building, vibration
 
 # Vigran's worked example: a 1 m x 1 m steel sheet 1 mm thick, E = 210 GPa,
 # nu = 0.3, m'' = 7.8 kg/m2, corrugated into a sinusoid 20 mm deep
 # (amplitude H = 10 mm) at a 100 mm pitch.
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, b_xz = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, b_xz = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
 print(round(flat_b, 1), round(b_x, 1), round(b_z))     # 19.2 17.5 2202
 print(round(mass, 2))                                  # 8.52 kg/m2 (+9 %)
 
@@ -485,14 +470,14 @@ flat = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": 7.8,
 corr = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": mass,
         "bending_stiffness_x": b_x, "bending_stiffness_z": b_z,
         "bending_stiffness_xz": b_xz}
-print(round(orthotropic_plate_resonance(1, 1, **flat), 1),
-      round(orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
-print(round(orthotropic_plate_resonance(1, 1, **corr), 1),
-      round(orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
+print(round(building.orthotropic_plate_resonance(1, 1, **flat), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
+print(round(building.orthotropic_plate_resonance(1, 1, **corr), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
 
 # The same sheet, flat and corrugated, in the coincidence picture:
-print(round(coincidence_frequency(7.8, flat_b)))               # 11925 Hz
-print([round(f) for f in orthotropic_critical_frequencies(mass, b_x, b_z)])
+print(round(vibration.coincidence_frequency(7.8, flat_b)))               # 11925 Hz
+print([round(f) for f in building.orthotropic_critical_frequencies(mass, b_x, b_z)])
 # [1165, 13064]
 ```
 
@@ -516,33 +501,28 @@ the corrugated sheet gives away up to 13 dB, and $R_\mathrm{w}$ falls from 28 dB
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_transmission_loss, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000, 12500, 16000], dtype=float)
 eta = 0.011
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, _ = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, _ = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
-fc1, fc2 = orthotropic_critical_frequencies(mass, b_x, b_z)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
+fc1, fc2 = building.orthotropic_critical_frequencies(mass, b_x, b_z)
 
-flat = single_panel_transmission_loss(
-    bands, 7.8, critical_frequency=coincidence_frequency(7.8, flat_b),
+flat = building.single_panel_transmission_loss(
+    bands, 7.8, critical_frequency=vibration.coincidence_frequency(7.8, flat_b),
     loss_factor=eta,
 )
-corrugated = orthotropic_transmission_loss(
+corrugated = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     loss_factor=eta,
 )
-heckl = orthotropic_transmission_loss(
+heckl = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     method="heckl",
 )
@@ -591,21 +571,21 @@ fill (any [`PorousMediumResult`](/phonometry/materials/absorbers/porous-absorber
 the cavity and lowers $f_0$.
 
 ```python
-from phonometry import double_wall_transmission_loss, mass_spring_mass_resonance
-from phonometry import mass_law_transmission_loss, miki
+from phonometry import building
+from phonometry import materials
 
 # Two 12 kg/m2 leaves, 75 mm air gap.
-f0 = mass_spring_mass_resonance(12.0, 12.0, 0.075)
+f0 = building.mass_spring_mass_resonance(12.0, 12.0, 0.075)
 print(round(f0))                                          # 89 Hz
 
 # Below f0 the double wall equals the mass law of the total mass 24 kg/m2:
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
 print(round(float(dw.transmission_loss[0]), 1),
-      round(float(mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
+      round(float(building.mass_law_transmission_loss(bands[0], 24.0)), 1))   # equal
 
 # A mineral-wool fill (a materials porous model) lowers the resonance:
-fill = miki([f0], 7000.0)
-print(round(mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
+fill = materials.miki([f0], 7000.0)
+print(round(building.mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
 
 dw.plot()   # double-wall R(f) with the mass-spring-mass resonance marked (needs matplotlib)
 ```
@@ -627,11 +607,11 @@ double-wall curve sits.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import mass_spring_mass_resonance, plot_double_wall_geometry
+from phonometry import building
 
 # Two 8.8 kg/m2 plasterboard leaves on a 100 mm cavity.
-f0 = mass_spring_mass_resonance(8.8, 8.8, 0.1)
-plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
+f0 = building.mass_spring_mass_resonance(8.8, 8.8, 0.1)
+building.plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0)
 plt.show()
 
 # A double-wall prediction retains its geometry and redraws it:
@@ -683,25 +663,20 @@ Hall & Hopkins (2001).
 | Vertical-twist tie (proprietary) | 100 | 43.4 |
 
 ```python
-from phonometry import (
-    double_wall_transmission_loss,
-    mass_spring_mass_resonance,
-    wall_tie_stiffness,
-    wall_tie_stiffness_per_area,
-)
+from phonometry import building
 
-print(wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
+print(building.wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
 
 # Hopkins Fig. 4.35: two 140 kg/m2 leaves across an empty 75 mm cavity.
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
 
 # Add 2.5 ties per m2 of s_75mm = 2 MN/m: the resonance nearly doubles.
-ties = wall_tie_stiffness_per_area(2.5, 2.0e6)
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075,
-                                       tie_stiffness_per_area=ties)))  # 50 Hz
+ties = building.wall_tie_stiffness_per_area(2.5, 2.0e6)
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075,
+                                                tie_stiffness_per_area=ties)))  # 50 Hz
 
-dw = double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
-                                   tie_stiffness_per_area=ties)
+dw = building.double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
+                                            tie_stiffness_per_area=ties)
 ```
 
 **The tie as a point connection (Hopkins Eqs. 4.84 to 4.88).** Each tie
@@ -727,11 +702,11 @@ differently.
 
 ```python
 import numpy as np
-from phonometry import plate_bending_stiffness, wall_tie_coupling_loss_factor
+from phonometry import building, vibration
 
 freq = np.logspace(np.log10(50.0), np.log10(5000.0), 60)
-b1 = plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
-res = wall_tie_coupling_loss_factor(
+b1 = vibration.plate_bending_stiffness(2.0e10, 0.1, 0.2)   # 100 mm masonry leaves
+res = building.wall_tie_coupling_loss_factor(
     freq, 150.0, 170.0, b1, b1, ties_per_area=2.5, tie="butterfly"
 )
 print(res.coupling_loss_factor[0], res.rigid_coupling_loss_factor[0])
@@ -767,17 +742,14 @@ $10\log_{10}(S/S_\mathrm{a})$; a 1 % opening can never do better than 20 dB, wha
 wall.
 
 ```python
-from phonometry import (
-    composite_transmission_loss, slit_transmission_coefficient,
-    slit_resonance_frequencies,
-)
+from phonometry import building
 
 # A 2 mm x 100 mm-deep slit: its transmission peaks at the half-wavelength
 # resonances of the slit depth.
-print(slit_resonance_frequencies(depth=0.1, width=0.002, orders=2).round().tolist())  # [~1500, ~3100]
+print(building.slit_resonance_frequencies(depth=0.1, width=0.002, orders=2).round().tolist())  # [~1500, ~3100]
 
 # A wall of Rw = 50 dB with 1 % of its area left open as a slit is capped:
-print(round(float(composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
+print(round(float(building.composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
 ```
 
 The leak that undoes a heavy wall is almost invisible, and `.plot_geometry()`
@@ -796,10 +768,10 @@ resonances near 1.5 and 3.1 kHz rather than as a simple open area.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import slit_transmission_coefficient
+from phonometry import building
 
 f = np.geomspace(100.0, 5000.0, 200)
-result = slit_transmission_coefficient(f, width=0.002, depth=0.1)
+result = building.slit_transmission_coefficient(f, width=0.002, depth=0.1)
 
 # One line: the wall section with the slit to scale.
 result.plot_geometry()
@@ -885,8 +857,8 @@ dimensions and an edge condition.*
 ```python
 import matplotlib.pyplot as plt
 
-sig_big = radiation_efficiency(bands, 1.5, 1.25, fc)
-sig_small = radiation_efficiency(bands, 0.5, 0.4, fc)
+sig_big = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
+sig_small = vibration.radiation_efficiency(bands, 0.5, 0.4, fc)
 
 fig, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(11, 4.5))
 ax_l.loglog(bands, sig_big.radiation_efficiency, "-o", ms=3, label="1.5 x 1.25 m")
@@ -904,17 +876,17 @@ plt.show()
 </details>
 
 ```python
-from phonometry import radiation_efficiency, sound_power_from_vibration
+from phonometry import emission, vibration
 
 # The 6 mm glass pane (1.5 x 1.25 m) of the single-panel example above.
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 print(sig.radiation_efficiency[bands == 2000].round(2))
 # 2.6, the coincidence peak: the plate out-radiates a piston near fc
 
 # Feed the prediction straight into ISO 7849 as the radiation factor:
-lw = sound_power_from_vibration(velocity_level=80.0, area=1.875,
-                                radiation_factor=sig.radiation_efficiency,
-                                frequencies=bands)
+lw = emission.sound_power_from_vibration(velocity_level=80.0, area=1.875,
+                                         radiation_factor=sig.radiation_efficiency,
+                                         frequencies=bands)
 
 sig.plot()   # sigma(f) with the coincidence peak (needs matplotlib)
 ```
@@ -936,11 +908,11 @@ reads them against the SDOF resonator and adds the moment and longitudinal-rod
 cases.
 
 ```python
-from phonometry import infinite_plate_impedance, infinite_beam_mobility, injected_power
+from phonometry import vibration
 
-z_plate = infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
+z_plate = vibration.infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
 print(round(z_plate))                                 # real, frequency independent
-w = injected_power(force=10.0, mobility=1.0 / z_plate)
+w = vibration.injected_power(force=10.0, mobility=1.0 / z_plate)
 print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' m''))
 ```
 

--- a/site/src/content/docs/buildings/design/resilient-layers.mdx
+++ b/site/src/content/docs/buildings/design/resilient-layers.mdx
@@ -103,21 +103,18 @@ the floor, caps the injected power.
 
 ```python
 import numpy as np
-from phonometry import (
-    hammer_impact_velocity, infinite_plate_impedance, plate_bending_stiffness,
-    plate_contact_stiffness, tapping_force_spectrum,
-)
+from phonometry import building, vibration
 
-print(round(hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
+print(round(building.hammer_impact_velocity(), 3))     # 0.886 m/s (0.5 kg dropped 40 mm)
 
 # A 140 mm cast in-situ concrete slab: 2200 kg/m3, cL = 3800 m/s, nu = 0.2.
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-k = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+k = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 freqs = np.array([100, 200, 400, 800, 1600, 3150], dtype=float)
-res = tapping_force_spectrum(freqs, k, z)
+res = building.tapping_force_spectrum(freqs, k, z)
 res.over_critical            # False: the hammer rebounds off concrete
 round(res.cut_off_frequency)  # 6948 Hz, above the building acoustics range
 res.peak_force               # |Fn| per band, within 1 dB of res.upper_limit
@@ -153,10 +150,10 @@ fig, ax = plt.subplots()
 for label, rho_s, c_s, nu_s, h_s in (("140 mm concrete", 2200.0, 3800.0, 0.2, 0.14),
                                      ("22 mm chipboard", 650.0, 2400.0, 0.3, 0.022)):
     e_s = rho_s * c_s**2 * (1 - nu_s**2)
-    z_s = infinite_plate_impedance(plate_bending_stiffness(e_s, h_s, nu_s),
-                                   rho_s * h_s)
-    k_s = plate_contact_stiffness(e_s, poisson_ratio=nu_s)
-    r = tapping_force_spectrum(freqs, k_s, z_s)
+    z_s = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(e_s, h_s, nu_s),
+                                             rho_s * h_s)
+    k_s = building.plate_contact_stiffness(e_s, poisson_ratio=nu_s)
+    r = building.tapping_force_spectrum(freqs, k_s, z_s)
     ax.loglog(freqs, r.peak_force, label=f"{label} (fco = {r.cut_off_frequency:.0f} Hz)")
     ax.axhline(r.upper_limit, ls="--", lw=0.8)
     ax.axhline(r.lower_limit, ls=":", lw=0.8)
@@ -212,23 +209,20 @@ band runs 7.8 dB high.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    covering_contact_stiffness, covering_improvement, infinite_plate_impedance,
-    plate_bending_stiffness, plate_contact_stiffness,
-)
+from phonometry import building, vibration
 
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14          # 140 mm concrete slab
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-plate = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+plate = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0])
 
 d = 0.005
 for label, modulus_over_thickness in (("PVC", 1.5e11), ("backed vinyl", 2.8e8)):
-    res = covering_improvement(
-        bands, covering_contact_stiffness(modulus_over_thickness * d, d),
+    res = building.covering_improvement(
+        bands, building.covering_contact_stiffness(modulus_over_thickness * d, d),
         plate, z)
     plt.semilogx(bands, res.improvement, marker="o",
                  label=f"{label}: fco = {res.cut_off_frequency:.0f} Hz")
@@ -240,13 +234,13 @@ plt.show()
 </details>
 
 ```python
-from phonometry import covering_contact_stiffness, covering_improvement
+from phonometry import building
 
 # Covering No. 2 of Hopkins Fig. 4.64: E/d = 2.8e8 N/m3, a vinyl or carpet
 # with a resilient backing, 5 mm thick on the same 140 mm slab.
 d = 0.005
-covering = covering_contact_stiffness(2.8e8 * d, d)
-res = covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
+covering = building.covering_contact_stiffness(2.8e8 * d, d)
+res = building.covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
 round(res.cut_off_frequency)        # 100 Hz
 round(res.bare_cut_off_frequency)   # 6948 Hz, the bare slab's own cut-off
 res.improvement                     # 3.2, 17.0, 33.3, 43.0 dB, band values
@@ -306,16 +300,14 @@ same in all three.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-)
+from phonometry import building
 
 # The worked floating floor of ISO 12354-2:2017 Annex G.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)     # 52.8 Hz
 freqs = np.logspace(np.log10(40.0), np.log10(5000.0), 400)
 for model, kwargs in (("en12354", {}), ("cremer", {}),
                       ("cremer_hammer", {"limiting_frequency": 521.0})):
-    res = floating_floor_improvement_spectrum(
+    res = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=f0, model=model, **kwargs)
     plt.semilogx(freqs, res.improvement, label=model)
 plt.axvline(f0, ls=":")
@@ -326,19 +318,15 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    combined_dynamic_stiffness, double_floating_floor_resonances,
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-    weighted_floating_floor_improvement,
-)
+from phonometry import building
 
 # 35 mm screed, m' = 73.5 kg/m2, on a resilient layer of s' = 8 MN/m3.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)
 round(f0, 1)                                                    # 52.8 Hz
 
 bands = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
          800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0]
-res = floating_floor_improvement_spectrum(
+res = building.floating_floor_improvement_spectrum(
     bands, resonance_frequency=f0, mass_per_area=73.5, dynamic_stiffness=8.0e6)
 res.improvement          # 0.0, 2.3, 5.4, 8.3, 11.2 ... 59.3 dB
 round(res.delta_lw, 1)   # 32.2 dB, the Formula (C.4) weighted improvement
@@ -346,12 +334,12 @@ res.plot()
 
 # Two resilient layers act as springs in series (Formula C.6), which drops the
 # resonance by sqrt(2) and buys about 4.5 dB everywhere above it.
-round(floating_floor_resonance_frequency(
-    combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
+round(building.floating_floor_resonance_frequency(
+    building.combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37.3 Hz
 
 # One floating floor on top of another has two resonances instead of one; the
 # adverse dip disappears, but the steep rise only starts above the higher.
-double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
+building.double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
 ```
 
 The weighted single numbers come straight from the same two inputs, so a
@@ -369,10 +357,10 @@ Vér's two-subsystem SEA model turns into a 30 dB per decade rise rather than
 it.
 
 ```python
-from phonometry import resilient_mount_improvement
+from phonometry import building
 
 # 50 mm concrete walking surface on 4 mounts per m2 of 2 MN/m stiffness.
-resilient_mount_improvement(
+building.resilient_mount_improvement(
     [125.0, 250.0, 500.0, 1000.0], impedance=3.8e5, mass_per_area=115.0,
     loss_factor=0.02, mount_stiffness=2.0e6, mount_density=4.0)
 ```
@@ -406,30 +394,27 @@ to gain. From 200 Hz upwards it costs: 1 dB at 200 Hz falling to 10 dB from
 the range of interest is therefore the entire design brief.
 
 ```python
-from phonometry import (
-    lining_improvement, lining_improvement_in_situ, lining_resonance_frequency,
-    weighted_lining_improvement,
-)
+from phonometry import building
 
 # A 9.5 mm plasterboard laminated with 32 mm EPS (s' = 65 MN/m3), bonded with
 # adhesive dabs to a 100 mm aircrete block wall of 51 kg/m2.
-f0 = lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
+f0 = building.lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
 round(f0)                                       # 542 Hz: squarely in the way
-round(weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
+round(building.weighted_lining_improvement(f0, 45.0))    # -9 dB, it makes things worse
 
 # The same lining on studs over a 100 mm mineral-wool-filled cavity.
-f0 = lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
+f0 = building.lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
 round(f0, 1)                                     # 70.8 Hz
-round(weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
+round(building.weighted_lining_improvement(f0, 45.0), 1)  # +13.8 dB (80 Hz band)
 
 # External thermal insulation systems have their own Annex D fits.
-res = lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
+res = building.lining_improvement(100.0, system="mineral_wool")   # Formula (D.3)
 res.delta_rw, res.delta_ra, res.delta_ratr               # (10.5, 8.0, 9.7) dB
-lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
+building.lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
 res.plot()   # the Annex D ratings against fo, with this system marked
 
 # A laboratory rating transfers to the field through Formula (D.8).
-round(lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
+round(building.lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4.4 dB on a Rw 60 wall
 ```
 
 ## What the formulae assume about the build

--- a/site/src/content/docs/buildings/design/structure-borne-power.mdx
+++ b/site/src/content/docs/buildings/design/structure-borne-power.mdx
@@ -454,11 +454,11 @@ level must be converted to the plate-independent source quantities (Formulae
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, reception_plate_power
+from phonometry import ReportMetadata, building
 
 freqs = np.array([125, 250, 500, 1000, 2000, 4000], float)
 lv = np.array([70.0, 72, 68, 64, 60, 55])   # spatial mean plate velocity level [dB]
-res = reception_plate_power(               # the clause 7.2.2 low-mobility plate
+res = building.reception_plate_power(               # the clause 7.2.2 low-mobility plate
     lv, freqs, mass_per_area=230.0, area=7.0, reverberation_time=0.25,
 )
 

--- a/site/src/content/docs/buildings/insulation/flanking-lab.mdx
+++ b/site/src/content/docs/buildings/insulation/flanking-lab.mdx
@@ -382,7 +382,7 @@ off the shifted contour at 500 Hz.*
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import ceiling_attenuation_class, plenum_flanking_reduction_index
+from phonometry import building
 
 fig, (ax_path, ax_cac) = plt.subplots(1, 2, figsize=(13.0, 5.6))
 
@@ -392,7 +392,7 @@ freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 ceiling = np.array([17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0])
 x = np.arange(freqs.size)
 for depth, style in ((0.43, "-o"), (0.86, "--o")):
-    res = plenum_flanking_reduction_index(
+    res = building.plenum_flanking_reduction_index(
         ceiling, ceiling, ceiling_length=4.75, plenum_height=depth,
         frequency=freqs,
     )
@@ -405,7 +405,7 @@ ax_path.legend()
 # Right: an accredited ASTM E1414 test report rated per ASTM E413.
 dnc = np.array([14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
                 41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9])
-cac = ceiling_attenuation_class(dnc)
+cac = building.ceiling_attenuation_class(dnc)
 xc = np.arange(dnc.size)
 ax_cac.fill_between(xc, cac.measured, cac.shifted_reference,
                     where=cac.measured < cac.shifted_reference,
@@ -452,27 +452,27 @@ $R_\mathrm{cl,p} = R_\mathrm{cl} + 10\log_{10}(H_\mathrm{S}/L_\mathrm{S})$ (Eq. 
 ceiling path be added to the direct path as transmission factors.
 
 ```python
-from phonometry import partition_referenced_reduction_index
+from phonometry import building
 # `plenum_flanking_reduction_index` is the import of the figure block above.
 
 freqs = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0]   # 9.5 mm plasterboard
 
 # Vigran's example geometry: LS = LR = 4.75 m, plenum 0.43 m, reflecting walls.
-res = plenum_flanking_reduction_index(
+res = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, frequency=freqs
 )
 print(round(res.geometry_term, 1))    # 10.4 dB charged against RS + RR
 res.plot()                            # Rcl against the two ceilings
 
 # A lined plenum attenuates the sideways path (Eq. (9.18) instead of (9.20)):
-damped = plenum_flanking_reduction_index(
+damped = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43,
     attenuation_source=[0.5] * 7, attenuation_receiving=[0.5] * 7,
 )
 
 # Referred to the partition instead of the ceiling (Eq. (9.13)):
-print(partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
+print(building.partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
 ```
 
 ### The measured quantity: normalized ceiling attenuation
@@ -497,7 +497,7 @@ deficiency exceeds 8 dB (clauses 5.3 and 5.4), and reads the rating off the
 shifted contour at 500 Hz (clause 5.5).
 
 ```python
-from phonometry import normalized_ceiling_attenuation, weighted_rating
+from phonometry import building
 # `ceiling_attenuation_class` is the import of the figure block above.
 
 # Dn,c from the measured pair: source- and receiving-room levels over the
@@ -506,20 +506,20 @@ from phonometry import normalized_ceiling_attenuation, weighted_rating
 l1_c = [80.0] * 16                       # source room, per band
 l2_c = [45.0] * 16                       # receiving room, over the plenum path
 absorption = [12.0] * 16                 # receiving-room A per band (m2)
-astm = normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
-iso140_9 = normalized_ceiling_attenuation(l1_c, l2_c, absorption)
+astm = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
+iso140_9 = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption)
 print(round(float(astm[0]), 2), round(float(iso140_9[0]), 2))   # 35.0 34.21
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
        41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9]
-res = ceiling_attenuation_class(dnc)
+res = building.ceiling_attenuation_class(dnc)
 print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34, 27.0, 7.0
 res.plot()                                                  # Dn,c vs the contour
 
 # The ISO single number of the same spectrum, shifted to A0 = 10 m2:
 iso = [v - 0.79 for v in dnc]
-print(weighted_rating(iso).rating)                          # Dn,c,w
+print(building.weighted_rating(iso).rating)                          # Dn,c,w
 ```
 
 ## ISO 10848 flanking-transmission reports (`.report()`)

--- a/site/src/content/docs/buildings/insulation/heavy-impact-sources.mdx
+++ b/site/src/content/docs/buildings/insulation/heavy-impact-sources.mdx
@@ -79,19 +79,15 @@ band ends up deciding the number.*
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    a_weighted_maximum_impact_level,
-    heavy_impact_source_limits,
-    heavy_impact_source_specification,
-)
+from phonometry import building
 
 fig, (ax_src, ax_rate) = plt.subplots(1, 2, figsize=(13.0, 5.6))
 
 # Left: the printed nominal spectra inside their printed tolerance bands.
 x = np.arange(5)
 for source in ("rubber_ball", "bang_machine"):
-    spec = heavy_impact_source_specification(source)
-    _f, lower, upper = heavy_impact_source_limits(source)
+    spec = building.heavy_impact_source_specification(source)
+    _f, lower, upper = building.heavy_impact_source_limits(source)
     label = source.replace("_", " ")
     ax_src.fill_between(x, lower, upper, alpha=0.30, label=f"{label} tolerance")
     ax_src.plot(x, spec.force_exposure_level, "-o", label=f"{label} nominal")
@@ -102,7 +98,7 @@ ax_src.legend()
 
 # Right: ISO 717-2:2020 Table D.4, measured levels against their A-weighted
 # contributions, with the energy sum drawn across them.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 xr = np.arange(4)
 ax_rate.bar(xr - 0.19, res.levels, width=0.36, label="Li,Fmax (measured)")
 ax_rate.bar(xr + 0.19, res.corrected, width=0.36, label="Li,Fmax + A (Table D.3)")
@@ -155,22 +151,22 @@ less into the top one, which is why the two sources are not interchangeable and
 why a floor can pass one and fail the other.
 
 ```python
-from phonometry import check_heavy_impact_source, impact_force_exposure_level
+from phonometry import building
 # `heavy_impact_source_specification` and `heavy_impact_source_limits` are the
 # imports of the figure block above.
 
-spec = heavy_impact_source_specification("rubber_ball")
+spec = building.heavy_impact_source_specification("rubber_ball")
 print(spec.drop_height, spec.effective_mass)      # 1.0 m, 2.5 kg
 print(spec.contact_time, spec.contact_time_tolerance)   # 0.02 s +/- 0.002 s
 
-freqs, lower, upper = heavy_impact_source_limits("bang_machine")
+freqs, lower, upper = building.heavy_impact_source_limits("bang_machine")
 print(list(zip(freqs, lower, upper))[0])          # (31.5, 46.0, 48.0)
 
 # A calibration run: five measured octave-band LFE against the printed table.
 # Name the source: the check defaults to the rubber ball, and the bang machine
 # limits fetched above would reject a conforming ball outright.
-check = check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9],
-                                  source="rubber_ball")
+check = building.check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9],
+                                           source="rubber_ball")
 print(check.passed, list(check.within_tolerance))
 check.plot()   # measured LFE over the tolerance band (needs matplotlib)
 ```
@@ -185,7 +181,7 @@ any single band value and must not be compared with the table above.
 
 ```python
 import numpy as np
-from phonometry import OctaveFilterBank, impact_force_exposure_level
+from phonometry import building, filters
 
 fs = 48_000
 t = np.arange(0.0, 0.020, 1.0 / fs)          # the 20 ms contact time
@@ -193,12 +189,12 @@ force = 1500.0 * np.sin(np.pi * t / 0.020)   # a single-peak half-sine pulse
 
 # Broadband, i.e. the whole pulse energy: 10 lg(Fp^2 t / 2) = 43.5 dB.
 # Not a band value, and not comparable with the table above.
-print(round(impact_force_exposure_level(force, fs), 2))
+print(round(building.impact_force_exposure_level(force, fs), 2))
 
 # The five octave-band values the specification is actually written in.
-bank = OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
+bank = filters.OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
 _, freqs, bands = bank.filter(force, sigbands=True, calculate_level=False)
-lfe = [impact_force_exposure_level(b, fs) for b in bands]
+lfe = [building.impact_force_exposure_level(b, fs) for b in bands]
 print([round(v, 1) for v in lfe])   # [-1.4, 14.0, 22.1, 20.2, 17.1]
 
 # Those five go to the conformance check; this synthetic half-sine is not a
@@ -285,10 +281,10 @@ standardization for a maximum.*
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import fast_reverberation_correction
+from phonometry import building
 
 t = np.linspace(0.2, 5.0, 481)
-fast = np.asarray(fast_reverberation_correction(t), dtype=float)
+fast = np.asarray(building.fast_reverberation_correction(t), dtype=float)
 energy = 10 * np.log10(t / 0.5)
 print(round(float(fast[-1]), 1), round(float(energy[-1]), 1))    # 5.1 10.0
 
@@ -306,23 +302,20 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    heavy_impact_octave_levels,
-    standardized_maximum_impact_level,
-)
+from phonometry import building
 # `fast_reverberation_correction` is the import of the figure block above.
 
 freqs = [63.0, 125.0, 250.0, 500.0]
 li_fmax = [65.3, 64.5, 58.0, 55.8]           # energy-averaged over ball positions
 t = [1.43, 3.70, 3.10, 2.38]                 # receiving-room reverberation time
 
-res = standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
+res = building.standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
 print(res.volume_term)                        # 10 lg(41.4/50) = -0.8 dB
-print(fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
+print(building.fast_reverberation_correction([0.5]))   # exactly 0 dB at T = T0
 res.plot()   # measured and standardized spectra (needs matplotlib)
 
 # One-third-octave measurements combine into octaves with Formula (20):
-print(heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
+print(building.heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB per octave
 ```
 
 ## Measuring in the field (ISO 16283-2:2020, Clauses 6 to 9)
@@ -399,7 +392,7 @@ deliberately unrounded intermediate the standard prints:
 # `a_weighted_maximum_impact_level` is the import of the figure block above.
 
 # ISO 717-2:2020 Table D.4: a field measurement in octave bands.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 print(list(res.corrected))   # 39.1, 48.3, 49.3, 52.6 dB
 print(res.unrounded)         # 55.350667... dB
 print(res.rating)            # 55 dB

--- a/site/src/content/docs/buildings/insulation/spanish-building-code.mdx
+++ b/site/src/content/docs/buildings/insulation/spanish-building-code.mdx
@@ -168,7 +168,7 @@ $C_{\mathrm{tr},100-5000}$ are both $-5$, so the $D_{2\mathrm{m,nT,Atr}}$ that D
 requires happens not to discriminate between the two readings at all.
 
 ```python
-from phonometry import building, weighted_rating_extended
+from phonometry import building
 
 d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
           38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5, 39.4, 41.5]
@@ -176,7 +176,7 @@ d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
 direct = building.d2m_nt_atr(d2m_nt)
 direct.intermediate, direct.reported   # 32.8 dBA -> 33 dBA
 
-iso = weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
+iso = building.weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
 iso.rating, iso.ctr_100_5000           # 38 dB, -5 dB -> 33 dBA, the same figure
 iso.c, iso.c_100_5000                  # -2 and -1: core range versus enlarged range
 ```

--- a/site/src/content/docs/buildings/rooms/enclosed-space-absorption.mdx
+++ b/site/src/content/docs/buildings/rooms/enclosed-space-absorption.mdx
@@ -517,10 +517,7 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import (
-    enclosed_space_reverberation, hard_object_absorption, object_fraction,
-    ReportMetadata,
-)
+from phonometry import ReportMetadata, room
 
 surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (20.0, [0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.55]),  # carpeted floor
@@ -528,10 +525,10 @@ surfaces = [                                   # per octave band, 125 Hz - 8 kHz
     (45.0, [0.02, 0.02, 0.03, 0.04, 0.05, 0.05, 0.05]),  # painted-plaster walls
 ]
 volumes = [0.5, 0.8, 0.3]                      # furniture, m^3
-result = enclosed_space_reverberation(
+result = room.enclosed_space_reverberation(
     surfaces, 50.0,
-    objects=hard_object_absorption(volumes),
-    object_fraction=object_fraction(volumes, 50.0),
+    objects=room.hard_object_absorption(volumes),
+    object_fraction=room.object_fraction(volumes, 50.0),
     air_condition="20C_50-70",
 )
 result.report(

--- a/site/src/content/docs/buildings/rooms/reverberation-prediction.mdx
+++ b/site/src/content/docs/buildings/rooms/reverberation-prediction.mdx
@@ -661,9 +661,9 @@ embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 decimal separator).
 
 ```python
-from phonometry import reverberation_time_models, ReportMetadata
+from phonometry import ReportMetadata, room
 
-result = reverberation_time_models(
+result = room.reverberation_time_models(
     (8.0, 5.0, 3.0),                       # a shoebox room, one treated wall pair
     ([0.10, 0.15, 0.30, 0.45, 0.55, 0.60], # treated wall pair, per octave band
      [0.08, 0.10, 0.12, 0.15, 0.18, 0.20], # side walls

--- a/site/src/content/docs/buildings/rooms/room-impulse-response.mdx
+++ b/site/src/content/docs/buildings/rooms/room-impulse-response.mdx
@@ -349,15 +349,14 @@ sequence, visible as the near-constant magnitude on the right.
 
 ```python
 from phonometry import room
-from phonometry import plot_excitation
 
 fs = 48000
 sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)   # ESS excitation
 mls = room.mls_signal(12).astype(float)             # length 2**12 - 1
 
 # One-liner: waveform + spectrogram (sweep), sequence + flat spectrum (MLS)
-plot_excitation(sweep, fs, kind="sweep")
-plot_excitation(mls, fs, kind="mls")
+room.plot_excitation(sweep, fs, kind="sweep")
+room.plot_excitation(mls, fs, kind="mls")
 
 # By hand: the sweep spectrogram and the MLS magnitude spectrum
 import numpy as np

--- a/site/src/content/docs/devices/electroacoustics/loudspeakers.mdx
+++ b/site/src/content/docs/devices/electroacoustics/loudspeakers.mdx
@@ -188,10 +188,10 @@ whose first null is at $ka\sin\theta = 3.8317$.
 
 ```python
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 200),
-                       angles=np.linspace(0.0, np.pi / 2, 91))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 200),
+                                        angles=np.linspace(0.0, np.pi / 2, 91))
 print(round(res.radiation_mass, 4))            # 0.0014 kg = 8 rho a^3 / 3
 print(round(float(res.directivity_index[0]), 2))  # 3.01 dB half-space limit
 res.plot()                                      # R1 and X1 vs ka
@@ -224,9 +224,9 @@ to happen.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
 res.plot()   # normalized R1 and X1 against ka
 plt.show()
 ```
@@ -269,9 +269,9 @@ on the same polar axes, so the narrowing of the main lobe and the emergence of
 the side lobes read at a glance:
 
 ```python
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-pattern = piston_directivity_pattern([3.0, 8.0, 16.0])
+pattern = electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0])
 print(pattern.directivity_db.shape)  # (3, 361): one row per ka
 pattern.plot()                       # polar beam pattern in dB (needs matplotlib)
 ```
@@ -287,9 +287,9 @@ and is by then radiating into a beam a few degrees wide.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
+electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0]).plot()
 plt.show()
 ```
 
@@ -313,10 +313,10 @@ first side lobes have appeared.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
-                       angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
+res = electroacoustics.radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
+                                        angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
 
 # One line: the piston in its baffle with the lobe of the highest frequency.
 res.plot_geometry()
@@ -382,25 +382,22 @@ or current used is reported with the result.
 
 ```python
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, ReportMetadata, loudspeaker_characteristics,
-    radiating_piston,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(np.geomspace(20, 20000, 260),
                6.6 + 24 * np.exp(-(np.log2(np.geomspace(20, 20000, 260) / 52.0) ** 2) / 0.12)),
     distortion=(np.geomspace(50, 5000, 140),
                 0.3 + 2.6 * np.exp(-(np.log2(np.geomspace(50, 5000, 140) / 70.0) ** 2) / 0.45)),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -409,7 +406,7 @@ print(tuple(round(x) for x in result.effective_range))       # (37, 21361) Hz
 print(round(result.minimum_impedance, 1))                    # 6.6 ohm
 
 # The same response, but actually measured at 2 m with 1 V into 8 ohm.
-referred = loudspeaker_characteristics(
+referred = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distance=2.0, input_voltage=1.0,
 )
@@ -468,15 +465,15 @@ whole curve.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # low-frequency roll-off
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # high-frequency roll-off
 
-result = loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
-                                     sensitivity_band=(200.0, 4000.0))
+result = electroacoustics.loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
+                                                      sensitivity_band=(200.0, 4000.0))
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -497,13 +494,13 @@ is the load the amplifier actually sees.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 fz = np.geomspace(20, 20000, 260)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(fz, 6.6 + 24 * np.exp(-(np.log2(fz / 52.0) ** 2) / 0.12)),
 )
@@ -527,13 +524,13 @@ at 1 m is uninterpretable (clause 24.1.2.7).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 thd_f = np.geomspace(50, 5000, 140)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distortion=(thd_f, 0.3 + 2.6 * np.exp(-(np.log2(thd_f / 70.0) ** 2) / 0.45)),
 )
@@ -581,18 +578,16 @@ computed `index_db`, or the polar data the second route needs.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, loudspeaker_characteristics, radiating_piston,
-)
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )

--- a/site/src/content/docs/devices/electroacoustics/microphones.mdx
+++ b/site/src/content/docs/devices/electroacoustics/microphones.mdx
@@ -341,10 +341,7 @@ curve crosses the declared limit.
 
 ```python
 import numpy as np
-from phonometry import (
-    MicrophoneDirectivity, MicrophoneElectrical, MicrophoneNoise,
-    MicrophoneOverload, ReportMetadata, microphone_characteristics,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
@@ -355,19 +352,19 @@ angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,          # 12.5 mV/Pa at 1 kHz
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
-    noise=MicrophoneNoise(                             # A-weighted, V
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    noise=electroacoustics.MicrophoneNoise(                             # A-weighted, V
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(np.linspace(100, 140, 81),
                     0.5 * 10 ** ((np.linspace(100, 140, 81) - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
-    electrical=MicrophoneElectrical(
+    electrical=electroacoustics.MicrophoneElectrical(
         rated_impedance=150.0, minimum_load_impedance=1000.0,
         powering="Phantom P48 (IEC 61938)", supply_current_ma=3.1,
     ),
@@ -383,10 +380,10 @@ print(round(result.signal_to_noise_ratio_db, 1))        # 80.0 dB re 1 Pa
 for b in (0.0, 0.5, 1.0):
     polar = 20 * np.log10(
         np.maximum(np.abs((1 - b) + b * np.cos(np.radians(angles))), 1e-3))
-    family = microphone_characteristics(
+    family = electroacoustics.microphone_characteristics(
         freqs, response, 12.5, tolerance_db=3.0,
-        directivity=MicrophoneDirectivity(polar=(angles, polar),
-                                          frequency=1000.0))
+        directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, polar),
+                                                           frequency=1000.0))
     print(b, round(family.directivity_index_db, 1))     # 0.0 / 4.8 / 4.8 dB
 
 result.report("microphone.pdf", metadata=ReportMetadata(measurement_standard="IEC 60268-4"))
@@ -453,14 +450,14 @@ peak rather than a defect.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # low-frequency roll-off
 response -= 10 * np.log10(1 + (freqs / 19000.0) ** 8)   # high-frequency roll-off
 response += 2.0 * np.exp(-(np.log2(freqs / 9000.0) ** 2) / 0.3)  # presence region
 
-result = microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
+result = electroacoustics.microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
 result.plot()   # quantity="response" (the default)
 plt.show()
 ```
@@ -482,16 +479,16 @@ the 4.8 dB directivity index of the fiche is computed from.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneDirectivity, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
 )
 result.plot(quantity="directivity")
 plt.show()
@@ -513,15 +510,15 @@ bands and why the same capsule reads so differently through the 468 network.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneNoise, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    noise=MicrophoneNoise(
+    noise=electroacoustics.MicrophoneNoise(
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
@@ -546,15 +543,15 @@ its percentage.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneOverload, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 spl_axis = np.linspace(100, 140, 81)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(spl_axis, 0.5 * 10 ** ((spl_axis - 130.0) * 0.08)),
         thd_percent=0.5,
     ),

--- a/site/src/content/docs/devices/electroacoustics/swept-sine-distortion.mdx
+++ b/site/src/content/docs/devices/electroacoustics/swept-sine-distortion.mdx
@@ -94,12 +94,12 @@ separation.*
 
 ```python
 import numpy as np
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
-x = synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
 res.thd, res.thd_frequencies
@@ -129,10 +129,10 @@ Four things must be set before the first take:
 import numpy as np
 
 # `synchronized_sweep_signal` and `swept_sine_distortion` as imported above.
-x = synchronized_sweep_signal(fs, f1, f2, seconds, amplitude=0.5, fade=0.02)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds, amplitude=0.5, fade=0.02)
 # ... play x, record y, and keep recording until the decay has died ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3,
-                            amplitude=0.5, fade=0.02)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3,
+                                             amplitude=0.5, fade=0.02)
 ```
 
 - **`amplitude`** is the reference the returned $H_1$ and every ratio are
@@ -182,14 +182,14 @@ the conformance tests pin.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)             # 3 kHz post-filter
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 h1 = 1.0 + 3.0 * a3 / 4.0                              # Chebyshev gain
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -240,10 +240,10 @@ from scipy import signal as sp_signal
 # `swept_sine_distortion` and `synchronized_sweep_signal` as imported above.
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 for k in range(3):
     mag = np.abs(np.asarray(res.harmonic_responses[k]))
@@ -319,10 +319,10 @@ be ignored; the band of every $H_n$ is also capped at $f_2$ by the inverse
 filter.
 
 ```python
-from phonometry import sweep_signal, swept_sine_distortion
+from phonometry import electroacoustics, room
 
-x = sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
+x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
 
@@ -349,12 +349,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # `synchronized_sweep_signal` and `swept_sine_distortion` as imported above.
-x = synchronized_sweep_signal(48000, 20.0, 6000.0, 4.0)
+x = electroacoustics.synchronized_sweep_signal(48000, 20.0, 6000.0, 4.0)
 y = x + 0.12 * x**2 + 0.08 * x**3            # the memoryless oracle
 actual = len(x) / 48000                       # the generator quantizes T
 for method in ("synchronized", "farina"):
-    res = swept_sine_distortion(y, 48000, f1=20.0, f2=6000.0, seconds=actual,
-                                n_harmonics=3, method=method)
+    res = electroacoustics.swept_sine_distortion(y, 48000, f1=20.0, f2=6000.0, seconds=actual,
+                                                 n_harmonics=3, method=method)
     plt.semilogx(res.frequencies,
                  np.unwrap(np.angle(np.asarray(res.harmonic_responses[1]))))
 plt.show()
@@ -397,16 +397,14 @@ all-pass parts:
 
 ```python
 import numpy as np
-from phonometry import (
-    excess_phase, group_delay, minimum_phase, phase_decomposition,
-)
+from phonometry import signals
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
-h_min = minimum_phase(np.abs(H))       # phase from the magnitude alone
-tau_g = group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
-phi_x = excess_phase(H)                # unwrap(arg H) - phi_min
+h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone
+tau_g = signals.group_delay(H, fs)             # -(1/2pi) dphi/df, seconds
+phi_x = signals.excess_phase(H)                # unwrap(arg H) - phi_min
 
-res = phase_decomposition(H, fs)       # everything on one axis
+res = signals.phase_decomposition(H, fs)       # everything on one axis
 res.excess_group_delay                 # the all-pass part, in seconds
 res.plot()                             # magnitude, phases, group delays
 ```
@@ -440,7 +438,7 @@ magnitude and phase together by a single filter; one that is not, cannot.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import phase_decomposition
+from phonometry import signals
 
 fs = 48000.0
 delay = int(0.0025 * fs)                      # a 2.5 ms processing latency
@@ -453,7 +451,7 @@ imp = np.zeros(16384)
 imp[delay] = 1.0
 ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
-res = phase_decomposition(np.fft.rfft(ir), fs)
+res = signals.phase_decomposition(np.fft.rfft(ir), fs)
 res.plot()   # |H|, the three phases and the group delays
 plt.show()
 ```

--- a/site/src/content/docs/devices/emission/sound-power-pressure.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-pressure.mdx
@@ -397,11 +397,11 @@ surface integral.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import measurement_positions, plot_microphone_positions
+from phonometry import emission
 
 # The 10 ISO 3744 Annex B microphones on a 2 m hemisphere.
-plot_microphone_positions(measurement_positions("hemisphere", radius=2.0),
-                          radius=2.0)
+emission.plot_microphone_positions(emission.measurement_positions("hemisphere", radius=2.0),
+                                   radius=2.0)
 plt.show()
 ```
 
@@ -562,10 +562,10 @@ and a localized investigation after that carries unequal areas.*
 import matplotlib.pyplot as plt
 
 fig, (axl, axr) = plt.subplots(1, 2, subplot_kw={"projection": "3d"})
-plot_microphone_positions(
+emission.plot_microphone_positions(
     emission.precision_positions("hemisphere", radius=1.0, count=40),
     ax=axl, radius=1.0)
-plot_microphone_positions(
+emission.plot_microphone_positions(
     emission.precision_positions("sphere", radius=1.0, count=20),
     ax=axr, radius=1.0)
 plt.show()

--- a/site/src/content/docs/devices/noise-control/duct-path.mdx
+++ b/site/src/content/docs/devices/noise-control/duct-path.mdx
@@ -79,20 +79,20 @@ level leaving it. `DuctElement` carries exactly the two spectra an element
 owns, and `duct_path` walks them:
 
 ```python
-from phonometry import DuctElement, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 
-path = duct_path(
+path = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined",
-                    attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
-                    self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
-                    self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined",
+                                  attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
+                                  self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
+                                  self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
     ],
     source_label="Fan, centrifugal FC, 5000 cfm, 2 in w.g.",
 )
@@ -167,21 +167,18 @@ logarithmic terms take the same values as the foot-pound form in cfm and
 inches of water gauge.
 
 ```python
-from phonometry import (
-    blade_passing_frequency, fan_casing_attenuation,
-    fan_efficiency_correction, fan_sound_power,
-)
+from phonometry import noise_control
 
 CFM, IN_WG = 0.0004719474432, 249.0
 
-fan = fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
-                      fan_type="forward_curved", relative_efficiency=80.0)
+fan = noise_control.fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
+                                    fan_type="forward_curved", relative_efficiency=80.0)
 print([round(float(v)) for v in fan.values])
 # [99, 99, 89, 84, 82, 77, 72, 67]
 
-print(fan_efficiency_correction(80.0))          # 6.0 dB off the peak
-print(blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
-print(fan_casing_attenuation().values)          # what the housing holds back
+print(noise_control.fan_efficiency_correction(80.0))          # 6.0 dB off the peak
+print(noise_control.blade_passing_frequency(1200.0, 24))      # 480.0 Hz, in the 500 Hz band
+print(noise_control.fan_casing_attenuation().values)          # what the housing holds back
 # [ 0.  0.  5. 10. 15. 20. 22. 25.]
 fan.plot()                                      # the band spectrum, one line
 ```
@@ -256,15 +253,15 @@ duty = dict(volume_flow=5000 * CFM, static_pressure=2 * IN_WG,
             fan_type="forward_curved")
 
 # One line for one fan: the band spectrum.
-fan_sound_power(relative_efficiency=80.0, **duty).plot()
+noise_control.fan_sound_power(relative_efficiency=80.0, **duty).plot()
 plt.show()
 
 fig, ax = plt.subplots()
 for efficiency in (90.0, 80.0, 55.0):
-    res = fan_sound_power(relative_efficiency=efficiency, **duty)
+    res = noise_control.fan_sound_power(relative_efficiency=efficiency, **duty)
     ax.semilogx(res.frequencies, res.values, "o-",
                 label=f"{efficiency:.0f} % of peak")
-casing = fan_casing_attenuation()
+casing = noise_control.fan_casing_attenuation()
 ax.semilogx(casing.frequencies, casing.values, "s-.", label="Casing")
 ax.set_xlabel("Frequency [Hz]"); ax.set_ylabel("Level [dB]")
 ax.legend()
@@ -298,17 +295,15 @@ for 25 mm to 52 mm linings and clipped at 40 dB per run because flanking
 takes over beyond that.
 
 ```python
-from phonometry import (
-    lined_rectangular_duct_attenuation, unlined_rectangular_duct_attenuation,
-)
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
-bare = unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
-lined = lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
-                                           1 * IN, include_unlined=True)
+bare = noise_control.unlined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT)
+lined = noise_control.lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT,
+                                                         1 * IN, include_unlined=True)
 print(np.round(bare.values, 1))    # [1.1 0.7 0.5 0.2 0.2 0.2 0.2 0.2]
 print(np.round(lined.values, 1))   # [ 1.3  1.3  2.5  6.7 12.8 10.6  9.7  9. ]
 ```
@@ -336,12 +331,12 @@ branch area does not match the feeder, and a 25 per cent branch therefore
 costs 6 dB.
 
 ```python
-from phonometry import elbow_insertion_loss, split_loss
+from phonometry import noise_control
 
 IN = 0.0254
 area = 36 * IN * 24 * IN
-print(round(split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
-print(elbow_insertion_loss(
+print(round(noise_control.split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
+print(noise_control.elbow_insertion_loss(
     [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
     24 * IN, bend_type="round").values)          # [0. 1. 2. 3. 3. 3. 3. 3.]
 ```
@@ -364,15 +359,15 @@ the impedance transition, and a manufacturer's diffuser rating already
 contains whatever is left of it.
 
 ```python
-from phonometry import end_reflection_loss, equivalent_diameter
+from phonometry import noise_control
 import numpy as np
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0]
-print(np.round(end_reflection_loss(bands, 0.30, method="bies").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="bies").values, 1))
 # [12.  7.  3.  1.  0.  0.]
-print(np.round(end_reflection_loss(bands, 0.30, method="long").values, 1))
+print(np.round(noise_control.end_reflection_loss(bands, 0.30, method="long").values, 1))
 # [12.7  7.7  3.7  1.3  0.4  0.1]
-print(round(equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
+print(round(noise_control.equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
 ```
 
 **Silencers and plenums.** A parallel-splitter attenuator reduces, in Bies
@@ -383,17 +378,17 @@ chamber (Bies Eq. (8.275)), whose reverberant term uses the plenum
 [room constant](/phonometry/buildings/rooms/room-image-sources/).
 
 ```python
-from phonometry import plenum_attenuation, splitter_silencer_insertion_loss
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
-sil = splitter_silencer_insertion_loss(
+sil = noise_control.splitter_silencer_insertion_loss(
     None, height=24 * IN, length=5 * FT,      # None -> the default octave bands
     airway_widths=[0.10] * 5, splitter_thickness=0.10,
 )
 print(np.round(sil.values, 1))
 # [ 5.8  8.6 14.1 28.2 34.5 33.5 18.4 12.1]
-print(round(plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
+print(round(noise_control.plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
 ```
 
 Read that estimate for what it is. The 5 ft unit Long's return path
@@ -430,8 +425,8 @@ import matplotlib.pyplot as plt
 # `bands`, IN and FT as above; every model returns an HvacSpectrumResult.
 
 # One line for one element:
-lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT, 1 * IN,
-                                   include_unlined=True).plot()
+noise_control.lined_rectangular_duct_attenuation(bands, 36 * IN, 24 * IN, 5 * FT, 1 * IN,
+                                                 include_unlined=True).plot()
 plt.show()
 
 # By hand: the bend family of panel (b), keyed on W / lambda.
@@ -440,7 +435,7 @@ for label, kwargs in (("Square, lined", dict(bend_type="square", lined=True)),
                       ("Square, bare", dict(bend_type="square")),
                       ("Square, vanes", dict(bend_type="square", vanes=True)),
                       ("Round, bare", dict(bend_type="round"))):
-    el = elbow_insertion_loss(bands, 24 * IN, **kwargs)
+    el = noise_control.elbow_insertion_loss(bands, 24 * IN, **kwargs)
     ax.semilogx(el.frequencies, el.values, "o-", label=label)
 ax.set_xlabel("Frequency [Hz]"); ax.set_ylabel("Insertion loss [dB]")
 ax.legend()
@@ -474,14 +469,14 @@ is the whole message: the fifth-and-a-half power of the airway velocity
 means that *doubling the face velocity of a silencer adds about 17 dB*.
 
 ```python
-from phonometry import silencer_self_noise
+from phonometry import noise_control
 import numpy as np
 
 IN = 0.0254
-slow = silencer_self_noise(None, airway_velocity=10.0, passages=5,
-                           height=24 * IN)
-fast = silencer_self_noise(None, airway_velocity=20.0, passages=5,
-                           height=24 * IN)
+slow = noise_control.silencer_self_noise(None, airway_velocity=10.0, passages=5,
+                                         height=24 * IN)
+fast = noise_control.silencer_self_noise(None, airway_velocity=20.0, passages=5,
+                                         height=24 * IN)
 print(np.round(slow.values, 1))
 # [40.8 40.8 38.8 36.8 31.8 26.8 21.8 16.8]
 print(round(float(fast.values[0] - slow.values[0]), 1))     # 16.6 dB
@@ -512,15 +507,15 @@ band $f_\mathrm{P} = 48.8\,U_\mathrm{G}$ (Eq. 13.32, $U_\mathrm{G}$ in **ft/s**)
 numbering with band 0 at 32 Hz.
 
 ```python
-from phonometry import diffuser_sound_power
+from phonometry import noise_control
 import numpy as np
 
 IN, CFM, IN_WG = 0.0254, 0.0004719474432, 249.0
 
 # The supply diffuser of Long's worked sheet: 24 x 24 in, 312 cfm, 0.05 in pd.
-print(np.round(diffuser_sound_power(None, (24 * IN) ** 2,
-                                    volume_flow=312 * CFM,
-                                    pressure_drop=0.05 * IN_WG).values, 1))
+print(np.round(noise_control.diffuser_sound_power(None, (24 * IN) ** 2,
+                                                  volume_flow=312 * CFM,
+                                                  pressure_drop=0.05 * IN_WG).values, 1))
 # [ 33.4  32.4  29.1  23.6  15.9   5.9  -6.4 -21. ]
 # Long Table 14.9 prints 33/32/29/23/15/4/0/0 for that row.
 
@@ -540,12 +535,12 @@ penalty for throttling a balancing damper, which is where a great many
 finished installations fail.
 
 ```python
-from phonometry import air_terminal_damper_correction, air_terminal_velocity_limit
+from phonometry import noise_control
 
-print(air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
-print(air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
-print(air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
-print(air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
+print(noise_control.air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
+print(noise_control.air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
+print(noise_control.air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
+print(noise_control.air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
 ```
 
 Fifteen decibels in the neck against two decibels 1.5 m back in the duct,
@@ -577,14 +572,14 @@ import matplotlib.pyplot as plt
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 # One line for one element:
-silencer_self_noise(bands, airway_velocity=20.0, passages=5,
-                    height=24 * IN).plot()
+noise_control.silencer_self_noise(bands, airway_velocity=20.0, passages=5,
+                                  height=24 * IN).plot()
 plt.show()
 
 fig, ax = plt.subplots()
 for velocity in (5.0, 10.0, 20.0, 40.0):
-    res = silencer_self_noise(bands, airway_velocity=velocity, passages=5,
-                              height=24 * IN)
+    res = noise_control.silencer_self_noise(bands, airway_velocity=velocity, passages=5,
+                                            height=24 * IN)
     ax.semilogx(res.frequencies, res.values, "o-", label=f"{velocity:.0f} m/s")
 ax.set_xlabel("Frequency [Hz]"); ax.set_ylabel("Regenerated L_W [dB re 1 pW]")
 ax.legend()
@@ -633,12 +628,12 @@ every other loss, with $Q = 2$ by default for a diffuser flush in a
 ceiling.
 
 ```python
-from phonometry import room_constant, room_effect
+from phonometry import noise_control, room
 
 # The 20 x 20 x 8 ft room of Long's worked sheet, drywall and carpet.
 area = 2 * 6.10 * 6.10 + 4 * 6.10 * 2.44        # 134.0 m2
-r_const = room_constant(area, 0.15)             # 23.6 m2
-print(round(float(room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
+r_const = room.room_constant(area, 0.15)             # 23.6 m2
+print(round(float(noise_control.room_effect(1.83, r_const, directivity=2.0)), 1))   # 6.6 dB
 ```
 
 Long's sheet prints 5 to 7 dB for that room across the bands, so a single
@@ -713,54 +708,54 @@ arithmetic: the return path, not the supply, is what the office hears above
 
 ```python
 import numpy as np
-from phonometry import DuctElement, combine_duct_paths, duct_path
+from phonometry import noise_control
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 fan = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 source = "Fan, centrifugal FC, 5000 cfm, 2 in w.g."
 
-supply = duct_path(
+supply = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silencer, 3 ft, standard pressure drop",
-                    [7, 12, 16, 28, 35, 35, 28, 17],
-                    [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
-        DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
-                    [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
-        DuctElement("Split, 25 per cent", 6.0, code="5"),
-        DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
-                    [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
-        DuctElement("Flexible duct, 12 in, 6 ft",
-                    [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
-        DuctElement("Rectangular diffuser, 312 cfm", None,
-                    [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 3 ft, standard pressure drop",
+                                  [7, 12, 16, 28, 35, 35, 28, 17],
+                                  [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Duct, 36 x 24 in, 5 ft, 1 in lining",
+                                  [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
+        noise_control.DuctElement("Split, 25 per cent", 6.0, code="5"),
+        noise_control.DuctElement("Duct, 18 x 12 in, 6 ft, 1 in lining",
+                                  [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
+        noise_control.DuctElement("Flexible duct, 12 in, 6 ft",
+                                  [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
+        noise_control.DuctElement("Rectangular diffuser, 312 cfm", None,
+                                  [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
     ],
     room_effect=[6, 6, 5, 5, 6, 7, 6, 6],
     source_label=source, target=30.0, label="Supply",
 )
 
-ret = duct_path(
+ret = noise_control.duct_path(
     bands, fan,
     [
-        DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
-        DuctElement("Silencer, 5 ft, low-frequency type",
-                    [16, 21, 35, 41, 41, 28, 21, 15],
-                    [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
-        DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
-                    [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
-        DuctElement("Plenum, 800 sq ft, 50 per cent lined",
-                    [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
-        DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
-                    [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, unlined", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
+        noise_control.DuctElement("Silencer, 5 ft, low-frequency type",
+                                  [16, 21, 35, 41, 41, 28, 21, 15],
+                                  [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
+        noise_control.DuctElement("Elbow, 36 x 24 in, lined, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
+                                  [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
+        noise_control.DuctElement("Plenum, 800 sq ft, 50 per cent lined",
+                                  [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
+        noise_control.DuctElement("Rectangular grille, 24 x 24 in, 563 cfm", None,
+                                  [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
     ],
     room_effect=[9, 8, 6, 8, 8, 8, 9, 10],
     source_label=source, target=30.0, label="Return",
 )
 
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 print(np.round(supply.received_level, 0))    # Long: 52 42 30 18  9 -2 -2 -1
 print(np.round(ret.received_level, 0))       # Long: 52 41 27 25 23 25 22 12
 print(np.round(total.received_level, 0))     # Long: 55 45 32 26 23 25 22 12
@@ -791,7 +786,7 @@ nothing at all: the return already sets the answer everywhere except at
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import combine_duct_paths
+from phonometry import noise_control
 
 # `supply` and `ret` are the two DuctPathResult objects built above.
 
@@ -800,7 +795,7 @@ supply.plot()
 plt.show()
 
 # The concept figure: both paths, their energy sum and the criterion.
-total = combine_duct_paths([supply, ret], label="Supply + return")
+total = noise_control.combine_duct_paths([supply, ret], label="Supply + return")
 total.plot()
 plt.gca().set_ylim(-6.0, 62.0)
 plt.show()
@@ -897,7 +892,7 @@ import matplotlib.pyplot as plt
 # with OCTAVE_BANDS, which starts at 16 Hz, so the sheet's eight bands are
 # nc_curve(30)[2:].
 printed = [3, 3, 5, 11, 25, 22, 16, 13]      # Long's 18 x 12 in, 6 ft row
-computed = lined_rectangular_duct_attenuation(
+computed = noise_control.lined_rectangular_duct_attenuation(
     bands, 18 * IN, 12 * IN, 6 * FT, 1 * IN, include_unlined=True).values
 
 fig, ax = plt.subplots()
@@ -944,18 +939,18 @@ $k_x = -M\kappa_{pq}/\sqrt{1 - M^2}$.
 
 ```python
 import numpy as np
-from phonometry import plane_wave_limit, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.2: a 0.65 x 0.4 m air-conditioning duct at 15 m/s.
-modes = rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
+modes = noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
 print(modes.modes[:3])                          # ((1, 0), (0, 1), (1, 1))
 print(np.round(modes.cut_on[:3], 1))            # [263.6 428.3 502.9] Hz
 print(np.round(modes.cut_on_no_flow[:3], 1))    # [263.8 428.8 503.4] Hz
 print(round(modes.plane_wave_limit, 1))         # 263.6 Hz
 
 IN = 0.0254
-print(round(plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
-print(round(plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
+print(round(noise_control.plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
+print(round(noise_control.plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
 ```
 
 Those ventilation numbers are blunt: in that duct plane waves are the whole
@@ -1002,11 +997,11 @@ rung.
 
 ```python
 import numpy as np
-from phonometry import circular_duct_cut_on
+from phonometry import noise_control
 
 # Norton problem 7.1: a 254 mm circular duct carrying steam at 200 m/s.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 print(steam.modes)
 # ((1, 0), (2, 0), (0, 1), (3, 0), (4, 0), (1, 1))
 print(np.round(steam.cut_on_no_flow, 1))
@@ -1032,16 +1027,16 @@ at the frequency at which it appears.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import circular_duct_cut_on, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # One line for one duct: the cut-on ladder with the plane-wave band shaded.
-steam = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+steam = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 steam.plot()
 plt.show()
 
 # The ventilation duct of problem 7.2, where the flow shift is negligible.
-rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
+noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot()
 plt.show()
 ```
 
@@ -1056,17 +1051,17 @@ they describe the plane-wave mode alone, which a measurement will not.
 
 ```python
 import warnings
-from phonometry import DuctElement, PlaneWaveWarning, duct_path
+from phonometry import noise_control
 
 IN = 0.0254
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 with warnings.catch_warnings(record=True) as caught:
     warnings.simplefilter("always")
-    duct_path(bands, [90.0] * 8, [DuctElement("Straight run", 3.0)],
-              section={"width": 36 * IN, "height": 24 * IN},
-              flow_velocity=6.0, label="Supply")
-print(caught[0].category is PlaneWaveWarning)
+    noise_control.duct_path(bands, [90.0] * 8, [noise_control.DuctElement("Straight run", 3.0)],
+                            section={"width": 36 * IN, "height": 24 * IN},
+                            flow_velocity=6.0, label="Supply")
+print(caught[0].category is noise_control.PlaneWaveWarning)
 print(str(caught[0].message))
 # Supply: 6 of 8 frequencies are above the first duct cut-on frequency
 # (188 Hz), where higher-order modes propagate and the plane-wave result

--- a/site/src/content/docs/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/devices/noise-control/noise-control.mdx
@@ -245,10 +245,10 @@ outlet generate, which has to be added separately from the models above.
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import plot_plenum_geometry
+from phonometry import noise_control
 
 # The r, S_out and S_w that Wells' formula actually uses, drawn exactly.
-plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
+noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35)
 plt.show()
 ```
 
@@ -356,12 +356,12 @@ absorption.
 
 ```python
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
 
-enc = enclosure_insertion_loss(
+enc = noise_control.enclosure_insertion_loss(
     panel_R, external_area=6.0, internal_area=5.0,
     internal_absorption=0.3, frequencies=bands,
 )
@@ -382,12 +382,12 @@ together with the panels, not as an afterthought.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # measured, dB
 
-enc = enclosure_insertion_loss(
+enc = noise_control.enclosure_insertion_loss(
     panel_R, external_area=6.0, internal_area=5.0,
     internal_absorption=0.3, frequencies=bands,
 )
@@ -419,12 +419,12 @@ the verdict against that minimum mean insertion loss.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, enclosure_insertion_loss
+from phonometry import ReportMetadata, noise_control
 
 octaves = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 sheet_steel_R = np.array([18.0, 22.0, 28.0, 33.0, 38.0, 42.0, 45.0])
 
-case = enclosure_insertion_loss(
+case = noise_control.enclosure_insertion_loss(
     sheet_steel_R, external_area=24.0, internal_area=30.0,
     internal_absorption=0.30, frequencies=octaves,
 )
@@ -483,7 +483,7 @@ elements = np.vstack([sheet_steel, door, opening])
 built = -10.0 * np.log10((areas * 10.0 ** (-elements / 10.0)).sum(0)
                          / areas.sum())
 
-leaky = enclosure_insertion_loss(
+leaky = noise_control.enclosure_insertion_loss(
     built, external_area=24.0, internal_area=30.0,
     internal_absorption=0.30, frequencies=octaves,
 )

--- a/site/src/content/docs/devices/noise-control/room-to-room.mdx
+++ b/site/src/content/docs/devices/noise-control/room-to-room.mdx
@@ -134,14 +134,12 @@ speaking into the same 8 m x 9 m x 3 m receiving room through the same
 
 ```python
 import numpy as np
-from phonometry import (
-    SourceRoom, equivalent_absorption_area, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 
 # Receiving room 8 x 9 x 3 m: walls 102 m2, floor and ceiling 72 m2 each.
-receiving = equivalent_absorption_area([
+receiving = room.equivalent_absorption_area([
     (102.0, [0.04, 0.04, 0.09, 0.15, 0.17, 0.23]),   # walls
     (72.0,  [0.02, 0.06, 0.14, 0.37, 0.60, 0.66]),   # floor
     (72.0,  [0.30, 0.20, 0.15, 0.05, 0.05, 0.05]),   # ceiling
@@ -155,9 +153,9 @@ partitions = {
     "Double brick, 50 mm cavity":      [37, 41, 48, 60, 61, 61],
 }
 for name, tl in partitions.items():
-    res = room_to_room_transmission(
+    res = noise_control.room_to_room_transmission(
         bands, tl, 8.0 * 3.0, receiving,
-        source=SourceRoom(level=90.0), label=name,
+        source=noise_control.SourceRoom(level=90.0), label=name,
     )
     print(f"{name:32s} {np.round(res.noise_reduction, 1)}")
 # Two 13 mm wallboards, 64 mm gap  [18.5 26.8 38.  47.8 47.3 43.9]
@@ -194,17 +192,17 @@ import matplotlib.pyplot as plt
 
 # One line per wall: the RoomToRoomResult draws both spectra, the criterion
 # and the noise reduction against the transmission loss.
-room_to_room_transmission(
+noise_control.room_to_room_transmission(
     bands, partitions["125 mm plastered brick"], 8.0 * 3.0, receiving,
-    source=SourceRoom(level=90.0),
+    source=noise_control.SourceRoom(level=90.0),
 ).plot()
 plt.show()
 
 # By hand: the gap each wall shows, and the room behind it.
 fig, (top, bottom) = plt.subplots(2, 1, sharex=True)
 for name, tl in partitions.items():
-    res = room_to_room_transmission(bands, tl, 8.0 * 3.0, receiving,
-                                    source=SourceRoom(level=90.0))
+    res = noise_control.room_to_room_transmission(bands, tl, 8.0 * 3.0, receiving,
+                                                  source=noise_control.SourceRoom(level=90.0))
     top.semilogx(bands, res.noise_reduction - np.asarray(tl, float),
                  "o-", label=name)
 top.axhline(0.0)
@@ -242,10 +240,7 @@ $10\log_{10} 4 = 6.02\ \text{dB}$, and without it the printed answers come out
 6 dB low.
 
 ```python
-from phonometry import (
-    DesignCriterion, SourceRoom, equivalent_absorption_area, mean_absorption,
-    room_constant, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [0.07, 0.20, 0.40, 0.52, 0.60, 0.67]      # absorbent ceiling
@@ -259,18 +254,18 @@ plant = [(80.0, [0.01, 0.01, 0.015, 0.02, 0.02, 0.02]),
 operator = [(25.0, [0.08, 0.24, 0.57, 0.69, 0.71, 0.73]),
             (25.0, ceiling), (60.0, walls)]
 
-chain = room_to_room_transmission(
+chain = noise_control.room_to_room_transmission(
     bands,
     [39.0, 42.0, 50.0, 58.0, 63.0, 67.0],       # TL of the separating wall
     5.0 * 3.0,                                  # the wall is 5 m x 3 m
-    equivalent_absorption_area(operator),
-    source=SourceRoom(
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(
         power_level=[105.0, 103.0, 98.0, 108.0, 107.0, 109.0],
-        room_constant=room_constant(268.0, mean_absorption(plant)),
+        room_constant=room.room_constant(268.0, room.mean_absorption(plant)),
         directivity=4.0,                        # floor-wall intersection
         model="constant_volume",                # the conservative bound
     ),
-    criterion=DesignCriterion(target=45.0),
+    criterion=noise_control.DesignCriterion(target=45.0),
     label="Plant room to operator room",
 )
 
@@ -401,7 +396,7 @@ $\text{TL} = \text{IL} + 10\log_{10}(S_\mathrm{E} / R_\mathrm{i})$, which is
 
 ```python
 import numpy as np
-from phonometry import enclosure_required_transmission_loss, mean_absorption
+from phonometry import noise_control, room
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 wool = [0.10, 0.20, 0.45, 0.65, 0.75, 0.80, 0.80, 0.80]   # 50 mm blanket
@@ -418,11 +413,11 @@ radiating = 2 * (2.5 * 2.5) + 2 * (3.5 * 2.5) + 2.5 * 3.5
 machine = 2 * (1.5 * 1.5) + 2 * (2.5 * 1.5) + 1.5 * 2.5
 bare_floor = 2.5 * 3.5 - 1.5 * 2.5
 
-required = enclosure_required_transmission_loss(
+required = noise_control.enclosure_required_transmission_loss(
     lp1 - nc45,
     radiating,
     radiating + bare_floor + machine,
-    mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
+    room.mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
     frequencies=bands,
     model="norton",
 )
@@ -542,11 +537,11 @@ transmission loss rather than get lost:
 
 ```python
 # The chain of section 3 again, with 3 dB allowed for flanking and leaks.
-honest = room_to_room_transmission(
+honest = noise_control.room_to_room_transmission(
     bands, [39.0, 42.0, 50.0, 58.0, 63.0, 67.0], 15.0,
-    equivalent_absorption_area(operator),
-    source=SourceRoom(level=chain.source_level),
-    criterion=DesignCriterion(target=45.0, flanking_penalty=3.0),
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(level=chain.source_level),
+    criterion=noise_control.DesignCriterion(target=45.0, flanking_penalty=3.0),
 )
 print(np.round(honest.received_level, 1))
 # [75.4 63.4 44.4 44.  36.9 33.7]      every band 3 dB worse

--- a/site/src/content/docs/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/devices/noise-control/silencers.mdx
@@ -111,10 +111,10 @@ and transparent. The four-pole product reproduces this exactly.
 
 ```python
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 print(round(res.transmission_loss.max(), 2))   # 6.55 dB peak (m = 4)
 # The troughs at f = n c / 2L are exactly 0 dB (no dissipation).
 print(round(float(res.transmission_loss[np.argmin(res.transmission_loss)]), 6))
@@ -141,7 +141,7 @@ is lengthened to move the notch and widened to deepen the peak.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
 
@@ -149,14 +149,14 @@ freqs = np.linspace(20.0, 2000.0, 2000)
 # two acoustic impedances are given (Pa.s/m3 -- see the next subsection for
 # where they come from). With both set to rho c / S = 4.14e4 for this 0.01 m2
 # pipe the two curves coincide, which is what "anechoic ports" means.
-expansion_chamber(freqs, 0.3, 0.04, 0.01,
-                  source_impedance=4.14e4, radiation_impedance=4.14e4).plot()
+noise_control.expansion_chamber(freqs, 0.3, 0.04, 0.01,
+                                source_impedance=4.14e4, radiation_impedance=4.14e4).plot()
 plt.show()
 
 # By hand: the family of area ratios of the concept figure.
 fig, ax = plt.subplots()
 for m in (2.0, 4.0, 8.0, 16.0):
-    res = expansion_chamber(freqs, 0.3, m * 0.01, 0.01)
+    res = noise_control.expansion_chamber(freqs, 0.3, m * 0.01, 0.01)
     ax.plot(freqs, res.transmission_loss, label=f"m = {int(m)}")
 ax.set_xlabel("Frequency [Hz]"); ax.set_ylabel("Transmission loss [dB]")
 ax.legend()
@@ -181,18 +181,18 @@ circular diameters $d = 2\sqrt{S/\pi}$ of the 0.04 and 0.01 m² cross-sections.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber, plot_silencer_geometry
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 
 # One line: the dimensioned cross-section of the chamber just computed.
 res.plot_geometry()
 plt.show()
 
 # The same drawing without a result, from the free function:
-plot_silencer_geometry("expansion chamber", length=0.3,
-                       chamber_area=0.04, pipe_area=0.01)
+noise_control.plot_silencer_geometry("expansion chamber", length=0.3,
+                                     chamber_area=0.04, pipe_area=0.01)
 plt.show()
 ```
 
@@ -262,17 +262,17 @@ z_r = z0 * ((1.0 - 2.0 * special.j1(x) / x)
 
 # One line: the result draws the insertion loss beside the transmission loss
 # whenever both impedances are given.
-expansion_chamber(freqs, 0.3, 0.04, pipe_area,
-                  source_impedance=z0, radiation_impedance=z_r).plot()
+noise_control.expansion_chamber(freqs, 0.3, 0.04, pipe_area,
+                                source_impedance=z0, radiation_impedance=z_r).plot()
 plt.show()
 
 # By hand: the two source impedances of the figure against the same outlet.
 fig, ax = plt.subplots()
-ax.plot(freqs, expansion_chamber(freqs, 0.3, 0.04, pipe_area).transmission_loss,
+ax.plot(freqs, noise_control.expansion_chamber(freqs, 0.3, 0.04, pipe_area).transmission_loss,
         label="Transmission loss")
 for factor, label in ((20.0, "stiff source"), (1.0, "matched source")):
-    res = expansion_chamber(freqs, 0.3, 0.04, pipe_area,
-                            source_impedance=factor * z0, radiation_impedance=z_r)
+    res = noise_control.expansion_chamber(freqs, 0.3, 0.04, pipe_area,
+                                          source_impedance=factor * z0, radiation_impedance=z_r)
     ax.plot(freqs, res.insertion_loss, label=f"Insertion loss, {label}")
 ax.set_xlabel("Frequency [Hz]"); ax.set_ylabel("Attenuation [dB]")
 ax.legend()
@@ -328,37 +328,35 @@ trim it against a measurement.
 
 ```python
 import numpy as np
-from phonometry import (
-    helmholtz_resonator, quarter_wave_resonator, extended_tube_chamber,
-)
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
 
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 print(round(float(hr.resonances[0]), 1))       # 122.1 Hz, for le = 20 mm
 hr.plot()   # TL spike at the tuning frequency (needs matplotlib)
 
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 print(round(float(qw.resonances[0]), 1))       # 285.8 Hz = c / 4 le
 
 # Bies Example 8.1, the published anchor: a 1.516 m stub at c = 343.24 m/s.
-print(round(float(quarter_wave_resonator(
+print(round(float(noise_control.quarter_wave_resonator(
     f, duct_area=0.01, length=1.516, branch_area=2e-3,
     speed_of_sound=343.24).resonances[0]), 1))  # 56.6 Hz
 
 # The same stub in hot exhaust gas: c(500 degC) = 343*sqrt(773/293) = 557 m/s
 # (see the caution below), which moves the notch by a factor 1.62.
 f_hot = np.linspace(20.0, 900.0, 6000)
-qw_hot = quarter_wave_resonator(f_hot, duct_area=0.01, length=0.3,
-                                branch_area=2e-3, speed_of_sound=557.0)
+qw_hot = noise_control.quarter_wave_resonator(f_hot, duct_area=0.01, length=0.3,
+                                              branch_area=2e-3, speed_of_sound=557.0)
 print(round(float(qw_hot.resonances[0]), 1))   # 464.2 Hz, not 285.8
 
 # Each extension is a quarter-wave stub, so its own length picks the trough
 # it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
 # second trough, and L/2 = 0.2 m would take the first one at c/2L.
-et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
-                           inlet_extension=0.1)
+et = noise_control.extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
+                                         inlet_extension=0.1)
 print(round(float(et.transmission_loss[np.argmin(abs(f - 428.75))]), 1))
 # 0.6 dB at c/2L: the L/4 stub is tuned an octave above it
 ```
@@ -390,10 +388,10 @@ general.*
 import matplotlib.pyplot as plt
 
 # `f`, and extended_tube_chamber / expansion_chamber, as in section 1.
-plain = expansion_chamber(f, 0.4, 0.04, 0.01)
-inlet = extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1)
-both = extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
-                             outlet_extension=0.2)
+plain = noise_control.expansion_chamber(f, 0.4, 0.04, 0.01)
+inlet = noise_control.extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1)
+both = noise_control.extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
+                                           outlet_extension=0.2)
 
 # One line for one device:
 inlet.plot()
@@ -427,8 +425,8 @@ are the annular spaces the extensions create.*
 import matplotlib.pyplot as plt
 
 # One line: the dimensioned cross-section of the device just computed.
-extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
-                      outlet_extension=0.2).plot_geometry()
+noise_control.extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
+                                    outlet_extension=0.2).plot_geometry()
 plt.show()
 ```
 
@@ -460,12 +458,12 @@ damped design is usually the safer one.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator, quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line for one device: TL vs frequency with the resonance marked.
 hr.plot()
@@ -529,11 +527,11 @@ its target.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 
 # One line: the side branch drawn to scale, cavity as its equal-volume cube.
 hr.plot_geometry()
@@ -576,10 +574,10 @@ cold extremes and accepted with margin rather than designed at one value.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # One line: the closed 0.3 m tube on its duct, to scale.
 qw.plot_geometry()
@@ -636,11 +634,11 @@ figure, matplotlib (`pip install "phonometry[report,plot]"`); pass
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, expansion_chamber
+from phonometry import ReportMetadata, noise_control
 
 # A 0.5 m chamber of area ratio m = 8, at the octave-band centres.
 freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-res = expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
 res.report(
     "silencer_fiche.pdf",
     metadata=ReportMetadata(
@@ -700,7 +698,7 @@ all, because an impedance is not a shape.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import SilencerChain
+from phonometry import noise_control
 from phonometry.noise_control import helmholtz_impedance, quarter_wave_impedance
 
 freqs = np.linspace(20.0, 500.0, 481)
@@ -709,7 +707,7 @@ s_shell = np.pi * 0.200**2              # nominal 400 mm shell
 
 # The elements in order, inlet to outlet; each call keeps what it was given.
 chain = (
-    SilencerChain(freqs)
+    noise_control.SilencerChain(freqs)
     .duct(0.10, s_duct)
     .shunt(quarter_wave_impedance(freqs, 343.0 / (4.0 * 125.0), np.pi * 0.050**2),
            label="Quarter-wave stub")
@@ -787,7 +785,7 @@ blue curves stop at 891 Hz because that is where their model does.*
 import matplotlib.pyplot as plt
 
 # The reactive side, drawn only as far as its own validity ceiling.
-chamber = expansion_chamber(f, 0.3, 0.04, 0.01)
+chamber = noise_control.expansion_chamber(f, 0.3, 0.04, 0.01)
 inside = f <= chamber.plane_wave_limit
 
 fig, ax = plt.subplots()

--- a/site/src/content/docs/environment/propagation/atmospheric-refraction.mdx
+++ b/site/src/content/docs/environment/propagation/atmospheric-refraction.mdx
@@ -71,26 +71,21 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    atmospheric_ray_paths,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 c0 = 340.0
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
 zs = 2.0
 fig, axes = plt.subplots(2, 1, figsize=(11, 8.2), sharex=True)
 
-rays = atmospheric_ray_paths(profile, source_height=zs,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=3000)
+rays = environment.atmospheric_ray_paths(profile, source_height=zs,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=3000)
 for i in range(rays.heights.shape[0]):
     axes[0].plot(rays.ranges[i], rays.heights[i], color="#1f77b4", lw=0.8, alpha=0.7)
 axes[0].plot([0.0], [zs], "o", color="#d62728", label="Source")
 grad = (profile.speed_at(10.0) - c0) / 10.0
-x_sh = shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
+x_sh = environment.shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
 axes[0].axvline(x_sh, color="#d62728", ls="--", label="Shadow-zone boundary")
 axes[0].set(ylabel="Height [m]", ylim=(0, 40), title="Sound rays (upward refraction)")
 axes[0].legend()
@@ -100,9 +95,9 @@ with warnings.catch_warnings():
     # impedance model below its published fit range, as every outdoor ground
     # does (see "Choosing the ground impedance" in the ground-effect guide).
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(400.0, profile, source_height=zs,
-                                        flow_resistivity=200e3,
-                                        max_range=600.0, max_height=40.0)
+    pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=zs,
+                                                    flow_resistivity=200e3,
+                                                    max_range=600.0, max_height=40.0)
 img = axes[1].imshow(pe.relative_level, cmap="RdBu_r", vmin=-30, vmax=6,
                      aspect="auto", origin="lower", interpolation="bilinear",
                      extent=(pe.ranges[0], pe.ranges[-1], pe.heights[0], pe.heights[-1]))
@@ -179,9 +174,9 @@ hedgerows, scrub, suburban terrain — run from a few tenths of a metre to about
 value, so it is the one argument to change first when the site is not a field.
 
 ```python
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
 profile.speed_at(10.0)   # effective sound speed 10 m above the ground
 profile.plot()           # c_eff(z) with height on the vertical axis
 ```
@@ -198,11 +193,11 @@ the distance between them suggests.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
 # The two canonical surface layers of Salomons Eq. 4.5 over grassland.
-down = log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
-up = log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
+down = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
+up = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
 ax = down.plot(color="#1f77b4")
 up.plot(ax=ax, color="#d62728")
 plt.show()
@@ -220,12 +215,12 @@ travel times and the number of ground reflections.
 
 ```python
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0)
 rays.turning_points      # turning points per ray
 rays.plot()              # the curved ray fan (needs matplotlib)
 ```
@@ -248,13 +243,13 @@ depends on a gradient nobody measured.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
 # Downward refraction: the favourable-propagation mirror of the shadow case.
-profile = log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
-rays = atmospheric_ray_paths(profile, source_height=2.0,
-                             launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                             max_range=600.0, n_steps=600)
+profile = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
+rays = environment.atmospheric_ray_paths(profile, source_height=2.0,
+                                         launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                         max_range=600.0, n_steps=600)
 rays.plot()   # shallow rays return to the ground and bounce on down-range
 plt.show()
 ```
@@ -312,7 +307,7 @@ fig, ax = plt.subplots()
 for hs, hr, label in [(0.5, 1.5, "0.5 / 1.5 m"), (2.0, 2.0, "2 / 2 m"),
                       (2.0, 10.0, "2 / 10 m")]:
     ax.loglog(gradients,
-              [shadow_zone_distance(-g, hs, hr, ground_speed=340.0)
+              [environment.shadow_zone_distance(-g, hs, hr, ground_speed=340.0)
                for g in gradients], label=label)
 ax.set_xlabel("Upward gradient |g| [1/s]")
 ax.set_ylabel("Shadow-zone distance [m]")
@@ -343,12 +338,12 @@ at the top of the grid suppresses top-boundary reflections. The result is the
 free field) over the whole range-height plane.
 
 ```python
-from phonometry import atmospheric_parabolic_equation, log_linear_sound_speed_profile
+from phonometry import environment
 
-profile = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
-pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                    flow_resistivity=200e3,  # grassland
-                                    max_range=600.0, max_height=40.0)
+profile = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # upward
+pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                flow_resistivity=200e3,  # grassland
+                                                max_range=600.0, max_height=40.0)
 pe.level_at_height(2.0)   # relative level vs range at 2 m
 pe.plot()                 # the range-height relative-level field (needs matplotlib)
 ```
@@ -372,17 +367,12 @@ import warnings
 
 import matplotlib.pyplot as plt
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    linear_sound_speed_profile,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 cases = [
-    (log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
-    (linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
-    (log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
+    (environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Downward (b = +1 m/s)"),
+    (environment.linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogeneous (b = 0)"),
+    (environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Upward (b = -1 m/s)"),
 ]
 fig, ax = plt.subplots(figsize=(11, 6.2))
 with warnings.catch_warnings():
@@ -391,15 +381,15 @@ with warnings.catch_warnings():
     # does (see "Choosing the ground impedance" in the ground-effect guide).
     warnings.simplefilter("ignore")
     for profile, label in cases:
-        pe = atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
-                                            flow_resistivity=200e3,
-                                            max_range=600.0, max_height=40.0)
+        pe = environment.atmospheric_parabolic_equation(400.0, profile, source_height=2.0,
+                                                        flow_resistivity=200e3,
+                                                        max_range=600.0, max_height=40.0)
         ax.plot(pe.ranges, pe.level_at_height(2.0), label=label)
 # The closed-form boundary of the equivalent linear upward gradient (its
 # 10 m mean), the dotted line of the figure.
 up = cases[2][0]
 grad = float(up.speed_at(10.0) - 340.0) / 10.0
-ax.axvline(shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
+ax.axvline(environment.shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
            color="k", ls=":", label="Shadow-zone boundary")
 ax.set(xlabel="Range [m]", ylabel="Level re free field [dB]", ylim=(-40, 10))
 ax.legend()
@@ -475,12 +465,12 @@ import numpy as np
 # imported by the snippets above. A rigid ground needs no porous model, so
 # this case raises no warning at all.
 c0, freq, zs = 343.0, 500.0, 2.0
-flat = linear_sound_speed_profile(1e-12, ground_speed=c0, max_height=200.0)
+flat = environment.linear_sound_speed_profile(1e-12, ground_speed=c0, max_height=200.0)
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(freq, flat, source_height=zs,
-                                        impedance=1e6 + 0j, max_range=520.0,
-                                        max_height=150.0)
+    pe = environment.atmospheric_parabolic_equation(freq, flat, source_height=zs,
+                                                    impedance=1e6 + 0j, max_range=520.0,
+                                                    max_height=150.0)
 ranges = np.asarray(pe.ranges)
 solver = np.asarray(pe.level_at_height(zs))
 k = 2.0 * np.pi * freq / c0

--- a/site/src/content/docs/environment/propagation/ground-barriers.mdx
+++ b/site/src/content/docs/environment/propagation/ground-barriers.mdx
@@ -105,7 +105,7 @@ $$
 
 ```python
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 
@@ -113,7 +113,7 @@ bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 # receiver 1.5 m high, 50 m apart. The impedance comes from the Delany-Bazley
 # porous model of phonometry.materials (a semi-infinite ground).
 # Argument order: frequencies, source_height, receiver_height, distance.
-res = ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
+res = environment.ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
 print(res.excess_attenuation)     # the ground dip (dB re free field)
 print(res.reflection_coefficient) # complex Q per band
 res.plot()                        # excess attenuation vs frequency
@@ -144,7 +144,7 @@ flow resistivity is a resistivity in Pa·s/m², not a pressure.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 4000.0, 400)
 grounds = [
@@ -155,7 +155,7 @@ grounds = [
 ]
 fig, ax = plt.subplots(figsize=(11, 6.4))
 for label, sigma, color in grounds:
-    res = ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
+    res = environment.ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
     ax.plot(freqs, res.excess_attenuation, color=color, label=label)
 ax.axhline(6.0, color="k", ls=":", label="Hard-ground limit (+6 dB)")
 ax.axhline(0.0, color="k", lw=0.8)
@@ -200,7 +200,7 @@ c0, f, d = 343.0, 500.0, 50.0
 k = 2 * np.pi * f / c0
 q_mag, rp_mag, dl_q, dl_p = [], [], [], []
 for h in heights:
-    res = ground_effect([f], h, h, d, flow_resistivity=2e5, model="miki")
+    res = environment.ground_effect([f], h, h, d, flow_resistivity=2e5, model="miki")
     rp = res.plane_reflection_coefficient[0]
     q = res.reflection_coefficient[0]
     phase = np.exp(1j * k * (float(res.r_reflected) - float(res.r_direct)))
@@ -303,13 +303,13 @@ the 4 m screen of the snippets, they differ by just 0.15 m.
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier.svg" alt="Section of the barrier geometry: a loudspeaker source 1 m above the ground, a thin 4 m screen at 50 m and a microphone receiver 1.5 m high at 100 m, the blocked direct path of 100.00 m drawn dashed through the screen and the diffracted path bent over the edge in two segments A = 50.09 m and B = 50.06 m, with the resulting path difference of 0.15 m giving a Fresnel number of 0.44 and a Kurze-Anderson insertion loss of 10.0 dB at 500 Hz, rising to 15.5 dB at 2 kHz" width="92%" />
 
 ```python
-from phonometry import barrier_insertion_loss, kurze_anderson_attenuation
+from phonometry import environment
 
-kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
+environment.kurze_anderson_attenuation(0.0)     # 5.0 dB at the shadow boundary
 
 # A 4 m barrier 50 m from a 1 m source, receiver 1.5 m high at 100 m.
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="kurze_anderson")
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="kurze_anderson")
 il.plot()                           # insertion loss vs frequency
 ```
 
@@ -348,9 +348,9 @@ import numpy as np
 widths = np.linspace(0.0, 30.0, 40)
 fig, ax = plt.subplots()
 for freq in (250.0, 500.0, 1000.0):
-    thin = float(barrier_insertion_loss(
+    thin = float(environment.barrier_insertion_loss(
         [freq], 1.0, 50.0, 4.0, 100.0, 1.5, method="exact").insertion_loss[0])
-    gain = [0.0 if e == 0.0 else float(barrier_insertion_loss(
+    gain = [0.0 if e == 0.0 else float(environment.barrier_insertion_loss(
         [freq], 1.0, 50.0, 4.0, 100.0, 1.5, method="exact",
         thickness=e).insertion_loss[0]) - thin for e in widths]
     ax.plot(widths, gain, label=f"{freq:g} Hz")
@@ -376,8 +376,8 @@ boundary-element solution.
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_barrier_four_paths.svg" alt="To-scale section of the coherent four-path barrier model: a source 1 m above the ground with its mirror image 1 m below, a 4 m screen at 50 m, and a receiver 1.5 m high at 100 m with its own mirror image below the ground. Four diffracted routes are drawn in four distinguishable strokes from the source or its image over the top edge to the receiver or its image, each labelled with the number of ground bounces and with the spherical reflection coefficient Q marked at every bounce; a side panel lists the four path lengths and the path-length differences that set the interference, and an inset repeats the two-edge geometry of a thick barrier with its top width e" width="92%" />
 
 ```python
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="exact", ground_flow_resistivity=2e5)
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="exact", ground_flow_resistivity=2e5)
 il.ground        # True: the four-path coherent ground model was applied
 il.plot()
 ```
@@ -404,16 +404,16 @@ design value.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 # The 4 m barrier of the snippets above, on a fine frequency grid.
 freqs = np.geomspace(50.0, 5000.0, 240)
-il_ka = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="kurze_anderson")
-il_ex = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact")
-il_gr = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact", ground_flow_resistivity=2e5)
+il_ka = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="kurze_anderson")
+il_ex = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact")
+il_gr = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact", ground_flow_resistivity=2e5)
 fig, ax = plt.subplots(figsize=(11, 6.4))
 ax.semilogx(freqs, il_ka.insertion_loss, "--", label="Kurze-Anderson (thin screen)")
 ax.semilogx(freqs, il_ex.insertion_loss, label="Exact rigid half-plane")
@@ -445,10 +445,10 @@ thin-screen methods above key on.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 5000.0, 240)
-il = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+il = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 
 # One line: the section to scale, with the path-length difference annotated.
 il.plot_geometry()

--- a/site/src/content/docs/environment/propagation/outdoor-propagation.mdx
+++ b/site/src/content/docs/environment/propagation/outdoor-propagation.mdx
@@ -821,18 +821,13 @@ level supplied through the metadata `requirement` then adds a PASS/FAIL verdict
 
 ```python
 import numpy as np
-from phonometry import (
-    Barrier,
-    ReportMetadata,
-    SourceEmission,
-    outdoor_propagation_attenuation,
-)
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 lw = np.array([95, 100, 103, 105, 104, 101, 95, 88], dtype=float)
-result = outdoor_propagation_attenuation(
+result = environment.outdoor_propagation_attenuation(
     200.0, 4.0, 2.0, freqs, 1.0, 1.0, 1.0,
-    barrier=Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
+    barrier=environment.Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
     temperature=10.0, relative_humidity=70.0,
 )
 result.report(
@@ -842,7 +837,7 @@ result.report(
         test_room="Nearest dwelling facade",
         requirement=50.0,  # maximum acceptable A-weighted downwind level
     ),
-    source_emission=SourceEmission(sound_power_level=lw),
+    source_emission=environment.SourceEmission(sound_power_level=lw),
 )
 ```
 
@@ -862,12 +857,12 @@ adds a PASS/FAIL verdict (a higher insertion loss is better).
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, barrier_insertion_loss
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 # hs = 1 m, barrier 4 m high at 50 m, receiver 1.5 m high at 100 m *from the
 # source*; method="exact" is the wave-theoretic rigid half-plane the fiche names.
-result = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5, method="exact")
+result = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5, method="exact")
 result.report(
     "barrier_insertion_loss.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/environment/sources/cnossos-rail-emission.mdx
+++ b/site/src/content/docs/environment/sources/cnossos-rail-emission.mdx
@@ -169,29 +169,23 @@ starts to matter.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    BrakeType, ContactFilter, RailRoughnessClass, RailwayTrack, RailwayVehicle,
-    RollingStock, TrackTransferClass, TractionVehicle, WheelDiameter,
-    aerodynamic_sound_power, contact_filter, impact_roughness_single,
-    rail_roughness, railway_source_power, track_transfer, traction_sound_power,
-    wheel_roughness, wheel_transfer,
-)
+from phonometry import environment
 
-stock = RollingStock(
+stock = environment.RollingStock(
     axles=4,
-    wheel_roughness=wheel_roughness(BrakeType.NON_TREAD),
-    contact_filter=contact_filter(ContactFilter.LOAD_50_DIAMETER_920),
-    wheel_transfer=wheel_transfer(WheelDiameter.MM_920),
-    traction=traction_sound_power(TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
-    aerodynamic=aerodynamic_sound_power(),
+    wheel_roughness=environment.wheel_roughness(environment.BrakeType.NON_TREAD),
+    contact_filter=environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920),
+    wheel_transfer=environment.wheel_transfer(environment.WheelDiameter.MM_920),
+    traction=environment.traction_sound_power(environment.TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
+    aerodynamic=environment.aerodynamic_sound_power(),
 )
-track = RailwayTrack(
-    rail_roughness=rail_roughness(RailRoughnessClass.NORMAL),
-    track_transfer=track_transfer(TrackTransferClass.MONOBLOCK_MEDIUM),
-    impact_roughness=impact_roughness_single(),
+track = environment.RailwayTrack(
+    rail_roughness=environment.rail_roughness(environment.RailRoughnessClass.NORMAL),
+    track_transfer=environment.track_transfer(environment.TrackTransferClass.MONOBLOCK_MEDIUM),
+    impact_roughness=environment.impact_roughness_single(),
 )
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
 )
 result.plot()
 plt.show()
@@ -224,8 +218,8 @@ def total(bands):
     return 10.0 * np.log10(np.sum(10.0 ** (np.asarray(bands) / 10.0)))
 
 fig, (left, right) = plt.subplots(1, 2, figsize=(12, 4.6))
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0)
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0)
 for name, spectrum in result.components.items():
     for row, height in ((0, "0,5 m"), (1, "4,0 m")):
         values = np.asarray(spectrum)[row]
@@ -238,8 +232,8 @@ left.legend(fontsize="small")
 speeds = np.linspace(60.0, 350.0, 30)
 for row, label in [(0, "Source A (0,5 m)"), (1, "Source B (4,0 m)")]:
     right.plot(speeds, [
-        total(railway_source_power(
-            RailwayVehicle(stock, flow_rate=96.0, speed=float(v)),
+        total(environment.railway_source_power(
+            environment.RailwayVehicle(stock, flow_rate=96.0, speed=float(v)),
             track, phi=90.0, psi=10.0).line_power[row]) for v in speeds],
         label=label)
 right.axvline(200.0, ls=":", label="Aerodynamic threshold")
@@ -310,24 +304,20 @@ rough ones.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    RAILWAY_THIRD_OCTAVE_BANDS, BrakeType, ContactFilter, RailRoughnessClass,
-    contact_filter, rail_roughness, roughness_to_frequency,
-    total_effective_roughness, wheel_roughness,
-)
+from phonometry import environment
 
-rail = rail_roughness(RailRoughnessClass.NORMAL)
-wheel = wheel_roughness(BrakeType.NON_TREAD)
-filt = contact_filter(ContactFilter.LOAD_50_DIAMETER_920)
+rail = environment.rail_roughness(environment.RailRoughnessClass.NORMAL)
+wheel = environment.wheel_roughness(environment.BrakeType.NON_TREAD)
+filt = environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920)
 
 fig, ax = plt.subplots()
 for speed in (60.0, 160.0, 300.0):
-    total = total_effective_roughness(
-        roughness_to_frequency(rail[1], rail[0], speed),
-        roughness_to_frequency(wheel[1], wheel[0], speed),
-        roughness_to_frequency(filt[1], filt[0], speed),
+    total = environment.total_effective_roughness(
+        environment.roughness_to_frequency(rail[1], rail[0], speed),
+        environment.roughness_to_frequency(wheel[1], wheel[0], speed),
+        environment.roughness_to_frequency(filt[1], filt[0], speed),
     )
-    ax.semilogx(RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
+    ax.semilogx(environment.RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
 ax.legend()
 plt.show()
 ```
@@ -349,10 +339,10 @@ worked example. Two readings are shipped, and the default is the one that
 reproduces the Commission's own reference source module:
 
 ```python
-from phonometry import RoughnessInterpolation
+from phonometry import environment
 
-RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
-RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
+environment.RoughnessInterpolation.PROPORTIONAL   # levels interpolated linearly in lambda
+environment.RoughnessInterpolation.ENERGY         # energies interpolated linearly in lambda
 ```
 
 They differ by up to about 1 dB on a steep part of a spectrum. This is the
@@ -397,12 +387,12 @@ the 2015 one:
 | Tram | curve or switch turnout with $R \le 200\ \text{m}$ | 5 dB |
 
 ```python
-from phonometry import curve_squeal_excess
+from phonometry import environment
 
-curve_squeal_excess(280.0)                       # 8.0 dB
-curve_squeal_excess(450.0)                       # 5.0 dB
-curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
-curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
+environment.curve_squeal_excess(280.0)                       # 8.0 dB
+environment.curve_squeal_excess(450.0)                       # 5.0 dB
+environment.curve_squeal_excess(280.0, tram=True)            # 0.0 dB, trams need R <= 200 m
+environment.curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, the curve is too short
 ```
 
 The 2015 text read "8 dB for R < 300 m and 5 dB for 300 m < R < 500 m", which
@@ -461,10 +451,10 @@ available, because comparing with a study computed before 2021 needs the old
 one:
 
 ```python
-from phonometry import DirectivityEdition, vertical_directivity
+from phonometry import environment
 
-vertical_directivity(-30.0)                                        # zeros
-vertical_directivity(-30.0, edition=DirectivityEdition.ORIGINAL_2015)  # positive
+environment.vertical_directivity(-30.0)                                        # zeros
+environment.vertical_directivity(-30.0, edition=environment.DirectivityEdition.ORIGINAL_2015)  # positive
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/cnossos_rail_directivity.svg" alt="Two polar plots of the CNOSSOS-EU railway directivity. Left, the vertical correction of source A at 250 Hz and 4 kHz for both editions: the 2021 form is identically zero everywhere below the horizon and above about 41.4 degrees turns negative, while the 2015 form is symmetric about the horizon and positive on both sides, the two agreeing only in the wedge from 0 to 41.4 degrees. Right, the horizontal dipole in the plane of the track: 0 dB broadside to the track and minus 20 dB along it, with the along-track null marked" width="92%" />
@@ -492,9 +482,9 @@ bands = {7: "250 Hz", 19: "4 kHz"}       # indices into the 24 third-octaves
 fig, (left, right) = plt.subplots(1, 2, subplot_kw={"projection": "polar"},
                                   figsize=(12, 5.0))
 for band, name in bands.items():
-    for edition, style in [(DirectivityEdition.CURRENT, "-"),
-                           (DirectivityEdition.ORIGINAL_2015, "--")]:
-        values = [float(vertical_directivity(float(a), edition=edition)[band])
+    for edition, style in [(environment.DirectivityEdition.CURRENT, "-"),
+                           (environment.DirectivityEdition.ORIGINAL_2015, "--")]:
+        values = [float(environment.vertical_directivity(float(a), edition=edition)[band])
                   for a in psi]
         left.plot(np.radians(psi), values, style,
                   label=f"{name}, {edition.value}")
@@ -544,11 +534,11 @@ interpolation, so choosing between them is a judgement about the deck, made
 before the calculation and recorded with it.
 
 ```python
-from phonometry import BridgeType, RailwayTrack, bridge_transfer
+from phonometry import environment
 
-RailwayTrack(
+environment.RailwayTrack(
     rail_roughness=..., track_transfer=...,
-    bridge_transfer=bridge_transfer(BridgeType.PLUS_10_DBA),   # Table G-7, col. 1
+    bridge_transfer=environment.bridge_transfer(environment.BridgeType.PLUS_10_DBA),   # Table G-7, col. 1
 )
 ```
 

--- a/site/src/content/docs/environment/sources/cnossos-road-emission.mdx
+++ b/site/src/content/docs/environment/sources/cnossos-road-emission.mdx
@@ -119,19 +119,17 @@ governs.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    JunctionType, RoadSurface, RoadTraffic, RoadVehicleCategory, road_source_power,
-)
+from phonometry import environment
 
 traffic = [
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1200.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 45.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1200.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 45.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
 ]
-result = road_source_power(
-    traffic, surface=RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
-    junction_distance=60.0, junction_type=JunctionType.CROSSING,
+result = environment.road_source_power(
+    traffic, surface=environment.RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
+    junction_distance=60.0, junction_type=environment.JunctionType.CROSSING,
 )
 print(result.total_line_power.round(1))
 # [89.1 82.7 81.3 80.2 80.4 76.2 71.7 66. ]  dB re 1 pW per metre of line
@@ -243,10 +241,10 @@ import numpy as np
 # `road_source_power`, `RoadTraffic`, `RoadVehicleCategory` and `JunctionType`
 # are imported by the figure snippet above.
 def a_line(**kwargs):
-    return float(road_source_power(**kwargs).a_weighted_line_power)
+    return float(environment.road_source_power(**kwargs).a_weighted_line_power)
 
-light = [RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 50.0)]
-heavy = [RoadTraffic(RoadVehicleCategory.HEAVY, 1000.0, 50.0)]
+light = [environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 50.0)]
+heavy = [environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 1000.0, 50.0)]
 temps = np.linspace(-10.0, 40.0, 60)
 fig, (t_ax, s_ax, j_ax) = plt.subplots(1, 3, figsize=(13, 4.2))
 for flow, name in [(light, "Light (1)"), (heavy, "Heavy (3)")]:
@@ -259,18 +257,18 @@ t_ax.legend()
 speeds = np.linspace(20.0, 130.0, 60)
 for share in (0.2, 0.5):
     s_ax.plot(speeds, [
-        a_line(traffic=[RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, v,
-                                    studded_fraction=share)],
+        a_line(traffic=[environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, v,
+                                                studded_fraction=share)],
                studded_months=4.0)
-        - a_line(traffic=[RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, v)])
+        - a_line(traffic=[environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, v)])
         for v in speeds], label=f"Qstud,ratio = {share:g}, Ts = 4 months")
 s_ax.set(xlabel="Speed v [km/h]", ylabel="Change in line power [dB(A)]")
 s_ax.legend(fontsize="small")
 
 xs = np.linspace(0.0, 120.0, 60)
 ref = a_line(traffic=light)
-for junction, name in [(JunctionType.CROSSING, "Crossing with lights"),
-                       (JunctionType.ROUNDABOUT, "Roundabout")]:
+for junction, name in [(environment.JunctionType.CROSSING, "Crossing with lights"),
+                       (environment.JunctionType.ROUNDABOUT, "Roundabout")]:
     j_ax.plot(xs, [a_line(traffic=light, junction_distance=float(x),
                           junction_type=junction) - ref for x in xs], label=name)
 j_ax.set(xlabel="Distance to the junction |x| [m]",
@@ -310,20 +308,17 @@ from about 60 km/h, which is why a lorry is still an engine at urban speeds.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    CNOSSOS_A_WEIGHTING, road_propulsion_noise, road_rolling_noise,
-    road_vehicle_sound_power,
-)
+from phonometry import environment
 
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 speeds = np.linspace(20.0, 130.0, 221)
 fig, ax = plt.subplots()
 for category, name in [("1", "Light vehicles (1)"), ("3", "Heavy vehicles (3)")]:
-    rolling = [a_weighted(road_rolling_noise(category, v)) for v in speeds]
-    propulsion = [a_weighted(road_propulsion_noise(category, v)) for v in speeds]
-    total = [a_weighted(road_vehicle_sound_power(category, v)) for v in speeds]
+    rolling = [a_weighted(environment.road_rolling_noise(category, v)) for v in speeds]
+    propulsion = [a_weighted(environment.road_propulsion_noise(category, v)) for v in speeds]
+    total = [a_weighted(environment.road_vehicle_sound_power(category, v)) for v in speeds]
     ax.plot(speeds, total, lw=2.4, label=f"{name} - total")
     ax.plot(speeds, rolling, ls="--", lw=1.2, label=f"{name} - rolling")
     ax.plot(speeds, propulsion, ls=":", lw=1.2, label=f"{name} - propulsion")
@@ -370,16 +365,16 @@ import numpy as np
 
 # `road_propulsion_noise` and `CNOSSOS_A_WEIGHTING` are imported by the
 # speed-law figure snippet above.
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 slopes = np.linspace(-14.0, 14.0, 141)
 fig, ax = plt.subplots()
 for category in ("1", "2", "3"):
     for speed, style in [(50.0, "--"), (80.0, "-")]:
-        flat = a_weighted(road_propulsion_noise(category, speed))
+        flat = a_weighted(environment.road_propulsion_noise(category, speed))
         ax.plot(slopes,
-                [a_weighted(road_propulsion_noise(category, speed, gradient=s)) - flat
+                [a_weighted(environment.road_propulsion_noise(category, speed, gradient=s)) - flat
                  for s in slopes], style, label=f"Category {category}, {speed:g} km/h")
 ax.set_xlabel("Road gradient s [%]")
 ax.set_ylabel("Propulsion-noise correction [dB(A)]")
@@ -427,9 +422,9 @@ down onto it, but a rough texture only generates tyre noise, and tyre noise is
 already the rolling term.
 
 ```python
-from phonometry import RoadSurface, road_surface_coefficients
+from phonometry import environment
 
-row = road_surface_coefficients(RoadSurface.TWO_LAYER_ZOAB_FINE)
+row = environment.road_surface_coefficients(environment.RoadSurface.TWO_LAYER_ZOAB_FINE)
 row.speed_range          # (80.0, 130.0) km/h, the printed validity range
 row.alpha["1"]           # alpha per octave band for light vehicles
 row.beta["1"]            # -0.1, the speed coefficient
@@ -455,10 +450,10 @@ import numpy as np
 # `RoadSurface` and `road_surface_coefficients` are imported just above.
 bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
 fig, ax = plt.subplots()
-for surface in (RoadSurface.REFERENCE, RoadSurface.TWO_LAYER_ZOAB_FINE,
-                RoadSurface.ONE_LAYER_ZOAB, RoadSurface.THIN_LAYER_A,
-                RoadSurface.SMA_NL8, RoadSurface.HARD_ELEMENTS_NOT_HERRINGBONE):
-    row = road_surface_coefficients(surface)
+for surface in (environment.RoadSurface.REFERENCE, environment.RoadSurface.TWO_LAYER_ZOAB_FINE,
+                environment.RoadSurface.ONE_LAYER_ZOAB, environment.RoadSurface.THIN_LAYER_A,
+                environment.RoadSurface.SMA_NL8, environment.RoadSurface.HARD_ELEMENTS_NOT_HERRINGBONE):
+    row = environment.road_surface_coefficients(surface)
     # The reference row carries no speed range: it is valid by definition.
     span = ("all speeds" if row.speed_range is None
             else "{:g}-{:g} km/h".format(*row.speed_range))
@@ -491,30 +486,27 @@ arithmetic and is offered as such.
 
 ```python
 import numpy as np
-from phonometry import (
-    PropagationGeometry, RoadTraffic, RoadVehicleCategory,
-    line_source_segment_power, predicted_receiver_level, road_source_power,
-)
+from phonometry import environment
 
-result = road_source_power([
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 90.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 120.0, 80.0),
+result = environment.road_source_power([
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 90.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 120.0, 80.0),
 ])
-segment = line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
+segment = environment.line_source_segment_power(result.total_line_power, 20.0)  # a 20 m segment
 
 # One segment, the one directly opposite a receiver 100 m from the road.
-levels = predicted_receiver_level(
+levels = environment.predicted_receiver_level(
     segment,
-    PropagationGeometry(100.0, result.source_height, 4.0),
+    environment.PropagationGeometry(100.0, result.source_height, 4.0),
     frequencies=result.frequencies,
 )
 
 # The road is the energy sum of its segments: 1 km either way, in 20 m steps.
 energy = np.zeros_like(levels)
 for x in np.arange(-990.0, 1000.0, 20.0):        # segment centres along the road
-    energy += 10 ** (predicted_receiver_level(
+    energy += 10 ** (environment.predicted_receiver_level(
         segment,
-        PropagationGeometry(float(np.hypot(100.0, x)), result.source_height, 4.0),
+        environment.PropagationGeometry(float(np.hypot(100.0, x)), result.source_height, 4.0),
         frequencies=result.frequencies,
     ) / 10)
 road = 10 * np.log10(energy)
@@ -544,13 +536,13 @@ For the A-weighted total, use the octave-band weighting the Directive itself
 prints in 2.5.5 as amended, rather than recomputing it:
 
 ```python
-from phonometry import CNOSSOS_A_WEIGHTING
+from phonometry import environment
 
-CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
+environment.CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
 result.a_weighted_line_power
 
 # The two receiver spectra of the segmentation above, A-weighted:
-weight = np.asarray(CNOSSOS_A_WEIGHTING)
+weight = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 print(round(float(10 * np.log10(np.sum(10 ** ((levels + weight) / 10)))), 1))
 # 52.9 dB(A) - one 20 m segment, not the road
 print(round(float(10 * np.log10(np.sum(10 ** ((road + weight) / 10)))), 1))
@@ -567,13 +559,13 @@ and the 2021 one). Both coefficient objects can be replaced:
 ```python
 import dataclasses
 
-from phonometry import ROAD_COEFFICIENTS
+from phonometry import environment
 
 # One measured national row for light vehicles, the rest of Appendix F as published.
 national = dataclasses.replace(
-    ROAD_COEFFICIENTS,
+    environment.ROAD_COEFFICIENTS,
     rolling_a={
-        **ROAD_COEFFICIENTS.rolling_a,
+        **environment.ROAD_COEFFICIENTS.rolling_a,
         "1": (83.4, 89.0, 88.1, 93.6, 100.4, 96.9, 87.0, 76.5),
     },
 )

--- a/site/src/content/docs/es/aircraft/aircraft-noise.mdx
+++ b/site/src/content/docs/es/aircraft/aircraft-noise.mdx
@@ -327,10 +327,10 @@ calculado y no es un certificado oficial de ruido de un Estado; no reproduce
 ningún TCDSN.
 
 ```python
-from phonometry import effective_perceived_noise_level, ReportMetadata
+from phonometry import ReportMetadata, aircraft
 
 # spectra: un array (K, 24) de niveles de tercio de octava muestreado cada dt s
-res = effective_perceived_noise_level(spectra, dt=0.5)
+res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 res.report(
     "ficha_epnl.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/es/aircraft/anp-fleet.mdx
+++ b/site/src/content/docs/es/aircraft/anp-fleet.mdx
@@ -40,9 +40,9 @@ tú ninguna tabla.
 Apúntalo a un directorio para leer cualquier otra exportación CSV de ANP.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 print(len(db.aircraft_ids))          # 155 tipos de aeronave
 ac = db.aircraft("747100")
 print(ac.description)                # Boeing 747-100 / JT9DBD
@@ -83,9 +83,9 @@ con JT9D. Busca en las descripciones para encontrar la tuya en lugar de adivinar
 la cadena:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for aid in db.aircraft_ids:
     rec = db.aircraft(aid)
     if "A320" in rec.description:
@@ -134,9 +134,9 @@ de la Doc 29.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 curves = ac.npd_curves("D", "SEL")
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -152,18 +152,18 @@ plt.show()
 </details>
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-load_anp_database().aircraft("747100").npd_curves("D", "SEL").plot(language="es")
+aircraft.load_anp_database().aircraft("747100").npd_curves("D", "SEL").plot(language="es")
 ```
 
 Para leer un valor suelto en vez de dibujar la familia, `level` interpola a
 cualquier potencia y distancia:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-curves = load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
+curves = aircraft.load_anp_database().aircraft("A320-232").npd_curves("D", "SEL")
 print(curves.powers)                       # [10000. 14000. 19000. 23000.] lb
 print(curves.level(19000.0, [304.8, 1000.0, 3000.0]))
 ```
@@ -196,9 +196,9 @@ y más ancha.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -214,9 +214,9 @@ plt.show()
 </details>
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-load_anp_database().aircraft("747100").profile("D", stage_length=1).plot(language="es")
+aircraft.load_anp_database().aircraft("747100").profile("D", stage_length=1).plot(language="es")
 ```
 
 La **longitud de etapa** selecciona el tramo de distancia de viaje: una etapa más
@@ -243,9 +243,9 @@ que nombra las etapas que sí, que es además la forma de descubrir los tramos q
 una aeronave trae de verdad:
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-db = load_anp_database()
+db = aircraft.load_anp_database()
 for identifier, operation, stage in (("A320-232", "D", 1), ("747100", "D", 9)):
     try:
         db.profile(identifier, operation, stage)
@@ -297,9 +297,9 @@ no ofrece ninguna corrección de banda dependiente de la humedad, así que un
 aeródromo caluroso y seco no se modela pasándole su temperatura.
 
 ```python
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 flyover = ac.event_level([3000.0, 500.0, 0.0], "D")
 print(round(float(flyover.level), 1))     # 100.4 dB
 ```
@@ -312,9 +312,9 @@ por debajo de 50°.
 
 ```python
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 contour = ac.noise_contour(
     "D",
     x=np.linspace(-2000.0, 12000.0, 40),
@@ -345,9 +345,9 @@ sección son el mismo cálculo en un punto y en 1 200 de ellos.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import load_anp_database
+from phonometry import aircraft
 
-ac = load_anp_database().aircraft("747100")
+ac = aircraft.load_anp_database().aircraft("747100")
 profile = ac.profile("D", stage_length=1)
 x = np.linspace(-2000.0, 12000.0, 40)
 y = np.linspace(-3000.0, 3000.0, 30)

--- a/site/src/content/docs/es/aircraft/rotorcraft-noise.mdx
+++ b/site/src/content/docs/es/aircraft/rotorcraft-noise.mdx
@@ -850,11 +850,11 @@ La regla práctica es ejecutar primero una sección con
 elevaciones completo solo si esa sección resulta estar apantallada.
 
 ```python
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bandas = [63.0, 250.0, 1000.0, 4000.0]
-diffraction_attenuation(bandas, 0.0, edge_height=2.5)   # incidencia rasante
-diffraction_attenuation(bandas, 1.0, edge_height=2.5)   # 1 m dentro de la sombra
+aircraft.diffraction_attenuation(bandas, 0.0, edge_height=2.5)   # incidencia rasante
+aircraft.diffraction_attenuation(bandas, 1.0, edge_height=2.5)   # 1 m dentro de la sombra
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_insertion_loss_es.svg" alt="Atenuación por difracción frente a la diferencia de camino para cuatro bandas de 63 Hz a 4 kHz, sobre una arista de 2,5 m: cada curva vale cero a la izquierda de su propio umbral dependiente de la banda cerca de la línea de visión, las tres bandas con C_h = 1 cruzan unos 4,8 dB en incidencia rasante mientras que la de 63 Hz cruza en 3,0 dB, y solo la curva de 4 kHz alcanza el tope de 25 dB dentro del rango representado" width="82%" />
@@ -874,11 +874,11 @@ de $C_h$, no solo de la longitud de onda.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import diffraction_attenuation
+from phonometry import aircraft
 
 bandas = np.array([63.0, 250.0, 1000.0, 4000.0])
 delta = np.linspace(-0.4, 1.5, 441)
-ld = np.array([diffraction_attenuation(bandas, float(d), edge_height=2.5)
+ld = np.array([aircraft.diffraction_attenuation(bandas, float(d), edge_height=2.5)
               for d in delta])
 
 fig, ax = plt.subplots(figsize=(9, 6))

--- a/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
@@ -271,35 +271,31 @@ más tres por cada elemento de flanco, $1 + 4\times3$.
 
 ```python
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 
 # Uniones del Anexo E (sin redondear): forjado-fachada en T rígida, fachada
 # pasante, forjado-partición interior en cruz rígida, partición pasante.
-k_floor_ext = junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
-k_ext_ext = junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
-k_floor_int = junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
-k_int_int = junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_ext_ext = building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
+k_int_int = building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0)
 print(round(k_floor_ext, 1), round(k_ext_ext, 1))     # 6.4 11.2  (tabla L.5)
 print(round(k_floor_int, 1), round(k_int_int, 1))     # 8.8 11.0  (tabla L.6)
 
 # Perímetro del forjado: topa contra una fachada arriba y abajo en cada uno de
 # sus dos bordes exteriores, y cruza las particiones interiores en los otros dos.
-a_at_ext = perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
-a_at_int = perimeter_absorption_coefficient(
-    [76.8, 128.4, 128.4], [junction_vibration_reduction(
+a_at_ext = building.perimeter_absorption_coefficient([92.6, 92.6], [k_floor_ext] * 2)
+a_at_int = building.perimeter_absorption_coefficient(
+    [76.8, 128.4, 128.4], [building.junction_vibration_reduction(
         "rigid_cross", "through", 360.0 / 484.0), k_floor_int, k_floor_int])
 floor_perimeter = 9.0 * (a_at_ext + a_at_int)         # 2,659 m (fórmula C.4)
 
-floor = HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
-                           floor_perimeter, 2200.0, 3800.0)
-el = in_situ_element(floor, bands)
+floor = building.HomogeneousElement("floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005,
+                                    floor_perimeter, 2200.0, 3800.0)
+el = building.in_situ_element(floor, bands)
 print(np.round(el.total_loss_factor[[0, 10]], 4))     # [0.0831 0.029 ]  tabla L.3
 print(np.round(el.sound_reduction_index[[0, 10]], 1)) # [31.8 54.9]      tabla L.3
 print(np.round(el.impact_level[[0, 10]], 1))          # [57.3 63.6]      tabla G.3
@@ -312,13 +308,13 @@ margen de 0,06 dB, y el mismo conjunto de datos alimenta los dos totales.
 ```python
 # Suelo flotante: losa de 35 mm, m' = 73,5 kg/m2 sobre s' = 8 MN/m3.
 f0 = 160.0 * np.sqrt(8.0 / 73.5)                      # 52,8 Hz (fórmula C.2)
-delta = floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
+delta = building.floating_floor_improvement(bands, resonance_frequency=f0)  # 30 lg(f/f0)
 
-wall = in_situ_element(HomogeneousElement(
+wall = building.in_situ_element(building.HomogeneousElement(
     "ext1", 11.0, 4.0, 2.75, 219.0, 92.6, 0.0125, 2.375, 600.0, 1900.0), bands)
 
 # Trayectoria D1 (Df: forjado separador -> fachada 1), tabla L.4.
-d1 = airborne_flanking_path(
+d1 = building.airborne_flanking_path(
     label="D1", kind="Df", element_i=el, element_j=wall,
     vibration_reduction_index=k_floor_ext, coupling_length=4.0,
     separating_area=20.0, delta_r_i=delta)
@@ -333,9 +329,9 @@ sola llamada:
 # `paths` contiene las doce trayectorias por flancos de los cuatro elementos,
 # construidas como `d1` más arriba; el bloque de código bajo la figura las
 # construye todas.
-res = detailed_airborne_prediction(
-    bands, direct_index=direct_reduction_index(el.sound_reduction_index,
-                                               delta_r_source=delta),
+res = building.detailed_airborne_prediction(
+    bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
+                                                        delta_r_source=delta),
     flanking_paths=paths)
 print(np.round(res.r_prime[[0, 10]], 1))   # [28.8 55.9]   total de la tabla L.1
 print(res.rating.rating, res.dominant[0])  # 57 'Dd'
@@ -358,26 +354,22 @@ $R'_\mathrm{w} = 57$ dB no dice nada de eso.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HomogeneousElement, airborne_flanking_path, detailed_airborne_prediction,
-    direct_reduction_index, floating_floor_improvement, in_situ_element,
-    junction_vibration_reduction, perimeter_absorption_coefficient,
-)
+from phonometry import building
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150], float)
 k = {
-    "floor-ext": junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
-    "ext-ext": junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
-    "floor-floor": junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
-    "floor-int": junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
-    "int-int": junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
-    "int-ext": junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
-    "extT-ext": junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
-    "corner": junction_vibration_reduction("corner", "corner", 1.0),
-    "int-int-x": junction_vibration_reduction("rigid_cross", "through", 1.0),
+    "floor-ext": building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0),
+    "ext-ext": building.junction_vibration_reduction("rigid_t", "through", 484.0 / 219.0),
+    "floor-floor": building.junction_vibration_reduction("rigid_cross", "through", 360.0 / 484.0),
+    "floor-int": building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0),
+    "int-int": building.junction_vibration_reduction("rigid_cross", "through", 484.0 / 360.0),
+    "int-ext": building.junction_vibration_reduction("rigid_t", "corner", 360.0 / 219.0),
+    "extT-ext": building.junction_vibration_reduction("rigid_t", "through", 360.0 / 219.0),
+    "corner": building.junction_vibration_reduction("corner", "corner", 1.0),
+    "int-int-x": building.junction_vibration_reduction("rigid_cross", "through", 1.0),
 }
-a = perimeter_absorption_coefficient
+a = building.perimeter_absorption_coefficient
 floor_sum = 9.0 * (a([92.6, 92.6], [k["floor-ext"]] * 2)
                    + a([76.8, 128.4, 128.4],
                        [k["floor-floor"], k["floor-int"], k["floor-int"]]))
@@ -397,10 +389,10 @@ specs = {
     "int2": (13.75, 5.0, 2.75, 360.0, 128.4, 0.01,
              10.0 * int_top + 2.75 * int_side, 1800.0, 2500.0),
 }
-situ = {name: in_situ_element(HomogeneousElement(name, *spec), bands)
+situ = {name: building.in_situ_element(building.HomogeneousElement(name, *spec), bands)
         for name, spec in specs.items()}
-delta = floating_floor_improvement(bands,
-                                   resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
+delta = building.floating_floor_improvement(bands,
+                                            resonance_frequency=160.0 * np.sqrt(8.0 / 73.5))
 
 paths = []
 for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
@@ -409,21 +401,21 @@ for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
     cross = k["floor-ext"] if name.startswith("ext") else k["floor-int"]
     through = k["ext-ext"] if name.startswith("ext") else k["int-int"]
     paths += [
-        airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
-                               element_j=wall, vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0,
-                               delta_r_i=delta),
-        airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
-                               element_j=situ["floor"], vibration_reduction_index=cross,
-                               coupling_length=lij, separating_area=20.0),
-        airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
-                               element_j=wall, vibration_reduction_index=through,
-                               coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=wall, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=wall,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=wall,
+                                        element_j=wall, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
     ]
-res = detailed_airborne_prediction(
+res = building.detailed_airborne_prediction(
     bands,
-    direct_index=direct_reduction_index(situ["floor"].sound_reduction_index,
-                                        delta_r_source=delta),
+    direct_index=building.direct_reduction_index(situ["floor"].sound_reduction_index,
+                                                 delta_r_source=delta),
     flanking_paths=paths)
 
 # Una línea: las contribuciones por trayectoria y banda con R' superpuesto.
@@ -437,19 +429,18 @@ La parte de impactos del mismo edificio se apoya en el mismo diccionario
 `situ`:
 
 ```python
-from phonometry import (detailed_impact_prediction, direct_impact_level,
-                        impact_flanking_path)
+from phonometry import building
 
-direct = direct_impact_level(situ["floor"].impact_level, delta_l=delta)
+direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
-    impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
-                         vibration_reduction_index=(
+    building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
+                                  vibration_reduction_index=(
                              k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
-                         coupling_length=lij, delta_l=delta)
+                                  coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
 ]
-imp = detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
+imp = building.detailed_impact_prediction(bands, direct_level=direct, flanking_paths=flanking)
 print(np.round(imp.l_prime_n[[3, 10]], 1))     # [54.  35.9]   total de la tabla G.1
 print(imp.rating.rating, imp.rating.ci)        # 41 2           impreso 41,0 (2)
 ```
@@ -531,10 +522,7 @@ longitud de acoplamiento. El bloque de abajo es un extracto: parte de esos cuatr
 arrays.
 
 ```python
-from phonometry import (flanking_impact_level_from_flanking_level,
-                        flanking_reduction_index_from_flanking_level,
-                        flanking_reduction_index_from_normalized_difference,
-                        resonant_sound_reduction_index)
+from phonometry import building
 
 # ISO 12354-1 L.2.1: edificio de entramado de madera, forjado 20 m2, unión 4 m.
 r_wall_leaf = ...   # R medido de la hoja interior por banda, dB (ISO 10140-2)
@@ -542,19 +530,19 @@ dv_n = ...          # dif. de niveles de velocidad de unión normalizada, dB (IS
 dnf_13 = ...        # dif. de niveles por flancos normalizada de laboratorio Dn,f, dB
 lnf_13 = ...        # nivel de impactos normalizado por flancos de laboratorio Ln,f, dB
 
-r_star = resonant_sound_reduction_index(r_wall_leaf, bands,
-                                        critical_frequency=2200.0)   # +8 dB bajo fc
-r_ff = flanking_reduction_index_from_normalized_difference(
+r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
+                                                 critical_frequency=2200.0)   # +8 dB bajo fc
+r_ff = building.flanking_reduction_index_from_normalized_difference(
     index_i=r_star, index_j=r_star, normalized_velocity_level_difference=dv_n,
     separating_area=20.0, coupling_length=4.0)                        # tabla L.11
 
 # ISO 12354-1 L.2.2: unión medida entre dos paredes de entramado de madera.
-r13 = flanking_reduction_index_from_flanking_level(
+r13 = building.flanking_reduction_index_from_flanking_level(
     dnf_13, separating_area=10.44, coupling_length=2.41,
     laboratory_coupling_length=2.5)                                   # tabla L.15
 
 # ISO 12354-2 fórmula (13): el gemelo de impactos, a partir de un Ln,f medido.
-ln_13 = flanking_impact_level_from_flanking_level(
+ln_13 = building.flanking_impact_level_from_flanking_level(
     lnf_13, area=20.0, laboratory_area=10.0,
     coupling_length=4.0, laboratory_coupling_length=4.5)
 ```

--- a/site/src/content/docs/es/buildings/design/installed-structure-borne.mdx
+++ b/site/src/content/docs/es/buildings/design/installed-structure-borne.mdx
@@ -605,7 +605,7 @@ anterior, y frente al espectro de este ejemplo las dos se diferencian en unos
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, installed_source_prediction
+from phonometry import ReportMetadata, building
 
 bands = np.array([63, 125, 250, 500, 1000, 2000], float)
 lwc = np.array([84.4, 82.5, 69.9, 67.6, 61.6, 49.9])   # potencia característica [dB]
@@ -618,7 +618,7 @@ paths = [
      "flanking_reduction_index": np.array([37.0, 41.2, 35.9, 37.7, 49, 57.8]),
      "element_area": 12.8},
 ]
-res = installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
+res = building.installed_source_prediction(lwc, 16.2, paths, frequencies=bands)
 
 res.report(
     "installed_structure_borne.pdf",

--- a/site/src/content/docs/es/buildings/design/panel-sound-insulation.mdx
+++ b/site/src/content/docs/es/buildings/design/panel-sound-insulation.mdx
@@ -115,37 +115,32 @@ la superficie abierto mantiene $R$ en 20,0 dB valga lo que valga la pared.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (
-    coincidence_frequency, composite_transmission_loss,
-    double_wall_transmission_loss, mass_law_transmission_loss,
-    mass_spring_mass_resonance, plate_bending_stiffness,
-    radiation_efficiency, single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000], dtype=float)
 fig, ax = plt.subplots(2, 2, figsize=(12, 9))
 
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(15.0, bp)
-ml = mass_law_transmission_loss(bands, 15.0, incidence="field")
-sp = single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(15.0, bp)
+ml = building.mass_law_transmission_loss(bands, 15.0, incidence="field")
+sp = building.single_panel_transmission_loss(bands, 15.0, critical_frequency=fc, loss_factor=0.024)
 ax[0, 0].semilogx(bands, ml, "--", label="ley de masas de campo")
 ax[0, 0].semilogx(bands, sp.transmission_loss, "-o", ms=3, label="R de panel simple (Sharp)")
 ax[0, 0].axvline(fc, ls=":", color="r"); ax[0, 0].set_title("Panel simple")
 
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
-ax[0, 1].semilogx(bands, mass_law_transmission_loss(bands, 24.0), "--", label="hoja simple")
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+ax[0, 1].semilogx(bands, building.mass_law_transmission_loss(bands, 24.0), "--", label="hoja simple")
 ax[0, 1].semilogx(bands, dw.transmission_loss, "-o", ms=3, label="pared doble")
-ax[0, 1].axvline(mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
+ax[0, 1].axvline(building.mass_spring_mass_resonance(12.0, 12.0, 0.075), ls=":", color="r")
 ax[0, 1].set_title("Pared doble")
 
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 ax[1, 0].loglog(bands, sig.radiation_efficiency, "-o", ms=3, label=r"$\sigma(f)$")
 ax[1, 0].axhline(1.0, ls=":"); ax[1, 0].set_title("Eficiencia de radiación")
 
 wall = sp.transmission_loss
-comp = [float(composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
+comp = [float(building.composite_transmission_loss([0.99, 0.01], [w, 0.0])) for w in wall]
 ax[1, 1].semilogx(bands, wall, "-o", ms=3, label="pared maciza")
 ax[1, 1].semilogx(bands, comp, "-s", ms=3, label="pared + rendija 1 %")
 ax[1, 1].axhline(20.0, ls=":"); ax[1, 1].set_title("Compuesta con abertura")
@@ -200,21 +195,18 @@ $R_\mathrm{w} = 27$ dB.
 
 ```python
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # Vidrio flotado de 6 mm: E = 62 GPa, rho = 2500 kg/m3, nu = 0.24, eta = 0.024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006                                 # 15 kg/m2
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
-fc = coincidence_frequency(mass, bp)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)     # B' [N.m]
+fc = vibration.coincidence_frequency(mass, bp)
 print(round(fc))                                      # 2107 Hz (Hopkins declara ~2079)
 
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 print(round(res.rating().rating))                     # 32  ->  Rw = 32 dB (vidrio 6 mm de catálogo)
 
 res.plot()   # R(f) previsto con la frecuencia crítica marcada (requiere matplotlib)
@@ -255,19 +247,16 @@ de las desviaciones desfavorables, y la referencia desplazada leída a
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 # Vidrio flotado de 6 mm: E = 62 GPa, rho = 2500 kg/m3, nu = 0,24, eta = 0,024.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
                   1000, 1250, 1600, 2000, 2500, 3150], dtype=float)
 mass = 2500.0 * 0.006
-bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
-fc = coincidence_frequency(mass, bp)
-res = single_panel_transmission_loss(bands, mass, critical_frequency=fc,
-                                     loss_factor=0.024)
+bp = vibration.plate_bending_stiffness(6.2e10, 0.006, 0.24)
+fc = vibration.coincidence_frequency(mass, bp)
+res = building.single_panel_transmission_loss(bands, mass, critical_frequency=fc,
+                                              loss_factor=0.024)
 w = res.rating()
 
 # Una línea cada una: el R(f) previsto, o la curva evaluada frente a la referencia:
@@ -359,18 +348,18 @@ valor plano, que es exactamente lo que dice ser: una estimación, no la caída.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import plateau_transmission_loss, single_panel_transmission_loss
+from phonometry import building
 
 # Vidrio float de 6 mm: la tabla 3.1 de Norton da 2,47 kg/m2 por mm, una
 # meseta de coincidencia de 27 dB y B/A = 10; su frecuencia crítica es 2033 Hz.
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000], dtype=float)
-quick = plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
-                                  field_correction=5.5)
-physical = single_panel_transmission_loss(bands, 2.47 * 6.0,
-                                          critical_frequency=2033.0,
-                                          loss_factor=0.02)
+quick = building.plateau_transmission_loss(bands, material="glass", thickness_mm=6.0,
+                                           field_correction=5.5)
+physical = building.single_panel_transmission_loss(bands, 2.47 * 6.0,
+                                                   critical_frequency=2033.0,
+                                                   loss_factor=0.02)
 
 print(round(quick.plateau_start), round(quick.plateau_end))   # 374 3742
 print(quick.plateau_height)                                   # 27.0
@@ -389,11 +378,11 @@ a su problema 3.11, banda a banda, en las dos regiones que la construcción fija
 analíticamente.
 
 ```python
-from phonometry import plateau_transmission_loss
+from phonometry import building
 
 octaves = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
-res = plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
-                                air_density=1.21)
+res = building.plateau_transmission_loss(octaves, material="brick", thickness_mm=110.0,
+                                         air_density=1.21)
 print(res.transmission_loss.round(1))
 # [35.8 37.  37.  43.3 53.3 63.3 73.3]
 ```
@@ -474,20 +463,16 @@ importa porque los dos modelos de panel infinito solo valen por encima de unos
 $1{,}5f_{1,1}$.
 
 ```python
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_plate_resonance, plate_bending_stiffness,
-)
+from phonometry import building, vibration
 
 # Ejemplo resuelto de Vigran: chapa de acero de 1 m x 1 m y 1 mm de espesor,
 # E = 210 GPa, nu = 0,3, m'' = 7,8 kg/m2, grecada con una sinusoide de 20 mm
 # de altura total (amplitud H = 10 mm) y paso de 100 mm.
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, b_xz = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, b_xz = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
 print(round(flat_b, 1), round(b_x, 1), round(b_z))     # 19.2 17.5 2202
 print(round(mass, 2))                                  # 8.52 kg/m2 (+9 %)
 
@@ -497,14 +482,14 @@ flat = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": 7.8,
 corr = {"length_x": 1.0, "length_z": 1.0, "mass_per_area": mass,
         "bending_stiffness_x": b_x, "bending_stiffness_z": b_z,
         "bending_stiffness_xz": b_xz}
-print(round(orthotropic_plate_resonance(1, 1, **flat), 1),
-      round(orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
-print(round(orthotropic_plate_resonance(1, 1, **corr), 1),
-      round(orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
+print(round(building.orthotropic_plate_resonance(1, 1, **flat), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **flat), 1))    # 4.9 19.7
+print(round(building.orthotropic_plate_resonance(1, 1, **corr), 1),
+      round(building.orthotropic_plate_resonance(2, 2, **corr), 1))    # 25.5 102.1
 
 # La misma chapa, plana y grecada, en la imagen de la coincidencia:
-print(round(coincidence_frequency(7.8, flat_b)))               # 11925 Hz
-print([round(f) for f in orthotropic_critical_frequencies(mass, b_x, b_z)])
+print(round(vibration.coincidence_frequency(7.8, flat_b)))               # 11925 Hz
+print([round(f) for f in building.orthotropic_critical_frequencies(mass, b_x, b_z)])
 # [1165, 13064]
 ```
 
@@ -528,33 +513,28 @@ y $R_\mathrm{w}$ baja de 28 dB a 25 dB, con un panel más rígido y apenas más 
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coincidence_frequency, corrugated_plate_mass_factor,
-    corrugated_plate_stiffness, orthotropic_critical_frequencies,
-    orthotropic_transmission_loss, plate_bending_stiffness,
-    single_panel_transmission_loss,
-)
+from phonometry import building, vibration
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000,
                   1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000,
                   10000, 12500, 16000], dtype=float)
 eta = 0.011
-flat_b = plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
-b_x, b_z, _ = corrugated_plate_stiffness(
+flat_b = vibration.plate_bending_stiffness(2.1e11, 1.0e-3, 0.3)
+b_x, b_z, _ = building.corrugated_plate_stiffness(
     1.0e-3, 0.010, 0.100, youngs_modulus=2.1e11, poisson_ratio=0.3,
 )
-mass = 7.8 * corrugated_plate_mass_factor(0.010, 0.100)
-fc1, fc2 = orthotropic_critical_frequencies(mass, b_x, b_z)
+mass = 7.8 * building.corrugated_plate_mass_factor(0.010, 0.100)
+fc1, fc2 = building.orthotropic_critical_frequencies(mass, b_x, b_z)
 
-flat = single_panel_transmission_loss(
-    bands, 7.8, critical_frequency=coincidence_frequency(7.8, flat_b),
+flat = building.single_panel_transmission_loss(
+    bands, 7.8, critical_frequency=vibration.coincidence_frequency(7.8, flat_b),
     loss_factor=eta,
 )
-corrugated = orthotropic_transmission_loss(
+corrugated = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     loss_factor=eta,
 )
-heckl = orthotropic_transmission_loss(
+heckl = building.orthotropic_transmission_loss(
     bands, mass, critical_frequency_lower=fc1, critical_frequency_upper=fc2,
     method="heckl",
 )
@@ -606,21 +586,21 @@ frecuencia límite $f_\mathrm{l} = c_0/(2\pi d)$ donde el refuerzo satura en 6 d
 cámara y baja $f_0$.
 
 ```python
-from phonometry import double_wall_transmission_loss, mass_spring_mass_resonance
-from phonometry import mass_law_transmission_loss, miki
+from phonometry import building
+from phonometry import materials
 
 # Dos hojas de 12 kg/m2, cámara de aire de 75 mm.
-f0 = mass_spring_mass_resonance(12.0, 12.0, 0.075)
+f0 = building.mass_spring_mass_resonance(12.0, 12.0, 0.075)
 print(round(f0))                                          # 89 Hz
 
 # Por debajo de f0 la pared doble iguala la ley de masas de la masa total 24 kg/m2:
-dw = double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
+dw = building.double_wall_transmission_loss(bands, 12.0, 12.0, 0.075)
 print(round(float(dw.transmission_loss[0]), 1),
-      round(float(mass_law_transmission_loss(bands[0], 24.0)), 1))   # iguales
+      round(float(building.mass_law_transmission_loss(bands[0], 24.0)), 1))   # iguales
 
 # Un relleno de lana mineral (un modelo poroso de materials) baja la resonancia:
-fill = miki([f0], 7000.0)
-print(round(mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
+fill = materials.miki([f0], 7000.0)
+print(round(building.mass_spring_mass_resonance(12.0, 12.0, 0.075, cavity_medium=fill)))  # < 89 Hz
 
 dw.plot()   # R(f) de pared doble con la resonancia masa-muelle-masa marcada (requiere matplotlib)
 ```
@@ -642,12 +622,12 @@ de toda curva de pared doble.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import mass_spring_mass_resonance, plot_double_wall_geometry
+from phonometry import building
 
 # Dos placas de yeso de 8.8 kg/m² sobre una cámara de 100 mm.
-f0 = mass_spring_mass_resonance(8.8, 8.8, 0.1)
-plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0,
-                          language="es")
+f0 = building.mass_spring_mass_resonance(8.8, 8.8, 0.1)
+building.plot_double_wall_geometry(8.8, 8.8, 0.1, resonance_frequency=f0,
+                                   language="es")
 plt.show()
 
 # Una predicción de pared doble retiene su geometría y la redibuja:
@@ -701,25 +681,20 @@ Wilson y Craik (1999) y la de 100 mm de Hall y Hopkins (2001).
 | Llave de torsión vertical (propietaria) | 100 | 43,4 |
 
 ```python
-from phonometry import (
-    double_wall_transmission_loss,
-    mass_spring_mass_resonance,
-    wall_tie_stiffness,
-    wall_tie_stiffness_per_area,
-)
+from phonometry import building
 
-print(wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
+print(building.wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
 
 # Hopkins Fig. 4.35: dos hojas de 140 kg/m2 con cámara vacía de 75 mm.
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz
 
 # Se añaden 2,5 llaves/m2 de s_75mm = 2 MN/m: la resonancia casi se duplica.
-ties = wall_tie_stiffness_per_area(2.5, 2.0e6)
-print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075,
-                                       tie_stiffness_per_area=ties)))  # 50 Hz
+ties = building.wall_tie_stiffness_per_area(2.5, 2.0e6)
+print(round(building.mass_spring_mass_resonance(140.0, 140.0, 0.075,
+                                                tie_stiffness_per_area=ties)))  # 50 Hz
 
-dw = double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
-                                   tie_stiffness_per_area=ties)
+dw = building.double_wall_transmission_loss(bands, 140.0, 140.0, 0.075,
+                                            tie_stiffness_per_area=ties)
 ```
 
 **La llave como unión puntual (Hopkins Ecs. 4.84 a 4.88).** Cada llave
@@ -746,11 +721,11 @@ distinta.
 
 ```python
 import numpy as np
-from phonometry import plate_bending_stiffness, wall_tie_coupling_loss_factor
+from phonometry import building, vibration
 
 freq = np.logspace(np.log10(50.0), np.log10(5000.0), 60)
-b1 = plate_bending_stiffness(2.0e10, 0.1, 0.2)   # hojas de fábrica de 100 mm
-res = wall_tie_coupling_loss_factor(
+b1 = vibration.plate_bending_stiffness(2.0e10, 0.1, 0.2)   # hojas de fábrica de 100 mm
+res = building.wall_tie_coupling_loss_factor(
     freq, 150.0, 170.0, b1, b1, ties_per_area=2.5, tie="butterfly"
 )
 print(res.coupling_loss_factor[0], res.rigid_coupling_loss_factor[0])
@@ -787,17 +762,14 @@ a $10\log_{10}(S/S_\mathrm{a})$: una abertura del 1 % nunca puede superar los 20
 sea la pared.
 
 ```python
-from phonometry import (
-    composite_transmission_loss, slit_transmission_coefficient,
-    slit_resonance_frequencies,
-)
+from phonometry import building
 
 # Una rendija de 2 mm x 100 mm de fondo: su transmisión tiene máximos en las
 # resonancias de media longitud de onda del fondo de la rendija.
-print(slit_resonance_frequencies(depth=0.1, width=0.002, orders=2).round().tolist())  # [~1500, ~3100]
+print(building.slit_resonance_frequencies(depth=0.1, width=0.002, orders=2).round().tolist())  # [~1500, ~3100]
 
 # Una pared de Rw = 50 dB con el 1 % de su área abierta como rendija queda limitada:
-print(round(float(composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
+print(round(float(building.composite_transmission_loss([0.99, 0.01], [50.0, 0.0])), 1))   # 20.0
 ```
 
 La fuga que arruina una pared pesada es casi invisible, y `.plot_geometry()`
@@ -817,10 +789,10 @@ simple área abierta.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import slit_transmission_coefficient
+from phonometry import building
 
 f = np.geomspace(100.0, 5000.0, 200)
-result = slit_transmission_coefficient(f, width=0.002, depth=0.1)
+result = building.slit_transmission_coefficient(f, width=0.002, depth=0.1)
 
 # Una línea: la sección de la pared con la rendija a escala.
 result.plot_geometry(language="es")
@@ -909,8 +881,8 @@ una condición de borde.*
 ```python
 import matplotlib.pyplot as plt
 
-sig_big = radiation_efficiency(bands, 1.5, 1.25, fc)
-sig_small = radiation_efficiency(bands, 0.5, 0.4, fc)
+sig_big = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
+sig_small = vibration.radiation_efficiency(bands, 0.5, 0.4, fc)
 
 fig, (ax_l, ax_r) = plt.subplots(1, 2, figsize=(11, 4.5))
 ax_l.loglog(bands, sig_big.radiation_efficiency, "-o", ms=3, label="1,5 x 1,25 m")
@@ -928,17 +900,17 @@ plt.show()
 </details>
 
 ```python
-from phonometry import radiation_efficiency, sound_power_from_vibration
+from phonometry import emission, vibration
 
 # El panel de vidrio de 6 mm (1.5 x 1.25 m) del ejemplo de panel simple anterior.
-sig = radiation_efficiency(bands, 1.5, 1.25, fc)
+sig = vibration.radiation_efficiency(bands, 1.5, 1.25, fc)
 print(sig.radiation_efficiency[bands == 2000].round(2))
 # 2.6, el pico de coincidencia: la placa radia más que un pistón cerca de fc
 
 # Alimenta la predicción directamente a ISO 7849 como el factor de radiación:
-lw = sound_power_from_vibration(velocity_level=80.0, area=1.875,
-                                radiation_factor=sig.radiation_efficiency,
-                                frequencies=bands)
+lw = emission.sound_power_from_vibration(velocity_level=80.0, area=1.875,
+                                         radiation_factor=sig.radiation_efficiency,
+                                         frequencies=bands)
 
 sig.plot()   # sigma(f) con el pico de coincidencia (requiere matplotlib)
 ```
@@ -961,11 +933,11 @@ las lee frente al resonador SDOF y añade los casos de momento y de barra
 longitudinal.
 
 ```python
-from phonometry import infinite_plate_impedance, infinite_beam_mobility, injected_power
+from phonometry import vibration
 
-z_plate = infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
+z_plate = vibration.infinite_plate_impedance(bp, mass)          # Z = 8 sqrt(B' m'') [N.s/m]
 print(round(z_plate))                                 # real, independiente de la frecuencia
-w = injected_power(force=10.0, mobility=1.0 / z_plate)
+w = vibration.injected_power(force=10.0, mobility=1.0 / z_plate)
 print(round(float(w) * 1e3, 3), "mW")                 # W = |F|^2 / (16 sqrt(B' m''))
 ```
 

--- a/site/src/content/docs/es/buildings/design/resilient-layers.mdx
+++ b/site/src/content/docs/es/buildings/design/resilient-layers.mdx
@@ -105,21 +105,18 @@ martillo, y no el suelo, la que limita la potencia inyectada.
 
 ```python
 import numpy as np
-from phonometry import (
-    hammer_impact_velocity, infinite_plate_impedance, plate_bending_stiffness,
-    plate_contact_stiffness, tapping_force_spectrum,
-)
+from phonometry import building, vibration
 
-print(round(hammer_impact_velocity(), 3))     # 0.886 m/s (0,5 kg desde 40 mm)
+print(round(building.hammer_impact_velocity(), 3))     # 0.886 m/s (0,5 kg desde 40 mm)
 
 # Losa de hormigón in situ de 140 mm: 2200 kg/m3, cL = 3800 m/s, nu = 0,2.
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-k = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+k = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 freqs = np.array([100, 200, 400, 800, 1600, 3150], dtype=float)
-res = tapping_force_spectrum(freqs, k, z)
+res = building.tapping_force_spectrum(freqs, k, z)
 res.over_critical             # False: el martillo rebota sobre el hormigón
 round(res.cut_off_frequency)  # 6948 Hz, por encima del rango de edificación
 res.peak_force                # |Fn| por banda, a menos de 1 dB de upper_limit
@@ -156,10 +153,10 @@ fig, ax = plt.subplots()
 for label, rho_s, c_s, nu_s, h_s in (("hormigón de 140 mm", 2200.0, 3800.0, 0.2, 0.14),
                                      ("tablero de 22 mm", 650.0, 2400.0, 0.3, 0.022)):
     e_s = rho_s * c_s**2 * (1 - nu_s**2)
-    z_s = infinite_plate_impedance(plate_bending_stiffness(e_s, h_s, nu_s),
-                                   rho_s * h_s)
-    k_s = plate_contact_stiffness(e_s, poisson_ratio=nu_s)
-    r = tapping_force_spectrum(freqs, k_s, z_s)
+    z_s = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(e_s, h_s, nu_s),
+                                             rho_s * h_s)
+    k_s = building.plate_contact_stiffness(e_s, poisson_ratio=nu_s)
+    r = building.tapping_force_spectrum(freqs, k_s, z_s)
     ax.loglog(freqs, r.peak_force, label=f"{label} (fco = {r.cut_off_frequency:.0f} Hz)")
     ax.axhline(r.upper_limit, ls="--", lw=0.8)
     ax.axhline(r.lower_limit, ls=":", lw=0.8)
@@ -219,23 +216,20 @@ queda 7,8 dB alta.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    covering_contact_stiffness, covering_improvement, infinite_plate_impedance,
-    plate_bending_stiffness, plate_contact_stiffness,
-)
+from phonometry import building, vibration
 
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14        # losa de hormigón 140 mm
 E = rho * c_l**2 * (1 - nu**2)
-z = infinite_plate_impedance(plate_bending_stiffness(E, h, nu), rho * h)
-plate = plate_contact_stiffness(E, poisson_ratio=nu)
+z = vibration.infinite_plate_impedance(vibration.plate_bending_stiffness(E, h, nu), rho * h)
+plate = building.plate_contact_stiffness(E, poisson_ratio=nu)
 
 bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
                   800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0])
 
 d = 0.005
 for label, modulus_over_thickness in (("PVC", 1.5e11), ("vinilo", 2.8e8)):
-    res = covering_improvement(
-        bands, covering_contact_stiffness(modulus_over_thickness * d, d),
+    res = building.covering_improvement(
+        bands, building.covering_contact_stiffness(modulus_over_thickness * d, d),
         plate, z)
     plt.semilogx(bands, res.improvement, marker="o",
                  label=f"{label}: fco = {res.cut_off_frequency:.0f} Hz")
@@ -247,13 +241,13 @@ plt.show()
 </details>
 
 ```python
-from phonometry import covering_contact_stiffness, covering_improvement
+from phonometry import building
 
 # Revestimiento n.o 2 de la fig. 4.64 de Hopkins: E/d = 2,8e8 N/m3, un vinilo
 # o moqueta con soporte elástico, 5 mm sobre la misma losa de 140 mm.
 d = 0.005
-covering = covering_contact_stiffness(2.8e8 * d, d)
-res = covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
+covering = building.covering_contact_stiffness(2.8e8 * d, d)
+res = building.covering_improvement([125.0, 250.0, 500.0, 1000.0], covering, plate, z)
 round(res.cut_off_frequency)        # 100 Hz
 round(res.bare_cut_off_frequency)   # 6948 Hz, el corte de la losa desnuda
 res.improvement                     # 3,2 / 17,0 / 33,3 / 43,0 dB, por banda
@@ -314,16 +308,14 @@ misma en las tres.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-)
+from phonometry import building
 
 # El suelo flotante del ejemplo del anexo G de ISO 12354-2:2017.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)     # 52,8 Hz
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)     # 52,8 Hz
 freqs = np.logspace(np.log10(40.0), np.log10(5000.0), 400)
 for model, kwargs in (("en12354", {}), ("cremer", {}),
                       ("cremer_hammer", {"limiting_frequency": 521.0})):
-    res = floating_floor_improvement_spectrum(
+    res = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=f0, model=model, **kwargs)
     plt.semilogx(freqs, res.improvement, label=model)
 plt.axvline(f0, ls=":")
@@ -334,19 +326,15 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    combined_dynamic_stiffness, double_floating_floor_resonances,
-    floating_floor_improvement_spectrum, floating_floor_resonance_frequency,
-    weighted_floating_floor_improvement,
-)
+from phonometry import building
 
 # Solera de 35 mm, m' = 73,5 kg/m2, sobre una capa elástica de s' = 8 MN/m3.
-f0 = floating_floor_resonance_frequency(8.0e6, 73.5)
+f0 = building.floating_floor_resonance_frequency(8.0e6, 73.5)
 round(f0, 1)                                                    # 52,8 Hz
 
 bands = [50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
          800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000.0]
-res = floating_floor_improvement_spectrum(
+res = building.floating_floor_improvement_spectrum(
     bands, resonance_frequency=f0, mass_per_area=73.5, dynamic_stiffness=8.0e6)
 res.improvement          # 0,0, 2,3, 5,4, 8,3, 11,2 ... 59,3 dB
 round(res.delta_lw, 1)   # 32,2 dB, la reducción ponderada de la fórmula (C.4)
@@ -354,12 +342,12 @@ res.plot()
 
 # Dos capas elásticas actúan como resortes en serie (fórmula C.6), lo que baja
 # la resonancia en sqrt(2) y compra unos 4,5 dB en todo lo que hay por encima.
-round(floating_floor_resonance_frequency(
-    combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37,3 Hz
+round(building.floating_floor_resonance_frequency(
+    building.combined_dynamic_stiffness([8.0e6, 8.0e6]), 73.5), 1)       # 37,3 Hz
 
 # Un suelo flotante sobre otro tiene dos resonancias en vez de una; desaparece
 # la caída adversa, pero la subida pronunciada no empieza hasta la más alta.
-double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
+building.double_floating_floor_resonances(7.25e6, 12.78, 7.25e6, 12.78)  # (74, 194) Hz
 ```
 
 Las magnitudes globales salen directamente de esos mismos dos datos, así que
@@ -377,10 +365,10 @@ lugar de 40. Menos apoyos, una superficie de paso más gruesa o más
 amortiguamiento interno la elevan.
 
 ```python
-from phonometry import resilient_mount_improvement
+from phonometry import building
 
 # Superficie de paso de hormigón de 50 mm sobre 4 apoyos/m2 de 2 MN/m.
-resilient_mount_improvement(
+building.resilient_mount_improvement(
     [125.0, 250.0, 500.0, 1000.0], impedance=3.8e5, mass_per_area=115.0,
     loss_factor=0.02, mount_stiffness=2.0e6, mount_density=4.0)
 ```
@@ -415,30 +403,27 @@ resonancia bien por debajo del rango de interés es, por tanto, todo el
 encargo de diseño.
 
 ```python
-from phonometry import (
-    lining_improvement, lining_improvement_in_situ, lining_resonance_frequency,
-    weighted_lining_improvement,
-)
+from phonometry import building
 
 # Placa de yeso de 9,5 mm laminada con 32 mm de EPS (s' = 65 MN/m3), adherida
 # con pelladas a una pared de bloque de hormigón celular de 100 mm y 51 kg/m2.
-f0 = lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
+f0 = building.lining_resonance_frequency(51.0, 6.3, dynamic_stiffness=65e6)
 round(f0)                                       # 542 Hz: justo en medio
-round(weighted_lining_improvement(f0, 45.0))    # -9 dB, empeora las cosas
+round(building.weighted_lining_improvement(f0, 45.0))    # -9 dB, empeora las cosas
 
 # La misma capa sobre montantes con cámara de 100 mm rellena de lana.
-f0 = lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
+f0 = building.lining_resonance_frequency(51.0, 6.3, cavity_depth=0.100)
 round(f0, 1)                                     # 70,8 Hz
-round(weighted_lining_improvement(f0, 45.0), 1)  # +13,8 dB (banda de 80 Hz)
+round(building.weighted_lining_improvement(f0, 45.0), 1)  # +13,8 dB (banda de 80 Hz)
 
 # Los sistemas de aislamiento térmico exterior tienen sus propios ajustes.
-res = lining_improvement(100.0, system="mineral_wool")   # fórmula (D.3)
+res = building.lining_improvement(100.0, system="mineral_wool")   # fórmula (D.3)
 res.delta_rw, res.delta_ra, res.delta_ratr               # (10,5, 8,0, 9,7) dB
-lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
+building.lining_improvement(100.0, system="mineral_wool", anchors=True).delta_rw  # (D.5)
 res.plot()   # las magnitudes del anexo D frente a fo, con este sistema marcado
 
 # Una magnitud de laboratorio se traslada a obra con la fórmula (D.8).
-round(lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4,4 dB con Rw 60
+round(building.lining_improvement_in_situ(10.0, 100.0, 60.0), 1)  # 4,4 dB con Rw 60
 ```
 
 ## Qué suponen las fórmulas sobre la ejecución

--- a/site/src/content/docs/es/buildings/design/structure-borne-power.mdx
+++ b/site/src/content/docs/es/buildings/design/structure-borne-power.mdx
@@ -481,11 +481,11 @@ alimentar la EN 12354-5.
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, reception_plate_power
+from phonometry import ReportMetadata, building
 
 freqs = np.array([125, 250, 500, 1000, 2000, 4000], float)
 lv = np.array([70.0, 72, 68, 64, 60, 55])   # nivel de velocidad medio de la placa [dB]
-res = reception_plate_power(               # la placa de baja movilidad del ap. 7.2.2
+res = building.reception_plate_power(               # la placa de baja movilidad del ap. 7.2.2
     lv, freqs, mass_per_area=230.0, area=7.0, reverberation_time=0.25,
 )
 

--- a/site/src/content/docs/es/buildings/insulation/flanking-lab.mdx
+++ b/site/src/content/docs/es/buildings/insulation/flanking-lab.mdx
@@ -400,7 +400,7 @@ clase se lee sobre la curva desplazada a 500 Hz.*
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import ceiling_attenuation_class, plenum_flanking_reduction_index
+from phonometry import building
 
 fig, (ax_path, ax_cac) = plt.subplots(1, 2, figsize=(13.0, 5.6))
 
@@ -411,7 +411,7 @@ freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 ceiling = np.array([17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0])
 x = np.arange(freqs.size)
 for depth, style in ((0.43, "-o"), (0.86, "--o")):
-    res = plenum_flanking_reduction_index(
+    res = building.plenum_flanking_reduction_index(
         ceiling, ceiling, ceiling_length=4.75, plenum_height=depth,
         frequency=freqs,
     )
@@ -424,7 +424,7 @@ ax_path.legend()
 # Derecha: un informe de ensayo acreditado ASTM E1414 valorado según ASTM E413.
 dnc = np.array([14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
                 41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9])
-cac = ceiling_attenuation_class(dnc)
+cac = building.ceiling_attenuation_class(dnc)
 xc = np.arange(dnc.size)
 ax_cac.fill_between(xc, cac.measured, cac.shifted_reference,
                     where=cac.measured < cac.shifted_reference,
@@ -474,7 +474,7 @@ que permite sumar el trayecto por el techo al trayecto directo como factores de
 transmisión.
 
 ```python
-from phonometry import partition_referenced_reduction_index
+from phonometry import building
 # `plenum_flanking_reduction_index` es el import del bloque de figura de arriba.
 
 freqs = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
@@ -482,20 +482,20 @@ ceiling = [17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0]   # placa de yeso de 9,5 mm
 
 # La geometría del ejemplo de Vigran: LS = LR = 4,75 m, plenum 0,43 m,
 # paredes laterales reflectantes.
-res = plenum_flanking_reduction_index(
+res = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, frequency=freqs
 )
 print(round(res.geometry_term, 1))    # 10.4 dB cobrados a RS + RR
 res.plot()                            # Rcl frente a los dos techos
 
 # Un plenum revestido atenúa el trayecto lateral (Ec. (9.18) en vez de (9.20)):
-damped = plenum_flanking_reduction_index(
+damped = building.plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43,
     attenuation_source=[0.5] * 7, attenuation_receiving=[0.5] * 7,
 )
 
 # Referido al tabique en lugar de al techo (Ec. (9.13)):
-print(partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
+print(building.partition_referenced_reduction_index(res.reduction_index, 2.7, 4.75))
 ```
 
 ### La magnitud medida: la atenuación normalizada del techo
@@ -522,7 +522,7 @@ referencia en pasos de 1 dB mientras la suma de las deficiencias no supere
 lee la valoración sobre la curva desplazada a 500 Hz (apartado 5.5).
 
 ```python
-from phonometry import normalized_ceiling_attenuation, weighted_rating
+from phonometry import building
 # `ceiling_attenuation_class` es el import del bloque de figura de arriba.
 
 # Dn,c a partir de la pareja medida: los niveles del recinto emisor y del
@@ -531,20 +531,20 @@ from phonometry import normalized_ceiling_attenuation, weighted_rating
 l1_c = [80.0] * 16                       # recinto emisor, por banda
 l2_c = [45.0] * 16                       # recinto receptor, por el trayecto del plenum
 absorption = [12.0] * 16                 # A del recinto receptor por banda (m2)
-astm = normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
-iso140_9 = normalized_ceiling_attenuation(l1_c, l2_c, absorption)
+astm = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
+iso140_9 = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption)
 print(round(float(astm[0]), 2), round(float(iso140_9[0]), 2))   # 35.0 34.21
 
 # Una placa acústica de yeso perforada de 28 mm, medida según ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
        41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9]
-res = ceiling_attenuation_class(dnc)
+res = building.ceiling_attenuation_class(dnc)
 print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34, 27.0, 7.0
 res.plot()                                                  # Dn,c frente a la curva
 
 # El número único ISO del mismo espectro, trasladado a A0 = 10 m2:
 iso = [v - 0.79 for v in dnc]
-print(weighted_rating(iso).rating)                          # Dn,c,w
+print(building.weighted_rating(iso).rating)                          # Dn,c,w
 ```
 
 ## Informes de transmisión por flancos ISO 10848 (`.report()`)

--- a/site/src/content/docs/es/buildings/insulation/heavy-impact-sources.mdx
+++ b/site/src/content/docs/es/buildings/insulation/heavy-impact-sources.mdx
@@ -82,11 +82,7 @@ acaba decidiendo el número la banda medida más silenciosa.*
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    a_weighted_maximum_impact_level,
-    heavy_impact_source_limits,
-    heavy_impact_source_specification,
-)
+from phonometry import building
 
 fig, (ax_src, ax_rate) = plt.subplots(1, 2, figsize=(13.0, 5.6))
 
@@ -95,8 +91,8 @@ fig, (ax_src, ax_rate) = plt.subplots(1, 2, figsize=(13.0, 5.6))
 labels = {"rubber_ball": "pelota de caucho", "bang_machine": "máquina de neumático"}
 x = np.arange(5)
 for source in ("rubber_ball", "bang_machine"):
-    spec = heavy_impact_source_specification(source)
-    _f, lower, upper = heavy_impact_source_limits(source)
+    spec = building.heavy_impact_source_specification(source)
+    _f, lower, upper = building.heavy_impact_source_limits(source)
     label = labels[source]
     ax_src.fill_between(x, lower, upper, alpha=0.30, label=f"tolerancia de la {label}")
     ax_src.plot(x, spec.force_exposure_level, "-o", label=f"{label} nominal")
@@ -107,7 +103,7 @@ ax_src.legend()
 
 # Derecha: la Tabla D.4 de ISO 717-2:2020, los niveles medidos frente a sus
 # contribuciones ponderadas A, con la suma energética trazada sobre ellas.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 xr = np.arange(4)
 ax_rate.bar(xr - 0.19, res.levels, width=0.36, label="Li,Fmax (medido)")
 ax_rate.bar(xr + 0.19, res.corrected, width=0.36, label="Li,Fmax + A (Tabla D.3)")
@@ -160,23 +156,23 @@ más bajas (8 dB a 31,5 Hz, 9 dB a 63 Hz) y 7 dB menos en la más alta, y por es
 intercambiables y un forjado puede cumplir con una y fallar con la otra.
 
 ```python
-from phonometry import check_heavy_impact_source, impact_force_exposure_level
+from phonometry import building
 # `heavy_impact_source_specification` y `heavy_impact_source_limits` son los
 # imports del bloque de figura de arriba.
 
-spec = heavy_impact_source_specification("rubber_ball")
+spec = building.heavy_impact_source_specification("rubber_ball")
 print(spec.drop_height, spec.effective_mass)      # 1.0 m, 2.5 kg
 print(spec.contact_time, spec.contact_time_tolerance)   # 0.02 s +/- 0.002 s
 
-freqs, lower, upper = heavy_impact_source_limits("bang_machine")
+freqs, lower, upper = building.heavy_impact_source_limits("bang_machine")
 print(list(zip(freqs, lower, upper))[0])          # (31.5, 46.0, 48.0)
 
 # Una calibración: cinco LFE medidos por octava frente a la tabla impresa.
 # Nombra la fuente: la comprobación toma la pelota de caucho por defecto, y los
 # límites de la máquina de neumático leídos arriba rechazarían de plano una
 # pelota conforme.
-check = check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9],
-                                  source="rubber_ball")
+check = building.check_heavy_impact_source([39.4, 30.2, 23.6, 18.5, 12.9],
+                                           source="rubber_ball")
 print(check.passed, list(check.within_tolerance))
 check.plot()   # LFE medido sobre la banda de tolerancia (requiere matplotlib)
 ```
@@ -192,7 +188,7 @@ cualquier valor por banda y no debe compararse con la tabla anterior.
 
 ```python
 import numpy as np
-from phonometry import OctaveFilterBank, impact_force_exposure_level
+from phonometry import building, filters
 
 fs = 48_000
 t = np.arange(0.0, 0.020, 1.0 / fs)          # el tiempo de contacto de 20 ms
@@ -200,13 +196,13 @@ force = 1500.0 * np.sin(np.pi * t / 0.020)   # un impulso semisenoidal de pico �
 
 # Banda ancha, la energía del impulso completo: 10 lg(Fp^2 t / 2) = 43,5 dB.
 # No es un valor por banda ni es comparable con la tabla anterior.
-print(round(impact_force_exposure_level(force, fs), 2))
+print(round(building.impact_force_exposure_level(force, fs), 2))
 
 # Los cinco valores por banda de octava en los que sí está escrita la
 # especificación.
-bank = OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
+bank = filters.OctaveFilterBank(fs, fraction=1, limits=[31.5, 500.0])
 _, freqs, bands = bank.filter(force, sigbands=True, calculate_level=False)
-lfe = [impact_force_exposure_level(b, fs) for b in bands]
+lfe = [building.impact_force_exposure_level(b, fs) for b in bands]
 print([round(v, 1) for v in lfe])   # [-1.4, 14.0, 22.1, 20.2, 17.1]
 
 # Esos cinco van a la comprobación de conformidad; este semiseno sintético no
@@ -297,10 +293,10 @@ define una estandarización aparte para un máximo.*
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import fast_reverberation_correction
+from phonometry import building
 
 t = np.linspace(0.2, 5.0, 481)
-fast = np.asarray(fast_reverberation_correction(t), dtype=float)
+fast = np.asarray(building.fast_reverberation_correction(t), dtype=float)
 energy = 10 * np.log10(t / 0.5)
 print(round(float(fast[-1]), 1), round(float(energy[-1]), 1))    # 5.1 10.0
 
@@ -318,23 +314,20 @@ plt.show()
 </details>
 
 ```python
-from phonometry import (
-    heavy_impact_octave_levels,
-    standardized_maximum_impact_level,
-)
+from phonometry import building
 # `fast_reverberation_correction` es el import del bloque de figura de arriba.
 
 freqs = [63.0, 125.0, 250.0, 500.0]
 li_fmax = [65.3, 64.5, 58.0, 55.8]           # promediado en energía sobre posiciones
 t = [1.43, 3.70, 3.10, 2.38]                 # tiempo de reverberación del receptor
 
-res = standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
+res = building.standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
 print(res.volume_term)                        # 10 lg(41.4/50) = -0.8 dB
-print(fast_reverberation_correction([0.5]))   # exactamente 0 dB con T = T0
+print(building.fast_reverberation_correction([0.5]))   # exactamente 0 dB con T = T0
 res.plot()   # espectros medido y estandarizado (requiere matplotlib)
 
 # Las mediciones en tercios se combinan en octavas con la Fórmula (20):
-print(heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB por octava
+print(building.heavy_impact_octave_levels([60.0] * 6))   # +10 lg 3 dB por octava
 ```
 
 ## La medición in situ (apartados 6 a 9 de ISO 16283-2:2020)
@@ -415,7 +408,7 @@ resultado intermedio sin redondear que imprime la norma:
 # `a_weighted_maximum_impact_level` es el import del bloque de figura de arriba.
 
 # ISO 717-2:2020 Tabla D.4: una medición in situ en bandas de octava.
-res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
+res = building.a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
 print(list(res.corrected))   # 39.1, 48.3, 49.3, 52.6 dB
 print(res.unrounded)         # 55.350667... dB
 print(res.rating)            # 55 dB

--- a/site/src/content/docs/es/buildings/insulation/spanish-building-code.mdx
+++ b/site/src/content/docs/es/buildings/insulation/spanish-building-code.mdx
@@ -175,7 +175,7 @@ $D_{2\mathrm{m,nT,Atr}}$ que el DB HR exige de verdad no llega a distinguir entr
 dos lecturas.
 
 ```python
-from phonometry import building, weighted_rating_extended
+from phonometry import building
 
 d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
           38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5, 39.4, 41.5]
@@ -183,7 +183,7 @@ d2m_nt = [28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2, 34.7,
 direct = building.d2m_nt_atr(d2m_nt)
 direct.intermediate, direct.reported   # 32,8 dBA -> 33 dBA
 
-iso = weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
+iso = building.weighted_rating_extended(d2m_nt, building.DB_HR_FREQUENCIES)
 iso.rating, iso.ctr_100_5000           # 38 dB, -5 dB -> 33 dBA, la misma cifra
 iso.c, iso.c_100_5000                  # -2 y -1: el rango básico frente al ampliado
 ```

--- a/site/src/content/docs/es/buildings/rooms/enclosed-space-absorption.mdx
+++ b/site/src/content/docs/es/buildings/rooms/enclosed-space-absorption.mdx
@@ -537,10 +537,7 @@ matplotlib (`pip install "phonometry[report,plot]"`); solo se admite
 decimal de coma).
 
 ```python
-from phonometry import (
-    enclosed_space_reverberation, hard_object_absorption, object_fraction,
-    ReportMetadata,
-)
+from phonometry import ReportMetadata, room
 
 surfaces = [                                   # por banda de octava, 125 Hz - 8 kHz
     (20.0, [0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.55]),  # suelo enmoquetado
@@ -548,10 +545,10 @@ surfaces = [                                   # por banda de octava, 125 Hz - 8
     (45.0, [0.02, 0.02, 0.03, 0.04, 0.05, 0.05, 0.05]),  # paredes de yeso pintado
 ]
 volumes = [0.5, 0.8, 0.3]                      # mobiliario, m^3
-result = enclosed_space_reverberation(
+result = room.enclosed_space_reverberation(
     surfaces, 50.0,
-    objects=hard_object_absorption(volumes),
-    object_fraction=object_fraction(volumes, 50.0),
+    objects=room.hard_object_absorption(volumes),
+    object_fraction=room.object_fraction(volumes, 50.0),
     air_condition="20C_50-70",
 )
 result.report(

--- a/site/src/content/docs/es/buildings/rooms/reverberation-prediction.mdx
+++ b/site/src/content/docs/es/buildings/rooms/reverberation-prediction.mdx
@@ -690,9 +690,9 @@ matplotlib (`pip install "phonometry[report,plot]"`); solo se admite
 decimal de coma).
 
 ```python
-from phonometry import reverberation_time_models, ReportMetadata
+from phonometry import ReportMetadata, room
 
-result = reverberation_time_models(
+result = room.reverberation_time_models(
     (8.0, 5.0, 3.0),                       # sala tipo caja, un par de paredes tratado
     ([0.10, 0.15, 0.30, 0.45, 0.55, 0.60], # par de paredes tratado, por banda de octava
      [0.08, 0.10, 0.12, 0.15, 0.18, 0.20], # paredes laterales

--- a/site/src/content/docs/es/buildings/rooms/room-impulse-response.mdx
+++ b/site/src/content/docs/es/buildings/rooms/room-impulse-response.mdx
@@ -362,15 +362,14 @@ casi constante de la derecha.
 
 ```python
 from phonometry import room
-from phonometry import plot_excitation
 
 fs = 48000
 sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)   # excitación ESS
 mls = room.mls_signal(12).astype(float)             # longitud 2**12 - 1
 
 # Una línea: forma de onda + espectrograma (barrido), secuencia + espectro (MLS)
-plot_excitation(sweep, fs, kind="sweep")
-plot_excitation(mls, fs, kind="mls")
+room.plot_excitation(sweep, fs, kind="sweep")
+room.plot_excitation(mls, fs, kind="mls")
 
 # A mano: el espectrograma del barrido y el espectro de magnitud de la MLS
 import numpy as np

--- a/site/src/content/docs/es/devices/electroacoustics/loudspeakers.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/loudspeakers.mdx
@@ -202,10 +202,10 @@ está en $ka\sin\theta = 3{,}8317$.
 
 ```python
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 200),
-                       angles=np.linspace(0.0, np.pi / 2, 91))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 200),
+                                        angles=np.linspace(0.0, np.pi / 2, 91))
 print(round(res.radiation_mass, 4))            # 0.0014 kg = 8 rho a^3 / 3
 print(round(float(res.directivity_index[0]), 2))  # 3.01 dB, límite de semiespacio
 res.plot()                                      # R1 y X1 vs ka
@@ -238,9 +238,9 @@ donde tiene que producirse el cruce a un radiador más pequeño.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
+res = electroacoustics.radiating_piston(radius=0.075, frequencies=np.geomspace(20, 20000, 400))
 res.plot(language="es")   # R1 y X1 normalizadas frente a ka
 plt.show()
 ```
@@ -286,9 +286,9 @@ una familia sobre los mismos ejes polares, de modo que el estrechamiento del
 lóbulo principal y la aparición de los lóbulos secundarios se leen de un vistazo:
 
 ```python
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-pattern = piston_directivity_pattern([3.0, 8.0, 16.0])
+pattern = electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0])
 print(pattern.directivity_db.shape)  # (3, 361): una fila por ka
 pattern.plot()                       # diagrama de haz polar en dB (necesita matplotlib)
 ```
@@ -305,9 +305,9 @@ anchura.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import piston_directivity_pattern
+from phonometry import electroacoustics
 
-piston_directivity_pattern([3.0, 8.0, 16.0]).plot(language="es")
+electroacoustics.piston_directivity_pattern([3.0, 8.0, 16.0]).plot(language="es")
 plt.show()
 ```
 
@@ -331,10 +331,10 @@ frecuencia y han aparecido los primeros lóbulos secundarios.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import radiating_piston
+from phonometry import electroacoustics
 
-res = radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
-                       angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
+res = electroacoustics.radiating_piston(0.1, np.array([500.0, 2000.0, 4000.0]),
+                                        angles=np.linspace(-np.pi / 2, np.pi / 2, 181))
 
 # Una línea: el pistón en su pantalla con el lóbulo de la frecuencia más alta.
 res.plot_geometry(language="es")
@@ -404,25 +404,22 @@ coherencia de los datos a varios niveles. El módulo se mide al menos de 20 Hz a
 
 ```python
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, ReportMetadata, loudspeaker_characteristics,
-    radiating_piston,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # caída en baja frecuencia
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # caída en alta frecuencia
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(np.geomspace(20, 20000, 260),
                6.6 + 24 * np.exp(-(np.log2(np.geomspace(20, 20000, 260) / 52.0) ** 2) / 0.12)),
     distortion=(np.geomspace(50, 5000, 140),
                 0.3 + 2.6 * np.exp(-(np.log2(np.geomspace(50, 5000, 140) / 70.0) ** 2) / 0.45)),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )
@@ -431,7 +428,7 @@ print(tuple(round(x) for x in result.effective_range))       # (37, 21361) Hz
 print(round(result.minimum_impedance, 1))                    # 6.6 ohmios
 
 # La misma respuesta, pero medida de verdad a 2 m con 1 V en 8 ohmios.
-referred = loudspeaker_characteristics(
+referred = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distance=2.0, input_voltage=1.0,
 )
@@ -495,15 +492,15 @@ octava de máxima sensibilidad, no a la media de toda la curva.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 + 1.2 * np.sin(2 * np.log2(freqs / 900.0))
 spl -= 10 * np.log10(1 + (50.0 / freqs) ** 6)       # caída en baja frecuencia
 spl -= 10 * np.log10(1 + (freqs / 16000.0) ** 7)    # caída en alta frecuencia
 
-result = loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
-                                     sensitivity_band=(200.0, 4000.0))
+result = electroacoustics.loudspeaker_characteristics(freqs, spl, rated_impedance=8.0,
+                                                      sensitivity_band=(200.0, 4000.0))
 result.plot(language="es")   # quantity="response" (por defecto)
 plt.show()
 ```
@@ -524,13 +521,13 @@ mínimo, no el nominal, es la carga que ve realmente el amplificador.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 fz = np.geomspace(20, 20000, 260)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     impedance=(fz, 6.6 + 24 * np.exp(-(np.log2(fz / 52.0) ** 2) / 0.12)),
 )
@@ -555,13 +552,13 @@ entrada y sin el nivel de presión acústica que produjo a 1 m es ininterpretabl
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import loudspeaker_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 thd_f = np.geomspace(50, 5000, 140)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
     distortion=(thd_f, 0.3 + 2.6 * np.exp(-(np.log2(thd_f / 70.0) ** 2) / 0.45)),
 )
@@ -609,18 +606,16 @@ ya calculado, o los datos polares que necesita la segunda vía.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    LoudspeakerDirectivity, loudspeaker_characteristics, radiating_piston,
-)
+from phonometry import electroacoustics
 
 freqs = np.geomspace(30, 24000, 320)
 spl = 87.0 - 10 * np.log10(1 + (50.0 / freqs) ** 6)
 
-result = loudspeaker_characteristics(
+result = electroacoustics.loudspeaker_characteristics(
     freqs, spl, rated_impedance=8.0, sensitivity_band=(200.0, 4000.0),
-    directivity=LoudspeakerDirectivity(
-        piston=radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
-                                angles=np.radians(np.linspace(0, 90, 46))),
+    directivity=electroacoustics.LoudspeakerDirectivity(
+        piston=electroacoustics.radiating_piston(0.075, np.array([1000.0, 2000.0, 4000.0]),
+                                                 angles=np.radians(np.linspace(0, 90, 46))),
         frequency=2000.0,
     ),
 )

--- a/site/src/content/docs/es/devices/electroacoustics/microphones.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/microphones.mdx
@@ -361,10 +361,7 @@ lee en ella donde la curva cruza el límite declarado.
 
 ```python
 import numpy as np
-from phonometry import (
-    MicrophoneDirectivity, MicrophoneElectrical, MicrophoneNoise,
-    MicrophoneOverload, ReportMetadata, microphone_characteristics,
-)
+from phonometry import ReportMetadata, electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # caída en baja frecuencia
@@ -375,19 +372,19 @@ angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,          # 12,5 mV/Pa a 1 kHz
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
-    noise=MicrophoneNoise(                             # ponderada A, V
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    noise=electroacoustics.MicrophoneNoise(                             # ponderada A, V
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(np.linspace(100, 140, 81),
                     0.5 * 10 ** ((np.linspace(100, 140, 81) - 130.0) * 0.08)),
         thd_percent=0.5,
     ),
-    electrical=MicrophoneElectrical(
+    electrical=electroacoustics.MicrophoneElectrical(
         rated_impedance=150.0, minimum_load_impedance=1000.0,
         powering="Phantom P48 (IEC 61938)", supply_current_ma=3.1,
     ),
@@ -403,10 +400,10 @@ print(round(result.signal_to_noise_ratio_db, 1))        # 80.0 dB re 1 Pa
 for b in (0.0, 0.5, 1.0):
     polar = 20 * np.log10(
         np.maximum(np.abs((1 - b) + b * np.cos(np.radians(angles))), 1e-3))
-    family = microphone_characteristics(
+    family = electroacoustics.microphone_characteristics(
         freqs, response, 12.5, tolerance_db=3.0,
-        directivity=MicrophoneDirectivity(polar=(angles, polar),
-                                          frequency=1000.0))
+        directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, polar),
+                                                           frequency=1000.0))
     print(b, round(family.directivity_index_db, 1))     # 0.0 / 4.8 / 4.8 dB
 
 result.report("microfono.pdf", metadata=ReportMetadata(measurement_standard="IEC 60268-4"),
@@ -477,14 +474,14 @@ aquí es un pico de presencia deliberado, no un defecto.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)      # caída en baja frecuencia
 response -= 10 * np.log10(1 + (freqs / 19000.0) ** 8)   # caída en alta frecuencia
 response += 2.0 * np.exp(-(np.log2(freqs / 9000.0) ** 2) / 0.3)  # región de presencia
 
-result = microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
+result = electroacoustics.microphone_characteristics(freqs, response, 12.5, tolerance_db=3.0)
 result.plot(language="es")   # quantity="response" (por defecto)
 plt.show()
 ```
@@ -507,16 +504,16 @@ el índice de directividad de 4,8 dB de la ficha.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneDirectivity, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 angles = np.linspace(0, 179, 359)
 cardioid = 20 * np.log10((1 + np.cos(np.radians(angles))) / 2)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    directivity=MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
+    directivity=electroacoustics.MicrophoneDirectivity(polar=(angles, cardioid), frequency=1000.0),
 )
 result.plot(quantity="directivity", language="es")
 plt.show()
@@ -539,15 +536,15 @@ distinto a través de la red 468.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneNoise, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 noise_f = np.geomspace(20, 20000, 31)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    noise=MicrophoneNoise(
+    noise=electroacoustics.MicrophoneNoise(
         voltage=1.25e-6,
         spectrum=(noise_f, 6.0 + 12.0 * np.log10(1000.0 / noise_f)),
     ),
@@ -572,15 +569,15 @@ y ninguno significa nada sin su porcentaje.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import MicrophoneOverload, microphone_characteristics
+from phonometry import electroacoustics
 
 freqs = np.geomspace(20, 20000, 400)
 response = -10 * np.log10(1 + (30.0 / freqs) ** 4)
 spl_axis = np.linspace(100, 140, 81)
 
-result = microphone_characteristics(
+result = electroacoustics.microphone_characteristics(
     freqs, response, 12.5, tolerance_db=3.0,
-    overload=MicrophoneOverload(
+    overload=electroacoustics.MicrophoneOverload(
         distortion=(spl_axis, 0.5 * 10 ** ((spl_axis - 130.0) * 0.08)),
         thd_percent=0.5,
     ),

--- a/site/src/content/docs/es/devices/electroacoustics/swept-sine-distortion.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/swept-sine-distortion.mdx
@@ -94,12 +94,12 @@ que alargar el barrido sea lo que compra separación.*
 
 ```python
 import numpy as np
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
-x = synchronized_sweep_signal(fs, f1, f2, seconds)   # reproducir esto...
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # reproducir esto...
 # ... grabar la respuesta del dispositivo en `y` (con su cola de caída) ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # H1..H3 complejas sobre res.frequencies
 res.thd, res.thd_frequencies
@@ -130,10 +130,10 @@ Hay cuatro cosas que fijar antes de la primera toma:
 import numpy as np
 
 # `synchronized_sweep_signal` y `swept_sine_distortion` importados arriba.
-x = synchronized_sweep_signal(fs, f1, f2, seconds, amplitude=0.5, fade=0.02)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds, amplitude=0.5, fade=0.02)
 # ... reproduce x, graba y, y sigue grabando hasta que la caída se apague ...
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3,
-                            amplitude=0.5, fade=0.02)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3,
+                                             amplitude=0.5, fade=0.02)
 ```
 
 - **`amplitude`** es la referencia contra la que se calculan el $H_1$ devuelto y
@@ -188,14 +188,14 @@ de excitación. Ese es el mismo oráculo que fijan los tests de conformidad.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import swept_sine_distortion, synchronized_sweep_signal
+from phonometry import electroacoustics
 
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)             # postfiltro de 3 kHz
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 h1 = 1.0 + 3.0 * a3 / 4.0                              # ganancia de Chebyshev
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -247,10 +247,10 @@ from scipy import signal as sp_signal
 # `swept_sine_distortion` y `synchronized_sweep_signal` importados arriba.
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 a2, a3 = 0.12, 0.08
-x = synchronized_sweep_signal(fs, f1, f2, seconds)
+x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
 b, a = sp_signal.butter(2, 3000.0, fs=fs)
 y = sp_signal.lfilter(b, a, x + a2 * x**2 + a3 * x**3)
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 for k in range(3):
     mag = np.abs(np.asarray(res.harmonic_responses[k]))
@@ -329,10 +329,10 @@ excitación y deben ignorarse; la banda de cada $H_n$ queda además limitada a
 $f_2$ por el filtro inverso.
 
 ```python
-from phonometry import sweep_signal, swept_sine_distortion
+from phonometry import electroacoustics, room
 
-x = sweep_signal(fs, f1, f2, seconds)          # el ESS de ISO 18233
-res = swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
+x = room.sweep_signal(fs, f1, f2, seconds)          # el ESS de ISO 18233
+res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # los mismos paneles |Hn| + THD(f) que el método sincronizado (necesita matplotlib)
 ```
 
@@ -359,12 +359,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # `synchronized_sweep_signal` y `swept_sine_distortion` importados arriba.
-x = synchronized_sweep_signal(48000, 20.0, 6000.0, 4.0)
+x = electroacoustics.synchronized_sweep_signal(48000, 20.0, 6000.0, 4.0)
 y = x + 0.12 * x**2 + 0.08 * x**3            # el oráculo sin memoria
 actual = len(x) / 48000                       # el generador cuantiza T
 for method in ("synchronized", "farina"):
-    res = swept_sine_distortion(y, 48000, f1=20.0, f2=6000.0, seconds=actual,
-                                n_harmonics=3, method=method)
+    res = electroacoustics.swept_sine_distortion(y, 48000, f1=20.0, f2=6000.0, seconds=actual,
+                                                 n_harmonics=3, method=method)
     plt.semilogx(res.frequencies,
                  np.unwrap(np.angle(np.asarray(res.harmonic_responses[1]))))
 plt.show()
@@ -408,16 +408,14 @@ medida en su parte invertible y su parte paso todo:
 
 ```python
 import numpy as np
-from phonometry import (
-    excess_phase, group_delay, minimum_phase, phase_decomposition,
-)
+from phonometry import signals
 
 H = np.fft.rfft(ir)                    # respuesta unilateral, DC..Nyquist
-h_min = minimum_phase(np.abs(H))       # la fase solo desde la magnitud
-tau_g = group_delay(H, fs)             # -(1/2pi) dphi/df, en segundos
-phi_x = excess_phase(H)                # unwrap(arg H) - phi_min
+h_min = signals.minimum_phase(np.abs(H))       # la fase solo desde la magnitud
+tau_g = signals.group_delay(H, fs)             # -(1/2pi) dphi/df, en segundos
+phi_x = signals.excess_phase(H)                # unwrap(arg H) - phi_min
 
-res = phase_decomposition(H, fs)       # todo sobre un mismo eje
+res = signals.phase_decomposition(H, fs)       # todo sobre un mismo eje
 res.excess_group_delay                 # la parte paso todo, en s
 res.plot()                             # magnitud, fases, retardos de grupo
 ```
@@ -452,7 +450,7 @@ corregir en magnitud y fase a la vez con un solo filtro; una que no lo es, no.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import phase_decomposition
+from phonometry import signals
 
 fs = 48000.0
 delay = int(0.0025 * fs)                      # una latencia de procesado de 2,5 ms
@@ -465,7 +463,7 @@ imp = np.zeros(16384)
 imp[delay] = 1.0
 ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
-res = phase_decomposition(np.fft.rfft(ir), fs)
+res = signals.phase_decomposition(np.fft.rfft(ir), fs)
 res.plot(language="es")   # |H|, las tres fases y los retardos de grupo
 plt.show()
 ```

--- a/site/src/content/docs/es/devices/emission/sound-power-pressure.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-pressure.mdx
@@ -409,11 +409,11 @@ los diez niveles sustituya a la integral de superficie.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import measurement_positions, plot_microphone_positions
+from phonometry import emission
 
 # Los 10 micrófonos del Anexo B de ISO 3744 sobre un hemisferio de 2 m.
-plot_microphone_positions(measurement_positions("hemisphere", radius=2.0),
-                          radius=2.0, language="es")
+emission.plot_microphone_positions(emission.measurement_positions("hemisphere", radius=2.0),
+                                   radius=2.0, language="es")
 plt.show()
 ```
 
@@ -583,10 +583,10 @@ investigación localizada posterior lleva áreas desiguales.*
 import matplotlib.pyplot as plt
 
 fig, (axi, axd) = plt.subplots(1, 2, subplot_kw={"projection": "3d"})
-plot_microphone_positions(
+emission.plot_microphone_positions(
     emission.precision_positions("hemisphere", radius=1.0, count=40),
     ax=axi, radius=1.0)
-plot_microphone_positions(
+emission.plot_microphone_positions(
     emission.precision_positions("sphere", radius=1.0, count=20),
     ax=axd, radius=1.0)
 plt.show()

--- a/site/src/content/docs/es/devices/noise-control/duct-path.mdx
+++ b/site/src/content/docs/es/devices/noise-control/duct-path.mdx
@@ -80,20 +80,20 @@ y el nivel que sale de él. `DuctElement` lleva exactamente los dos espectros
 que pertenecen a un elemento, y `duct_path` los recorre:
 
 ```python
-from phonometry import DuctElement, duct_path
+from phonometry import noise_control
 
 bandas = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 ventilador = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 
-trayecto = duct_path(
+trayecto = noise_control.duct_path(
     bandas, ventilador,
     [
-        DuctElement("Codo, 36 x 24 in, sin revestir",
-                    attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
-                    self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silenciador, 3 ft, pérdida de carga estándar",
-                    attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
-                    self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Codo, 36 x 24 in, sin revestir",
+                                  attenuation=[0, 1, 2, 3, 3, 3, 3, 3],
+                                  self_noise=[41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silenciador, 3 ft, pérdida de carga estándar",
+                                  attenuation=[7, 12, 16, 28, 35, 35, 28, 17],
+                                  self_noise=[49, 43, 44, 42, 42, 45, 35, 24], code="3"),
     ],
     source_label="Ventilador centrífugo FC, 5000 cfm, 2 in c.a.",
 )
@@ -170,21 +170,18 @@ $P_\text{REF} = 249$ Pa, de modo que los dos términos logarítmicos toman los
 mismos valores que la forma anglosajona en cfm y pulgadas de columna de agua.
 
 ```python
-from phonometry import (
-    blade_passing_frequency, fan_casing_attenuation,
-    fan_efficiency_correction, fan_sound_power,
-)
+from phonometry import noise_control
 
 CFM, IN_CA = 0.0004719474432, 249.0
 
-ventilador = fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_CA,
-                             fan_type="forward_curved", relative_efficiency=80.0)
+ventilador = noise_control.fan_sound_power(volume_flow=5000 * CFM, static_pressure=2 * IN_CA,
+                                           fan_type="forward_curved", relative_efficiency=80.0)
 print([round(float(v)) for v in ventilador.values])
 # [99, 99, 89, 84, 82, 77, 72, 67]
 
-print(fan_efficiency_correction(80.0))          # 6.0 dB fuera del máximo
-print(blade_passing_frequency(1200.0, 24))      # 480.0 Hz, en la banda de 500 Hz
-print(fan_casing_attenuation().values)          # lo que retiene la carcasa
+print(noise_control.fan_efficiency_correction(80.0))          # 6.0 dB fuera del máximo
+print(noise_control.blade_passing_frequency(1200.0, 24))      # 480.0 Hz, en la banda de 500 Hz
+print(noise_control.fan_casing_attenuation().values)          # lo que retiene la carcasa
 # [ 0.  0.  5. 10. 15. 20. 22. 25.]
 ventilador.plot(language="es")                  # el espectro por bandas
 ```
@@ -267,15 +264,15 @@ servicio = dict(volume_flow=5000 * CFM, static_pressure=2 * IN_CA,
                 fan_type="forward_curved")
 
 # Una línea para un ventilador: el espectro por bandas.
-fan_sound_power(relative_efficiency=80.0, **servicio).plot(language="es")
+noise_control.fan_sound_power(relative_efficiency=80.0, **servicio).plot(language="es")
 plt.show()
 
 fig, ax = plt.subplots()
 for rendimiento in (90.0, 80.0, 55.0):
-    res = fan_sound_power(relative_efficiency=rendimiento, **servicio)
+    res = noise_control.fan_sound_power(relative_efficiency=rendimiento, **servicio)
     ax.semilogx(res.frequencies, res.values, "o-",
                 label=f"{rendimiento:.0f} % del máximo")
-carcasa = fan_casing_attenuation()
+carcasa = noise_control.fan_casing_attenuation()
 ax.semilogx(carcasa.frequencies, carcasa.values, "s-.", label="Carcasa")
 ax.set_xlabel("Frecuencia [Hz]"); ax.set_ylabel("Nivel [dB]")
 ax.legend()
@@ -310,17 +307,15 @@ evalúan las regresiones de Reynolds, válidas para revestimientos de 25 mm a
 transmisión por flancos.
 
 ```python
-from phonometry import (
-    lined_rectangular_duct_attenuation, unlined_rectangular_duct_attenuation,
-)
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
 bandas = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
-desnudo = unlined_rectangular_duct_attenuation(bandas, 36 * IN, 24 * IN, 5 * FT)
-revestido = lined_rectangular_duct_attenuation(bandas, 36 * IN, 24 * IN, 5 * FT,
-                                               1 * IN, include_unlined=True)
+desnudo = noise_control.unlined_rectangular_duct_attenuation(bandas, 36 * IN, 24 * IN, 5 * FT)
+revestido = noise_control.lined_rectangular_duct_attenuation(bandas, 36 * IN, 24 * IN, 5 * FT,
+                                                             1 * IN, include_unlined=True)
 print(np.round(desnudo.values, 1))    # [1.1 0.7 0.5 0.2 0.2 0.2 0.2 0.2]
 print(np.round(revestido.values, 1))  # [ 1.3  1.3  2.5  6.7 12.8 10.6  9.7  9. ]
 ```
@@ -349,12 +344,12 @@ el área total de los ramales no coincide con la del conducto que los
 alimenta, de modo que un ramal del 25 por ciento cuesta 6 dB.
 
 ```python
-from phonometry import elbow_insertion_loss, split_loss
+from phonometry import noise_control
 
 IN = 0.0254
 area = 36 * IN * 24 * IN
-print(round(split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
-print(elbow_insertion_loss(
+print(round(noise_control.split_loss(area, [0.25 * area, 0.75 * area], branch=0), 1))  # 6.0
+print(noise_control.elbow_insertion_loss(
     [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
     24 * IN, bend_type="round").values)          # [0. 1. 2. 3. 3. 3. 3. 3.]
 ```
@@ -378,15 +373,15 @@ abocinamiento suaviza la transición de impedancia, y la valoración de un
 difusor de fabricante ya contiene lo que quede de ella.
 
 ```python
-from phonometry import end_reflection_loss, equivalent_diameter
+from phonometry import noise_control
 import numpy as np
 
 bandas = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0]
-print(np.round(end_reflection_loss(bandas, 0.30, method="bies").values, 1))
+print(np.round(noise_control.end_reflection_loss(bandas, 0.30, method="bies").values, 1))
 # [12.  7.  3.  1.  0.  0.]
-print(np.round(end_reflection_loss(bandas, 0.30, method="long").values, 1))
+print(np.round(noise_control.end_reflection_loss(bandas, 0.30, method="long").values, 1))
 # [12.7  7.7  3.7  1.3  0.4  0.1]
-print(round(equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
+print(round(noise_control.equivalent_diameter(0.36 * 0.24), 3))    # 0.332 m
 ```
 
 **Silenciadores y plenums.** Un atenuador de bafles paralelos se reduce, en
@@ -398,17 +393,17 @@ energética de la Ec. 8.241 de modo que domina el paso más permeable.
 [constante de sala](/phonometry/es/buildings/rooms/room-image-sources/) del plenum.
 
 ```python
-from phonometry import plenum_attenuation, splitter_silencer_insertion_loss
+from phonometry import noise_control
 import numpy as np
 
 IN, FT = 0.0254, 0.3048
-sil = splitter_silencer_insertion_loss(
+sil = noise_control.splitter_silencer_insertion_loss(
     None, height=24 * IN, length=5 * FT,      # None -> las bandas de octava por omisión
     airway_widths=[0.10] * 5, splitter_thickness=0.10,
 )
 print(np.round(sil.values, 1))
 # [ 5.8  8.6 14.1 28.2 34.5 33.5 18.4 12.1]
-print(round(plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
+print(round(noise_control.plenum_attenuation(0.36, 2.4, 74.0, 0.5), 1))   # 16.1 dB
 ```
 
 Interpreta esa estimación por lo que es. La unidad de 5 ft que especifica de
@@ -447,8 +442,8 @@ import matplotlib.pyplot as plt
 # `bandas`, IN y FT como arriba; todos los modelos devuelven un HvacSpectrumResult.
 
 # Una línea para un elemento:
-lined_rectangular_duct_attenuation(bandas, 36 * IN, 24 * IN, 5 * FT, 1 * IN,
-                                   include_unlined=True).plot(language="es")
+noise_control.lined_rectangular_duct_attenuation(bandas, 36 * IN, 24 * IN, 5 * FT, 1 * IN,
+                                                 include_unlined=True).plot(language="es")
 plt.show()
 
 # A mano: la familia de codos del panel (b), indexada por W / lambda.
@@ -457,7 +452,7 @@ for label, kwargs in (("Cuadrado, revestido", dict(bend_type="square", lined=Tru
                       ("Cuadrado, desnudo", dict(bend_type="square")),
                       ("Cuadrado, con álabes", dict(bend_type="square", vanes=True)),
                       ("Circular, desnudo", dict(bend_type="round"))):
-    el = elbow_insertion_loss(bandas, 24 * IN, **kwargs)
+    el = noise_control.elbow_insertion_loss(bandas, 24 * IN, **kwargs)
     ax.semilogx(el.frequencies, el.values, "o-", label=label)
 ax.set_xlabel("Frecuencia [Hz]"); ax.set_ylabel("Pérdida por inserción [dB]")
 ax.legend()
@@ -494,14 +489,14 @@ paso de aire significa que *duplicar la velocidad frontal de un silenciador
 añade unos 17 dB*.
 
 ```python
-from phonometry import silencer_self_noise
+from phonometry import noise_control
 import numpy as np
 
 IN = 0.0254
-lento = silencer_self_noise(None, airway_velocity=10.0, passages=5,
-                            height=24 * IN)
-rapido = silencer_self_noise(None, airway_velocity=20.0, passages=5,
-                             height=24 * IN)
+lento = noise_control.silencer_self_noise(None, airway_velocity=10.0, passages=5,
+                                          height=24 * IN)
+rapido = noise_control.silencer_self_noise(None, airway_velocity=20.0, passages=5,
+                                           height=24 * IN)
 print(np.round(lento.values, 1))
 # [40.8 40.8 38.8 36.8 31.8 26.8 21.8 16.8]
 print(round(float(rapido.values[0] - lento.values[0]), 1))     # 16.6 dB
@@ -534,15 +529,15 @@ de pico $f_\mathrm{P} = 48{,}8\,U_\mathrm{G}$ (Ec. 13.32, $U_\mathrm{G}$ en **ft
 numeración de bandas de Long con la banda 0 en 32 Hz.
 
 ```python
-from phonometry import diffuser_sound_power
+from phonometry import noise_control
 import numpy as np
 
 IN, CFM, IN_WG = 0.0254, 0.0004719474432, 249.0
 
 # El difusor de impulsión de la hoja de Long: 24 x 24 in, 312 cfm, 0.05 in pd.
-print(np.round(diffuser_sound_power(None, (24 * IN) ** 2,
-                                    volume_flow=312 * CFM,
-                                    pressure_drop=0.05 * IN_WG).values, 1))
+print(np.round(noise_control.diffuser_sound_power(None, (24 * IN) ** 2,
+                                                  volume_flow=312 * CFM,
+                                                  pressure_drop=0.05 * IN_WG).values, 1))
 # [ 33.4  32.4  29.1  23.6  15.9   5.9  -6.4 -21. ]
 # La Tabla 14.9 de Long imprime 33/32/29/23/15/4/0/0 en esa fila.
 
@@ -563,12 +558,12 @@ una compuerta de regulación, que es donde fracasan muchísimas instalaciones
 terminadas.
 
 ```python
-from phonometry import air_terminal_damper_correction, air_terminal_velocity_limit
+from phonometry import noise_control
 
-print(air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
-print(air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
-print(air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
-print(air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
+print(noise_control.air_terminal_velocity_limit(30, opening="supply"))   # 2.2 m/s
+print(noise_control.air_terminal_velocity_limit(30, opening="return"))   # 2.5 m/s
+print(noise_control.air_terminal_damper_correction(3.0, location="diffuser_neck"))  # 15.0 dB
+print(noise_control.air_terminal_damper_correction(3.0, location="supply_duct"))    #  2.0 dB
 ```
 
 Quince decibelios en el cuello frente a dos decibelios a 1,5 m aguas arriba
@@ -603,14 +598,14 @@ import matplotlib.pyplot as plt
 bandas = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 # Una línea para un elemento:
-silencer_self_noise(bandas, airway_velocity=20.0, passages=5,
-                    height=24 * IN).plot(language="es")
+noise_control.silencer_self_noise(bandas, airway_velocity=20.0, passages=5,
+                                  height=24 * IN).plot(language="es")
 plt.show()
 
 fig, ax = plt.subplots()
 for velocidad in (5.0, 10.0, 20.0, 40.0):
-    res = silencer_self_noise(bandas, airway_velocity=velocidad, passages=5,
-                              height=24 * IN)
+    res = noise_control.silencer_self_noise(bandas, airway_velocity=velocidad, passages=5,
+                                            height=24 * IN)
     ax.semilogx(res.frequencies, res.values, "o-", label=f"{velocidad:.0f} m/s")
 ax.set_xlabel("Frecuencia [Hz]")
 ax.set_ylabel("L_W regenerada [dB re 1 pW]")
@@ -664,12 +659,12 @@ junto a cualquier otra pérdida, con $Q = 2$ por defecto para un difusor
 enrasado en el techo.
 
 ```python
-from phonometry import room_constant, room_effect
+from phonometry import noise_control, room
 
 # La sala de 20 x 20 x 8 ft de la hoja resuelta de Long, con cartón-yeso y moqueta.
 area = 2 * 6.10 * 6.10 + 4 * 6.10 * 2.44        # 134.0 m2
-r_sala = room_constant(area, 0.15)              # 23.6 m2
-print(round(float(room_effect(1.83, r_sala, directivity=2.0)), 1))   # 6.6 dB
+r_sala = room.room_constant(area, 0.15)              # 23.6 m2
+print(round(float(noise_control.room_effect(1.83, r_sala, directivity=2.0)), 1))   # 6.6 dB
 ```
 
 La hoja de Long imprime de 5 a 7 dB para esa sala en todas las bandas, así
@@ -749,54 +744,54 @@ por encima de 1 kHz es el retorno, no la impulsión.*
 
 ```python
 import numpy as np
-from phonometry import DuctElement, combine_duct_paths, duct_path
+from phonometry import noise_control
 
 bandas = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 ventilador = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
 fuente = "Ventilador centrífugo FC, 5000 cfm, 2 in c.a."
 
-impulsion = duct_path(
+impulsion = noise_control.duct_path(
     bandas, ventilador,
     [
-        DuctElement("Codo, 36 x 24 in, sin revestir", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
-        DuctElement("Silenciador, 3 ft, pérdida de carga estándar",
-                    [7, 12, 16, 28, 35, 35, 28, 17],
-                    [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
-        DuctElement("Conducto, 36 x 24 in, 5 ft, revestimiento de 1 in",
-                    [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
-        DuctElement("Derivación, 25 por ciento", 6.0, code="5"),
-        DuctElement("Conducto, 18 x 12 in, 6 ft, revestimiento de 1 in",
-                    [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
-        DuctElement("Conducto flexible, 12 in, 6 ft",
-                    [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
-        DuctElement("Difusor rectangular, 312 cfm", None,
-                    [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
+        noise_control.DuctElement("Codo, 36 x 24 in, sin revestir", [0, 1, 2, 3, 3, 3, 3, 3],
+                                  [41, 39, 36, 29, 20, 6, 0, 0], code="2"),
+        noise_control.DuctElement("Silenciador, 3 ft, pérdida de carga estándar",
+                                  [7, 12, 16, 28, 35, 35, 28, 17],
+                                  [49, 43, 44, 42, 42, 45, 35, 24], code="3"),
+        noise_control.DuctElement("Conducto, 36 x 24 in, 5 ft, revestimiento de 1 in",
+                                  [2, 2, 3, 7, 15, 12, 11, 9], code="4"),
+        noise_control.DuctElement("Derivación, 25 por ciento", 6.0, code="5"),
+        noise_control.DuctElement("Conducto, 18 x 12 in, 6 ft, revestimiento de 1 in",
+                                  [3, 3, 5, 11, 25, 22, 16, 13], code="6"),
+        noise_control.DuctElement("Conducto flexible, 12 in, 6 ft",
+                                  [14, 14, 16, 15, 17, 22, 16, 13], code="7"),
+        noise_control.DuctElement("Difusor rectangular, 312 cfm", None,
+                                  [33, 32, 29, 23, 15, 4, 0, 0], code="8"),
     ],
     room_effect=[6, 6, 5, 5, 6, 7, 6, 6],
     source_label=fuente, target=30.0, label="Impulsión",
 )
 
-retorno = duct_path(
+retorno = noise_control.duct_path(
     bandas, ventilador,
     [
-        DuctElement("Codo, 36 x 24 in, sin revestir", [0, 1, 2, 3, 3, 3, 3, 3],
-                    [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
-        DuctElement("Silenciador, 5 ft, tipo baja frecuencia",
-                    [16, 21, 35, 41, 41, 28, 21, 15],
-                    [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
-        DuctElement("Codo, 36 x 24 in, revestido, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
-                    [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
-        DuctElement("Plenum, 800 sq ft, 50 por ciento revestido",
-                    [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
-        DuctElement("Rejilla rectangular, 24 x 24 in, 563 cfm", None,
-                    [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
+        noise_control.DuctElement("Codo, 36 x 24 in, sin revestir", [0, 1, 2, 3, 3, 3, 3, 3],
+                                                [43, 42, 39, 33, 24, 12, 0, 0], code="2"),
+        noise_control.DuctElement("Silenciador, 5 ft, tipo baja frecuencia",
+                                                [16, 21, 35, 41, 41, 28, 21, 15],
+                                                [51, 49, 53, 56, 56, 59, 60, 53], code="3"),
+        noise_control.DuctElement("Codo, 36 x 24 in, revestido, 1 in", [1, 2, 3, 4, 5, 6, 8, 10],
+                                                [39, 38, 34, 28, 18, 4, 0, 0], code="4"),
+        noise_control.DuctElement("Plenum, 800 sq ft, 50 por ciento revestido",
+                                                [12, 13, 19, 20, 20, 20, 21, 21], code="5"),
+        noise_control.DuctElement("Rejilla rectangular, 24 x 24 in, 563 cfm", None,
+                                                [30, 29, 26, 20, 12, 1, 0, 0], code="6"),
     ],
     room_effect=[9, 8, 6, 8, 8, 8, 9, 10],
     source_label=fuente, target=30.0, label="Retorno",
 )
 
-total = combine_duct_paths([impulsion, retorno], label="Impulsión + retorno")
+total = noise_control.combine_duct_paths([impulsion, retorno], label="Impulsión + retorno")
 print(np.round(impulsion.received_level, 0))  # Long: 52 42 30 18  9 -2 -2 -1
 print(np.round(retorno.received_level, 0))    # Long: 52 41 27 25 23 25 22 12
 print(np.round(total.received_level, 0))      # Long: 55 45 32 26 23 25 22 12
@@ -827,7 +822,7 @@ en todas partes salvo a 63 Hz, y esa es la fila sobre la que discutir.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import combine_duct_paths
+from phonometry import noise_control
 
 # `impulsion` y `retorno` son los dos DuctPathResult construidos arriba.
 
@@ -836,7 +831,7 @@ impulsion.plot(language="es")
 plt.show()
 
 # La figura de concepto: ambos trayectos, su suma energética y el criterio.
-total = combine_duct_paths([impulsion, retorno], label="Impulsión + retorno")
+total = noise_control.combine_duct_paths([impulsion, retorno], label="Impulsión + retorno")
 total.plot(language="es")
 plt.gca().set_ylim(-6.0, 62.0)
 plt.show()
@@ -939,7 +934,7 @@ import matplotlib.pyplot as plt
 # bandas alineada con OCTAVE_BANDS, que empieza en 16 Hz, así que las ocho
 # bandas de la hoja son nc_curve(30)[2:].
 impresa = [3, 3, 5, 11, 25, 22, 16, 13]      # fila de 18 x 12 in, 6 ft de Long
-calculada = lined_rectangular_duct_attenuation(
+calculada = noise_control.lined_rectangular_duct_attenuation(
     bandas, 18 * IN, 12 * IN, 6 * FT, 1 * IN, include_unlined=True).values
 
 fig, ax = plt.subplots()
@@ -990,18 +985,18 @@ $k_x = -M\kappa_{pq}/\sqrt{1 - M^2}$.
 
 ```python
 import numpy as np
-from phonometry import plane_wave_limit, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # Problema 7.2 de Norton: un conducto de climatización de 0.65 x 0.4 m a 15 m/s.
-modos = rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
+modos = noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6)
 print(modos.modes[:3])                          # ((1, 0), (0, 1), (1, 1))
 print(np.round(modos.cut_on[:3], 1))            # [263.6 428.3 502.9] Hz
 print(np.round(modos.cut_on_no_flow[:3], 1))    # [263.8 428.8 503.4] Hz
 print(round(modos.plane_wave_limit, 1))         # 263.6 Hz
 
 IN = 0.0254
-print(round(plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
-print(round(plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
+print(round(noise_control.plane_wave_limit(width=36 * IN, height=24 * IN), 1))   # 187.6 Hz
+print(round(noise_control.plane_wave_limit(diameter=12 * IN), 1))                # 659.5 Hz
 ```
 
 Esas cifras de ventilación son contundentes: en ese conducto las ondas planas
@@ -1051,11 +1046,11 @@ todos los peldaños.
 
 ```python
 import numpy as np
-from phonometry import circular_duct_cut_on
+from phonometry import noise_control
 
 # Problema 7.1 de Norton: un conducto circular de 254 mm con vapor a 200 m/s.
-vapor = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+vapor = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 print(vapor.modes)
 # ((1, 0), (2, 0), (0, 1), (3, 0), (4, 0), (1, 1))
 print(np.round(vapor.cut_on_no_flow, 1))
@@ -1082,16 +1077,16 @@ que aparece.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import circular_duct_cut_on, rectangular_duct_cut_on
+from phonometry import noise_control
 
 # Una línea para un conducto: la escalera de corte con la banda de onda plana.
-vapor = circular_duct_cut_on(0.254, flow_velocity=200.0,
-                             speed_of_sound=405.0, count=6)
+vapor = noise_control.circular_duct_cut_on(0.254, flow_velocity=200.0,
+                                           speed_of_sound=405.0, count=6)
 vapor.plot(language="es")
 plt.show()
 
 # El conducto de ventilación del problema 7.2, donde el flujo casi no cuenta.
-rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot(language="es")
+noise_control.rectangular_duct_cut_on(0.65, 0.40, flow_velocity=15.0, count=6).plot(language="es")
 plt.show()
 ```
 
@@ -1107,17 +1102,17 @@ medición no hará.
 
 ```python
 import warnings
-from phonometry import DuctElement, PlaneWaveWarning, duct_path
+from phonometry import noise_control
 
 IN = 0.0254
 bandas = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 
 with warnings.catch_warnings(record=True) as avisos:
     warnings.simplefilter("always")
-    duct_path(bandas, [90.0] * 8, [DuctElement("Tramo recto", 3.0)],
-              section={"width": 36 * IN, "height": 24 * IN},
-              flow_velocity=6.0, label="Impulsión")
-print(avisos[0].category is PlaneWaveWarning)
+    noise_control.duct_path(bandas, [90.0] * 8, [noise_control.DuctElement("Tramo recto", 3.0)],
+                            section={"width": 36 * IN, "height": 24 * IN},
+                            flow_velocity=6.0, label="Impulsión")
+print(avisos[0].category is noise_control.PlaneWaveWarning)
 print(str(avisos[0].message))
 # Impulsión: 6 of 8 frequencies are above the first duct cut-on frequency
 # (188 Hz), where higher-order modes propagate and the plane-wave result

--- a/site/src/content/docs/es/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/es/devices/noise-control/noise-control.mdx
@@ -256,10 +256,10 @@ del propio plenum, que hay que añadir aparte con los modelos anteriores.
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import plot_plenum_geometry
+from phonometry import noise_control
 
 # Las r, S_out y S_w que la fórmula de Wells usa de verdad, dibujadas exactas.
-plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35, language="es")
+noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=0.35, language="es")
 plt.show()
 ```
 
@@ -371,12 +371,12 @@ Este módulo nunca predice $R$; combina un $R$ dado con la absorción interior.
 
 ```python
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # medido, dB
 
-enc = enclosure_insertion_loss(
+enc = noise_control.enclosure_insertion_loss(
     panel_R, external_area=6.0, internal_area=5.0,
     internal_absorption=0.3, frequencies=bands,
 )
@@ -397,12 +397,12 @@ el revestimiento junto con los paneles, no como un añadido posterior.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import enclosure_insertion_loss
+from phonometry import noise_control
 
 bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 panel_R = np.array([18.0, 24.0, 30.0, 36.0, 42.0, 46.0])   # medido, dB
 
-enc = enclosure_insertion_loss(
+enc = noise_control.enclosure_insertion_loss(
     panel_R, external_area=6.0, internal_area=5.0,
     internal_absorption=0.3, frequencies=bands,
 )
@@ -435,12 +435,12 @@ media en su recuadro con las áreas de las que sale y, cuando se declara un
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, enclosure_insertion_loss
+from phonometry import ReportMetadata, noise_control
 
 octaves = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 sheet_steel_R = np.array([18.0, 22.0, 28.0, 33.0, 38.0, 42.0, 45.0])
 
-case = enclosure_insertion_loss(
+case = noise_control.enclosure_insertion_loss(
     sheet_steel_R, external_area=24.0, internal_area=30.0,
     internal_absorption=0.30, frequencies=octaves,
 )
@@ -500,7 +500,7 @@ elements = np.vstack([sheet_steel, door, opening])
 built = -10.0 * np.log10((areas * 10.0 ** (-elements / 10.0)).sum(0)
                          / areas.sum())
 
-leaky = enclosure_insertion_loss(
+leaky = noise_control.enclosure_insertion_loss(
     built, external_area=24.0, internal_area=30.0,
     internal_absorption=0.30, frequencies=octaves,
 )

--- a/site/src/content/docs/es/devices/noise-control/room-to-room.mdx
+++ b/site/src/content/docs/es/devices/noise-control/room-to-room.mdx
@@ -138,14 +138,12 @@ cámara de 50 mm, los tres hablando al mismo recinto receptor de
 
 ```python
 import numpy as np
-from phonometry import (
-    SourceRoom, equivalent_absorption_area, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 
 # Recinto receptor 8 x 9 x 3 m: paredes 102 m2, suelo y techo 72 m2 cada uno.
-receiving = equivalent_absorption_area([
+receiving = room.equivalent_absorption_area([
     (102.0, [0.04, 0.04, 0.09, 0.15, 0.17, 0.23]),   # paredes
     (72.0,  [0.02, 0.06, 0.14, 0.37, 0.60, 0.66]),   # suelo
     (72.0,  [0.30, 0.20, 0.15, 0.05, 0.05, 0.05]),   # techo
@@ -159,9 +157,9 @@ partitions = {
     "Doble hoja de ladrillo, cámara de 50 mm":      [37, 41, 48, 60, 61, 61],
 }
 for name, tl in partitions.items():
-    res = room_to_room_transmission(
+    res = noise_control.room_to_room_transmission(
         bands, tl, 8.0 * 3.0, receiving,
-        source=SourceRoom(level=90.0), label=name,
+        source=noise_control.SourceRoom(level=90.0), label=name,
     )
     print(f"{name:44s} {np.round(res.noise_reduction, 1)}")
 # Dos placas de yeso de 13 mm, cámara de 64 mm  [18.5 26.8 38.  47.8 47.3 43.9]
@@ -199,17 +197,17 @@ import matplotlib.pyplot as plt
 
 # Una línea por muro: el RoomToRoomResult dibuja los dos espectros, la curva
 # de criterio y la reducción de ruido frente a la pérdida por transmisión.
-room_to_room_transmission(
+noise_control.room_to_room_transmission(
     bands, partitions["Ladrillo enfoscado de 125 mm"], 8.0 * 3.0, receiving,
-    source=SourceRoom(level=90.0),
+    source=noise_control.SourceRoom(level=90.0),
 ).plot(language="es")
 plt.show()
 
 # A mano: la separación que muestra cada muro, y el recinto que hay detrás.
 fig, (top, bottom) = plt.subplots(2, 1, sharex=True)
 for name, tl in partitions.items():
-    res = room_to_room_transmission(bands, tl, 8.0 * 3.0, receiving,
-                                    source=SourceRoom(level=90.0))
+    res = noise_control.room_to_room_transmission(bands, tl, 8.0 * 3.0, receiving,
+                                                  source=noise_control.SourceRoom(level=90.0))
     top.semilogx(bands, res.noise_reduction - np.asarray(tl, float),
                  "o-", label=name)
 top.axhline(0.0)
@@ -248,10 +246,7 @@ $10\log_{10} 4 = 6{,}02\ \text{dB}$, y sin él las respuestas impresas salen 6 d
 por debajo.
 
 ```python
-from phonometry import (
-    DesignCriterion, SourceRoom, equivalent_absorption_area, mean_absorption,
-    room_constant, room_to_room_transmission,
-)
+from phonometry import noise_control, room
 
 bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
 ceiling = [0.07, 0.20, 0.40, 0.52, 0.60, 0.67]      # techo absorbente
@@ -265,18 +260,18 @@ plant = [(80.0, [0.01, 0.01, 0.015, 0.02, 0.02, 0.02]),
 operator = [(25.0, [0.08, 0.24, 0.57, 0.69, 0.71, 0.73]),
             (25.0, ceiling), (60.0, walls)]
 
-chain = room_to_room_transmission(
+chain = noise_control.room_to_room_transmission(
     bands,
     [39.0, 42.0, 50.0, 58.0, 63.0, 67.0],       # TL del muro separador
     5.0 * 3.0,                                  # el muro mide 5 m x 3 m
-    equivalent_absorption_area(operator),
-    source=SourceRoom(
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(
         power_level=[105.0, 103.0, 98.0, 108.0, 107.0, 109.0],
-        room_constant=room_constant(268.0, mean_absorption(plant)),
+        room_constant=room.room_constant(268.0, room.mean_absorption(plant)),
         directivity=4.0,                        # intersección suelo-pared
         model="constant_volume",                # la cota conservadora
     ),
-    criterion=DesignCriterion(target=45.0),
+    criterion=noise_control.DesignCriterion(target=45.0),
     label="Plant room to operator room",
 )
 
@@ -410,7 +405,7 @@ los paneles, $\text{TL} = \text{IL} + 10\log_{10}(S_\mathrm{E} / R_\mathrm{i})$,
 
 ```python
 import numpy as np
-from phonometry import enclosure_required_transmission_loss, mean_absorption
+from phonometry import noise_control, room
 
 bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 wool = [0.10, 0.20, 0.45, 0.65, 0.75, 0.80, 0.80, 0.80]   # manta de 50 mm
@@ -427,11 +422,11 @@ radiating = 2 * (2.5 * 2.5) + 2 * (3.5 * 2.5) + 2.5 * 3.5
 machine = 2 * (1.5 * 1.5) + 2 * (2.5 * 1.5) + 1.5 * 2.5
 bare_floor = 2.5 * 3.5 - 1.5 * 2.5
 
-required = enclosure_required_transmission_loss(
+required = noise_control.enclosure_required_transmission_loss(
     lp1 - nc45,
     radiating,
     radiating + bare_floor + machine,
-    mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
+    room.mean_absorption([(radiating, wool), (bare_floor + machine, concrete)]),
     frequencies=bands,
     model="norton",
 )
@@ -556,11 +551,11 @@ necesaria en lugar de perderse:
 
 ```python
 # Otra vez la cadena del apartado 3, con 3 dB de provisión por flancos y fugas.
-honest = room_to_room_transmission(
+honest = noise_control.room_to_room_transmission(
     bands, [39.0, 42.0, 50.0, 58.0, 63.0, 67.0], 15.0,
-    equivalent_absorption_area(operator),
-    source=SourceRoom(level=chain.source_level),
-    criterion=DesignCriterion(target=45.0, flanking_penalty=3.0),
+    room.equivalent_absorption_area(operator),
+    source=noise_control.SourceRoom(level=chain.source_level),
+    criterion=noise_control.DesignCriterion(target=45.0, flanking_penalty=3.0),
 )
 print(np.round(honest.received_level, 1))
 # [75.4 63.4 44.4 44.  36.9 33.7]      cada banda 3 dB peor

--- a/site/src/content/docs/es/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/es/devices/noise-control/silencers.mdx
@@ -114,10 +114,10 @@ transparente. El producto de cuatro polos lo reproduce exactamente.
 
 ```python
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 print(round(res.transmission_loss.max(), 2))   # máximo 6.55 dB (m = 4)
 # Las caídas en f = n c / 2L son exactamente 0 dB (sin disipación).
 print(round(float(res.transmission_loss[np.argmin(res.transmission_loss)]), 6))
@@ -146,7 +146,7 @@ para profundizar el máximo.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
 
@@ -155,15 +155,15 @@ freqs = np.linspace(20.0, 2000.0, 2000)
 # subapartado siguiente). Con las dos puestas a rho c / S = 4.14e4 para este
 # tubo de 0.01 m2 las dos curvas coinciden, que es lo que significa «puertos
 # anecoicos».
-expansion_chamber(freqs, 0.3, 0.04, 0.01,
-                  source_impedance=4.14e4,
-                  radiation_impedance=4.14e4).plot(language="es")
+noise_control.expansion_chamber(freqs, 0.3, 0.04, 0.01,
+                                source_impedance=4.14e4,
+                                radiation_impedance=4.14e4).plot(language="es")
 plt.show()
 
 # A mano: la familia de relaciones de áreas de la figura de concepto.
 fig, ax = plt.subplots()
 for m in (2.0, 4.0, 8.0, 16.0):
-    res = expansion_chamber(freqs, 0.3, m * 0.01, 0.01)
+    res = noise_control.expansion_chamber(freqs, 0.3, m * 0.01, 0.01)
     ax.plot(freqs, res.transmission_loss, label=f"m = {int(m)}")
 ax.set_xlabel("Frecuencia [Hz]"); ax.set_ylabel("Pérdida de transmisión [dB]")
 ax.legend()
@@ -189,18 +189,18 @@ diámetros circulares equivalentes $d = 2\sqrt{S/\pi}$ de las secciones de 0,04 
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import expansion_chamber, plot_silencer_geometry
+from phonometry import noise_control
 
 freqs = np.linspace(20.0, 2000.0, 2000)
-res = expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.3, chamber_area=0.04, pipe_area=0.01)
 
 # Una línea: la sección acotada de la cámara recién calculada.
 res.plot_geometry(language="es")
 plt.show()
 
 # El mismo dibujo sin resultado, con la función libre:
-plot_silencer_geometry("expansion chamber", length=0.3,
-                       chamber_area=0.04, pipe_area=0.01, language="es")
+noise_control.plot_silencer_geometry("expansion chamber", length=0.3,
+                                     chamber_area=0.04, pipe_area=0.01, language="es")
 plt.show()
 ```
 
@@ -273,17 +273,17 @@ z_r = z0 * ((1.0 - 2.0 * special.j1(x) / x)
 
 # Una línea: el resultado dibuja la pérdida por inserción junto a la de
 # transmisión siempre que se den las dos impedancias.
-expansion_chamber(freqs, 0.3, 0.04, pipe_area,
-                  source_impedance=z0, radiation_impedance=z_r).plot(language="es")
+noise_control.expansion_chamber(freqs, 0.3, 0.04, pipe_area,
+                                source_impedance=z0, radiation_impedance=z_r).plot(language="es")
 plt.show()
 
 # A mano: las dos impedancias de fuente de la figura contra la misma salida.
 fig, ax = plt.subplots()
-ax.plot(freqs, expansion_chamber(freqs, 0.3, 0.04, pipe_area).transmission_loss,
+ax.plot(freqs, noise_control.expansion_chamber(freqs, 0.3, 0.04, pipe_area).transmission_loss,
         label="Pérdida de transmisión")
 for factor, label in ((20.0, "fuente rígida"), (1.0, "fuente adaptada")):
-    res = expansion_chamber(freqs, 0.3, 0.04, pipe_area,
-                            source_impedance=factor * z0, radiation_impedance=z_r)
+    res = noise_control.expansion_chamber(freqs, 0.3, 0.04, pipe_area,
+                                          source_impedance=factor * z0, radiation_impedance=z_r)
     ax.plot(freqs, res.insertion_loss, label=f"Pérdida por inserción, {label}")
 ax.set_xlabel("Frecuencia [Hz]"); ax.set_ylabel("Atenuación [dB]")
 ax.legend()
@@ -342,38 +342,36 @@ construirlo largo y recortarlo guiándose por una medición.
 
 ```python
 import numpy as np
-from phonometry import (
-    helmholtz_resonator, quarter_wave_resonator, extended_tube_chamber,
-)
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
 
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 print(round(float(hr.resonances[0]), 1))       # 122.1 Hz, para le = 20 mm
 hr.plot()   # pico de TL en la frecuencia de sintonía (necesita matplotlib)
 
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 print(round(float(qw.resonances[0]), 1))       # 285.8 Hz = c / 4 le
 
 # Ejemplo 8.1 de Bies, el anclaje publicado: un tubo de 1.516 m con c = 343.24 m/s.
-print(round(float(quarter_wave_resonator(
+print(round(float(noise_control.quarter_wave_resonator(
     f, duct_area=0.01, length=1.516, branch_area=2e-3,
     speed_of_sound=343.24).resonances[0]), 1))  # 56.6 Hz
 
 # El mismo tubo en gases de escape calientes: c(500 degC) = 343*sqrt(773/293) = 557 m/s
 # (ver la advertencia de abajo), que desplaza la muesca en un factor 1.62.
 f_hot = np.linspace(20.0, 900.0, 6000)
-qw_hot = quarter_wave_resonator(f_hot, duct_area=0.01, length=0.3,
-                                branch_area=2e-3, speed_of_sound=557.0)
+qw_hot = noise_control.quarter_wave_resonator(f_hot, duct_area=0.01, length=0.3,
+                                              branch_area=2e-3, speed_of_sound=557.0)
 print(round(float(qw_hot.resonances[0]), 1))   # 464.2 Hz, no 285.8
 
 # Cada extensión es un tubo de cuarto de onda, así que su propia longitud
 # elige la caída que rellena: L/4 = 0,1 m cortocircuita el conducto en
 # c/4(L/4) = c/L, la segunda caída de la cámara, y L/2 = 0,2 m tomaría la
 # primera, en c/2L.
-et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
-                           inlet_extension=0.1)
+et = noise_control.extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
+                                         inlet_extension=0.1)
 print(round(float(et.transmission_loss[np.argmin(abs(f - 428.75))]), 1))
 # 0.6 dB en c/2L: el tubo L/4 está sintonizado una octava por encima
 ```
@@ -405,10 +403,10 @@ diseñe contra el espectro de la fuente y no en general.*
 import matplotlib.pyplot as plt
 
 # `f`, y extended_tube_chamber / expansion_chamber, como en el apartado 1.
-plain = expansion_chamber(f, 0.4, 0.04, 0.01)
-inlet = extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1)
-both = extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
-                             outlet_extension=0.2)
+plain = noise_control.expansion_chamber(f, 0.4, 0.04, 0.01)
+inlet = noise_control.extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1)
+both = noise_control.extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
+                                           outlet_extension=0.2)
 
 # Una línea para un dispositivo:
 inlet.plot(language="es")
@@ -442,8 +440,8 @@ son los espacios anulares que crean las extensiones.*
 import matplotlib.pyplot as plt
 
 # Una línea: la sección acotada del dispositivo recién calculado.
-extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
-                      outlet_extension=0.2).plot_geometry(language="es")
+noise_control.extended_tube_chamber(f, 0.4, 0.04, 0.01, inlet_extension=0.1,
+                                    outlet_extension=0.2).plot_geometry(language="es")
 plt.show()
 ```
 
@@ -478,12 +476,12 @@ más seguro.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator, quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # Una línea para un dispositivo: TL vs frecuencia con la resonancia marcada.
 hr.plot(language="es")
@@ -550,11 +548,11 @@ el pico de su objetivo.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import helmholtz_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-hr = helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
-                         neck_length=0.02, cavity_volume=1e-3)
+hr = noise_control.helmholtz_resonator(f, duct_area=0.01, neck_area=1e-4,
+                                       neck_length=0.02, cavity_volume=1e-3)
 
 # Una línea: la rama lateral a escala, cavidad como cubo de igual volumen.
 hr.plot_geometry(language="es")
@@ -600,10 +598,10 @@ diseñarse a un solo valor.
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import quarter_wave_resonator
+from phonometry import noise_control
 
 f = np.linspace(20.0, 600.0, 4000)
-qw = quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
+qw = noise_control.quarter_wave_resonator(f, duct_area=0.01, length=0.3, branch_area=2e-3)
 
 # Una línea: el tubo cerrado de 0,3 m sobre su conducto, a escala.
 qw.plot_geometry(language="es")
@@ -665,11 +663,11 @@ la figura que incrusta la ficha, matplotlib (`pip install
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, expansion_chamber
+from phonometry import ReportMetadata, noise_control
 
 # Una cámara de 0,5 m con relación de áreas m = 8, en los centros de octava.
 freqs = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-res = expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
+res = noise_control.expansion_chamber(freqs, length=0.5, chamber_area=0.08, pipe_area=0.01)
 res.report(
     "ficha_silenciador.pdf",
     metadata=ReportMetadata(
@@ -732,7 +730,7 @@ impedancia no es una forma.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import SilencerChain
+from phonometry import noise_control
 from phonometry.noise_control import helmholtz_impedance, quarter_wave_impedance
 
 freqs = np.linspace(20.0, 500.0, 481)
@@ -742,7 +740,7 @@ s_shell = np.pi * 0.200**2              # envolvente nominal de 400 mm
 # Los elementos en orden, de entrada a salida; cada llamada guarda lo que
 # se le dio.
 chain = (
-    SilencerChain(freqs)
+    noise_control.SilencerChain(freqs)
     .duct(0.10, s_duct)
     .shunt(quarter_wave_impedance(freqs, 343.0 / (4.0 * 125.0), np.pi * 0.050**2),
            label="Ramal de cuarto de onda")
@@ -827,7 +825,7 @@ corta su modelo.*
 import matplotlib.pyplot as plt
 
 # El lado reactivo, dibujado solo hasta su propio techo de validez.
-chamber = expansion_chamber(f, 0.3, 0.04, 0.01)
+chamber = noise_control.expansion_chamber(f, 0.3, 0.04, 0.01)
 inside = f <= chamber.plane_wave_limit
 
 fig, ax = plt.subplots()

--- a/site/src/content/docs/es/environment/propagation/atmospheric-refraction.mdx
+++ b/site/src/content/docs/es/environment/propagation/atmospheric-refraction.mdx
@@ -76,26 +76,21 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    atmospheric_ray_paths,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 c0 = 340.0
-perfil = log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
+perfil = environment.log_linear_sound_speed_profile(-1.0, ground_speed=c0, max_height=60.0)
 zs = 2.0
 fig, axes = plt.subplots(2, 1, figsize=(11, 8.2), sharex=True)
 
-rayos = atmospheric_ray_paths(perfil, source_height=zs,
-                              launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                              max_range=600.0, n_steps=3000)
+rayos = environment.atmospheric_ray_paths(perfil, source_height=zs,
+                                          launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                          max_range=600.0, n_steps=3000)
 for i in range(rayos.heights.shape[0]):
     axes[0].plot(rayos.ranges[i], rayos.heights[i], color="#1f77b4", lw=0.8, alpha=0.7)
 axes[0].plot([0.0], [zs], "o", color="#d62728", label="Fuente")
 grad = (perfil.speed_at(10.0) - c0) / 10.0
-x_sh = shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
+x_sh = environment.shadow_zone_distance(float(grad), zs, zs, ground_speed=c0)
 axes[0].axvline(x_sh, color="#d62728", ls="--", label="Límite de la zona de sombra")
 axes[0].set(ylabel="Altura [m]", ylim=(0, 40), title="Rayos sonoros (refracción hacia arriba)")
 axes[0].legend()
@@ -106,9 +101,9 @@ with warnings.catch_warnings():
     # publicado, como todo suelo exterior (ver «Elección de la impedancia del
     # suelo» en la guía de efecto suelo).
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(400.0, perfil, source_height=zs,
-                                        flow_resistivity=200e3,
-                                        max_range=600.0, max_height=40.0)
+    pe = environment.atmospheric_parabolic_equation(400.0, perfil, source_height=zs,
+                                                    flow_resistivity=200e3,
+                                                    max_range=600.0, max_height=40.0)
 img = axes[1].imshow(pe.relative_level, cmap="RdBu_r", vmin=-30, vmax=6,
                      aspect="auto", origin="lower", interpolation="bilinear",
                      extent=(pe.ranges[0], pe.ranges[-1], pe.heights[0], pe.heights[-1]))
@@ -190,9 +185,9 @@ valor de pradera, así que es el primer argumento que hay que cambiar cuando el
 emplazamiento no es un campo.
 
 ```python
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
-perfil = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # hacia arriba
+perfil = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # hacia arriba
 perfil.speed_at(10.0)   # velocidad efectiva del sonido a 10 m del suelo
 perfil.plot()           # c_eff(z) con la altura en el eje vertical
 ```
@@ -209,11 +204,11 @@ exteriores de lo que sugiere la distancia entre ellas.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import log_linear_sound_speed_profile
+from phonometry import environment
 
 # Las dos capas superficiales canónicas de la Ec. 4.5 de Salomons sobre pradera.
-bajada = log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
-subida = log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
+bajada = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0, max_height=60.0)
+subida = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0, max_height=60.0)
 ax = bajada.plot(color="#1f77b4", language="es")
 subida.plot(ax=ax, color="#d62728", language="es")
 plt.show()
@@ -231,12 +226,12 @@ retorno, los tiempos de propagación y el número de reflexiones en el suelo.
 
 ```python
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
-perfil = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
-rayos = atmospheric_ray_paths(perfil, source_height=2.0,
-                              launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                              max_range=600.0)
+perfil = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)
+rayos = environment.atmospheric_ray_paths(perfil, source_height=2.0,
+                                          launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                          max_range=600.0)
 rayos.turning_points      # puntos de retorno por rayo
 rayos.plot()              # el abanico de rayos curvados (necesita matplotlib)
 ```
@@ -260,13 +255,13 @@ de un gradiente que nadie midió.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import atmospheric_ray_paths, log_linear_sound_speed_profile
+from phonometry import environment
 
 # Refracción hacia abajo: el espejo favorable del caso con sombra.
-perfil = log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
-rayos = atmospheric_ray_paths(perfil, source_height=2.0,
-                              launch_angles_deg=np.linspace(-8.0, 8.0, 17),
-                              max_range=600.0, n_steps=600)
+perfil = environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0)
+rayos = environment.atmospheric_ray_paths(perfil, source_height=2.0,
+                                          launch_angles_deg=np.linspace(-8.0, 8.0, 17),
+                                          max_range=600.0, n_steps=600)
 rayos.plot(language="es")   # los rayos rasantes vuelven al suelo y rebotan a lo largo
 plt.show()
 ```
@@ -327,7 +322,7 @@ fig, ax = plt.subplots()
 for hs, hr, etiqueta in [(0.5, 1.5, "0,5 / 1,5 m"), (2.0, 2.0, "2 / 2 m"),
                          (2.0, 10.0, "2 / 10 m")]:
     ax.loglog(gradientes,
-              [shadow_zone_distance(-g, hs, hr, ground_speed=340.0)
+              [environment.shadow_zone_distance(-g, hs, hr, ground_speed=340.0)
                for g in gradientes], label=etiqueta)
 ax.set_xlabel("Gradiente hacia arriba |g| [1/s]")
 ax.set_ylabel("Distancia de zona de sombra [m]")
@@ -360,12 +355,12 @@ $\Delta L(z, r) = 20\log_{10}(|p| R_1)$ (dB respecto al campo
 libre) en todo el plano distancia-altura.
 
 ```python
-from phonometry import atmospheric_parabolic_equation, log_linear_sound_speed_profile
+from phonometry import environment
 
-perfil = log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # hacia arriba
-pe = atmospheric_parabolic_equation(400.0, perfil, source_height=2.0,
-                                    flow_resistivity=200e3,  # pradera
-                                    max_range=600.0, max_height=40.0)
+perfil = environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0)  # hacia arriba
+pe = environment.atmospheric_parabolic_equation(400.0, perfil, source_height=2.0,
+                                                flow_resistivity=200e3,  # pradera
+                                                max_range=600.0, max_height=40.0)
 pe.level_at_height(2.0)   # nivel relativo frente a distancia a 2 m
 pe.plot()                 # el campo de nivel relativo distancia-altura (necesita matplotlib)
 ```
@@ -389,17 +384,12 @@ import warnings
 
 import matplotlib.pyplot as plt
 
-from phonometry import (
-    atmospheric_parabolic_equation,
-    linear_sound_speed_profile,
-    log_linear_sound_speed_profile,
-    shadow_zone_distance,
-)
+from phonometry import environment
 
 casos = [
-    (log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Hacia abajo (b = +1 m/s)"),
-    (linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogénea (b = 0)"),
-    (log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Hacia arriba (b = -1 m/s)"),
+    (environment.log_linear_sound_speed_profile(+1.0, ground_speed=340.0), "Hacia abajo (b = +1 m/s)"),
+    (environment.linear_sound_speed_profile(0.0, ground_speed=340.0), "Homogénea (b = 0)"),
+    (environment.log_linear_sound_speed_profile(-1.0, ground_speed=340.0), "Hacia arriba (b = -1 m/s)"),
 ]
 fig, ax = plt.subplots(figsize=(11, 6.2))
 with warnings.catch_warnings():
@@ -409,15 +399,15 @@ with warnings.catch_warnings():
     # suelo» en la guía de efecto suelo).
     warnings.simplefilter("ignore")
     for perfil, etiqueta in casos:
-        pe = atmospheric_parabolic_equation(400.0, perfil, source_height=2.0,
-                                            flow_resistivity=200e3,
-                                            max_range=600.0, max_height=40.0)
+        pe = environment.atmospheric_parabolic_equation(400.0, perfil, source_height=2.0,
+                                                        flow_resistivity=200e3,
+                                                        max_range=600.0, max_height=40.0)
         ax.plot(pe.ranges, pe.level_at_height(2.0), label=etiqueta)
 # El límite en forma cerrada del gradiente lineal equivalente hacia arriba
 # (su media a 10 m), la línea punteada de la figura.
 subida = casos[2][0]
 grad = float(subida.speed_at(10.0) - 340.0) / 10.0
-ax.axvline(shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
+ax.axvline(environment.shadow_zone_distance(grad, 2.0, 2.0, ground_speed=340.0),
            color="k", ls=":", label="Límite de la zona de sombra")
 ax.set(xlabel="Distancia [m]", ylabel="Nivel respecto al campo libre [dB]",
        ylim=(-40, 10))
@@ -498,12 +488,12 @@ import numpy as np
 # los fragmentos de arriba. Un suelo rígido no necesita modelo poroso, así que
 # este caso no levanta ningún aviso.
 c0, freq, zs = 343.0, 500.0, 2.0
-plano = linear_sound_speed_profile(1e-12, ground_speed=c0, max_height=200.0)
+plano = environment.linear_sound_speed_profile(1e-12, ground_speed=c0, max_height=200.0)
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    pe = atmospheric_parabolic_equation(freq, plano, source_height=zs,
-                                        impedance=1e6 + 0j, max_range=520.0,
-                                        max_height=150.0)
+    pe = environment.atmospheric_parabolic_equation(freq, plano, source_height=zs,
+                                                    impedance=1e6 + 0j, max_range=520.0,
+                                                    max_height=150.0)
 distancias = np.asarray(pe.ranges)
 metodo = np.asarray(pe.level_at_height(zs))
 k = 2.0 * np.pi * freq / c0

--- a/site/src/content/docs/es/environment/propagation/ground-barriers.mdx
+++ b/site/src/content/docs/es/environment/propagation/ground-barriers.mdx
@@ -104,7 +104,7 @@ $$
 
 ```python
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 
@@ -112,7 +112,7 @@ bands = np.array([63., 125., 250., 500., 1000., 2000., 4000., 8000.])
 # receptor a 1.5 m de altura, separados 50 m. La impedancia procede del modelo
 # poroso de Delany-Bazley de phonometry.materials (suelo semiinfinito).
 # Orden de los argumentos: frecuencias, source_height, receiver_height, distancia.
-res = ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
+res = environment.ground_effect(bands, 1.0, 1.5, 50.0, flow_resistivity=2e5)
 print(res.excess_attenuation)     # la caída del suelo (dB re campo libre)
 print(res.reflection_coefficient) # Q complejo por banda
 res.plot()                        # atenuación en exceso frente a frecuencia
@@ -145,7 +145,7 @@ resistividad en Pa·s/m², no una presión.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import ground_effect
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 4000.0, 400)
 grounds = [
@@ -156,7 +156,7 @@ grounds = [
 ]
 fig, ax = plt.subplots(figsize=(11, 6.4))
 for label, sigma, color in grounds:
-    res = ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
+    res = environment.ground_effect(freqs, 1.0, 1.5, 50.0, flow_resistivity=sigma)
     ax.plot(freqs, res.excess_attenuation, color=color, label=label)
 ax.axhline(6.0, color="k", ls=":", label="Límite de suelo rígido (+6 dB)")
 ax.axhline(0.0, color="k", lw=0.8)
@@ -203,7 +203,7 @@ c0, f, d = 343.0, 500.0, 50.0
 k = 2 * np.pi * f / c0
 q_mod, rp_mod, dl_q, dl_p = [], [], [], []
 for h in alturas:
-    res = ground_effect([f], h, h, d, flow_resistivity=2e5, model="miki")
+    res = environment.ground_effect([f], h, h, d, flow_resistivity=2e5, model="miki")
     rp = res.plane_reflection_coefficient[0]
     q = res.reflection_coefficient[0]
     fase = np.exp(1j * k * (float(res.r_reflected) - float(res.r_direct)))
@@ -312,13 +312,13 @@ difieren en solo 0,15 m.
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_ground_barrier_es.svg" alt="Sección de la geometría de barrera: una fuente altavoz a 1 m del suelo, una pantalla delgada de 4 m a 50 m y un receptor micrófono a 1,5 m de altura a 100 m, el camino directo bloqueado de 100,00 m dibujado a trazos a través de la pantalla y el camino difractado doblado sobre el borde en dos segmentos A = 50,09 m y B = 50,06 m, con una diferencia de caminos de 0,15 m que da un número de Fresnel de 0,44 y una pérdida por inserción de Kurze-Anderson de 10,0 dB a 500 Hz, que sube a 15,5 dB a 2 kHz" width="92%" />
 
 ```python
-from phonometry import barrier_insertion_loss, kurze_anderson_attenuation
+from phonometry import environment
 
-kurze_anderson_attenuation(0.0)     # 5.0 dB en el límite de sombra
+environment.kurze_anderson_attenuation(0.0)     # 5.0 dB en el límite de sombra
 
 # Una barrera de 4 m a 50 m de una fuente a 1 m, receptor a 1.5 m y 100 m.
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="kurze_anderson")
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="kurze_anderson")
 il.plot()                           # pérdida por inserción frente a frecuencia
 ```
 
@@ -359,9 +359,9 @@ import numpy as np
 anchos = np.linspace(0.0, 30.0, 40)
 fig, ax = plt.subplots()
 for freq in (250.0, 500.0, 1000.0):
-    delgada = float(barrier_insertion_loss(
+    delgada = float(environment.barrier_insertion_loss(
         [freq], 1.0, 50.0, 4.0, 100.0, 1.5, method="exact").insertion_loss[0])
-    ganancia = [0.0 if e == 0.0 else float(barrier_insertion_loss(
+    ganancia = [0.0 if e == 0.0 else float(environment.barrier_insertion_loss(
         [freq], 1.0, 50.0, 4.0, 100.0, 1.5, method="exact",
         thickness=e).insertion_loss[0]) - delgada for e in anchos]
     ax.plot(anchos, ganancia, label=f"{freq:g} Hz")
@@ -387,8 +387,8 @@ coherente y recíproco pero no una solución completa por elementos de contorno.
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_barrier_four_paths_es.svg" alt="Sección a escala del modelo coherente de barrera de cuatro caminos: una fuente a 1 m del suelo con su imagen especular 1 m por debajo, una pantalla de 4 m a 50 m, y un receptor a 1,5 m de altura a 100 m con su propia imagen especular bajo el suelo. Se dibujan cuatro rutas difractadas con cuatro trazos distinguibles desde la fuente o su imagen sobre el borde superior hasta el receptor o su imagen, cada una etiquetada con el número de rebotes en el suelo y con el coeficiente de reflexión esférica Q marcado en cada rebote; un panel lateral enumera las cuatro longitudes de camino y las diferencias de camino que fijan la interferencia, y un recuadro repite la geometría de dos bordes de una barrera gruesa con su ancho superior e" width="92%" />
 
 ```python
-il = barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
-                            method="exact", ground_flow_resistivity=2e5)
+il = environment.barrier_insertion_loss(bands, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                        method="exact", ground_flow_resistivity=2e5)
 il.ground        # True: se aplicó el modelo coherente de cuatro caminos
 il.plot()
 ```
@@ -417,16 +417,16 @@ diseño.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 # La barrera de 4 m de los fragmentos anteriores, en una malla fina de frecuencia.
 freqs = np.geomspace(50.0, 5000.0, 240)
-il_ka = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="kurze_anderson")
-il_ex = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact")
-il_gr = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
-                               method="exact", ground_flow_resistivity=2e5)
+il_ka = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="kurze_anderson")
+il_ex = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact")
+il_gr = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5,
+                                           method="exact", ground_flow_resistivity=2e5)
 fig, ax = plt.subplots(figsize=(11, 6.4))
 ax.semilogx(freqs, il_ka.insertion_loss, "--", label="Kurze-Anderson (pantalla delgada)")
 ax.semilogx(freqs, il_ex.insertion_loss, label="Semiplano rígido exacto")
@@ -459,10 +459,10 @@ del que dependen los métodos de pantalla delgada de arriba.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import barrier_insertion_loss
+from phonometry import environment
 
 freqs = np.geomspace(50.0, 5000.0, 240)
-il = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
+il = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5)
 
 # Una línea: la sección a escala, con la diferencia de caminos anotada.
 il.plot_geometry(language="es")

--- a/site/src/content/docs/es/environment/propagation/outdoor-propagation.mdx
+++ b/site/src/content/docs/es/environment/propagation/outdoor-propagation.mdx
@@ -861,18 +861,13 @@ en español.
 
 ```python
 import numpy as np
-from phonometry import (
-    Barrier,
-    ReportMetadata,
-    SourceEmission,
-    outdoor_propagation_attenuation,
-)
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 lw = np.array([95, 100, 103, 105, 104, 101, 95, 88], dtype=float)
-result = outdoor_propagation_attenuation(
+result = environment.outdoor_propagation_attenuation(
     200.0, 4.0, 2.0, freqs, 1.0, 1.0, 1.0,
-    barrier=Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
+    barrier=environment.Barrier(source_to_edge=105.0, edge_to_receiver=105.0),
     temperature=10.0, relative_humidity=70.0,
 )
 result.report(
@@ -882,7 +877,7 @@ result.report(
         test_room="Fachada de la vivienda más próxima",
         requirement=50.0,  # nivel máximo aceptable a favor del viento
     ),
-    source_emission=SourceEmission(sound_power_level=lw),
+    source_emission=environment.SourceEmission(sound_power_level=lw),
     language="es",
 )
 ```
@@ -904,12 +899,12 @@ inserción más alta es mejor).
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, barrier_insertion_loss
+from phonometry import ReportMetadata, environment
 
 freqs = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 # hs = 1 m, barrera de 4 m de alto a 50 m, receptor a 1,5 m de altura y a 100 m
 # *de la fuente*; method="exact" es el semiplano rígido ondulatorio que nombra la ficha.
-result = barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5, method="exact")
+result = environment.barrier_insertion_loss(freqs, 1.0, 50.0, 4.0, 100.0, 1.5, method="exact")
 result.report(
     "barrier_insertion_loss.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/es/environment/sources/cnossos-rail-emission.mdx
+++ b/site/src/content/docs/es/environment/sources/cnossos-rail-emission.mdx
@@ -172,29 +172,23 @@ la fuente B empieza a importar.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    BrakeType, ContactFilter, RailRoughnessClass, RailwayTrack, RailwayVehicle,
-    RollingStock, TrackTransferClass, TractionVehicle, WheelDiameter,
-    aerodynamic_sound_power, contact_filter, impact_roughness_single,
-    rail_roughness, railway_source_power, track_transfer, traction_sound_power,
-    wheel_roughness, wheel_transfer,
-)
+from phonometry import environment
 
-stock = RollingStock(
+stock = environment.RollingStock(
     axles=4,
-    wheel_roughness=wheel_roughness(BrakeType.NON_TREAD),
-    contact_filter=contact_filter(ContactFilter.LOAD_50_DIAMETER_920),
-    wheel_transfer=wheel_transfer(WheelDiameter.MM_920),
-    traction=traction_sound_power(TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
-    aerodynamic=aerodynamic_sound_power(),
+    wheel_roughness=environment.wheel_roughness(environment.BrakeType.NON_TREAD),
+    contact_filter=environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920),
+    wheel_transfer=environment.wheel_transfer(environment.WheelDiameter.MM_920),
+    traction=environment.traction_sound_power(environment.TractionVehicle.ELECTRIC_MULTIPLE_UNIT),
+    aerodynamic=environment.aerodynamic_sound_power(),
 )
-track = RailwayTrack(
-    rail_roughness=rail_roughness(RailRoughnessClass.NORMAL),
-    track_transfer=track_transfer(TrackTransferClass.MONOBLOCK_MEDIUM),
-    impact_roughness=impact_roughness_single(),
+track = environment.RailwayTrack(
+    rail_roughness=environment.rail_roughness(environment.RailRoughnessClass.NORMAL),
+    track_transfer=environment.track_transfer(environment.TrackTransferClass.MONOBLOCK_MEDIUM),
+    impact_roughness=environment.impact_roughness_single(),
 )
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0,
 )
 result.plot(language="es")
 plt.show()
@@ -228,8 +222,8 @@ def total(bands):
     return 10.0 * np.log10(np.sum(10.0 ** (np.asarray(bands) / 10.0)))
 
 fig, (izq, der) = plt.subplots(1, 2, figsize=(12, 4.6))
-result = railway_source_power(
-    RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0)
+result = environment.railway_source_power(
+    environment.RailwayVehicle(stock, flow_rate=96.0, speed=160.0), track, phi=90.0, psi=10.0)
 for name, spectrum in result.components.items():
     for row, height in ((0, "0,5 m"), (1, "4,0 m")):
         values = np.asarray(spectrum)[row]
@@ -242,8 +236,8 @@ izq.legend(fontsize="small")
 velocidades = np.linspace(60.0, 350.0, 30)
 for row, label in [(0, "Fuente A (0,5 m)"), (1, "Fuente B (4,0 m)")]:
     der.plot(velocidades, [
-        total(railway_source_power(
-            RailwayVehicle(stock, flow_rate=96.0, speed=float(v)),
+        total(environment.railway_source_power(
+            environment.RailwayVehicle(stock, flow_rate=96.0, speed=float(v)),
             track, phi=90.0, psi=10.0).line_power[row]) for v in velocidades],
         label=label)
 der.axvline(200.0, ls=":", label="Umbral aerodinámico")
@@ -317,24 +311,20 @@ rugosas.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    RAILWAY_THIRD_OCTAVE_BANDS, BrakeType, ContactFilter, RailRoughnessClass,
-    contact_filter, rail_roughness, roughness_to_frequency,
-    total_effective_roughness, wheel_roughness,
-)
+from phonometry import environment
 
-rail = rail_roughness(RailRoughnessClass.NORMAL)
-wheel = wheel_roughness(BrakeType.NON_TREAD)
-filt = contact_filter(ContactFilter.LOAD_50_DIAMETER_920)
+rail = environment.rail_roughness(environment.RailRoughnessClass.NORMAL)
+wheel = environment.wheel_roughness(environment.BrakeType.NON_TREAD)
+filt = environment.contact_filter(environment.ContactFilter.LOAD_50_DIAMETER_920)
 
 fig, ax = plt.subplots()
 for speed in (60.0, 160.0, 300.0):
-    total = total_effective_roughness(
-        roughness_to_frequency(rail[1], rail[0], speed),
-        roughness_to_frequency(wheel[1], wheel[0], speed),
-        roughness_to_frequency(filt[1], filt[0], speed),
+    total = environment.total_effective_roughness(
+        environment.roughness_to_frequency(rail[1], rail[0], speed),
+        environment.roughness_to_frequency(wheel[1], wheel[0], speed),
+        environment.roughness_to_frequency(filt[1], filt[0], speed),
     )
-    ax.semilogx(RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
+    ax.semilogx(environment.RAILWAY_THIRD_OCTAVE_BANDS, total, label=f"v = {speed:g} km/h")
 ax.legend()
 plt.show()
 ```
@@ -357,10 +347,10 @@ y la que va por defecto es la que reproduce el propio módulo de fuente de
 referencia de la Comisión:
 
 ```python
-from phonometry import RoughnessInterpolation
+from phonometry import environment
 
-RoughnessInterpolation.PROPORTIONAL   # niveles interpolados linealmente en lambda
-RoughnessInterpolation.ENERGY         # energías interpoladas linealmente en lambda
+environment.RoughnessInterpolation.PROPORTIONAL   # niveles interpolados linealmente en lambda
+environment.RoughnessInterpolation.ENERGY         # energías interpoladas linealmente en lambda
 ```
 
 Difieren hasta cerca de 1 dB en un tramo de pendiente pronunciada del espectro.
@@ -406,12 +396,12 @@ de 2021, no la de 2015:
 | Tranvía | curva o aguja con $R \le 200\ \text{m}$ | 5 dB |
 
 ```python
-from phonometry import curve_squeal_excess
+from phonometry import environment
 
-curve_squeal_excess(280.0)                       # 8.0 dB
-curve_squeal_excess(450.0)                       # 5.0 dB
-curve_squeal_excess(280.0, tram=True)            # 0.0 dB, los tranvías piden R <= 200 m
-curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, la curva es demasiado corta
+environment.curve_squeal_excess(280.0)                       # 8.0 dB
+environment.curve_squeal_excess(450.0)                       # 5.0 dB
+environment.curve_squeal_excess(280.0, tram=True)            # 0.0 dB, los tranvías piden R <= 200 m
+environment.curve_squeal_excess(280.0, track_length=20.0)    # 0.0 dB, la curva es demasiado corta
 ```
 
 El texto de 2015 decía «8 dB para R < 300 m y 5 dB para 300 m < R < 500 m», lo
@@ -474,10 +464,10 @@ Ambas están disponibles, porque comparar con un estudio calculado antes de 2021
 requiere la antigua:
 
 ```python
-from phonometry import DirectivityEdition, vertical_directivity
+from phonometry import environment
 
-vertical_directivity(-30.0)                                        # ceros
-vertical_directivity(-30.0, edition=DirectivityEdition.ORIGINAL_2015)  # positivo
+environment.vertical_directivity(-30.0)                                        # ceros
+environment.vertical_directivity(-30.0, edition=environment.DirectivityEdition.ORIGINAL_2015)  # positivo
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/cnossos_rail_directivity_es.svg" alt="Dos diagramas polares de la directividad ferroviaria de CNOSSOS-EU. Izquierda, la corrección vertical de la fuente A a 250 Hz y 4 kHz para las dos ediciones: la forma de 2021 es idénticamente nula en todo el semiespacio por debajo del horizonte y por encima de unos 41,4 grados se vuelve negativa, mientras que la de 2015 es simétrica respecto al horizonte y positiva a ambos lados, coincidiendo las dos solo en la cuña de 0 a 41,4 grados. Derecha, el dipolo horizontal en el plano de la vía: 0 dB en la perpendicular a la vía y menos 20 dB a lo largo de ella, con el cero longitudinal marcado" width="92%" />
@@ -507,9 +497,9 @@ bands = {7: "250 Hz", 19: "4 kHz"}       # índices en los 24 tercios de octava
 fig, (izq, der) = plt.subplots(1, 2, subplot_kw={"projection": "polar"},
                                figsize=(12, 5.0))
 for band, name in bands.items():
-    for edition, style in [(DirectivityEdition.CURRENT, "-"),
-                           (DirectivityEdition.ORIGINAL_2015, "--")]:
-        values = [float(vertical_directivity(float(a), edition=edition)[band])
+    for edition, style in [(environment.DirectivityEdition.CURRENT, "-"),
+                           (environment.DirectivityEdition.ORIGINAL_2015, "--")]:
+        values = [float(environment.vertical_directivity(float(a), edition=edition)[band])
                   for a in psi]
         izq.plot(np.radians(psi), values, style,
                  label=f"{name}, {edition.value}")
@@ -561,11 +551,11 @@ interpolación, así que elegir entre las dos es un juicio sobre el tablero, hec
 antes del cálculo y registrado con él.
 
 ```python
-from phonometry import BridgeType, RailwayTrack, bridge_transfer
+from phonometry import environment
 
-RailwayTrack(
+environment.RailwayTrack(
     rail_roughness=..., track_transfer=...,
-    bridge_transfer=bridge_transfer(BridgeType.PLUS_10_DBA),   # Tabla G-7, col. 1
+    bridge_transfer=environment.bridge_transfer(environment.BridgeType.PLUS_10_DBA),   # Tabla G-7, col. 1
 )
 ```
 

--- a/site/src/content/docs/es/environment/sources/cnossos-road-emission.mdx
+++ b/site/src/content/docs/es/environment/sources/cnossos-road-emission.mdx
@@ -122,19 +122,17 @@ exactamente dónde manda cada categoría.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import (
-    JunctionType, RoadSurface, RoadTraffic, RoadVehicleCategory, road_source_power,
-)
+from phonometry import environment
 
 traffic = [
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1200.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 45.0, 50.0),
-    RoadTraffic(RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1200.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MEDIUM_HEAVY, 90.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 45.0, 50.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.MOTORCYCLES, 60.0, 50.0),
 ]
-result = road_source_power(
-    traffic, surface=RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
-    junction_distance=60.0, junction_type=JunctionType.CROSSING,
+result = environment.road_source_power(
+    traffic, surface=environment.RoadSurface.THIN_LAYER_A, temperature=12.0, gradient=3.0,
+    junction_distance=60.0, junction_type=environment.JunctionType.CROSSING,
 )
 print(result.total_line_power.round(1))
 # [89.1 82.7 81.3 80.2 80.4 76.2 71.7 66. ]  dB re 1 pW por metro de línea
@@ -252,10 +250,10 @@ import numpy as np
 # `road_source_power`, `RoadTraffic`, `RoadVehicleCategory` y `JunctionType`
 # los importa el fragmento de la figura de arriba.
 def a_line(**kwargs):
-    return float(road_source_power(**kwargs).a_weighted_line_power)
+    return float(environment.road_source_power(**kwargs).a_weighted_line_power)
 
-ligeros = [RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 50.0)]
-pesados = [RoadTraffic(RoadVehicleCategory.HEAVY, 1000.0, 50.0)]
+ligeros = [environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 50.0)]
+pesados = [environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 1000.0, 50.0)]
 temps = np.linspace(-10.0, 40.0, 60)
 fig, (t_ax, s_ax, j_ax) = plt.subplots(1, 3, figsize=(13, 4.2))
 for flujo, name in [(ligeros, "Ligeros (1)"), (pesados, "Pesados (3)")]:
@@ -269,10 +267,10 @@ t_ax.legend()
 velocidades = np.linspace(20.0, 130.0, 60)
 for share in (0.2, 0.5):
     s_ax.plot(velocidades, [
-        a_line(traffic=[RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, v,
-                                    studded_fraction=share)],
+        a_line(traffic=[environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, v,
+                                                studded_fraction=share)],
                studded_months=4.0)
-        - a_line(traffic=[RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, v)])
+        - a_line(traffic=[environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, v)])
         for v in velocidades], label=f"Qstud,ratio = {share:g}, Ts = 4 meses")
 s_ax.set(xlabel="Velocidad v [km/h]",
          ylabel="Cambio en la potencia de línea [dB(A)]")
@@ -280,8 +278,8 @@ s_ax.legend(fontsize="small")
 
 xs = np.linspace(0.0, 120.0, 60)
 ref = a_line(traffic=ligeros)
-for junction, name in [(JunctionType.CROSSING, "Cruce con semáforo"),
-                       (JunctionType.ROUNDABOUT, "Glorieta")]:
+for junction, name in [(environment.JunctionType.CROSSING, "Cruce con semáforo"),
+                       (environment.JunctionType.ROUNDABOUT, "Glorieta")]:
     j_ax.plot(xs, [a_line(traffic=ligeros, junction_distance=float(x),
                           junction_type=junction) - ref for x in xs], label=name)
 j_ax.set(xlabel="Distancia al cruce |x| [m]",
@@ -323,20 +321,17 @@ a velocidades urbanas.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    CNOSSOS_A_WEIGHTING, road_propulsion_noise, road_rolling_noise,
-    road_vehicle_sound_power,
-)
+from phonometry import environment
 
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 speeds = np.linspace(20.0, 130.0, 221)
 fig, ax = plt.subplots()
 for category, name in [("1", "Vehículos ligeros (1)"), ("3", "Vehículos pesados (3)")]:
-    rolling = [a_weighted(road_rolling_noise(category, v)) for v in speeds]
-    propulsion = [a_weighted(road_propulsion_noise(category, v)) for v in speeds]
-    total = [a_weighted(road_vehicle_sound_power(category, v)) for v in speeds]
+    rolling = [a_weighted(environment.road_rolling_noise(category, v)) for v in speeds]
+    propulsion = [a_weighted(environment.road_propulsion_noise(category, v)) for v in speeds]
+    total = [a_weighted(environment.road_vehicle_sound_power(category, v)) for v in speeds]
     ax.plot(speeds, total, lw=2.4, label=f"{name} - total")
     ax.plot(speeds, rolling, ls="--", lw=1.2, label=f"{name} - rodadura")
     ax.plot(speeds, propulsion, ls=":", lw=1.2, label=f"{name} - propulsión")
@@ -384,16 +379,16 @@ import numpy as np
 
 # `road_propulsion_noise` y `CNOSSOS_A_WEIGHTING` los importa el fragmento de la
 # figura de las leyes de velocidad de más arriba.
-weights = np.asarray(CNOSSOS_A_WEIGHTING)
+weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 a_weighted = lambda bands: 10.0 * np.log10(np.sum(10.0 ** ((bands + weights) / 10.0)))
 
 pendientes = np.linspace(-14.0, 14.0, 141)
 fig, ax = plt.subplots()
 for category in ("1", "2", "3"):
     for speed, style in [(50.0, "--"), (80.0, "-")]:
-        plano = a_weighted(road_propulsion_noise(category, speed))
+        plano = a_weighted(environment.road_propulsion_noise(category, speed))
         ax.plot(pendientes,
-                [a_weighted(road_propulsion_noise(category, speed, gradient=s)) - plano
+                [a_weighted(environment.road_propulsion_noise(category, speed, gradient=s)) - plano
                  for s in pendientes], style, label=f"Categoría {category}, {speed:g} km/h")
 ax.set_xlabel("Pendiente de la vía s [%]")
 ax.set_ylabel("Corrección del ruido de propulsión [dB(A)]")
@@ -443,9 +438,9 @@ motor que se radia hacia ella, pero una textura rugosa solo genera ruido de
 neumático, y el ruido de neumático ya es el término de rodadura.
 
 ```python
-from phonometry import RoadSurface, road_surface_coefficients
+from phonometry import environment
 
-row = road_surface_coefficients(RoadSurface.TWO_LAYER_ZOAB_FINE)
+row = environment.road_surface_coefficients(environment.RoadSurface.TWO_LAYER_ZOAB_FINE)
 row.speed_range          # (80.0, 130.0) km/h, el rango de validez impreso
 row.alpha["1"]           # alpha por banda de octava para vehículos ligeros
 row.beta["1"]            # -0.1, el coeficiente de velocidad
@@ -472,10 +467,10 @@ import numpy as np
 # `RoadSurface` y `road_surface_coefficients` se importan justo arriba.
 bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
 fig, ax = plt.subplots()
-for surface in (RoadSurface.REFERENCE, RoadSurface.TWO_LAYER_ZOAB_FINE,
-                RoadSurface.ONE_LAYER_ZOAB, RoadSurface.THIN_LAYER_A,
-                RoadSurface.SMA_NL8, RoadSurface.HARD_ELEMENTS_NOT_HERRINGBONE):
-    row = road_surface_coefficients(surface)
+for surface in (environment.RoadSurface.REFERENCE, environment.RoadSurface.TWO_LAYER_ZOAB_FINE,
+                environment.RoadSurface.ONE_LAYER_ZOAB, environment.RoadSurface.THIN_LAYER_A,
+                environment.RoadSurface.SMA_NL8, environment.RoadSurface.HARD_ELEMENTS_NOT_HERRINGBONE):
+    row = environment.road_surface_coefficients(surface)
     # La fila de referencia no lleva rango de velocidad: es válida por definición.
     span = ("todas las velocidades" if row.speed_range is None
             else "{:g}-{:g} km/h".format(*row.speed_range))
@@ -508,30 +503,27 @@ es aritmética y se ofrece como tal.
 
 ```python
 import numpy as np
-from phonometry import (
-    PropagationGeometry, RoadTraffic, RoadVehicleCategory,
-    line_source_segment_power, predicted_receiver_level, road_source_power,
-)
+from phonometry import environment
 
-result = road_source_power([
-    RoadTraffic(RoadVehicleCategory.LIGHT, 1000.0, 90.0),
-    RoadTraffic(RoadVehicleCategory.HEAVY, 120.0, 80.0),
+result = environment.road_source_power([
+    environment.RoadTraffic(environment.RoadVehicleCategory.LIGHT, 1000.0, 90.0),
+    environment.RoadTraffic(environment.RoadVehicleCategory.HEAVY, 120.0, 80.0),
 ])
-segment = line_source_segment_power(result.total_line_power, 20.0)  # tramo de 20 m
+segment = environment.line_source_segment_power(result.total_line_power, 20.0)  # tramo de 20 m
 
 # Un tramo, el que queda justo enfrente de un receptor a 100 m de la carretera.
-levels = predicted_receiver_level(
+levels = environment.predicted_receiver_level(
     segment,
-    PropagationGeometry(100.0, result.source_height, 4.0),
+    environment.PropagationGeometry(100.0, result.source_height, 4.0),
     frequencies=result.frequencies,
 )
 
 # La carretera es la suma energética de sus tramos: 1 km a cada lado, en pasos de 20 m.
 energy = np.zeros_like(levels)
 for x in np.arange(-990.0, 1000.0, 20.0):        # centros de tramo a lo largo de la vía
-    energy += 10 ** (predicted_receiver_level(
+    energy += 10 ** (environment.predicted_receiver_level(
         segment,
-        PropagationGeometry(float(np.hypot(100.0, x)), result.source_height, 4.0),
+        environment.PropagationGeometry(float(np.hypot(100.0, x)), result.source_height, 4.0),
         frequencies=result.frequencies,
     ) / 10)
 road = 10 * np.log10(energy)
@@ -563,13 +555,13 @@ Para el total ponderado A, usa la ponderación por bandas de octava que la propi
 Directiva imprime en el 2.5.5 modificado, en lugar de recalcularla:
 
 ```python
-from phonometry import CNOSSOS_A_WEIGHTING
+from phonometry import environment
 
-CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
+environment.CNOSSOS_A_WEIGHTING   # (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
 result.a_weighted_line_power
 
 # Los dos espectros en el receptor del troceado de arriba, ponderados A:
-weight = np.asarray(CNOSSOS_A_WEIGHTING)
+weight = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 print(round(float(10 * np.log10(np.sum(10 ** ((levels + weight) / 10)))), 1))
 # 52.9 dB(A) - un tramo de 20 m, no la carretera
 print(round(float(10 * np.log10(np.sum(10 ** ((road + weight) / 10)))), 1))
@@ -587,13 +579,13 @@ coeficientes se pueden reemplazar:
 ```python
 import dataclasses
 
-from phonometry import ROAD_COEFFICIENTS
+from phonometry import environment
 
 # Una fila nacional medida para vehículos ligeros y el resto del Apéndice F tal cual.
 national = dataclasses.replace(
-    ROAD_COEFFICIENTS,
+    environment.ROAD_COEFFICIENTS,
     rolling_a={
-        **ROAD_COEFFICIENTS.rolling_a,
+        **environment.ROAD_COEFFICIENTS.rolling_a,
         "1": (83.4, 89.0, 88.1, 93.6, 100.4, 96.9, 87.0, 76.5),
     },
 )

--- a/site/src/content/docs/es/materials/absorbers/metamaterial-absorbers.mdx
+++ b/site/src/content/docs/es/materials/absorbers/metamaterial-absorbers.mdx
@@ -126,18 +126,16 @@ y de su cavidad.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 
 f = np.array([300.0])
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -165,7 +163,7 @@ curva de absorción por sí sola, no.*
 ```python
 # La impedancia a 300 Hz en función de la altura de ranura, una línea cada una.
 for factor in (0.6, 1.0, 1.7):
-    z_h = slit_helmholtz_absorber(
+    z_h = materials.slit_helmholtz_absorber(
         np.array([300.0]), design.resonator, slit_height=factor * design.slit_height,
         lattice_step=3.0e-2, period=5.0e-2,
     ).normalized_impedance[0]
@@ -232,22 +230,20 @@ $\alpha \approx 1$ a la frecuencia de diseño.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 print(round(design.absorption, 4))          # ~1.0 (absorción perfecta)
 print(round(design.slit_height * 1e3, 3))    # altura de ranura resuelta, mm
 
 f = np.linspace(150.0, 500.0, 700)
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -271,9 +267,9 @@ resonancia.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator
+from phonometry import materials
 
-resonator = HelmholtzResonator(
+resonator = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
@@ -295,13 +291,13 @@ sonido lento.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator, critical_coupling_design, materials
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 
@@ -330,20 +326,18 @@ y ensancharla la subamortigua, y ambos bajan el pico por debajo de uno.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
 a, d, f0 = 3.0e-2, 5.0e-2, 300.0
-base = HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
-design = critical_coupling_design(f0, base, lattice_step=a, period=d)
+base = materials.HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
+design = materials.critical_coupling_design(f0, base, lattice_step=a, period=d)
 h0 = design.slit_height
 
 f = np.linspace(150.0, 500.0, 700)
 fig, ax = plt.subplots()
 for factor, label in [(1.0, "acoplamiento crítico"),
                       (0.6, "ranura estrecha"), (1.7, "ranura ancha")]:
-    res = slit_helmholtz_absorber(
+    res = materials.slit_helmholtz_absorber(
         f, design.resonator, slit_height=factor * h0,
         lattice_step=a, period=d,
     )
@@ -386,7 +380,7 @@ modelo responde directamente, y la respuesta es más suave de lo que sugiere el
 # El mismo diseño de 300 Hz, evaluado fuera de la normal. Tanto el cálculo de
 # diseño como el evaluador toman `angle` en radianes.
 for degrees in (0.0, 15.0, 30.0, 45.0, 60.0):
-    off = slit_helmholtz_absorber(
+    off = materials.slit_helmholtz_absorber(
         np.array([300.0]), design.resonator, slit_height=design.slit_height,
         lattice_step=3.0e-2, period=5.0e-2, angle=np.radians(degrees),
     )
@@ -414,16 +408,14 @@ panel puede ser delgado:
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
-res = slit_helmholtz_absorber(
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+res = materials.slit_helmholtz_absorber(
     np.array([300.0]), design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -468,7 +460,7 @@ explica el panel metadifusor de 2 cm de la
 
 ```python
 f_sweep = np.geomspace(50.0, 3000.0, 400)
-swept = slit_helmholtz_absorber(
+swept = materials.slit_helmholtz_absorber(
     f_sweep, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -578,11 +570,11 @@ que ya no está críticamente acoplado a ninguna etapa.*
 ```python
 # `slit_helmholtz_absorber` acepta una lista: esa es la cadena de la ranura.
 f_chain = np.linspace(120.0, 700.0, 700)
-graded = [critical_coupling_design(target, base, lattice_step=3.0e-2,
-                                   period=5.0e-2).resonator
+graded = [materials.critical_coupling_design(target, base, lattice_step=3.0e-2,
+                                             period=5.0e-2).resonator
           for target in (250.0, 320.0, 410.0, 520.0)]
-chain = slit_helmholtz_absorber(f_chain, graded, slit_height=1.20e-3,
-                                lattice_step=3.0e-2, period=5.0e-2)
+chain = materials.slit_helmholtz_absorber(f_chain, graded, slit_height=1.20e-3,
+                                          lattice_step=3.0e-2, period=5.0e-2)
 step = float(f_chain[1] - f_chain[0])
 print(round(float(chain.absorption.max()), 3),
       round(float(np.sum(chain.absorption >= 0.8)) * step))     # 0.999 51

--- a/site/src/content/docs/es/materials/absorbers/porous-absorbers.mdx
+++ b/site/src/content/docs/es/materials/absorbers/porous-absorbers.mdx
@@ -403,23 +403,20 @@ $\rho_\mathrm{t}/\rho_0 = 25,9$.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PorousLayer, decoupling_frequency, johnson_champoux_allard,
-    layered_absorber, limp_frame, limp_frame_applicable,
-)
+from phonometry import materials
 
 # Allard & Atalla, tabla 11.2: capa fibrosa blanda, 50 mm.
 f = np.linspace(1.0, 2000.0, 800)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     f, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 
-print(round(decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
+print(round(materials.decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
 # 127.4
 print(round(float(limp.effective_density[0].real), 1))     # 31.2 = rho_t
-print(limp_frame_applicable(20e3), limp_frame_applicable(25e3))  # True False
+print(materials.limp_frame_applicable(20e3), materials.limp_frame_applicable(25e3))  # True False
 
 limp.plot(language="es")   # Zc y k normalizados del medio corregido
 plt.show()
@@ -453,18 +450,16 @@ octava y algo mayor a ambos lados de 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PorousLayer, johnson_champoux_allard, layered_absorber, limp_frame,
-)
+from phonometry import materials
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 1000], dtype=float)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     bands, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 for medium in (rigid, limp):
-    print(layered_absorber(bands, [PorousLayer(0.05, medium)]).absorption.round(2))
+    print(materials.layered_absorber(bands, [materials.PorousLayer(0.05, medium)]).absorption.round(2))
 # [0.07 0.11 0.17 0.24 0.32 0.43 0.54 0.64 0.88]   esqueleto rígido
 # [0.04 0.08 0.15 0.24 0.36 0.48 0.61 0.71 0.91]   esqueleto flexible
 ```
@@ -591,31 +586,28 @@ fig. 6.10.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, biot_waves, frame_elastic_coefficient,
-    frame_quarter_wave_resonance, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 # Allard & Atalla, tabla 6.1: lana de vidrio "Domisol Coffrage", 100 mm, pegada.
 f = np.linspace(200.0, 1500.0, 1301)
 shear = 2.2e6 * (1 + 0.1j)          # 220 N/cm2, factor de pérdidas 0,1
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     f, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 
-print(frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
-print(round(frame_quarter_wave_resonance(
+print(materials.frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
+print(round(materials.frame_quarter_wave_resonance(
     0.10, shear_modulus=shear, poisson_ratio=0.0, frame_density=130.0), 1))
 # 459.9
 
-waves = biot_waves(med, porosity=0.94, tortuosity=1.06,
-                   frame_density=130.0, shear_modulus=shear)
+waves = materials.biot_waves(med, porosity=0.94, tortuosity=1.06,
+                             frame_density=130.0, shear_modulus=shear)
 print(round(float(abs(waves.airborne_velocity_ratio[800])), 1))     # 42.4
 print(np.round(waves.frame_borne_velocity_ratio[-1], 3))  # (0.811+0.473j)
 
-biot = layered_absorber(f, [PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
-rigid = layered_absorber(f, [PorousLayer(0.10, med)])
+biot = materials.layered_absorber(f, [materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
+rigid = materials.layered_absorber(f, [materials.PorousLayer(0.10, med)])
 
 fig, ax = plt.subplots()
 for res, style in ((rigid, "--"), (biot, "-")):
@@ -652,19 +644,17 @@ de 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 bands = np.array([250, 315, 400, 500, 630, 800, 1000], dtype=float)
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     bands, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 shear = 2.2e6 * (1 + 0.1j)
-for layer in (PorousLayer(0.10, med),
-              PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
-    print(layered_absorber(bands, [layer]).absorption.round(2))
+for layer in (materials.PorousLayer(0.10, med),
+              materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
+    print(materials.layered_absorber(bands, [layer]).absorption.round(2))
 # [0.55 0.58 0.62 0.65 0.69 0.74 0.78]   esqueleto rígido
 # [0.53 0.56 0.61 0.77 0.71 0.74 0.78]   Biot poroelástico
 ```

--- a/site/src/content/docs/es/materials/diffusers/metadiffusers.mdx
+++ b/site/src/content/docs/es/materials/diffusers/metadiffusers.mdx
@@ -154,12 +154,7 @@ la secuencia de cinco pozos seis veces (`periods=6`, un panel de 2,1 m):
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    metadiffuser_polar_response,
-    metadiffuser_reflection,
-)
+from phonometry import materials
 
 # El metadifusor de residuo cuadrático publicado: cinco ranuras con dos
 # resonadores cada una en un panel de 35 cm x 2 cm (paso de 7 cm),
@@ -177,12 +172,12 @@ filas = [  # ranura h, cuello l_n, cavidad l_c, cuello w_n, cavidad w_c [mm]
 ]
 pozos = []
 for h, ln, lc, wn, wc in filas:
-    resonador = HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
+    resonador = materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
     # dos resonadores idénticos por ranura
-    pozos.append(MetadiffuserWell(h * mm, (resonador, resonador)))
+    pozos.append(materials.MetadiffuserWell(h * mm, (resonador, resonador)))
 
 f = np.arange(1800.0, 2601.0, 5.0)
-panel = metadiffuser_reflection(f, pozos, depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(f, pozos, depth=0.02, period=0.07)
 alfa1 = panel.well_absorption[0]
 print(round(float(alfa1.max()), 2), int(f[alfa1.argmax()]))  # 0.99 2305
 
@@ -197,8 +192,8 @@ print(round(float(panel.absorption.max()), 3), peak)
 
 # Comparación de campo lejano: la secuencia de cinco pozos repetida seis
 # veces (2,1 m).
-polar = metadiffuser_polar_response(2000.0, pozos, depth=0.02,
-                                    period=0.07, periods=6)
+polar = materials.metadiffuser_polar_response(2000.0, pozos, depth=0.02,
+                                              period=0.07, periods=6)
 print(round(polar.coefficient, 2))                           # 0.32
 ```
 
@@ -271,12 +266,7 @@ a su fase de reflexión.*
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    materials,
-    metadiffuser_polar_response,
-)
+from phonometry import materials
 
 mm = 1e-3
 filas = [
@@ -287,17 +277,17 @@ filas = [
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 pozos = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in filas
 ]
 
 # El panel metadifusor y el QRD al que se ajustó, a 2 kHz y con seis
 # repeticiones del periodo (paneles de 2,1 m).
-meta = metadiffuser_polar_response(2000.0, pozos, depth=0.02, period=0.07,
-                                   periods=6)
+meta = materials.metadiffuser_polar_response(2000.0, pozos, depth=0.02, period=0.07,
+                                             periods=6)
 secuencia = np.roll(materials.quadratic_residue_sequence(5), -1)
 profundidades = secuencia * (343.0 / 500.0) / (2 * 5)
 qrd = materials.predict_diffuser_polar_response(
@@ -344,11 +334,11 @@ grados de los objetivos del QRD manteniendo $|R_n|$ cerca de uno:
 
 ```python
 import numpy as np
-from phonometry import materials, metadiffuser_reflection
+from phonometry import materials
 
 # pozos: las cinco ranuras publicadas del ejemplo de arriba.
-panel = metadiffuser_reflection(np.array([2000.0]), pozos,
-                                depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(np.array([2000.0]), pozos,
+                                          depth=0.02, period=0.07)
 fases = np.degrees(np.angle(panel.reflection[:, 0]))
 print(np.round(np.abs(panel.reflection[:, 0]), 2))  # [0.97 1.   1.   0.97 0.98]
 print(np.round(fases))                              # [ 75. -71. -71.  74.   2.]
@@ -380,7 +370,7 @@ import matplotlib.pyplot as plt
 
 # `pozos` y `profundidades` vienen de los bloques de arriba.
 barrido = np.linspace(1600.0, 2600.0, 201)
-barrida = metadiffuser_reflection(barrido, pozos, depth=0.02, period=0.07)
+barrida = materials.metadiffuser_reflection(barrido, pozos, depth=0.02, period=0.07)
 k_barrido = 2 * np.pi * barrido / 343.0
 fase_objetivo = np.angle(np.exp(-2j * np.outer(profundidades, k_barrido)))
 error = np.degrees(np.angle(np.exp(1j * (np.angle(barrida.reflection)
@@ -422,10 +412,10 @@ def panel_con(cavidad_mm):
     prueba = [(14.7, 13.0, cavidad_mm, 6.2, 9.0)] + filas[1:]
     construidos = []
     for h, ln, lc, wn, wc in prueba:
-        resonador = HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
-        construidos.append(MetadiffuserWell(h * mm, (resonador, resonador)))
-    return metadiffuser_reflection(np.array([2000.0]), construidos,
-                                   depth=0.02, period=0.07)
+        resonador = materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
+        construidos.append(materials.MetadiffuserWell(h * mm, (resonador, resonador)))
+    return materials.metadiffuser_reflection(np.array([2000.0]), construidos,
+                                             depth=0.02, period=0.07)
 
 mejor = None
 for cavidad_mm in np.linspace(4.0, 22.0, 60):

--- a/site/src/content/docs/es/perception/speech/objective-intelligibility.mdx
+++ b/site/src/content/docs/es/perception/speech/objective-intelligibility.mdx
@@ -88,7 +88,7 @@ da error en lugar de devolver un número. Tienen que sobrevivir al menos unos
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(11)
@@ -107,9 +107,9 @@ noise = rng.standard_normal(n)
 noise *= np.sqrt(np.mean(clean ** 2) / np.mean(noise ** 2))   # SNR de 0 dB
 degraded = clean + noise
 
-d = stoi(clean, degraded, fs)               # STOI, remuestreado a 10 kHz por dentro
+d = speech.stoi(clean, degraded, fs)               # STOI, remuestreado a 10 kHz por dentro
 print(round(d.value, 3))                    # 0.708
-print(round(stoi(clean, clean, fs).value, 6))   # 1.0  (una señal contra sí misma)
+print(round(speech.stoi(clean, clean, fs).value, 6))   # 1.0  (una señal contra sí misma)
 ```
 
 Todo hasta los segmentos de 384 ms es común; las dos medidas solo se separan
@@ -208,7 +208,7 @@ segmento, STOI es **invariante al nivel de reproducción** de la señal degradad
 y a mayor SNR corresponde una puntuación monótonamente mayor.
 
 ```python
-from phonometry import stoi
+from phonometry import speech
 
 # La señal `clean` tipo habla de la sección 1, degradada con cuatro relaciones
 # señal-ruido. Conviene que la referencia siga siendo tipo habla: una referencia
@@ -217,7 +217,7 @@ from phonometry import stoi
 for snr_db in (-10, 0, 10, 20):
     g = 10.0 ** (-snr_db / 20.0)
     noisy = clean + g * rng.standard_normal(clean.size)
-    print(snr_db, round(stoi(clean, noisy, fs).value, 3))
+    print(snr_db, round(speech.stoi(clean, noisy, fs).value, 3))
 # -10 0.083 | 0 0.484 | 10 0.858 | 20 0.956
 ```
 
@@ -240,7 +240,7 @@ degradación, algo que el número único no puede indicar.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.signal import butter, lfilter
-from phonometry import stoi
+from phonometry import speech
 
 # Material tipo habla: ruido de banda limitada con envolvente silábica de
 # 3,5 Hz, en un enmascarador plano con SNR de 0 dB.
@@ -252,7 +252,7 @@ carrier = lfilter(b, a, rng.standard_normal(t.size))
 clean = carrier * (0.15 + 0.85 * np.abs(np.sin(2 * np.pi * 3.5 * t)) ** 2)
 masker = rng.standard_normal(clean.size)
 gain = np.sqrt(np.mean(clean ** 2)) / np.sqrt(np.mean(masker ** 2))
-res = stoi(clean, clean + gain * masker, fs)
+res = speech.stoi(clean, clean + gain * masker, fs)
 print(round(res.value, 3))    # 0.727
 
 # En una línea: la correlación intermedia por banda que hay tras el índice.
@@ -308,11 +308,11 @@ ref = np.fft.irfft(spec, n) * np.where(env < 0.08, 0.0, env)
 
 masker = fig_rng.standard_normal(n)
 masker *= np.sqrt(np.mean(ref ** 2) / np.mean(masker ** 2))
-steady = stoi(ref, ref + masker, fs)
+steady = speech.stoi(ref, ref + masker, fs)
 
 hole = np.ones(n)
 hole[int(1.6 * fs):int(1.95 * fs)] = 0.0        # un corte de 0,35 s
-dropout = stoi(ref, ref * hole, fs)
+dropout = speech.stoi(ref, ref * hole, fs)
 
 print(round(steady.value, 3), round(dropout.value, 3))   # 0.772 0.874
 print(round(float(dropout.segment_scores.min()), 3))     # -0.078
@@ -350,7 +350,7 @@ el promedio por banda de STOI apenas capta.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(20)
@@ -369,8 +369,8 @@ snrs = np.arange(-15.0, 20.1, 5.0)
 
 def curve(masker, extended):
     p_m = np.sqrt(np.mean(masker ** 2))
-    return [stoi(clean, clean + (p_clean / (p_m * 10.0 ** (s / 20.0))) * masker,
-                 fs, extended=extended).value for s in snrs]
+    return [speech.stoi(clean, clean + (p_clean / (p_m * 10.0 ** (s / 20.0))) * masker,
+                        fs, extended=extended).value for s in snrs]
 
 fig, (a, b) = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
 for ax, extended, title in ((a, False, "STOI"), (b, True, "ESTOI")):

--- a/site/src/content/docs/es/perception/speech/speech-intelligibility.mdx
+++ b/site/src/content/docs/es/perception/speech/speech-intelligibility.mdx
@@ -566,18 +566,18 @@ imprime `0,0588` en cada una de sus 17 bandas y por tanto suma 0,9996.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import SII_METHODS, sii_procedure
+from phonometry import speech
 
 # Una línea: el .plot() de cada procedimiento escalona su Ii sobre sus límites.
 fig, ax = plt.subplots(figsize=(10, 6))
-for method in SII_METHODS:
-    sii_procedure(method).plot(ax=ax, linewidth=1.8)
+for method in speech.SII_METHODS:
+    speech.sii_procedure(method).plot(ax=ax, linewidth=1.8)
 plt.show()
 
 # A mano, replicando lo que dibuja SIIProcedure.plot():
 fig, ax = plt.subplots()
-for method in SII_METHODS:
-    proc = sii_procedure(method)
+for method in speech.SII_METHODS:
+    proc = speech.sii_procedure(method)
     ii = proc.band_importance
     ax.plot(proc.band_edges, np.append(ii, ii[-1]), drawstyle="steps-post",
             label=method)

--- a/site/src/content/docs/es/signals/filters/filter-banks.mdx
+++ b/site/src/content/docs/es/signals/filters/filter-banks.mdx
@@ -359,16 +359,16 @@ magnitud unidad en todas las frecuencias (solo gira la fase).
 
 ```python
 import numpy as np
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 rng = np.random.default_rng(1)
 x = rng.standard_normal(fs)                 # un segundo de ruido
 
-eq = ParametricEQ(fs, [
-    EQSection("lowshelf", 100.0, gain_db=4.0),
-    EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # recorte de 1 octava
-    EQSection("highshelf", 8000.0, gain_db=3.0),
+eq = filters.ParametricEQ(fs, [
+    filters.EQSection("lowshelf", 100.0, gain_db=4.0),
+    filters.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # recorte de 1 octava
+    filters.EQSection("highshelf", 8000.0, gain_db=3.0),
 ])
 y = eq.filter(x)              # aplicar la cascada
 res = eq.response()           # resultado congelado con la cascada SOS
@@ -393,21 +393,21 @@ figura.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 familia = [
-    EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
-    EQSection("lowshelf", 125.0, gain_db=6.0),
-    EQSection("highshelf", 4000.0, gain_db=-6.0),
-    EQSection("lowpass", 10000.0),
-    EQSection("highpass", 50.0),
-    EQSection("bandpass", 500.0, q=2.0),
-    EQSection("notch", 2000.0, q=6.0),
+    filters.EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
+    filters.EQSection("lowshelf", 125.0, gain_db=6.0),
+    filters.EQSection("highshelf", 4000.0, gain_db=-6.0),
+    filters.EQSection("lowpass", 10000.0),
+    filters.EQSection("highpass", 50.0),
+    filters.EQSection("bandpass", 500.0, q=2.0),
+    filters.EQSection("notch", 2000.0, q=6.0),
 ]
 fig, ax = plt.subplots(figsize=(10, 6))
 for section in familia:
-    res = ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
+    res = filters.ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
     ax.semilogx(res.frequencies, res.magnitude_db,
                 label=f"{section.filter_type} @ {section.f0:g} Hz")
 ax.set(xlim=(20, 20000), ylim=(-27, 9),

--- a/site/src/content/docs/es/signals/filters/filter-compliance.mdx
+++ b/site/src/content/docs/es/signals/filters/filter-compliance.mdx
@@ -397,14 +397,10 @@ traducidas y coma como separador decimal), p. ej.
 `result.report("iec61260_es.pdf", language="es")`.
 
 ```python
-from phonometry import (
-    OctaveFilterBank,
-    ReportMetadata,
-    filter_class_compliance,
-)
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # overall_class == 1
 result.plot(language="es")   # la banda de peor margen sobre su corredor de clase
 
 result.report(
@@ -432,8 +428,8 @@ ANSI S1.11-2004, que conserva la **clase 0** más estricta que la edición de 20
 eliminó, de modo que un banco de orden 6 puede certificarse a clase 0:
 
 ```python
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
-result = filter_class_compliance(bank, edition="1995")   # overall_class == 0
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
+result = filters.filter_class_compliance(bank, edition="1995")   # overall_class == 0
 result.plot(language="es")   # el corredor de clase 0 de la edición de 1995
 result.report("iec61260_1995.pdf",
               metadata=ReportMetadata(measurement_standard="IEC 61260:1995",

--- a/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
@@ -227,10 +227,10 @@ ficha acreditada de una página con una fila opcional de CUMPLE/NO CUMPLE
 frente a una clase exigida:
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # result.overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # result.overall_class == 1
 result.report(
     "iec61260_es.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/es/signals/metrology/data-qualification.mdx
+++ b/site/src/content/docs/es/signals/metrology/data-qualification.mdx
@@ -122,12 +122,12 @@ Tabla A.6 de B&P, cuyas filas de $\alpha = 0{,}05$ reproduce exactamente
 (veinte observaciones, $A = 86$, aceptado en $(64, 125]$) corre tal cual:
 
 ```python
-from phonometry import trend_test
+from phonometry import metrology
 
 values = [5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
           5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0]
 
-res = trend_test(values)                  # B&P Ejemplo 4.4
+res = metrology.trend_test(values)                  # B&P Ejemplo 4.4
 print(res.statistic, res.bounds)          # 86, (64, 125]: semiabierto
 print(res.trend_free, round(res.p_value, 3))   # True, 0.586
 res.plot(language="es")
@@ -149,14 +149,14 @@ monótona, que es por lo que el recuento funciona sin conocer la distribución.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 example = np.array([5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
                     5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0])
 drifting = example + np.linspace(0.0, 4.0, example.size)   # deriva ascendente
 
-res_flat = trend_test(example)
-res_drift = trend_test(drifting)
+res_flat = metrology.trend_test(example)
+res_drift = metrology.trend_test(drifting)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, example.size + 1)
@@ -215,17 +215,17 @@ inmediato, mientras que el mismo ruido sin deriva pasa:
 
 ```python
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 noise = np.random.default_rng(42).standard_normal(n)
 
-res = stationarity_test(noise, fs)        # 20 segmentos, medias cuadráticas
+res = metrology.stationarity_test(noise, fs)        # 20 segmentos, medias cuadráticas
 print(res.stationary, res.count, res.bounds)   # True, 91, (64, 125)
 
 drifting = noise * np.linspace(1.0, 1.2, n)    # rampa de ganancia del +20 %
-res = stationarity_test(drifting, fs)
+res = metrology.stationarity_test(drifting, fs)
 print(res.stationary, res.count)          # False, 7  (tendencia al alza -> A bajo)
 res.plot(language="es")
 ```
@@ -246,15 +246,15 @@ ancho de banda ni de las unidades del registro.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 steady = np.random.default_rng(42).standard_normal(n)
 ramp = np.random.default_rng(42).standard_normal(n) * np.linspace(1.0, 1.2, n)
 
-res_steady = stationarity_test(steady, fs)
-res_ramp = stationarity_test(ramp, fs)
+res_steady = metrology.stationarity_test(steady, fs)
+res_ramp = metrology.stationarity_test(ramp, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, res_steady.n_segments + 1)
@@ -356,8 +356,8 @@ glide = np.sin(2 * np.pi * (200 * t + (2000 - 200) / (2 * t[-1]) * t ** 2))
 sos = signal.butter(6, [200 / (fs / 2), 400 / (fs / 2)], btype="band",
                     output="sos")
 
-full = stationarity_test(glide, fs)
-banded = stationarity_test(signal.sosfiltfilt(sos, glide), fs)
+full = metrology.stationarity_test(glide, fs)
+banded = metrology.stationarity_test(signal.sosfiltfilt(sos, glide), fs)
 print(full.count, full.stationary)       # 96 True   -- ciego
 print(banded.count, banded.stationary)   # 173 False -- lo pilla
 
@@ -387,15 +387,15 @@ clásica $(6, 15]$:
 
 ```python
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
-res = trend_test(rng.standard_normal(40), method="runs")
+res = metrology.trend_test(rng.standard_normal(40), method="runs")
 print(res.statistic, res.bounds, res.trend_free)
 res.plot(language="es")   # la secuencia sobre su mediana con el veredicto
 
 alternating = np.tile([1.0, -1.0], 10)   # 20 rachas: rechazado por el otro lado
-print(trend_test(alternating, method="runs").trend_free)   # False
+print(metrology.trend_test(alternating, method="runs").trend_free)   # False
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test_es.svg" alt="Dos paneles de secuencias clasificadas respecto a su mediana, puntos por encima en azul y por debajo en rojo. Izquierda: cuarenta observaciones gaussianas con veinte rachas dentro de la región de aceptación de catorce a veintisiete, veredicto sin tendencia. Derecha: una secuencia de veinte valores estrictamente alternante que también da veinte rachas, pero contra la región de aceptación de seis a quince para veinte valores, veredicto rechazado por alternancia demasiado rápida" width="92%" />
@@ -412,19 +412,19 @@ demasiado pocas.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
 sequences = [rng.standard_normal(40), np.tile([1.0, -1.0], 10)]
 
 # Una línea por secuencia: los valores analizados con el veredicto:
-trend_test(sequences[0], method="runs").plot(language="es")
+metrology.trend_test(sequences[0], method="runs").plot(language="es")
 plt.show()
 
 # Los dos veredictos lado a lado, clasificados respecto a la mediana:
 fig, axes = plt.subplots(1, 2, figsize=(11, 4.5))
 for ax, seq in zip(axes, sequences):
-    res = trend_test(seq, method="runs")
+    res = metrology.trend_test(seq, method="runs")
     idx = np.arange(1, seq.size + 1)
     median = np.median(seq)
     above = seq > median
@@ -472,13 +472,13 @@ nivel y pone al lado la curva de Rice, tomando los momentos del propio
 
 ```python
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # una sinusoide de 60 Hz...
 
-res = level_crossing_rate(x, fs)
+res = metrology.level_crossing_rate(x, fs)
 print(round(res.zero_crossing_rate, 1))   # ...tiene 120 ceros por segundo
 print(round(res.apparent_frequency, 1))   # 60.0
 res.plot(language="es")
@@ -501,7 +501,7 @@ segundo y la dispersión es la estadística del registro, no un fallo del modelo
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 20480.0
 n = 1 << 19
@@ -511,7 +511,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[(freqs < 800.0) | (freqs > 1200.0)] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
+res = metrology.level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.levels, res.rice_rates, label="Rice (Ec. 5.196)")
@@ -588,13 +588,13 @@ la mezcla de Rice (Ecs. (5.217)/(5.223)) interpola ambas, disponible como
 
 ```python
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # banda estrecha: r es en esencia 1
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 print(round(res.irregularity_factor, 3))       # 0.997
 print(res.peak_exceedance(4.0))                # exp(-8): aprox. 1 entre 3000
 res.plot(language="es")   # excedencia empírica contra la mezcla de Rice (figura de abajo)
@@ -617,7 +617,7 @@ un registro que no es de banda estrecha sobrestima los extremos.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 from phonometry.metrology.data_qualification import _rice_peak_exceedance
 
 fs = 20480.0
@@ -628,7 +628,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[freqs > 2000.0] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 peaks = res.peak_values
 empirical = 1.0 - np.arange(1, peaks.size + 1) / peaks.size
 z = np.linspace(-2.5, 4.5, 400)

--- a/site/src/content/docs/es/signals/spectra/cepstrum-echoes.mdx
+++ b/site/src/content/docs/es/signals/spectra/cepstrum-echoes.mdx
@@ -85,13 +85,13 @@ se separan - en el dominio cepstral (Havelock cap. 27, Ecs. (22)-(23)).
 
 ```python
 import numpy as np
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(1)
 x = rng.standard_normal(4096)
 
-res = cepstrum(x, fs, kind="power")
+res = signals.cepstrum(x, fs, kind="power")
 print(res.quefrencies[:3], res.cepstrum.shape)   # eje de quefrencia, en s
 res.plot(language="es")
 ```
@@ -111,7 +111,7 @@ potencia, y la ondícula fuente se concentra por debajo de 2 ms.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 # Una ondícula fuente de banda limitada más una reflexión en 8 ms (a = 0,5)
@@ -121,13 +121,13 @@ s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
 # Una línea por variante: cada CepstrumResult se dibuja solo:
-cepstrum(x, fs, kind="power").plot(language="es")
+signals.cepstrum(x, fs, kind="power").plot(language="es")
 plt.show()
 
 # Las tres variantes superpuestas a mano en un mismo eje de quefrencia:
 fig, ax = plt.subplots()
 for kind, style in (("power", "-"), ("real", "--"), ("complex", ":")):
-    res = cepstrum(x, fs, kind=kind)
+    res = signals.cepstrum(x, fs, kind=kind)
     q_ms = 1e3 * res.quefrencies
     mask = (q_ms > 0.5) & (q_ms <= 20.0)
     ax.plot(q_ms[mask], res.cepstrum[mask], style, label=f"cepstrum {kind}")
@@ -181,14 +181,14 @@ muestras).
 
 ```python
 import numpy as np
-from phonometry import echo_detection
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(2)
 s = rng.standard_normal(12000)               # fuente de banda ancha
 x = s + 0.5 * np.roll(s, 384)                # eco: 8 ms, a = 0.5
 
-res = echo_detection(x, fs, min_quefrency=0.002)
+res = signals.echo_detection(x, fs, min_quefrency=0.002)
 print(res.delay, res.reflection_coefficient)  # 0.008 s, ~0.5
 res.plot(language="es")
 ```
@@ -211,7 +211,7 @@ búsqueda empieza por encima de ella.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import echo_detection, noise_signal
+from phonometry import signals
 
 fs = 48000.0
 n = 12000
@@ -220,9 +220,9 @@ impulse[0] = 1.0
 b, a = sp_signal.butter(2, [0.004, 0.9], btype="bandpass")
 direct = sp_signal.lfilter(b, a, impulse)              # clic de banda ancha
 ir = direct + 0.5 * np.roll(direct, int(0.008 * fs))   # eco a 8 ms
-ir += noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
+ir += signals.noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
 
-res = echo_detection(ir, fs, min_quefrency=0.002)
+res = signals.echo_detection(ir, fs, min_quefrency=0.002)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 half = res.nfft // 2 + 1
@@ -309,15 +309,15 @@ lineal en el dominio logarítmico:
 
 ```python
 import numpy as np
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(3)
 s = rng.standard_normal(12000)
 x = s + 0.5 * np.roll(s, 384)                # el mismo eco de 8 ms
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")    # envolvente de ln|X|
-high = lifter(x, fs, cutoff=0.004, mode="highpass")  # el rizado del eco
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")    # envolvente de ln|X|
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")  # el rizado del eco
 print(np.allclose(low.liftered_db + high.liftered_db, low.spectrum_db))
 low.plot(language="es")
 ```
@@ -336,7 +336,7 @@ $20\log_{10}(1 \pm a) = +3{,}5$ y $-6{,}0$ dB.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 # Una ondícula de banda limitada con un eco puro de 8 ms (a = 0,5), de modo
@@ -346,8 +346,8 @@ s = np.zeros(4096)
 s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")
-high = lifter(x, fs, cutoff=0.004, mode="highpass")
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")
 
 # Una línea: el cepstrum con el corte y los dos espectros logarítmicos:
 low.plot(language="es")
@@ -390,14 +390,14 @@ que la transformada directa elimina y guarda en `linear_phase_samples`:
 ```python
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 x = np.zeros(2048)
 b, a = sp_signal.butter(2, 0.3)
 x[37:293] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 
-res = cepstrum(x, fs, kind="complex")
+res = signals.cepstrum(x, fs, kind="complex")
 print(res.linear_phase_samples)              # negativo: retardo eliminado
 print(np.max(np.abs(res.invert() - x)))      # ~1e-14
 res.plot(language="es")   # el cepstrum complejo frente a la quefrencia
@@ -466,13 +466,13 @@ en un bin de análisis las formas cerradas son:
 
 ```python
 import numpy as np
-from phonometry import envelope_spectrum
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(4 * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 k = int(round(25.0 * res.nfft / fs))
 print(res.mean_level, res.amplitude[k])      # ~1.0 y ~0.4
 res.plot(language="es")
@@ -495,15 +495,15 @@ que el espectro de la propia portadora esconde.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope_spectrum, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 seconds = 4.0
 t = np.arange(int(seconds * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
-x += noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.frequencies, res.amplitude, lw=1.4,
@@ -567,8 +567,8 @@ t_s = np.arange(int(4 * fs)) / fs
 ring = np.sin(2 * np.pi * 3000.0 * t_s) * np.exp(-(t_s % (1 / 120.0)) / 0.001)
 raw = ring + 3.0 * np.sin(2 * np.pi * 50.0 * t_s)
 
-wide = envelope_spectrum(raw, fs)
-narrow = envelope_spectrum(raw, fs, band=(2000.0, 4000.0))
+wide = signals.envelope_spectrum(raw, fs)
+narrow = signals.envelope_spectrum(raw, fs, band=(2000.0, 4000.0))
 k120 = int(round(120.0 * wide.nfft / fs))
 print(round(wide.amplitude[k120], 4),        # 0,0093: enterrada
       round(narrow.amplitude[k120], 4))      # 0,1964: 26 dB mejor

--- a/site/src/content/docs/es/signals/spectra/correlation-delay.mdx
+++ b/site/src/content/docs/es/signals/spectra/correlation-delay.mdx
@@ -58,9 +58,9 @@ $\tau = +\tau_0$ (ecuación 5.21). Hay tres normalizaciones disponibles:
 
 ```python
 import numpy as np
-from phonometry import correlation
+from phonometry import signals
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # retardo y su coeficiente
 res.plot()
@@ -80,23 +80,23 @@ insesgadez con una varianza que crece allí (abajo).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import correlation, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 delay = 102                                  # 12,45 ms
-x = noise_signal(fs, 2.0, seed=4)
-interference = noise_signal(fs, 2.0, rms=0.5, seed=5)
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
 y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 
 # Una línea: la estimación de correlación frente al retardo en segundos:
 res.plot(language="es")
 plt.show()
 
 # Las tres normalizaciones a mano, con los mismos registros:
-biased = correlation(x, y, fs, normalization="biased")
-unbiased = correlation(x, y, fs, normalization="unbiased")
+biased = signals.correlation(x, y, fs, normalization="biased")
+unbiased = signals.correlation(x, y, fs, normalization="unbiased")
 
 fig, (ax_c, ax_n) = plt.subplots(2, 1)
 ax_c.plot(1e3 * res.lags, res.values, label="coeficiente")
@@ -257,18 +257,18 @@ bajo el pico.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import noise_signal, time_delay
+from phonometry import signals
 
 fs = 8192.0
 delay = 20  # muestras
 b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # señal común coloreada
-s = sp_signal.lfilter(b, a, noise_signal(fs, 4.0, color="white", seed=10))
-x = s + noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
-y = np.roll(s, delay) + noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
-direct = time_delay(x, y, fs, method="direct", max_delay=0.01)
-phat = time_delay(x, y, fs, method="gcc", weighting="phat",
-                  nperseg=2048, max_delay=0.01)
+direct = signals.time_delay(x, y, fs, method="direct", max_delay=0.01)
+phat = signals.time_delay(x, y, fs, method="gcc", weighting="phat",
+                          nperseg=2048, max_delay=0.01)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(1e3 * direct.lags,
@@ -306,10 +306,10 @@ $$
 $$
 
 ```python
-from phonometry import time_delay
+from phonometry import signals
 
-res = time_delay(x, y, fs, method="gcc", weighting="ml",
-                 nperseg=2048, upsample=16, signal_bandwidth=1000.0)
+res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
+                         nperseg=2048, upsample=16, signal_bandwidth=1000.0)
 print(res.delay, res.delay_samples)     # segundos y muestras fraccionarias
 print(res.delay_std, res.delay_interval)  # sigma de la ec. 8.129, +/-2 sigma
 res.plot()                              # correlación con el retardo marcado
@@ -333,12 +333,12 @@ registros estacionarios, así que se usa el correlador directo en lugar de
 la GCC promediada por Welch):
 
 ```python
-from phonometry import align_impulse_responses, impulse_response_delay
+from phonometry import signals
 
-t_arrival = impulse_response_delay(ir, fs)              # segundos desde t = 0
-dt = impulse_response_delay(ir_b, fs, reference=ir_a)   # retardo del par
+t_arrival = signals.impulse_response_delay(ir, fs)              # segundos desde t = 0
+dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # retardo del par
 
-res = align_impulse_responses(ir_b, ir_a, fs)  # elimina el retardo estimado
+res = signals.align_impulse_responses(ir_b, ir_a, fs)  # elimina el retardo estimado
 res.plot()                       # superposición referencia frente a alineada
 ```
 
@@ -356,17 +356,17 @@ la referencia.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import align_impulse_responses, fractional_delay
+from phonometry import signals
 
 fs = 48000.0
 t = np.arange(int(0.03 * fs)) / fs
 rng = np.random.default_rng(6)
 # Pulso de referencia de banda limitada: ráfaga tonal gaussiana de 2 kHz en 5 ms.
 ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
-ir_b = fractional_delay(ir_a, 7.37)[: ir_a.size]
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
 ir_b += 0.005 * rng.standard_normal(ir_a.size)
 
-res = align_impulse_responses(ir_b, ir_a, fs)
+res = signals.align_impulse_responses(ir_b, ir_a, fs)
 
 # Una línea: referencia y RI alineada superpuestas:
 res.plot(language="es")
@@ -437,13 +437,13 @@ conformidad fija la envolvente AM recuperada y el par $\cos \to \sin$ de
 la Tabla 13.1 al nivel de 1e-9, y la frecuencia instantánea de un barrido sigue su rampa.
 
 ```python
-from phonometry import envelope
+from phonometry import signals
 
-res = envelope(x, fs)
+res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)
 res.plot()               # señal + envolvente, frecuencia instantánea
 
-slow = envelope(x, fs, decimation_factor=32)   # con antialias, fs/32
+slow = signals.envelope(x, fs, decimation_factor=32)   # con antialias, fs/32
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope_es.svg" alt="Dos paneles para un modo de 250 hercios en decaimiento con ruido ligero. Arriba: la señal oscilante con la envolvente de Hilbert exponencial y suave trazando su decaimiento por arriba y por abajo. Abajo: la frecuencia instantánea manteniéndose sobre la línea discontinua de la portadora de 250 hercios mientras el modo es fuerte y con un temblor creciente a medida que la señal se hunde en el suelo de ruido" width="86%" />
@@ -459,7 +459,7 @@ la señal se hunde en el suelo de ruido (abajo, diezmado ×8 con antialias).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(0.4 * fs)) / fs
@@ -467,7 +467,7 @@ rng = np.random.default_rng(7)
 x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # un modo golpeado
 x += 0.001 * rng.standard_normal(t.size)
 
-res = envelope(x, fs, decimation_factor=8)
+res = signals.envelope(x, fs, decimation_factor=8)
 
 # Una línea: señal + envolvente y la frecuencia instantánea:
 res.plot(language="es")

--- a/site/src/content/docs/es/signals/spectra/miso-coherence.mdx
+++ b/site/src/content/docs/es/signals/spectra/miso-coherence.mdx
@@ -45,20 +45,20 @@ la fuente equivocada.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import miso_coherence, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 # La entrada 1 excita un camino de baja frecuencia; la entrada 2 =
 # 0.7*x1 + ruido independiente excita un camino de alta frecuencia, de modo
 # que la entrada 2 está correlacionada con la entrada 1.
-x1 = noise_signal(fs, 32.0, color="white", seed=1)
-x2 = 0.7 * x1 + noise_signal(fs, 32.0, color="white", seed=2)
+x1 = signals.noise_signal(fs, 32.0, color="white", seed=1)
+x2 = 0.7 * x1 + signals.noise_signal(fs, 32.0, color="white", seed=2)
 low = signal.butter(4, 400.0, fs=fs, output="sos")
 high = signal.butter(4, 1500.0, btype="high", fs=fs, output="sos")
-noise = noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
+noise = signals.noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
 y = signal.sosfilt(low, x1) + signal.sosfilt(high, x2) + noise
 
-res = miso_coherence([x1, x2], y, fs, nperseg=2048)
+res = signals.miso_coherence([x1, x2], y, fs, nperseg=2048)
 f = res.frequencies
 band = (f >= 20.0) & (f <= 4000.0)
 
@@ -154,7 +154,7 @@ exactamente a las coherencias ordinarias cuando las entradas son mutuamente
 no correlacionadas (Ec. 7.117).
 
 ```python
-res = miso_coherence([x1, x2], y, fs)
+res = signals.miso_coherence([x1, x2], y, fs)
 res.ordinary_coherence   # forma (q, F): cada entrada por sí sola
 res.multiple_coherence   # forma (F,):  todas las entradas conjuntamente
 res.partial_coherence    # forma (q, F): condicionada a las entradas previas
@@ -261,8 +261,8 @@ ventilador de la sala contigua, que no es coherente con ninguna de las dos.
 Pasa `order` para saltarte el orden por defecto:
 
 ```python
-x3 = noise_signal(fs, 32.0, color="white", seed=4)   # la tercera fuente, débil
-res = miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
+x3 = signals.noise_signal(fs, 32.0, color="white", seed=4)   # la tercera fuente, débil
+res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): el orden aplicado
 res.plot(language="es")   # los dos paneles, recalculados en el orden aplicado
 ```

--- a/site/src/content/docs/es/signals/spectra/spectral-analysis.mdx
+++ b/site/src/content/docs/es/signals/spectra/spectral-analysis.mdx
@@ -124,12 +124,12 @@ real, así que esos bins llevan la mitad de grados de libertad y un intervalo
 proporcionalmente más ancho.
 
 ```python
-from phonometry import power_spectral_density
+from phonometry import signals
 
 # record: un canal de una captura calibrada, en pascales (ver la guía de
 #   Calibración más abajo); trabajando en dBFS es el vector bruto en [-1, 1] y
 #   el resultado sale en FS^2/Hz. fs: su frecuencia de muestreo en Hz.
-res = power_spectral_density(record, fs)          # Hann, solape 50 %, IC 95 %
+res = signals.power_spectral_density(record, fs)          # Hann, solape 50 %, IC 95 %
 print(res.n_averages, res.random_error)           # nd y 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD en dB con la banda de IC
@@ -148,9 +148,9 @@ $$
 $$
 
 ```python
-from phonometry import resolution_bias_error
+from phonometry import signals
 
-eps_b = resolution_bias_error(res.resolution_bandwidth, 25.0)  # pico de Br = 25 Hz
+eps_b = signals.resolution_bias_error(res.resolution_bandwidth, 25.0)  # pico de Br = 25 Hz
 ```
 
 Un $B_\mathrm{e}$ estrecho (segmentos largos) suprime el sesgo pero deja menos
@@ -215,7 +215,7 @@ estimación:
 ```python
 calibration_factor = 1.002             # Pa por unidad digital, del calibrador
 pressure = calibration_factor * record
-psd = power_spectral_density(pressure, fs)      # ahora en Pa^2/Hz
+psd = signals.power_spectral_density(pressure, fs)      # ahora en Pa^2/Hz
 ```
 
 La ordenada es entonces $10\log_{10}(G_{xx}/p_0^2)$ dB re (20 µPa)²/Hz, y con
@@ -244,18 +244,14 @@ misma estimación, y el intervalo que hay debajo sigue valiendo.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    fractional_octave_smoothing,
-    noise_signal,
-    power_spectral_density,
-)
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 20.0, color="pink", seed=11)
-res = power_spectral_density(x, fs, nperseg=4096)
+x = signals.noise_signal(fs, 20.0, color="pink", seed=11)
+res = signals.power_spectral_density(x, fs, nperseg=4096)
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
-smooth = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
+smooth = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.fill_between(freqs, 10 * np.log10(res.ci_lower[band]),
@@ -296,9 +292,9 @@ camino de retardo puro la fase es lineal y esa pendiente lee directamente el
 retardo de propagación.
 
 ```python
-from phonometry import cross_spectral_density
+from phonometry import signals
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # errores del bin 100
 res.plot()   # magnitud, fase con banda ±sigma, coherencia
 ```
@@ -316,16 +312,16 @@ cuantifica cuánto fiarse de ella por frecuencia.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import cross_spectral_density, noise_signal
+from phonometry import signals
 
 fs = 8000.0
 tau = 0.002                                   # 2 ms = 16 muestras
 delay = int(tau * fs)
-x = noise_signal(fs, 8.0, seed=8)
-noise = noise_signal(fs, 8.0, rms=0.3, seed=9)
+x = signals.noise_signal(fs, 8.0, seed=8)
+noise = signals.noise_signal(fs, 8.0, rms=0.3, seed=9)
 y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 
 # Una línea: magnitud, fase con su banda ±sigma y coherencia:
 res.plot(language="es")
@@ -382,14 +378,14 @@ cadena verificable con una señal sintética:
 
 ```python
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 en toda frecuencia
 
-res = coherent_output_spectrum(x, y, fs)
+res = signals.coherent_output_spectrum(x, y, fs)
 print(np.median(res.coherence))          # -> SNR/(1+SNR) = 0.719
 print(np.median(res.snr_db))             # -> 10·lg(2.56) = 4.1 dB
 res.plot()                               # Gyy, Gvv, Gnn y el panel de SNR
@@ -408,14 +404,14 @@ frecuencia.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 por banda
 
-res = coherent_output_spectrum(x, y, fs, nperseg=2048)
+res = signals.coherent_output_spectrum(x, y, fs, nperseg=2048)
 
 # Una línea: los tres espectros y el panel de SNR:
 res.plot(language="es")
@@ -509,15 +505,15 @@ frecuencia (`"amplitude"`, que se eleva antes al cuadrado), o una curva ya en
 decibelios (`"db"`, que se convierte y se vuelve a convertir).
 
 ```python
-from phonometry import fractional_octave_smoothing
+from phonometry import signals
 
 freqs = res.frequencies                    # de la estimación del §1
-smooth_psd = fractional_octave_smoothing(freqs, res.psd, 3.0)
+smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
 magnitude = np.sqrt(res.psd)               # aquí valdría cualquier |H| lineal
-smooth_mag = fractional_octave_smoothing(freqs, magnitude, 6.0,
-                                         domain="amplitude")  # una FRF |H|
+smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,
+                                                 domain="amplitude")  # una FRF |H|
 levels = 10.0 * np.log10(res.psd)          # aquí valdría cualquier curva en dB
-smooth_db = fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
 ```
 
 Una sola línea espectral con ordenada de PSD $P$ (unidades²/Hz) en un bin de
@@ -579,10 +575,10 @@ reproduce el mismo registro bit a bit.
 | `violet` | +2 | +6,02 dB/octava |
 
 ```python
-from phonometry import noise_signal
+from phonometry import signals
 
-pink = noise_signal(48000, 10.0, color="pink", seed=7)     # determinista
-white = noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
+pink = signals.noise_signal(48000, 10.0, color="pink", seed=7)     # determinista
+white = signals.noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
 ```
 
 Medida sobre tres décadas (20 Hz – 20 kHz) con el estimador de la sección 1,
@@ -641,9 +637,9 @@ periódico (DFT-even) exactamente como las aplican los estimadores de Welch:
   suelo de fuga frente a resolución.
 
 ```python
-from phonometry import window_metrics
+from phonometry import signals
 
-m = window_metrics("hann", 2048)
+m = signals.window_metrics("hann", 2048)
 print(m.enbw_bins)              # 1.5, exacto
 print(m.scalloping_loss_db)     # 1.42 dB
 print(m.highest_sidelobe_db)    # -31.5 dB
@@ -673,12 +669,12 @@ ventana hace las dos cosas.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import window_metrics
+from phonometry import signals
 
 n, oversample = 1024, 256
 fig, ax = plt.subplots(figsize=(10, 6.2))
 for name in ("boxcar", "hann", "hamming", "blackman"):
-    res = window_metrics(name, n)
+    res = signals.window_metrics(name, n)
     spectrum = np.abs(np.fft.rfft(res.taps, n=n * oversample))
     level = 20.0 * np.log10(spectrum / spectrum[0])
     bins = np.arange(level.size) / oversample
@@ -741,9 +737,9 @@ $K = 2p - 1$, todas las de concentración casi unidad. Un $p$ mayor
 admite más ventanas (menos varianza) a costa de resolución.
 
 ```python
-from phonometry import multitaper_psd
+from phonometry import signals
 
-res = multitaper_psd(record, fs)                 # p = NW = 4, K = 7, adaptativo
+res = signals.multitaper_psd(record, fs)                 # p = NW = 4, K = 7, adaptativo
 print(res.degrees_of_freedom.mean())             # ~2K de un solo registro
 print(res.eigenvalues)                           # concentraciones
 res.plot(language="es")                          # densidad con la banda de IC
@@ -802,12 +798,12 @@ confianza.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import multitaper_psd, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8192 / fs, color="pink", seed=11)   # registro de 171 ms
-single = multitaper_psd(x, fs, n_tapers=1, adaptive=False)
-res = multitaper_psd(x, fs)                              # NW = 4, K = 7
+x = signals.noise_signal(fs, 8192 / fs, color="pink", seed=11)   # registro de 171 ms
+single = signals.multitaper_psd(x, fs, n_tapers=1, adaptive=False)
+res = signals.multitaper_psd(x, fs)                              # NW = 4, K = 7
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
 

--- a/site/src/content/docs/es/signals/spectra/synchronous-averaging.mdx
+++ b/site/src/content/docs/es/signals/spectra/synchronous-averaging.mdx
@@ -45,11 +45,7 @@ treinta y dos, y solo por dónde cae el nodo.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    comb_filter_response,
-    noise_signal,
-    time_synchronous_average,
-)
+from phonometry import signals
 
 fs = 8192.0
 period = 1.0 / 32.0        # una revolución: 256 muestras a esta frecuencia
@@ -60,8 +56,8 @@ periodic = (
     + 0.5 * np.cos(2.0 * np.pi * 3.0 * phase + 0.4)
     - 0.3 * np.cos(2.0 * np.pi * 6.0 * phase)
 )
-recording = periodic + noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
-res = time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
+recording = periodic + signals.noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
 
 fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(11, 4.6))
 t_ms = 1e3 * res.times
@@ -73,9 +69,9 @@ ax0.set_xlabel("Tiempo [ms]"); ax0.set_ylabel("Amplitud"); ax0.legend()
 
 orders = np.linspace(31.0, 33.0, 4000)
 freqs = orders / period
-ax1.plot(orders, comb_filter_response(freqs, period, 32), color="#2ca02c",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 32), color="#2ca02c",
          label="N = 32 (potencia de dos)")
-ax1.plot(orders, comb_filter_response(freqs, period, 20), color="#1f77b4",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 20), color="#1f77b4",
          label="N = 20 (nodo en 32,05)")
 ax1.axvline(32.05, color="#d62728", ls=":", label="Tono interferente")
 ax1.set_xlabel("Frecuencia [órdenes]"); ax1.set_ylabel("Magnitud del filtro peine")
@@ -123,12 +119,12 @@ directamente:
 
 ```python
 import numpy as np
-from phonometry import comb_filter_response
+from phonometry import signals
 
 period = 1.0 / 32.0
-comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 en un diente
-comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
-comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 en un nodo
+signals.comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 en un diente
+signals.comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
+signals.comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 en un nodo
 ```
 
 `SynchronousAverageResult` lleva la respuesta sobre los primeros armónicos en
@@ -145,7 +141,7 @@ es una reducción de potencia de $10\log_{10} N$ dB, declarada como
 `amplitude_snr_gain`:
 
 ```python
-res = time_synchronous_average(recording, fs, period=period, n_averages=100)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=100)
 res.noise_reduction_db      # 20.0 dB = 10*log10(100)
 res.amplitude_snr_gain      # 10.0   = sqrt(100)
 res.plot(language="es")     # forma de onda promediada + el peine aplicado
@@ -164,7 +160,7 @@ número de periodos promediados crece de 1 a 128.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import time_synchronous_average
+from phonometry import signals
 
 fs = 8192.0
 samples = 256
@@ -179,8 +175,8 @@ recording = np.tile(true, 128) + rng.standard_normal(128 * samples)
 counts = [1, 2, 4, 8, 16, 32, 64, 128]
 errors = []
 for n in counts:
-    res = time_synchronous_average(recording[:n * samples], fs, period=period,
-                                   n_averages=n)
+    res = signals.time_synchronous_average(recording[:n * samples], fs, period=period,
+                                           n_averages=n)
     errors.append(np.sqrt(np.mean((res.period_waveform - true) ** 2)))
 
 # Una línea: la forma de onda promediada y el peine que aplicó:
@@ -230,8 +226,8 @@ promedio de extremo a extremo lo confirma:
 phase = np.arange(41 * 256) / 256
 recording = np.cos(2 * np.pi * 8.0 * phase) + 0.7 * np.cos(2 * np.pi * 32.05 * phase)
 
-leak_20 = time_synchronous_average(recording, fs, period=period, n_averages=20)
-leak_32 = time_synchronous_average(recording, fs, period=period, n_averages=32)
+leak_20 = signals.time_synchronous_average(recording, fs, period=period, n_averages=20)
+leak_32 = signals.time_synchronous_average(recording, fs, period=period, n_averages=32)
 # leak_20.period_waveform coincide con el 8.º orden limpio; leak_32 no
 ```
 
@@ -323,7 +319,7 @@ fs = 8192.0
 period = 1.0 / 31.7                       # fs * period no es entero
 t = np.arange(int(40 * period * fs)) / fs
 recording = np.cos(2.0 * np.pi * t / period)  # un ciclo por revolución
-res = time_synchronous_average(recording, fs, period=period)
+res = signals.time_synchronous_average(recording, fs, period=period)
 res.interpolated                          # True: alineación por retardo fraccionario
 res.samples_per_period                    # muestras enteras de un periodo
 ```

--- a/site/src/content/docs/es/signals/spectra/system-measurement.mdx
+++ b/site/src/content/docs/es/signals/spectra/system-measurement.mdx
@@ -103,10 +103,10 @@ en `1e-13`.
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # dos códigos de 16384 muestras
+pair = room.golay_pair(14)                       # dos códigos de 16384 muestras
 
 # Medición simulada: reproducir cada código periódicamente y grabar un
 # periodo en régimen estacionario de un sistema paso banda tipo sala.
@@ -115,7 +115,7 @@ length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 print(ir.method, ir.size)                   # golay 16384
 ir.plot(language="es")
 ```
@@ -134,16 +134,16 @@ identidad de forma cerrada que fijan los tests.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # dos códigos de 16384 muestras
+pair = room.golay_pair(14)                       # dos códigos de 16384 muestras
 b, a = signal.butter(2, [200.0, 2000.0], btype="bandpass", fs=fs)
 length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 
 # Una línea: la respuesta al impulso recuperada:
 ir.plot(language="es")
@@ -244,10 +244,10 @@ del artículo; `target` es `"pink"` (el énfasis clásico de medición de salas,
 por defecto), `"white"`, o cualquier par `(frecuencias_hz, magnitud_db)`:
 
 ```python
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-sweep = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+sweep = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 print(round(sweep.crest_factor_db, 1))      # 4.2 (dB; el ideal es 3,02)
 sweep.plot(language="es")
 ```
@@ -269,10 +269,10 @@ lo que ve el amplificador es el objetivo y no una aproximación suya.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-res = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+res = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 x = np.asarray(res)
 
 nperseg = 8192   # 75 % de solape: con 50 % un barrido riza ~2 dB
@@ -320,20 +320,20 @@ array de referencia para el
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import impulse_response, shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
 freqs = np.array([50.0, 200.0, 1000.0, 8000.0])
 emphasis = np.array([12.0, 6.0, 0.0, 0.0])   # refuerzo LF contra el retumbo
-sweep = shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
-                            target=(freqs, emphasis))
+sweep = room.shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
+                                 target=(freqs, emphasis))
 
 # Medición simulada de un sistema conocido (sustituir por emitir/grabar):
 b, a = signal.butter(2, [200.0, 4000.0], btype="bandpass", fs=fs)
 excitation = np.concatenate([np.asarray(sweep), np.zeros(fs)])
 recorded = signal.lfilter(b, a, excitation)
 
-ir = impulse_response(recorded, excitation, fs, length=fs)
+ir = room.impulse_response(recorded, excitation, fs, length=fs)
 ir.plot(language="es")
 ```
 
@@ -424,7 +424,7 @@ respuesta de fase mixta (Kirkeby y Nelson, Sec. 2.4).
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 # Una respuesta medida tipo altavoz (sustituir por una RI medida).
@@ -433,7 +433,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 print(round(inv.flatness_db, 5))    # 1e-05 (dB: desviación en banda de 0 dB)
 print(round(inv.max_gain_db, 1))    # -6.0 (dB: refuerzo fuera de banda acotado)
 inv.plot(language="es")
@@ -456,7 +456,7 @@ sale por abajo.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -464,7 +464,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-res = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+res = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 f = res.frequencies[1:]
 h_mag = np.abs(res.response_spectrum)[1:]
 inv_mag = np.abs(res.spectrum)[1:]
@@ -499,17 +499,16 @@ retardo de modelado ya eliminado, y la función acepta directamente un
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import (impulse_response, regularized_inverse_filter,
-                        sweep_signal)
+from phonometry import room, signals
 
 fs = 48000
-sweep = sweep_signal(fs, 50.0, 20000.0, 1.0)
+sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)
 excitation = np.concatenate([sweep, np.zeros(fs // 2)])
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
 recorded = signal.lfilter(b, a, excitation)     # en la práctica: emitir/grabar
 
-ir = impulse_response(recorded, excitation, fs)  # vale cualquier frontal
-inv = regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
+ir = room.impulse_response(recorded, excitation, fs)  # vale cualquier frontal
+inv = signals.regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
 flat_recording = inv.apply(recorded)             # retardo ya eliminado
 inv.plot(language="es")   # magnitudes medida, inversa y ecualizada (figura de arriba)
 ```
@@ -550,7 +549,7 @@ un posprocesado que amplifica ruido:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter, shaped_sweep_signal
+from phonometry import room, signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -558,12 +557,12 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)                    # la respuesta medida
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 target_db = 20.0 * np.log10(
     np.abs(inv.spectrum[1:]) * np.abs(inv.response_spectrum).max()
 )
-sweep = shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
-                            target=(inv.frequencies[1:], target_db))
+sweep = room.shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
+                                 target=(inv.frequencies[1:], target_db))
 sweep.plot(language="es")   # forma de onda y espectro contra el objetivo invertido
 ```
 

--- a/site/src/content/docs/es/signals/spectra/test-signals.mdx
+++ b/site/src/content/docs/es/signals/spectra/test-signals.mdx
@@ -69,15 +69,15 @@ apartado A2.2 en el que cada ráfaga tonal ocupa un periodo de repetición
 completo:
 
 ```python
-from phonometry import tone_burst
+from phonometry import signals
 
 # Una ráfaga tonal de 5 ms de tono de 5 kHz (25 periodos completos), como en la
 # tabla AII.
-single = tone_burst(48000, 5000, 25)
+single = signals.tone_burst(48000, 5000, 25)
 print(single.burst_samples)         # 240 muestras = 5 ms a 48 kHz
 
 # Apartado A2.2: ráfagas tonales de 5 ms a 10 ráfagas por segundo.
-train = tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
+train = signals.tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
 print(train.period_samples, train.duty_cycle)   # 4800, 0.05
 train.plot(language="es")           # forma de onda con la envolvente
 ```
@@ -107,11 +107,11 @@ definido como el encendido.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import tone_burst
+from phonometry import signals
 
 fs = 48000.0
-single = tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
-train = tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
+single = signals.tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
+train = signals.tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
 
 fig, axes = plt.subplots(2, 1, figsize=(10, 6.4))
 t_ms = 1e3 * np.arange(single.signal.size) / single.fs
@@ -174,10 +174,10 @@ ventana de Kaiser, a partir de dos números que controla quien llama:
   misma cota de rizado de Kaiser $\delta = 10^{-A/20}$.
 
 ```python
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB de rechazo de alias
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB de rechazo de alias
 print(res.up, res.down)                  # 160, 147
 print(res.n_taps, res.passband_edge_hz)  # FIR diseñado, 20947.5 Hz
 res.plot()   # el filtro antisolapamiento entregado frente a su especificación
@@ -198,10 +198,10 @@ misma cota de rizado.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB de rechazo de alias
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB de rechazo de alias
 
 # res es el ResampledSignalResult calculado en el ejemplo de arriba.
 # Una línea: el filtro antisolapamiento entregado frente a su especificación:
@@ -285,10 +285,10 @@ Dos convenciones de frontera cubren los dos casos de uso:
 
 ```python
 import numpy as np
-from phonometry import fractional_delay
+from phonometry import signals
 
-y = fractional_delay(x, 0.37)                    # 0,37 muestras más tarde
-z = fractional_delay(x, -2.5, mode="circular")   # avance, con vuelta
+y = signals.fractional_delay(x, 0.37)                    # 0,37 muestras más tarde
+z = signals.fractional_delay(x, -2.5, mode="circular")   # avance, con vuelta
 ```
 
 Una sutileza que conviene conocer: un registro real de longitud par no

--- a/site/src/content/docs/es/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/es/signals/spectra/time-frequency.mdx
@@ -68,9 +68,9 @@ Welch sin eliminación de tendencia, se cumplen tres identidades:
   más la identidad COLA, una de las comprobaciones de conformidad).
 
 ```python
-from phonometry import spectrogram
+from phonometry import signals
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frecuencias, tiempos)
 print(res.time_resolution)         # T_B = nperseg/fs, en s
 print(res.resolution_bandwidth)    # Be del segmento con ventana, en Hz
@@ -171,7 +171,7 @@ tiempo, la herramienta correcta es el espectrograma de bandas de
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import noise_signal, spectrogram
+from phonometry import signals
 
 fs = 16000.0
 t = np.arange(int(4.0 * fs)) / fs
@@ -186,10 +186,10 @@ n_imp = int(0.06 * fs)                              # impacto en t = 2,5 s
 x[int(2.5 * fs):int(2.5 * fs) + n_imp] += 0.4 * (
     rng.standard_normal(n_imp) * np.exp(-np.arange(n_imp) / (0.012 * fs))
 )
-x += noise_signal(fs, 4.0, color="pink",            # fondo a 45 dB SPL
-                  rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
+x += signals.noise_signal(fs, 4.0, color="pink",            # fondo a 45 dB SPL
+                          rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 level = 10.0 * np.log10(res.power / p_ref**2)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -233,9 +233,9 @@ ventana, así que una sinusoide de amplitud de pico $A$ sobre una frecuencia de
 análisis lee `amplitude` $= A$ y `power` $= A^2/2$ exactamente:
 
 ```python
-from phonometry import zoom_fft
+from phonometry import signals
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # malla a la resolución del registro
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # malla a la resolución del registro
 print(res.bin_spacing)                   # fs/N por defecto
 print(res.resolution_bandwidth)          # Be del registro con ventana
 peak = res.amplitude.argmax()
@@ -303,7 +303,7 @@ distinción que hace el apartado entre densidad de muestreo y resolución.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import zoom_fft
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(8192) / fs                 # registro de 1 s: resolución de 1 Hz
@@ -315,7 +315,7 @@ coarse = 2.0 * np.abs(np.fft.rfft(x[:1024] * w)) / np.sum(w)
 coarse_f = np.fft.rfftfreq(1024, 1.0 / fs)
 band = (coarse_f >= 950.0) & (coarse_f <= 1050.0)
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # malla de 0,25 Hz
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # malla de 0,25 Hz
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(coarse_f[band], 20.0 * np.log10(coarse[band]), "o--",

--- a/site/src/content/docs/es/simulation/fdtd-simulation.mdx
+++ b/site/src/content/docs/es/simulation/fdtd-simulation.mdx
@@ -654,8 +654,7 @@ milimétricas que el TMM modela analíticamente, se desplazan unos grados.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (HelmholtzResonator, MetadiffuserWell,
-                        metadiffuser_polar_response, simulation)
+from phonometry import materials, simulation
 
 c0, dx, f0, pitch = 343.0, 0.0005, 2000.0, 0.07
 rows = [(14.7, 13.0, 16.4, 6.2, 9.0), (30.9, 9.1, 4.3, 3.5, 9.0),
@@ -703,12 +702,12 @@ pattern = simulation.far_field_from_contour(
     origin=((lat + face / 2.0) * dx, r_face * dx))
 levels = 20 * np.log10(np.abs(pattern) / np.abs(pattern).max())
 
-wells = [MetadiffuserWell(h * 1e-3,
-                          (HelmholtzResonator(ln * 1e-3, wn * 1e-3,
-                                              lc * 1e-3, wc * 1e-3),) * 2)
+wells = [materials.MetadiffuserWell(h * 1e-3,
+                                    (materials.HelmholtzResonator(ln * 1e-3, wn * 1e-3,
+                                                        lc * 1e-3, wc * 1e-3),) * 2)
          for h, ln, lc, wn, wc in rows]
-model = metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
-                                    angles=angles, periods=1)
+model = materials.metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
+                                              angles=angles, periods=1)
 ax = model.plot(color="#1f77b4", marker="", linestyle="--",
                 label="Modelo TMM + Fraunhofer", language="es")
 ax.plot(np.radians(angles), levels, color="#d62728", lw=2.2,

--- a/site/src/content/docs/es/vibration/machinery/machine-diagnostics.mdx
+++ b/site/src/content/docs/es/vibration/machinery/machine-diagnostics.mdx
@@ -47,12 +47,12 @@ diagnóstico: un descascarillado en la pista exterior.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import bearing_fault_frequencies, envelope_spectrum, noise_signal
+from phonometry import signals, vibration
 
 # El rodamiento: 15 rodillos sobre un diámetro primitivo de 34 mm, rodillos
 # de 6 mm, ángulo de contacto de 12,96 grados, eje a 2000 r/min.
-faults = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
-                                   contact_angle_deg=12.96)
+faults = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
+                                             contact_angle_deg=12.96)
 bpfo, shaft = faults["BPFO"], faults.shaft_rate    # 207,0 Hz, 33,33 Hz
 
 # Una pista exterior descascarillada: un impacto por periodo de BPFO, cada uno
@@ -68,11 +68,11 @@ tau = np.arange(int(0.004 * fs)) / fs
 ring = np.exp(-tau / 6.0e-4) * np.sin(2.0 * np.pi * 3000.0 * tau)
 x = np.convolve(impacts, ring)[: t.size] * 0.6
 x += 0.35 * np.sin(2.0 * np.pi * shaft * t)          # desequilibrio residual
-x += noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
 
 # Se filtra en banda la resonancia que excitan los impactos, se detecta su
 # envolvente, se transforma, y el resultado dibuja sus propias líneas encima.
-spectrum = envelope_spectrum(x, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(x, fs, band=(2000.0, 4000.0))
 faults.within(1.0, 5.0 * bpfo).plot(spectrum=spectrum, language="es")
 plt.show()
 ```
@@ -190,9 +190,9 @@ que es la razón de que la adquisición de la sección 5 importe aquí, y no sol
 en principio.
 
 ```python
-from phonometry import bearing_fault_frequencies
+from phonometry import vibration
 
-res = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
+res = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
 print(round(res["BPFO"], 1), round(res["BPFI"], 1))   # 207.0 293.0
 print(round(res["BPFO"] + res["BPFI"], 1))            # 500.0 = 15 x 33,33
 print(res.as_dict())
@@ -256,10 +256,10 @@ eje, mientras que un desgaste distribuido levanta grupos altos de bandas
 laterales y eleva los armónicos superiores del engrane.
 
 ```python
-from phonometry import gear_mesh_frequencies
+from phonometry import vibration
 
 # Un piñón de 28 dientes en un eje a 1500 r/min, con dos órdenes de bandas.
-res = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+res = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 print(round(res["GMF"], 1))            # 700.0
 print(round(res["GMF+1x"], 1))         # 725.0  (GMF + un orden de eje)
 print(res.harmonics("GMF", 3))         # [ 700. 1400. 2100.]
@@ -292,12 +292,12 @@ viste el armónico de ranura dominante con bandas laterales a $\pm$ la
 frecuencia de giro del eje y a $\pm$ la frecuencia de deslizamiento.
 
 ```python
-from phonometry import induction_motor_frequencies
+from phonometry import vibration
 
 # Sesenta barras de rotor, seis polos magnéticos, 3600 r/min, sin deslizamiento:
 # una máquina de seis polos a esa velocidad va con un variador a 180 Hz, no con
 # la red.
-res = induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
+res = vibration.induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
 print(round(res["fe"]))                         # 180  la alimentación que implica
 print(round(res["1x"]), round(res["2x"]),
       round(res["2fe"]), round(res["fsh"]))     # 60 120 360 3600
@@ -334,11 +334,11 @@ el recuento de palas sustituido por el número de eventos de bombeo por vuelta
 lo que se trata pasando $4 \times \text{r/min}$ con una sola «pala»:
 
 ```python
-from phonometry import blade_pass_frequencies
+from phonometry import vibration
 
 # Una soplante volumétrica rotativa a 1200 r/min: cuatro pulsaciones por
 # vuelta, así que la frecuencia de pulsación se pide como 4 x r/min con N = 1.
-res = blade_pass_frequencies(4 * 1200.0, 1, harmonics=3)
+res = vibration.blade_pass_frequencies(4 * 1200.0, 1, harmonics=3)
 print(round(res["BPF"], 1))        # 80.0 Hz, la frecuencia de pulsación
 print(round(res.shaft_rate, 1))    # 80.0 Hz - NO la del eje, que es 20
 ```
@@ -361,7 +361,7 @@ lóbulos alcanzado desde otro armónico es otro patrón, que gira a otra velocid
 
 ```python
 # Seis palas, cuatro álabes, 3500 r/min (blade_pass_frequencies importado arriba).
-res = blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
+res = vibration.blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
 print(round(res.shaft_rate, 1))   # 58.3 Hz, el eje mismo
 print(round(res["BPF"]))          # 350
 print(round(res["lobe n=1 m=2"]), round(res["lobe n=1 m=10"]))    # 175 35
@@ -399,7 +399,7 @@ import numpy as np
 # La biblioteca prevé las líneas; los espectros de debajo se sintetizan
 # exactamente a esas frecuencias, así que la figura y los valores impresos
 # concuerdan.
-gear = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+gear = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 freq = np.linspace(0.0, 2400.0, 4800)
 amp = np.full_like(freq, 0.004)
 for order, height in enumerate((1.0, 0.40, 0.16), start=1):
@@ -517,7 +517,7 @@ from scipy import signal as sp_signal
 # El registro x, su frecuencia de muestreo fs, su base de tiempos t y la BPFO
 # prevista son los que se construyeron para la figura que abre la página.
 band = (2000.0, 4000.0)
-spec = envelope_spectrum(x, fs, band=band)     # lleva .envelope y .times
+spec = signals.envelope_spectrum(x, fs, band=band)     # lleva .envelope y .times
 
 # El mismo filtro paso banda Butterworth de cuarto orden y fase nula que aplica la
 # llamada internamente, ejecutado aquí para poder dibujar el registro intermedio.
@@ -558,24 +558,19 @@ momento. El rodamiento soporta un piñón de 28 dientes, así que el soporte lle
 tres familias a la vez.
 
 ```python
-from phonometry import (
-    bearing_fault_frequencies,
-    combine_fault_lines,
-    envelope_spectrum,
-    gear_mesh_frequencies,
-)
+from phonometry import signals, vibration
 
 record, fs = x, 20000.0          # el registro del soporte y su muestreo
 shaft_rpm = 2000.0               # del tacómetro, no de la placa de características
 
 # Las líneas propias del rodamiento, la familia de engrane del piñón que soporta
 # y los armónicos del eje. Todos en unos ejes.
-bearing = bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
-                                    contact_angle_deg=12.96)
-gear = gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
-lines = combine_fault_lines(bearing, gear)
+bearing = vibration.bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
+                                              contact_angle_deg=12.96)
+gear = vibration.gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
+lines = vibration.combine_fault_lines(bearing, gear)
 
-spectrum = envelope_spectrum(record, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(record, fs, band=(2000.0, 4000.0))
 lines.within(1.0, 1600.0).plot(spectrum=spectrum, language="es")
 ```
 

--- a/site/src/content/docs/es/vibration/structural/junction-transmission.mdx
+++ b/site/src/content/docs/es/vibration/structural/junction-transmission.mdx
@@ -86,10 +86,10 @@ se encuentra con el muro continuo de 200 mm.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # Un forjado de hormigón de 140 mm contra un muro de 200 mm en unión en T.
-res = junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
+res = vibration.junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
 res.plot_geometry(language="es")
 plt.show()
 ```
@@ -110,10 +110,10 @@ onda, y no $\psi$, quien fija la forma de la curva.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # Unión en X entre una placa de hormigón de 100 mm y otra de 200 mm (cL = 3200 m/s).
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 res.plot(language="es")  # tau(theta) de los caminos de esquina y recto, con medias
 plt.show()
 ```
@@ -146,9 +146,9 @@ la razón de sus movilidades de momento flector. Para **placas idénticas**
 ambos valen 1.
 
 ```python
-from phonometry import junction_wave_parameters
+from phonometry import vibration
 
-chi, psi = junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+chi, psi = vibration.junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 #  -> (sqrt(0.5), 4.0)
 ```
 
@@ -223,14 +223,11 @@ que un cambio de sección sea mal sitio donde buscar aislamiento.
 
 ```python
 import numpy as np
-from phonometry import (
-    corner_transmission_coefficient,
-    straight_transmission_coefficient,
-)
+from phonometry import vibration
 
 theta = np.radians(np.linspace(0.0, 90.0, 91))
-tau12 = corner_transmission_coefficient(theta, chi, psi, "X")
-tau13 = straight_transmission_coefficient(theta, chi, psi, "X")
+tau12 = vibration.corner_transmission_coefficient(theta, chi, psi, "X")
+tau13 = vibration.straight_transmission_coefficient(theta, chi, psi, "X")
 ```
 
 El clip de abajo ejecuta este experimento en el dominio del tiempo con el
@@ -268,10 +265,10 @@ que sirven de oráculo desde primeros principios de la biblioteca:
   `inline_transmission_coefficient` de la sección 2).
 
 ```python
-from phonometry import angular_average_transmission_coefficient
+from phonometry import vibration
 
-angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
-angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
 ```
 
 Las dos direcciones cumplen la relación de consistencia SEA (Ec. 5.7),
@@ -293,14 +290,13 @@ al descriptor de unión. Para la unión en X idéntica de hormigón de 100 mm
 $K_{ij} = 10\log_{10} 12 + 5\log_{10}(203/1000) \approx 7{,}3\ \text{dB}$.
 
 ```python
-from phonometry import (coupling_loss_factor, junction_transmission,
-                        wave_vibration_reduction_index)
+from phonometry import vibration
 
-eta = coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
-                           junction_length=4.0, frequency=500.0, plate_area=10.0)
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
-kij = wave_vibration_reduction_index(res.corner_average,
-                                     res.critical_frequency2)  # 7.33 dB
+eta = vibration.coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
+                                     junction_length=4.0, frequency=500.0, plate_area=10.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
+kij = vibration.wave_vibration_reduction_index(res.corner_average,
+                                               res.critical_frequency2)  # 7.33 dB
 kij = res.corner_reduction_index  # lo mismo, precalculado en el resultado
 
 res.plot()   # tau(theta) de los caminos de esquina y recto de esta unión (requiere matplotlib)
@@ -327,7 +323,7 @@ porque las placas perpendiculares fijan cada vez más la línea de unión:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import junction_transmission, wave_vibration_reduction_index
+from phonometry import vibration
 
 # Placas de hormigón (cL = 3200 m/s, rho = 2400 kg/m3): placa 1 fija en
 # 100 mm, placa 2 en barrido de 50 mm a 400 mm.
@@ -337,22 +333,22 @@ curves = {"X esquina": [], "X recta": [], "unión en T (1) esquina": [],
           "L esquina": []}
 for ratio in ratios:
     h2 = h1 * float(ratio)
-    res_x = junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
+    res_x = vibration.junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
     curves["X esquina"].append(res_x.corner_reduction_index)
     # En el resultado solo viene precalculado el índice de esquina; el camino
     # recto es la media angular tau13 convertida de la misma forma.
-    curves["X recta"].append(float(wave_vibration_reduction_index(
+    curves["X recta"].append(float(vibration.wave_vibration_reduction_index(
         res_x.straight_average, res_x.critical_frequency2)))
-    res_t = junction_transmission("T1", h1, cl, rho * h1, h2, cl, rho * h2)
+    res_t = vibration.junction_transmission("T1", h1, cl, rho * h1, h2, cl, rho * h2)
     curves["unión en T (1) esquina"].append(res_t.corner_reduction_index)
-    res_l = junction_transmission("L", h1, cl, rho * h1, h2, cl, rho * h2)
+    res_l = vibration.junction_transmission("L", h1, cl, rho * h1, h2, cl, rho * h2)
     curves["L esquina"].append(res_l.corner_reduction_index)
 
 fig, ax = plt.subplots()
 for label, values in curves.items():
     ax.plot(ratios, values, "--" if label == "X recta" else "-", label=label)
 # La unión en X de placas idénticas: Kij = 10 lg 12 + 5 lg(fc2/1000).
-res_eq = junction_transmission("X", h1, cl, rho * h1, h1, cl, rho * h1)
+res_eq = vibration.junction_transmission("X", h1, cl, rho * h1, h1, cl, rho * h1)
 ax.scatter([1.0], [res_eq.corner_reduction_index], zorder=6,
            label="placas idénticas (tau = 1/12)")
 ax.set_xlabel("Relación de espesores h2/h1")
@@ -375,10 +371,10 @@ Entregarlo a
 tres trayectorias por flancos de la unión y su efecto sobre el índice aparente:
 
 ```python
-from phonometry import building, junction_transmission
+from phonometry import building, vibration
 
 # La unión en X de hormigón de 100 mm / 200 mm de la figura de tau(theta):
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 k12 = res.corner_reduction_index                     # 9.8 dB (camino de esquina)
 
 # Llévalo al modelo simplificado de EN 12354-1 como Kij de esta unión:
@@ -513,15 +509,7 @@ que es la condición para que un modelo SEA de dos subsistemas sea fiable.*
 import math
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coupling_loss_factor,
-    cylindrical_shell_modal_density,
-    flat_plate_modal_density,
-    plate_bending_stiffness,
-    point_connection_coupling_loss_factor,
-    power_injection_clf,
-    right_angle_transmission_coefficient,
-)
+from phonometry import vibration
 from phonometry.vibration.structural.point_mobility import plate_bending_wave_speed
 
 rho, nu, young = 2700.0, 0.33, 7.1e10                 # aluminio
@@ -532,13 +520,13 @@ bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0])
 # 5,5 mm x 2,0 m x 1,2 m en ángulo recto por el borde de 1,2 m, soldada y
 # después atornillada.
 h1, h2, area1, length = 0.003, 0.0055, 2.5 * 1.2, 1.2
-tau = right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
-                                           wave_speed1=cl, wave_speed2=cl)
-cb = plate_bending_wave_speed(bands, plate_bending_stiffness(young, h1, nu),
+tau = vibration.right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
+                                                     wave_speed1=cl, wave_speed2=cl)
+cb = plate_bending_wave_speed(bands, vibration.plate_bending_stiffness(young, h1, nu),
                               rho * h1)
-welded = [float(coupling_loss_factor(tau, 2.0 * c, length, f, area1))
+welded = [float(vibration.coupling_loss_factor(tau, 2.0 * c, length, f, area1))
           for c, f in zip(cb, bands, strict=True)]
-bolted = point_connection_coupling_loss_factor(
+bolted = vibration.point_connection_coupling_loss_factor(
     bands, 12, thickness1=h1, thickness2=h2, surface_density1=rho * h1,
     surface_density2=rho * h2, wave_speed1=cl, wave_speed2=cl,
     plate_area1=area1)
@@ -548,11 +536,11 @@ bolted = point_connection_coupling_loss_factor(
 t_p, t_c, radius = 0.005, 0.003, 0.75
 area_c = 2.0 * math.pi * radius * 2.0
 area_p = 3.5 * 3.0 - math.pi * radius**2
-sea = power_injection_clf(
+sea = vibration.power_injection_clf(
     500.0, rho * t_p * area_p * 0.0272**2, rho * t_c * area_c * 0.0132**2,
     4.4e-3, 2.4e-3,
-    flat_plate_modal_density(area_p, t_p, cl),
-    float(cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
+    vibration.flat_plate_modal_density(area_p, t_p, cl),
+    float(vibration.cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
 
 print(f"{float(sea.coupling_loss_factor12[0]):.2e}")   # 4.26e-04
 print(f"{float(sea.coupling_loss_factor21[0]):.2e}")   # 3.91e-04

--- a/site/src/content/docs/es/vibration/structural/transfer-stiffness.mdx
+++ b/site/src/content/docs/es/vibration/structural/transfer-stiffness.mdx
@@ -483,13 +483,13 @@ y de gráficos (`pip install "phonometry[report,plot]"`).
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, TransferStiffnessResult, transfer_stiffness_direct
+from phonometry import ReportMetadata, vibration
 
 freqs = np.array([20, 31.5, 50, 80, 125, 200, 315, 500, 800, 1250, 2000], dtype=float)
 k21 = 1e6 + 1j * (2 * np.pi * freqs) * 80.0     # elemento Kelvin-Voigt k + jwc
 u1 = 1e-6 + 0j
-k = transfer_stiffness_direct(k21 * u1, u1)     # método directo: k2,1 = F2,b/u1
-res = TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
+k = vibration.transfer_stiffness_direct(k21 * u1, u1)     # método directo: k2,1 = F2,b/u1
+res = vibration.TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
 res.report(
     "rigidez_transferencia.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/materials/absorbers/metamaterial-absorbers.mdx
+++ b/site/src/content/docs/materials/absorbers/metamaterial-absorbers.mdx
@@ -123,18 +123,16 @@ lengths.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
 
 f = np.array([300.0])
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -161,7 +159,7 @@ says which side you are on; the absorption curve alone does not.*
 ```python
 # The impedance at 300 Hz as a function of slit height, in one line each.
 for factor in (0.6, 1.0, 1.7):
-    z_h = slit_helmholtz_absorber(
+    z_h = materials.slit_helmholtz_absorber(
         np.array([300.0]), design.resonator, slit_height=factor * design.slit_height,
         lattice_step=3.0e-2, period=5.0e-2,
     ).normalized_impedance[0]
@@ -225,22 +223,20 @@ $\alpha \approx 1$ at the design frequency.
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 print(round(design.absorption, 4))          # ~1.0 (perfect absorption)
 print(round(design.slit_height * 1e3, 3))    # solved slit height, mm
 
 f = np.linspace(150.0, 500.0, 700)
-res = slit_helmholtz_absorber(
+res = materials.slit_helmholtz_absorber(
     f, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -263,9 +259,9 @@ the cavity length to place the resonance.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator
+from phonometry import materials
 
-resonator = HelmholtzResonator(
+resonator = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
@@ -287,13 +283,13 @@ mechanism.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import HelmholtzResonator, critical_coupling_design, materials
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(
+design = materials.critical_coupling_design(
     300.0, base, lattice_step=3.0e-2, period=5.0e-2,
 )
 
@@ -321,20 +317,18 @@ under-damps it, both dropping the peak below one.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
 a, d, f0 = 3.0e-2, 5.0e-2, 300.0
-base = HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
-design = critical_coupling_design(f0, base, lattice_step=a, period=d)
+base = materials.HelmholtzResonator(1.0e-3, 3.0e-3, 30.0e-3, 27.0e-3)
+design = materials.critical_coupling_design(f0, base, lattice_step=a, period=d)
 h0 = design.slit_height
 
 f = np.linspace(150.0, 500.0, 700)
 fig, ax = plt.subplots()
 for factor, label in [(1.0, "critically coupled"),
                       (0.6, "narrow slit"), (1.7, "wide slit")]:
-    res = slit_helmholtz_absorber(
+    res = materials.slit_helmholtz_absorber(
         f, design.resonator, slit_height=factor * h0,
         lattice_step=a, period=d,
     )
@@ -375,7 +369,7 @@ algebra suggests:
 # The same 300 Hz design, evaluated off normal. Both the solver and the
 # evaluator take `angle` in radians.
 for degrees in (0.0, 15.0, 30.0, 45.0, 60.0):
-    off = slit_helmholtz_absorber(
+    off = materials.slit_helmholtz_absorber(
         np.array([300.0]), design.resonator, slit_height=design.slit_height,
         lattice_step=3.0e-2, period=5.0e-2, angle=np.radians(degrees),
     )
@@ -402,16 +396,14 @@ everything about why the panel can be thin:
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator, critical_coupling_design, slit_helmholtz_absorber,
-)
+from phonometry import materials
 
-base = HelmholtzResonator(
+base = materials.HelmholtzResonator(
     neck_length=1.0e-3, neck_side=3.0e-3,
     cavity_length=30.0e-3, cavity_side=27.0e-3,
 )
-design = critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
-res = slit_helmholtz_absorber(
+design = materials.critical_coupling_design(300.0, base, lattice_step=3.0e-2, period=5.0e-2)
+res = materials.slit_helmholtz_absorber(
     np.array([300.0]), design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -454,7 +446,7 @@ metadiffuser panel of the
 
 ```python
 f_sweep = np.geomspace(50.0, 3000.0, 400)
-swept = slit_helmholtz_absorber(
+swept = materials.slit_helmholtz_absorber(
     f_sweep, design.resonator, slit_height=design.slit_height,
     lattice_step=3.0e-2, period=5.0e-2,
 )
@@ -554,11 +546,11 @@ compromise no longer critically coupled to any one stage.*
 ```python
 # `slit_helmholtz_absorber` takes a list: that is the chain along the slit.
 f_chain = np.linspace(120.0, 700.0, 700)
-graded = [critical_coupling_design(target, base, lattice_step=3.0e-2,
-                                   period=5.0e-2).resonator
+graded = [materials.critical_coupling_design(target, base, lattice_step=3.0e-2,
+                                             period=5.0e-2).resonator
           for target in (250.0, 320.0, 410.0, 520.0)]
-chain = slit_helmholtz_absorber(f_chain, graded, slit_height=1.20e-3,
-                                lattice_step=3.0e-2, period=5.0e-2)
+chain = materials.slit_helmholtz_absorber(f_chain, graded, slit_height=1.20e-3,
+                                          lattice_step=3.0e-2, period=5.0e-2)
 step = float(f_chain[1] - f_chain[0])
 print(round(float(chain.absorption.max()), 3),
       round(float(np.sum(chain.absorption >= 0.8)) * step))     # 0.999 51

--- a/site/src/content/docs/materials/absorbers/porous-absorbers.mdx
+++ b/site/src/content/docs/materials/absorbers/porous-absorbers.mdx
@@ -383,23 +383,20 @@ and the limp one settles on $\rho_\mathrm{t}/\rho_0 = 25.9$.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PorousLayer, decoupling_frequency, johnson_champoux_allard,
-    layered_absorber, limp_frame, limp_frame_applicable,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 11.2: soft fibrous layer, 50 mm.
 f = np.linspace(1.0, 2000.0, 800)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     f, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 
-print(round(decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
+print(round(materials.decoupling_frequency(25e3, porosity=0.98, frame_density=30.0), 1))
 # 127.4
 print(round(float(limp.effective_density[0].real), 1))     # 31.2 = rho_t
-print(limp_frame_applicable(20e3), limp_frame_applicable(25e3))  # True False
+print(materials.limp_frame_applicable(20e3), materials.limp_frame_applicable(25e3))  # True False
 
 limp.plot()   # normalised Zc and k of the corrected medium
 plt.show()
@@ -432,18 +429,16 @@ slightly higher one either side of 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PorousLayer, johnson_champoux_allard, layered_absorber, limp_frame,
-)
+from phonometry import materials
 
 bands = np.array([100, 125, 160, 200, 250, 315, 400, 500, 1000], dtype=float)
-rigid = johnson_champoux_allard(
+rigid = materials.johnson_champoux_allard(
     bands, 25e3, porosity=0.98, tortuosity=1.02,
     viscous_length=90e-6, thermal_length=180e-6,
 )
-limp = limp_frame(rigid, frame_density=30.0, porosity=0.98)
+limp = materials.limp_frame(rigid, frame_density=30.0, porosity=0.98)
 for medium in (rigid, limp):
-    print(layered_absorber(bands, [PorousLayer(0.05, medium)]).absorption.round(2))
+    print(materials.layered_absorber(bands, [materials.PorousLayer(0.05, medium)]).absorption.round(2))
 # [0.07 0.11 0.17 0.24 0.32 0.43 0.54 0.64 0.88]   rigid frame
 # [0.04 0.08 0.15 0.24 0.36 0.48 0.61 0.71 0.91]   limp frame
 ```
@@ -564,31 +559,28 @@ imaginary part that the book measures and plots in its Fig. 6.10.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, biot_waves, frame_elastic_coefficient,
-    frame_quarter_wave_resonance, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 # Allard & Atalla Table 6.1: glass wool "Domisol Coffrage", 100 mm, glued.
 f = np.linspace(200.0, 1500.0, 1301)
 shear = 2.2e6 * (1 + 0.1j)          # 220 N/cm2, loss factor 0.1
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     f, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 
-print(frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
-print(round(frame_quarter_wave_resonance(
+print(materials.frame_elastic_coefficient(shear, 0.0))       # (4400000+440000j)
+print(round(materials.frame_quarter_wave_resonance(
     0.10, shear_modulus=shear, poisson_ratio=0.0, frame_density=130.0), 1))
 # 459.9
 
-waves = biot_waves(med, porosity=0.94, tortuosity=1.06,
-                   frame_density=130.0, shear_modulus=shear)
+waves = materials.biot_waves(med, porosity=0.94, tortuosity=1.06,
+                             frame_density=130.0, shear_modulus=shear)
 print(round(float(abs(waves.airborne_velocity_ratio[800])), 1))     # 42.4
 print(np.round(waves.frame_borne_velocity_ratio[-1], 3))  # (0.811+0.473j)
 
-biot = layered_absorber(f, [PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
-rigid = layered_absorber(f, [PorousLayer(0.10, med)])
+biot = materials.layered_absorber(f, [materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)])
+rigid = materials.layered_absorber(f, [materials.PorousLayer(0.10, med)])
 
 fig, ax = plt.subplots()
 for res, style in ((rigid, "--"), (biot, "-")):
@@ -623,19 +615,17 @@ sharpest; on third-octave centres the largest shift is the 0.12 at 500 Hz:
 
 ```python
 import numpy as np
-from phonometry import (
-    PoroelasticLayer, PorousLayer, johnson_champoux_allard, layered_absorber,
-)
+from phonometry import materials
 
 bands = np.array([250, 315, 400, 500, 630, 800, 1000], dtype=float)
-med = johnson_champoux_allard(
+med = materials.johnson_champoux_allard(
     bands, 40e3, porosity=0.94, tortuosity=1.06,
     viscous_length=0.56e-4, thermal_length=1.1e-4,
 )
 shear = 2.2e6 * (1 + 0.1j)
-for layer in (PorousLayer(0.10, med),
-              PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
-    print(layered_absorber(bands, [layer]).absorption.round(2))
+for layer in (materials.PorousLayer(0.10, med),
+              materials.PoroelasticLayer(0.10, med, 0.94, 1.06, 130.0, shear)):
+    print(materials.layered_absorber(bands, [layer]).absorption.round(2))
 # [0.55 0.58 0.62 0.65 0.69 0.74 0.78]   rigid frame
 # [0.53 0.56 0.61 0.77 0.71 0.74 0.78]   Biot poroelastic
 ```

--- a/site/src/content/docs/materials/diffusers/metadiffusers.mdx
+++ b/site/src/content/docs/materials/diffusers/metadiffusers.mdx
@@ -142,12 +142,7 @@ five-well sequence six times (`periods=6`, a 2.1 m panel):
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    metadiffuser_polar_response,
-    metadiffuser_reflection,
-)
+from phonometry import materials
 
 # The published quadratic-residue metadiffuser: five slits with two
 # resonators each in a 35 cm x 2 cm panel (7 cm pitch), tuned to mimic a
@@ -164,12 +159,12 @@ rows = [  # slit h, neck l_n, cavity l_c, neck w_n, cavity w_c  [mm]
 ]
 wells = []
 for h, ln, lc, wn, wc in rows:
-    resonator = HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
+    resonator = materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
     # two identical resonators per slit
-    wells.append(MetadiffuserWell(h * mm, (resonator, resonator)))
+    wells.append(materials.MetadiffuserWell(h * mm, (resonator, resonator)))
 
 f = np.arange(1800.0, 2601.0, 5.0)
-panel = metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(f, wells, depth=0.02, period=0.07)
 alpha1 = panel.well_absorption[0]
 print(round(float(alpha1.max()), 2), int(f[alpha1.argmax()]))  # 0.99 2305
 
@@ -183,8 +178,8 @@ print(round(float(panel.absorption.max()), 3), peak)
 # 0.253 2260
 
 # Far-field comparison: the five-well sequence repeated six times (2.1 m).
-polar = metadiffuser_polar_response(2000.0, wells, depth=0.02,
-                                    period=0.07, periods=6)
+polar = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02,
+                                              period=0.07, periods=6)
 print(round(polar.coefficient, 2))                             # 0.32
 ```
 
@@ -256,12 +251,7 @@ only difference between them is how each well reaches its reflection phase.*
 
 ```python
 import numpy as np
-from phonometry import (
-    HelmholtzResonator,
-    MetadiffuserWell,
-    materials,
-    metadiffuser_polar_response,
-)
+from phonometry import materials
 
 mm = 1e-3
 rows = [
@@ -272,17 +262,17 @@ rows = [
     (20.3, 18.0, 20.7, 3.2, 9.0),
 ]
 wells = [
-    MetadiffuserWell(
+    materials.MetadiffuserWell(
         h * mm,
-        2 * (HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
+        2 * (materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm),),
     )
     for h, ln, lc, wn, wc in rows
 ]
 
 # The metadiffuser panel and the QRD it was tuned to at 2 kHz, both with
 # six repetitions of the period (2.1 m panels).
-meta = metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
-                                   periods=6)
+meta = materials.metadiffuser_polar_response(2000.0, wells, depth=0.02, period=0.07,
+                                             periods=6)
 sequence = np.roll(materials.quadratic_residue_sequence(5), -1)
 depths = sequence * (343.0 / 500.0) / (2 * 5)
 qrd = materials.predict_diffuser_polar_response(
@@ -325,11 +315,11 @@ targets while keeping $|R_n|$ near one:
 
 ```python
 import numpy as np
-from phonometry import materials, metadiffuser_reflection
+from phonometry import materials
 
 # wells: the five published slits from the example above.
-panel = metadiffuser_reflection(np.array([2000.0]), wells,
-                                depth=0.02, period=0.07)
+panel = materials.metadiffuser_reflection(np.array([2000.0]), wells,
+                                          depth=0.02, period=0.07)
 phases = np.degrees(np.angle(panel.reflection[:, 0]))
 print(np.round(np.abs(panel.reflection[:, 0]), 2))  # [0.97 1.   1.   0.97 0.98]
 print(np.round(phases))                             # [ 75. -71. -71.  74.   2.]
@@ -360,7 +350,7 @@ import matplotlib.pyplot as plt
 
 # `wells` and `depths` come from the blocks above.
 sweep = np.linspace(1600.0, 2600.0, 201)
-swept = metadiffuser_reflection(sweep, wells, depth=0.02, period=0.07)
+swept = materials.metadiffuser_reflection(sweep, wells, depth=0.02, period=0.07)
 k_sweep = 2 * np.pi * sweep / 343.0
 target_phase = np.angle(np.exp(-2j * np.outer(depths, k_sweep)))
 error = np.degrees(np.angle(np.exp(1j * (np.angle(swept.reflection)
@@ -400,10 +390,10 @@ def panel_with(cavity_mm):
     trial = [(14.7, 13.0, cavity_mm, 6.2, 9.0)] + rows[1:]
     built = []
     for h, ln, lc, wn, wc in trial:
-        resonator = HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
-        built.append(MetadiffuserWell(h * mm, (resonator, resonator)))
-    return metadiffuser_reflection(np.array([2000.0]), built,
-                                   depth=0.02, period=0.07)
+        resonator = materials.HelmholtzResonator(ln * mm, wn * mm, lc * mm, wc * mm)
+        built.append(materials.MetadiffuserWell(h * mm, (resonator, resonator)))
+    return materials.metadiffuser_reflection(np.array([2000.0]), built,
+                                             depth=0.02, period=0.07)
 
 best = None
 for cavity_mm in np.linspace(4.0, 22.0, 60):

--- a/site/src/content/docs/perception/speech/objective-intelligibility.mdx
+++ b/site/src/content/docs/perception/speech/objective-intelligibility.mdx
@@ -84,7 +84,7 @@ returning a number. At least about **0.4 s of active speech** has to survive.
 
 ```python
 import numpy as np
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(11)
@@ -102,9 +102,9 @@ noise = rng.standard_normal(n)
 noise *= np.sqrt(np.mean(clean ** 2) / np.mean(noise ** 2))   # 0 dB SNR
 degraded = clean + noise
 
-d = stoi(clean, degraded, fs)               # STOI, resampled to 10 kHz inside
+d = speech.stoi(clean, degraded, fs)               # STOI, resampled to 10 kHz inside
 print(round(d.value, 3))                    # 0.708
-print(round(stoi(clean, clean, fs).value, 6))   # 1.0  (a signal against itself)
+print(round(speech.stoi(clean, clean, fs).value, 6))   # 1.0  (a signal against itself)
 ```
 
 Everything up to the 384 ms segments is shared; the two measures only part
@@ -197,7 +197,7 @@ gain, STOI is **invariant to the overall playback level** of the degraded
 signal, and higher SNR gives a monotonically higher score.
 
 ```python
-from phonometry import stoi
+from phonometry import speech
 
 # The speech-like `clean` of section 1, degraded at four signal-to-noise
 # ratios. Keep the reference speech-like: a flat Gaussian reference has no
@@ -205,7 +205,7 @@ from phonometry import stoi
 for snr_db in (-10, 0, 10, 20):
     g = 10.0 ** (-snr_db / 20.0)
     noisy = clean + g * rng.standard_normal(clean.size)
-    print(snr_db, round(stoi(clean, noisy, fs).value, 3))
+    print(snr_db, round(speech.stoi(clean, noisy, fs).value, 3))
 # -10 0.083 | 0 0.484 | 10 0.858 | 20 0.956
 ```
 
@@ -228,7 +228,7 @@ bites, which the single number cannot.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.signal import butter, lfilter
-from phonometry import stoi
+from phonometry import speech
 
 # Speech-like material: band-limited noise with a 3.5 Hz syllabic envelope,
 # in a flat masker at 0 dB SNR.
@@ -240,7 +240,7 @@ carrier = lfilter(b, a, rng.standard_normal(t.size))
 clean = carrier * (0.15 + 0.85 * np.abs(np.sin(2 * np.pi * 3.5 * t)) ** 2)
 masker = rng.standard_normal(clean.size)
 gain = np.sqrt(np.mean(clean ** 2)) / np.sqrt(np.mean(masker ** 2))
-res = stoi(clean, clean + gain * masker, fs)
+res = speech.stoi(clean, clean + gain * masker, fs)
 print(round(res.value, 3))    # 0.727
 
 # One line: the per-band intermediate correlation behind the index.
@@ -295,11 +295,11 @@ ref = np.fft.irfft(spec, n) * np.where(env < 0.08, 0.0, env)
 
 masker = fig_rng.standard_normal(n)
 masker *= np.sqrt(np.mean(ref ** 2) / np.mean(masker ** 2))
-steady = stoi(ref, ref + masker, fs)
+steady = speech.stoi(ref, ref + masker, fs)
 
 hole = np.ones(n)
 hole[int(1.6 * fs):int(1.95 * fs)] = 0.0        # a 0.35 s dropout
-dropout = stoi(ref, ref * hole, fs)
+dropout = speech.stoi(ref, ref * hole, fs)
 
 print(round(steady.value, 3), round(dropout.value, 3))   # 0.772 0.874
 print(round(float(dropout.segment_scores.min()), 3))     # -0.078
@@ -337,7 +337,7 @@ average largely misses.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import stoi
+from phonometry import speech
 
 fs = 10000
 rng = np.random.default_rng(20)
@@ -356,8 +356,8 @@ snrs = np.arange(-15.0, 20.1, 5.0)
 
 def curve(masker, extended):
     p_m = np.sqrt(np.mean(masker ** 2))
-    return [stoi(clean, clean + (p_clean / (p_m * 10.0 ** (s / 20.0))) * masker,
-                 fs, extended=extended).value for s in snrs]
+    return [speech.stoi(clean, clean + (p_clean / (p_m * 10.0 ** (s / 20.0))) * masker,
+                        fs, extended=extended).value for s in snrs]
 
 fig, (a, b) = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
 for ax, extended, title in ((a, False, "STOI"), (b, True, "ESTOI")):

--- a/site/src/content/docs/perception/speech/speech-intelligibility.mdx
+++ b/site/src/content/docs/perception/speech/speech-intelligibility.mdx
@@ -541,18 +541,18 @@ and so sums to 0.9996.
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import SII_METHODS, sii_procedure
+from phonometry import speech
 
 # One line: each procedure's own .plot() steps its Ii over its band limits.
 fig, ax = plt.subplots(figsize=(10, 6))
-for method in SII_METHODS:
-    sii_procedure(method).plot(ax=ax, linewidth=1.8)
+for method in speech.SII_METHODS:
+    speech.sii_procedure(method).plot(ax=ax, linewidth=1.8)
 plt.show()
 
 # By hand, mirroring what SIIProcedure.plot() draws:
 fig, ax = plt.subplots()
-for method in SII_METHODS:
-    proc = sii_procedure(method)
+for method in speech.SII_METHODS:
+    proc = speech.sii_procedure(method)
     ii = proc.band_importance
     ax.plot(proc.band_edges, np.append(ii, ii[-1]), drawstyle="steps-post",
             label=method)

--- a/site/src/content/docs/signals/filters/filter-banks.mdx
+++ b/site/src/content/docs/signals/filters/filter-banks.mdx
@@ -338,16 +338,16 @@ all-pass has unit magnitude everywhere (only the phase turns).
 
 ```python
 import numpy as np
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 rng = np.random.default_rng(1)
 x = rng.standard_normal(fs)                 # one second of noise
 
-eq = ParametricEQ(fs, [
-    EQSection("lowshelf", 100.0, gain_db=4.0),
-    EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
-    EQSection("highshelf", 8000.0, gain_db=3.0),
+eq = filters.ParametricEQ(fs, [
+    filters.EQSection("lowshelf", 100.0, gain_db=4.0),
+    filters.EQSection("peaking", 1000.0, gain_db=-6.0, bw=1.0),  # one-octave cut
+    filters.EQSection("highshelf", 8000.0, gain_db=3.0),
 ])
 y = eq.filter(x)              # apply the cascade
 res = eq.response()           # frozen result carrying the SOS cascade
@@ -370,21 +370,21 @@ itself this way — `res.plot()` above produced exactly this figure.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import EQSection, ParametricEQ
+from phonometry import filters
 
 fs = 48000
 family = [
-    EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
-    EQSection("lowshelf", 125.0, gain_db=6.0),
-    EQSection("highshelf", 4000.0, gain_db=-6.0),
-    EQSection("lowpass", 10000.0),
-    EQSection("highpass", 50.0),
-    EQSection("bandpass", 500.0, q=2.0),
-    EQSection("notch", 2000.0, q=6.0),
+    filters.EQSection("peaking", 1000.0, gain_db=6.0, q=1.4),
+    filters.EQSection("lowshelf", 125.0, gain_db=6.0),
+    filters.EQSection("highshelf", 4000.0, gain_db=-6.0),
+    filters.EQSection("lowpass", 10000.0),
+    filters.EQSection("highpass", 50.0),
+    filters.EQSection("bandpass", 500.0, q=2.0),
+    filters.EQSection("notch", 2000.0, q=6.0),
 ]
 fig, ax = plt.subplots(figsize=(10, 6))
 for section in family:
-    res = ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
+    res = filters.ParametricEQ(fs, [section]).response(f_min=20.0, f_max=20000.0)
     ax.semilogx(res.frequencies, res.magnitude_db,
                 label=f"{section.filter_type} @ {section.f0:g} Hz")
 ax.set(xlim=(20, 20000), ylim=(-27, 9),

--- a/site/src/content/docs/signals/filters/filter-compliance.mdx
+++ b/site/src/content/docs/signals/filters/filter-compliance.mdx
@@ -377,14 +377,10 @@ a comma decimal separator), e.g.
 `result.report("iec61260_es.pdf", language="es")`.
 
 ```python
-from phonometry import (
-    OctaveFilterBank,
-    ReportMetadata,
-    filter_class_compliance,
-)
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # overall_class == 1
 result.plot()   # the worst-margin band on its class corridor
 
 result.report(
@@ -412,8 +408,8 @@ ANSI S1.11-2004 mask, which keeps the stricter **class 0** that the 2014 edition
 dropped, so a modest order-6 bank can be certified to class 0:
 
 ```python
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
-result = filter_class_compliance(bank, edition="1995")   # overall_class == 0
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
+result = filters.filter_class_compliance(bank, edition="1995")   # overall_class == 0
 result.plot()   # the class-0 corridor of the 1995 edition
 result.report("iec61260_1995.pdf",
               metadata=ReportMetadata(measurement_standard="IEC 61260:1995",

--- a/site/src/content/docs/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/signals/metrology/compliance-verification.mdx
@@ -210,10 +210,10 @@ band drawn on its class corridor) and `.report()`, the one-page accredited
 fiche with an optional PASS/FAIL row against a required class:
 
 ```python
-from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+from phonometry import ReportMetadata, filters
 
-bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-result = filter_class_compliance(bank)   # result.overall_class == 1
+bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filters.filter_class_compliance(bank)   # result.overall_class == 1
 result.report(
     "iec61260.pdf",
     metadata=ReportMetadata(

--- a/site/src/content/docs/signals/metrology/data-qualification.mdx
+++ b/site/src/content/docs/signals/metrology/data-qualification.mdx
@@ -119,12 +119,12 @@ suite pins. The book's Example 4.4 (twenty observations, $A = 86$, accepted in
 $(64, 125]$) runs verbatim:
 
 ```python
-from phonometry import trend_test
+from phonometry import metrology
 
 values = [5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
           5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0]
 
-res = trend_test(values)                  # B&P Example 4.4
+res = metrology.trend_test(values)                  # B&P Example 4.4
 print(res.statistic, res.bounds)          # 86, (64, 125] — half-open
 print(res.trend_free, round(res.p_value, 3))   # True, 0.586
 res.plot()
@@ -146,14 +146,14 @@ zero, which is why the counting works without knowing the distribution.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 example = np.array([5.2, 6.2, 3.7, 6.4, 3.9, 4.0, 3.9, 5.3, 4.0, 4.6,
                     5.9, 6.5, 4.3, 5.7, 3.1, 5.6, 5.2, 3.9, 6.2, 5.0])
 drifting = example + np.linspace(0.0, 4.0, example.size)   # rising drift
 
-res_flat = trend_test(example)
-res_drift = trend_test(drifting)
+res_flat = metrology.trend_test(example)
+res_drift = metrology.trend_test(drifting)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, example.size + 1)
@@ -210,17 +210,17 @@ while the same noise without the drift passes:
 
 ```python
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 noise = np.random.default_rng(42).standard_normal(n)
 
-res = stationarity_test(noise, fs)        # 20 segments, mean squares
+res = metrology.stationarity_test(noise, fs)        # 20 segments, mean squares
 print(res.stationary, res.count, res.bounds)   # True, 91, (64, 125)
 
 drifting = noise * np.linspace(1.0, 1.2, n)    # +20 % gain ramp
-res = stationarity_test(drifting, fs)
+res = metrology.stationarity_test(drifting, fs)
 print(res.stationary, res.count)          # False, 7  (upward trend -> low A)
 res.plot()
 ```
@@ -241,15 +241,15 @@ enters.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import stationarity_test
+from phonometry import metrology
 
 fs = 8192.0
 n = 1 << 16
 steady = np.random.default_rng(42).standard_normal(n)
 ramp = np.random.default_rng(42).standard_normal(n) * np.linspace(1.0, 1.2, n)
 
-res_steady = stationarity_test(steady, fs)
-res_ramp = stationarity_test(ramp, fs)
+res_steady = metrology.stationarity_test(steady, fs)
+res_ramp = metrology.stationarity_test(ramp, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 index = np.arange(1, res_steady.n_segments + 1)
@@ -345,8 +345,8 @@ glide = np.sin(2 * np.pi * (200 * t + (2000 - 200) / (2 * t[-1]) * t ** 2))
 sos = signal.butter(6, [200 / (fs / 2), 400 / (fs / 2)], btype="band",
                     output="sos")
 
-full = stationarity_test(glide, fs)
-banded = stationarity_test(signal.sosfiltfilt(sos, glide), fs)
+full = metrology.stationarity_test(glide, fs)
+banded = metrology.stationarity_test(signal.sosfiltfilt(sos, glide), fs)
 print(full.count, full.stationary)       # 96 True   -- blind
 print(banded.count, banded.stationary)   # 173 False -- caught
 
@@ -375,15 +375,15 @@ acceptance region at $\alpha = 0.05$ is the classical $(6, 15]$:
 
 ```python
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
-res = trend_test(rng.standard_normal(40), method="runs")
+res = metrology.trend_test(rng.standard_normal(40), method="runs")
 print(res.statistic, res.bounds, res.trend_free)
 res.plot()   # the sequence about its median with the runs verdict
 
 alternating = np.tile([1.0, -1.0], 10)   # 20 runs: rejected the other way
-print(trend_test(alternating, method="runs").trend_free)   # False
+print(metrology.trend_test(alternating, method="runs").trend_free)   # False
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/runs_test.svg" alt="Two panels of sequences classified about their median, points above in blue and below in red. Left: forty Gaussian observations with twenty runs inside the acceptance region from fourteen to twenty-seven, verdict trend-free. Right: a strictly alternating twenty-value sequence also giving twenty runs, but against the acceptance region from six to fifteen for twenty values, verdict rejected for too-rapid alternation" width="92%" />
@@ -399,19 +399,19 @@ too **many** runs is as non-random as too few.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import trend_test
+from phonometry import metrology
 
 rng = np.random.default_rng(3)
 sequences = [rng.standard_normal(40), np.tile([1.0, -1.0], 10)]
 
 # One line per sequence — the tested values with the verdict:
-trend_test(sequences[0], method="runs").plot()
+metrology.trend_test(sequences[0], method="runs").plot()
 plt.show()
 
 # Both verdicts side by side, classified about the median:
 fig, axes = plt.subplots(1, 2, figsize=(11, 4.5))
 for ax, seq in zip(axes, sequences):
-    res = trend_test(seq, method="runs")
+    res = metrology.trend_test(seq, method="runs")
     idx = np.arange(1, seq.size + 1)
     median = np.median(seq)
     above = seq > median
@@ -459,13 +459,13 @@ the Rice curve next to them, taking the moments from the record's own
 
 ```python
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # a 60 Hz sine ...
 
-res = level_crossing_rate(x, fs)
+res = metrology.level_crossing_rate(x, fs)
 print(round(res.zero_crossing_rate, 1))   # ... has 120 zeros per second
 print(round(res.apparent_frequency, 1))   # 60.0
 res.plot()
@@ -488,7 +488,7 @@ statistics of the record, not a failure of the model.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import level_crossing_rate
+from phonometry import metrology
 
 fs = 20480.0
 n = 1 << 19
@@ -498,7 +498,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[(freqs < 800.0) | (freqs > 1200.0)] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
+res = metrology.level_crossing_rate(x, fs, levels=np.linspace(-3.5, 3.5, 29) * np.std(x))
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.levels, res.rice_rates, label="Rice (Eq. 5.196)")
@@ -571,13 +571,13 @@ available as `peak_exceedance()` / `peak_density()` on the result:
 
 ```python
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 
 fs = 8192.0
 t = np.arange(1 << 16) / fs
 x = np.sin(2 * np.pi * 60.0 * t)          # narrowband: r is essentially 1
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 print(round(res.irregularity_factor, 3))       # 0.997
 print(res.peak_exceedance(4.0))                # exp(-8): about 1 in 3000
 res.plot()   # empirical exceedance against the Rice mixture (figure below)
@@ -600,7 +600,7 @@ extremes.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import peak_statistics
+from phonometry import metrology
 from phonometry.metrology.data_qualification import _rice_peak_exceedance
 
 fs = 20480.0
@@ -611,7 +611,7 @@ spec = rng.standard_normal(freqs.size) + 1j * rng.standard_normal(freqs.size)
 spec[freqs > 2000.0] = 0.0
 x = np.fft.irfft(spec, n)
 
-res = peak_statistics(x, fs)
+res = metrology.peak_statistics(x, fs)
 peaks = res.peak_values
 empirical = 1.0 - np.arange(1, peaks.size + 1) / peaks.size
 z = np.linspace(-2.5, 4.5, 400)

--- a/site/src/content/docs/signals/spectra/cepstrum-echoes.mdx
+++ b/site/src/content/docs/signals/spectra/cepstrum-echoes.mdx
@@ -80,13 +80,13 @@ computes the three standard variants over the quefrency axis:
 
 ```python
 import numpy as np
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(1)
 x = rng.standard_normal(4096)
 
-res = cepstrum(x, fs, kind="power")
+res = signals.cepstrum(x, fs, kind="power")
 print(res.quefrencies[:3], res.cepstrum.shape)   # quefrency axis, in s
 res.plot()
 ```
@@ -106,7 +106,7 @@ wavelet concentrates below 2 ms.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited source wavelet plus one reflection at 8 ms (a = 0.5)
@@ -116,13 +116,13 @@ s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
 # One line per variant — each CepstrumResult draws itself:
-cepstrum(x, fs, kind="power").plot()
+signals.cepstrum(x, fs, kind="power").plot()
 plt.show()
 
 # The three variants overlaid by hand on one quefrency axis:
 fig, ax = plt.subplots()
 for kind, style in (("power", "-"), ("real", "--"), ("complex", ":")):
-    res = cepstrum(x, fs, kind=kind)
+    res = signals.cepstrum(x, fs, kind=kind)
     q_ms = 1e3 * res.quefrencies
     mask = (q_ms > 0.5) & (q_ms <= 20.0)
     ax.plot(q_ms[mask], res.cepstrum[mask], style, label=f"{kind} cepstrum")
@@ -171,14 +171,14 @@ delay still lands on it, but the reported coefficient underestimates $|a|$
 
 ```python
 import numpy as np
-from phonometry import echo_detection
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(2)
 s = rng.standard_normal(12000)               # broadband source
 x = s + 0.5 * np.roll(s, 384)                # echo: 8 ms, a = 0.5
 
-res = echo_detection(x, fs, min_quefrency=0.002)
+res = signals.echo_detection(x, fs, min_quefrency=0.002)
 print(res.delay, res.reflection_coefficient)  # 0.008 s, ~0.5
 res.plot()
 ```
@@ -200,7 +200,7 @@ source's own envelope, which is why the search starts above it.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import echo_detection, noise_signal
+from phonometry import signals
 
 fs = 48000.0
 n = 12000
@@ -209,9 +209,9 @@ impulse[0] = 1.0
 b, a = sp_signal.butter(2, [0.004, 0.9], btype="bandpass")
 direct = sp_signal.lfilter(b, a, impulse)              # broadband click
 ir = direct + 0.5 * np.roll(direct, int(0.008 * fs))   # echo at 8 ms
-ir += noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
+ir += signals.noise_signal(fs, n / fs, color="white", rms=1e-4, seed=13)
 
-res = echo_detection(ir, fs, min_quefrency=0.002)
+res = signals.echo_detection(ir, fs, min_quefrency=0.002)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 half = res.nfft // 2 + 1
@@ -294,15 +294,15 @@ exactly complementary in dB, because the split is linear in the log domain:
 
 ```python
 import numpy as np
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 rng = np.random.default_rng(3)
 s = rng.standard_normal(12000)
 x = s + 0.5 * np.roll(s, 384)                # the same 8 ms echo
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
-high = lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")    # envelope of ln|X|
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")  # the echo ripple
 print(np.allclose(low.liftered_db + high.liftered_db, low.spectrum_db))
 low.plot()
 ```
@@ -321,7 +321,7 @@ $20\log_{10}(1 \pm a) = +3.5$ and $-6.0$ dB.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import lifter
+from phonometry import signals
 
 fs = 48000.0
 # A band-limited wavelet carrying a pure 8 ms echo (a = 0.5), so the
@@ -331,8 +331,8 @@ s = np.zeros(4096)
 s[37:37 + 256] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 x = s + 0.5 * np.roll(s, 384)
 
-low = lifter(x, fs, cutoff=0.004, mode="lowpass")
-high = lifter(x, fs, cutoff=0.004, mode="highpass")
+low = signals.lifter(x, fs, cutoff=0.004, mode="lowpass")
+high = signals.lifter(x, fs, cutoff=0.004, mode="highpass")
 
 # One line — the cepstrum with the cutoff and the two log spectra:
 low.plot()
@@ -374,14 +374,14 @@ removes and stores in `linear_phase_samples`:
 ```python
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import cepstrum
+from phonometry import signals
 
 fs = 48000.0
 x = np.zeros(2048)
 b, a = sp_signal.butter(2, 0.3)
 x[37:293] = sp_signal.lfilter(b, a, np.r_[1.0, np.zeros(255)])
 
-res = cepstrum(x, fs, kind="complex")
+res = signals.cepstrum(x, fs, kind="complex")
 print(res.linear_phase_samples)              # negative: a bulk delay removed
 print(np.max(np.abs(res.invert() - x)))      # ~1e-14
 res.plot()   # the complex cepstrum against quefrency (as in the figure above)
@@ -446,13 +446,13 @@ on an analysis bin the closed forms are:
 
 ```python
 import numpy as np
-from phonometry import envelope_spectrum
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(4 * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 k = int(round(25.0 * res.nfft / fs))
 print(res.mean_level, res.amplitude[k])      # ~1.0 and ~0.4
 res.plot()
@@ -474,15 +474,15 @@ is why the chain finds bearing defects that the carrier's own spectrum hides.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope_spectrum, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 seconds = 4.0
 t = np.arange(int(seconds * fs)) / fs
 x = (1.0 + 0.4 * np.cos(2 * np.pi * 25.0 * t)) * np.cos(2 * np.pi * 1000.0 * t)
-x += noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.03, seed=8)
 
-res = envelope_spectrum(x, fs)
+res = signals.envelope_spectrum(x, fs)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(res.frequencies, res.amplitude, lw=1.4, label="Envelope spectrum")
@@ -539,8 +539,8 @@ t_s = np.arange(int(4 * fs)) / fs
 ring = np.sin(2 * np.pi * 3000.0 * t_s) * np.exp(-(t_s % (1 / 120.0)) / 0.001)
 raw = ring + 3.0 * np.sin(2 * np.pi * 50.0 * t_s)
 
-wide = envelope_spectrum(raw, fs)
-narrow = envelope_spectrum(raw, fs, band=(2000.0, 4000.0))
+wide = signals.envelope_spectrum(raw, fs)
+narrow = signals.envelope_spectrum(raw, fs, band=(2000.0, 4000.0))
 k120 = int(round(120.0 * wide.nfft / fs))
 print(round(wide.amplitude[k120], 4),        # 0.0093 — buried
       round(narrow.amplitude[k120], 4))      # 0.1964 — 26 dB better

--- a/site/src/content/docs/signals/spectra/correlation-delay.mdx
+++ b/site/src/content/docs/signals/spectra/correlation-delay.mdx
@@ -56,9 +56,9 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 
 ```python
 import numpy as np
-from phonometry import correlation
+from phonometry import signals
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
 res.plot()
@@ -78,23 +78,23 @@ there (bottom).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import correlation, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 delay = 102                                  # 12.45 ms
-x = noise_signal(fs, 2.0, seed=4)
-interference = noise_signal(fs, 2.0, rms=0.5, seed=5)
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
 y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
 
-res = correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
+res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 
 # One line — the correlation estimate against the lag in seconds:
 res.plot()
 plt.show()
 
 # The three normalizations by hand, from the same records:
-biased = correlation(x, y, fs, normalization="biased")
-unbiased = correlation(x, y, fs, normalization="unbiased")
+biased = signals.correlation(x, y, fs, normalization="biased")
+unbiased = signals.correlation(x, y, fs, normalization="unbiased")
 
 fig, (ax_c, ax_n) = plt.subplots(2, 1)
 ax_c.plot(1e3 * res.lags, res.values, label="coefficient")
@@ -245,18 +245,18 @@ position: it is what says whether a reflection could be sitting under the peak.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import noise_signal, time_delay
+from phonometry import signals
 
 fs = 8192.0
 delay = 20  # samples
 b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
-s = sp_signal.lfilter(b, a, noise_signal(fs, 4.0, color="white", seed=10))
-x = s + noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
-y = np.roll(s, delay) + noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
-direct = time_delay(x, y, fs, method="direct", max_delay=0.01)
-phat = time_delay(x, y, fs, method="gcc", weighting="phat",
-                  nperseg=2048, max_delay=0.01)
+direct = signals.time_delay(x, y, fs, method="direct", max_delay=0.01)
+phat = signals.time_delay(x, y, fs, method="gcc", weighting="phat",
+                          nperseg=2048, max_delay=0.01)
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(1e3 * direct.lags,
@@ -291,10 +291,10 @@ $$
 $$
 
 ```python
-from phonometry import time_delay
+from phonometry import signals
 
-res = time_delay(x, y, fs, method="gcc", weighting="ml",
-                 nperseg=2048, upsample=16, signal_bandwidth=1000.0)
+res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
+                         nperseg=2048, upsample=16, signal_bandwidth=1000.0)
 print(res.delay, res.delay_samples)     # seconds and fractional samples
 print(res.delay_std, res.delay_interval)  # Eq. 8.129 sigma, +/-2 sigma
 res.plot()                              # correlation with the delay marked
@@ -316,12 +316,12 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
-from phonometry import align_impulse_responses, impulse_response_delay
+from phonometry import signals
 
-t_arrival = impulse_response_delay(ir, fs)              # seconds from t = 0
-dt = impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
+t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
-res = align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
+res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
 res.plot()                                     # reference vs aligned overlay
 ```
 
@@ -338,17 +338,17 @@ back onto its reference: the band-limited shift removes the estimated
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import align_impulse_responses, fractional_delay
+from phonometry import signals
 
 fs = 48000.0
 t = np.arange(int(0.03 * fs)) / fs
 rng = np.random.default_rng(6)
 # Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
 ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
-ir_b = fractional_delay(ir_a, 7.37)[: ir_a.size]
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
 ir_b += 0.005 * rng.standard_normal(ir_a.size)
 
-res = align_impulse_responses(ir_b, ir_a, fs)
+res = signals.align_impulse_responses(ir_b, ir_a, fs)
 
 # One line — reference and aligned IR overlaid:
 res.plot()
@@ -415,13 +415,13 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
-from phonometry import envelope
+from phonometry import signals
 
-res = envelope(x, fs)
+res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)
 res.plot()               # signal + envelope, instantaneous frequency
 
-slow = envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
+slow = signals.envelope(x, fs, decimation_factor=32)   # anti-aliased, fs/32
 ```
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/hilbert_envelope.svg" alt="Two panels for a decaying 250 hertz mode in light noise. Top: the oscillating signal with the smooth exponential Hilbert envelope tracing its decay above and below. Bottom: the instantaneous frequency staying on the dashed 250 hertz carrier line while the mode is strong and jittering increasingly as the signal decays into the noise floor" width="86%" />
@@ -437,7 +437,7 @@ noise floor (bottom, ×8 anti-aliased decimation).*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import envelope
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(int(0.4 * fs)) / fs
@@ -445,7 +445,7 @@ rng = np.random.default_rng(7)
 x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 x += 0.001 * rng.standard_normal(t.size)
 
-res = envelope(x, fs, decimation_factor=8)
+res = signals.envelope(x, fs, decimation_factor=8)
 
 # One line — signal + envelope and the instantaneous frequency:
 res.plot()

--- a/site/src/content/docs/signals/spectra/miso-coherence.mdx
+++ b/site/src/content/docs/signals/spectra/miso-coherence.mdx
@@ -43,19 +43,19 @@ spend money quietening the wrong source.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import miso_coherence, noise_signal
+from phonometry import signals
 
 fs = 8192.0
 # Input 1 drives a low-frequency path; input 2 = 0.7*x1 + independent noise
 # drives a high-frequency path, so input 2 is correlated with input 1.
-x1 = noise_signal(fs, 32.0, color="white", seed=1)
-x2 = 0.7 * x1 + noise_signal(fs, 32.0, color="white", seed=2)
+x1 = signals.noise_signal(fs, 32.0, color="white", seed=1)
+x2 = 0.7 * x1 + signals.noise_signal(fs, 32.0, color="white", seed=2)
 low = signal.butter(4, 400.0, fs=fs, output="sos")
 high = signal.butter(4, 1500.0, btype="high", fs=fs, output="sos")
-noise = noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
+noise = signals.noise_signal(fs, 32.0, color="white", rms=0.05, seed=3)
 y = signal.sosfilt(low, x1) + signal.sosfilt(high, x2) + noise
 
-res = miso_coherence([x1, x2], y, fs, nperseg=2048)
+res = signals.miso_coherence([x1, x2], y, fs, nperseg=2048)
 f = res.frequencies
 band = (f >= 20.0) & (f <= 4000.0)
 
@@ -148,7 +148,7 @@ exactly to the ordinary coherences when the inputs are mutually uncorrelated
 (Eq. 7.117).
 
 ```python
-res = miso_coherence([x1, x2], y, fs)
+res = signals.miso_coherence([x1, x2], y, fs)
 res.ordinary_coherence   # shape (q, F): each input on its own
 res.multiple_coherence   # shape (F,):  all inputs jointly
 res.partial_coherence    # shape (q, F): conditioned on the preceding inputs
@@ -252,8 +252,8 @@ recorded alongside the two above — a fan in the next room, coherent with
 neither. Pass `order` to override the default:
 
 ```python
-x3 = noise_signal(fs, 32.0, color="white", seed=4)   # the third, weak source
-res = miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
+x3 = signals.noise_signal(fs, 32.0, color="white", seed=4)   # the third, weak source
+res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order
 ```

--- a/site/src/content/docs/signals/spectra/spectral-analysis.mdx
+++ b/site/src/content/docs/signals/spectra/spectral-analysis.mdx
@@ -118,12 +118,12 @@ has a single real Fourier component, so those bins carry half the degrees of
 freedom and a correspondingly wider interval.
 
 ```python
-from phonometry import power_spectral_density
+from phonometry import signals
 
 # record: one channel of a calibrated capture, in pascals (see the Calibration
 #   guide below); in dBFS work it is the raw [-1, 1] array and the result is
 #   FS^2/Hz. fs: its sample rate in Hz.
-res = power_spectral_density(record, fs)          # Hann, 50 % overlap, 95 % CI
+res = signals.power_spectral_density(record, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -141,9 +141,9 @@ $$
 $$
 
 ```python
-from phonometry import resolution_bias_error
+from phonometry import signals
 
-eps_b = resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
+eps_b = signals.resolution_bias_error(res.resolution_bandwidth, 25.0)  # Br = 25 Hz peak
 ```
 
 Narrow $B_\mathrm{e}$ (long segments) suppresses the bias but leaves fewer averages and
@@ -205,7 +205,7 @@ of its own, so the sensitivity factor goes on the *record*, before the estimate:
 ```python
 calibration_factor = 1.002             # Pa per digital unit, from the calibrator
 pressure = calibration_factor * record
-psd = power_spectral_density(pressure, fs)      # now in Pa^2/Hz
+psd = signals.power_spectral_density(pressure, fs)      # now in Pa^2/Hz
 ```
 
 The ordinate is then $10\log_{10}(G_{xx}/p_0^2)$ dB re (20 µPa)²/Hz, and with
@@ -234,18 +234,14 @@ applies.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    fractional_octave_smoothing,
-    noise_signal,
-    power_spectral_density,
-)
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 20.0, color="pink", seed=11)
-res = power_spectral_density(x, fs, nperseg=4096)
+x = signals.noise_signal(fs, 20.0, color="pink", seed=11)
+res = signals.power_spectral_density(x, fs, nperseg=4096)
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
-smooth = fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
+smooth = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)[band]
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.fill_between(freqs, 10 * np.log10(res.ci_lower[band]),
@@ -285,9 +281,9 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
-from phonometry import cross_spectral_density
+from phonometry import signals
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
 ```
@@ -306,16 +302,16 @@ frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import cross_spectral_density, noise_signal
+from phonometry import signals
 
 fs = 8000.0
 tau = 0.002                                   # 2 ms = 16 samples
 delay = int(tau * fs)
-x = noise_signal(fs, 8.0, seed=8)
-noise = noise_signal(fs, 8.0, rms=0.3, seed=9)
+x = signals.noise_signal(fs, 8.0, seed=8)
+noise = signals.noise_signal(fs, 8.0, rms=0.3, seed=9)
 y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 
-res = cross_spectral_density(x, y, fs)
+res = signals.cross_spectral_density(x, y, fs)
 
 # One line — magnitude, phase with its ±sigma band and coherence:
 res.plot()
@@ -371,14 +367,14 @@ synthetic signal:
 
 ```python
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 at every frequency
 
-res = coherent_output_spectrum(x, y, fs)
+res = signals.coherent_output_spectrum(x, y, fs)
 print(np.median(res.coherence))          # -> SNR/(1+SNR) = 0.719
 print(np.median(res.snr_db))             # -> 10·lg(2.56) = 4.1 dB
 res.plot()                               # Gyy, Gvv, Gnn and the SNR panel
@@ -396,14 +392,14 @@ around its closed form $10\log_{10}(0.64/0.25) = 4.1$ dB at every frequency.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import coherent_output_spectrum, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8.0, color="white", seed=1)
-noise = noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
+x = signals.noise_signal(fs, 8.0, color="white", seed=1)
+noise = signals.noise_signal(fs, 8.0, color="white", rms=0.5, seed=2)
 y = 0.8 * x + noise                      # SNR = 0.64/0.25 per band
 
-res = coherent_output_spectrum(x, y, fs, nperseg=2048)
+res = signals.coherent_output_spectrum(x, y, fs, nperseg=2048)
 
 # One line — the three spectra and the SNR panel:
 res.plot()
@@ -490,15 +486,15 @@ magnitude such as a frequency-response $|H|$ (`"amplitude"`, squared first), or
 a curve already in decibels (`"db"`, converted and converted back).
 
 ```python
-from phonometry import fractional_octave_smoothing
+from phonometry import signals
 
 freqs = res.frequencies                    # from the section 1 estimate
-smooth_psd = fractional_octave_smoothing(freqs, res.psd, 3.0)
+smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
 magnitude = np.sqrt(res.psd)               # any linear |H| would do here
-smooth_mag = fractional_octave_smoothing(freqs, magnitude, 6.0,
-                                         domain="amplitude")  # an FRF |H|
+smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,
+                                                 domain="amplitude")  # an FRF |H|
 levels = 10.0 * np.log10(res.psd)          # any dB curve would do here
-smooth_db = fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -555,10 +551,10 @@ seed reproduces the same record bit for bit.
 | `violet` | +2 | +6.02 dB/octave |
 
 ```python
-from phonometry import noise_signal
+from phonometry import signals
 
-pink = noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
-white = noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
+pink = signals.noise_signal(48000, 10.0, color="pink", seed=7)     # deterministic
+white = signals.noise_signal(48000, 10.0, color="white", rms=0.5, seed=7)
 ```
 
 Measured over three decades (20 Hz – 20 kHz) with the estimator of section 1,
@@ -611,9 +607,9 @@ as the Welch estimators apply it:
   resolution.
 
 ```python
-from phonometry import window_metrics
+from phonometry import signals
 
-m = window_metrics("hann", 2048)
+m = signals.window_metrics("hann", 2048)
 print(m.enbw_bins)              # 1.5, exactly
 print(m.scalloping_loss_db)     # 1.42 dB
 print(m.highest_sidelobe_db)    # -31.5 dB
@@ -641,12 +637,12 @@ beside a strong one, and no window does both.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import window_metrics
+from phonometry import signals
 
 n, oversample = 1024, 256
 fig, ax = plt.subplots(figsize=(10, 6.2))
 for name in ("boxcar", "hann", "hamming", "blackman"):
-    res = window_metrics(name, n)
+    res = signals.window_metrics(name, n)
     spectrum = np.abs(np.fft.rfft(res.taps, n=n * oversample))
     level = 20.0 * np.log10(spectrum / spectrum[0])
     bins = np.arange(level.size) / oversample
@@ -705,9 +701,9 @@ taper count is $K = 2p - 1$, all tapers with near-unity concentration.
 Larger $p$ admits more tapers (lower variance) at the cost of resolution.
 
 ```python
-from phonometry import multitaper_psd
+from phonometry import signals
 
-res = multitaper_psd(record, fs)                 # p = NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(record, fs)                 # p = NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band
@@ -761,12 +757,12 @@ which is exactly what widens the confidence interval there.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import multitaper_psd, noise_signal
+from phonometry import signals
 
 fs = 48000.0
-x = noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
-single = multitaper_psd(x, fs, n_tapers=1, adaptive=False)
-res = multitaper_psd(x, fs)                              # NW = 4, K = 7
+x = signals.noise_signal(fs, 8192 / fs, color="pink", seed=11)   # 171 ms record
+single = signals.multitaper_psd(x, fs, n_tapers=1, adaptive=False)
+res = signals.multitaper_psd(x, fs)                              # NW = 4, K = 7
 band = (res.frequencies >= 20.0) & (res.frequencies <= 20000.0)
 freqs = res.frequencies[band]
 

--- a/site/src/content/docs/signals/spectra/synchronous-averaging.mdx
+++ b/site/src/content/docs/signals/spectra/synchronous-averaging.mdx
@@ -44,11 +44,7 @@ thirty-two here, and only because of where the node lands.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    comb_filter_response,
-    noise_signal,
-    time_synchronous_average,
-)
+from phonometry import signals
 
 fs = 8192.0
 period = 1.0 / 32.0        # one revolution: 256 samples at this rate
@@ -59,8 +55,8 @@ periodic = (
     + 0.5 * np.cos(2.0 * np.pi * 3.0 * phase + 0.4)
     - 0.3 * np.cos(2.0 * np.pi * 6.0 * phase)
 )
-recording = periodic + noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
-res = time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
+recording = periodic + signals.noise_signal(fs, phase.size / fs, rms=0.9, seed=11)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=n_avg)
 
 fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(11, 4.6))
 t_ms = 1e3 * res.times
@@ -72,9 +68,9 @@ ax0.set_xlabel("Time [ms]"); ax0.set_ylabel("Amplitude"); ax0.legend()
 
 orders = np.linspace(31.0, 33.0, 4000)
 freqs = orders / period
-ax1.plot(orders, comb_filter_response(freqs, period, 32), color="#2ca02c",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 32), color="#2ca02c",
          label="N = 32 (power of two)")
-ax1.plot(orders, comb_filter_response(freqs, period, 20), color="#1f77b4",
+ax1.plot(orders, signals.comb_filter_response(freqs, period, 20), color="#1f77b4",
          label="N = 20 (node on 32.05)")
 ax1.axvline(32.05, color="#d62728", ls=":", label="Interfering tone")
 ax1.set_xlabel("Frequency [orders]"); ax1.set_ylabel("Comb filter magnitude")
@@ -121,12 +117,12 @@ every $j$ that is not a multiple of $N$, where the response is exactly zero.
 
 ```python
 import numpy as np
-from phonometry import comb_filter_response
+from phonometry import signals
 
 period = 1.0 / 32.0
-comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
-comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
-comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
+signals.comb_filter_response(np.array([16.0 / period]), period, 8)   # 1.0 at a tooth
+signals.comb_filter_response(np.array([0.25 / period]), period, 2)   # 1/sqrt(2)
+signals.comb_filter_response(np.array([0.5 / period]), period, 2)    # 0.0 at a node
 ```
 
 `SynchronousAverageResult` carries the response over the first few harmonics
@@ -143,7 +139,7 @@ That is a power reduction of $10\log_{10} N$ dB, reported as
 `amplitude_snr_gain`:
 
 ```python
-res = time_synchronous_average(recording, fs, period=period, n_averages=100)
+res = signals.time_synchronous_average(recording, fs, period=period, n_averages=100)
 res.noise_reduction_db      # 20.0 dB = 10*log10(100)
 res.amplitude_snr_gain      # 10.0   = sqrt(100)
 res.plot()                  # averaged waveform + the comb it applied
@@ -162,7 +158,7 @@ the ideal $\sigma/\sqrt{N}$ line as the number of averaged periods grows from
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import time_synchronous_average
+from phonometry import signals
 
 fs = 8192.0
 samples = 256
@@ -177,8 +173,8 @@ recording = np.tile(true, 128) + rng.standard_normal(128 * samples)
 counts = [1, 2, 4, 8, 16, 32, 64, 128]
 errors = []
 for n in counts:
-    res = time_synchronous_average(recording[:n * samples], fs, period=period,
-                                   n_averages=n)
+    res = signals.time_synchronous_average(recording[:n * samples], fs, period=period,
+                                           n_averages=n)
     errors.append(np.sqrt(np.mean((res.period_waveform - true) ** 2)))
 
 # One line — the averaged waveform and the comb filter it applied:
@@ -228,8 +224,8 @@ average confirms it:
 phase = np.arange(41 * 256) / 256
 recording = np.cos(2 * np.pi * 8.0 * phase) + 0.7 * np.cos(2 * np.pi * 32.05 * phase)
 
-leak_20 = time_synchronous_average(recording, fs, period=period, n_averages=20)
-leak_32 = time_synchronous_average(recording, fs, period=period, n_averages=32)
+leak_20 = signals.time_synchronous_average(recording, fs, period=period, n_averages=20)
+leak_32 = signals.time_synchronous_average(recording, fs, period=period, n_averages=32)
 # leak_20.period_waveform matches the clean 8th-order tone; leak_32 does not
 ```
 
@@ -315,7 +311,7 @@ fs = 8192.0
 period = 1.0 / 31.7                       # fs * period is not an integer
 t = np.arange(int(40 * period * fs)) / fs
 recording = np.cos(2.0 * np.pi * t / period)  # one cycle per revolution
-res = time_synchronous_average(recording, fs, period=period)
+res = signals.time_synchronous_average(recording, fs, period=period)
 res.interpolated                          # True: fractional-delay alignment
 res.samples_per_period                    # integer samples of one period
 ```

--- a/site/src/content/docs/signals/spectra/system-measurement.mdx
+++ b/site/src/content/docs/signals/spectra/system-measurement.mdx
@@ -99,10 +99,10 @@ comes back to machine precision, a closed-form identity the tests and the
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 
 # Simulated measurement: play each code periodically and record one
 # steady-state period of a room-like band-pass system.
@@ -111,7 +111,7 @@ length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 print(ir.method, ir.size)                   # golay 16384
 ir.plot()
 ```
@@ -129,16 +129,16 @@ complementary correlations land on the true response to machine precision
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import golay_impulse_response, golay_pair
+from phonometry import room
 
 fs = 48000
-pair = golay_pair(14)                       # two 16384-sample codes
+pair = room.golay_pair(14)                       # two 16384-sample codes
 b, a = signal.butter(2, [200.0, 2000.0], btype="bandpass", fs=fs)
 length = pair[0].size
 rec_a = signal.lfilter(b, a, np.tile(pair[0], 3))[2 * length:]
 rec_b = signal.lfilter(b, a, np.tile(pair[1], 3))[2 * length:]
 
-ir = golay_impulse_response(rec_a, rec_b, pair, fs=fs)
+ir = room.golay_impulse_response(rec_a, rec_b, pair, fs=fs)
 
 # One line — the recovered impulse response:
 ir.plot()
@@ -232,10 +232,10 @@ details; `target` is `"pink"` (the classical room-measurement emphasis,
 default), `"white"`, or any `(frequencies_hz, magnitude_db)` pair:
 
 ```python
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-sweep = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+sweep = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 print(round(sweep.crest_factor_db, 1))      # 4.2 (dB; the ideal is 3.02)
 sweep.plot()
 ```
@@ -257,10 +257,10 @@ approximation of it.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal as sp_signal
-from phonometry import shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
-res = shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
+res = room.shaped_sweep_signal(fs, 50.0, 5000.0, 2.0, target="pink")
 x = np.asarray(res)
 
 nperseg = 8192   # 75 % overlap: 50 % would ripple ~2 dB on a sweep
@@ -305,20 +305,20 @@ for the [spectral method](/phonometry/buildings/rooms/room-acoustics/) of
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import impulse_response, shaped_sweep_signal
+from phonometry import room
 
 fs = 48000
 freqs = np.array([50.0, 200.0, 1000.0, 8000.0])
 emphasis = np.array([12.0, 6.0, 0.0, 0.0])   # LF boost against rumble
-sweep = shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
-                            target=(freqs, emphasis))
+sweep = room.shaped_sweep_signal(fs, 50.0, 8000.0, 3.0,
+                                 target=(freqs, emphasis))
 
 # Simulated measurement of a known system (replace with play/record):
 b, a = signal.butter(2, [200.0, 4000.0], btype="bandpass", fs=fs)
 excitation = np.concatenate([np.asarray(sweep), np.zeros(fs)])
 recorded = signal.lfilter(b, a, excitation)
 
-ir = impulse_response(recorded, excitation, fs, length=fs)
+ir = room.impulse_response(recorded, excitation, fs, length=fs)
 ir.plot()
 ```
 
@@ -404,7 +404,7 @@ of a mixed-phase response causal
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 # A loudspeaker-like measured response (replace with a measured IR).
@@ -413,7 +413,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 print(round(inv.flatness_db, 5))    # 1e-05 (dB: in-band deviation from 0 dB)
 print(round(inv.max_gain_db, 1))    # -6.0 (dB: capped out-of-band boost)
 inv.plot()
@@ -435,7 +435,7 @@ this axis in the same two regions where the blue response runs off the bottom.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter
+from phonometry import signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -443,7 +443,7 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)
 
-res = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+res = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 f = res.frequencies[1:]
 h_mag = np.abs(res.response_spectrum)[1:]
 inv_mag = np.abs(res.spectrum)[1:]
@@ -478,17 +478,16 @@ rate rides along:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import (impulse_response, regularized_inverse_filter,
-                        sweep_signal)
+from phonometry import room, signals
 
 fs = 48000
-sweep = sweep_signal(fs, 50.0, 20000.0, 1.0)
+sweep = room.sweep_signal(fs, 50.0, 20000.0, 1.0)
 excitation = np.concatenate([sweep, np.zeros(fs // 2)])
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
 recorded = signal.lfilter(b, a, excitation)     # play/record in reality
 
-ir = impulse_response(recorded, excitation, fs)  # any front end works
-inv = regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
+ir = room.impulse_response(recorded, excitation, fs)  # any front end works
+inv = signals.regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
 flat_recording = inv.apply(recorded)             # delay already removed
 inv.plot()   # measured, inverse and equalized magnitudes (figure above)
 ```
@@ -529,7 +528,7 @@ post-processing:
 ```python
 import numpy as np
 from scipy import signal
-from phonometry import regularized_inverse_filter, shaped_sweep_signal
+from phonometry import room, signals
 
 fs = 48000.0
 b, a = signal.butter(2, [100.0, 8000.0], btype="bandpass", fs=fs)
@@ -537,12 +536,12 @@ imp = np.zeros(2048)
 imp[0] = 1.0
 h = signal.lfilter(b, a, imp)                    # the measured response
 
-inv = regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
+inv = signals.regularized_inverse_filter(h, fs, f_range=(200.0, 4000.0))
 target_db = 20.0 * np.log10(
     np.abs(inv.spectrum[1:]) * np.abs(inv.response_spectrum).max()
 )
-sweep = shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
-                            target=(inv.frequencies[1:], target_db))
+sweep = room.shaped_sweep_signal(int(fs), 200.0, 4000.0, 3.0,
+                                 target=(inv.frequencies[1:], target_db))
 sweep.plot()   # waveform and spectrum against the inverted-response target
 ```
 

--- a/site/src/content/docs/signals/spectra/test-signals.mdx
+++ b/site/src/content/docs/signals/spectra/test-signals.mdx
@@ -65,14 +65,14 @@ single burst or as the repetitive train of Clause A2.2 in which each burst
 occupies one full repetition period:
 
 ```python
-from phonometry import tone_burst
+from phonometry import signals
 
 # One 5 ms burst of 5 kHz tone (25 full periods), as in Table AII.
-single = tone_burst(48000, 5000, 25)
+single = signals.tone_burst(48000, 5000, 25)
 print(single.burst_samples)         # 240 samples = 5 ms at 48 kHz
 
 # Clause A2.2: 5 ms bursts at 10 bursts per second.
-train = tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
+train = signals.tone_burst(48000, 5000, 25, repetitions=4, repetition_rate=10)
 print(train.period_samples, train.duty_cycle)   # 4800, 0.05
 train.plot()                        # waveform with the gating envelope
 ```
@@ -100,11 +100,11 @@ off time has to be as well defined as the on time.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import tone_burst
+from phonometry import signals
 
 fs = 48000.0
-single = tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
-train = tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
+single = signals.tone_burst(fs, 5000, 25, pre_silence=0.001, post_silence=0.001)
+train = signals.tone_burst(fs, 5000, 25, repetitions=4, repetition_rate=10)
 
 fig, axes = plt.subplots(2, 1, figsize=(10, 6.4))
 t_ms = 1e3 * np.arange(single.signal.size) / single.fs
@@ -164,10 +164,10 @@ numbers the caller controls:
   bound $\delta = 10^{-A/20}$.
 
 ```python
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 print(res.up, res.down)                  # 160, 147
 print(res.n_taps, res.passband_edge_hz)  # designed FIR, 20947.5 Hz
 res.plot()   # the delivered anti-alias filter against its design spec
@@ -187,10 +187,10 @@ it, flat within the same ripple bound.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import noise_signal, resample_signal
+from phonometry import signals
 
-x = noise_signal(44100, 5.0, color="pink", seed=1)
-res = resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
+x = signals.noise_signal(44100, 5.0, color="pink", seed=1)
+res = signals.resample_signal(x, 44100, fs_new=48000)   # 120 dB alias rejection
 
 # res is the ResampledSignalResult computed in the example above.
 # One line — the delivered anti-alias filter against its design spec:
@@ -268,10 +268,10 @@ boundary conventions cover the two use cases:
 
 ```python
 import numpy as np
-from phonometry import fractional_delay
+from phonometry import signals
 
-y = fractional_delay(x, 0.37)                    # 0.37 samples later
-z = fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
+y = signals.fractional_delay(x, 0.37)                    # 0.37 samples later
+z = signals.fractional_delay(x, -2.5, mode="circular")   # advance, wrapped
 ```
 
 One subtlety worth knowing: a real record of even length cannot carry a

--- a/site/src/content/docs/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/signals/spectra/time-frequency.mdx
@@ -65,9 +65,9 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
-from phonometry import spectrogram
+from phonometry import signals
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)
 print(res.time_resolution)         # T_B = nperseg/fs, in s
 print(res.resolution_bandwidth)    # Be of the tapered segment, in Hz
@@ -157,7 +157,7 @@ else; when absolute band levels over time are the goal, the band spectrogram of
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import noise_signal, spectrogram
+from phonometry import signals
 
 fs = 16000.0
 t = np.arange(int(4.0 * fs)) / fs
@@ -172,10 +172,10 @@ n_imp = int(0.06 * fs)                              # impact at t = 2.5 s
 x[int(2.5 * fs):int(2.5 * fs) + n_imp] += 0.4 * (
     rng.standard_normal(n_imp) * np.exp(-np.arange(n_imp) / (0.012 * fs))
 )
-x += noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
-                  rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
+x += signals.noise_signal(fs, 4.0, color="pink",            # 45 dB SPL floor
+                          rms=p_ref * 10.0 ** (45.0 / 20.0), seed=10)
 
-res = spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
+res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 level = 10.0 * np.log10(res.power / p_ref**2)
 
 fig, ax = plt.subplots(figsize=(10, 6))
@@ -215,9 +215,9 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
-from phonometry import zoom_fft
+from phonometry import signals
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
 print(res.bin_spacing)                   # fs/N by default
 print(res.resolution_bandwidth)          # Be of the tapered record
 peak = res.amplitude.argmax()
@@ -279,7 +279,7 @@ density and resolution.*
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import signal
-from phonometry import zoom_fft
+from phonometry import signals
 
 fs = 8192.0
 t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
@@ -291,7 +291,7 @@ coarse = 2.0 * np.abs(np.fft.rfft(x[:1024] * w)) / np.sum(w)
 coarse_f = np.fft.rfftfreq(1024, 1.0 / fs)
 band = (coarse_f >= 950.0) & (coarse_f <= 1050.0)
 
-res = zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
+res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0, n_points=145)   # 0.25 Hz grid
 
 fig, ax = plt.subplots(figsize=(10, 6))
 ax.plot(coarse_f[band], 20.0 * np.log10(coarse[band]), "o--",

--- a/site/src/content/docs/simulation/fdtd-simulation.mdx
+++ b/site/src/content/docs/simulation/fdtd-simulation.mdx
@@ -616,8 +616,7 @@ few degrees.*
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import (HelmholtzResonator, MetadiffuserWell,
-                        metadiffuser_polar_response, simulation)
+from phonometry import materials, simulation
 
 c0, dx, f0, pitch = 343.0, 0.0005, 2000.0, 0.07
 rows = [(14.7, 13.0, 16.4, 6.2, 9.0), (30.9, 9.1, 4.3, 3.5, 9.0),
@@ -664,12 +663,12 @@ pattern = simulation.far_field_from_contour(
     origin=((lat + face / 2.0) * dx, r_face * dx))
 levels = 20 * np.log10(np.abs(pattern) / np.abs(pattern).max())
 
-wells = [MetadiffuserWell(h * 1e-3,
-                          (HelmholtzResonator(ln * 1e-3, wn * 1e-3,
-                                              lc * 1e-3, wc * 1e-3),) * 2)
+wells = [materials.MetadiffuserWell(h * 1e-3,
+                                    (materials.HelmholtzResonator(ln * 1e-3, wn * 1e-3,
+                                                        lc * 1e-3, wc * 1e-3),) * 2)
          for h, ln, lc, wn, wc in rows]
-model = metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
-                                    angles=angles, periods=1)
+model = materials.metadiffuser_polar_response(f0, wells, depth=0.02, period=pitch,
+                                              angles=angles, periods=1)
 ax = model.plot(color="#1f77b4", marker="", linestyle="--",
                 label="TMM + Fraunhofer model")
 ax.plot(np.radians(angles), levels, color="#d62728", lw=2.2,

--- a/site/src/content/docs/vibration/machinery/machine-diagnostics.mdx
+++ b/site/src/content/docs/vibration/machinery/machine-diagnostics.mdx
@@ -42,12 +42,12 @@ That is the diagnosis: a spall on the outer race.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import bearing_fault_frequencies, envelope_spectrum, noise_signal
+from phonometry import signals, vibration
 
 # The bearing: 15 rollers on a 34 mm pitch diameter, 6 mm rollers,
 # 12.96 degrees contact angle, shaft at 2000 r/min.
-faults = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
-                                   contact_angle_deg=12.96)
+faults = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0,
+                                             contact_angle_deg=12.96)
 bpfo, shaft = faults["BPFO"], faults.shaft_rate    # 207.0 Hz, 33.33 Hz
 
 # A spalled outer race: one impact per BPFO period, each ringing a 3 kHz
@@ -62,11 +62,11 @@ tau = np.arange(int(0.004 * fs)) / fs
 ring = np.exp(-tau / 6.0e-4) * np.sin(2.0 * np.pi * 3000.0 * tau)
 x = np.convolve(impacts, ring)[: t.size] * 0.6
 x += 0.35 * np.sin(2.0 * np.pi * shaft * t)          # residual unbalance
-x += noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
+x += signals.noise_signal(fs, seconds, color="white", rms=0.25, seed=17)
 
 # Band-pass the resonance the impacts ring, envelope it, transform it,
 # and let the result draw its own lines on top.
-spectrum = envelope_spectrum(x, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(x, fs, band=(2000.0, 4000.0))
 faults.within(1.0, 5.0 * bpfo).plot(spectrum=spectrum)
 plt.show()
 ```
@@ -175,9 +175,9 @@ $\pm f_\mathrm{s}$ sideband costs record length, which is why the acquisition of
 5 matters here and not only in principle.
 
 ```python
-from phonometry import bearing_fault_frequencies
+from phonometry import vibration
 
-res = bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
+res = vibration.bearing_fault_frequencies(2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96)
 print(round(res["BPFO"], 1), round(res["BPFI"], 1))   # 207.0 293.0
 print(round(res["BPFO"] + res["BPFI"], 1))            # 500.0 = 15 x 33.33
 print(res.as_dict())
@@ -235,10 +235,10 @@ flat sidebands spaced by the shaft rate, while distributed wear raises tall
 sideband groups and lifts the higher mesh harmonics.
 
 ```python
-from phonometry import gear_mesh_frequencies
+from phonometry import vibration
 
 # A 28-tooth pinion on a 1500 r/min shaft, with two sideband orders.
-res = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+res = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 print(round(res["GMF"], 1))            # 700.0
 print(round(res["GMF+1x"], 1))         # 725.0  (GMF + one shaft order)
 print(res.harmonics("GMF", 3))         # [ 700. 1400. 2100.]
@@ -269,11 +269,11 @@ $n = 1, 2, \ldots$. Dynamic eccentricity dresses the dominant slot harmonic
 with sidebands at $\pm$ the shaft rate and $\pm$ the slip frequency.
 
 ```python
-from phonometry import induction_motor_frequencies
+from phonometry import vibration
 
 # Sixty rotor bars, six magnetic poles, 3600 r/min, no slip: a six-pole
 # machine at that speed is running on a 180 Hz inverter drive, not on mains.
-res = induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
+res = vibration.induction_motor_frequencies(3600.0, 6, 60, slip=0.0)
 print(round(res["fe"]))                         # 180  the supply it implies
 print(round(res["1x"]), round(res["2x"]),
       round(res["2fe"]), round(res["fsh"]))     # 60 120 360 3600
@@ -308,11 +308,11 @@ rotary positive-displacement blower repeats four times per revolution, which is
 handled by passing $4 \times \text{r/min}$ with a single "blade":
 
 ```python
-from phonometry import blade_pass_frequencies
+from phonometry import vibration
 
 # A rotary positive-displacement blower at 1200 r/min: four pulsations per
 # revolution, so the pulsation rate is asked for as 4 x r/min with N = 1.
-res = blade_pass_frequencies(4 * 1200.0, 1, harmonics=3)
+res = vibration.blade_pass_frequencies(4 * 1200.0, 1, harmonics=3)
 print(round(res["BPF"], 1))        # 80.0 Hz, the pulsation rate
 print(round(res.shaft_rate, 1))    # 80.0 Hz - NOT the shaft rate, which is 20
 ```
@@ -335,7 +335,7 @@ different speed.
 
 ```python
 # Six blades, four vanes, 3500 r/min (blade_pass_frequencies imported above).
-res = blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
+res = vibration.blade_pass_frequencies(3500.0, 6, harmonics=1, n_vanes=4)
 print(round(res.shaft_rate, 1))   # 58.3 Hz, the shaft itself
 print(round(res["BPF"]))          # 350
 print(round(res["lobe n=1 m=2"]), round(res["lobe n=1 m=10"]))    # 175 35
@@ -370,7 +370,7 @@ import numpy as np
 
 # The library predicts the lines; the spectra under them are synthesised at
 # exactly those frequencies, so the figure and the printed values agree.
-gear = gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
+gear = vibration.gear_mesh_frequencies(1500.0, 28, harmonics=3, sidebands=2)
 freq = np.linspace(0.0, 2400.0, 4800)
 amp = np.full_like(freq, 0.004)
 for order, height in enumerate((1.0, 0.40, 0.16), start=1):
@@ -477,7 +477,7 @@ from scipy import signal as sp_signal
 # The record x, its sample rate fs, its time base t and the predicted BPFO
 # are the ones built for the opening figure.
 band = (2000.0, 4000.0)
-spec = envelope_spectrum(x, fs, band=band)     # carries .envelope and .times
+spec = signals.envelope_spectrum(x, fs, band=band)     # carries .envelope and .times
 
 # The same zero-phase 4th-order Butterworth band-pass the call applies
 # internally, run here so the intermediate record can be drawn.
@@ -515,24 +515,19 @@ bearing supports a 28-tooth pinion, so the housing carries three families at
 once.
 
 ```python
-from phonometry import (
-    bearing_fault_frequencies,
-    combine_fault_lines,
-    envelope_spectrum,
-    gear_mesh_frequencies,
-)
+from phonometry import signals, vibration
 
 record, fs = x, 20000.0          # the housing record and its sample rate
 shaft_rpm = 2000.0               # from the tacho, not from the nameplate
 
 # The bearing's own lines, the mesh family of the pinion it supports, and the
 # shaft harmonics. Put them all on one axes.
-bearing = bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
-                                    contact_angle_deg=12.96)
-gear = gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
-lines = combine_fault_lines(bearing, gear)
+bearing = vibration.bearing_fault_frequencies(shaft_rpm, 15, 6.0, 34.0,
+                                              contact_angle_deg=12.96)
+gear = vibration.gear_mesh_frequencies(shaft_rpm, 28, harmonics=2, sidebands=1)
+lines = vibration.combine_fault_lines(bearing, gear)
 
-spectrum = envelope_spectrum(record, fs, band=(2000.0, 4000.0))
+spectrum = signals.envelope_spectrum(record, fs, band=(2000.0, 4000.0))
 lines.within(1.0, 1600.0).plot(spectrum=spectrum)
 ```
 

--- a/site/src/content/docs/vibration/structural/junction-transmission.mdx
+++ b/site/src/content/docs/vibration/structural/junction-transmission.mdx
@@ -83,10 +83,10 @@ continuous 200 mm wall.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # A 140 mm concrete floor meeting a 200 mm wall at a T-junction.
-res = junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
+res = vibration.junction_transmission("T2", 0.14, 3500.0, 320.0, 0.2, 3500.0, 460.0)
 res.plot_geometry()
 plt.show()
 ```
@@ -107,10 +107,10 @@ curve.*
 
 ```python
 import matplotlib.pyplot as plt
-from phonometry import junction_transmission
+from phonometry import vibration
 
 # X-junction between a 100 mm and a 200 mm concrete plate (cL = 3200 m/s).
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 res.plot()  # tau(theta) for the corner and straight paths, with averages
 plt.show()
 ```
@@ -142,9 +142,9 @@ cut-off angle $\theta_\text{co} = \arcsin\chi$; $\psi$ is the ratio of their
 bending-moment mobilities. For **identical plates** both are 1.
 
 ```python
-from phonometry import junction_wave_parameters
+from phonometry import vibration
 
-chi, psi = junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+chi, psi = vibration.junction_wave_parameters(0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 #  -> (sqrt(0.5), 4.0)
 ```
 
@@ -218,14 +218,11 @@ place to look for isolation.
 
 ```python
 import numpy as np
-from phonometry import (
-    corner_transmission_coefficient,
-    straight_transmission_coefficient,
-)
+from phonometry import vibration
 
 theta = np.radians(np.linspace(0.0, 90.0, 91))
-tau12 = corner_transmission_coefficient(theta, chi, psi, "X")
-tau13 = straight_transmission_coefficient(theta, chi, psi, "X")
+tau12 = vibration.corner_transmission_coefficient(theta, chi, psi, "X")
+tau13 = vibration.straight_transmission_coefficient(theta, chi, psi, "X")
 ```
 
 The clip below runs this experiment in the time domain with the library's 2D
@@ -260,10 +257,10 @@ to exact fractions that serve as the library's first-principles oracle:
   a change of section, `inline_transmission_coefficient` of section 2 applies).
 
 ```python
-from phonometry import angular_average_transmission_coefficient
+from phonometry import vibration
 
-angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
-angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "X", section="corner")  # 1/12
+vibration.angular_average_transmission_coefficient(1.0, 1.0, "L", section="corner")  # 1/3
 ```
 
 The two directions obey the SEA consistency relationship (Eq. 5.7),
@@ -285,14 +282,13 @@ X-junction ($f_\mathrm{c} \approx 203\ \text{Hz}$),
 $K_{ij} = 10\log_{10} 12 + 5\log_{10}(203/1000) \approx 7.3\ \text{dB}$.
 
 ```python
-from phonometry import (coupling_loss_factor, junction_transmission,
-                        wave_vibration_reduction_index)
+from phonometry import vibration
 
-eta = coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
-                           junction_length=4.0, frequency=500.0, plate_area=10.0)
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
-kij = wave_vibration_reduction_index(res.corner_average,
-                                     res.critical_frequency2)  # 7.33 dB
+eta = vibration.coupling_loss_factor(1.0 / 12.0, group_velocity=200.0,
+                                     junction_length=4.0, frequency=500.0, plate_area=10.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
+kij = vibration.wave_vibration_reduction_index(res.corner_average,
+                                               res.critical_frequency2)  # 7.33 dB
 kij = res.corner_reduction_index  # the same, precomputed on the result
 
 res.plot()   # tau(theta) for this junction's corner and straight paths (needs matplotlib)
@@ -319,7 +315,7 @@ perpendicular plates increasingly pin the junction line:
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import junction_transmission, wave_vibration_reduction_index
+from phonometry import vibration
 
 # Concrete plates (cL = 3200 m/s, rho = 2400 kg/m3): plate 1 fixed at
 # 100 mm, plate 2 swept from 50 mm to 400 mm.
@@ -329,22 +325,22 @@ curves = {"X corner": [], "X straight": [], "T-junction (1) corner": [],
           "L corner": []}
 for ratio in ratios:
     h2 = h1 * float(ratio)
-    res_x = junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
+    res_x = vibration.junction_transmission("X", h1, cl, rho * h1, h2, cl, rho * h2)
     curves["X corner"].append(res_x.corner_reduction_index)
     # Only the corner index is precomputed on the result; the straight path
     # is the angular average tau13 converted the same way.
-    curves["X straight"].append(float(wave_vibration_reduction_index(
+    curves["X straight"].append(float(vibration.wave_vibration_reduction_index(
         res_x.straight_average, res_x.critical_frequency2)))
-    res_t = junction_transmission("T1", h1, cl, rho * h1, h2, cl, rho * h2)
+    res_t = vibration.junction_transmission("T1", h1, cl, rho * h1, h2, cl, rho * h2)
     curves["T-junction (1) corner"].append(res_t.corner_reduction_index)
-    res_l = junction_transmission("L", h1, cl, rho * h1, h2, cl, rho * h2)
+    res_l = vibration.junction_transmission("L", h1, cl, rho * h1, h2, cl, rho * h2)
     curves["L corner"].append(res_l.corner_reduction_index)
 
 fig, ax = plt.subplots()
 for label, values in curves.items():
     ax.plot(ratios, values, "--" if label == "X straight" else "-", label=label)
 # The identical-plate X-junction: Kij = 10 lg 12 + 5 lg(fc2/1000).
-res_eq = junction_transmission("X", h1, cl, rho * h1, h1, cl, rho * h1)
+res_eq = vibration.junction_transmission("X", h1, cl, rho * h1, h1, cl, rho * h1)
 ax.scatter([1.0], [res_eq.corner_reduction_index], zorder=6,
            label="identical plates (tau = 1/12)")
 ax.set_xlabel("Thickness ratio h2/h1")
@@ -365,10 +361,10 @@ $\tau(\theta)$ figure: its corner path gives $K_{12} = 9.8\ \text{dB}$. Handing 
 junction's three flanking paths and their effect on the apparent rating:
 
 ```python
-from phonometry import building, junction_transmission
+from phonometry import building, vibration
 
 # The 100 mm / 200 mm concrete X-junction of the tau(theta) figure:
-res = junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
+res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
 k12 = res.corner_reduction_index                     # 9.8 dB (corner path)
 
 # Feed it to the EN 12354-1 simplified model as this junction's Kij:
@@ -493,15 +489,7 @@ model to be trustworthy.*
 import math
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import (
-    coupling_loss_factor,
-    cylindrical_shell_modal_density,
-    flat_plate_modal_density,
-    plate_bending_stiffness,
-    point_connection_coupling_loss_factor,
-    power_injection_clf,
-    right_angle_transmission_coefficient,
-)
+from phonometry import vibration
 from phonometry.vibration.structural.point_mobility import plate_bending_wave_speed
 
 rho, nu, young = 2700.0, 0.33, 7.1e10                 # aluminium
@@ -511,13 +499,13 @@ bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0])
 # Predicted: a 3 mm x 2.5 m x 1.2 m plate meeting a 5.5 mm x 2.0 m x 1.2 m
 # plate at right angles along the 1.2 m edge, welded and then bolted.
 h1, h2, area1, length = 0.003, 0.0055, 2.5 * 1.2, 1.2
-tau = right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
-                                           wave_speed1=cl, wave_speed2=cl)
-cb = plate_bending_wave_speed(bands, plate_bending_stiffness(young, h1, nu),
+tau = vibration.right_angle_transmission_coefficient(h1, h2, density1=rho, density2=rho,
+                                                     wave_speed1=cl, wave_speed2=cl)
+cb = plate_bending_wave_speed(bands, vibration.plate_bending_stiffness(young, h1, nu),
                               rho * h1)
-welded = [float(coupling_loss_factor(tau, 2.0 * c, length, f, area1))
+welded = [float(vibration.coupling_loss_factor(tau, 2.0 * c, length, f, area1))
           for c, f in zip(cb, bands, strict=True)]
-bolted = point_connection_coupling_loss_factor(
+bolted = vibration.point_connection_coupling_loss_factor(
     bands, 12, thickness1=h1, thickness2=h2, surface_density1=rho * h1,
     surface_density2=rho * h2, wave_speed1=cl, wave_speed2=cl,
     plate_area1=area1)
@@ -527,11 +515,11 @@ bolted = point_connection_coupling_loss_factor(
 t_p, t_c, radius = 0.005, 0.003, 0.75
 area_c = 2.0 * math.pi * radius * 2.0
 area_p = 3.5 * 3.0 - math.pi * radius**2
-sea = power_injection_clf(
+sea = vibration.power_injection_clf(
     500.0, rho * t_p * area_p * 0.0272**2, rho * t_c * area_c * 0.0132**2,
     4.4e-3, 2.4e-3,
-    flat_plate_modal_density(area_p, t_p, cl),
-    float(cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
+    vibration.flat_plate_modal_density(area_p, t_p, cl),
+    float(vibration.cylindrical_shell_modal_density(500.0, area_c, t_c, radius, cl)[0]))
 
 print(f"{float(sea.coupling_loss_factor12[0]):.2e}")   # 4.26e-04
 print(f"{float(sea.coupling_loss_factor21[0]):.2e}")   # 3.91e-04

--- a/site/src/content/docs/vibration/structural/transfer-stiffness.mdx
+++ b/site/src/content/docs/vibration/structural/transfer-stiffness.mdx
@@ -460,13 +460,13 @@ $L_k(f)$ spectrum, so it needs both the report and plot extras
 
 ```python
 import numpy as np
-from phonometry import ReportMetadata, TransferStiffnessResult, transfer_stiffness_direct
+from phonometry import ReportMetadata, vibration
 
 freqs = np.array([20, 31.5, 50, 80, 125, 200, 315, 500, 800, 1250, 2000], dtype=float)
 k21 = 1e6 + 1j * (2 * np.pi * freqs) * 80.0     # Kelvin-Voigt element k + jwc
 u1 = 1e-6 + 0j
-k = transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
-res = TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
+k = vibration.transfer_stiffness_direct(k21 * u1, u1)     # direct method: k2,1 = F2,b/u1
+res = vibration.TransferStiffnessResult(frequencies=freqs, transfer_stiffness=k)
 res.report(
     "transfer_stiffness.pdf",
     metadata=ReportMetadata(


### PR DESCRIPTION
Follows #592 and #594, which did the same for the tests, the figure scripts and
the conformance runner. The guides take their names from the domain package
now, in English and in Spanish in step:

```diff
-from phonometry import single_panel_transmission_loss
-R = single_panel_transmission_loss(...)
+from phonometry import building
+R = building.single_panel_transmission_loss(...)
```

## What it buys

Two thirds of the pages already led with that form. The remaining third
imported the function flat off the top level, so both forms appeared on the
same page and often in adjacent blocks.

Reading the domain at the call site is the point. The panel page now says out
loud that `plate_bending_stiffness` and `coincidence_frequency` come from
`vibration` while `single_panel_transmission_loss` comes from `building`, which
is a fact about the library the flat form hid.

## Two things the rewrite had to get right

**Every block keeps carrying its own imports.** The pages run concatenated, so
a name bound in the first block is in scope in the twelfth, and a
whole-page rewrite happily drops the second import as redundant. But a block is
also read and copied on its own, and one that calls through a package it never
imported is a `NameError` for the reader who copies it. Each block imports what
it uses, as before.

**Wrapped calls stay aligned.** Where qualifying a callee moved the open
parenthesis its arguments were aligned under, the continuation lines moved with
it, so a wrapped call is still a tidy block rather than a ragged one.

## Verification

The snippet gate passes whole: 4309 blocks over 524 pages, static checks and the
execution pass. That is what proves the examples still run, and that the Spanish
pages teach the same API as their English twins, name for name.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

