### PR TITLE
Let imports say what they are for, and names say what they are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Imports say what they are for, and names say what they are. An import that
+  only a type checker needs sits under `if TYPE_CHECKING` now, 313 of them; a
+  well-known package is imported under the alias everyone writes, 190 of them;
+  and the 83 places that wrote `from ._layout import fiche_paragraph as
+  Paragraph` call it `fiche_paragraph`, because the alias made a helper of this
+  package look like the class reportlab publishes under that name. Four
+  functions in the conformance domains imported numpy a second time, inside the
+  function, where the module already had it.
+
+  `INP` and `T20` are selected but find nothing: both are already clean in
+  `src`, and they are here to keep it that way. A print is what the scripts are
+  for, so they are exempt, and so are the tests.
+
+  The clip freshness gate needed a repair first. It hashes the AST of the code
+  that draws each clip, and its own preamble says an alarm nobody believes
+  would be worse than no alarm, because a false positive costs a re-render.
+  It hashed the whole of each module it reached, so moving an import under
+  `if TYPE_CHECKING` looked like a change to the drawing even though nothing
+  in that block exists while a frame is rendered: it marked most of the
+  forty-two clips stale. It now skips those blocks, and hashes the remaining
+  imports as a sorted set, so sorting them is not a change either. The
+  imports are still hashed, because the walk stops at the package boundary
+  and for `import numpy as np` the statement is the only record it has.
+
+  `TC006`, which quotes the first argument of `typing.cast`, is not selected.
+  That argument is never evaluated for its value, so the rewrite is inert, and
+  it moved two clips through `figures.media._save_animation`.
+
 - Ruff is the formatter, and there is a configuration to say so. The tree had
   none: no `[tool.ruff]`, no `ruff.toml`, no pre-commit, no `.editorconfig`, and
   CI ran `ruff check .` on ruff's default rules alone, which are four families

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,9 +149,19 @@ select = [
     "UP", "B", "SIM", "C4", "RET", "A",
     "PIE", "DTZ", "G",      # zero findings today: these only guard the future
     "FURB",                 # long-hand forms of builtins
+    "TC",                   # imports only a type checker needs
+    "ICN",                  # the conventional alias for a well-known package
+    "N812",                 # an alias must not disguise a function as a class
+    "INP", "T20",           # both already clean in `src`, and kept that way
 ]
 ignore = [
     "B905",  # selected by "B"; see the note below
+    # TC006 quotes the first argument of `typing.cast`, which that function
+    # ignores entirely at run time. It is inert, and it moved the recorded
+    # fingerprint of two clips through `figures.media._save_animation`. The
+    # clip gate says plainly that an alarm nobody believes is worse than no
+    # alarm, so an inert rewrite is not worth one.
+    "TC006",
     # SIM300 calls anything with an upper-case name a literal, and gets three
     # idioms in this tree backwards for it. `spectrum[OCTAVE_BANDS == f]` is a
     # numpy mask, not a condition, and `res.transmission_loss[BANDS <= f0]`
@@ -163,14 +173,6 @@ ignore = [
 ]
 # Selected next, in their own review, because each is a change to code rather
 # than to its shape and the diff has to be readable to be checked:
-#   TC    (313) moves imports that only a type checker needs under
-#               `if TYPE_CHECKING`. Measured here, it costs more than it is
-#               worth in this pass: it reorders imports, which makes `I` fire
-#               where it was at zero, and the clip freshness fingerprint hashes
-#               the AST of the drawing closure, imports included. Both together
-#               moved the recorded fingerprint of most of the 42 committed
-#               clips, for drawings that are provably identical. The top-level
-#               import is already lazy, so the runtime gain is small.
 #   PT    (295) pytest idiom. 241 of them are `pytest.raises` without `match=`,
 #               and the habit here is already the other way: 1755 of the 2065
 #               `pytest.raises` in the suite do pass `match=`. These are the
@@ -188,8 +190,12 @@ ignore = [
 # `import matplotlib.pyplot`, and the scripts put the repository on `sys.path`
 # before importing from it. Both are imports that cannot be at the top of the
 # file. `src/` raises no E402 at all, which is where it would matter.
-"tests/**" = ["E402"]
-"scripts/**" = ["E402"]
+# A print is what a command line tool is for, and neither the scripts nor the
+# tests are packages anyone imports by name. Both rules are here to hold `src`,
+# where they already find nothing.
+"scripts/**" = ["E402", "T201", "INP001"]
+"tests/**" = ["E402", "T201", "INP001"]
+".github/**" = ["T201", "INP001"]
 # The PyOctaveBand transition shim exists to re-export the whole package under
 # the old name; the star import is the point of the file.
 "stub/src/pyoctaveband/__init__.py" = ["F403"]

--- a/scripts/animation_fingerprint.py
+++ b/scripts/animation_fingerprint.py
@@ -69,7 +69,10 @@ from __future__ import annotations
 import ast
 import hashlib
 import pathlib
-from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
 
 _SCRIPTS = pathlib.Path(__file__).resolve().parent
 
@@ -340,6 +343,41 @@ def _dump(node: ast.AST) -> str:
     )
 
 
+def _is_type_checking(test: ast.expr) -> bool:
+    """Is *test* the ``TYPE_CHECKING`` guard, however it was imported?"""
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    return isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+
+
+def _module_level(body: list[ast.stmt]) -> str:
+    """The part of a module body that can reach a frame, hashed stably.
+
+    Two things are taken out, both because leaving them in makes a change
+    that cannot move a pixel look like one, which is the false alarm this
+    module says it would rather not raise than raise wrongly.
+
+    A block guarded by ``if TYPE_CHECKING:`` is read by a type checker and by
+    nothing else. No name it binds exists while the clip renders, so moving
+    an import under that guard changes what mypy sees and nothing else.
+
+    Import *order* goes too, but the imports themselves stay: they are
+    hashed as a sorted set. Sorting them is what an import sorter does, and
+    it cannot change which name ends up bound to which module. Dropping them
+    would not be safe, because the walk stops at the package boundary, so for
+    ``import numpy as np`` the statement is the only record the fingerprint
+    has that the name points where it did.
+    """
+    live = [
+        s for s in body if not (isinstance(s, ast.If) and _is_type_checking(s.test))
+    ]
+    imports = sorted(
+        _dump(s) for s in live if isinstance(s, (ast.Import, ast.ImportFrom))
+    )
+    rest = [s for s in live if not isinstance(s, (ast.Import, ast.ImportFrom))]
+    return "\x00".join([*imports, _dump(ast.Module(body=rest, type_ignores=[]))])
+
+
 def _literals(sources: Sources, symbols: Iterable[Symbol]) -> set[str]:
     """Every string literal in *symbols*, f-string fragments included."""
     out: set[str] = set()
@@ -512,9 +550,7 @@ def fingerprint_parts(
     for module in sorted({module for module, _ in symbols}):
         body = sources.modules[module].body
         if body:
-            code.append(
-                f"{module}.<module>\x00" + _dump(ast.Module(body=body, type_ignores=[]))
-            )
+            code.append(f"{module}.<module>\x00" + _module_level(body))
     code.sort()
     exact, patterns = _table_entries(sources)
     text = _selected_translations(_literals(sources, symbols), exact, patterns)

--- a/scripts/api_taxonomy.py
+++ b/scripts/api_taxonomy.py
@@ -34,7 +34,10 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 @dataclasses.dataclass(frozen=True)

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -25,11 +25,13 @@ import argparse
 import sys
 import time
 import timeit
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:  # allow `python scripts/bench.py` from anywhere

--- a/scripts/check_conformance_claims.py
+++ b/scripts/check_conformance_claims.py
@@ -46,7 +46,10 @@ import dataclasses
 import pathlib
 import re
 import sys
-from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 

--- a/scripts/check_figure_contrast.py
+++ b/scripts/check_figure_contrast.py
@@ -67,7 +67,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from xml.etree import ElementTree
+from xml.etree import ElementTree as ET
 
 import numpy as np
 
@@ -216,7 +216,7 @@ def _polygon_area(path_d: str) -> float:
     return float(abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1))) / 2.0)
 
 
-def _parse_style(element: ElementTree.Element) -> dict[str, str]:
+def _parse_style(element: ET.Element) -> dict[str, str]:
     """Declarations of an element's ``style`` attribute plus its presentation
     attributes, lowercased keys, presentation attributes taking lower priority.
     """
@@ -233,12 +233,12 @@ def _parse_style(element: ElementTree.Element) -> dict[str, str]:
     return declarations
 
 
-def _tag(element: ElementTree.Element) -> str:
+def _tag(element: ET.Element) -> str:
     """Local name of an element's tag."""
     return element.tag.removeprefix(_SVG_NS)
 
 
-def _element_area(element: ElementTree.Element, defs: dict[str, str]) -> float:
+def _element_area(element: ET.Element, defs: dict[str, str]) -> float:
     """Area of a drawable element in SVG user units (0 when not an area shape)."""
     tag = _tag(element)
     if tag == "path":
@@ -253,7 +253,7 @@ def _element_area(element: ElementTree.Element, defs: dict[str, str]) -> float:
     return 0.0
 
 
-def _collect_defs(root: ElementTree.Element) -> dict[str, str]:
+def _collect_defs(root: ET.Element) -> dict[str, str]:
     """Map every ``id`` in the document to the path data it carries."""
     return {
         element.get("id", ""): element.get("d", "")
@@ -262,7 +262,7 @@ def _collect_defs(root: ElementTree.Element) -> dict[str, str]:
     }
 
 
-def _collect_clip_areas(root: ElementTree.Element) -> dict[str, float]:
+def _collect_clip_areas(root: ET.Element) -> dict[str, float]:
     """Map every ``clipPath`` id to the area of the rectangle it encloses.
 
     matplotlib clips the artists of an axes to the axes rectangle, so this is
@@ -279,14 +279,14 @@ def _collect_clip_areas(root: ElementTree.Element) -> dict[str, float]:
     return areas
 
 
-def _clip_id(element: ElementTree.Element) -> str:
+def _clip_id(element: ET.Element) -> str:
     """Referenced ``clipPath`` id of an element, or ``""`` when unclipped."""
     match = re.fullmatch(r"url\(#(.+)\)", element.get("clip-path", "").strip())
     return match.group(1) if match else ""
 
 
 def _axes_geometry(
-    group: ElementTree.Element,
+    group: ET.Element,
     clip_areas: dict[str, float],
     fallback: tuple[float, float, float],
 ) -> tuple[tuple[float, float, float], float, str]:
@@ -331,7 +331,7 @@ def _axes_geometry(
 
 
 def _walk(
-    node: ElementTree.Element,
+    node: ET.Element,
     *,
     figure: str,
     defs: dict[str, str],
@@ -400,7 +400,7 @@ def _walk(
 
 def measure(path: Path) -> list[Region]:
     """Every filled area region of one SVG figure, measured against its page."""
-    root = ElementTree.parse(path).getroot()
+    root = ET.parse(path).getroot()
     defs = _collect_defs(root)
     regions: list[Region] = []
     _walk(

--- a/scripts/check_mathtext.py
+++ b/scripts/check_mathtext.py
@@ -90,9 +90,9 @@ def is_label(run: str) -> bool:
 
 
 def check(paths: list[pathlib.Path]) -> tuple[int, list[tuple[str, int, str, str]]]:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib import mathtext
 
     parser = mathtext.MathTextParser("agg")

--- a/scripts/check_stroke_contrast.py
+++ b/scripts/check_stroke_contrast.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import pathlib
 import re
-from xml.etree import ElementTree
+from xml.etree import ElementTree as ET
 
 #: The dark documentation page, from scripts/figures/theme.py.
 PAGE = (0x1C, 0x21, 0x28)
@@ -81,14 +81,14 @@ def _parse(style: str) -> tuple[tuple[int, int, int] | None, float, float]:
     )
 
 
-def _group_id(element: ElementTree.Element) -> str:
+def _group_id(element: ET.Element) -> str:
     """The ``id`` of a group element, without matplotlib's trailing counter."""
     if element.tag != f"{SVG_NS}g":
         return ""
     return element.get("id", "").rsplit("_", 1)[0]
 
 
-def _is_field(element: ElementTree.Element) -> bool:
+def _is_field(element: ET.Element) -> bool:
     """Whether this subtree paints an opaque field over the axes it is in."""
     if element.tag == f"{SVG_NS}image":
         return True
@@ -100,7 +100,7 @@ def _is_field(element: ElementTree.Element) -> bool:
 
 
 def _strokes(
-    element: ElementTree.Element, on_field: bool = False
+    element: ET.Element, on_field: bool = False
 ) -> list[tuple[tuple[int, int, int], float, float]]:
     """Every measurable stroke in a subtree, as ``(rgb, opacity, width)``."""
     group = _group_id(element)
@@ -124,7 +124,7 @@ def main() -> int:
     rows: list[tuple[float, str, str]] = []
     for svg in sorted(images.glob("*_dark.svg")):
         seen: set[tuple[tuple[int, int, int], float, float]] = set()
-        root = ElementTree.parse(svg).getroot()
+        root = ET.parse(svg).getroot()
         for rgb, alpha, width in _strokes(root):
             key = (rgb, alpha, width)
             if key in seen:

--- a/scripts/check_stub_metadata.py
+++ b/scripts/check_stub_metadata.py
@@ -29,10 +29,13 @@ import sys
 import tarfile
 import zipfile
 from email import message_from_string
-from email.message import Message
+from typing import TYPE_CHECKING
 
 from packaging.requirements import Requirement
 from packaging.version import Version
+
+if TYPE_CHECKING:
+    from email.message import Message
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 _DIST = _ROOT / "stub" / "dist"

--- a/scripts/conformance/domains/aircraft.py
+++ b/scripts/conformance/domains/aircraft.py
@@ -58,16 +58,15 @@ def _chk_ecac_event_level() -> Outcome:
         [98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0],
     ]
     vref = 160.0 * 0.514444
-    import numpy as _np
 
