### PR TITLE
Bind the top-level names on first use, not on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `import phonometry` imports the top level and nothing else. The nineteen
+  domain packages and the four names it publishes arrive on first use, through
+  a module `__getattr__` (PEP 562), so the statement costs **4.4 ms and 56
+  entries in `sys.modules`** where it cost **954 ms and 1182**. Exactly one of
+  those fifty-six is the library itself, where 235 of the 1182 were; the rest
+  are the interpreter's and the standard library's.
+
+  Nothing changes for a caller. `phonometry.building` and
+  `from phonometry import building` work as they did, `dir(phonometry)` still
+  lists all twenty-three names before anything is touched, and the resolved
+  attribute is cached in the module namespace, so the import happens once.
+  The type checker sees the same package it always did: the imports are
+  written out under `if TYPE_CHECKING`, which is the half of the module a
+  checker reads and the interpreter never runs.
+
+  What this buys is a program that uses one domain not paying for the other
+  eighteen. A script that reads a WAV imported scipy, matplotlib and the
+  aircraft noise-power-distance tables before its first line ran, because the
+  top level had to bind every name it published.
+
 - Every example in the documentation reaches a function through the package
   that owns it: `from phonometry import building` and then
   `building.single_panel_transmission_loss(...)`, in both languages in step.

--- a/src/phonometry/__init__.py
+++ b/src/phonometry/__init__.py
@@ -25,29 +25,46 @@ of every diagnostic the library raises, so one
 
 from __future__ import annotations
 
-from . import aircraft as aircraft
-from . import broadcast as broadcast
-from . import building as building
-from . import electroacoustics as electroacoustics
-from . import emission as emission
-from . import environment as environment
-from . import filters as filters
-from . import hearing as hearing
-from . import io as io
-from . import materials as materials
-from . import metrology as metrology
-from . import noise_control as noise_control
-from . import psychoacoustics as psychoacoustics
-from . import room as room
-from . import signals as signals
-from . import simulation as simulation
-from . import speech as speech
-from . import underwater as underwater
-from . import vibration as vibration
-from ._internal.warnings import PhonometryWarning
-from ._report import ReportMetadata
-from ._version import __version__
-from .io import Signal
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for the type checker, never at run time
+    from . import aircraft as aircraft
+    from . import broadcast as broadcast
+    from . import building as building
+    from . import electroacoustics as electroacoustics
+    from . import emission as emission
+    from . import environment as environment
+    from . import filters as filters
+    from . import hearing as hearing
+    from . import io as io
+    from . import materials as materials
+    from . import metrology as metrology
+    from . import noise_control as noise_control
+    from . import psychoacoustics as psychoacoustics
+    from . import room as room
+    from . import signals as signals
+    from . import simulation as simulation
+    from . import speech as speech
+    from . import underwater as underwater
+    from . import vibration as vibration
+    from ._internal.warnings import PhonometryWarning as PhonometryWarning
+    from ._report import ReportMetadata as ReportMetadata
+    from ._version import __version__ as __version__
+    from .io import Signal as Signal
+
+#: The nineteen domain packages, imported on first use.
+_PACKAGES = ['aircraft', 'broadcast', 'building', 'electroacoustics', 'emission', 'environment', 'filters', 'hearing', 'io', 'materials', 'metrology', 'noise_control', 'psychoacoustics', 'room', 'signals', 'simulation', 'speech', 'underwater', 'vibration']
+
+#: The four names that belong to no domain, and the private module each is
+#: defined in. ``Signal`` is ``phonometry.io``'s, and reached from here too
+#: because seven packages accept one.
+_NAMES = {
+    "PhonometryWarning": "._internal.warnings",
+    "ReportMetadata": "._report",
+    "Signal": ".io",
+    "__version__": "._version",
+}
 
 __all__ = [
     "PhonometryWarning",
@@ -74,3 +91,26 @@ __all__ = [
     "underwater",
     "vibration",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Import a domain package, or one of the four names, on first use.
+
+    PEP 562. Importing every package eagerly cost a second and pulled in
+    twelve hundred modules for a caller who wanted one of them; the whole
+    library is still one attribute away, and the attribute is cached in the
+    module namespace so the import happens once.
+    """
+    if name in _PACKAGES:
+        value: object = import_module(f".{name}", __name__)
+    elif name in _NAMES:
+        value = getattr(import_module(_NAMES[name], __name__), name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """What the package publishes, whether or not it has been touched yet."""
+    return sorted(__all__)


### PR DESCRIPTION
## What and why

`import phonometry` bound all nineteen domain packages eagerly, so a script that reads a WAV paid for scipy, matplotlib and the aircraft noise-power-distance tables before its first line ran.

A module `__getattr__` (PEP 562) resolves each name the first time it is read and caches it in the module namespace, so the import happens once, and only for what the program actually uses.

Measured here, median of five clean interpreters:

| | `import phonometry` | entries in `sys.modules` | of those, ours |
|---|---|---|---|
| before | 954 ms | 1182 | 235 |
| after | 4.4 ms | 56 | 1 |

Nothing changes for a caller. `phonometry.building` and `from phonometry import building` work as they did, `dir(phonometry)` still lists all twenty-three names before anything is touched, and an unknown name still raises `AttributeError` naming the module. The type checker is not affected either: the imports are written out under `if TYPE_CHECKING`, which is the half of the module a checker reads and the interpreter never runs.

Stacked on #599, so it wants that one first.

## Validation

No new computation. This changes when the same modules are imported, not what anything computes; the conformance report is unchanged and the full suite passes with the same counts as before.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`
- [x] `mypy src scripts`
- [x] `bandit -r src` (exit 0)
- [x] `pytest -q`

`ruff format --check` is not clean anywhere in this repository, `main` included (806 files), so it is not a gate here; the touched file is not among the ones it would rewrite.

Regenerated where this change touches them: none apply. No public name is added, moved or renamed, so the API reference, taxonomy, llms artifacts, figures, fiches and conformance rows are all unchanged. The only files here are the top-level `__init__.py` and the changelog entry.

Always:

- [x] CHANGELOG entry under `[Unreleased]`

Documentation needs no change in either language: the import forms it teaches (`from phonometry import building`, then `building.foo(...)`) are exactly the ones that still work.

## Summary by Sourcery

Make top-level imports lazy to substantially reduce startup time and dependencies for callers that use only part of the package.

Enhancements:
- Defer loading of top-level domain packages and exported names until first access while preserving the existing public API, directory listing, and type-checking behavior.

Documentation:
- Document the reduced import cost and unchanged access behavior in the unreleased changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved startup time by loading phonometry features only when they are used.
  * Reduced unnecessary module and dependency loading for faster initial access.

* **Compatibility**
  * Existing top-level feature access remains unchanged.
  * Discoverability through directory and attribute listings is preserved.
  * Frequently accessed features are resolved once and reused for consistent performance.

* **Documentation**
  * Added an Unreleased changelog entry describing these improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->