### PR TITLE
Say how to write `Signal`, the type the io guide is about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   returns, not on each rectangle, so reading `ax.patches` would have missed it
   on every bar renderer and let this back in.
 
+- The `io` guide says how to write the type it talks about. It names `Signal`
+  sixteen times in prose and never once said the spelling, so a reader looking
+  for it found the private module the library imports it from and wrote
+  `pm.io._signal.Signal`, which is what happened. It is `io.Signal` after
+  `from phonometry import io`, or `phonometry.Signal`, and the class docstring
+  and both index pages say so too, in English and in Spanish.
+
+  `SignalOrigin` carried a reason that stopped being true: it was named that
+  way rather than `SignalSource` partly because the top level could not hold
+  two classes of one spelling. It can hold neither now, each being reached
+  through its own package, and the reason that survives is the better one, that
+  this is a passive record and not a source of sound.
+
 - `plot_excitation` is exported by `phonometry.room`, the package that owns it.
   It was the one of the twenty-four plotting helpers that no domain published:
   it is defined in the private `_plot.room`, the top level re-exported it, and

--- a/docs/io/audio-files.md
+++ b/docs/io/audio-files.md
@@ -16,9 +16,9 @@ timing a measurement depends on.
 The type is `phonometry.io.Signal`. Write it `io.Signal` after
 `from phonometry import io`, or `phonometry.Signal`, which is the same class:
 the top level publishes it because seven packages accept one, and those are
-the only two spellings. The module it is defined in is private, and reaching
-into it gets a class that is equal to this one in every way except that
-nothing promises it will still be there.
+the two supported spellings. The module it is defined in is private, and
+reaching into it gets the same object back, with nothing promising it will
+stay reachable that way.
 
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,

--- a/docs/io/audio-files.md
+++ b/docs/io/audio-files.md
@@ -13,6 +13,13 @@ kept, channels are never mixed down, and no sample is ever normalized,
 because each of those "conveniences" silently destroys the level or the
 timing a measurement depends on.
 
+The type is `phonometry.io.Signal`. Write it `io.Signal` after
+`from phonometry import io`, or `phonometry.Signal`, which is the same class:
+the top level publishes it because seven packages accept one, and those are
+the only two spellings. The module it is defined in is private, and reaching
+into it gets a class that is equal to this one in every way except that
+nothing promises it will still be there.
+
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,
 IEEE float, `WAVE_FORMAT_EXTENSIBLE` with its channel mask, BWF `bext`

--- a/docs/io/index.md
+++ b/docs/io/index.md
@@ -25,7 +25,8 @@ a level computed from an ADPCM or MP3 approximation of the waveform is not
 defensible, and the warning plus the `lossy` stamp keep that fact attached
 to the data.
 
-What comes back from a file is a `Signal`: the samples with their rate,
+What comes back from a file is a `Signal` (`io.Signal`, or
+`phonometry.Signal`; the module it is defined in is private): the samples with their rate,
 calibration, channel labels and `bext` provenance in one immutable object
 that behaves as the bare array everywhere (`np.asarray` hands any existing
 function the samples), draws itself with `.plot()`, and walks straight into

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22878,6 +22878,13 @@ kept, channels are never mixed down, and no sample is ever normalized,
 because each of those "conveniences" silently destroys the level or the
 timing a measurement depends on.
 
+The type is `phonometry.io.Signal`. Write it `io.Signal` after
+`from phonometry import io`, or `phonometry.Signal`, which is the same class:
+the top level publishes it because seven packages accept one, and those are
+the only two spellings. The module it is defined in is private, and reaching
+into it gets a class that is equal to this one in every way except that
+nothing promises it will still be there.
+
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,
 IEEE float, `WAVE_FORMAT_EXTENSIBLE` with its channel mask, BWF `bext`
@@ -23416,7 +23423,8 @@ a level computed from an ADPCM or MP3 approximation of the waveform is not
 defensible, and the warning plus the `lossy` stamp keep that fact attached
 to the data.
 