-    xs = _np.linspace(-40000.0, 40000.0, 801)
-    path = _np.column_stack(
+    xs = np.linspace(-40000.0, 40000.0, 801)
+    path = np.column_stack(
         [
             xs,
-            _np.zeros_like(xs),
-            _np.full_like(xs, 300.0),
-            _np.full_like(xs, 10000.0),
-            _np.full_like(xs, vref),
+            np.zeros_like(xs),
+            np.full_like(xs, 300.0),
+            np.full_like(xs, 10000.0),
+            np.full_like(xs, vref),
         ]
     )
     got = ph.aircraft.event_level(

--- a/scripts/conformance/domains/assessment.py
+++ b/scripts/conformance/domains/assessment.py
@@ -52,15 +52,14 @@ _ISO1996_3 = "Impulsive-sound prominence (ISO/PAS 1996-3)"
 
 def _iso1996_3_ramp_onset() -> Any:
     """Detected onset of a 30 dB LpAF ramp over 0.30 s (dt = 20 ms)."""
-    import numpy as _np
 
     from phonometry.environment.assessment.impulsive_sound import detect_onsets
 
     dt = 0.02
-    pre = _np.full(round(0.2 / dt), 40.0)
-    rise = 40.0 + 30.0 * (_np.arange(1, round(0.3 / dt) + 1) / round(0.3 / dt))
-    post = _np.full(round(0.3 / dt), 70.0)
-    return detect_onsets(_np.concatenate([pre, rise, post]), dt)[0]
+    pre = np.full(round(0.2 / dt), 40.0)
+    rise = 40.0 + 30.0 * (np.arange(1, round(0.3 / dt) + 1) / round(0.3 / dt))
+    post = np.full(round(0.3 / dt), 70.0)
+    return detect_onsets(np.concatenate([pre, rise, post]), dt)[0]
 
 
 @register(

--- a/scripts/conformance/domains/building.py
+++ b/scripts/conformance/domains/building.py
@@ -497,9 +497,8 @@ def _chk_iso717_2_reference_floor() -> Outcome:
     "Floor-covering ΔLw: zero improvement gives ΔLw = 0",
 )
 def _chk_iso16251_zero_improvement() -> Outcome:
-    import numpy as _np
 
-    dlw = ph.building.weighted_impact_improvement(_np.zeros(16))
+    dlw = ph.building.weighted_impact_improvement(np.zeros(16))
     return Outcome(
         expected="ΔLw = 0 dB (ΔL = 0 -> Ln,r = Ln,r,0)",
         computed=f"ΔLw = {dlw} dB",

--- a/scripts/conformance/domains/outdoor.py
+++ b/scripts/conformance/domains/outdoor.py
@@ -18,7 +18,7 @@ methods of ISO 3745 and ISO 9614-3.
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 import reference_data as ref
@@ -26,6 +26,9 @@ import reference_data as ref
 import phonometry as ph
 
 from ..registry import Outcome, numeric, register
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _iso9613_table1(point: tuple[float, float, float, float]) -> Outcome:

--- a/scripts/conformance/domains/psychoacoustics.py
+++ b/scripts/conformance/domains/psychoacoustics.py
@@ -125,7 +125,7 @@ def _iso532_b5_signal(
         signal,
         int(fs),
         float(entry["Nmax"]),
-        cast(Literal["free", "diffuse"], field),
+        cast("Literal['free', 'diffuse']", field),
     )
 
 

--- a/scripts/conformance/domains/underwater.py
+++ b/scripts/conformance/domains/underwater.py
@@ -398,11 +398,10 @@ def _chk_uww_flux_vs_modes() -> Outcome:
     # the incoherent modal sum, whose many-mode limit is exactly F = π/(r·H) --
     # Equation (9.42) with ψc = π/2. Averaged over receiver depth to remove the
     # sin² sampling bias of a single depth.
-    import numpy as _np
 
-    ranges = _np.linspace(20_000.0, 30_000.0, 1001)
+    ranges = np.linspace(20_000.0, 30_000.0, 1001)
     energies = [
-        _np.mean(
+        np.mean(
             10.0
             ** (
                 -ph.underwater.normal_modes(
@@ -416,9 +415,9 @@ def _chk_uww_flux_vs_modes() -> Outcome:
                 / 10.0
             )
         )
-        for zr in _np.linspace(10.0, 90.0, 9)
+        for zr in np.linspace(10.0, 90.0, 9)
     ]
-    numeric_pl = -10.0 * math.log10(float(_np.mean(energies)))
+    numeric_pl = -10.0 * math.log10(float(np.mean(energies)))
     flux = ph.underwater.weston_propagation_loss(
         ranges,
         100.0,
@@ -427,7 +426,7 @@ def _chk_uww_flux_vs_modes() -> Outcome:
         reflection_loss_gradient_value=0.0,
     )
     expected = -10.0 * math.log10(
-        float(_np.mean(10.0 ** (-flux.propagation_loss / 10.0)))
+        float(np.mean(10.0 ** (-flux.propagation_loss / 10.0)))
     )
     return numeric(expected, numeric_pl, 1.0, unit="dB", places=3)
 
@@ -459,15 +458,14 @@ def _chk_uwf_appendix_d() -> Outcome:
 def _chk_uwf_otariid_c() -> Outcome:
     # NMFS's own footnote states the printed 1.37 should read 1.36; recomputing
     # C = -max W(f) from the same row's a/b/f1/f2 gives 1.3643 dB.
-    import numpy as _np
 
     params = ph.underwater.weighting_parameters("OW", guidance="nmfs-2024")
-    freqs = _np.logspace(0.0, 6.0, 400_001)
+    freqs = np.logspace(0.0, 6.0, 400_001)
     shape = (
         ph.underwater.auditory_weighting(freqs, "OW", guidance="nmfs-2024").weighting
         - params.c_db
     )
-    return numeric(1.3643, -float(_np.max(shape)), 5e-4, unit="dB", places=4)
+    return numeric(1.3643, -float(np.max(shape)), 5e-4, unit="dB", places=4)
 
 
 @register(

--- a/scripts/conformance/registry.py
+++ b/scripts/conformance/registry.py
@@ -26,8 +26,11 @@ import functools
 import math
 import pathlib
 import sys
-from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # The checks do not re-type their expected values: they read the test suite's
 # shared tables (``reference_data``) and its worked-example helpers

--- a/scripts/diagrams/aircraft.py
+++ b/scripts/diagrams/aircraft.py
@@ -12,8 +12,10 @@ aircraft glyph that marks the aircraft along a path.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
-from .canvas import SVG, Theme
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 
 def _arc(

--- a/scripts/diagrams/buildings.py
+++ b/scripts/diagrams/buildings.py
@@ -10,8 +10,12 @@ put the two together before anything is built.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
 from .parts import _accel, _accel_wall, _rot_arrow, _spring_v
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 #: Width, in px, a stage-box title has to leave inside the box at the larger
 #: size to keep it. It is the threshold the size decision is taken on, not a

--- a/scripts/diagrams/canvas.py
+++ b/scripts/diagrams/canvas.py
@@ -33,8 +33,8 @@ from __future__ import annotations
 import os
 import re
 import sys
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from .i18n import lookup, visit
 from .outline import (
@@ -45,6 +45,9 @@ from .outline import (
     emit_runs,
     measure,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 
 @dataclass(frozen=True)

--- a/scripts/diagrams/devices.py
+++ b/scripts/diagrams/devices.py
@@ -11,9 +11,12 @@ diagram draws what is done to a device once it has been graded.
 from __future__ import annotations
 
 import itertools
+from typing import TYPE_CHECKING
 
-from .canvas import SVG, Theme
 from .parts import _accel, _box_solid, _box_wire, _motion_arrows, _rot_arrow
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 # ---------------------------------------------------------------------------
 # d6 - Two-microphone (p-p) intensity probe (IEC 61043)

--- a/scripts/diagrams/environment.py
+++ b/scripts/diagrams/environment.py
@@ -10,7 +10,10 @@ draw what happens to the level once it has arrived.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 # ---------------------------------------------------------------------------
 # d2 - Environmental noise microphone positions (ISO 1996-2)

--- a/scripts/diagrams/materials.py
+++ b/scripts/diagrams/materials.py
@@ -10,8 +10,12 @@ building it will end up in.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
 from .parts import _accel, _exciter, _motion_arrows, _rot_arrow, _spring_v
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 
 def _d_impedance_tube(s: SVG, th: Theme) -> None:

--- a/scripts/diagrams/outline.py
+++ b/scripts/diagrams/outline.py
@@ -46,7 +46,7 @@ from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
-import matplotlib
+import matplotlib as mpl
 from matplotlib import (
     _text_helpers,
     ft2font,
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 #: acute, grave, breve and dot below.
 _COMBINING = "\u0302\u0304\u0305\u0307\u0303\u0301\u0300\u0306\u0323"
 
-_MPL_TTF = Path(matplotlib.get_data_path()) / "fonts" / "ttf"
+_MPL_TTF = Path(mpl.get_data_path()) / "fonts" / "ttf"
 
 #: A face request: ``(mono, bold, italic)``.
 FaceKey = tuple[bool, bool, bool]

--- a/scripts/diagrams/parts.py
+++ b/scripts/diagrams/parts.py
@@ -12,7 +12,10 @@ primitive.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 
 def _box_solid(

--- a/scripts/diagrams/perception.py
+++ b/scripts/diagrams/perception.py
@@ -10,7 +10,10 @@ and annoyance.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 # ---------------------------------------------------------------------------
 # d3 - Operator / bystander microphone positions (ECMA-74, clause 8.6)

--- a/scripts/diagrams/signals.py
+++ b/scripts/diagrams/signals.py
@@ -12,9 +12,12 @@ whether the record was fit to analyse at all.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
-from .canvas import SVG, Theme
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .canvas import SVG, Theme
 
 # ---------------------------------------------------------------------------
 # d1 - Calibration chain (IEC 60942)

--- a/scripts/diagrams/simulation.py
+++ b/scripts/diagrams/simulation.py
@@ -13,7 +13,10 @@ wrong.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 
 def _d_fdtd(s: SVG, th: Theme) -> None:

--- a/scripts/diagrams/underwater.py
+++ b/scripts/diagrams/underwater.py
@@ -9,7 +9,10 @@ the deep ocean into a waveguide.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 # ---------------------------------------------------------------------------
 # Ship radiated-noise measurement geometry (ISO 17208-1)

--- a/scripts/diagrams/vibration.py
+++ b/scripts/diagrams/vibration.py
@@ -10,7 +10,8 @@ exposed to.
 
 from __future__ import annotations
 
-from .canvas import SVG, Theme
+from typing import TYPE_CHECKING
+
 from .parts import (
     _accel,
     _accel_wall,
@@ -21,6 +22,9 @@ from .parts import (
     _rot_arrow,
     _spring_v,
 )
+
+if TYPE_CHECKING:
+    from .canvas import SVG, Theme
 
 
 def _d_human_vibration(s: SVG, th: Theme) -> None:

--- a/scripts/fdtd_gpu_remote.py
+++ b/scripts/fdtd_gpu_remote.py
@@ -48,10 +48,9 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import NDArray
 
 _SCRIPTS = Path(__file__).resolve().parent
 if str(_SCRIPTS) not in sys.path:
@@ -59,6 +58,9 @@ if str(_SCRIPTS) not in sys.path:
 
 import fdtd_gpu
 import job_runner
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 _REPO_ROOT = _SCRIPTS.parent
 

--- a/scripts/figures/materials.py
+++ b/scripts/figures/materials.py
@@ -8,7 +8,7 @@ alike) that scatter rather than absorb. Everything here is embedded by a page
 under ``materials/``.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +33,9 @@ from .theme import (
     LABEL_FREQ_HZ,
     save_figure,
 )
+
+if TYPE_CHECKING:
+    from phonometry.materials.absorbers.layered import Layer
 
 
 def generate_dynamic_stiffness(output_dir: str) -> None:
@@ -770,7 +773,6 @@ def generate_porous_absorber_designs(output_dir: str) -> None:
     import warnings as _warnings
 
     from phonometry import materials
-    from phonometry.materials.absorbers.layered import Layer
 
     f = np.logspace(np.log10(50.0), np.log10(5000.0), 500)
     with _warnings.catch_warnings():

--- a/scripts/figures/metrology.py
+++ b/scripts/figures/metrology.py
@@ -9,8 +9,7 @@ against, and the GUM budget that puts an uncertainty on the number finally
 reported. Everything here is embedded by a page under ``signals/metrology/``.
 """
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -27,6 +26,9 @@ from .theme import (
     COLOR_TERTIARY,
     save_figure,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def generate_calibration_stability(output_dir: str) -> None:

--- a/scripts/figures/vibration.py
+++ b/scripts/figures/vibration.py
@@ -9,7 +9,7 @@ embedded by a page under ``vibration/``.
 """
 
 import math
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 
 def _sci_math(value: float, digits: int = 2) -> str:
@@ -26,7 +26,6 @@ def _sci_math(value: float, digits: int = 2) -> str:
 
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.artist import Artist
 from matplotlib.axes import Axes
 
 from phonometry._plot.common import format_frequency_axis, theme_fill
@@ -44,6 +43,9 @@ from .theme import (
     _band_index_axis,
     save_figure,
 )
+
+if TYPE_CHECKING:
+    from matplotlib.artist import Artist
 
 
 def generate_junction_transmission(output_dir: str) -> None:

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -39,8 +39,7 @@ import shutil
 import sys
 from collections.abc import Mapping
 from pathlib import Path
-from types import ModuleType
-from typing import Any, get_overloads
+from typing import TYPE_CHECKING, Any, get_overloads
 
 from api_taxonomy import (
     OBJECT_MODULE_OVERRIDES,
@@ -49,6 +48,9 @@ from api_taxonomy import (
     module_section,
     public_names,
 )
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 ROOT = Path(__file__).resolve().parent.parent
 CONTENT_DIR = ROOT / "site" / "src" / "content" / "docs" / "reference" / "api"

--- a/scripts/generate_brand.py
+++ b/scripts/generate_brand.py
@@ -26,9 +26,9 @@ import math
 from dataclasses import dataclass
 from pathlib import Path
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, PathPatch, Rectangle
 from matplotlib.path import Path as MplPath

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -35,8 +35,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-from collections.abc import Callable, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # The fiche builders live in the ``reports`` package beside this file. Running
 # this script puts ``scripts/`` on the import path for free, but loading the
@@ -140,6 +139,9 @@ from reports.vibration import (
 )
 
 from phonometry import ReportMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 #: Committed output directory for the example fiches.
 _DEFAULT_DIR = os.path.normpath(

--- a/src/phonometry/_internal/levels_math.py
+++ b/src/phonometry/_internal/levels_math.py
@@ -10,10 +10,12 @@ as they are touched.
 
 from __future__ import annotations
 
-from typing import overload
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
-from numpy.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 
 @overload

--- a/src/phonometry/_internal/utils.py
+++ b/src/phonometry/_internal/utils.py
@@ -5,11 +5,13 @@ Signal processing utilities for phonometry.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from scipy import signal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def _typesignal(x: Sequence[float] | np.ndarray) -> np.ndarray:

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -10,9 +10,12 @@ through these helpers; existing modules migrate as they are touched.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 
 def require_positive(value: float, name: str) -> float:

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -32,6 +31,8 @@ from .common import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..building.measurement.flanking_transmission import VibrationReductionResult

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -23,13 +23,14 @@ figures) so the plot can be composed into a larger layout.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
     from matplotlib.container import BarContainer
     from matplotlib.typing import ColorType

--- a/src/phonometry/_plot/geometry/building.py
+++ b/src/phonometry/_plot/geometry/building.py
@@ -13,7 +13,6 @@ leaf never imports domain code at module level.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
@@ -33,6 +32,8 @@ from ._draft import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ...building.prediction.aperture_transmission import (

--- a/src/phonometry/_plot/geometry/electroacoustics.py
+++ b/src/phonometry/_plot/geometry/electroacoustics.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..common import (
     _C_EDGE,
@@ -40,6 +39,7 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ...electroacoustics.piston import RadiatingPistonResult
 

--- a/src/phonometry/_plot/geometry/emission.py
+++ b/src/phonometry/_plot/geometry/emission.py
@@ -19,7 +19,6 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..common import (
     _C_EDGE,
@@ -45,6 +44,7 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ...emission.intensity import IntensityResult
 

--- a/src/phonometry/_plot/geometry/materials.py
+++ b/src/phonometry/_plot/geometry/materials.py
@@ -20,7 +20,6 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..common import (
     _C_EDGE,
@@ -44,6 +43,7 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ...materials.absorbers.four_microphone import TransferMatrix
     from ...materials.absorbers.impedance_tube import ImpedanceTubeResult

--- a/src/phonometry/_plot/geometry/room.py
+++ b/src/phonometry/_plot/geometry/room.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..common import (
     _C_EDGE,
@@ -41,6 +40,7 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ...room.image_source import ImageSourceResult
     from ...room.open_plan import OpenPlanResult

--- a/src/phonometry/_plot/geometry/simulation.py
+++ b/src/phonometry/_plot/geometry/simulation.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..common import (
     _C_EDGE,
@@ -34,6 +33,7 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ...simulation.fdtd import FDTD2D
 

--- a/src/phonometry/_report/_frf_fiche.py
+++ b/src/phonometry/_report/_frf_fiche.py
@@ -40,10 +40,11 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     import numpy as np
+
+    from .metadata import ReportMetadata
 
 
 def frequency_range(frequencies: np.ndarray, language: str = "en") -> str:
@@ -123,7 +124,7 @@ def render_frf_fiche(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -131,8 +132,8 @@ def render_frf_fiche(
     styles, title_style, basis_style, caption_style = document_styles(accent)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if header_pairs:
@@ -141,7 +142,7 @@ def render_frf_fiche(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         metrics_table(metric_rows),
     ]
     # The FRF is a continuous spectrum, not a band quantity: the plot self-scales

--- a/src/phonometry/_report/_insulation_fiche.py
+++ b/src/phonometry/_report/_insulation_fiche.py
@@ -42,13 +42,13 @@ from ._layout import (
     verdict_flow,
 )
 from .iso717 import _Y_TOP_AIRBORNE, _Y_TOP_IMPACT, _metadata_pairs
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.measurement.insulation import (
         ImpactRatingResult,
         WeightedRatingResult,
     )
+    from .metadata import ReportMetadata
 
 #: A per-band table column: header markup, values and decimal places.
 Column = tuple[str, np.ndarray, int]
@@ -127,19 +127,19 @@ def band_value_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
 
     if len(columns) == 1:
         header = [
-            Paragraph(t("Frequency f [Hz]", language), head_style),
-            Paragraph(columns[0][0], head_style),
+            fiche_paragraph(t("Frequency f [Hz]", language), head_style),
+            fiche_paragraph(columns[0][0], head_style),
         ]
         widths = [28 * mm, 28 * mm]
     else:
-        header = [Paragraph(t("f [Hz]", language), head_style)] + [
-            Paragraph(markup, head_style) for markup, _, _ in columns
+        header = [fiche_paragraph(t("f [Hz]", language), head_style)] + [
+            fiche_paragraph(markup, head_style) for markup, _, _ in columns
         ]
         widths = col_widths
 
@@ -249,7 +249,7 @@ def render_insulation_fiche(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -286,8 +286,8 @@ def render_insulation_fiche(
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title_text = t(spec["title"], language)
     flow: list[Any] = [
-        Paragraph(title_text, title_style),
-        Paragraph(t(spec["basis"], language), basis_style),
+        fiche_paragraph(title_text, title_style),
+        fiche_paragraph(t(spec["basis"], language), basis_style),
     ]
 
     # Metadata header block (only the supplied fields; the same grid the two
@@ -305,7 +305,7 @@ def render_insulation_fiche(
     value_header = t("{vh} [dB]", language).format(vh=spec["symbol"])
     columns, caption, col_widths = build_columns(value_header, curve, verbose, language)
     value_table = band_value_table(centers, columns, language, col_widths)
-    left_cell = [Paragraph(caption, caption_style), value_table]
+    left_cell = [fiche_paragraph(caption, caption_style), value_table]
 
     def _plot(ax: Any = None, language: str = language) -> Any:
         axes = rating.plot(ax=ax, language=language)
@@ -331,7 +331,7 @@ def render_insulation_fiche(
         textColor=colors.HexColor(_MUTED_HEX),
         spaceBefore=4,
     )
-    flow.append(Paragraph(t(spec["statement"], language), statement_style))
+    flow.append(fiche_paragraph(t(spec["statement"], language), statement_style))
     if metadata is not None and metadata.requirement is not None:
         text, passed = requirement_verdict(
             rating, rating_symbol, metadata.requirement, language

--- a/src/phonometry/_report/_layout.py
+++ b/src/phonometry/_report/_layout.py
@@ -22,13 +22,16 @@ import math
 import os
 import re
 import tempfile
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from ._i18n import format_number, t
-from .metadata import ReportMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .metadata import ReportMetadata
 
 #: Installation hints for the three soft dependencies of the report.
 _REPORTLAB_HINT = (
@@ -206,7 +209,7 @@ def render_figure_drawing(
         decimal separator.
     """
     try:
-        import matplotlib
+        import matplotlib as mpl
         from matplotlib.backends.backend_agg import FigureCanvasAgg
         from matplotlib.figure import Figure
     except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
@@ -265,7 +268,7 @@ def render_figure_drawing(
 
         localize_axes(ax, language)
         fig.tight_layout()
-        with matplotlib.rc_context({"svg.fonttype": "path"}):
+        with mpl.rc_context({"svg.fonttype": "path"}):
             fig.savefig(svg_path, format="svg")
         drawing = svg2rlg(svg_path)
     finally:

--- a/src/phonometry/_report/_material_fiche.py
+++ b/src/phonometry/_report/_material_fiche.py
@@ -19,13 +19,16 @@ actionable :class:`ImportError`.
 from __future__ import annotations
 
 import html
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ._i18n import t
 from ._layout import escaped_pairs, fmt_meta
-from .metadata import ReportMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .metadata import ReportMetadata
 
 
 @dataclass(frozen=True)
@@ -134,7 +137,7 @@ def render_material_fiche(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         from ._layout import _REPORTLAB_HINT
 
@@ -155,8 +158,8 @@ def render_material_fiche(
     styles, title_style, basis_style, caption_style = document_styles(accent)
 
     flow: list[Any] = [
-        Paragraph(content.title, title_style),
-        Paragraph(content.basis_line, basis_style),
+        fiche_paragraph(content.title, title_style),
+        fiche_paragraph(content.basis_line, basis_style),
     ]
 
     if content.metadata_pairs:
@@ -165,7 +168,7 @@ def render_material_fiche(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(content.caption, caption_style),
+        fiche_paragraph(content.caption, caption_style),
         metrics_table(content.metric_rows),
     ]
     # Non-band plot (a self-scaling design curve): no fixed top on the y-axis.

--- a/src/phonometry/_report/_noise_control_fiche.py
+++ b/src/phonometry/_report/_noise_control_fiche.py
@@ -25,7 +25,7 @@ reportlab, matplotlib and svglib are soft dependencies imported lazily
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -46,7 +46,9 @@ from ._layout import (
     verdict_flow,
 )
 from ._sound_power_fiche import band_labels, d1, metadata_pairs, power_value_table
-from .metadata import ReportMetadata
+
+if TYPE_CHECKING:
+    from .metadata import ReportMetadata
 
 __all__ = [
     "PREDICTION_DISCLAIMER",
@@ -174,7 +176,7 @@ def render_noise_control_fiche(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -182,8 +184,8 @@ def render_noise_control_fiche(
     styles, title_style, basis_style, caption_style = document_styles(accent)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -193,7 +195,7 @@ def render_noise_control_fiche(
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    left_cell = [Paragraph(caption, caption_style), value_table]
+    left_cell = [fiche_paragraph(caption, caption_style), value_table]
     plot_drawing = render_figure_drawing(
         result.plot, figure_width_mm * mm, y_top=None, language=language
     )
@@ -209,7 +211,7 @@ def render_noise_control_fiche(
 
     flow.append(result_box(statement, styles, accent, extended))
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             prediction_statement,
             ParagraphStyle(
                 "noise_control_prediction",
@@ -226,7 +228,7 @@ def render_noise_control_fiche(
 
     basis_style_strip = measurement_basis_style()
     for strip in basis_strips:
-        flow.append(Paragraph(strip, basis_style_strip))
+        flow.append(fiche_paragraph(strip, basis_style_strip))
     flow.extend(footer_flow(metadata, language, disclaimer=PREDICTION_DISCLAIMER))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/_sound_power_fiche.py
+++ b/src/phonometry/_report/_sound_power_fiche.py
@@ -21,9 +21,8 @@ reportlab, matplotlib and svglib are soft dependencies imported lazily
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -44,7 +43,11 @@ from ._layout import (
     result_box,
     verdict_flow,
 )
-from .metadata import ReportMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .metadata import ReportMetadata
 
 #: Reference sound power for the sound power level, 1 pW = 10^-12 W.
 POWER_REFERENCE = "1 pW"
@@ -315,7 +318,7 @@ def power_value_table(
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
@@ -331,7 +334,7 @@ def power_value_table(
     )
 
     n = len(rows_data)
-    rows: list[list[Any]] = [[Paragraph(h, head_style) for h in header]]
+    rows: list[list[Any]] = [[fiche_paragraph(h, head_style) for h in header]]
     rows.extend([list(row) for row in rows_data])
 
     style_cmds: list[Any] = [
@@ -429,7 +432,7 @@ def render_sound_power_fiche(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -437,8 +440,8 @@ def render_sound_power_fiche(
     styles, title_style, basis_style, caption_style = document_styles(accent)
 
     flow: list[Any] = [
-        Paragraph(copy.title, title_style),
-        Paragraph(copy.basis, basis_style),
+        fiche_paragraph(copy.title, title_style),
+        fiche_paragraph(copy.basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -448,7 +451,7 @@ def render_sound_power_fiche(
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(copy.caption, caption_style))
+    flow.append(fiche_paragraph(copy.caption, caption_style))
     flow.append(value_table)
     flow.append(Spacer(1, 8))
 
@@ -478,7 +481,7 @@ def render_sound_power_fiche(
 
     basis_style_strip = measurement_basis_style()
     for strip in copy.basis_strips:
-        flow.append(Paragraph(strip, basis_style_strip))
+        flow.append(fiche_paragraph(strip, basis_style_strip))
     flow.extend(footer_flow(metadata, language, disclaimer=disclaimer))
 
     return build_document(path, flow, copy.title)

--- a/src/phonometry/_report/annex16_epnl.py
+++ b/src/phonometry/_report/annex16_epnl.py
@@ -54,10 +54,10 @@ from ._layout import (
     render_figure_drawing,
     result_box,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..aircraft.certification import EPNLResult
+    from .metadata import ReportMetadata
 
 
 def _metadata_pairs(
@@ -182,7 +182,7 @@ def render_annex16_epnl_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -214,8 +214,8 @@ def render_annex16_epnl_report(
     )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -224,7 +224,7 @@ def render_annex16_epnl_report(
             flow.append(Spacer(1, 3))
             flow.append(grid_table(header_pairs))
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Reference conditions: 25 &#176;C (ISA + 10 &#176;C), 70% relative humidity, 1013.25 hPa sea-level pressure, zero wind (ICAO Annex 16 Vol I Part II, 3.6.1.5).",
                 language,
@@ -234,7 +234,7 @@ def render_annex16_epnl_report(
     )
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Intermediate quantities", language), caption_style))
+    flow.append(fiche_paragraph(t("Intermediate quantities", language), caption_style))
     flow.append(
         metrics_table(_metric_rows(result, language), col_widths=[48 * mm, 26 * mm])
     )
@@ -256,7 +256,7 @@ def render_annex16_epnl_report(
     )
     if limit is not None:
         flow.append(Spacer(1, 6))
-        flow.append(Paragraph(t("Certification limit", language), caption_style))
+        flow.append(fiche_paragraph(t("Certification limit", language), caption_style))
         flow.append(
             compliance_table(_verdict_rows(result, limit, language), language=language)
         )
@@ -272,7 +272,7 @@ def render_annex16_epnl_report(
         spaceBefore=2,
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "This is a computational EPNL result per ICAO Annex 16 Vol I Appendix 2; it is not an official State noise certificate (e.g. EASA Form 45).",
                 language,

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -64,10 +64,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..room.noise_criteria import NCResult, RCResult
+    from .metadata import ReportMetadata
 
 #: Shared title for both room-noise rating fiches.
 _TITLE = "Room noise rating"
@@ -146,14 +146,14 @@ def _value_table(
     from reportlab.lib import colors
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
     head = _thead_style()
 
     n_data = len(columns[0][1])
-    rows: list[list[Any]] = [[Paragraph(header, head) for header, _ in columns]]
+    rows: list[list[Any]] = [[fiche_paragraph(header, head) for header, _ in columns]]
     for i in range(n_data):
         rows.append([cells[i] for _, cells in columns])
 
@@ -218,11 +218,11 @@ def _assemble_left(
     language: str,
 ) -> tuple[list[Any], list[Any]]:
     """Wrap the caption and value table into a two-panel left cell."""
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     caption = t("Octave-band sound pressure levels", language)
     left_cell = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         _value_table(columns, col_widths),
     ]
     return left_cell, [widths[0], widths[1]]
@@ -455,7 +455,7 @@ def _render_room_noise(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -475,8 +475,8 @@ def _render_room_noise(
         basis = t(basis_template, language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():

--- a/src/phonometry/_report/broadcast.py
+++ b/src/phonometry/_report/broadcast.py
@@ -49,10 +49,10 @@ from ._layout import (
     result_box,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..broadcast.program_loudness import ProgramLoudnessResult
+    from .metadata import ReportMetadata
 
 #: EBU R 128 target programme loudness, LUFS.
 _DEFAULT_TARGET_LUFS = -23.0
@@ -266,7 +266,7 @@ def render_program_loudness_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -295,8 +295,8 @@ def render_program_loudness_report(
     )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -306,7 +306,7 @@ def render_program_loudness_report(
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Compliance summary", language), caption_style))
+    flow.append(fiche_paragraph(t("Compliance summary", language), caption_style))
     flow.append(
         compliance_table(
             _compliance_rows(result, target, tolerance_lu, language),
@@ -345,9 +345,9 @@ def render_program_loudness_report(
             language,
         )
     )
-    flow.append(Paragraph(tolerance_note, basis_strip_style))
+    flow.append(fiche_paragraph(tolerance_note, basis_strip_style))
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Gating -70 LUFS absolute / -10 LU relative (ITU-R BS.1770); 1 LU = 1 dB; true peak per EBU Tech 3341; LRA per EBU Tech 3342 (not recommended for programmes under 60 s).",
                 language,

--- a/src/phonometry/_report/duct_path.py
+++ b/src/phonometry/_report/duct_path.py
@@ -54,10 +54,10 @@ from ._layout import (
 )
 from ._noise_control_fiche import PREDICTION_DISCLAIMER
 from ._sound_power_fiche import metadata_pairs
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..noise_control.duct_path import DuctPathResult
+    from .metadata import ReportMetadata
 
 #: Rows whose values are a level rather than a correction, shaded to separate
 #: them from the attenuation rows exactly as the published sheets do.
@@ -384,7 +384,7 @@ def render_duct_path_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
 
@@ -397,8 +397,8 @@ def render_duct_path_report(
     styles, title_style, basis_style, caption_style = document_styles(accent)
 
     flow: list[Any] = [
-        Paragraph(t("Duct-borne noise path calculation", language), title_style),
-        Paragraph(
+        fiche_paragraph(t("Duct-borne noise path calculation", language), title_style),
+        fiche_paragraph(
             t(
                 "Octave-band sound level in an occupied space from an air "
                 "distribution system, estimated element by element along the "
@@ -421,7 +421,7 @@ def render_duct_path_report(
     rows = _visible_rows(result.table(), verbose)
     table, _count = _sheet_table(result, verbose, language, rows)
     flow.append(
-        Paragraph(t("Octave-band path calculation, dB", language), caption_style)
+        fiche_paragraph(t("Octave-band path calculation, dB", language), caption_style)
     )
     table_index = len(flow)
     flow.append(table)
@@ -451,7 +451,7 @@ def render_duct_path_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Predicted (estimated) result computed from the declared duct "
                 "geometry, element data and room condition; it is not a "
@@ -472,7 +472,7 @@ def render_duct_path_report(
 
     basis_style_strip = measurement_basis_style()
     for strip in _basis_strips(result, language):
-        flow.append(Paragraph(strip, basis_style_strip))
+        flow.append(fiche_paragraph(strip, basis_style_strip))
     flow.extend(footer_flow(metadata, language, disclaimer=PREDICTION_DISCLAIMER))
 
     _fit_to_one_page(flow, table_index, result, rows, verbose, language)

--- a/src/phonometry/_report/en12354_5.py
+++ b/src/phonometry/_report/en12354_5.py
@@ -55,10 +55,10 @@ from ._sound_power_fiche import (
     power_value_table,
     render_sound_power_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.prediction.installed_structure_borne import InstalledSourceResult
+    from .metadata import ReportMetadata
 
 
 def _basis(language: str = "en") -> str:

--- a/src/phonometry/_report/en15657.py
+++ b/src/phonometry/_report/en15657.py
@@ -53,10 +53,10 @@ from ._sound_power_fiche import (
     power_value_table,
     render_sound_power_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.measurement.structure_borne_power import StructureBornePowerResult
+    from .metadata import ReportMetadata
 
 
 def _basis(language: str = "en") -> str:

--- a/src/phonometry/_report/enclosure.py
+++ b/src/phonometry/_report/enclosure.py
@@ -45,10 +45,10 @@ from ._noise_control_fiche import (
     power_value_table,
     render_noise_control_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..noise_control.enclosures import EnclosureResult
+    from .metadata import ReportMetadata
 
 
 def _basis(language: str = "en") -> str:

--- a/src/phonometry/_report/human_vibration.py
+++ b/src/phonometry/_report/human_vibration.py
@@ -67,10 +67,10 @@ from ._layout import (
     stacked_table,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..vibration.human.exposure import DailyVibrationExposure
+    from .metadata import ReportMetadata
 
 #: Number of decimal places the fiche displays vibration magnitudes at. Two
 #: decimals resolve the whole-body ELV (1.15 m/s2) and the small whole-body
@@ -173,7 +173,7 @@ def _operations_table(
     from reportlab.lib import colors
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("humanvib")
     kind = str(result.assessment.kind)
@@ -192,22 +192,22 @@ def _operations_table(
         widths = [66.0, 30.0, 24.0, 30.0, 24.0]
 
     a8_energy = float(result.a8) ** 2
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for label, total_value, duration_s, partial in zip(
         result.labels, result.total_values, result.durations_s, result.partials
     ):
         row = [
-            Paragraph(html.escape(str(label)), label_style),
-            Paragraph(_fmt_acc(float(total_value), language), value_style),
-            Paragraph(_fmt_hours(float(duration_s), language), value_style),
-            Paragraph(_fmt_acc(float(partial), language), value_style),
+            fiche_paragraph(html.escape(str(label)), label_style),
+            fiche_paragraph(_fmt_acc(float(total_value), language), value_style),
+            fiche_paragraph(_fmt_hours(float(duration_s), language), value_style),
+            fiche_paragraph(_fmt_acc(float(partial), language), value_style),
         ]
         if verbose:
             from ._i18n import format_number
 
             share = 100.0 * float(partial) ** 2 / a8_energy if a8_energy > 0.0 else 0.0
             row.append(
-                Paragraph(
+                fiche_paragraph(
                     format_number(share, language, decimals=0) + " %", value_style
                 )
             )
@@ -215,13 +215,13 @@ def _operations_table(
 
     total_hours = float(sum(float(d) for d in result.durations_s))
     total_row = [
-        Paragraph(f"<b>{t('Daily total', language)}</b>", label_style),
-        Paragraph("", value_style),
-        Paragraph(f"<b>{_fmt_hours(total_hours, language)}</b>", value_style),
-        Paragraph(f"<b>{_fmt_acc(float(result.a8), language)}</b>", value_style),
+        fiche_paragraph(f"<b>{t('Daily total', language)}</b>", label_style),
+        fiche_paragraph("", value_style),
+        fiche_paragraph(f"<b>{_fmt_hours(total_hours, language)}</b>", value_style),
+        fiche_paragraph(f"<b>{_fmt_acc(float(result.a8), language)}</b>", value_style),
     ]
     if verbose:
-        total_row.append(Paragraph("", value_style))
+        total_row.append(fiche_paragraph("", value_style))
     data.append(total_row)
 
     table = stacked_table(data, [w * mm for w in widths])
@@ -282,25 +282,25 @@ def _assessment_table(result: DailyVibrationExposure, language: str = "en") -> A
     """The Directive 2002/44/EC assessment table (exceeded / not exceeded)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("humanvib")
 
     data: list[list[Any]] = [
         [
-            Paragraph(t("Directive 2002/44/EC value", language), header_style),
-            Paragraph(t("Threshold", language), header_style),
-            Paragraph(t("Measured", language), header_style),
-            Paragraph(t("Result", language), header_style),
+            fiche_paragraph(t("Directive 2002/44/EC value", language), header_style),
+            fiche_paragraph(t("Threshold", language), header_style),
+            fiche_paragraph(t("Measured", language), header_style),
+            fiche_paragraph(t("Result", language), header_style),
         ]
     ]
     for label, threshold, measured, exceeded in _assessment_rows(result, language):
         data.append(
             [
-                Paragraph(label, label_style),
-                Paragraph(threshold, value_style),
-                Paragraph(measured, value_style),
-                Paragraph(exceedance_markup(exceeded, language), label_style),
+                fiche_paragraph(label, label_style),
+                fiche_paragraph(threshold, value_style),
+                fiche_paragraph(measured, value_style),
+                fiche_paragraph(exceedance_markup(exceeded, language), label_style),
             ]
         )
     return stacked_table(data, [66 * mm, 32 * mm, 42 * mm, 34 * mm])
@@ -408,7 +408,7 @@ def render_human_vibration_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -417,8 +417,8 @@ def render_human_vibration_report(
     title = t("Daily vibration exposure assessment", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis(result, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis(result, language), basis_style),
     ]
 
     header_pairs = _metadata_pairs(metadata, language)
@@ -427,7 +427,7 @@ def render_human_vibration_report(
         flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Exposure analysis", language), caption_style))
+    flow.append(fiche_paragraph(t("Exposure analysis", language), caption_style))
     flow.append(_operations_table(result, verbose, language))
     flow.append(Spacer(1, 10))
     # Full-width, landscape per-operation contribution chart (self-scaling).
@@ -446,7 +446,7 @@ def render_human_vibration_report(
     flow.append(Spacer(1, 6))
 
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t("Assessment against Directive 2002/44/EC exposure values", language),
             caption_style,
         )
@@ -464,7 +464,7 @@ def render_human_vibration_report(
         spaceBefore=6,
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The exposure action value (EAV) and exposure limit value (ELV) "
                 "are daily exposures A(8) (Directive 2002/44/EC, Article 3). "
@@ -486,7 +486,7 @@ def render_human_vibration_report(
         )
     else:
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "The whole-body exposure basis a<sub>w,max</sub> is the "
                     "highest frequency-weighted axis value "
@@ -504,7 +504,7 @@ def render_human_vibration_report(
             "Annexes B and C give the health-guidance caution zone as the range "
             "of magnitudes for which health effects are potentially present."
         )
-    flow.append(Paragraph(t(exposure_note, language), note_style))
+    flow.append(fiche_paragraph(t(exposure_note, language), note_style))
     flow.extend(footer_flow(metadata, language))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/hvac.py
+++ b/src/phonometry/_report/hvac.py
@@ -46,10 +46,10 @@ from ._noise_control_fiche import (
     power_value_table,
     render_noise_control_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..noise_control.hvac import HvacSpectrumResult
+    from .metadata import ReportMetadata
 
 #: Reference sound power for a regenerated-noise sound power level, 1 pW.
 _POWER_REFERENCE = "1 pW"

--- a/src/phonometry/_report/iec60268_4.py
+++ b/src/phonometry/_report/iec60268_4.py
@@ -61,10 +61,10 @@ from .iec60268_5 import (
     _range_text,
     _thin_freq_ticklabels,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..electroacoustics.microphone import MicrophoneCharacteristics
+    from .metadata import ReportMetadata
 
 
 def _basis(metadata: ReportMetadata | None, language: str = "en") -> str:
@@ -321,7 +321,7 @@ def render_iec60268_4_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -330,8 +330,8 @@ def render_iec60268_4_report(
     title = t("Microphone characteristics", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis(metadata, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis(metadata, language), basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -342,7 +342,7 @@ def render_iec60268_4_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Rated characteristics", language), caption_style),
+        fiche_paragraph(t("Rated characteristics", language), caption_style),
         metrics_table(_rated_rows(result, language), col_widths=[35 * mm, 21 * mm]),
     ]
     response = _response_drawing(result, 116 * mm, language)

--- a/src/phonometry/_report/iec60268_5.py
+++ b/src/phonometry/_report/iec60268_5.py
@@ -52,10 +52,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..electroacoustics.loudspeaker import LoudspeakerCharacteristics
+    from .metadata import ReportMetadata
 
 #: IEC 60263 clause 2 scale proportion: one frequency decade equals this many
 #: decibels on the ordinate (the "square" 25 dB-per-decade grid).
@@ -196,7 +196,7 @@ def _drawing_from_figure(fig: Any, target_width: float, language: str = "en") ->
     proportions set on each axes survive.
     """
     try:
-        import matplotlib
+        import matplotlib as mpl
     except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
         raise ImportError(_MATPLOTLIB_HINT) from exc
     try:
@@ -210,7 +210,7 @@ def _drawing_from_figure(fig: Any, target_width: float, language: str = "en") ->
     svg_fd, svg_path = tempfile.mkstemp(suffix=".svg")
     os.close(svg_fd)
     try:
-        with matplotlib.rc_context({"svg.fonttype": "path"}):
+        with mpl.rc_context({"svg.fonttype": "path"}):
             fig.savefig(svg_path, format="svg", bbox_inches="tight")
         drawing = svg2rlg(svg_path)
     finally:
@@ -378,7 +378,7 @@ def render_iec60268_5_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -387,8 +387,8 @@ def render_iec60268_5_report(
     title = t("Loudspeaker characteristics", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis(metadata, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis(metadata, language), basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -399,7 +399,7 @@ def render_iec60268_5_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Rated characteristics", language), caption_style),
+        fiche_paragraph(t("Rated characteristics", language), caption_style),
         metrics_table(_rated_rows(result, language), col_widths=[33 * mm, 23 * mm]),
     ]
     response = _response_drawing(result, 116 * mm, language)

--- a/src/phonometry/_report/iec61043.py
+++ b/src/phonometry/_report/iec61043.py
@@ -67,12 +67,12 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..emission.intensity_compliance import (
         IntensityInstrumentComplianceResult,
     )
+    from .metadata import ReportMetadata
 
 #: Fiche prose for the ``"instrument"`` column of Table 2, and the fallback
 #: for an unrecognised device kind.

--- a/src/phonometry/_report/iec61260.py
+++ b/src/phonometry/_report/iec61260.py
@@ -46,10 +46,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..filters.compliance import FilterComplianceResult
+    from .metadata import ReportMetadata
 
 
 def _binding_margin(result: FilterComplianceResult, cls: int) -> float:
@@ -218,7 +218,7 @@ def render_iec61260_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -227,8 +227,8 @@ def render_iec61260_report(
     title = t("Filter class compliance", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis(metadata, result.edition, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis(metadata, result.edition, language), basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -253,7 +253,7 @@ def render_iec61260_report(
         else "{fraction} bank, sampling rate f<sub>s</sub> = {fs} Hz; relative attenuation referenced to the mid-band level (IEC 61260:1995, 3.13 Note)."
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(basis_strip_key, language).format(
                 fraction=_fraction_label(result.fraction, language),
                 fs=format_number(result.fs, language, decimals=0),
@@ -266,7 +266,7 @@ def render_iec61260_report(
     # Two-panel body: the per-band classification table on the left, the
     # mask-overlay plot (self-scaling dB axis) on the right.
     left_cell = [
-        Paragraph(t("Per-band classification", language), caption_style),
+        fiche_paragraph(t("Per-band classification", language), caption_style),
         metrics_table(_metric_rows(result, language)),
     ]
     plot_drawing = render_figure_drawing(
@@ -281,7 +281,7 @@ def render_iec61260_report(
         # band's processing Nyquist (no decimated signal energy exists there),
         # so the stated class attests the verified range and says so.
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "Stop-band limits verified up to each band's processing Nyquist frequency; the multirate anti-aliasing leaves no signal energy beyond it, but the Table 1 limits there are not demonstrated, so the stated class attests the verified frequency range.",
                     language,

--- a/src/phonometry/_report/iec61400.py
+++ b/src/phonometry/_report/iec61400.py
@@ -63,10 +63,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..environment.sources.wind_turbine import WindTurbineTonalityResult
+    from .metadata import ReportMetadata
 
 
 def _fmt(value: float, language: str, decimals: int = 1) -> str:
@@ -291,7 +291,7 @@ def render_wind_turbine_tonality_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -303,8 +303,8 @@ def render_wind_turbine_tonality_report(
     )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis_line(measurement_standard, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis_line(measurement_standard, language), basis_style),
     ]
 
     header_pairs = _metadata_pairs(metadata, language)
@@ -314,7 +314,7 @@ def render_wind_turbine_tonality_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Critical-band analysis", language), caption_style),
+        fiche_paragraph(t("Critical-band analysis", language), caption_style),
         metrics_table(_metric_rows(result, language), col_widths=[38 * mm, 18 * mm]),
     ]
     # Non-band plot (the narrowband spectrum with the critical band, masking
@@ -333,9 +333,9 @@ def render_wind_turbine_tonality_report(
         flow.extend(verdict_flow(text, passed, styles, language))
 
     basis_strip_style = measurement_basis_style()
-    flow.append(Paragraph(_decision_note(result, language), basis_strip_style))
+    flow.append(fiche_paragraph(_decision_note(result, language), basis_strip_style))
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The tonal audibility &#916;L<sub>a</sub> = &#916;L<sub>tn</sub> "
                 "&#8722; L<sub>a</sub> is the amount by which the tonality rises "

--- a/src/phonometry/_report/iso10052.py
+++ b/src/phonometry/_report/iso10052.py
@@ -37,7 +37,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ._insulation_fiche import iso717_columns_builder, render_insulation_fiche
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.measurement.insulation import (
@@ -49,6 +48,7 @@ if TYPE_CHECKING:
         SurveyFacadeResult,
         SurveyImpactResult,
     )
+    from .metadata import ReportMetadata
 
 #: The survey-method field statement each report prints verbatim; it names the
 #: control (survey) method so it is never conflated with the ISO 16283

--- a/src/phonometry/_report/iso10140.py
+++ b/src/phonometry/_report/iso10140.py
@@ -23,16 +23,16 @@ extra, matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from ._i18n import t
 from ._insulation_fiche import Column, render_insulation_fiche
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ..building.measurement.insulation import (
         ImpactRatingResult,
         WeightedRatingResult,
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         LabAirborneInsulationResult,
         LabImpactInsulationResult,
     )
+    from .metadata import ReportMetadata
 
 #: Per-quantity fixed labels: title, basis line, the quantity symbol used in
 #: the table header, the rating symbol of the boxed result, the plot y-axis

--- a/src/phonometry/_report/iso10534.py
+++ b/src/phonometry/_report/iso10534.py
@@ -54,10 +54,10 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..materials.absorbers.impedance_tube import ImpedanceTubeResult
+    from .metadata import ReportMetadata
 
 #: Printable label for each accepted ``ReportMetadata.tube_shape`` value.
 _SHAPE_LABELS = {
@@ -168,7 +168,7 @@ def _value_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     freqs = np.asarray(result.frequency, dtype=np.float64)
@@ -178,11 +178,11 @@ def _value_table(
 
     if verbose:
         header = [
-            Paragraph(t("f [Hz]", language), head_style),
-            Paragraph("&#945;", head_style),
-            Paragraph("|r|", head_style),
-            Paragraph("Re z", head_style),
-            Paragraph("Im z", head_style),
+            fiche_paragraph(t("f [Hz]", language), head_style),
+            fiche_paragraph("&#945;", head_style),
+            fiche_paragraph("|r|", head_style),
+            fiche_paragraph("Re z", head_style),
+            fiche_paragraph("Im z", head_style),
         ]
         rows: list[list[Any]] = [header]
         for fk, ak, rk, zk in zip(freqs, alpha, r_mag, z):
@@ -198,10 +198,10 @@ def _value_table(
         col_widths = [16 * mm, 18 * mm, 18 * mm, 18 * mm, 18 * mm]
     else:
         header = [
-            Paragraph(t("f [Hz]", language), head_style),
-            Paragraph("&#945;", head_style),
-            Paragraph("Re z", head_style),
-            Paragraph("Im z", head_style),
+            fiche_paragraph(t("f [Hz]", language), head_style),
+            fiche_paragraph("&#945;", head_style),
+            fiche_paragraph("Re z", head_style),
+            fiche_paragraph("Im z", head_style),
         ]
         rows = [header]
         for fk, ak, zk in zip(freqs, alpha, z):
@@ -271,10 +271,10 @@ def _body(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     left_cell = [
-        Paragraph(_caption(verbose, language), caption_style),
+        fiche_paragraph(_caption(verbose, language), caption_style),
         _value_table(result, verbose, language),
     ]
     plot_drawing = render_figure_drawing(
@@ -316,7 +316,7 @@ def render_iso10534_report(
         from reportlab.lib import colors
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -333,8 +333,8 @@ def render_iso10534_report(
     title = t("Impedance-tube sound absorption and impedance", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis_line(metadata, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis_line(metadata, language), basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)

--- a/src/phonometry/_report/iso10846.py
+++ b/src/phonometry/_report/iso10846.py
@@ -41,10 +41,10 @@ import numpy as np
 
 from ._frf_fiche import frequency_range, frf_metadata_pairs, render_frf_fiche
 from ._i18n import format_number, t
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..vibration.structural.transfer_stiffness import TransferStiffnessResult
+    from .metadata import ReportMetadata
 
 
 def _is_indirect(result: TransferStiffnessResult) -> bool:

--- a/src/phonometry/_report/iso10848.py
+++ b/src/phonometry/_report/iso10848.py
@@ -62,7 +62,6 @@ from ._layout import (
     two_panel_body,
 )
 from .iso717 import _metadata_pairs
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.measurement.flanking_transmission import (
@@ -74,6 +73,7 @@ if TYPE_CHECKING:
         ImpactRatingResult,
         WeightedRatingResult,
     )
+    from .metadata import ReportMetadata
 
 #: Designation of each applicable ISO 10848 part. The overall flanking
 #: descriptors ``Dn,f`` / ``Ln,f`` are defined in the Part 1 frame document
@@ -314,16 +314,16 @@ def _kij_value_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     header: list[Any] = [
-        Paragraph(t("f [Hz]", language), head_style),
-        Paragraph("K<sub>ij</sub> [dB]", head_style),
+        fiche_paragraph(t("f [Hz]", language), head_style),
+        fiche_paragraph("K<sub>ij</sub> [dB]", head_style),
     ]
     widths = [24 * mm, 30 * mm]
     if verbose:
-        header.append(Paragraph(t("In mean", language), head_style))
+        header.append(fiche_paragraph(t("In mean", language), head_style))
         widths = [16 * mm, 22 * mm, 18 * mm]
 
     rows: list[list[Any]] = [header]
@@ -421,7 +421,7 @@ def render_vibration_reduction_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -437,8 +437,8 @@ def render_vibration_reduction_report(
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title_text = t(_KIJ_TITLE, language)
     flow: list[Any] = [
-        Paragraph(title_text, title_style),
-        Paragraph(t(_KIJ_BASIS, language), basis_style),
+        fiche_paragraph(title_text, title_style),
+        fiche_paragraph(t(_KIJ_BASIS, language), basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -452,7 +452,7 @@ def render_vibration_reduction_report(
     in_mean, low, high = _kij_mean_membership(frequencies, bracketed)
     caption = t("Vibration reduction index per band", language)
     left_cell = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         _kij_value_table(frequencies, k_ij, bracketed, in_mean, verbose, language),
     ]
     plot_drawing = render_figure_drawing(
@@ -475,7 +475,7 @@ def render_vibration_reduction_report(
         textColor=colors.HexColor(_MUTED_HEX),
         spaceBefore=4,
     )
-    flow.append(Paragraph(t(_KIJ_STATEMENT, language), statement_style))
+    flow.append(fiche_paragraph(t(_KIJ_STATEMENT, language), statement_style))
     if bracketed is not None and bool(np.any(bracketed)):
         note_style = ParagraphStyle(
             "kij_note",
@@ -485,7 +485,7 @@ def render_vibration_reduction_report(
             spaceBefore=2,
         )
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "Values in brackets are bracketed bands, excluded from the "
                     "single number.",

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -56,10 +56,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..materials.absorbers.rating import AbsorptionRatingResult
+    from .metadata import ReportMetadata
 
 #: Threshold below which an unfavourable deviation is shown as an em dash.
 _DEVIATION_EPS = 0.005
@@ -159,7 +159,7 @@ def _value_table(
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
@@ -167,16 +167,16 @@ def _value_table(
 
     if verbose:
         header = [
-            Paragraph(t("f [Hz]", language), head_style),
-            Paragraph(t("Practical &#945;<sub>p</sub>", language), head_style),
-            Paragraph(t("Shifted ref.", language), head_style),
-            Paragraph(t("Unfav. dev.", language), head_style),
+            fiche_paragraph(t("f [Hz]", language), head_style),
+            fiche_paragraph(t("Practical &#945;<sub>p</sub>", language), head_style),
+            fiche_paragraph(t("Shifted ref.", language), head_style),
+            fiche_paragraph(t("Unfav. dev.", language), head_style),
         ]
         col_widths = [15 * mm, 20 * mm, 17 * mm, 18 * mm]
     else:
         header = [
-            Paragraph(t("Frequency f [Hz]", language), head_style),
-            Paragraph("&#945;<sub>p</sub>", head_style),
+            fiche_paragraph(t("Frequency f [Hz]", language), head_style),
+            fiche_paragraph("&#945;<sub>p</sub>", head_style),
         ]
         col_widths = [28 * mm, 28 * mm]
 
@@ -229,16 +229,16 @@ def _third_octave_table(
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
     head_style = _thead_style()
 
     header = [
-        Paragraph(t("Frequency f [Hz]", language), head_style),
-        Paragraph("&#945;<sub>s</sub>", head_style),
-        Paragraph("&#945;<sub>p</sub>", head_style),
+        fiche_paragraph(t("Frequency f [Hz]", language), head_style),
+        fiche_paragraph("&#945;<sub>s</sub>", head_style),
+        fiche_paragraph("&#945;<sub>p</sub>", head_style),
     ]
     col_widths = [24 * mm, 16 * mm, 16 * mm]
 
@@ -328,7 +328,7 @@ def render_iso11654_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -359,8 +359,8 @@ def render_iso11654_report(
         basis = t("Sound absorption rating per ISO 11654:1997.", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -392,7 +392,7 @@ def render_iso11654_report(
         )
         caption = t("Octave-band &#945;<sub>p</sub>", language)
     left_cell = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         value_table,
     ]
     plot_drawing = render_figure_drawing(
@@ -424,7 +424,7 @@ def render_iso11654_report(
             spaceBefore=4,
         )
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "A shape indicator applies: ISO 11654 (5.3 NOTE) recommends using &#945;<sub>w</sub> in combination with the complete sound absorption coefficient curve, shown above.",
                     language,

--- a/src/phonometry/_report/iso12354.py
+++ b/src/phonometry/_report/iso12354.py
@@ -58,7 +58,6 @@ from ._layout import (
     verdict_flow,
 )
 from .iso717 import _metadata_pairs
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.prediction.detailed_model import (
@@ -70,6 +69,7 @@ if TYPE_CHECKING:
         AirbornePredictionResult,
         ImpactPredictionResult,
     )
+    from .metadata import ReportMetadata
 
 #: Model standard deviation of the simplified single-number prediction, stated
 #: for reference in the method statement (EN 12354-1:2000 Clause 5, EN 12354-2
@@ -171,7 +171,7 @@ def _render_prediction_fiche(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -182,8 +182,8 @@ def _render_prediction_fiche(
     if basis_values is not None:
         basis_text = basis_text.format(**basis_values)
     flow: list[Any] = [
-        Paragraph(title_text, title_style),
-        Paragraph(basis_text, basis_style),
+        fiche_paragraph(title_text, title_style),
+        fiche_paragraph(basis_text, basis_style),
     ]
 
     # Metadata header grid (the same room/element grid the insulation fiches
@@ -199,7 +199,7 @@ def _render_prediction_fiche(
     # Two-panel body: the model-term metrics table on the left, the result's own
     # vector plot (self-scaling bar chart) on the right.
     left_cell = [
-        Paragraph(t(left_caption_key, language), caption_style),
+        fiche_paragraph(t(left_caption_key, language), caption_style),
         metrics_table(metric_rows, col_widths=[34 * mm, 22 * mm]),
     ]
     plot_drawing = render_figure_drawing(
@@ -223,7 +223,9 @@ def _render_prediction_fiche(
     )
     statement_key, statement_values = statement
     values = statement_values or {"sd": _MODEL_SD_DB}
-    flow.append(Paragraph(t(statement_key, language).format(**values), statement_style))
+    flow.append(
+        fiche_paragraph(t(statement_key, language).format(**values), statement_style)
+    )
 
     if metadata is not None and metadata.requirement is not None:
         text, passed = _prediction_verdict(

--- a/src/phonometry/_report/iso15186.py
+++ b/src/phonometry/_report/iso15186.py
@@ -37,7 +37,6 @@ extra, matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -49,14 +48,16 @@ from ._insulation_fiche import (
     render_insulation_fiche,
 )
 from ._layout import fmt_num
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ..building.measurement.insulation import WeightedRatingResult
     from ..building.measurement.intensity_insulation import (
         IntensityElementNormalizedResult,
         IntensityReductionResult,
     )
+    from .metadata import ReportMetadata
 
 #: Fixed labels for the intensity sound reduction index fiche: title, basis
 #: line, the quantity symbol used in the table header, the rating symbol of the

--- a/src/phonometry/_report/iso16251.py
+++ b/src/phonometry/_report/iso16251.py
@@ -62,12 +62,12 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.measurement.floor_covering_improvement import (
         FloorCoveringImprovementResult,
     )
+    from .metadata import ReportMetadata
 
 
 def _metadata_pairs(
@@ -173,7 +173,7 @@ def _value_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
@@ -181,11 +181,11 @@ def _value_table(
     limited = np.asarray(result.limited, dtype=bool)
 
     header = [
-        Paragraph(t("Frequency f [Hz]", language), head_style),
-        Paragraph(t("&#916;L [dB]", language), head_style),
+        fiche_paragraph(t("Frequency f [Hz]", language), head_style),
+        fiche_paragraph(t("&#916;L [dB]", language), head_style),
     ]
     if ln_r is not None:
-        header.append(Paragraph(t("L<sub>n,r</sub> [dB]", language), head_style))
+        header.append(fiche_paragraph(t("L<sub>n,r</sub> [dB]", language), head_style))
         widths = [21 * mm, 20 * mm, 20 * mm]
     else:
         widths = [28 * mm, 28 * mm]
@@ -266,7 +266,7 @@ def _body(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     ln_r = _reference_floor_with_covering(result) if verbose else None
     caption = (
@@ -278,7 +278,7 @@ def _body(
         else t("One-third-octave improvement &#916;L [dB]", language)
     )
     left_cell: list[Any] = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         _value_table(result, ln_r, language),
     ]
 
@@ -341,7 +341,7 @@ def render_iso16251_report(
         from reportlab.lib.styles import ParagraphStyle
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -358,8 +358,8 @@ def render_iso16251_report(
     title = t("Floor-covering impact sound improvement", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis_line(metadata, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis_line(metadata, language), basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)
@@ -380,7 +380,7 @@ def render_iso16251_report(
         spaceBefore=4,
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Weighted reduction of impact sound pressure level "
                 "&#916;L<sub>w</sub> rated on the 100 Hz to 3150 Hz "
@@ -395,7 +395,7 @@ def render_iso16251_report(
     )
     if _is_background_limited(result):
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "One or more bands are at the 1,3 dB limit of measurement "
                     "(ISO 16251-1:2014 Formula (2), reported as &gt; &#916;L); "

--- a/src/phonometry/_report/iso16283.py
+++ b/src/phonometry/_report/iso16283.py
@@ -43,7 +43,6 @@ matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -54,9 +53,10 @@ from ._insulation_fiche import (
     iso717_columns_builder,
     render_insulation_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ..building.measurement.insulation import (
         AirborneInsulationResult,
         FacadeInsulationResult,
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
         ImpactRatingResult,
         WeightedRatingResult,
     )
+    from .metadata import ReportMetadata
 
 #: The field engineering-method statement the airborne (ISO 16283-1) and facade
 #: (ISO 16283-3) reports print verbatim.

--- a/src/phonometry/_report/iso17497.py
+++ b/src/phonometry/_report/iso17497.py
@@ -61,7 +61,6 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..materials.diffusers.reverberation_room_scattering import ScatteringResult
@@ -69,6 +68,7 @@ if TYPE_CHECKING:
         DiffusionResult,
         DiffusionSpectrum,
     )
+    from .metadata import ReportMetadata
 
 #: Header of the band centre-frequency column of every ISO 17497 table.
 _FREQUENCY_COLUMN = "f [Hz]"
@@ -190,11 +190,11 @@ def _header_flow(
     """The shared title/basis/metadata-grid opening of an ISO 17497 fiche."""
     from reportlab.platypus import Spacer
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
     if header_pairs:
         flow.append(Spacer(1, 3))
@@ -212,7 +212,7 @@ def _scattering_table(
     """Build the per-band ``f | alpha_s | s`` table (``alpha_spec`` if verbose)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
@@ -221,10 +221,10 @@ def _scattering_table(
     if verbose:
         spec = np.asarray(result.specular, dtype=np.float64)
         header = [
-            Paragraph(t(_FREQUENCY_COLUMN, language), head_style),
-            Paragraph("&#945;<sub>s</sub>", head_style),
-            Paragraph("&#945;<sub>spec</sub>", head_style),
-            Paragraph("s", head_style),
+            fiche_paragraph(t(_FREQUENCY_COLUMN, language), head_style),
+            fiche_paragraph("&#945;<sub>s</sub>", head_style),
+            fiche_paragraph("&#945;<sub>spec</sub>", head_style),
+            fiche_paragraph("s", head_style),
         ]
         rows: list[list[Any]] = [header]
         for fk, ak, spk, sk in zip(freqs, a_s, spec, s):
@@ -239,9 +239,9 @@ def _scattering_table(
         col_widths = [22 * mm, 22 * mm, 24 * mm, 20 * mm]
     else:
         header = [
-            Paragraph(t(_FREQUENCY_COLUMN, language), head_style),
-            Paragraph("&#945;<sub>s</sub>", head_style),
-            Paragraph("s", head_style),
+            fiche_paragraph(t(_FREQUENCY_COLUMN, language), head_style),
+            fiche_paragraph("&#945;<sub>s</sub>", head_style),
+            fiche_paragraph("s", head_style),
         ]
         rows = [header]
         for fk, ak, sk in zip(freqs, a_s, s):
@@ -284,7 +284,7 @@ def render_scattering_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -326,7 +326,7 @@ def render_scattering_report(
         )
     )
     left_cell = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         _scattering_table(result, verbose, language),
     ]
     plot_fn = functools.partial(plot_scattering_report, result)
@@ -366,7 +366,7 @@ def _diffusion_table(
     """Build the per-band ``f | d`` table (adds ``d_n`` when requested)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
@@ -374,9 +374,9 @@ def _diffusion_table(
     if show_normalized and result.normalized is not None:
         d_n = np.asarray(result.normalized, dtype=np.float64)
         header = [
-            Paragraph(t(_FREQUENCY_COLUMN, language), head_style),
-            Paragraph("d", head_style),
-            Paragraph("d<sub>n</sub>", head_style),
+            fiche_paragraph(t(_FREQUENCY_COLUMN, language), head_style),
+            fiche_paragraph("d", head_style),
+            fiche_paragraph("d<sub>n</sub>", head_style),
         ]
         rows: list[list[Any]] = [header]
         for fk, dk, dnk in zip(freqs, d, d_n):
@@ -390,8 +390,8 @@ def _diffusion_table(
         col_widths = [20 * mm, 18 * mm, 18 * mm]
     else:
         header = [
-            Paragraph(t(_FREQUENCY_COLUMN, language), head_style),
-            Paragraph("d", head_style),
+            fiche_paragraph(t(_FREQUENCY_COLUMN, language), head_style),
+            fiche_paragraph("d", head_style),
         ]
         rows = [header]
         for fk, dk in zip(freqs, d):
@@ -428,7 +428,7 @@ def render_diffusion_spectrum_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -471,7 +471,7 @@ def render_diffusion_spectrum_report(
         else t("One-third-octave diffusion coefficient d", language)
     )
     left_cell = [
-        Paragraph(caption, caption_style),
+        fiche_paragraph(caption, caption_style),
         _diffusion_table(result, show_normalized, language),
     ]
     plot_fn = functools.partial(plot_diffusion_report, result)
@@ -498,14 +498,14 @@ def _polar_table(result: DiffusionResult, language: str = "en") -> Any:
     """Build the corrected ``angle | reflected level`` polar-response table."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     angles = np.asarray(result.angles, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
     header = [
-        Paragraph(t("Angle &#952; [&#176;]", language), head_style),
-        Paragraph("L [dB]", head_style),
+        fiche_paragraph(t("Angle &#952; [&#176;]", language), head_style),
+        fiche_paragraph("L [dB]", head_style),
     ]
     rows: list[list[Any]] = [header]
     for ang, lev in zip(angles, levels):
@@ -542,7 +542,7 @@ def render_diffusion_polar_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -573,7 +573,10 @@ def render_diffusion_polar_report(
     from .._plot.materials import plot_diffusion_polar_report
 
     caption = t("Corrected polar response L per receiver angle", language)
-    left_cell = [Paragraph(caption, caption_style), _polar_table(result, language)]
+    left_cell = [
+        fiche_paragraph(caption, caption_style),
+        _polar_table(result, language),
+    ]
     plot_fn = functools.partial(plot_diffusion_polar_report, result)
     plot_drawing = render_figure_drawing(
         plot_fn,

--- a/src/phonometry/_report/iso1996_impulse.py
+++ b/src/phonometry/_report/iso1996_impulse.py
@@ -63,10 +63,10 @@ from ._layout import (
     stacked_table,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..environment.assessment.impulsive_sound import ImpulseProminenceResult
+    from .metadata import ReportMetadata
 
 #: Minimum onset rate, in dB/s, for a level rise to qualify as an impulse
 #: (NT ACOU 112:2002, clause 4.5). Kept here so the renderer does not import
@@ -186,7 +186,7 @@ def _per_impulse_table(result: ImpulseProminenceResult, language: str = "en") ->
     from reportlab.lib import colors
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso1996imp")
 
@@ -206,23 +206,25 @@ def _per_impulse_table(result: ImpulseProminenceResult, language: str = "en") ->
     ]
     widths = [22.0, 34.0, 34.0, 34.0, 50.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for i in shown:
         emph = "<b>{}</b>".format if i == governing else str
         data.append(
             [
-                Paragraph(emph(str(i + 1)), label_style),
-                Paragraph(_fmt(orate[i], language, decimals=0), value_style),
-                Paragraph(_fmt(ld[i], language), value_style),
-                Paragraph(emph(_fmt(per[i], language, decimals=2)), value_style),
-                Paragraph(_qualifies_markup(bool(qualifies[i]), language), value_style),
+                fiche_paragraph(emph(str(i + 1)), label_style),
+                fiche_paragraph(_fmt(orate[i], language, decimals=0), value_style),
+                fiche_paragraph(_fmt(ld[i], language), value_style),
+                fiche_paragraph(emph(_fmt(per[i], language, decimals=2)), value_style),
+                fiche_paragraph(
+                    _qualifies_markup(bool(qualifies[i]), language), value_style
+                ),
             ]
         )
     if dropped:
         note = t("&#8230; plus {n} more impulses of lower prominence", language).format(
             n=dropped
         )
-        data.append([Paragraph(note, label_style), "", "", "", ""])
+        data.append([fiche_paragraph(note, label_style), "", "", "", ""])
 
     table = stacked_table(data, [w * mm for w in widths])
     dec_row = shown.index(governing) + 1  # +1 for the header row
@@ -374,7 +376,7 @@ def render_impulse_prominence_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -386,8 +388,8 @@ def render_impulse_prominence_report(
     )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis_line(measurement_standard, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis_line(measurement_standard, language), basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)
@@ -396,7 +398,7 @@ def render_impulse_prominence_report(
         flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Candidate impulses", language), caption_style))
+    flow.append(fiche_paragraph(t("Candidate impulses", language), caption_style))
     flow.append(_per_impulse_table(result, language))
     flow.append(Spacer(1, 8))
 
@@ -421,9 +423,9 @@ def render_impulse_prominence_report(
         flow.extend(verdict_flow(text, passed, styles, language))
 
     basis_strip_style = measurement_basis_style()
-    flow.append(Paragraph(_prominence_note(result, language), basis_strip_style))
+    flow.append(fiche_paragraph(_prominence_note(result, language), basis_strip_style))
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The predicted prominence P = 3 lg(OR) + 2 lg(LD) combines the "
                 "onset rate OR (dB/s) and the level difference LD (dB) of each "
@@ -436,7 +438,7 @@ def render_impulse_prominence_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The L<sub>Aeq</sub> adjustment K<sub>I</sub> = 1.8 (P &#8722; "
                 "5) dB for P &gt; 5, else 0 dB, is applied to the "

--- a/src/phonometry/_report/iso1996_tone.py
+++ b/src/phonometry/_report/iso1996_tone.py
@@ -64,10 +64,10 @@ from ._layout import (
     stacked_table,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..psychoacoustics.quality.tone_audibility import ToneAudibilityResult
+    from .metadata import ReportMetadata
 
 
 def _fmt(value: float, language: str, decimals: int = 1) -> str:
@@ -160,7 +160,7 @@ def _key_quantity_table(
     from reportlab.lib import colors
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso1996tone")
 
@@ -189,22 +189,24 @@ def _key_quantity_table(
         headers.insert(6, "U [dB]")
         widths = [23.0, 20.0, 22.0, 22.0, 24.0, 25.0, 18.0, 20.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for i in order.tolist():
         emph = "<b>{}</b>".format if i == decisive else str
         present = bool(delta[i] > 0.0)
         gs = int(groups[i]) if groups is not None else None
         row = [
-            Paragraph(emph(_fmt(freqs[i], language)), label_style),
-            Paragraph(_type_label(gs, language), value_style),
-            Paragraph(_fmt(lt[i], language), value_style),
-            Paragraph(_fmt(lpn[i], language), value_style),
-            Paragraph(_fmt(dfc[i], language, decimals=0), value_style),
-            Paragraph(emph(_fmt(delta[i], language)), value_style),
-            Paragraph(_present_markup(present, language), value_style),
+            fiche_paragraph(emph(_fmt(freqs[i], language)), label_style),
+            fiche_paragraph(_type_label(gs, language), value_style),
+            fiche_paragraph(_fmt(lt[i], language), value_style),
+            fiche_paragraph(_fmt(lpn[i], language), value_style),
+            fiche_paragraph(_fmt(dfc[i], language, decimals=0), value_style),
+            fiche_paragraph(emph(_fmt(delta[i], language)), value_style),
+            fiche_paragraph(_present_markup(present, language), value_style),
         ]
         if show_u and uncertainties is not None:
-            row.insert(6, Paragraph(_fmt(uncertainties[i], language), value_style))
+            row.insert(
+                6, fiche_paragraph(_fmt(uncertainties[i], language), value_style)
+            )
         data.append(row)
 
     table = stacked_table(data, [w * mm for w in widths])
@@ -317,7 +319,7 @@ def render_tone_audibility_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -343,8 +345,8 @@ def render_tone_audibility_report(
         )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)
@@ -353,7 +355,7 @@ def render_tone_audibility_report(
         flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Detected tones", language), caption_style))
+    flow.append(fiche_paragraph(t("Detected tones", language), caption_style))
     flow.append(_key_quantity_table(result, verbose, language))
     flow.append(Spacer(1, 8))
 
@@ -399,9 +401,9 @@ def render_tone_audibility_report(
             "{dl} dB &#8804; 0); no tonal adjustment applies (K = 0 dB).",
             language,
         ).format(dl=_fmt(delta, language))
-    flow.append(Paragraph(prominence, basis_strip_style))
+    flow.append(fiche_paragraph(prominence, basis_strip_style))
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The tonal audibility &#916;L<sub>ta</sub> = L<sub>pt</sub> "
                 "&#8722; L<sub>pn</sub> &#8722; a<sub>v</sub> is the amount by "
@@ -415,7 +417,7 @@ def render_tone_audibility_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "L<sub>pn</sub> is the critical-band masking-noise level "
                 "(Formula (12)), &#916;f<sub>c</sub> the critical bandwidth "
@@ -430,7 +432,7 @@ def render_tone_audibility_report(
     # ISO/PAS 20065 Clause 5.3.9; this fiche assesses the one spectrum supplied,
     # whose decisive audibility is that mean only for J = 1.
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Table J.1 assigns K from the mean audibility &#916;L, the "
                 "energy mean of the decisive audibilities of the J assessed "

--- a/src/phonometry/_report/iso1999.py
+++ b/src/phonometry/_report/iso1999.py
@@ -56,10 +56,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..hearing.noise_induced_hearing_loss import HtlanResult, NiptsResult
+    from .metadata import ReportMetadata
 
 #: The 2/3/4 kHz hearing-handicap audiometric set, in hertz. The mean threshold
 #: shift over these three frequencies is the descriptor most occupational
@@ -172,7 +172,7 @@ def _nipts_table(
     """The per-audiometric-frequency NIPTS table (median and fractile value)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso1999n")
 
@@ -186,19 +186,19 @@ def _nipts_table(
         headers += ["d<sub>u</sub> [dB]", "d<sub>l</sub> [dB]"]
         widths = [22.0, 18.0, 18.0, 19.0, 19.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for i, freq in enumerate(result.frequencies):
         row = [
-            Paragraph(_fmt_freq(float(freq), language), label_style),
-            Paragraph(_fmt_db(float(result.median[i]), language), value_style),
-            Paragraph(_fmt_db(float(result.value[i]), language), value_style),
+            fiche_paragraph(_fmt_freq(float(freq), language), label_style),
+            fiche_paragraph(_fmt_db(float(result.median[i]), language), value_style),
+            fiche_paragraph(_fmt_db(float(result.value[i]), language), value_style),
         ]
         if verbose:
             row += [
-                Paragraph(
+                fiche_paragraph(
                     _fmt_db(float(result.spread_upper[i]), language), value_style
                 ),
-                Paragraph(
+                fiche_paragraph(
                     _fmt_db(float(result.spread_lower[i]), language), value_style
                 ),
             ]
@@ -279,7 +279,7 @@ def render_nipts_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -293,8 +293,8 @@ def render_nipts_report(
     )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _nipts_metadata_pairs(metadata, language)
@@ -304,7 +304,7 @@ def render_nipts_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Threshold shift by frequency", language), caption_style),
+        fiche_paragraph(t("Threshold shift by frequency", language), caption_style),
         _nipts_table(result, verbose, language),
     ]
     left_width = 96.0 if verbose else 66.0
@@ -355,7 +355,7 @@ def _htlan_table(
     """The per-audiometric-frequency HTLAN table (age, noise and combined)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso1999h")
 
@@ -370,19 +370,21 @@ def _htlan_table(
         headers.insert(3, "H&#183;N/120 [dB]")
         widths = [20.0, 16.0, 16.0, 20.0, 20.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for i, freq in enumerate(result.frequencies):
         h = float(result.htla[i])
         n = float(result.nipts[i])
         row = [
-            Paragraph(_fmt_freq(float(freq), language), label_style),
-            Paragraph(_fmt_db(h, language), value_style),
-            Paragraph(_fmt_db(n, language), value_style),
+            fiche_paragraph(_fmt_freq(float(freq), language), label_style),
+            fiche_paragraph(_fmt_db(h, language), value_style),
+            fiche_paragraph(_fmt_db(n, language), value_style),
         ]
         if verbose:
-            row.append(Paragraph(_fmt_db(h * n / _HTLAN_DENOM, language), value_style))
+            row.append(
+                fiche_paragraph(_fmt_db(h * n / _HTLAN_DENOM, language), value_style)
+            )
         row.append(
-            Paragraph(_fmt_db(float(result.threshold[i]), language), value_style)
+            fiche_paragraph(_fmt_db(float(result.threshold[i]), language), value_style)
         )
         data.append(row)
 
@@ -461,7 +463,7 @@ def render_htlan_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -475,8 +477,8 @@ def render_htlan_report(
     )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _nipts_metadata_pairs(metadata, language)
@@ -486,7 +488,7 @@ def render_htlan_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Threshold level by frequency", language), caption_style),
+        fiche_paragraph(t("Threshold level by frequency", language), caption_style),
         _htlan_table(result, verbose, language),
     ]
     left_width = 92.0 if verbose else 74.0
@@ -572,8 +574,7 @@ def _prediction_notes(
     from reportlab.lib import colors
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 
-    from ._layout import _MUTED_HEX
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import _MUTED_HEX, fiche_paragraph
 
     note_style = ParagraphStyle(
         "iso1999_notes",
@@ -584,7 +585,7 @@ def _prediction_notes(
         spaceBefore=6,
     )
     notes: list[Any] = [
-        Paragraph(
+        fiche_paragraph(
             t(
                 "These values are a statistical prediction for a noise-exposed "
                 "population (ISO 1999:2013), not a clinical diagnosis or a "
@@ -593,7 +594,7 @@ def _prediction_notes(
             ),
             note_style,
         ),
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Q is the percentage of the noise-exposed population predicted "
                 "to show a larger (worse) value than the one stated, as "
@@ -606,7 +607,7 @@ def _prediction_notes(
     ]
     if with_age_component:
         notes.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "The age component H (database A) is evaluated from "
                     "ISO 7029:2017, the edition ISO 1999:2013 references "
@@ -620,7 +621,7 @@ def _prediction_notes(
         )
     if handicap_mean:
         notes.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "ISO 1999:2013 does not specify frequencies or frequency "
                     "combinations for evaluating hearing disability (Scope, "
@@ -633,7 +634,7 @@ def _prediction_notes(
         )
     if _outside_validated_domain(l_ex, years, fractile):
         notes.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "The stated conditions lie outside the validated domain of "
                     "ISO 1999:2013 (exposure durations of 1 year to 40 years, "

--- a/src/phonometry/_report/iso2631_5.py
+++ b/src/phonometry/_report/iso2631_5.py
@@ -60,10 +60,10 @@ from ._layout import (
     result_box,
     stacked_table,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..vibration.human.multiple_shock import MultipleShockResult
+    from .metadata import ReportMetadata
 
 #: Display precision of the acceleration dose and compressive stress (two
 #: decimals resolve the Annex C worked example Dz = 55.97 m/s2 and Sd = 1.62
@@ -192,7 +192,7 @@ def _analysis_table(result: MultipleShockResult, language: str = "en") -> Any:
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso26315")
     ms2 = _unit_ms2()
@@ -235,19 +235,19 @@ def _analysis_table(result: MultipleShockResult, language: str = "en") -> Any:
 
     data: list[list[Any]] = [
         [
-            Paragraph(t("Quantity", language), header_style),
-            Paragraph(t("Symbol", language), header_style),
-            Paragraph(t("Value", language), header_style),
-            Paragraph(t("Reference", language), header_style),
+            fiche_paragraph(t("Quantity", language), header_style),
+            fiche_paragraph(t("Symbol", language), header_style),
+            fiche_paragraph(t("Value", language), header_style),
+            fiche_paragraph(t("Reference", language), header_style),
         ]
     ]
     for quantity, symbol, value, reference in rows:
         data.append(
             [
-                Paragraph(quantity, label_style),
-                Paragraph(symbol, value_style),
-                Paragraph(value, value_style),
-                Paragraph(reference, value_style),
+                fiche_paragraph(quantity, label_style),
+                fiche_paragraph(symbol, value_style),
+                fiche_paragraph(value, value_style),
+                fiche_paragraph(reference, value_style),
             ]
         )
     table = stacked_table(data, [70 * mm, 26 * mm, 42 * mm, 36 * mm])
@@ -270,7 +270,7 @@ def _classification_table(result: MultipleShockResult, language: str = "en") -> 
     from reportlab.lib import colors
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso26315cls")
     r10, r50, r90 = (_fmt(x, _R_DECIMALS, language) for x in result.risk_thresholds)
@@ -309,19 +309,19 @@ def _classification_table(result: MultipleShockResult, language: str = "en") -> 
 
     data: list[list[Any]] = [
         [
-            Paragraph(t("Risk band", language), header_style),
-            Paragraph(t("Risk of lumbar injury", language), header_style),
-            Paragraph(t("Stress variable R (Table C.2)", language), header_style),
-            Paragraph(t("Classification", language), header_style),
+            fiche_paragraph(t("Risk band", language), header_style),
+            fiche_paragraph(t("Risk of lumbar injury", language), header_style),
+            fiche_paragraph(t("Stress variable R (Table C.2)", language), header_style),
+            fiche_paragraph(t("Classification", language), header_style),
         ]
     ]
     for index, (band, probability, r_range) in enumerate(bands):
         data.append(
             [
-                Paragraph(band, label_style),
-                Paragraph(probability, value_style),
-                Paragraph(r_range, value_style),
-                Paragraph(_mark(index == active), label_style),
+                fiche_paragraph(band, label_style),
+                fiche_paragraph(probability, value_style),
+                fiche_paragraph(r_range, value_style),
+                fiche_paragraph(_mark(index == active), label_style),
             ]
         )
     table = stacked_table(data, [40 * mm, 36 * mm, 62 * mm, 36 * mm])
@@ -356,7 +356,7 @@ def _zone_row(result: MultipleShockResult, language: str = "en") -> Any:
     """The classification zone row stating the Annex C risk band for ``R``."""
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     band = t(_BAND_LABELS[_band_index(result)], language)
     zone_style = ParagraphStyle(
@@ -367,7 +367,7 @@ def _zone_row(result: MultipleShockResult, language: str = "en") -> Any:
         spaceBefore=4,
     )
     lead = t("Health-risk classification", language)
-    return Paragraph(
+    return fiche_paragraph(
         f"{lead}: {t('stress variable R = {r} &#8594; {band}', language).format(r=_fmt(result.risk, _R_DECIMALS, language), band=band)}",
         zone_style,
     )
@@ -407,7 +407,7 @@ def render_iso2631_5_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -416,8 +416,8 @@ def render_iso2631_5_report(
     title = t("Whole-body multiple-shock health risk", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(
             t(
                 "Assessment of adverse health effects from whole-body vibration "
                 "containing multiple shocks per ISO 2631-5:2018 (Clause 5 spinal "
@@ -437,7 +437,7 @@ def render_iso2631_5_report(
     flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 6))
 
-    flow.append(Paragraph(t("Dose and stress analysis", language), caption_style))
+    flow.append(fiche_paragraph(t("Dose and stress analysis", language), caption_style))
     flow.append(_analysis_table(result, language))
     flow.append(Spacer(1, 4))
     # Full-width, landscape injury-probability curve (self-scaling 0-100 % axis).
@@ -456,7 +456,9 @@ def render_iso2631_5_report(
     flow.append(Spacer(1, 4))
 
     flow.append(
-        Paragraph(t("Annex C risk classification (Table C.2)", language), caption_style)
+        fiche_paragraph(
+            t("Annex C risk classification (Table C.2)", language), caption_style
+        )
     )
     flow.append(_classification_table(result, language))
     flow.append(_zone_row(result, language))
@@ -470,7 +472,7 @@ def render_iso2631_5_report(
         spaceBefore=5,
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "ISO 2631-5:2018 defines no exposure limit; the stress variable "
                 "R and the probability of lumbar injury P are the informative "

--- a/src/phonometry/_report/iso3382.py
+++ b/src/phonometry/_report/iso3382.py
@@ -60,10 +60,10 @@ from ._layout import (
     result_box,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..room.acoustics import RoomAcousticsResult
+    from .metadata import ReportMetadata
 
 #: Band centres whose T30 mean is the mid-frequency reverberation-time
 #: descriptor T_mid quoted for rooms: the 500 Hz and 1000 Hz bands at the
@@ -170,7 +170,7 @@ def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
@@ -211,14 +211,14 @@ def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
     body_font = 6.8 if compact else 8.0
 
     header = [
-        Paragraph(t("f [Hz]", language), head_style),
-        Paragraph("T<sub>20</sub> [s]", head_style),
-        Paragraph("T<sub>30</sub> [s]", head_style),
-        Paragraph("EDT [s]", head_style),
-        Paragraph("C<sub>50</sub> [dB]", head_style),
-        Paragraph("C<sub>80</sub> [dB]", head_style),
-        Paragraph("D<sub>50</sub>", head_style),
-        Paragraph("T<sub>s</sub> [ms]", head_style),
+        fiche_paragraph(t("f [Hz]", language), head_style),
+        fiche_paragraph("T<sub>20</sub> [s]", head_style),
+        fiche_paragraph("T<sub>30</sub> [s]", head_style),
+        fiche_paragraph("EDT [s]", head_style),
+        fiche_paragraph("C<sub>50</sub> [dB]", head_style),
+        fiche_paragraph("C<sub>80</sub> [dB]", head_style),
+        fiche_paragraph("D<sub>50</sub>", head_style),
+        fiche_paragraph("T<sub>s</sub> [ms]", head_style),
     ]
     rows: list[list[Any]] = [header]
     for i in range(n):
@@ -474,7 +474,7 @@ def render_iso3382_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -500,8 +500,8 @@ def render_iso3382_report(
         )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     # A one-third-octave range makes the stacked table tall; shrink the
@@ -521,7 +521,9 @@ def render_iso3382_report(
 
     # Full-width per-band parameter table, then the landscape decay-time plot
     # drawn by the result's own single-panel plot(ax=...).
-    flow.append(Paragraph(_fraction_label(result.frequency, language), caption_style))
+    flow.append(
+        fiche_paragraph(_fraction_label(result.frequency, language), caption_style)
+    )
     flow.append(_parameter_table(result, language))
     flow.append(Spacer(1, gap))
     plot_drawing = render_figure_drawing(
@@ -542,7 +544,7 @@ def render_iso3382_report(
 
     basis_strip_style = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Decay curves by Schroeder backward integration with noise "
                 "truncation and tail compensation (ISO 3382-1:2009, 5.3.3); "
@@ -555,7 +557,7 @@ def render_iso3382_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "C50/C80, D50 and Ts follow ISO 3382-1:2009 Equations (A.10), "
                 "(A.11) and (A.13). The just-noticeable differences (Table A.1) "

--- a/src/phonometry/_report/iso3382_3.py
+++ b/src/phonometry/_report/iso3382_3.py
@@ -57,10 +57,10 @@ from ._layout import (
     result_box,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..room.open_plan import OpenPlanResult
+    from .metadata import ReportMetadata
 
 
 def _num(value: float, language: str, *, decimals: int = 1) -> str:
@@ -217,7 +217,7 @@ def render_iso3382_3_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -242,8 +242,8 @@ def render_iso3382_3_report(
         )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -253,7 +253,7 @@ def render_iso3382_3_report(
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Single-number quantities", language), caption_style))
+    flow.append(fiche_paragraph(t("Single-number quantities", language), caption_style))
     flow.append(
         metrics_table(_metric_rows(result, language), col_widths=[62 * mm, 26 * mm])
     )
@@ -283,7 +283,7 @@ def render_iso3382_3_report(
 
     basis_strip_style = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Spatial decay rate D<sub>2,S</sub> and the nominal 4 m speech "
                 "level L<sub>p,A,S,4m</sub> from a least-squares fit of the "
@@ -297,7 +297,7 @@ def render_iso3382_3_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Distraction distance r<sub>D</sub> (STI = 0.50) and privacy "
                 "distance r<sub>P</sub> (STI = 0.20) from a linear regression "

--- a/src/phonometry/_report/iso354.py
+++ b/src/phonometry/_report/iso354.py
@@ -54,10 +54,10 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..materials.absorbers.sound_absorption import SoundAbsorptionMeasurement
+    from .metadata import ReportMetadata
 
 
 def _a2(value: float, language: str = "en") -> str:
@@ -134,12 +134,12 @@ def _alpha_table(freqs: np.ndarray, alpha_s: np.ndarray, language: str = "en") -
     """Build the compact two-column ``f | alpha_s`` table (accredited default)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     header = [
-        Paragraph(t("Frequency f [Hz]", language), head_style),
-        Paragraph("&#945;<sub>s</sub>", head_style),
+        fiche_paragraph(t("Frequency f [Hz]", language), head_style),
+        fiche_paragraph("&#945;<sub>s</sub>", head_style),
     ]
     rows: list[list[Any]] = [header]
     for fk, a_s in zip(freqs, alpha_s):
@@ -151,16 +151,16 @@ def _detail_table(result: SoundAbsorptionMeasurement, language: str = "en") -> A
     """Build the verbose table ``f | T1 | T2 | A1 | A2 | alpha_s`` (~102 mm wide)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
     header = [
-        Paragraph(t("f [Hz]", language), head_style),
-        Paragraph("T<sub>1</sub> [s]", head_style),
-        Paragraph("T<sub>2</sub> [s]", head_style),
-        Paragraph("A<sub>1</sub> [m<super>2</super>]", head_style),
-        Paragraph("A<sub>2</sub> [m<super>2</super>]", head_style),
-        Paragraph("&#945;<sub>s</sub>", head_style),
+        fiche_paragraph(t("f [Hz]", language), head_style),
+        fiche_paragraph("T<sub>1</sub> [s]", head_style),
+        fiche_paragraph("T<sub>2</sub> [s]", head_style),
+        fiche_paragraph("A<sub>1</sub> [m<super>2</super>]", head_style),
+        fiche_paragraph("A<sub>2</sub> [m<super>2</super>]", head_style),
+        fiche_paragraph("&#945;<sub>s</sub>", head_style),
     ]
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     t1 = np.asarray(result.t_empty, dtype=np.float64)
@@ -225,7 +225,7 @@ def render_iso354_report(
         from reportlab.lib import colors
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -256,8 +256,8 @@ def render_iso354_report(
         )
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)
@@ -276,7 +276,10 @@ def render_iso354_report(
             "and absorption areas",
             language,
         )
-        left_cell = [Paragraph(caption, caption_style), _detail_table(result, language)]
+        left_cell = [
+            fiche_paragraph(caption, caption_style),
+            _detail_table(result, language),
+        ]
         plot_drawing = render_figure_drawing(
             result.plot, 70 * mm, y_top=None, language=language
         )
@@ -288,7 +291,7 @@ def render_iso354_report(
     else:
         caption = t("One-third-octave &#945;<sub>s</sub>", language)
         left_cell = [
-            Paragraph(caption, caption_style),
+            fiche_paragraph(caption, caption_style),
             _alpha_table(freqs, alpha_s, language),
         ]
         plot_drawing = render_figure_drawing(

--- a/src/phonometry/_report/iso3741.py
+++ b/src/phonometry/_report/iso3741.py
@@ -56,10 +56,10 @@ from ._sound_power_fiche import (
     power_value_table,
     render_sound_power_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..emission.sound_power_reverberation import ReverberationSoundPowerResult
+    from .metadata import ReportMetadata
 
 #: Band-frequency column heading of the per-band table (translated by ``t``).
 _COL_FREQUENCY = "f [Hz]"

--- a/src/phonometry/_report/iso3744.py
+++ b/src/phonometry/_report/iso3744.py
@@ -58,11 +58,11 @@ from ._sound_power_fiche import (
     range_str,
     render_sound_power_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..emission.sound_power import SoundPowerResult
     from ..emission.sound_power_anechoic import PrecisionSoundPowerResult
+    from .metadata import ReportMetadata
 
 #: Band-frequency column heading of the per-band table (translated by ``t``).
 _COL_FREQUENCY = "f [Hz]"

--- a/src/phonometry/_report/iso4871.py
+++ b/src/phonometry/_report/iso4871.py
@@ -50,10 +50,10 @@ from ._layout import (
     fmt_num,
     footer_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..emission.declaration import NoiseEmissionDeclaration
+    from .metadata import ReportMetadata
 
 #: En dash printed wherever the declaration carries no value for a cell.
 _NOT_DECLARED = "&#8211;"
@@ -223,7 +223,7 @@ def _declaration_table(
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     styles = getSampleStyleSheet()
     accent = colors.HexColor(_ACCENT_HEX)
@@ -295,7 +295,7 @@ def _declaration_table(
     span_cols = 1 + n_modes
     data: list[list[Any]] = [
         [
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "Machine model number, operating conditions, and other "
                     "identifying information:",
@@ -305,28 +305,31 @@ def _declaration_table(
             )
         ]
         + [""] * n_modes,
-        [Paragraph(identity_text, ident_value_style)] + [""] * n_modes,
+        [fiche_paragraph(identity_text, ident_value_style)] + [""] * n_modes,
         [
-            Paragraph(
+            fiche_paragraph(
                 f"<b>{banner_text}</b><br/>"
                 f"{t('in accordance with ISO 4871:1996', language)}",
                 banner_style,
             )
         ]
         + [""] * n_modes,
-        [Paragraph("", col_header_style)]
-        + [Paragraph(f"<b>{html.escape(m.mode)}</b>", col_header_style) for m in modes],
+        [fiche_paragraph("", col_header_style)]
+        + [
+            fiche_paragraph(f"<b>{html.escape(m.mode)}</b>", col_header_style)
+            for m in modes
+        ],
     ]
     first_value_row = len(data)
     for label, cells in value_rows:
         data.append(
-            [Paragraph(label, label_style)]
-            + [Paragraph(cell, value_style) for cell in cells]
+            [fiche_paragraph(label, label_style)]
+            + [fiche_paragraph(cell, value_style) for cell in cells]
         )
     footnote_row = len(data)
     data.append(
         [
-            Paragraph(
+            fiche_paragraph(
                 f"{_footnote(declaration, language)}<br/><br/>"
                 f"{_note(declaration, language)}",
                 ident_label_style,
@@ -462,7 +465,7 @@ def render_iso4871_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -471,8 +474,8 @@ def render_iso4871_report(
     title = t("Noise emission declaration", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis(declaration, metadata, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis(declaration, metadata, language), basis_style),
         Spacer(1, 8),
         _declaration_table(declaration, language),
     ]
@@ -481,7 +484,9 @@ def render_iso4871_report(
     if verification_rows:
         flow.append(Spacer(1, 8))
         flow.append(
-            Paragraph(t("Verification (ISO 4871 clause 6.2)", language), caption_style)
+            fiche_paragraph(
+                t("Verification (ISO 4871 clause 6.2)", language), caption_style
+            )
         )
         flow.append(
             compliance_table(

--- a/src/phonometry/_report/iso532.py
+++ b/src/phonometry/_report/iso532.py
@@ -52,10 +52,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..psychoacoustics.loudness.zwicker import ZwickerLoudness
+    from .metadata import ReportMetadata
 
 
 def _metadata_pairs(
@@ -226,7 +226,7 @@ def render_iso532_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -236,8 +236,8 @@ def render_iso532_report(
     basis = _basis_line(result, metadata, language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -248,7 +248,7 @@ def render_iso532_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Loudness results", language), caption_style),
+        fiche_paragraph(t("Loudness results", language), caption_style),
         metrics_table(_metric_rows(result, language)),
     ]
     # Non-band plot (specific loudness N' over Bark): self-scaling axis. The
@@ -276,7 +276,7 @@ def render_iso532_report(
             )
 
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t("Loudness versus time N(t) (clause 6.5)", language),
                 caption_style,
             )

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -56,13 +56,13 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..building.measurement.insulation import (
         ImpactRatingResult,
         WeightedRatingResult,
     )
+    from .metadata import ReportMetadata
 
 #: Threshold below which an unfavourable deviation is shown as an em dash.
 _DEVIATION_EPS = 0.05
@@ -258,25 +258,27 @@ def _value_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head_style = band_table_header_style()
 
     if verbose:
         header = [
-            Paragraph(t("f [Hz]", language), head_style),
-            Paragraph(
+            fiche_paragraph(t("f [Hz]", language), head_style),
+            fiche_paragraph(
                 t("Measured {vh} [dB]", language).format(vh=value_header),
                 head_style,
             ),
-            Paragraph(t("Shifted ref. [dB]", language), head_style),
-            Paragraph(t("Unfav. dev. [dB]", language), head_style),
+            fiche_paragraph(t("Shifted ref. [dB]", language), head_style),
+            fiche_paragraph(t("Unfav. dev. [dB]", language), head_style),
         ]
         col_widths = [15 * mm, 19 * mm, 18 * mm, 18 * mm]
     else:
         header = [
-            Paragraph(t("Frequency f [Hz]", language), head_style),
-            Paragraph(t("{vh} [dB]", language).format(vh=value_header), head_style),
+            fiche_paragraph(t("Frequency f [Hz]", language), head_style),
+            fiche_paragraph(
+                t("{vh} [dB]", language).format(vh=value_header), head_style
+            ),
         ]
         col_widths = [28 * mm, 28 * mm]
 
@@ -470,7 +472,7 @@ def render_iso717_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -484,8 +486,8 @@ def render_iso717_report(
     basis = _basis_line(metadata, rating_part, language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     # Metadata header block (only the supplied fields).
@@ -509,7 +511,7 @@ def render_iso717_report(
         "Octave-band {vh} [dB]" if centers.size == 5 else "One-third-octave {vh} [dB]"
     )
     left_cell = [
-        Paragraph(
+        fiche_paragraph(
             t(caption_key, language).format(vh=value_header),
             caption_style,
         ),

--- a/src/phonometry/_report/iso7626.py
+++ b/src/phonometry/_report/iso7626.py
@@ -39,10 +39,10 @@ import numpy as np
 
 from ._frf_fiche import frequency_range, frf_metadata_pairs, render_frf_fiche
 from ._i18n import format_number, t
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..vibration.structural.mechanical_mobility import MobilityResult
+    from .metadata import ReportMetadata
 
 #: The mobility unit, m/(N.s), as reportlab markup (a middle dot, not a hyphen).
 _MOBILITY_UNIT = "m/(N&#183;s)"

--- a/src/phonometry/_report/iso7849.py
+++ b/src/phonometry/_report/iso7849.py
@@ -58,10 +58,10 @@ from ._sound_power_fiche import (
     power_value_table,
     render_sound_power_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..emission.vibration_sound_power import VibrationSoundPowerResult
+    from .metadata import ReportMetadata
 
 
 def _is_survey(result: Any) -> bool:

--- a/src/phonometry/_report/iso9052.py
+++ b/src/phonometry/_report/iso9052.py
@@ -48,10 +48,10 @@ from ._material_fiche import (
     render_material_fiche,
     standard_basis_line,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..materials.resilient.dynamic_stiffness import DynamicStiffnessResult
+    from .metadata import ReportMetadata
 
 
 def _mn(value: float, language: str = "en") -> str:

--- a/src/phonometry/_report/iso9053.py
+++ b/src/phonometry/_report/iso9053.py
@@ -47,10 +47,10 @@ from ._material_fiche import (
     render_material_fiche,
     standard_basis_line,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..materials.absorbers.airflow_resistance import StaticAirflowResult
+    from .metadata import ReportMetadata
 
 
 def _pas(value: float, language: str = "en") -> str:

--- a/src/phonometry/_report/iso9612.py
+++ b/src/phonometry/_report/iso9612.py
@@ -66,10 +66,10 @@ from ._layout import (
     stacked_table,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..hearing.occupational_exposure import ExposureResult
+    from .metadata import ReportMetadata
 
 #: Directive 2003/10/EC Article 3 daily exposure values, dB(A) re LEX,8h.
 _LOWER_ACTION_DBA = 80.0
@@ -174,7 +174,7 @@ def _task_table(
     from reportlab.lib import colors
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso9612")
 
@@ -194,34 +194,34 @@ def _task_table(
         ]
         widths = [42.0, 16.0, 16.0, 26.0, 28.0, 16.0, 16.0, 14.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     total_hours = 0.0
     for task in result.tasks:
         total_hours += task.duration_hours
         row = [
-            Paragraph(html.escape(task.label), label_style),
-            Paragraph(_fmt_hours(task.duration_hours, language), value_style),
-            Paragraph(str(task.n_samples), value_style),
-            Paragraph(_fmt_db(task.lp_aeqt, language), value_style),
-            Paragraph(_fmt_db(task.lex_8h_contribution, language), value_style),
+            fiche_paragraph(html.escape(task.label), label_style),
+            fiche_paragraph(_fmt_hours(task.duration_hours, language), value_style),
+            fiche_paragraph(str(task.n_samples), value_style),
+            fiche_paragraph(_fmt_db(task.lp_aeqt, language), value_style),
+            fiche_paragraph(_fmt_db(task.lex_8h_contribution, language), value_style),
         ]
         if verbose:
             row += [
-                Paragraph(_fmt_db(task.u1a, language), value_style),
-                Paragraph(_fmt_hours(task.u1b, language), value_style),
-                Paragraph(_fmt_db(task.u2, language), value_style),
+                fiche_paragraph(_fmt_db(task.u1a, language), value_style),
+                fiche_paragraph(_fmt_hours(task.u1b, language), value_style),
+                fiche_paragraph(_fmt_db(task.u2, language), value_style),
             ]
         data.append(row)
 
     total_row = [
-        Paragraph(f"<b>{t('Nominal day', language)}</b>", label_style),
-        Paragraph(f"<b>{_fmt_hours(total_hours, language)}</b>", value_style),
-        Paragraph("", value_style),
-        Paragraph("", value_style),
-        Paragraph(f"<b>{_fmt_db(result.lex_8h, language)}</b>", value_style),
+        fiche_paragraph(f"<b>{t('Nominal day', language)}</b>", label_style),
+        fiche_paragraph(f"<b>{_fmt_hours(total_hours, language)}</b>", value_style),
+        fiche_paragraph("", value_style),
+        fiche_paragraph("", value_style),
+        fiche_paragraph(f"<b>{_fmt_db(result.lex_8h, language)}</b>", value_style),
     ]
     if verbose:
-        total_row += [Paragraph("", value_style)] * 3
+        total_row += [fiche_paragraph("", value_style)] * 3
     data.append(total_row)
 
     table = stacked_table(data, [w * mm for w in widths])
@@ -250,7 +250,7 @@ def _sampling_table(result: ExposureResult, language: str = "en") -> Any:
     """The sampling summary of a job-based/full-day result (Formula (C.9) budget)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso9612")
 
@@ -286,12 +286,14 @@ def _sampling_table(result: ExposureResult, language: str = "en") -> Any:
     ]
     data: list[list[Any]] = [
         [
-            Paragraph(t("Metric", language), header_style),
-            Paragraph(t("Measured", language), header_style),
+            fiche_paragraph(t("Metric", language), header_style),
+            fiche_paragraph(t("Measured", language), header_style),
         ]
     ]
     for label, value in rows:
-        data.append([Paragraph(label, label_style), Paragraph(value, value_style)])
+        data.append(
+            [fiche_paragraph(label, label_style), fiche_paragraph(value, value_style)]
+        )
     return stacked_table(data, [120 * mm, 54 * mm])
 
 
@@ -341,25 +343,25 @@ def _assessment_table(result: ExposureResult, language: str = "en") -> Any:
     """The Directive 2003/10/EC assessment table (exceeded / not exceeded)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("iso9612")
 
     data: list[list[Any]] = [
         [
-            Paragraph(t("Directive 2003/10/EC value", language), header_style),
-            Paragraph(t("Threshold", language), header_style),
-            Paragraph(t("Measured", language), header_style),
-            Paragraph(t("Result", language), header_style),
+            fiche_paragraph(t("Directive 2003/10/EC value", language), header_style),
+            fiche_paragraph(t("Threshold", language), header_style),
+            fiche_paragraph(t("Measured", language), header_style),
+            fiche_paragraph(t("Result", language), header_style),
         ]
     ]
     for label, threshold, measured, exceeded in _assessment_rows(result, language):
         data.append(
             [
-                Paragraph(label, label_style),
-                Paragraph(threshold, value_style),
-                Paragraph(measured, value_style),
-                Paragraph(exceedance_markup(exceeded, language), label_style),
+                fiche_paragraph(label, label_style),
+                fiche_paragraph(threshold, value_style),
+                fiche_paragraph(measured, value_style),
+                fiche_paragraph(exceedance_markup(exceeded, language), label_style),
             ]
         )
     return stacked_table(data, [74 * mm, 24 * mm, 42 * mm, 34 * mm])
@@ -440,7 +442,7 @@ def render_iso9612_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -449,8 +451,8 @@ def render_iso9612_report(
     title = t("Occupational noise exposure determination", language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(_basis(result, language), basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(_basis(result, language), basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)
@@ -460,7 +462,7 @@ def render_iso9612_report(
     flow.append(Spacer(1, 8))
 
     if result.tasks:
-        flow.append(Paragraph(t("Work analysis", language), caption_style))
+        flow.append(fiche_paragraph(t("Work analysis", language), caption_style))
         flow.append(_task_table(result, verbose, language))
         flow.append(Spacer(1, 6))
         # Full-width, landscape per-task contribution chart (self-scaling axis).
@@ -474,7 +476,7 @@ def render_iso9612_report(
             )
         )
     else:
-        flow.append(Paragraph(t("Sampling summary", language), caption_style))
+        flow.append(fiche_paragraph(t("Sampling summary", language), caption_style))
         flow.append(_sampling_table(result, language))
     flow.append(Spacer(1, 8))
 
@@ -483,7 +485,7 @@ def render_iso9612_report(
     flow.append(Spacer(1, 6))
 
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t("Assessment against Directive 2003/10/EC exposure values", language),
             caption_style,
         )
@@ -507,7 +509,7 @@ def render_iso9612_report(
             textColor=colors.HexColor(_VERDICT_BAD_HEX),
         )
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "The ISO 9612 sampling rules recommend additional "
                     "measurements (3 dB spread rule of Clauses 9.3/11.3, "
@@ -519,7 +521,7 @@ def render_iso9612_report(
             )
         )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Noise exposure level and measurement uncertainty are stated "
                 "as separate values (ISO 9612:2009 Clause 15); U = k&#183;u "
@@ -531,7 +533,7 @@ def render_iso9612_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "When applying the exposure limit value, Directive 2003/10/EC "
                 "(Article 3) takes account of the attenuation of the "

--- a/src/phonometry/_report/iso9613.py
+++ b/src/phonometry/_report/iso9613.py
@@ -54,7 +54,6 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -64,6 +63,7 @@ if TYPE_CHECKING:
         OutdoorAttenuation,
         SourceEmission,
     )
+    from .metadata import ReportMetadata
 
     NDArrayF = NDArray[np.float64]
 else:  # pragma: no cover - runtime alias only
@@ -193,7 +193,7 @@ def _attenuation_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, _, value_style = analysis_cell_styles("iso9613atten")
     freqs = np.asarray(result.frequencies, dtype=np.float64)
@@ -220,25 +220,29 @@ def _attenuation_table(
             headers.append("L<sub>A</sub> [dB(A)]")
             widths = [20.0, 18.0, 17.0, 17.0, 17.0, 17.0, 18.0, 20.0, 22.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for i in range(freqs.size):
-        row = [Paragraph(_fmt(freqs[i], language, 0), value_style)]
+        row = [fiche_paragraph(_fmt(freqs[i], language, 0), value_style)]
         if levels is not None:
             row.append(
-                Paragraph(_fmt(levels.sound_power_level[i], language), value_style)
+                fiche_paragraph(
+                    _fmt(levels.sound_power_level[i], language), value_style
+                )
             )
         row += [
-            Paragraph(_fmt(result.a_div[i], language), value_style),
-            Paragraph(_fmt(result.a_atm[i], language), value_style),
-            Paragraph(_fmt(result.a_gr[i], language), value_style),
-            Paragraph(_fmt(result.a_bar[i], language), value_style),
-            Paragraph(_fmt(result.a_total[i], language), value_style),
+            fiche_paragraph(_fmt(result.a_div[i], language), value_style),
+            fiche_paragraph(_fmt(result.a_atm[i], language), value_style),
+            fiche_paragraph(_fmt(result.a_gr[i], language), value_style),
+            fiche_paragraph(_fmt(result.a_bar[i], language), value_style),
+            fiche_paragraph(_fmt(result.a_total[i], language), value_style),
         ]
         if levels is not None:
-            row.append(Paragraph(_fmt(levels.receiver_level[i], language), value_style))
+            row.append(
+                fiche_paragraph(_fmt(levels.receiver_level[i], language), value_style)
+            )
             if verbose:
                 row.append(
-                    Paragraph(
+                    fiche_paragraph(
                         _fmt(levels.receiver_level[i] + levels.ck[i], language),
                         value_style,
                     )
@@ -358,7 +362,7 @@ def render_outdoor_attenuation_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -380,8 +384,8 @@ def render_outdoor_attenuation_report(
         language,
     )
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _attenuation_metadata_pairs(result, metadata, language)
@@ -390,7 +394,7 @@ def render_outdoor_attenuation_report(
         flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph(t("Attenuation breakdown", language), caption_style))
+    flow.append(fiche_paragraph(t("Attenuation breakdown", language), caption_style))
     flow.append(_attenuation_table(result, levels, verbose, language))
     flow.append(Spacer(1, 8))
     flow.append(
@@ -417,7 +421,7 @@ def render_outdoor_attenuation_report(
 
     basis_strip_style = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The attenuation A = A<sub>div</sub> + A<sub>atm</sub> + "
                 "A<sub>gr</sub> + A<sub>bar</sub> (Eq. (4)); a negative "
@@ -429,7 +433,7 @@ def render_outdoor_attenuation_report(
     )
     if levels is not None:
         flow.append(
-            Paragraph(
+            fiche_paragraph(
                 t(
                     "The downwind level L<sub>fT</sub>(DW) = L<sub>w</sub> + "
                     "D<sub>c</sub> &#8722; A (Eq. (3)); L<sub>AT</sub>(DW) is its "
@@ -440,7 +444,7 @@ def render_outdoor_attenuation_report(
             )
         )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "A<sub>misc</sub> (foliage, industrial sites, housing; Annex A) "
                 "and reflections from vertical surfaces (clause 7.5) are not "
@@ -499,7 +503,7 @@ def _barrier_table(result: BarrierInsertionLoss, verbose: bool, language: str) -
     """The per-band barrier insertion-loss table (``IL`` and, verbose, ``N``)."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, _, value_style = analysis_cell_styles("iso9613bar")
     freqs = np.asarray(result.frequencies, dtype=np.float64)
@@ -512,14 +516,14 @@ def _barrier_table(result: BarrierInsertionLoss, verbose: bool, language: str) -
         headers.insert(1, "N")
         widths = [18.0, 16.0, 20.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for i in range(freqs.size):
         row = [
-            Paragraph(_fmt(freqs[i], language, 0), value_style),
-            Paragraph(_fmt(il[i], language), value_style),
+            fiche_paragraph(_fmt(freqs[i], language, 0), value_style),
+            fiche_paragraph(_fmt(il[i], language), value_style),
         ]
         if verbose:
-            row.insert(1, Paragraph(_fmt(n[i], language, 2), value_style))
+            row.insert(1, fiche_paragraph(_fmt(n[i], language, 2), value_style))
         data.append(row)
     return stacked_table(data, [w * mm for w in widths])
 
@@ -574,7 +578,7 @@ def render_barrier_insertion_loss_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -589,8 +593,8 @@ def render_barrier_insertion_loss_report(
         language,
     ).format(model=model)
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _barrier_metadata_pairs(result, metadata, language)
@@ -600,7 +604,7 @@ def render_barrier_insertion_loss_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(t("Insertion loss per band", language), caption_style),
+        fiche_paragraph(t("Insertion loss per band", language), caption_style),
         _barrier_table(result, verbose, language),
     ]
     plot_drawing = render_figure_drawing(
@@ -618,7 +622,7 @@ def render_barrier_insertion_loss_report(
 
     basis_strip_style = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The insertion loss IL = 20 lg|p<sub>free</sub> / "
                 "p<sub>barrier</sub>| is the level reduction the screen adds "

--- a/src/phonometry/_report/iso9614.py
+++ b/src/phonometry/_report/iso9614.py
@@ -77,7 +77,6 @@ from ._sound_power_fiche import (
     range_str,
     render_sound_power_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -88,6 +87,7 @@ if TYPE_CHECKING:
         PrecisionIntensityResult,
         SoundPowerIntensityResult,
     )
+    from .metadata import ReportMetadata
 
 #: Bias-error factor K of ISO 9614-2:1996 Table 1, in dB, by measurement grade.
 _K = {"engineering": 10.0, "survey": 7.0}

--- a/src/phonometry/_report/metadata.py
+++ b/src/phonometry/_report/metadata.py
@@ -13,8 +13,11 @@ a full accredited fiche and a lightweight prediction fiche.
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
 from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @dataclass(frozen=True)

--- a/src/phonometry/_report/rd1367.py
+++ b/src/phonometry/_report/rd1367.py
@@ -148,7 +148,7 @@ def _phase_table(
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("rd1367phase")
 
@@ -167,25 +167,25 @@ def _phase_table(
         headers.insert(7, "K [dB]")
         widths = [20.0, 34.0, 15.0, 25.0, 13.0, 13.0, 13.0, 16.0, 25.0]
 
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for period in result.periods:
         period_label = t(_PERIOD_LABELS[period.period], language)
         for index, phase in enumerate(period.phases, start=1):
             name = phase.label or t("Phase {n}", language).format(n=index)
             row = [
-                Paragraph(period_label if index == 1 else "", label_style),
-                Paragraph(html.escape(name), label_style),
-                Paragraph(_fmt(phase.hours, language), value_style),
-                Paragraph(_fmt(phase.laeq, language), value_style),
-                Paragraph(_fmt(phase.kt, language, decimals=0), value_style),
-                Paragraph(_fmt(phase.kf, language, decimals=0), value_style),
-                Paragraph(_fmt(phase.ki, language, decimals=0), value_style),
-                Paragraph(f"<b>{_fmt(phase.lkeq, language)}</b>", value_style),
+                fiche_paragraph(period_label if index == 1 else "", label_style),
+                fiche_paragraph(html.escape(name), label_style),
+                fiche_paragraph(_fmt(phase.hours, language), value_style),
+                fiche_paragraph(_fmt(phase.laeq, language), value_style),
+                fiche_paragraph(_fmt(phase.kt, language, decimals=0), value_style),
+                fiche_paragraph(_fmt(phase.kf, language, decimals=0), value_style),
+                fiche_paragraph(_fmt(phase.ki, language, decimals=0), value_style),
+                fiche_paragraph(f"<b>{_fmt(phase.lkeq, language)}</b>", value_style),
             ]
             if verbose:
                 row.insert(
                     7,
-                    Paragraph(
+                    fiche_paragraph(
                         _fmt(phase.correction, language, decimals=0), value_style
                     ),
                 )
@@ -225,7 +225,7 @@ def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
     """
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     header_style, label_style, value_style = analysis_cell_styles("rd1367result")
 
@@ -238,13 +238,15 @@ def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
         t("Result", language),
     ]
     widths = [24.0, 24.0, 32.0, 32.0, 32.0, 30.0]
-    data: list[list[Any]] = [[Paragraph(h, header_style) for h in headers]]
+    data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for period in result.periods:
         data.append(
             [
-                Paragraph(t(_PERIOD_LABELS[period.period], language), label_style),
-                Paragraph(_fmt(period.limit, language, decimals=0), value_style),
-                Paragraph(
+                fiche_paragraph(
+                    t(_PERIOD_LABELS[period.period], language), label_style
+                ),
+                fiche_paragraph(_fmt(period.limit, language, decimals=0), value_style),
+                fiche_paragraph(
                     _criterion_cell(
                         period.max_phase_level,
                         period.phase_limit,
@@ -253,7 +255,7 @@ def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
                     ),
                     value_style,
                 ),
-                Paragraph(
+                fiche_paragraph(
                     _criterion_cell(
                         float(period.reported_level),
                         period.daily_limit,
@@ -262,7 +264,7 @@ def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
                     ),
                     value_style,
                 ),
-                Paragraph(
+                fiche_paragraph(
                     _criterion_cell(
                         None
                         if period.reported_long_term is None
@@ -273,7 +275,7 @@ def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
                     ),
                     value_style,
                 ),
-                Paragraph(_status_markup(period.complies, language), value_style),
+                fiche_paragraph(_status_markup(period.complies, language), value_style),
             ]
         )
     return stacked_table(data, [w * mm for w in widths])
@@ -374,7 +376,7 @@ def render_activity_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -392,8 +394,8 @@ def render_activity_report(
     ).format(article=t(article, language))
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     header_pairs = _metadata_pairs(result, metadata, language)
@@ -402,11 +404,11 @@ def render_activity_report(
         flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 6))
 
-    flow.append(Paragraph(t("Noise phases", language), caption_style))
+    flow.append(fiche_paragraph(t("Noise phases", language), caption_style))
     flow.append(_phase_table(result, verbose, language))
     flow.append(Spacer(1, 6))
 
-    flow.append(Paragraph(t("Assessment by period", language), caption_style))
+    flow.append(fiche_paragraph(t("Assessment by period", language), caption_style))
     flow.append(_results_table(result, language))
     flow.append(Spacer(1, 6))
 
@@ -440,7 +442,7 @@ def render_activity_report(
 
     basis_strip_style = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "K<sub>t</sub> follows from the one-third-octave difference "
                 "L<sub>t</sub> = L<sub>f</sub> &#8722; L<sub>s</sub> against "
@@ -455,7 +457,7 @@ def render_activity_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "The period level is the duration-weighted energy mean of the "
                 "phase levels, rounded by adding 0,5 dB and taking the integer "

--- a/src/phonometry/_report/reverberation.py
+++ b/src/phonometry/_report/reverberation.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import html
 import math
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -59,11 +58,13 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from ..room.enclosed_space_absorption import ReverberationResult
     from ..room.reverberation_prediction import ReverberationModelResult
+    from .metadata import ReportMetadata
 
 #: Octave centres whose mean is the mid-frequency reverberation-time descriptor
 #: quoted for rooms (the 500 Hz and 1000 Hz octave bands).
@@ -179,7 +180,7 @@ def _target_line(requirement: float, styles: Any, language: str) -> list[Any]:
     from reportlab.lib import colors
     from reportlab.lib.styles import ParagraphStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     style = ParagraphStyle(
         "reverb_target",
@@ -192,7 +193,9 @@ def _target_line(requirement: float, styles: Any, language: str) -> list[Any]:
     text = t("Target reverberation time T = {req} s", language).format(
         req=format_number(requirement, language, decimals=2)
     )
-    return [Paragraph(f"<font color='{_ACCENT_HEX}'>&#9632;</font> {text}", style)]
+    return [
+        fiche_paragraph(f"<font color='{_ACCENT_HEX}'>&#9632;</font> {text}", style)
+    ]
 
 
 def _header_grid(
@@ -252,11 +255,11 @@ def _models_table(result: ReverberationModelResult, language: str) -> Any:
     """Build the per-band table with one reverberation-time column per model."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head = _band_header_style()
-    header = [Paragraph(t("f [Hz]", language), head)]
-    header += [Paragraph(name, head) for name in _MODEL_NAMES]
+    header = [fiche_paragraph(t("f [Hz]", language), head)]
+    header += [fiche_paragraph(name, head) for name in _MODEL_NAMES]
 
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     curves = [
@@ -323,15 +326,15 @@ def render_reverberation_models_report(
         from reportlab.lib import colors
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     flow: list[Any] = [
-        Paragraph(t("Reverberation-time prediction", language), title_style),
-        Paragraph(
+        fiche_paragraph(t("Reverberation-time prediction", language), title_style),
+        fiche_paragraph(
             t(
                 "Design-stage prediction of the reverberation time by five "
                 "statistical-acoustics models (Sabine, Eyring, "
@@ -354,7 +357,7 @@ def render_reverberation_models_report(
     from reportlab.lib.units import mm
 
     left_cell = [
-        Paragraph(t("Reverberation time by model [s]", language), caption_style),
+        fiche_paragraph(t("Reverberation time by model [s]", language), caption_style),
         _models_table(result, language),
     ]
     plot_drawing = render_figure_drawing(
@@ -372,7 +375,7 @@ def render_reverberation_models_report(
 
     basis_strip = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Design-stage prediction from the room geometry and surface "
                 "absorption by the classical statistical-acoustics models; it "
@@ -386,7 +389,7 @@ def render_reverberation_models_report(
         )
     )
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Sabine T = 24 ln10/c0 * V/(A + 4mV); Eyring replaces A by "
                 "-S ln(1 - alpha_bar); Millington-Sette sums -S_i ln(1 - "
@@ -411,13 +414,13 @@ def _enclosed_table(result: ReverberationResult, language: str) -> Any:
     """Build the per-band ``f | A | T`` table of the enclosed-space fiche."""
     from reportlab.lib.units import mm
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     head = _band_header_style()
     header = [
-        Paragraph(t("f [Hz]", language), head),
-        Paragraph("A [m<super>2</super>]", head),
-        Paragraph("T [s]", head),
+        fiche_paragraph(t("f [Hz]", language), head),
+        fiche_paragraph("A [m<super>2</super>]", head),
+        fiche_paragraph("T [s]", head),
     ]
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     area = np.asarray(result.absorption_area, dtype=np.float64)
@@ -489,7 +492,7 @@ def render_enclosed_space_report(
         from reportlab.lib import colors
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -511,8 +514,10 @@ def render_enclosed_space_report(
             language,
         )
     flow: list[Any] = [
-        Paragraph(t("Sound absorption in an enclosed space", language), title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(
+            t("Sound absorption in an enclosed space", language), title_style
+        ),
+        fiche_paragraph(basis, basis_style),
     ]
 
     extra = [
@@ -527,7 +532,7 @@ def render_enclosed_space_report(
     from reportlab.lib.units import mm
 
     left_cell = [
-        Paragraph(
+        fiche_paragraph(
             t("Absorption area A and reverberation time T", language), caption_style
         ),
         _enclosed_table(result, language),
@@ -545,7 +550,7 @@ def render_enclosed_space_report(
 
     basis_strip = measurement_basis_style()
     flow.append(
-        Paragraph(
+        fiche_paragraph(
             t(
                 "Estimate of the equivalent sound absorption area A and the "
                 "reverberation time T of an enclosed space from its surface, "

--- a/src/phonometry/_report/sii.py
+++ b/src/phonometry/_report/sii.py
@@ -51,10 +51,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..speech.sii import SIIResult
+    from .metadata import ReportMetadata
 
 #: The band procedure the fiche describes when the result carries no other.
 _DEFAULT_METHOD = "one-third-octave"
@@ -112,7 +112,7 @@ def _band_table(result: SIIResult, verbose: bool, language: str = "en") -> Any:
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
@@ -132,14 +132,14 @@ def _band_table(result: SIIResult, verbose: bool, language: str = "en") -> Any:
     disturbance = np.asarray(result.disturbance, dtype=np.float64)
 
     header = [
-        Paragraph(t("f [Hz]", language), head_style),
-        Paragraph("E&#8242;<sub>i</sub> [dB]", head_style),
-        Paragraph("I<sub>i</sub>", head_style),
-        Paragraph("A<sub>i</sub>", head_style),
+        fiche_paragraph(t("f [Hz]", language), head_style),
+        fiche_paragraph("E&#8242;<sub>i</sub> [dB]", head_style),
+        fiche_paragraph("I<sub>i</sub>", head_style),
+        fiche_paragraph("A<sub>i</sub>", head_style),
     ]
     col_widths = [16 * mm, 20 * mm, 19 * mm, 15 * mm]
     if verbose:
-        header.insert(3, Paragraph("D<sub>i</sub> [dB]", head_style))
+        header.insert(3, fiche_paragraph("D<sub>i</sub> [dB]", head_style))
         col_widths = [15 * mm, 18 * mm, 17 * mm, 18 * mm, 14 * mm]
 
     def d1(value: float) -> str:
@@ -234,7 +234,7 @@ def render_sii_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -258,8 +258,8 @@ def render_sii_report(
         ).format(method=method)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -270,7 +270,7 @@ def render_sii_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(
+        fiche_paragraph(
             t(
                 _TABLE_CAPTIONS.get(result.method, _TABLE_CAPTIONS[_DEFAULT_METHOD]),
                 language,

--- a/src/phonometry/_report/silencer.py
+++ b/src/phonometry/_report/silencer.py
@@ -45,10 +45,10 @@ from ._noise_control_fiche import (
     power_value_table,
     render_noise_control_fiche,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..noise_control.silencers import ReactiveSilencerResult
+    from .metadata import ReportMetadata
 
 
 def _basis(language: str = "en") -> str:

--- a/src/phonometry/_report/sti.py
+++ b/src/phonometry/_report/sti.py
@@ -47,10 +47,10 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
-from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
     from ..speech.sti import STIResult
+    from .metadata import ReportMetadata
 
 #: Nominal octave-band centre frequencies of the seven STI bands, in hertz
 #: (IEC 60268-16 A.5.1: 125 Hz to 8 kHz).
@@ -108,7 +108,7 @@ def _band_table(result: STIResult, language: str = "en") -> Any:
     from reportlab.lib.units import mm
     from reportlab.platypus import Table, TableStyle
 
-    from ._layout import fiche_paragraph as Paragraph
+    from ._layout import fiche_paragraph
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
@@ -123,8 +123,8 @@ def _band_table(result: STIResult, language: str = "en") -> Any:
 
     mti = np.asarray(result.mti, dtype=np.float64)
     header = [
-        Paragraph(t("f [Hz]", language), head_style),
-        Paragraph("MTI", head_style),
+        fiche_paragraph(t("f [Hz]", language), head_style),
+        fiche_paragraph("MTI", head_style),
     ]
     rows: list[list[Any]] = [header]
     for fk, m in zip(_STI_BAND_CENTERS, mti):
@@ -236,7 +236,7 @@ def render_sti_report(
         from reportlab.lib.units import mm
         from reportlab.platypus import Spacer
 
-        from ._layout import fiche_paragraph as Paragraph
+        from ._layout import fiche_paragraph
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
@@ -246,8 +246,8 @@ def render_sti_report(
     basis = _basis_line(result, metadata, language)
 
     flow: list[Any] = [
-        Paragraph(title, title_style),
-        Paragraph(basis, basis_style),
+        fiche_paragraph(title, title_style),
+        fiche_paragraph(basis, basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
@@ -258,7 +258,7 @@ def render_sti_report(
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph(
+        fiche_paragraph(
             t("Octave-band modulation transfer index MTI", language), caption_style
         ),
         _band_table(result, language),

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -50,7 +50,6 @@ levels and event metrics).
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
@@ -72,6 +71,8 @@ from .rotorcraft_propagation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -45,13 +45,13 @@ from math import ceil
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 from scipy import signal
 
 from ..io._resolve import SignalInput, resolve_fs, resolve_samples
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from .._report.metadata import ReportMetadata
 

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -72,7 +72,6 @@ are bracketed and excluded from the single-number mean when the per-band
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -86,6 +85,8 @@ from .insulation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -49,7 +49,6 @@ results (Clause 8 e)) also carries the spectrum adaptation term ``CI,Δ`` (ISO
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -61,6 +60,8 @@ from .insulation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -98,12 +98,10 @@ used when the *measurement* is reported in octaves.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import (
     require_choice,
@@ -113,7 +111,10 @@ from ..._internal.validation import (
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
 __all__ = [
     "HEAVY_IMPACT_A_WEIGHTING",

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -67,7 +67,6 @@ box the rating on the field report form.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
@@ -84,6 +83,8 @@ from .ratings import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -72,7 +72,6 @@ supplied."""
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
@@ -85,6 +84,8 @@ from .insulation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/lab_insulation.py
+++ b/src/phonometry/building/measurement/lab_insulation.py
@@ -50,7 +50,6 @@ per-band values are supplied.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -66,6 +65,8 @@ from .insulation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -61,7 +61,6 @@ rubber-ball heavy/soft impactor, out of scope here).
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -70,6 +69,8 @@ import numpy as np
 from ..._internal.levels_math import energy_sum
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -79,10 +79,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import require_positive
 from .flanking_transmission import total_loss_factor

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -67,7 +67,6 @@ supplied. No background correction is applied (Clause 6.2)."""
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, overload
 
@@ -83,6 +82,8 @@ from .insulation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/measurement/uncertainty.py
+++ b/src/phonometry/building/measurement/uncertainty.py
@@ -46,7 +46,6 @@ Clause/table numbers refer to ISO 12999-1:2020(E).
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from math import sqrt
 from types import MappingProxyType
@@ -55,6 +54,8 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from matplotlib.axes import Axes
 
 Situation = Literal["A", "B", "C"]

--- a/src/phonometry/building/prediction/aperture_transmission.py
+++ b/src/phonometry/building/prediction/aperture_transmission.py
@@ -58,13 +58,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 from scipy.special import j1, struve
 
 from ..._internal.validation import require_choice, require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
 #: Default speed of sound in air ``c0``, m/s (20 degC).
 _SPEED_OF_SOUND: float = 343.0

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -107,7 +107,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import (
     require_choice,
@@ -117,6 +116,7 @@ from ..._internal.validation import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
 __all__ = [
     "CEILING_ATTENUATION_CONTOUR",

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -95,12 +95,10 @@ tables are recorded in ``docs/ERRATA.md``.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import (
     require_choice,
@@ -109,7 +107,10 @@ from ..._internal.validation import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..._report.metadata import ReportMetadata
     from ..measurement.insulation import ImpactRatingResult, WeightedRatingResult

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -66,7 +66,6 @@ Clause/formula citations refer to EN 12354-3:2000 or EN 12354-4:2000.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from math import atan, log10, pi
 from typing import TYPE_CHECKING, Any
@@ -74,6 +73,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/prediction/installed_structure_borne.py
+++ b/src/phonometry/building/prediction/installed_structure_borne.py
@@ -80,10 +80,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import (
     require_choice,

--- a/src/phonometry/building/prediction/masonry_cavity_wall.py
+++ b/src/phonometry/building/prediction/masonry_cavity_wall.py
@@ -82,13 +82,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import require_finite_array, require_positive
 from ...vibration.structural.point_mobility import infinite_plate_mobility
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
 __all__ = [
     "WALL_TIE_STIFFNESS",

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -91,7 +91,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
-from numpy.typing import ArrayLike
 from scipy.integrate import quad
 from scipy.special import ellipe
 
@@ -104,6 +103,7 @@ from ...vibration.structural.radiation_efficiency import coincidence_frequency
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ...materials.absorbers.porous import PorousMediumResult
     from ..measurement.insulation import WeightedRatingResult

--- a/src/phonometry/building/prediction/resilient_layers.py
+++ b/src/phonometry/building/prediction/resilient_layers.py
@@ -76,7 +76,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.validation import (
     require_choice,
@@ -86,6 +85,7 @@ from ..._internal.validation import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
 # The ISO 12354-1 Annex D lining machinery now lives in :mod:`.linings`. Until
 # every caller in the tree reads it from there, the names this module used to

--- a/src/phonometry/building/prediction/simplified_model.py
+++ b/src/phonometry/building/prediction/simplified_model.py
@@ -57,12 +57,13 @@ Clause citations refer to EN 12354-1:2000 (airborne) or EN 12354-2:2000 (impact)
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from math import isfinite, log10
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -79,7 +79,6 @@ about 1,8 m2 specimens; larger windows insulate less, and the CEC corrects
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -87,6 +86,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from matplotlib.axes import Axes
 
 __all__ = [

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -37,11 +37,12 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..io._resolve import apply_calibration, resolve_fs
-from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike, NDArray
+
+    from ..io._signal import Signal
 
 #: Default number of harmonics summed for the THD (IEC 60268-3).
 _DEFAULT_N_HARMONICS = 10

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -32,7 +32,6 @@ import numpy as np
 # Shared Welch-core defaults and helpers (single source of truth for the
 # segment policy across the spectral estimators).
 from ..io._resolve import apply_calibration, resolve_pair_fs
-from ..io._signal import Signal
 from ..signals.spectra import (
     _DEFAULT_OVERLAP,
     _MIN_SAMPLES,
@@ -45,6 +44,8 @@ from ..signals.spectra import (
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 
 def _validate_pair(

--- a/src/phonometry/electroacoustics/intermodulation.py
+++ b/src/phonometry/electroacoustics/intermodulation.py
@@ -34,7 +34,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .distortion import (
     _amplitude_spectrum,
     _positive,
@@ -45,6 +44,8 @@ from .distortion import (
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 #: Intermodulation product search half-width, in FFT bins. Wide enough to catch
 #: a product under mild window leakage, narrow enough (together with the

--- a/src/phonometry/electroacoustics/noise_measurements.py
+++ b/src/phonometry/electroacoustics/noise_measurements.py
@@ -29,7 +29,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .distortion import (
     _AES17_BANDWIDTH_HZ,
     _AES17_HIGHPASS_HZ,
@@ -46,6 +45,8 @@ from .distortion import (
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 #: AES17-2015 5.2.7: the CCIR-RMS weighting is the ITU-R BS.468-4 curve with an
 #: additional flat gain of -5,63 dB, which places unity gain at 2 kHz. Table 1

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -81,13 +81,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 from scipy import special
 
 from .._internal.validation import require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: First zero of the Bessel function ``J1``; the first directivity null of the
 #: baffled piston sits at ``ka sin theta = J1_FIRST_ZERO`` (Beranek & Mellow).

--- a/src/phonometry/electroacoustics/swept_sine.py
+++ b/src/phonometry/electroacoustics/swept_sine.py
@@ -61,11 +61,12 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..io._resolve import apply_calibration, resolve_fs
-from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "SweptSineDistortionResult",

--- a/src/phonometry/emission/declaration.py
+++ b/src/phonometry/emission/declaration.py
@@ -38,11 +38,12 @@ declaration is most often built from a measured sound power via
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from .._report.metadata import ReportMetadata
 
 #: The two alternative forms of a noise emission declaration (ISO 4871 clause 4).

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -55,10 +55,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from .._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 from .._internal.validation import require_positive
 

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -60,18 +60,19 @@ from __future__ import annotations
 
 import math
 import warnings
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..._report.metadata import ReportMetadata
 

--- a/src/phonometry/environment/assessment/measurement.py
+++ b/src/phonometry/environment/assessment/measurement.py
@@ -48,7 +48,6 @@ repeated-measurement standard uncertainty (Formulae (17)–(20)) are provided.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
@@ -57,6 +56,8 @@ import numpy as np
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
 #: Masking-threshold reference frequency in Formula (C.3), in Hz.

--- a/src/phonometry/environment/assessment/rating.py
+++ b/src/phonometry/environment/assessment/rating.py
@@ -8,9 +8,12 @@ and composite whole-day rating levels (6.5, Formulae 5-6).
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def composite_rating_level(periods: Iterable[tuple[float, float, float]]) -> float:

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -80,7 +80,6 @@ operation (Article 25.2) only the last two apply.
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -88,6 +87,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -72,13 +72,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.warnings import PhonometryWarning
 from ...materials.absorbers.sound_absorption import attenuation_from_alpha
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: Reference air temperature ``T0`` (ISO 9613-1:1993, clause 4.2), in kelvins.
 _T0 = 293.15

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -48,12 +48,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .air_absorption import air_attenuation
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..._report.metadata import ReportMetadata
 

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -53,14 +53,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
-from numpy.typing import ArrayLike
 
 from ..._internal.rays import march_rays
 from ..._internal.validation import require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from numpy.typing import NDArray
+    from numpy.typing import ArrayLike, NDArray
 
     from ...materials.absorbers.porous import PorousMediumResult
 

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -41,12 +41,11 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import signal
 
-from .core import OctaveFilterBank
-
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
     from .._report.metadata import ReportMetadata
+    from .core import OctaveFilterBank
 
 __all__ = [
     "FilterComplianceResult",

--- a/src/phonometry/filters/equalizer.py
+++ b/src/phonometry/filters/equalizer.py
@@ -72,11 +72,12 @@ from ..io._resolve import (
     resolve_fs,
     resolve_samples,
 )
-from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "EQFilterType",

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -35,10 +35,10 @@ from .threshold import age_threshold
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from .._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 # ---------------------------------------------------------------------------
 # Normative constants.

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -46,7 +46,6 @@ refer to ISO 9612:2009(E).
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from math import log10, sqrt
 from typing import TYPE_CHECKING, Any, Literal
@@ -57,6 +56,8 @@ from .._internal.levels_math import energy_mean
 from .._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from .._report.metadata import ReportMetadata

--- a/src/phonometry/hearing/threshold.py
+++ b/src/phonometry/hearing/threshold.py
@@ -31,8 +31,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
-from numpy.typing import ArrayLike
 
 # ---------------------------------------------------------------------------
 # Normative constants.

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -26,13 +26,14 @@ the library expects from a bare array.
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -74,12 +74,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..._report.metadata import ReportMetadata
 

--- a/src/phonometry/materials/absorbers/biot.py
+++ b/src/phonometry/materials/absorbers/biot.py
@@ -81,12 +81,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.types import Real
 from ..._internal.validation import require_positive
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
 
+    from ..._internal.types import Real
     from .porous import PorousMediumResult
 
 Complex = NDArray[np.complex128]

--- a/src/phonometry/materials/absorbers/four_microphone.py
+++ b/src/phonometry/materials/absorbers/four_microphone.py
@@ -35,7 +35,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.types import Real
 from .impedance_tube import (
     _DIAMETER_POSITIVE,
     ImpedanceTubeWarning,
@@ -45,6 +44,8 @@ from .impedance_tube import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ..._internal.types import Real
 
 Complex = NDArray[np.complex128]
 

--- a/src/phonometry/materials/absorbers/impedance_tube.py
+++ b/src/phonometry/materials/absorbers/impedance_tube.py
@@ -38,12 +38,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.types import Real
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
+    from ..._internal.types import Real
     from ..._report.metadata import ReportMetadata
 
 Complex = NDArray[np.complex128]

--- a/src/phonometry/materials/absorbers/layered.py
+++ b/src/phonometry/materials/absorbers/layered.py
@@ -47,9 +47,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
-from numpy.typing import ArrayLike
 
-from ..._internal.types import Real
 from ..._internal.validation import (
     require_non_negative,
     require_positive,
@@ -68,6 +66,9 @@ from .porous import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
+
+    from ..._internal.types import Real
 
 __all__ = [
     "AirLayer",

--- a/src/phonometry/materials/absorbers/porous.py
+++ b/src/phonometry/materials/absorbers/porous.py
@@ -67,7 +67,6 @@ stack of them and solving it with the transfer matrix is the subject of
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -75,7 +74,6 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy import special
 
-from ..._internal.types import Real
 from ..._internal.validation import (
     require_choice,
     require_non_negative,
@@ -85,7 +83,11 @@ from ..._internal.validation import (
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from matplotlib.axes import Axes
+
+    from ..._internal.types import Real
 
 Complex = NDArray[np.complex128]
 

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -54,10 +54,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..._report.metadata import ReportMetadata
 

--- a/src/phonometry/materials/absorbers/slow_sound.py
+++ b/src/phonometry/materials/absorbers/slow_sound.py
@@ -72,16 +72,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 from scipy.optimize import root
 
-from ..._internal.types import Real
 from ..._internal.validation import require_positive, require_positive_array
 from ..._internal.warnings import PhonometryWarning
 from .porous import DEFAULT_AIR, AirProperties, Complex
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
+
+    from ..._internal.types import Real
 
 #: Default number of transverse modes kept per axis in the duct series.
 _DUCT_TERMS = 40

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -59,12 +59,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..._report.metadata import ReportMetadata
 

--- a/src/phonometry/materials/absorbers/standing_wave.py
+++ b/src/phonometry/materials/absorbers/standing_wave.py
@@ -22,10 +22,13 @@ measured one frequency at a time; see
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.types import Real
+if TYPE_CHECKING:
+    from ..._internal.types import Real
 
 Complex = NDArray[np.complex128]
 

--- a/src/phonometry/materials/absorbers/uncertainty.py
+++ b/src/phonometry/materials/absorbers/uncertainty.py
@@ -43,13 +43,14 @@ exposes the rounded view through :attr:`AbsorptionUncertaintyResult.reported_exp
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
 __all__ = [

--- a/src/phonometry/materials/diffusers/design.py
+++ b/src/phonometry/materials/diffusers/design.py
@@ -66,7 +66,6 @@ from typing import TYPE_CHECKING, Any, overload
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.types import Real
 from .scattering_diffusion import (
     DiffusionSpectrum,
     diffusion_spectrum,
@@ -76,6 +75,8 @@ from .scattering_diffusion import (
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+
+    from ..._internal.types import Real
 
 #: Complex-valued complex128 array alias (per-well reflection coefficients).
 Complex = NDArray[np.complex128]

--- a/src/phonometry/materials/diffusers/metadiffuser.py
+++ b/src/phonometry/materials/diffusers/metadiffuser.py
@@ -26,14 +26,11 @@ reduced to the ISO 17497-2 directional diffusion coefficient.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
-from ..._internal.types import Real
 from ..._internal.validation import require_positive, require_positive_array
 from ..absorbers.porous import DEFAULT_AIR, AirProperties, Complex
 from ..absorbers.slow_sound import HelmholtzResonator, slit_helmholtz_absorber
@@ -49,7 +46,12 @@ from .scattering_diffusion import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
+
+    from ..._internal.types import Real
 
 __all__ = [
     "MetadiffuserResult",

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -32,14 +32,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
-from ..._internal.types import Real
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
+    from ..._internal.types import Real
     from ..._report.metadata import ReportMetadata
 
 

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -32,14 +32,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 
-from ..._internal.types import Real
 from .reverberation_room_scattering import _positive_scalar
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
+    from ..._internal.types import Real
     from ..._report.metadata import ReportMetadata
 
 

--- a/src/phonometry/materials/resilient/dynamic_stiffness.py
+++ b/src/phonometry/materials/resilient/dynamic_stiffness.py
@@ -74,10 +74,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 from ..._internal.types import as_float_or_array
 from ..._internal.validation import require_positive

--- a/src/phonometry/materials/surfaces/road_absorption.py
+++ b/src/phonometry/materials/surfaces/road_absorption.py
@@ -69,7 +69,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.types import Real
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import (
     SignalInput,
@@ -80,6 +79,8 @@ from ...io._resolve import (
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
+
+    from ..._internal.types import Real
 
 Complex = NDArray[np.complex128]
 

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -78,12 +78,13 @@ import numpy as np
 from scipy import special
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from ..signals.spectra import _positive, _validate_signal, power_spectral_density
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "LevelCrossingResult",

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -41,8 +41,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
-from numpy.typing import ArrayLike
 
 from .._internal.warnings import PhonometryWarning
 

--- a/src/phonometry/noise_control/_criterion.py
+++ b/src/phonometry/noise_control/_criterion.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
-from numpy.typing import NDArray
 
 from .._internal.validation import require_choice
 
 if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
     from ..room.noise_criteria import NCResult, RCResult
 
 #: The room-criterion families a composed workflow can be rated against:

--- a/src/phonometry/noise_control/duct_modes.py
+++ b/src/phonometry/noise_control/duct_modes.py
@@ -44,13 +44,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import require_non_negative, require_positive
 from .._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 _C_AIR = 343.0
 

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -53,7 +53,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ._criterion import (
     as_band_spectrum,
@@ -66,6 +65,7 @@ from ._criterion import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from .._report.metadata import ReportMetadata
     from ..room.noise_criteria import NCResult, RCResult

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -63,12 +63,10 @@ interior room constant reuses :func:`phonometry.room.room_constant`.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import require_choice, require_positive
 from ..room.steady_field import room_constant
@@ -81,7 +79,10 @@ from ..room.steady_field import room_constant
 ENCLOSURE_MODELS: dict[str, float] = {"bies": 0.3, "norton": 0.0}
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from .._report.metadata import ReportMetadata
 

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -78,13 +78,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import require_choice, require_positive
 from ..room.steady_field import room_constant
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from .._report.metadata import ReportMetadata
 

--- a/src/phonometry/noise_control/room_to_room.py
+++ b/src/phonometry/noise_control/room_to_room.py
@@ -66,7 +66,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import (
     require_choice,
@@ -84,6 +83,7 @@ from ._criterion import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..room.noise_criteria import NCResult, RCResult
 

--- a/src/phonometry/psychoacoustics/erb_scale.py
+++ b/src/phonometry/psychoacoustics/erb_scale.py
@@ -53,10 +53,14 @@ filter shapes from notched-noise data", *Hearing Research* 47, 103-138.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-from numpy.typing import ArrayLike
 
 from .._internal.types import as_float_or_array
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 #: Slope-and-offset constant of ``ERB_N = C1 (C2 f + 1)``, Hz.
 ERB_C1 = 24.673

--- a/src/phonometry/psychoacoustics/loudness/contours.py
+++ b/src/phonometry/psychoacoustics/loudness/contours.py
@@ -9,13 +9,14 @@ parameters at the 29 preferred third-octave frequencies of ISO 266.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
 # ISO 226:2023 Table 1 (p. 4): frequency Hz -> (alpha_f, L_U dB, T_f dB).

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -53,10 +53,11 @@ import numpy as np
 from scipy import signal
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
 from ..._internal.validation import require_1d_signal

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -38,17 +38,19 @@ the exact sinusoidal-component method.
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
 from ..._internal.validation import require_1d_signal

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -57,17 +57,19 @@ required.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 from .moore_glasberg import (
     _ERB_C1,

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -27,12 +27,12 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ...io._resolve import resolve_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
     from ..._report.metadata import ReportMetadata
+    from ...io._signal import Signal
 from scipy import signal
 
 from ..._internal.utils import _typesignal

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -53,11 +53,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ...io._signal import Signal
 
 # --------------------------------------------------------------------------- #
 # Closed form: AM broadband noise (Fastl & Zwicker Eq. 10.2)

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -103,10 +103,11 @@ from scipy import signal
 from scipy.interpolate import PchipInterpolator
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
 from ..._internal.validation import require_1d_signal, require_positive

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -56,10 +56,11 @@ from scipy import signal
 from scipy.interpolate import PchipInterpolator
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
 from ..._internal.validation import require_1d_signal

--- a/src/phonometry/psychoacoustics/quality/sharpness.py
+++ b/src/phonometry/psychoacoustics/quality/sharpness.py
@@ -15,12 +15,14 @@ at, 1.00 acum (~0.96 Aures / ~1.02 von Bismarck through this front-end).
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
-from ...io._signal import Signal
 from ..loudness.zwicker import ZwickerLoudness, loudness_zwicker
+
+if TYPE_CHECKING:
+    from ...io._signal import Signal
 
 _DZ = 0.1  # Bark step of the ISO 532-1 specific-loudness pattern
 _Z = np.arange(1, 241) * _DZ  # Bark bin centers (0.1 .. 24.0), reference convention

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -25,11 +25,12 @@ import numpy as np
 from ..._internal.utils import _typesignal
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 from ...signals.spectra import _welch_autospectrum
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 
 class TonalityWarning(PhonometryWarning):

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -37,10 +37,11 @@ import numpy as np
 from scipy import signal
 
 from ...io._resolve import apply_calibration, resolve_fs
-from ...io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
 from ..._internal.validation import require_1d_signal

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -39,7 +39,6 @@ from a straight line.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -48,12 +47,14 @@ import numpy as np
 from .._internal.utils import _typesignal
 from ..filters.core import OctaveFilterBank
 from ..io._resolve import apply_calibration, resolve_fs
-from ..io._signal import Signal
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from matplotlib.axes import Axes
 
     from .._report.metadata import ReportMetadata
+    from ..io._signal import Signal
 
 #: Default octave-band analysis range (ISO 3382-1:2009, 5.1: engineering
 #: and precision methods cover at least 125 Hz to 4 kHz in octave bands).

--- a/src/phonometry/room/crowd_noise.py
+++ b/src/phonometry/room/crowd_noise.py
@@ -79,13 +79,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: Sound power level of one talker in normal conversation, dB re 1 pW
 #: (Long, Chapter 17, "a normal conversational level").

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -29,18 +29,19 @@ distribution is out of scope.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from .._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import require_fraction, require_positive

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -74,12 +74,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: Default speed of sound ``c0`` (20 degC dry air), in m/s.
 DEFAULT_SPEED_OF_SOUND = 343.0

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -77,7 +77,6 @@ from ..io._resolve import (
     apply_calibration,
     resolve_optional_pair_fs,
 )
-from ..io._signal import Signal
 
 
 class ImpulseResponseWarning(PhonometryWarning):
@@ -86,6 +85,8 @@ class ImpulseResponseWarning(PhonometryWarning):
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+
+    from ..io._signal import Signal
 
 #: Warn from mls_impulse_response when the recovered IR still carries more than
 #: this level (dB re its peak) in the last 10 % of the MLS period: an IR longer

--- a/src/phonometry/room/modes.py
+++ b/src/phonometry/room/modes.py
@@ -65,7 +65,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import require_positive
@@ -73,6 +72,7 @@ from .steady_field import schroeder_frequency
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: Speed of sound in air used when none is given, in m/s (20 degC).
 DEFAULT_SPEED_OF_SOUND = 343.0

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -41,10 +41,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from .._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 # ---------------------------------------------------------------------------
 # Normative constants - ANSI/ASA S12.2-2019.

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -61,7 +61,6 @@ worked example in the source texts.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from math import log
 from typing import TYPE_CHECKING, Any
@@ -69,6 +68,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from .._report.metadata import ReportMetadata

--- a/src/phonometry/room/steady_field.py
+++ b/src/phonometry/room/steady_field.py
@@ -80,13 +80,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import require_choice, require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 
 def _require_fraction_below_one(value: ArrayLike, name: str) -> NDArray[np.float64]:

--- a/src/phonometry/signals/cepstrum.py
+++ b/src/phonometry/signals/cepstrum.py
@@ -73,12 +73,13 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .spectra import _positive, _validate_signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "CepstrumResult",

--- a/src/phonometry/signals/envelope.py
+++ b/src/phonometry/signals/envelope.py
@@ -54,12 +54,13 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .spectra import _positive, _validate_signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "EnvelopeResult",

--- a/src/phonometry/signals/levels.py
+++ b/src/phonometry/signals/levels.py
@@ -16,7 +16,7 @@ signatures are unchanged -- a plain array with an explicit ``fs`` and
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -32,7 +32,11 @@ from ..io._resolve import (
 from ..io._resolve import (
     resolve_samples as _resolve_samples_raw,
 )
-from ..io._signal import Signal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..io._signal import Signal
 
 _REF_PRESSURE = 2e-5
 

--- a/src/phonometry/signals/miso.py
+++ b/src/phonometry/signals/miso.py
@@ -53,7 +53,6 @@ The random errors follow Bendat & Piersol Section 9.3: conditioning on the
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -73,6 +72,8 @@ from .spectra import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 

--- a/src/phonometry/signals/multitaper.py
+++ b/src/phonometry/signals/multitaper.py
@@ -32,7 +32,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .spectra import (
     _positive,
     _validate_confidence,
@@ -43,6 +42,8 @@ from .spectra import (
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "MultitaperSpectralDensityResult",

--- a/src/phonometry/signals/spectra.py
+++ b/src/phonometry/signals/spectra.py
@@ -70,11 +70,12 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..io._resolve import apply_calibration, resolve_fs, resolve_pair_fs
-from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "CoherentOutputSpectrumResult",

--- a/src/phonometry/signals/synchronous_average.py
+++ b/src/phonometry/signals/synchronous_average.py
@@ -85,13 +85,14 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .spectra import _positive
 from .test_signals import _validate_1d_finite, fractional_delay
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "SynchronousAverageResult",

--- a/src/phonometry/signals/test_signals.py
+++ b/src/phonometry/signals/test_signals.py
@@ -60,12 +60,13 @@ import numpy as np
 
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import apply_calibration, like_input, resolve_fs
-from ..io._signal import Signal
 from .spectra import _positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "ResampledSignalResult",

--- a/src/phonometry/signals/time_frequency.py
+++ b/src/phonometry/signals/time_frequency.py
@@ -56,7 +56,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..io._resolve import resolve_fs
-from ..io._signal import Signal
 from .spectra import (
     _DEFAULT_OVERLAP,
     _noverlap_samples,
@@ -69,6 +68,8 @@ from .spectra import (
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 __all__ = [
     "SpectrogramResult",

--- a/src/phonometry/simulation/elastic_fdtd.py
+++ b/src/phonometry/simulation/elastic_fdtd.py
@@ -72,7 +72,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import NDArray
 from scipy.optimize import brentq
 
 from .fdtd import (
@@ -92,6 +91,7 @@ from .fdtd import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import NDArray
 
 #: Boundary-condition names accepted by :func:`elastic_fdtd_simulation`.
 _BOUNDARY_NAMES = ("rigid", "absorbing", "free")

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -40,7 +40,6 @@ edge, and second-order convergence under grid refinement.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Protocol
@@ -51,6 +50,8 @@ from numpy.typing import ArrayLike, NDArray
 from .ntff import ContourPhasors
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+
     from matplotlib.axes import Axes
 
 Field2D = NDArray[np.float64]

--- a/src/phonometry/simulation/ntff.py
+++ b/src/phonometry/simulation/ntff.py
@@ -64,10 +64,13 @@ of meshed Schroeder-type diffusers against the library's Fraunhofer model
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 from scipy.special import hankel2
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "ContourPhasors",

--- a/src/phonometry/speech/objective_intelligibility.py
+++ b/src/phonometry/speech/objective_intelligibility.py
@@ -44,13 +44,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import NDArray
 
 from ..io._resolve import apply_calibration, resolve_pair_fs
-from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import NDArray
+
+    from ..io._signal import Signal
 
 # ---------------------------------------------------------------------------
 # Algorithm constants (Taal et al. 2011 Section II; Jensen & Taal 2016 II-A).

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -42,18 +42,19 @@ applied (see ``docs/ERRATA.md``).
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from .._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 #: The four band procedures of ANSI S3.5-1997, in the order of its Tables 1
 #: to 4: the critical-band procedure (21 bands), the equally-contributing

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -18,16 +18,18 @@ the male test-signal spectrum (A.6.1).
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
 
     from .._report.metadata import ReportMetadata
+    from ..io._signal import Signal
 from scipy import signal
 
 from .._internal.utils import _typesignal
@@ -35,7 +37,6 @@ from .._internal.warnings import PhonometryWarning
 from ..filters.core import OctaveFilterBank
 from ..filters.frequencies import nominal_frequencies
 from ..io._resolve import apply_calibration, resolve_fs, resolve_pair_fs
-from ..io._signal import Signal
 
 
 class STIWarning(PhonometryWarning):

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -62,13 +62,13 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy import signal as sig
 
-from ..._internal.types import Real
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
 
+    from ..._internal.types import Real
     from ..._report.metadata import ReportMetadata
 
 Complex = NDArray[np.complex128]

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -73,10 +73,10 @@ from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike
 
 # ---------------------------------------------------------------------------
 # Normative constants (Clause 5).

--- a/src/phonometry/vibration/structural/experimental_sea.py
+++ b/src/phonometry/vibration/structural/experimental_sea.py
@@ -79,7 +79,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.validation import (
     require_choice,
@@ -89,6 +88,7 @@ from ..._internal.validation import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "PowerInjectionResult",

--- a/src/phonometry/vibration/structural/junction_transmission.py
+++ b/src/phonometry/vibration/structural/junction_transmission.py
@@ -171,13 +171,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 from scipy.integrate import quad
 
 from ..._internal.validation import require_choice, require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: Reference frequency ``f_ref`` of Hopkins Eq. 5.116, in Hz.
 _REFERENCE_FREQUENCY: float = 1000.0

--- a/src/phonometry/vibration/structural/mechanical_mobility.py
+++ b/src/phonometry/vibration/structural/mechanical_mobility.py
@@ -78,10 +78,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.validation import require_non_negative, require_positive
 

--- a/src/phonometry/vibration/structural/point_mobility.py
+++ b/src/phonometry/vibration/structural/point_mobility.py
@@ -59,11 +59,15 @@ bending wavenumber.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.validation import require_positive
 from .mechanical_mobility import MobilityResult
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "beam_bending_wave_speed",

--- a/src/phonometry/vibration/structural/radiation_efficiency.py
+++ b/src/phonometry/vibration/structural/radiation_efficiency.py
@@ -67,12 +67,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.validation import require_choice, require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
 #: Default speed of sound in air ``c0``, m/s (20 degC).
 _SPEED_OF_SOUND: float = 343.0

--- a/src/phonometry/vibration/structural/transfer_stiffness.py
+++ b/src/phonometry/vibration/structural/transfer_stiffness.py
@@ -62,10 +62,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..._report.metadata import ReportMetadata
 
-from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.validation import require_non_negative, require_positive
 from ..._internal.warnings import PhonometryWarning

--- a/tests/aircraft/test_aircraft_atmospheric_absorption.py
+++ b/tests/aircraft/test_aircraft_atmospheric_absorption.py
@@ -9,9 +9,9 @@ published constants.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/aircraft/test_aircraft_plot_i18n.py
+++ b/tests/aircraft/test_aircraft_plot_i18n.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/aircraft/test_airport_noise.py
+++ b/tests/aircraft/test_airport_noise.py
@@ -8,9 +8,9 @@ decrease with distance, and the terminal-segment extrapolation.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/aircraft/test_anp_fleet.py
+++ b/tests/aircraft/test_anp_fleet.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import csv
 from importlib.resources import files
 
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 import pytest
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 from phonometry.aircraft import (

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -9,9 +9,9 @@ integrated-method EPNL Table 4-4.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/aircraft/test_epnl_report.py
+++ b/tests/aircraft/test_epnl_report.py
@@ -13,9 +13,9 @@ flyover keeps the fiche test independent.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -13,9 +13,9 @@ heterogeneous event chain, is tested in ``test_rotorcraft_terrain.py``.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/aircraft/test_rotorcraft_norah2.py
+++ b/tests/aircraft/test_rotorcraft_norah2.py
@@ -53,15 +53,15 @@ Measured deviations on which the tolerances rest (see the module docstring of
 
 from __future__ import annotations
 
-import pathlib
 import re
 import warnings
 import zipfile
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import contextlib
+from typing import TYPE_CHECKING
 
 import numpy as np
 import oracle_data
@@ -79,6 +79,9 @@ from phonometry.aircraft.rotorcraft_noise import (
     rotorcraft_event_level,
     rotorcraft_noise_contour,
 )
+
+if TYPE_CHECKING:
+    import pathlib
 
 # Resolution order (tests/oracle_data.py): NORAH2_DATA pointing at an existing
 # extraction root, then the full archive in the gitignored tests/data-local/,

--- a/tests/aircraft/test_rotorcraft_terrain.py
+++ b/tests/aircraft/test_rotorcraft_terrain.py
@@ -22,9 +22,9 @@ run must reproduce cell by cell.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/broadcast/test_broadcast_plot_i18n.py
+++ b/tests/broadcast/test_broadcast_plot_i18n.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/broadcast/test_program_loudness.py
+++ b/tests/broadcast/test_program_loudness.py
@@ -190,9 +190,9 @@ def test_k_weighting_response_rejects_bad_input() -> None:
 
 
 def test_k_weighting_response_plot() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = k_weighting_response()
@@ -656,9 +656,9 @@ def test_chunked_inter_sample_peak_matches_direct(
 
 
 def test_plot_smoke() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = program_loudness(_steps(((-30.0, 4.0), (-23.0, 4.0))), FS)

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -334,9 +334,9 @@ def test_result_is_frozen() -> None:
 
 
 def test_plot_returns_axes_with_dnt_curve() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = building.facade_insulation(
@@ -354,9 +354,9 @@ def test_plot_returns_axes_with_dnt_curve() -> None:
 
 
 def test_plot_forwards_kwargs() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = building.facade_insulation(_flat(16, 70.0), _flat(16, 30.0), _flat(16, 0.5))

--- a/tests/building/measurement/test_flanking_transmission.py
+++ b/tests/building/measurement/test_flanking_transmission.py
@@ -423,9 +423,9 @@ def test_scalar_input_accepted() -> None:
 # ---------------------------------------------------------------------------
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
 
     dv = np.full(len(THIRD_OCTAVE), 6.0)
     res = building.vibration_reduction_index(dv, 2.0, 4.0, 4.0, frequency=THIRD_OCTAVE)

--- a/tests/building/measurement/test_floor_covering_improvement.py
+++ b/tests/building/measurement/test_floor_covering_improvement.py
@@ -381,9 +381,9 @@ def test_result_octave_bands_method() -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     freqs = ref.ISO717_2_REFERENCE_FLOOR_FREQ
     bare = np.full(16, 75.0)
     res = building.impact_improvement(bare, bare - 8.0, freqs)

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -148,9 +148,9 @@ def test_reception_plate_velocity_shape_mismatch() -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = building.reception_plate_power(
         np.array([80.0, 82.0, 79.0]),
         np.array([500.0, 1000.0, 2000.0]),

--- a/tests/building/prediction/test_facade.py
+++ b/tests/building/prediction/test_facade.py
@@ -18,9 +18,9 @@ assert that the implementation stays self-consistent with the standard's own
 per-element values at the noisy bands.
 """
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import numpy as np
 import pytest

--- a/tests/building/prediction/test_installed_structure_borne.py
+++ b/tests/building/prediction/test_installed_structure_borne.py
@@ -216,9 +216,9 @@ def test_coupling_elastic_support_hand_value() -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     bands = np.array([250.0, 500.0, 1000.0])
     paths = [
         {

--- a/tests/building/prediction/test_orthotropic_panels.py
+++ b/tests/building/prediction/test_orthotropic_panels.py
@@ -33,13 +33,13 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 import reference_data
-from numpy.typing import ArrayLike
 from scipy.integrate import quad
 
 from phonometry import building, vibration
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
 #: ISO 717-1 one-third-octave band centres, 100 Hz to 3150 Hz.
 BANDS = np.array(
@@ -583,9 +583,9 @@ def test_orthotropic_plot_shades_the_coincidence_range() -> None:
     has to label the pair ``f_c1`` and ``f_c2`` and shade what lies between,
     in either language.
     """
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     def _legend(axes: Axes) -> list[str]:

--- a/tests/building/prediction/test_resilient_layers.py
+++ b/tests/building/prediction/test_resilient_layers.py
@@ -1172,9 +1172,9 @@ def test_mount_model_is_zero_at_and_below_its_own_resonance() -> None:
 # ===========================================================================
 def test_plots_return_axes(monkeypatch: pytest.MonkeyPatch) -> None:
     """Every public result exposes a working ``.plot()`` in both languages."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     plate_stiffness, impedance = _plate("concrete", 0.14)
     covering = building.covering_contact_stiffness(2.8e8 * 0.005, 0.005)
     freqs = np.array([100.0, 200.0, 400.0, 800.0, 1600.0])

--- a/tests/building/prediction/test_simplified_model_report.py
+++ b/tests/building/prediction/test_simplified_model_report.py
@@ -19,15 +19,19 @@ import reference_data as ref
 
 pytest.importorskip("reportlab")
 
+from typing import TYPE_CHECKING
+
 from phonometry import ReportMetadata, building
 from phonometry._i18n import fmt_minus
-from phonometry.building.prediction.facade import (
-    FacadePredictionResult,
-)
-from phonometry.building.prediction.simplified_model import (
-    AirbornePredictionResult,
-    ImpactPredictionResult,
-)
+
+if TYPE_CHECKING:
+    from phonometry.building.prediction.facade import (
+        FacadePredictionResult,
+    )
+    from phonometry.building.prediction.simplified_model import (
+        AirbornePredictionResult,
+        ImpactPredictionResult,
+    )
 
 _PDF_MAGIC = b"%PDF"
 

--- a/tests/building/test_building_plots.py
+++ b/tests/building/test_building_plots.py
@@ -10,9 +10,9 @@ centre frequencies, a rigid rather than resilient tie) have to be exercised.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/building/test_building_result_plots.py
+++ b/tests/building/test_building_result_plots.py
@@ -22,9 +22,9 @@ dependency, the kwarg-forwarding table, external axes) lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 import math
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 import reference_data as ref

--- a/tests/electroacoustics/test_electroacoustics_plot_i18n.py
+++ b/tests/electroacoustics/test_electroacoustics_plot_i18n.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/electroacoustics/test_frequency_response.py
+++ b/tests/electroacoustics/test_frequency_response.py
@@ -8,9 +8,9 @@ is biased high (relative to H1) when the output is noisy.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 import reference_data as ref

--- a/tests/electroacoustics/test_piston.py
+++ b/tests/electroacoustics/test_piston.py
@@ -118,9 +118,9 @@ def test_result_shapes_and_plot() -> None:
     assert res.directivity is not None
     assert res.directivity.shape == (2, 3)
     assert res.ka.shape == (2,)
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     ax = res.plot()
     assert ax.get_ylabel()
 
@@ -157,9 +157,9 @@ def test_directivity_pattern_first_null() -> None:
 
 
 def test_directivity_pattern_plot() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = electroacoustics.piston_directivity_pattern([2.0, 5.0, 10.0])
     ax = res.plot()
     # A polar axes carrying one curve per ka value.
@@ -173,9 +173,9 @@ def test_directivity_pattern_plot() -> None:
 def test_directivity_pattern_plot_kwargs_single_ka_only() -> None:
     # User plot kwargs restyle a single-ka curve, but are ignored for a
     # multi-ka family: one color/label would collapse the per-curve styling.
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     single = electroacoustics.piston_directivity_pattern(5.0)
     ax = single.plot(color="crimson", label="mine")
     assert ax.lines[0].get_color() == "crimson"

--- a/tests/electroacoustics/test_swept_sine.py
+++ b/tests/electroacoustics/test_swept_sine.py
@@ -15,9 +15,9 @@ documented as excitation-dependent.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/emission/test_emission_plot_i18n.py
+++ b/tests/emission/test_emission_plot_i18n.py
@@ -9,9 +9,9 @@ English default is covered elsewhere (and must stay byte-identical).
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/emission/test_emission_result_plots.py
+++ b/tests/emission/test_emission_result_plots.py
@@ -18,9 +18,9 @@ These are the content assertions. The generic plot contract lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -332,9 +332,9 @@ def test_field_indicators_per_band_matches_per_column_scalars() -> None:
 
 
 def test_field_indicators_plot_draws_indicators_and_ld() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     rng = np.random.default_rng(1)
@@ -550,9 +550,9 @@ def test_field_is_stationary_against_the_table_b3_limit() -> None:
 
 
 def test_field_indicators_plot_draws_f1_and_its_limit() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     rng = np.random.default_rng(43)

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -670,9 +670,9 @@ def test_field_indicators_shape_mismatch_raises() -> None:
 
 
 def test_anechoic_result_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     freqs = np.array([250.0, 500.0, 1000.0, 2000.0])
@@ -685,9 +685,9 @@ def test_anechoic_result_plot_returns_axes() -> None:
 
 
 def test_intensity_result_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     freqs = np.array([250.0, 500.0, 1000.0])

--- a/tests/emission/test_vibration_sound_power.py
+++ b/tests/emission/test_vibration_sound_power.py
@@ -163,9 +163,9 @@ def test_result_scalar_radiation_factor_broadcasts() -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = emission.sound_power_from_vibration(
         np.array([70.0, 75.0, 72.0]), 1.5, frequencies=np.array([250.0, 500.0, 1000.0])
     )

--- a/tests/environment/assessment/test_impulse_prominence.py
+++ b/tests/environment/assessment/test_impulse_prominence.py
@@ -98,9 +98,9 @@ def test_invalid_inputs_raise() -> None:
 
 
 def test_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = nt.impulse_prominence([1000.0, 200.0], [30.0, 15.0])

--- a/tests/environment/assessment/test_impulsive_sound.py
+++ b/tests/environment/assessment/test_impulsive_sound.py
@@ -27,9 +27,9 @@ from __future__ import annotations
 import importlib
 import math
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -344,9 +344,9 @@ def test_the_level_history_still_unpacks_as_the_pair_it_replaced() -> None:
 
 def test_the_level_history_draws_its_own_trace() -> None:
     """The thing a bare tuple could not do, and every other result here can."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     rng = np.random.default_rng(0)
     signal = 0.01 * rng.standard_normal(FS * 2)
     axes = iso.sound_pressure_level_history(signal, FS, dt=0.02).plot()

--- a/tests/environment/assessment/test_measurement.py
+++ b/tests/environment/assessment/test_measurement.py
@@ -254,8 +254,8 @@ def test_repeated_measurements_needs_two() -> None:
 # ---------------------------------------------------------------------------
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = environment.assess_tonal_audibility(54.1, 45.2, 430.0)
     assert res.plot() is not None

--- a/tests/environment/propagation/test_air_absorption.py
+++ b/tests/environment/propagation/test_air_absorption.py
@@ -313,9 +313,9 @@ def test_atmospheric_attenuation_direct_construction_guards_distance(
 
 def test_atmospheric_attenuation_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.axes import Axes
 
     res = environment.atmospheric_attenuation([63.0, 250.0, 1000.0, 4000.0], 20.0, 50.0)
@@ -335,9 +335,9 @@ def test_atmospheric_attenuation_plot_returns_axes() -> None:
 
 def test_atmospheric_attenuation_plot_rejects_unknown_language() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = environment.atmospheric_attenuation([1000.0], 20.0, 50.0)
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/environment/propagation/test_refraction.py
+++ b/tests/environment/propagation/test_refraction.py
@@ -513,9 +513,9 @@ def test_result_types_and_shapes() -> None:
 @pytest.mark.filterwarnings("ignore::phonometry.PhonometryWarning")
 def test_plots_smoke() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     prof = log_linear_sound_speed_profile(1.0, max_height=100.0)
     prof.plot()
     atmospheric_ray_paths(

--- a/tests/environment/sources/test_cnossos_rail.py
+++ b/tests/environment/sources/test_cnossos_rail.py
@@ -881,9 +881,9 @@ def test_invalid_inputs() -> None:
 
 
 def test_result_plot_draws_both_heights() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
 
     result = railway_source_power(
         RailwayVehicle(_reference_stock(), flow_rate=10.0, speed=100.0),

--- a/tests/environment/sources/test_cnossos_road.py
+++ b/tests/environment/sources/test_cnossos_road.py
@@ -30,9 +30,9 @@ import functools
 import math
 import warnings
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 import reference_data as ref

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -8,9 +8,9 @@ independently of the implementation.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/environment/test_environment_plot_i18n.py
+++ b/tests/environment/test_environment_plot_i18n.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/environment/test_environment_result_plots.py
+++ b/tests/environment/test_environment_result_plots.py
@@ -17,9 +17,9 @@ These are the content assertions. The generic plot contract lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/filters/test_filters_plot_i18n.py
+++ b/tests/filters/test_filters_plot_i18n.py
@@ -9,9 +9,9 @@ English default is covered elsewhere (and must stay byte-identical).
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/filters/test_parametric_eq.py
+++ b/tests/filters/test_parametric_eq.py
@@ -26,9 +26,9 @@ https://www.w3.org/TR/audio-eq-cookbook/), independent of the module:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/hearing/test_exposure_result_plots.py
+++ b/tests/hearing/test_exposure_result_plots.py
@@ -15,9 +15,9 @@ These are the content assertions. The generic plot contract lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/hearing/test_hearing.py
+++ b/tests/hearing/test_hearing.py
@@ -105,9 +105,9 @@ def test_invalid_inputs_raise() -> None:
 
 
 def test_result_fields_and_plot() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = h.age_threshold(55, "female", 0.75)

--- a/tests/hearing/test_hearing_plot_i18n.py
+++ b/tests/hearing/test_hearing_plot_i18n.py
@@ -17,9 +17,9 @@ def _legend_labels(ax) -> list[str]:
 def test_fractile_band_legend_follows_the_language() -> None:
     """The shaded fractile band's legend entry is localised like the rest."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     for result in (
         hearing.age_threshold(60.0, "male", fractile=0.9),
         hearing.nipts(95.0, 20.0, 0.9),
@@ -32,9 +32,9 @@ def test_fractile_band_legend_follows_the_language() -> None:
 
 def test_spanish_labels() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = hearing.age_threshold(60.0, "male", fractile=0.9)
 
     ax_en = res.plot(language="en")
@@ -47,9 +47,9 @@ def test_spanish_labels() -> None:
 
 def test_unknown_language_raises() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     result = hearing.age_threshold(60.0, "male")
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")
@@ -58,9 +58,9 @@ def test_unknown_language_raises() -> None:
 def test_exposure_plot_needs_per_task_contributions() -> None:
     """The job and full-day strategies carry no tasks, so plot() says so."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
 
     result = hearing.full_day_exposure([85.0, 86.0, 84.0], 8.0)
     assert result.tasks == ()

--- a/tests/hearing/test_noise_induced_hearing_loss.py
+++ b/tests/hearing/test_noise_induced_hearing_loss.py
@@ -232,9 +232,9 @@ def test_inside_validated_domain_is_silent() -> None:
 
 
 def test_plots_return_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     assert isinstance(m.nipts(95.0, 20.0, 0.9).plot(), plt.Axes)

--- a/tests/io/test_io_bext_write.py
+++ b/tests/io/test_io_bext_write.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import replace
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -29,6 +29,9 @@ from phonometry.io._bext import (
     fresh_metadata,
 )
 from phonometry.io._chunks import parse_wav_chunks
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 FS = 48000
 

--- a/tests/io/test_io_blocks.py
+++ b/tests/io/test_io_blocks.py
@@ -10,7 +10,7 @@ geometries (blocks that do not divide the length, overlap) are covered.
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -18,6 +18,9 @@ from wav_forge import chunk, float_wav, fmt_payload, pcm_wav, rf64_wav, riff_wav
 
 from phonometry import filters, signals
 from phonometry.io import LossyCompressionWarning, read, read_blocks, write
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 try:
     import soundfile as sf

--- a/tests/io/test_io_chunks.py
+++ b/tests/io/test_io_chunks.py
@@ -10,7 +10,7 @@ either side surfaces as a field-level mismatch instead of cancelling out.
 from __future__ import annotations
 
 import struct
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -26,6 +26,9 @@ from wav_forge import (
 
 from phonometry.io import _chunks
 from phonometry.io._chunks import WAVE_FORMAT_IMA_ADPCM, parse_wav_chunks
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 TONE = np.array([0, 8000, -8000, 32000], dtype=np.int64)
 

--- a/tests/io/test_io_convert.py
+++ b/tests/io/test_io_convert.py
@@ -12,7 +12,7 @@ the boundaries are exercised, not avoided.
 from __future__ import annotations
 
 from dataclasses import replace
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -31,6 +31,9 @@ from phonometry.io import (
     write_sidecar,
 )
 from phonometry.io._bext import fresh_metadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 try:
     import soundfile as sf

--- a/tests/io/test_io_flac.py
+++ b/tests/io/test_io_flac.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import builtins
 import struct
 from dataclasses import replace
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -22,6 +22,9 @@ import pytest
 from phonometry import __version__
 from phonometry.io import ClippingWarning, info, read, write
 from phonometry.io._bext import fresh_metadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 try:
     import soundfile as sf

--- a/tests/io/test_io_read.py
+++ b/tests/io/test_io_read.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import builtins
 import struct
 import warnings
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -34,6 +34,9 @@ from wav_forge import (
 
 from phonometry import signals
 from phonometry.io import LossyCompressionWarning, Signal, info, read
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 try:
     import soundfile as sf

--- a/tests/io/test_io_roundtrip.py
+++ b/tests/io/test_io_roundtrip.py
@@ -12,12 +12,15 @@ depth the files were stored at.
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from phonometry import metrology, signals
 from phonometry.io import Signal, read, write
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 FS = 48000
 

--- a/tests/io/test_io_sidecar.py
+++ b/tests/io/test_io_sidecar.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -19,6 +19,9 @@ from phonometry.io import (
     write_sidecar,
 )
 from phonometry.io._sidecar import SIDECAR_SCHEMA, SIDECAR_VERSION
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 FS = 48000
 

--- a/tests/io/test_io_signal.py
+++ b/tests/io/test_io_signal.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 import pytest
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 

--- a/tests/io/test_io_signal_structure.py
+++ b/tests/io/test_io_signal_structure.py
@@ -116,9 +116,9 @@ def test_the_two_narrowings_compose() -> None:
 
 def test_the_decibel_scale_needs_a_calibration_to_mean_anything() -> None:
     """Without a factor the samples are full-scale units, not pressures."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     one = _stereo().pick(0)
     axes = one.plot(scale="db")
     assert "dB" in axes.get_ylabel()
@@ -129,9 +129,9 @@ def test_the_decibel_scale_needs_a_calibration_to_mean_anything() -> None:
 
 def test_an_unknown_scale_is_refused_by_name() -> None:
     """A misspelt scale names the two that exist rather than drawing one."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     one = _stereo().pick(0)
     with pytest.raises(ValueError, match="scale must be"):
         one.plot(scale="log")
@@ -162,9 +162,9 @@ def test_the_decibel_waveform_is_not_called_a_level() -> None:
     axis says sound pressure in decibels, and the level trace lives on
     :class:`~phonometry.filters.TimeWeightedEnvelope` instead.
     """
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     axes = _stereo().pick(0).plot(scale="db")
     assert axes.get_ylabel() == "Sound pressure [dB re 20 uPa]"
     assert "level" not in axes.get_ylabel().lower()
@@ -172,9 +172,9 @@ def test_the_decibel_waveform_is_not_called_a_level() -> None:
 
 def test_the_decibel_axis_is_translated() -> None:
     """Every fixed string this package draws has a Spanish counterpart."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     axes = _stereo().pick(0).plot(scale="db", language="es")
     assert axes.get_ylabel() == "Presión sonora [dB re 20 uPa]"
 
@@ -215,9 +215,9 @@ def test_a_caller_supplied_label_reaches_the_lines_instead_of_crashing() -> None
     the caller's. The caller's wins now, and the generated one is still
     there when they say nothing.
     """
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     theirs = _stereo().plot(label="mine")
     assert [line.get_label() for line in theirs.get_lines()] == ["mine", "mine"]
     ours = _stereo().plot()

--- a/tests/io/test_io_write.py
+++ b/tests/io/test_io_write.py
@@ -13,7 +13,7 @@ approximately right is wrong.
 from __future__ import annotations
 
 import struct
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -22,6 +22,9 @@ from wav_forge import pcm_data
 from phonometry.io import ClippingWarning, Signal, info, read, write
 from phonometry.io._chunks import parse_wav_chunks
 from phonometry.io._write import build_wav_header, write_wav_stream
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 FS = 48000
 

--- a/tests/materials/absorbers/test_absorption_rating.py
+++ b/tests/materials/absorbers/test_absorption_rating.py
@@ -354,9 +354,9 @@ def test_weighted_absorption_rejects_non_finite() -> None:
 
 def test_plot_smoke() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = weighted_absorption(_ANNEX_A2_ALPHA_P)
     ax = res.plot()
     assert ax.get_ylabel() == "Sound absorption coefficient"

--- a/tests/materials/absorbers/test_absorption_uncertainty.py
+++ b/tests/materials/absorbers/test_absorption_uncertainty.py
@@ -196,9 +196,9 @@ def test_plot_single_number_raises() -> None:
 
 def test_plot_band_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = materials.sound_absorption_coefficient_uncertainty(
         ref.ISO12999_2_TABLE4_ALPHA_S, ref.ISO12999_2_TABLE4_FREQ
     )

--- a/tests/materials/absorbers/test_limp_frame.py
+++ b/tests/materials/absorbers/test_limp_frame.py
@@ -245,9 +245,9 @@ def test_limp_layer_drops_the_low_frequency_absorption_of_the_table_11_2_layer()
 
 
 def test_limp_frame_plot_smoke() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     limp = materials.limp_frame(
         _rigid(np.array([100.0, 400.0, 1600.0])),
         TABLE_11_2_FRAME_DENSITY,

--- a/tests/materials/diffusers/test_diffuser_design.py
+++ b/tests/materials/diffusers/test_diffuser_design.py
@@ -186,9 +186,9 @@ def test_spectrum_without_normalization() -> None:
 
 # --- Plot smoke test ----------------------------------------------------------
 def test_polar_response_plot_returns_polar_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     surface = predict_diffuser_polar_response(

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -582,9 +582,9 @@ def test_scattering_spectrum_rejects_2d_input() -> None:
 
 
 def test_scattering_spectrum_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = scattering_coefficient_spectrum(
@@ -621,9 +621,9 @@ def test_directional_diffusion_length_mismatch_raises() -> None:
 
 
 def test_directional_diffusion_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = directional_diffusion([-30.0, 0.0, 30.0], [70.0, 72.0, 69.0])
@@ -659,9 +659,9 @@ def test_diffusion_spectrum_normalized_mismatch_raises() -> None:
 
 
 def test_diffusion_spectrum_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = diffusion_spectrum(

--- a/tests/materials/resilient/test_dynamic_stiffness.py
+++ b/tests/materials/resilient/test_dynamic_stiffness.py
@@ -169,9 +169,9 @@ def test_non_positive_inputs_raise() -> None:
 # ---------------------------------------------------------------------------
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = materials.floating_floor_resonance(25.0, 200.0, 100.0)
     assert res.plot() is not None
 

--- a/tests/materials/surfaces/test_road_absorption.py
+++ b/tests/materials/surfaces/test_road_absorption.py
@@ -389,9 +389,9 @@ def test_the_functions_that_took_a_deprecated_fs_alias_still_require_fs() -> Non
 
 
 def test_insitu_absorption_spectrum_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     hi = _incident_ir()

--- a/tests/materials/test_materials_plot_i18n.py
+++ b/tests/materials/test_materials_plot_i18n.py
@@ -15,9 +15,9 @@ import numpy as np
 import pytest
 
 pytest.importorskip("matplotlib")
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 from phonometry import materials

--- a/tests/materials/test_materials_result_plots.py
+++ b/tests/materials/test_materials_result_plots.py
@@ -20,9 +20,9 @@ These are the content assertions. The generic plot contract lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -17,9 +17,9 @@ Clean-room oracles from Bendat & Piersol, *Random Data* 4e:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/metrology/test_iec61043_report.py
+++ b/tests/metrology/test_iec61043_report.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 import os
 
-import matplotlib
+import matplotlib as mpl
 import pytest
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 pytest.importorskip("reportlab")
 pytest.importorskip("svglib")

--- a/tests/metrology/test_metrology_plot_i18n.py
+++ b/tests/metrology/test_metrology_plot_i18n.py
@@ -9,9 +9,9 @@ English default is covered elsewhere (and must stay byte-identical).
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/metrology/test_metrology_result_plots.py
+++ b/tests/metrology/test_metrology_result_plots.py
@@ -16,9 +16,9 @@ These are the content assertions. The generic plot contract lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -194,9 +194,9 @@ def test_invalid_inputs_raise() -> None:
 
 
 def test_result_fields_and_plot() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     qs = [u.Quantity(3.0, 0.1, name="a"), u.Quantity(4.0, 0.2, name="b")]

--- a/tests/noise_control/test_duct_modes.py
+++ b/tests/noise_control/test_duct_modes.py
@@ -156,9 +156,9 @@ def test_rectangular_validation(kwargs: dict[str, float], match: str) -> None:
 
 def test_plot_draws_both_ladders_and_shades_the_plane_wave_band() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.axes import Axes
 
     res = duct_modes.circular_duct_cut_on(
@@ -172,7 +172,7 @@ def test_plot_draws_both_ladders_and_shades_the_plane_wave_band() -> None:
     assert [t.get_text() for t in ax.get_xticklabels()] == [
         f"({p}, {q})" for p, q in res.modes
     ]
-    matplotlib.pyplot.close(ax.figure)
+    mpl.pyplot.close(ax.figure)
 
 
 def test_plot_language_is_validated() -> None:

--- a/tests/noise_control/test_duct_path_report.py
+++ b/tests/noise_control/test_duct_path_report.py
@@ -274,9 +274,9 @@ def test_unknown_language_rejected(tmp_path) -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.axes import Axes
 
     res = _supply()

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -120,9 +120,9 @@ def test_result_type_and_plot() -> None:
         frequencies=[125.0, 250.0, 500.0],
     )
     assert isinstance(res, EnclosureResult)
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     assert res.plot().get_ylabel()
     # No-frequency plot uses band indices.
     assert (
@@ -175,9 +175,9 @@ def test_required_transmission_loss_callable_and_result_shape() -> None:
     assert isinstance(res, EnclosureResult)
     assert res.frequencies is not None
     assert res.panel_transmission_loss.shape == (3,)
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     assert res.plot().get_ylabel()
     with pytest.raises(ValueError, match="frequencies"):
         noise_control.enclosure_required_transmission_loss(lambda f: f, 6.0, 5.0, 0.3)

--- a/tests/noise_control/test_fdtd_crosscheck.py
+++ b/tests/noise_control/test_fdtd_crosscheck.py
@@ -31,13 +31,16 @@ source really does present the anechoic internal impedance that identity needs.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
-from numpy.typing import NDArray
 
 from phonometry.noise_control import silencers as sl
 from phonometry.simulation.fdtd import CWSource, GaussianPulse, fdtd_simulation
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 _C = 343.0
 #: FFT zero-padding factor for the pulse runs; the underlying spectrum is

--- a/tests/noise_control/test_hvac.py
+++ b/tests/noise_control/test_hvac.py
@@ -151,9 +151,9 @@ def test_flow_noise_bend_formula() -> None:
 
 
 def test_plot_and_validation() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     hvac.end_reflection_loss([125.0, 250.0], 0.3).plot()
     hvac.flow_noise_straight_duct([250.0, 500.0], 10.0, 0.04).plot()
     with pytest.raises(ValueError):

--- a/tests/noise_control/test_room_to_room.py
+++ b/tests/noise_control/test_room_to_room.py
@@ -12,12 +12,15 @@ Table 4.5. The published worked answers live in
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 from phonometry import noise_control
-from phonometry.noise_control.room_to_room import RoomToRoomResult
+
+if TYPE_CHECKING:
+    from phonometry.noise_control.room_to_room import RoomToRoomResult
 
 _BANDS = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
 _SOURCE = np.array([90.0, 88.0, 86.0, 84.0, 82.0, 80.0])
@@ -226,9 +229,9 @@ def test_validation() -> None:
 
 def test_plot_smoke() -> None:
     """``.plot()`` draws the two spectra, the criterion curve and the NR axis."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     result = _chain(
         criterion=noise_control.DesignCriterion(target=45.0, flanking_penalty=2.0)
     )

--- a/tests/psychoacoustics/loudness/test_contours.py
+++ b/tests/psychoacoustics/loudness/test_contours.py
@@ -175,9 +175,9 @@ def test_contours_rejects_out_of_range_phon() -> None:
 
 def test_contours_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.axes import Axes
 
     res = psychoacoustics.equal_loudness_contours()
@@ -196,9 +196,9 @@ def test_contours_plot_phon_labels_skipped_without_1khz() -> None:
     # subset that excludes 1 kHz they must be skipped (they would render
     # outside the axes), while a range including 1 kHz keeps them.
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.text import Annotation
 
     subset = psychoacoustics.equal_loudness_contours(
@@ -215,9 +215,9 @@ def test_contours_plot_phon_labels_skipped_without_1khz() -> None:
 
 def test_contours_plot_rejects_unknown_language() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = psychoacoustics.equal_loudness_contours()
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/psychoacoustics/loudness/test_ecma.py
+++ b/tests/psychoacoustics/loudness/test_ecma.py
@@ -165,9 +165,9 @@ def test_empty_signal() -> None:
 
 @pytest.mark.xdist_group("ecma-loudness-ref")
 def test_plot_smoke(ref_1k_40: psychoacoustics.EcmaLoudness) -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     axes = ref_1k_40.plot()
     assert axes.shape == (2,)
 

--- a/tests/psychoacoustics/quality/test_annoyance.py
+++ b/tests/psychoacoustics/quality/test_annoyance.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import math
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 import reference_data as ref

--- a/tests/psychoacoustics/quality/test_fluctuation_strength.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 import math
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 import reference_data as ref

--- a/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
@@ -354,9 +354,9 @@ def test_free_and_diffuse_differ() -> None:
 def test_plot_smoke(
     ref_calibration: psychoacoustics.EcmaFluctuationStrength,
 ) -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     axes = ref_calibration.plot()
     assert axes.shape == (2,)
     single = ref_calibration.plot(ax=axes[0])
@@ -369,8 +369,8 @@ def test_plot_accepts_matplotlib_color_alias(
 ) -> None:
     # ``c=`` is matplotlib's alias for ``color=``; the renderer must not
     # inject the canonical name alongside it (that raises a TypeError).
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     axes = ref_calibration.plot(c="#123456")
     assert axes[0].lines[0].get_color() == "#123456"

--- a/tests/psychoacoustics/quality/test_tonality.py
+++ b/tests/psychoacoustics/quality/test_tonality.py
@@ -221,9 +221,9 @@ def test_numeric_noise_power_warns() -> None:
 def test_plot_draws_criterion_curve_and_the_assessed_tone() -> None:
     """The TNR plot marks the tone against the clause 11.5 criterion curve."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = psychoacoustics.tone_to_noise_ratio(_tone_in_noise(1000.0, 0.1, 0.02), FS)
@@ -246,9 +246,9 @@ def test_plot_draws_criterion_curve_and_the_assessed_tone() -> None:
 def test_plot_labels_the_prominence_ratio_family() -> None:
     """A PR result selects the clause 12.6 criterion and its own label."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = psychoacoustics.prominence_ratio(

--- a/tests/psychoacoustics/quality/test_tonality_ecma.py
+++ b/tests/psychoacoustics/quality/test_tonality_ecma.py
@@ -295,8 +295,8 @@ def test_empty_signal() -> None:
 
 @pytest.mark.xdist_group("ecma-tonality-ref")
 def test_plot_smoke(ref_1k_40: psychoacoustics.EcmaTonality) -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     axes = ref_1k_40.plot()
     assert axes.shape == (2,)

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 import math
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 import reference_data as ref

--- a/tests/psychoacoustics/test_loudness_result_plots.py
+++ b/tests/psychoacoustics/test_loudness_result_plots.py
@@ -14,9 +14,9 @@ external axes, the soft matplotlib dependency) lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/psychoacoustics/test_psychoacoustics_plot_i18n.py
+++ b/tests/psychoacoustics/test_psychoacoustics_plot_i18n.py
@@ -18,9 +18,9 @@ def _result():
 
 def test_spanish_labels_and_comma_decimals() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = _result()
 
     ax_en = res.plot(language="en")
@@ -37,9 +37,9 @@ def test_spanish_labels_and_comma_decimals() -> None:
 
 def test_unknown_language_raises() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     result = _result()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")

--- a/tests/room/test_acoustics.py
+++ b/tests/room/test_acoustics.py
@@ -356,9 +356,9 @@ def test_band_plot_uses_nominal_frequency_labels() -> None:
     report prints, not the exact base-ten filter centres (125.89..., 1.99526k).
     """
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     ir = multitone_ir(1.0, 3.0, [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])

--- a/tests/room/test_image_source.py
+++ b/tests/room/test_image_source.py
@@ -423,9 +423,9 @@ def test_bad_dimension_and_fs() -> None:
 
 
 def test_reflectogram_plot_smoke() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = room.image_source_rir(
         (5.0, 4.0, 3.0),
         (1.2, 1.1, 1.3),
@@ -441,9 +441,9 @@ def test_reflectogram_plot_smoke() -> None:
 def test_reflectogram_plot_direct_only() -> None:
     # max_order=0 has no reflections; the reflectogram must not crash on the
     # empty scatter / colorbar.
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = room.image_source_rir(
         (5.0, 4.0, 3.0),
         (1.2, 1.1, 1.3),

--- a/tests/room/test_impulse_response.py
+++ b/tests/room/test_impulse_response.py
@@ -489,9 +489,9 @@ def test_mls_result_metadata() -> None:
 # Plotting (Agg backend): impulse response and excitation signals
 # --------------------------------------------------------------------------
 def test_impulse_response_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.axes import Axes
 
     rec, sweep = _synthetic_recording()
@@ -501,16 +501,16 @@ def test_impulse_response_plot_returns_axes() -> None:
     assert axes.size == 2
     assert all(isinstance(a, Axes) for a in axes)
 
-    _, single = matplotlib.pyplot.subplots()
+    _, single = mpl.pyplot.subplots()
     returned = ir.plot(ax=single)
     assert returned is single
-    matplotlib.pyplot.close("all")
+    mpl.pyplot.close("all")
 
 
 def test_plot_excitation_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from matplotlib.axes import Axes
 
     sweep = room.sweep_signal(FS, 20.0, 20000.0, 0.5)
@@ -523,13 +523,13 @@ def test_plot_excitation_returns_axes() -> None:
     assert isinstance(axes_m, np.ndarray)
     assert axes_m.size == 2
     assert all(isinstance(a, Axes) for a in axes_m)
-    matplotlib.pyplot.close("all")
+    mpl.pyplot.close("all")
 
 
 def test_plot_excitation_short_and_empty_guards() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     # A short sweep must not crash the spectrogram (nperseg capped by length).

--- a/tests/room/test_iso3382_3_report.py
+++ b/tests/room/test_iso3382_3_report.py
@@ -29,13 +29,17 @@ pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from phonometry import (
     ReportMetadata,
     room,
 )
-from phonometry.room import OpenPlanResult
+
+if TYPE_CHECKING:
+    from phonometry.room import OpenPlanResult
 
 _PDF_MAGIC = b"%PDF"
 

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -252,9 +252,9 @@ def test_result_fields_and_copy() -> None:
 
 
 def test_nc_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     ax = rn.noise_criterion(rn.nc_curve(40.0)).plot()
@@ -263,9 +263,9 @@ def test_nc_plot_returns_axes() -> None:
 
 
 def test_rc_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     ax = rn.room_criterion(rn.rc_curve(35.0)).plot()

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -405,9 +405,9 @@ def test_mismatched_air_band_count_raises() -> None:
 # ---------------------------------------------------------------------------
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = room.reverberation_time_models(
         DIMS, (0.2, 0.15, 0.3), frequencies=[125.0, 250.0]
     )

--- a/tests/room/test_room_plot_i18n.py
+++ b/tests/room/test_room_plot_i18n.py
@@ -15,9 +15,9 @@ import numpy as np
 import pytest
 
 pytest.importorskip("matplotlib")
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 from phonometry import room

--- a/tests/room/test_room_result_plots.py
+++ b/tests/room/test_room_result_plots.py
@@ -19,9 +19,9 @@ These are the content assertions. The generic plot contract lives in
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/room/test_steady_field.py
+++ b/tests/room/test_steady_field.py
@@ -169,9 +169,9 @@ def test_steady_field_validation() -> None:
 
 
 def test_steady_field_plot_smoke() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = room.steady_state_field(90.0, 100.0, 0.2)
     ax = res.plot()
     assert ax.get_xlabel() == "Distance from source [m]"

--- a/tests/signals/test_cepstrum.py
+++ b/tests/signals/test_cepstrum.py
@@ -39,9 +39,9 @@ responses.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_correlation.py
+++ b/tests/signals/test_correlation.py
@@ -15,9 +15,9 @@ frequency-domain fractional shifts, pinning the achievable accuracy.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_envelope.py
+++ b/tests/signals/test_envelope.py
@@ -11,9 +11,9 @@ the plain-subsampling decimation with the ECMA-internal convention.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_miso.py
+++ b/tests/signals/test_miso.py
@@ -25,9 +25,9 @@ few percent.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_multitaper.py
+++ b/tests/signals/test_multitaper.py
@@ -21,9 +21,9 @@ on the same record.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_phase.py
+++ b/tests/signals/test_phase.py
@@ -13,9 +13,9 @@ excess phase; ``minimum_phase`` is idempotent and phase-blind).
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_signal_toolbox.py
+++ b/tests/signals/test_signal_toolbox.py
@@ -20,9 +20,9 @@ Clean-room oracles, independent of the implementation:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import dataclasses
 

--- a/tests/signals/test_signals_plot_i18n.py
+++ b/tests/signals/test_signals_plot_i18n.py
@@ -9,9 +9,9 @@ English default is covered elsewhere (and must stay byte-identical).
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_spectra.py
+++ b/tests/signals/test_spectra.py
@@ -18,9 +18,9 @@ Bendat & Piersol's; it lives in ``test_multitaper.py``.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_synchronous_average.py
+++ b/tests/signals/test_synchronous_average.py
@@ -21,9 +21,9 @@ whose periodic part is known exactly:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/signals/test_window_metrics.py
+++ b/tests/signals/test_window_metrics.py
@@ -19,9 +19,9 @@ Clean-room oracles:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import dataclasses
 

--- a/tests/simulation/test_elastic_fdtd.py
+++ b/tests/simulation/test_elastic_fdtd.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/simulation/test_fdtd.py
+++ b/tests/simulation/test_fdtd.py
@@ -13,9 +13,9 @@ mode frequency under grid refinement.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/simulation/test_simulation_plot_i18n.py
+++ b/tests/simulation/test_simulation_plot_i18n.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/speech/test_objective_intelligibility.py
+++ b/tests/speech/test_objective_intelligibility.py
@@ -12,9 +12,9 @@ clean-room implementation from the two papers.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import itertools
 
 import numpy as np

--- a/tests/speech/test_sii.py
+++ b/tests/speech/test_sii.py
@@ -330,9 +330,9 @@ def test_result_fields_present() -> None:
 
 
 def test_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     ax = sii.speech_intelligibility_index("normal").plot()
@@ -373,9 +373,9 @@ def test_standard_speech_spectra_rejects_unknown_and_empty() -> None:
 
 def test_standard_speech_spectra_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
     from matplotlib.axes import Axes
 
@@ -400,9 +400,9 @@ def test_standard_speech_spectra_plot_returns_axes() -> None:
 
 def test_standard_speech_spectra_plot_forwards_kwargs_and_rejects_language() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     res = sii.standard_speech_spectra("normal")
@@ -813,9 +813,9 @@ def test_sii_procedure_returns_copies() -> None:
 
 def test_sii_procedure_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
     from matplotlib.axes import Axes
 
@@ -844,9 +844,9 @@ def test_sii_procedure_plot_returns_axes() -> None:
 
 def test_sii_result_plot_for_every_procedure() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     for method in sii.SII_METHODS:

--- a/tests/speech/test_speech_plot_i18n.py
+++ b/tests/speech/test_speech_plot_i18n.py
@@ -10,9 +10,9 @@ degrades a Spanish label to English silently.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/speech/test_sti_result_plots.py
+++ b/tests/speech/test_sti_result_plots.py
@@ -11,9 +11,9 @@ generic plot contract lives in ``tests/test_result_plots.py``.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_check_doc_snippets.py
+++ b/tests/test_check_doc_snippets.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 
-import pytest
+if TYPE_CHECKING:
+    import pytest
 
 _SCRIPT = (
     pathlib.Path(__file__).resolve().parent.parent / "scripts" / "check_doc_snippets.py"

--- a/tests/test_check_figure_contrast.py
+++ b/tests/test_check_figure_contrast.py
@@ -18,9 +18,9 @@ import sys
 import pytest
 
 pytest.importorskip("matplotlib")
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 _SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")

--- a/tests/test_figure_field_labels.py
+++ b/tests/test_figure_field_labels.py
@@ -25,9 +25,9 @@ from typing import Any
 import pytest
 
 pytest.importorskip("matplotlib")
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 _SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -15,9 +15,12 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 pytest.importorskip("reportlab")
 pytest.importorskip("svglib")

--- a/tests/test_golden_baseline.py
+++ b/tests/test_golden_baseline.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import os
 import sys
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/test_plot_common_i18n.py
+++ b/tests/test_plot_common_i18n.py
@@ -15,16 +15,15 @@ documentation figures via ``scripts/check_figures.py``.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
 pytest.importorskip("matplotlib")
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 from result_factories import _airborne_insulation, _impact_insulation
 
@@ -37,6 +36,9 @@ from phonometry._plot.common import (
     _plot_rating,
     _time_axis,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _axes():

--- a/tests/test_plot_fill_contrast.py
+++ b/tests/test_plot_fill_contrast.py
@@ -15,9 +15,9 @@ import numpy as np
 import pytest
 
 pytest.importorskip("matplotlib")
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 from matplotlib.colors import to_rgb
 

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -30,9 +30,9 @@ import ast
 import builtins
 import inspect
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_signal_return_contract.py
+++ b/tests/test_signal_return_contract.py
@@ -252,9 +252,9 @@ def test_the_envelope_plot_says_which_quantity_it_drew() -> None:
     when the record was A-weighted first, and an uncalibrated record has no
     reference to count decibels from at all.
     """
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry.filters import time_weighting
 
     calibrated = time_weighting(
@@ -270,9 +270,9 @@ def test_the_envelope_plot_says_which_quantity_it_drew() -> None:
 
 def test_the_envelope_plot_labels_each_channel() -> None:
     """The multichannel branch, which the single-channel cases never reach."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry.filters import time_weighting
 
     stereo = Signal(np.stack([_RECORD, 2.0 * _RECORD]), FS, calibration_factor=CAL)
@@ -283,9 +283,9 @@ def test_the_envelope_plot_labels_each_channel() -> None:
 
 def test_the_envelope_plot_is_translated() -> None:
     """Every fixed string this renderer draws has a Spanish counterpart."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry.filters import time_weighting
 
     axes = time_weighting(
@@ -364,9 +364,9 @@ def test_an_empty_block_keeps_the_carried_state_and_the_wrapper() -> None:
 
 def test_the_envelope_plot_takes_a_caller_supplied_label() -> None:
     """The same keyword collision as the waveform renderer, same resolution."""
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry.filters import time_weighting
 
     stereo = Signal(np.stack([_RECORD, 2.0 * _RECORD]), FS, calibration_factor=CAL)

--- a/tests/test_transition_stub.py
+++ b/tests/test_transition_stub.py
@@ -28,15 +28,19 @@ import re
 import shutil
 import subprocess
 import tomllib
-import types
 import warnings
+from typing import TYPE_CHECKING
 
 import pytest
 from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 import phonometry
+
+if TYPE_CHECKING:
+    import types
+
+    from packaging.specifiers import SpecifierSet
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 _STUB = _ROOT / "stub"

--- a/tests/underwater/bioacoustics/test_audiograms.py
+++ b/tests/underwater/bioacoustics/test_audiograms.py
@@ -16,9 +16,9 @@ Oracles:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/underwater/bioacoustics/test_weighting.py
+++ b/tests/underwater/bioacoustics/test_weighting.py
@@ -18,9 +18,9 @@ Oracles:
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/underwater/propagation/test_bathymetry.py
+++ b/tests/underwater/propagation/test_bathymetry.py
@@ -63,9 +63,9 @@ with the solver.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/propagation/test_closed_form.py
+++ b/tests/underwater/propagation/test_closed_form.py
@@ -10,9 +10,9 @@ recomputation), and the mutual agreement of Francois-Garrison and Ainslie-McColm
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/propagation/test_eigenrays.py
+++ b/tests/underwater/propagation/test_eigenrays.py
@@ -44,9 +44,9 @@ from __future__ import annotations
 import functools
 import warnings
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/underwater/propagation/test_gaussian_beams.py
+++ b/tests/underwater/propagation/test_gaussian_beams.py
@@ -137,9 +137,9 @@ from __future__ import annotations
 
 import warnings
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/propagation/test_numerical.py
+++ b/tests/underwater/propagation/test_numerical.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 
 import math
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/propagation/test_seabed_reflection.py
+++ b/tests/underwater/propagation/test_seabed_reflection.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import warnings
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/propagation/test_sound_speed.py
+++ b/tests/underwater/propagation/test_sound_speed.py
@@ -12,9 +12,9 @@ Equations 1.2 to 1.4, printed p. 20).
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/propagation/test_weston_regimes.py
+++ b/tests/underwater/propagation/test_weston_regimes.py
@@ -10,9 +10,9 @@ solvers of ``phonometry.underwater.propagation.numerical``.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/underwater/sources/test_ambient_noise.py
+++ b/tests/underwater/sources/test_ambient_noise.py
@@ -10,9 +10,9 @@ thermal-noise formula ``<p²> = 4π·k·T·ρ·f²/c`` computed directly.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -7,9 +7,9 @@ is the exact energy sum, equal to SEL_ss + 10·lg(N) for identical strikes.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/underwater/sources/test_ship_radiated_noise.py
+++ b/tests/underwater/sources/test_ship_radiated_noise.py
@@ -8,9 +8,9 @@ high-frequency limit.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/sources/test_ship_traffic_noise.py
+++ b/tests/underwater/sources/test_ship_traffic_noise.py
@@ -10,9 +10,9 @@ the mean-spectrum equation and asymptote statements printed in the 2002 paper.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/test_ainslie_worked_examples.py
+++ b/tests/underwater/test_ainslie_worked_examples.py
@@ -23,9 +23,9 @@ unrounded one, so it is what these tests feed in.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/underwater/test_sonar_equation.py
+++ b/tests/underwater/test_sonar_equation.py
@@ -7,9 +7,9 @@ pure arithmetic, independent of the implementation.
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import numpy as np
 import pytest
 

--- a/tests/underwater/test_underwater_plot_i18n.py
+++ b/tests/underwater/test_underwater_plot_i18n.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-import matplotlib
+import matplotlib as mpl
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 import pytest
 

--- a/tests/vibration/human/test_human_vibration.py
+++ b/tests/vibration/human/test_human_vibration.py
@@ -539,9 +539,9 @@ def test_daily_vibration_exposure_rejects_length_mismatch() -> None:
 
 
 def test_weighting_response_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     ax = hv.frequency_weighting("Wk", [1.0, 10.0, 100.0]).plot()
@@ -550,9 +550,9 @@ def test_weighting_response_plot_returns_axes() -> None:
 
 
 def test_weighted_spectrum_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = hv.weighted_acceleration([0.5, 0.8, 0.3], [16.0, 31.5, 63.0], "Wk")
@@ -562,9 +562,9 @@ def test_weighted_spectrum_plot_returns_axes() -> None:
 
 
 def test_daily_vibration_exposure_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     result = hv.daily_vibration_exposure([2.5, 3.0], [3600.0, 1800.0], kind="hav")

--- a/tests/vibration/structural/test_junction_transmission.py
+++ b/tests/vibration/structural/test_junction_transmission.py
@@ -430,9 +430,9 @@ def test_result_accepts_custom_angles() -> None:
 
 
 def test_plot_returns_axes() -> None:
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
 
     res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.15, 3000.0, 360.0)
     ax = res.plot()

--- a/tests/vibration/structural/test_mechanical_mobility.py
+++ b/tests/vibration/structural/test_mechanical_mobility.py
@@ -255,18 +255,18 @@ def test_mobility_result_bundle() -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = vibration.sdof_mobility_result(np.linspace(1.0, 50.0, 200), M, K, C)
     assert res.plot() is not None
 
 
 def test_rigid_mass_plot_two_panels_and_external_ax() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     import matplotlib.pyplot as plt
 
     f = np.logspace(np.log10(20.0), np.log10(2000.0), 40)
@@ -282,9 +282,9 @@ def test_rigid_mass_plot_two_panels_and_external_ax() -> None:
 
 def test_rigid_mass_plot_rejects_unknown_language() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = vibration.rigid_mass_calibration_check([0.1], [100.0], 10.0)
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/vibration/structural/test_transfer_stiffness.py
+++ b/tests/vibration/structural/test_transfer_stiffness.py
@@ -261,9 +261,9 @@ def test_result_bundle() -> None:
 
 def test_plot_returns_axes() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     f = np.logspace(1, 3, 50)
     t = vibration.base_transmissibility(f, 5.0, 1e6, 200.0)
     # The synthetic curve exceeds |T| = 0.1 near resonance, so the

--- a/tests/vibration/test_vibration_plot_i18n.py
+++ b/tests/vibration/test_vibration_plot_i18n.py
@@ -15,9 +15,9 @@ def _result():
 
 def test_spanish_labels() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     res = _result()
 
     ax_en = res.plot(language="en")
@@ -31,9 +31,9 @@ def test_spanish_labels() -> None:
 
 def test_rigid_mass_spanish_labels() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     f = np.array([20.0, 100.0, 500.0])
     res = vibration.rigid_mass_calibration_check([0.100, 0.102, 0.097], f, mass=10.0)
 
@@ -51,9 +51,9 @@ def test_rigid_mass_spanish_labels() -> None:
 
 def test_multiple_shock_spanish_title_translates_sex() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry.vibration.human.multiple_shock import (
         MZ_MALE,
         RISK_THRESHOLDS_MALE,
@@ -89,9 +89,9 @@ def test_multiple_shock_spanish_title_translates_sex() -> None:
 
 def test_unknown_language_raises() -> None:
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     result = _result()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")
@@ -100,9 +100,9 @@ def test_unknown_language_raises() -> None:
 def test_fault_frequency_overlay_labels() -> None:
     """The fault-line overlay localises its axes, title and family legend."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
 
     res = vibration.bearing_fault_frequencies(
         2000.0, 15, 6.0, 34.0, contact_angle_deg=12.96
@@ -128,9 +128,9 @@ def test_fault_frequency_overlay_labels() -> None:
 def test_fault_frequency_overlay_on_a_measured_spectrum() -> None:
     """With a spectrum the curve is drawn underneath and named."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry import signals
 
     res = vibration.bearing_fault_frequencies(
@@ -162,9 +162,9 @@ def test_crowded_fault_labels_do_not_overlap() -> None:
     their rotated labels used to be drawn on top of one another.
     """
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     from phonometry._plot.vibration import _LABEL_WIDTH_PT, _label_offsets
 
     res = vibration.bearing_fault_frequencies(
@@ -186,9 +186,9 @@ def test_crowded_fault_labels_do_not_overlap() -> None:
 def test_power_injection_labels() -> None:
     """The SEA loss-factor budget localises its axes and title."""
     pytest.importorskip("matplotlib")
-    import matplotlib
+    import matplotlib as mpl
 
-    matplotlib.use("Agg")
+    mpl.use("Agg")
 
     f = np.array([250.0, 500.0, 1000.0])
     res = vibration.power_injection_clf(f, 0.087, 0.013, 4.4e-3, 2.4e-3, 0.557, 0.606)


### PR DESCRIPTION
## What and why

Three linter families that this tree nearly satisfied already, and one repair to a gate that had to come first.

- **`TC`** moves the 313 imports only a type checker reads under `if TYPE_CHECKING`.
- **`ICN`** imports a well-known package under the alias everyone writes, 190 of them.
- **`N812`** retires an alias that disguised what a name was: 83 places wrote `from ._layout import fiche_paragraph as Paragraph`, which made a helper of this package read as the class reportlab publishes under that name.
- Four conformance domains imported numpy a second time, inside a function that already had it at module scope.
- **`INP`** and **`T20`** are selected and find nothing. Both are already clean in `src` and are here to hold it; a print is what the scripts are for, so they and the tests are exempt.

### The gate had to be repaired first

`scripts/animation_fingerprint.py` hashes the AST of the code that draws each clip, and its own preamble is explicit that a false positive is the failure mode to avoid, because it costs a several-minute re-render: *an alarm nobody believes would be worse than no alarm*, and *only a change to what the code does* should move the hash.

It hashed each reached module whole. Moving an import under `if TYPE_CHECKING` therefore read as a change to the drawing, even though nothing in that block exists while a frame renders, and sorting the remaining imports read as another. Together they marked **most of the forty-two clips stale** for drawings that are provably identical.

It now skips `if TYPE_CHECKING` blocks and hashes the remaining imports as a sorted set. It still hashes them: the walk stops at the package boundary, so for `import numpy as np` the statement is the only record the fingerprint has that the name points where it did. After the repair, **all 42 clips match**, with nothing re-rendered and no fingerprint re-stamped.

### One rule left out, and a trap in leaving it out

`TC006` quotes the first argument of `typing.cast`. That argument is never evaluated for its value, so the rewrite is inert, and it moved two clips through `figures.media._save_animation`. It is not selected.

Reverting it needs care, and I got it wrong first: an *unquoted* cast does evaluate the name. Where a cast names an import that lives only under `if TYPE_CHECKING`, the quotes are the only thing keeping it from raising `NameError` at run time. Ruff says exactly this as `TC004`, which fired on seven sites and is how the mistake surfaced before it could ship.

## Validation

No new computation. Imports moved, names renamed, nothing calculated differently: the conformance report is byte-identical at 550/550, the 71 committed fiches match within tolerance (this change touches `_report`, so that gate is the one that matters here), and all 42 clips match. `import phonometry` still costs 5,0 ms and 56 entries in `sys.modules`.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .` and `ruff format --check .`
- [x] `mypy src scripts`
- [x] `bandit -r src` (exit 0)
- [x] `pytest -q` — 8958 passed, 16 skipped, 0 failures

Regenerated where this change touches them:

- [x] `make conformance`, byte-identical
- [x] `make api-docs` and `make llms`, no change
- [x] `check_animation_freshness.py`, `check_reports.py`

Every domain package and every module under `scripts/` imports, which is the check that matters when 313 imports move.

Always:

- [x] CHANGELOG entry under `[Unreleased]`

Stacked on #602.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

