### PR TITLE
Point blame at the squash that actually landed

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,4 +7,4 @@
 
 # Formatted 673 of the 812 Python files, the first time this tree had a
 # formatter at all.
-71aff67c5136fa455fbef280c699540568003a77
+1d367277c5d2cfad909a8fec03968fd26ba9f032


### PR DESCRIPTION
The blame-ignore file named the reformat commit as it existed on the branch. The squash merge rewrote it into a commit with a different hash, so the file pointed at a revision that is not in this history and git blame ignored nothing. This points it at the merged squash.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