-What comes back from a file is a `Signal`: the samples with their rate,
+What comes back from a file is a `Signal` (`io.Signal`, or
+`phonometry.Signal`; the module it is defined in is private): the samples with their rate,
 calibration, channel labels and `bext` provenance in one immutable object
 that behaves as the bare array everywhere (`np.asarray` hands any existing
 function the samples), draws itself with `.plot()`, and walks straight into

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22881,9 +22881,9 @@ timing a measurement depends on.
 The type is `phonometry.io.Signal`. Write it `io.Signal` after
 `from phonometry import io`, or `phonometry.Signal`, which is the same class:
 the top level publishes it because seven packages accept one, and those are
-the only two spellings. The module it is defined in is private, and reaching
-into it gets a class that is equal to this one in every way except that
-nothing promises it will still be there.
+the two supported spellings. The module it is defined in is private, and
+reaching into it gets the same object back, with nothing promising it will
+stay reachable that way.
 
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,

--- a/site/public/llms/llms-io.txt
+++ b/site/public/llms/llms-io.txt
@@ -32,7 +32,8 @@ a level computed from an ADPCM or MP3 approximation of the waveform is not
 defensible, and the warning plus the `lossy` stamp keep that fact attached
 to the data.
 
-What comes back from a file is a `Signal`: the samples with their rate,
+What comes back from a file is a `Signal` (`io.Signal`, or
+`phonometry.Signal`; the module it is defined in is private): the samples with their rate,
 calibration, channel labels and `bext` provenance in one immutable object
 that behaves as the bare array everywhere (`np.asarray` hands any existing
 function the samples), draws itself with `.plot()`, and walks straight into
@@ -113,6 +114,13 @@ function on this page follows the same defaults: the native sample rate is
 kept, channels are never mixed down, and no sample is ever normalized,
 because each of those "conveniences" silently destroys the level or the
 timing a measurement depends on.
+
+The type is `phonometry.io.Signal`. Write it `io.Signal` after
+`from phonometry import io`, or `phonometry.Signal`, which is the same class:
+the top level publishes it because seven packages accept one, and those are
+the only two spellings. The module it is defined in is private, and reaching
+into it gets a class that is equal to this one in every way except that
+nothing promises it will still be there.
 
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,

--- a/site/public/llms/llms-io.txt
+++ b/site/public/llms/llms-io.txt
@@ -118,9 +118,9 @@ timing a measurement depends on.
 The type is `phonometry.io.Signal`. Write it `io.Signal` after
 `from phonometry import io`, or `phonometry.Signal`, which is the same class:
 the top level publishes it because seven packages accept one, and those are
-the only two spellings. The module it is defined in is private, and reaching
-into it gets a class that is equal to this one in every way except that
-nothing promises it will still be there.
+the two supported spellings. The module it is defined in is private, and
+reaching into it gets the same object back, with nothing promising it will
+stay reachable that way.
 
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,

--- a/site/src/content/docs/es/io/audio-files.mdx
+++ b/site/src/content/docs/es/io/audio-files.mdx
@@ -57,6 +57,12 @@ mezclan nunca, y ninguna muestra se normaliza jamás, porque cada una de esas
 «comodidades» destruye en silencio el nivel o los tiempos de los que depende
 una medición.
 
+El tipo es `phonometry.io.Signal`. Se escribe `io.Signal` tras
+`from phonometry import io`, o `phonometry.Signal`, que es la misma clase: el
+nivel superior la publica porque siete paquetes la aceptan, y esas son las dos
+únicas formas. El módulo donde está definida es privado, y entrar por ahí da
+una clase igual a esta en todo salvo en que nada garantiza que siga estando.
+
 La instalación base (NumPy y SciPy, nada más) lee toda la familia WAV lineal
 que escribe el equipamiento de medida: PCM a cualquier profundidad, incluido
 el de 24 bits, IEEE float, `WAVE_FORMAT_EXTENSIBLE` con su máscara de

--- a/site/src/content/docs/es/io/audio-files.mdx
+++ b/site/src/content/docs/es/io/audio-files.mdx
@@ -60,8 +60,9 @@ una medición.
 El tipo es `phonometry.io.Signal`. Se escribe `io.Signal` tras
 `from phonometry import io`, o `phonometry.Signal`, que es la misma clase: el
 nivel superior la publica porque siete paquetes la aceptan, y esas son las dos
-únicas formas. El módulo donde está definida es privado, y entrar por ahí da
-una clase igual a esta en todo salvo en que nada garantiza que siga estando.
+formas admitidas. El módulo donde está definida es privado, y entrar por ahí
+devuelve el mismo objeto, sin que nada garantice que siga siendo alcanzable
+así.
 
 La instalación base (NumPy y SciPy, nada más) lee toda la familia WAV lineal
 que escribe el equipamiento de medida: PCM a cualquier profundidad, incluido

--- a/site/src/content/docs/es/io/index.mdx
+++ b/site/src/content/docs/es/io/index.mdx
@@ -29,7 +29,8 @@ se señalan, a las claras: un nivel calculado sobre la aproximación ADPCM o
 MP3 de la forma de onda no es defendible, y el aviso más la marca `lossy`
 mantienen ese hecho pegado a los datos.
 
-Lo que vuelve de un archivo es un `Signal`: las muestras con su frecuencia,
+Lo que vuelve de un archivo es un `Signal` (`io.Signal`, o
+`phonometry.Signal`; el módulo donde está definido es privado): las muestras con su frecuencia,
 su calibración, sus etiquetas de canal y su procedencia `bext` en un único
 objeto inmutable que se comporta como el array desnudo en todas partes
 (`np.asarray` entrega las muestras a cualquier función existente), se

--- a/site/src/content/docs/io/audio-files.mdx
+++ b/site/src/content/docs/io/audio-files.mdx
@@ -56,6 +56,13 @@ kept, channels are never mixed down, and no sample is ever normalized,
 because each of those "conveniences" silently destroys the level or the
 timing a measurement depends on.
 
+The type is `phonometry.io.Signal`. Write it `io.Signal` after
+`from phonometry import io`, or `phonometry.Signal`, which is the same class:
+the top level publishes it because seven packages accept one, and those are
+the only two spellings. The module it is defined in is private, and reaching
+into it gets a class that is equal to this one in every way except that
+nothing promises it will still be there.
+
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,
 IEEE float, `WAVE_FORMAT_EXTENSIBLE` with its channel mask, BWF `bext`

--- a/site/src/content/docs/io/audio-files.mdx
+++ b/site/src/content/docs/io/audio-files.mdx
@@ -59,9 +59,9 @@ timing a measurement depends on.
 The type is `phonometry.io.Signal`. Write it `io.Signal` after
 `from phonometry import io`, or `phonometry.Signal`, which is the same class:
 the top level publishes it because seven packages accept one, and those are
-the only two spellings. The module it is defined in is private, and reaching
-into it gets a class that is equal to this one in every way except that
-nothing promises it will still be there.
+the two supported spellings. The module it is defined in is private, and
+reaching into it gets the same object back, with nothing promising it will
+stay reachable that way.
 
 The base install (NumPy and SciPy alone) reads the whole linear WAV family
 that measurement equipment writes: PCM at any depth including 24-bit,

--- a/site/src/content/docs/io/index.mdx
+++ b/site/src/content/docs/io/index.mdx
@@ -29,7 +29,8 @@ a level computed from an ADPCM or MP3 approximation of the waveform is not
 defensible, and the warning plus the `lossy` stamp keep that fact attached
 to the data.
 
-What comes back from a file is a `Signal`: the samples with their rate,
+What comes back from a file is a `Signal` (`io.Signal`, or
+`phonometry.Signal`; the module it is defined in is private): the samples with their rate,
 calibration, channel labels and `bext` provenance in one immutable object
 that behaves as the bare array everywhere (`np.asarray` hands any existing
 function the samples), draws itself with `.plot()`, and walks straight into

--- a/site/src/content/docs/reference/api/io/io.md
+++ b/site/src/content/docs/reference/api/io/io.md
@@ -410,6 +410,12 @@ Signal(
 
 A sampled acoustic signal with its rate, calibration and provenance.
 
+Written `io.Signal` after `from phonometry import io`, or
+`phonometry.Signal`: the top level publishes this one class because
+seven packages accept one, and those are the two spellings. The module
+holding this definition is private, and a name read out of it is the same
+object with nothing promising it will stay reachable that way.
+
 Returned by [`phonometry.io.read`](/phonometry/reference/api/io/io/#read); can also be constructed directly
 around an array. The object is a drop-in replacement for the bare array:
 it implements `__array__`, so `np.asarray(signal)` yields the
@@ -562,12 +568,12 @@ SignalOrigin(
 
 Where a [`Signal`](/phonometry/reference/api/io/io/#signal) came from, as read from the file itself.
 
-The name is deliberately not `SignalSource`: phonometry already exports
-a [`SignalSource`](/phonometry/reference/api/simulation/fdtd/#signalsource) (an FDTD excitation
-driven by an arbitrary sample sequence), and two public classes sharing a
-name across subpackages would collide the moment both are imported flat
-from `phonometry`. This one is a passive record -- an origin, not a
-source of sound.
+The name is deliberately not `SignalSource`, which
+[`SignalSource`](/phonometry/reference/api/simulation/fdtd/#signalsource) already is (an FDTD
+excitation driven by an arbitrary sample sequence). The two could share a
+spelling now that each is reached through its own package, and the reason
+for the distinction is the better one anyway: this is a passive record --
+an origin, not a source of sound.
 
 `bit_depth` is the *valid* bits per sample (an EXTENSIBLE container
 holding 20 valid bits in 24 reports 20), or `None` where the notion

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -43,12 +43,12 @@ if TYPE_CHECKING:
 class SignalOrigin:
     """Where a :class:`Signal` came from, as read from the file itself.
 
-    The name is deliberately not ``SignalSource``: phonometry already exports
-    a :class:`~phonometry.simulation.fdtd.SignalSource` (an FDTD excitation
-    driven by an arbitrary sample sequence), and two public classes sharing a
-    name across subpackages would collide the moment both are imported flat
-    from ``phonometry``. This one is a passive record -- an origin, not a
-    source of sound.
+    The name is deliberately not ``SignalSource``, which
+    :class:`~phonometry.simulation.SignalSource` already is (an FDTD
+    excitation driven by an arbitrary sample sequence). The two could share a
+    spelling now that each is reached through its own package, and the reason
+    for the distinction is the better one anyway: this is a passive record --
+    an origin, not a source of sound.
 
     ``bit_depth`` is the *valid* bits per sample (an EXTENSIBLE container
     holding 20 valid bits in 24 reports 20), or ``None`` where the notion
@@ -69,6 +69,12 @@ class SignalOrigin:
 @dataclass(frozen=True)
 class Signal:
     """A sampled acoustic signal with its rate, calibration and provenance.
+
+    Written ``io.Signal`` after ``from phonometry import io``, or
+    ``phonometry.Signal``: the top level publishes this one class because
+    seven packages accept one, and those are the two spellings. The module
+    holding this definition is private, and a name read out of it is the same
+    object with nothing promising it will stay reachable that way.
 
     Returned by :func:`phonometry.io.read`; can also be constructed directly
     around an array. The object is a drop-in replacement for the bare array:


### PR DESCRIPTION
## What and why

The `io` guide names `Signal` sixteen times in prose and never once said how to spell it. A reader looking for the type found the private module the library imports it from and wrote `pm.io._signal.Signal`, which is what prompted this. The guide, the class docstring and both index pages now say it: `io.Signal` after `from phonometry import io`, or `phonometry.Signal`. English and Spanish kept in step.

It also records why `SignalOrigin` is not called `SignalSource`. Part of the old reason was that the top level could not hold two classes of one spelling; it holds neither now, each being reached through its own package, so the reason that survives is the better one, that this is a passive record and not a source of sound.

One correction came out of review: the guides said reaching into the private module "gets a class that is equal to this one in every way", which invites the reader to picture two matching classes. There is one object (`phonometry.Signal is phonometry.io.Signal is phonometry.io._signal.Signal`). What the private path lacks is a promise, not identity.

## Validation

No new computation. Documentation and one class docstring; no numeric behaviour changes, and the conformance report is unchanged.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`
- [x] `mypy src scripts`
- [x] `bandit -r src` (exit 0)
- [x] `pytest -q`

`ruff format --check` is not clean anywhere in this repository, `main` included (806 files), so it is not a gate here; the two places it would rewrite `io/_signal.py` are pre-existing and outside the lines this branch touches.

Regenerated where this change touches them:

- [x] `make llms`, with `llms-full.txt` and the shard under `site/public/llms/` committed

The other generators do not apply: no new public name, so no `make api-docs` or taxonomy entry, and no figure, fiche or conformance row moves.

Always:

- [x] Documentation updated in English and Spanish, kept in step
- [x] CHANGELOG entry under `[Unreleased]`
