### PR TITLE
Give every docstring one shape, and a raw string where backslashes live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Docstrings hold one shape now. The summary sits on the first line, the
+  closing quotes take their own, and 873 docstrings moved to say so without
+  changing by a word. Where a docstring carries backslashes (matplotlib
+  mathtext, regular expressions) it is a raw string now, 37 sites, under one
+  invariant: the value Python stores in `__doc__` stays byte-identical,
+  checked by parsing the tree before and after. The check earned its keep
+  once. One test docstring wrote `\tau` twice and `\approx` once inside a
+  cooked string, so the stored value held a tab and a bell character where
+  the source shows mathematics; the raw prefix is the repair, and it is the
+  only docstring whose value moved.
+
+  Twenty-one magic methods explain themselves now: mostly the
+  `__post_init__` of a dataclass naming what it rejects, and `__len__` and
+  `__getitem__` naming what they count and where they forward.
+
+  The docstring rules that judge prose rather than shape stay out, measured
+  one by one. `D401` would put 999 summaries in the imperative mood; `D205`
+  would fold the deliberate multi-line opening sentence of 516 docstrings;
+  `D403` would capitalise `dBFS`, `dL` and `matplotlib`; and `D400`'s nine
+  missing periods are four questions that rightly end in their own mark and
+  five sentences that finish on the next line. `D210` stands down in the
+  tests alone, where a docstring may open with the clause it checks quoted
+  verbatim, and the space it objects to is all that separates the quotation
+  mark from the triple quote.
+
 - Imports say what they are for, and names say what they are. An import that
   only a type checker needs sits under `if TYPE_CHECKING` now, 313 of them; a
   well-known package is imported under the alias everyone writes, 190 of them;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,10 @@ select = [
     "ICN",                  # the conventional alias for a well-known package
     "N812",                 # an alias must not disguise a function as a class
     "INP", "T20",           # both already clean in `src`, and kept that way
+    "D105",                 # a magic method still explains itself
+    "D2", "D301",           # docstring shape: where the summary sits and how
+                            # quotes and backslashes are spelled. Shape only;
+                            # no rule here rewords prose.
 ]
 ignore = [
     "B905",  # selected by "B"; see the note below
@@ -170,6 +174,23 @@ ignore = [
     # two of the nineteen it finds here, and wrong about the rest; SonarCloud
     # flagged the result as assertions whose argument order no longer agrees.
     "SIM300",
+    # Four docstring rules are measured out because they would rewrite prose,
+    # and the documentation's voice is content here, not shape:
+    #   D401  (999) demands imperative mood ("Return the..."); the house style
+    #               opens with a noun phrase and the API reference renders it.
+    #   D205  (528) wants a one-line summary, a blank line, then the rest.
+    #               Measured, 516 of the 528 openings are deliberate multi-line
+    #               sentences; satisfying the rule means rewriting them all.
+    #   D403   (50) would capitalise the first word, which here is `dBFS`,
+    #               `dL`, `fc`, `matplotlib`: symbols and identifiers.
+    #   D404/D415   wording rules with 2 and 5 hits; same principle.
+    #   D400    (9) the trailing period. All nine first lines are right as
+    #               they stand: four are questions, which end in the mark
+    #               they deserve, and five open a sentence that finishes on
+    #               the next line.
+    "D205", "D400", "D401", "D403", "D404", "D415",
+    "D203",  # a blank line before a class docstring; D211 is the house shape
+    "D213",  # the summary on the second line; D212 is the house shape
 ]
 # Selected next, in their own review, because each is a change to code rather
 # than to its shape and the diff has to be readable to be checked:
@@ -194,7 +215,12 @@ ignore = [
 # tests are packages anyone imports by name. Both rules are here to hold `src`,
 # where they already find nothing.
 "scripts/**" = ["E402", "T201", "INP001"]
-"tests/**" = ["E402", "T201", "INP001"]
+# A test may open its docstring with the clause it checks, quoted verbatim:
+# `""" "Up till about 1000 Hz..." `. The space after the triple quote is what
+# keeps that from being four quotation marks in a row; D210 wants it gone and
+# has no way to fix it. The quotation stays, so the rule stands down in tests
+# and holds `src`, where it finds nothing.
+"tests/**" = ["E402", "T201", "INP001", "D210"]
 ".github/**" = ["T201", "INP001"]
 # The PyOctaveBand transition shim exists to re-export the whole package under
 # the old name; the star import is the point of the file.

--- a/scripts/api_taxonomy.py
+++ b/scripts/api_taxonomy.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Taxonomy for the generated API reference (scripts/generate_api_docs.py).
+"""Taxonomy for the generated API reference (scripts/generate_api_docs.py).
 
 Maps every public phonometry module to a documentation section. Sections
 become directories under ``site/src/content/docs/reference/api/<section>/``

--- a/scripts/check_decimal_comma.py
+++ b/scripts/check_decimal_comma.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Name the labels whose Spanish decimal the save-time comma pass will skip.
+r"""Name the labels whose Spanish decimal the save-time comma pass will skip.
 
 The Spanish edition of a figure is the English one with its text rewritten at
 save time, and the last step of that rewrite is the decimal comma::
 
-    if s and "$" not in s and re.search(r"\\d\\.\\d", s):
+    if s and "$" not in s and re.search(r"\d\.\d", s):
         artist.set_text(_decimal_comma(s))
 
 The guard is deliberate -- a bare comma inside ``$...$`` sets as a maths
@@ -12,7 +12,7 @@ separator with the wrong spacing -- but it tests the WHOLE string. So a label
 that carries mathematics ANYWHERE and a decimal number ANYWHERE ELSE keeps the
 English point in its Spanish variant:
 
-    "$L_\\mathrm{eq}$ = 52.4 dB"   ->  Spanish figure still prints 52.4
+    "$L_\mathrm{eq}$ = 52.4 dB"   ->  Spanish figure still prints 52.4
 
 Nothing downstream can see it. The language gate compares what each pass could
 not translate, and a number is not a word; the parity check sees a pair,

--- a/scripts/check_figure_language.py
+++ b/scripts/check_figure_language.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Find English text inside the Spanish edition of a figure.
+r"""Find English text inside the Spanish edition of a figure.
 
 Every figure ships in four variants (``X.svg``, ``X_dark.svg``, ``X_es.svg``,
 ``X_es_dark.svg``), and the Spanish ones are not drawn in Spanish. The figure
@@ -18,8 +18,8 @@ Two ways of looking for it do not work:
 
 * **Diffing the text nodes of ``X.svg`` and ``X_es.svg``.** A label with any
   mathtext in it is not a string in the file: matplotlib lays it out glyph by
-  glyph, so ``$|\\mu|$ = fluid / frame displacement`` is written as thirty
-  positioned ``<tspan>``\\ s with the mu pushed to the end (biot_waves_es.svg,
+  glyph, so ``$|\mu|$ = fluid / frame displacement`` is written as thirty
+  positioned ``<tspan>``\ s with the mu pushed to the end (biot_waves_es.svg,
   as committed). There is nothing there to look up in a table or to name in a
   report. Nor does that method reach a label a tick formatter builds at draw
   time: it is on no ``Text`` artist beforehand, which is why

--- a/scripts/check_figures.py
+++ b/scripts/check_figures.py
@@ -1,5 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""Tolerance-aware staleness check for the committed documentation figures.
+r"""Tolerance-aware staleness check for the committed documentation figures.
 
 The ``Documentation figures up to date`` CI job regenerates ``.github/images``
 with ``make graphs`` and must confirm the result still matches what is
@@ -18,7 +18,7 @@ committed versions (``git HEAD``) within a tolerance instead:
   relative tolerance. A moved element, changed label or new path fails; a
   last-bit coordinate wobble passes.
 * **Raster (WebP/PNG)** -- identical dimensions, at most
-  :data:`RASTER_TOL`\\ ``.max_sig_pixels`` meaningfully changed pixels and a
+  :data:`RASTER_TOL`\ ``.max_sig_pixels`` meaningfully changed pixels and a
   bounded root-mean-square difference (see
   :class:`~generated_assets.RasterTolerance`).
 * **Anything else** -- exact byte compare.

--- a/scripts/check_markdown_hazards.py
+++ b/scripts/check_markdown_hazards.py
@@ -1,5 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""Gate for markdown that does not render the way it reads.
+r"""Gate for markdown that does not render the way it reads.
 
 The guides are hard-wrapped, so a sentence long enough to wrap can put a
 ``-``, a ``>`` or a digit-and-dot at the start of a line. CommonMark does not
@@ -15,7 +15,7 @@ a source that looks right and renders wrong.
    marker never closes: the marker ends the paragraph first. The maths is then
    published as literal text, and in MDX the subscript braces become a
    JavaScript expression, so the page does not render at all. This is what
-   ``$L_{n,ij,w} = ... - \\Delta R_{j,w}`` followed by ``- K_{ij} ...`` did:
+   ``$L_{n,ij,w} = ... - \Delta R_{j,w}`` followed by ``- K_{ij} ...`` did:
    the site build failed with ``ReferenceError: n is not defined``, ``n`` being
    the first subscript. A list marker is only reported when it interrupts an
    open ``$``, because a list that legitimately follows its introducing line
@@ -40,7 +40,7 @@ a source that looks right and renders wrong.
 
 4. **An opening ``$$`` with the formula on the same line.** Display maths is a
    fence, and like a code fence everything after the opening delimiter is read
-   as *meta*, not as content. So ``$$\\tau = ...`` opens a block that only ends
+   as *meta*, not as content. So ``$$\tau = ...`` opens a block that only ends
    at the next line that is exactly ``$$``, and a trailing ``$$`` at the end of
    the second line does not close it. The block then swallows the document
    until the next display block, which becomes its terminator: two hundred
@@ -100,7 +100,7 @@ _MATH_META = re.compile(r"^\$\$\s*\S")
 
 
 def _unescaped_dollars(line: str) -> int:
-    """Inline ``$`` delimiters on a line, ignoring ``\\$`` and ``$$``."""
+    r"""Inline ``$`` delimiters on a line, ignoring ``\$`` and ``$$``."""
     return len(re.findall(r"(?<!\\)\$", re.sub(r"\$\$", "", line)))
 
 

--- a/scripts/check_mathtext.py
+++ b/scripts/check_mathtext.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Parse every ``$...$`` label the generators draw, and name what matplotlib refuses.
+r"""Parse every ``$...$`` label the generators draw, and name what matplotlib refuses.
 
 A label mathtext cannot parse does not degrade into a worse label: generation
 raises and the figure is never written. In a run of four hundred figures that
@@ -8,8 +8,8 @@ reports the figure as *stale* -- a description that sends the reader looking for
 a data change rather than a typo three characters wide.
 
 The reason this is worth its own check, rather than trusting the render: a
-construct can be legal alone and illegal in combination. ``^{\\prime}`` is a
-perfectly good prime, and ``^{\\prime}^{\\prime}`` is a double superscript
+construct can be legal alone and illegal in combination. ``^{\prime}`` is a
+perfectly good prime, and ``^{\prime}^{\prime}`` is a double superscript
 matplotlib rejects outright -- which is exactly what a mechanical substitution
 of ``′`` produces from a double prime, and exactly what it did produce in three
 labels of this tree.
@@ -58,9 +58,9 @@ _REGEX_SHAPE = re.compile(r"\(\.\+\)|\(\\d|\(\.\*\)|\\\d")
 
 
 def maths_runs(text: str) -> list[str]:
-    """Every ``$...$`` region of *text*, dollars included.
+    r"""Every ``$...$`` region of *text*, dollars included.
 
-    A dollar escaped as ``\\$`` opens nothing: that is how a pattern spells a
+    A dollar escaped as ``\$`` opens nothing: that is how a pattern spells a
     literal dollar it means to match.
     """
     runs: list[str] = []

--- a/scripts/check_subscript_slope.py
+++ b/scripts/check_subscript_slope.py
@@ -168,13 +168,13 @@ Sightings = dict[tuple[str, str], dict[str, list[int]]]
 
 
 def sightings(text: str, suffix: str) -> Sightings:
-    """Every one-letter subscript of *text*, by symbol and by slope.
+    r"""Every one-letter subscript of *text*, by symbol and by slope.
 
     A comma-separated subscript is read component by component, since that is
-    how a reader reads it: :math:`\\alpha_{\\mathrm{s},i}` is the Sabine
+    how a reader reads it: :math:`\alpha_{\mathrm{s},i}` is the Sabine
     absorption of surface *i*, one abbreviation and one index, and the letter
     that matters is the one being compared. Where the upright command wraps the
-    whole run, as ``L_\\mathrm{n,w,eq}`` does, every component of it is upright.
+    whole run, as ``L_\mathrm{n,w,eq}`` does, every component of it is upright.
     Any component that is not a single letter is passed over: a digit, a
     weighting prefix and a word are not what this is about.
     """

--- a/scripts/conformance/domains/assessment.py
+++ b/scripts/conformance/domains/assessment.py
@@ -52,7 +52,6 @@ _ISO1996_3 = "Impulsive-sound prominence (ISO/PAS 1996-3)"
 
 def _iso1996_3_ramp_onset() -> Any:
     """Detected onset of a 30 dB LpAF ramp over 0.30 s (dt = 20 ms)."""
-
     from phonometry.environment.assessment.impulsive_sound import detect_onsets
 
     dt = 0.02

--- a/scripts/diagrams/aircraft.py
+++ b/scripts/diagrams/aircraft.py
@@ -75,7 +75,8 @@ def _d_aircraft_certification(s: SVG, th: Theme) -> None:
     """The three ICAO Annex 16 Vol. I Chapter 3 reference points around the
     runway: lateral (450 m line), flyover (6.5 km from start of roll) and
     approach (2 000 m from the threshold, 120 m under the 3-degree path).
-    Plan and side views share the same x mapping (0.062 px per metre)."""
+    Plan and side views share the same x mapping (0.062 px per metre).
+    """
     yc = 185.0  # plan-view runway centre line
     x_sor = 330.0  # start of roll / threshold
     x_fly = x_sor + 6500.0 * 0.062  # flyover point, 6.5 km
@@ -208,7 +209,8 @@ def _d_aircraft_certification(s: SVG, th: Theme) -> None:
 def _d_rotorcraft_certification(s: SVG, th: Theme) -> None:
     """Chapter 8 overflight: level flight at 150 m over the central
     microphone with two sideline microphones 150 m to each side (plan
-    inset). Side view to scale at about 0.47 px per metre vertically."""
+    inset). Side view to scale at about 0.47 px per metre vertically.
+    """
     gy = 470.0
     hx, hy = 300.0, 150.0  # helicopter on the flight path
 
@@ -352,7 +354,8 @@ def _d_doc29_segment_geometry(s: SVG, th: Theme) -> None:
     to scale at 0.30 px per metre in the plane containing the segment and the
     observer), the plane normal to the flight path where the elevation, bank
     and depression angles live (Fig. 4-3), and the start-of-roll azimuth in
-    plan (Fig. 4-8)."""
+    plan (Fig. 4-8).
+    """
     sc = 0.30  # px per metre, panels (a)/(b)
 
     # --- (a) observer alongside the segment (Fig. 4-2b) --------------------
@@ -548,7 +551,8 @@ def _d_aircraft_noise_station(s: SVG, th: Theme) -> None:
     10 m meteorological mast and the independent tracking sensor; below it,
     the microphone itself at a larger scale and the plan that explains why
     its capsule points across the track. The Appendix 2 test window and the
-    sample-size rule are in the footer."""
+    sample-size rule are in the footer.
+    """
     gy = 320.0  # site ground line
     mx = 300.0  # microphone station
 
@@ -742,7 +746,8 @@ def _d_rotorcraft_hemisphere(s: SVG, th: Theme) -> None:
     nose in the vertical centre plane, and the azimuth φ measured about the
     nose axis from straight down. The third panel places the 60 m sphere on a
     track, so the source level and the three propagation adjustments read as
-    one chain."""
+    one chain.
+    """
     r = 112.0
 
     # --- (a) the polar angle, in the vertical centre plane (φ = 0) ---------

--- a/scripts/diagrams/buildings.py
+++ b/scripts/diagrams/buildings.py
@@ -1620,7 +1620,8 @@ def _d_iso12999(s: SVG, th: Theme) -> None:
 
 def _d_reception_plate(s: SVG, th: Theme) -> None:
     """EN 15657 reception plate: source machine on a resiliently supported
-    plate, averaged plate velocity, plate power balance."""
+    plate, averaged plate velocity, plate power balance.
+    """
     # ===== Source machine standing on the plate =====
     mx = 260.0
     s.text(mx, 150, "Source under test (pump, fan, boiler …)", 17, th.fg, bold=True)
@@ -1673,7 +1674,8 @@ def _d_reception_plate(s: SVG, th: Theme) -> None:
 
 def _d_installed_paths(s: SVG, th: Theme) -> None:
     """EN 12354-5: service equipment on a floor slab, structure-borne paths
-    into the receiving room below, and the prediction cascade."""
+    into the receiving room below, and the prediction cascade.
+    """
     bx0, bx1 = 80.0, 590.0
     top, slab_top, slab_bot, bot = 92.0, 296.0, 324.0, 528.0
 
@@ -1772,7 +1774,8 @@ def _d_insulation_lab(s: SVG, th: Theme) -> None:
     """ISO 10140 laboratory transmission suite in plan view: two
     structurally decoupled reverberant rooms, the test element mounted in
     the ~10 m2 test opening, a corner loudspeaker in the source room and a
-    continuously moving (rotating) microphone in each room."""
+    continuously moving (rotating) microphone in each room.
+    """
     top = 92.0
     sc = 72.0  # px per metre
     src_bot = top + 4.4 * sc  # source room 5.0 m x 4.4 m
@@ -1857,7 +1860,8 @@ def _d_insulation_lab(s: SVG, th: Theme) -> None:
 def _d_reverberation_prediction(s: SVG, th: Theme) -> None:
     """The guide's 10 x 7 x 3.5 m room through the Sabine and Eyring
     absorption terms into the per-band T60 table the library returns,
-    with the diffuse-field validity note."""
+    with the diffuse-field validity note.
+    """
     # Room data
     s.rect(170, 52, 560, 78, th.panel, th.fg, rx=10, sw=2)
     s.text(
@@ -1952,7 +1956,8 @@ def _d_panel_insulation(s: SVG, th: Theme) -> None:
     """A single 12.5 mm plasterboard leaf (m'' = 8.75 kg/m2) mounted in its
     test opening under diffuse incidence, with the predicted R(f) of
     ``single_panel_transmission_loss`` inset: the mass-law rise and the
-    coincidence dip at the fc = 2619 Hz of this leaf (Rw = 27 dB)."""
+    coincidence dip at the fc = 2619 Hz of this leaf (Rw = 27 dB).
+    """
     # --- test opening: heavy filler above and below, the leaf between ------
     px_l, px_r = 380.0, 396.0
     op_t, op_b = 108.0, 332.0
@@ -2085,7 +2090,8 @@ def _d_room_image_sources(s: SVG, th: Theme) -> None:
     """Plan of the guide's 7 x 5 x 3 m room with the source at (2, 1.6),
     the receiver at (5.2, 3.4) and the in-plane images of order 1 and 2 on
     the mirror-room grid, each labelled with its image_source_rir arrival
-    time (direct 10.7 ms, first reflections 17.3 to 21.6 ms)."""
+    time (direct 10.7 ms, first reflections 17.3 to 21.6 ms).
+    """
     sc = 32.0  # px per metre
 
     def x(mx: float) -> float:
@@ -2201,7 +2207,8 @@ def _d_room_image_sources(s: SVG, th: Theme) -> None:
 
 def _d_reception_plate_rigs(s: SVG, th: Theme) -> None:
     """The two plates EN 15657 clauses 7.2.2 and 7.3.2 specify, and the
-    three-plate bench of its Figure 2, drawn with conforming dimensions."""
+    three-plate bench of its Figure 2, drawn with conforming dimensions.
+    """
     top = 74.0
 
     # ===== Panel 1: the low-mobility plate in plan (clause 7.2.2) =====
@@ -2367,7 +2374,8 @@ def _d_reception_plate_rigs(s: SVG, th: Theme) -> None:
 
 def _d_iso16251_mockup(s: SVG, th: Theme) -> None:
     """The Annex A rig: the 1 200 x 800 x 200 mm slab on four elastic pads,
-    the covering specimen, the tapping machine and the accelerometers."""
+    the covering specimen, the tapping machine and the accelerometers.
+    """
     top = 74.0
 
     # ===== Left: a section through the rig =====
@@ -2799,7 +2807,8 @@ def _d_directivity_factor(s: SVG, th: Theme) -> None:
 
 def _d_decay_range(s: SVG, th: Theme) -> None:
     """The level budget of one band: INR, the truncation point and the three
-    ISO 3382 evaluation windows with their 15 dB margins."""
+    ISO 3382 evaluation windows with their 15 dB margins.
+    """
     x0, x1 = 118.0, 588.0  # time axis
     y0, y1 = 84.0, 384.0  # 0 dB to -70 dB
     per_db = (y1 - y0) / 70.0
@@ -2937,7 +2946,8 @@ def _d_decay_range(s: SVG, th: Theme) -> None:
 
 def _d_junction_catalogue(s: SVG, th: Theme) -> None:
     """The Annex E junction types, the three path branches and the mass ratio,
-    with the argument pair each drawing maps onto."""
+    with the argument pair each drawing maps onto.
+    """
     dark = bool(th.suffix)
     c_through = th.primary  # K13, the 'through' branch
     c_corner = "#f0a94e" if dark else "#d9820e"  # K12 = K23, the 'corner' branch
@@ -3520,7 +3530,8 @@ def _d_survey_sweep(s: SVG, th: Theme) -> None:
 
 def _d_iso12354_annexl(s: SVG, th: Theme) -> None:
     """The worked building both parts share: two stacked dwellings, the
-    separating floor and its four junctions, and where the thirteen paths run."""
+    separating floor and its four junctions, and where the thirteen paths run.
+    """
     top = 74.0
 
     # ===== Left: a section through the two dwellings =====
@@ -3665,7 +3676,8 @@ def _d_iso12354_annexl(s: SVG, th: Theme) -> None:
 
 def _d_resilient_buildups(s: SVG, th: Theme) -> None:
     """Floating floor, discrete mounts and a wall lining in section, each with
-    the formula its construction detail selects."""
+    the formula its construction detail selects.
+    """
     top = 74.0
     col = (48.0, 330.0, 612.0)
     cw = 240.0

--- a/scripts/diagrams/canvas.py
+++ b/scripts/diagrams/canvas.py
@@ -285,7 +285,7 @@ def _comment(s: str) -> str:
 
 
 def _math_tokens(run: str, s: str, script: bool = False) -> list[tuple[str, str]]:
-    """Split one math run into ``(kind, text)`` chunks.
+    r"""Split one math run into ``(kind, text)`` chunks.
 
     ``var`` is set in italic: at the baseline a single letter -- Latin or
     lowercase Greek, with any combining marks -- and at script level
@@ -295,7 +295,7 @@ def _math_tokens(run: str, s: str, script: bool = False) -> list[tuple[str, str]
     ``up`` stays upright: digits, operators, primes, brackets, capital
     Greek letters at every level (``Δ``, ``Φ``: operators and descriptors
     per the roman Δ of ISO 80000-2, the ``Δ_SOR`` print of ECAC Doc 29 and
-    the upright ``\\Delta`` mathtext sets in the matplotlib figures), and
+    the upright ``\Delta`` mathtext sets in the matplotlib figures), and
     at the baseline runs of two or more Latin letters, which are operator
     names and acronyms (log, grad, CN), never products; a product of two
     symbols is written with an explicit space or middle dot between them. ``sub`` and ``sup``
@@ -403,7 +403,7 @@ def _math_tokens(run: str, s: str, script: bool = False) -> list[tuple[str, str]
 
 
 def _math_runs(s: str) -> list[tuple[str, bool, float, float]]:
-    """Chunk a translated ``$...$`` string into styled runs.
+    r"""Chunk a translated ``$...$`` string into styled runs.
 
     Each run is ``(text, italic, shift, scale)``: the glyphs, whether they
     are italicised, how far the baseline drops (positive) or rises
@@ -430,7 +430,7 @@ def _math_runs(s: str) -> list[tuple[str, bool, float, float]]:
     ``$Δ_{SOR}$``, ``$Φ$``) -- in this corpus a capital Greek letter is an
     operator or a descriptor, matching the roman Δ of difference of ISO
     80000-2, the ``Δ_SOR`` print of ECAC Doc 29 §4.5.7 and the upright
-    ``\\Delta`` matplotlib's mathtext sets in the figures. The
+    ``\Delta`` matplotlib's mathtext sets in the figures. The
     grid steps ``dx``/``dt`` follow that baseline rule inside a formula
     (upright, per the roman d of ISO 80000-2); in plain prose ("dt from
     the Courant number") they are not mathematics and take no ``$...$``.

--- a/scripts/diagrams/devices.py
+++ b/scripts/diagrams/devices.py
@@ -815,7 +815,8 @@ def _d_box_array(s: SVG, th: Theme) -> None:
 def _d_radiation_factor(s: SVG, th: Theme) -> None:
     """The second, paired measurement Part 2 needs: an ISO 9614 intensity scan
     over a surface offset from the casing, taken on the same machine in the
-    same operating mode as the velocity survey that runs on the casing."""
+    same operating mode as the velocity survey that runs on the casing.
+    """
     gy = 400.0
     s.ground(gy, 60.0, 560.0)
 
@@ -1150,7 +1151,8 @@ def _d_loudspeaker_freefield(s: SVG, th: Theme) -> None:
 def _d_vibration_sound_power(s: SVG, th: Theme) -> None:
     """ISO/TS 7849 surface-velocity method: the machine's radiating surface
     divided into N equal cells, one accelerometer per cell centre, and the
-    survey sound power from the mean velocity level over the area S."""
+    survey sound power from the mean velocity level over the area S.
+    """
     gy = 470.0
     s.ground(gy, 50.0, 560.0)
 
@@ -1264,7 +1266,8 @@ def _d_swept_sine(s: SVG, th: Theme) -> None:
     """Farina's exponential-sweep method: sweep through the weakly nonlinear
     DUT, deconvolve with the inverse filter, and the order-n distortion
     products compress into impulse responses L*ln(n) ahead of the linear
-    one (L = 0.701 s for 20 Hz to 6 kHz in 4 s; 260 px per second)."""
+    one (L = 0.701 s for 20 Hz to 6 kHz in 4 s; 260 px per second).
+    """
 
     def box(x0: float, x1: float, y0: float, l1: str, l2: str, color: str) -> None:
         s.rect(x0, y0, x1 - x0, 76.0, th.panel, color, rx=10, sw=2)
@@ -1357,7 +1360,8 @@ def _d_swept_sine(s: SVG, th: Theme) -> None:
 def _d_program_loudness(s: SVG, th: Theme) -> None:
     """K-weighting, 400 ms blocks and the two gates into the integrated
     loudness of the guide's example (I = -23.1 LUFS, relative threshold
-    -39.0 LUFS), with the LRA and true-peak branches beside the chain."""
+    -39.0 LUFS), with the LRA and true-peak branches beside the chain.
+    """
     cx, bw = 450.0, 560.0
     x0 = cx - bw / 2
 
@@ -1462,7 +1466,8 @@ def _d_noise_control(s: SVG, th: Theme) -> None:
     machine enclosure (IL = R - C = 25 dB at 500 Hz), a duct run with the
     m = 4 expansion chamber (TL peak 6.5 dB at 286 Hz), a lined elbow
     (6 dB at 1 kHz), the open-end reflection (18 dB at 63 Hz) and an
-    operator cabin rated by the same IL = R - C (31 dB at 1 kHz)."""
+    operator cabin rated by the same IL = R - C (31 dB at 1 kHz).
+    """
     gy = 440.0
     s.ground(gy, 40.0, 860.0)
     for zx in (340.0, 660.0):

--- a/scripts/diagrams/environment.py
+++ b/scripts/diagrams/environment.py
@@ -252,7 +252,8 @@ def _d_impulse_prominence(s: SVG, th: Theme) -> None:
 def _d_wind_turbine(s: SVG, th: Theme) -> None:
     """IEC 61400-11 apparent-sound-power geometry: downwind ground-board
     microphone at R0 = H + D/2, slant distance R1 to the rotor centre and
-    the Figure 3 plan-view position pattern."""
+    the Figure 3 plan-view position pattern.
+    """
     import math
 
     gy = 470.0
@@ -408,7 +409,8 @@ def _d_ground_reflection(s: SVG, th: Theme) -> None:
     """Two-path ground interference: source, receiver, direct ray, the
     specular reflection unfolded through the image source, and the path
     difference that sets the interference phase (ISO 9613-2 ground effect,
-    Chien-Soroka geometry)."""
+    Chien-Soroka geometry).
+    """
     gy = 372.0
     sx, sy = 170.0, 232.0  # source (hs = 140 px)
     rx, ry = 700.0, 282.0  # receiver capsule tip (hr = 90 px)
@@ -506,7 +508,8 @@ def _d_atmospheric_refraction(s: SVG, th: Theme) -> None:
     Renterghem 2021, Ch. 11): wind profile arrows, an effective-sound-speed
     inset, downward-curved rays with a ground bounce on the downwind side
     and upward-curved rays opening an acoustic shadow on the upwind side.
-    Horizontal scale about 1 px per metre; heights exaggerated."""
+    Horizontal scale about 1 px per metre; heights exaggerated.
+    """
     gy = 452.0
     sx, sy = 450.0, gy - 56.0  # source, hs = 2 m (schematic)
     mlx, mrx = 90.0, 795.0  # receivers, 350 m to each side
@@ -633,7 +636,8 @@ def _d_ground_barrier(s: SVG, th: Theme) -> None:
     """The guide's barrier geometry: a 1 m source, a 4 m thin screen at
     50 m and a 1.5 m receiver at 100 m. The diffracted segments A and B,
     the blocked direct path d and the barrier_insertion_loss values
-    (N = 0.44 and 10.0 dB at 500 Hz, 15.5 dB at 2 kHz)."""
+    (N = 0.44 and 10.0 dB at 500 Hz, 15.5 dB at 2 kHz).
+    """
     gy = 340.0  # ground; 7 px/m horizontal, 60 px/m vertical
     sx, sy = 110.0, gy - 60.0  # source, hs = 1 m
     ex, ey = 460.0, gy - 240.0  # barrier top edge, 4 m

--- a/scripts/diagrams/materials.py
+++ b/scripts/diagrams/materials.py
@@ -853,7 +853,8 @@ def _dsr_arrangement(
 
 def _d_dynamic_stiffness_rig(s: SVG, th: Theme) -> None:
     """EN 29052-1 rig: the three excitation arrangements of Figures 1 to 3,
-    the specimen preparation of Clauses 5 and 6, and the Formula 4 reading."""
+    the specimen preparation of Clauses 5 and 6, and the Formula 4 reading.
+    """
     s.text(
         450,
         56,
@@ -1016,7 +1017,8 @@ def _d_porous_layer(s: SVG, th: Theme) -> None:
     normal-incidence plane wave, with a magnified microstructure detail and
     the JCA parameter set of the guide's material (sigma = 20 kPa.s/m2,
     phi = 0.98, alpha_inf = 1, Lambda = Lambda' = 87 um); the layered
-    absorber solves alpha = 0.91 at 1 kHz."""
+    absorber solves alpha = 0.91 at 1 kHz.
+    """
     import math
 
     lay_l, lay_r = 560.0, 700.0  # 140 px for 50 mm

--- a/scripts/diagrams/parts.py
+++ b/scripts/diagrams/parts.py
@@ -202,7 +202,8 @@ def _plate_top(
 ) -> None:
     """Horizontal slab in oblique projection: top face, front face and the
     visible right end face. ``(x0, y0)`` = front-left corner of the top face,
-    ``w`` its width, ``dp`` its oblique depth and ``t`` its thickness."""
+    ``w`` its width, ``dp`` its oblique depth and ``t`` its thickness.
+    """
     dxo, dyo = dp * 0.72, dp * 0.55
     s.path(
         f"M {x0} {y0} L {x0 + w} {y0} L {x0 + w + dxo} {y0 - dyo} "
@@ -225,7 +226,8 @@ def _plate_up(
     s: SVG, th: Theme, x0: float, y_base: float, t: float, h: float, dp: float
 ) -> None:
     """Vertical slab in oblique projection standing on ``y_base``: front
-    edge face, top face and the visible right-hand surface."""
+    edge face, top face and the visible right-hand surface.
+    """
     dxo, dyo = dp * 0.72, dp * 0.55
     y_top = y_base - h
     s.rect(x0, y_top, t, h, th.panel, th.fg, sw=1.8)

--- a/scripts/diagrams/perception.py
+++ b/scripts/diagrams/perception.py
@@ -840,7 +840,8 @@ def _d_tone_audibility_acquisition(s: SVG, th: Theme) -> None:
 
 def _d_dosimeter(s: SVG, th: Theme) -> None:
     """ISO 9612 occupational exposure: worn-dosimeter microphone position
-    (Clause 12.3) and the three measurement strategies (Clauses 9-11)."""
+    (Clause 12.3) and the three measurement strategies (Clauses 9-11).
+    """
     # --- Left: worker with a shoulder-mounted personal exposimeter ---------
     s.text(195, 84, "Worn instrument (Clause 12.3)", 18, th.fg, bold=True)
     gy = 560.0
@@ -960,7 +961,8 @@ def _d_sound_quality(s: SVG, th: Theme) -> None:
     """One calibrated signal into the two auditory front ends and the four
     sound-quality metrics of the guide, each with its reference sound and
     the value the library returns for it (1.00 acum, 1.000 tu_HMS,
-    0.9999 asper, 0.9957 vacil_HMS)."""
+    0.9999 asper, 0.9957 vacil_HMS).
+    """
     # Input signal
     s.rect(230, 52, 440, 56, th.panel, th.fg, rx=10, sw=2)
     s.text(450, 76, "Calibrated signal $x(t)$ in pascals", 14, th.fg, bold=True)
@@ -1074,7 +1076,8 @@ def _d_sound_quality(s: SVG, th: Theme) -> None:
 def _d_tone_audibility(s: SVG, th: Theme) -> None:
     """The engineering-method chain on the Annex E combustion-engine
     spectrum: critical band, LS/LT, masking threshold and the 5.01 dB
-    decisive audibility, closing on the Kt = 4 dB tonal adjustment."""
+    decisive audibility, closing on the Kt = 4 dB tonal adjustment.
+    """
     cx, bw = 450.0, 620.0
     x0 = cx - bw / 2
 
@@ -1148,7 +1151,8 @@ def _d_tone_audibility(s: SVG, th: Theme) -> None:
 def _d_psychoacoustic_annoyance(s: SVG, th: Theme) -> None:
     """The four sensations of the guide's worked example (N5 = 30 sone,
     S = 2.0 acum, F = 0.5 vacil, R = 0.3 asper) through the two weightings
-    (wS = 0.1001, wFR = 0.2125) into PA = 37.05."""
+    (wS = 0.1001, wFR = 0.2125) into PA = 37.05.
+    """
     inputs = (
         (
             42.0,
@@ -1224,7 +1228,8 @@ def _d_psychoacoustic_annoyance(s: SVG, th: Theme) -> None:
 def _d_objective_intelligibility(s: SVG, th: Theme) -> None:
     """The shared STOI/ESTOI front end, the split into the two intermediate
     correlations, and the guide's measured example: STOI = 0.727 for
-    speech-like material in a flat masker at 0 dB SNR."""
+    speech-like material in a flat masker at 0 dB SNR.
+    """
     cx, bw = 450.0, 600.0
     x0 = cx - bw / 2
 

--- a/scripts/diagrams/signals.py
+++ b/scripts/diagrams/signals.py
@@ -906,7 +906,8 @@ def _d_equal_loudness_weighting(s: SVG, th: Theme) -> None:
 def _d_slm_chain(s: SVG, th: Theme) -> None:
     """IEC 61672-1 sound level meter: the acoustic front end on the left
     (windscreen, microphone, coupled class 1 calibrator) feeding the
-    four-stage level chain on the right."""
+    four-stage level chain on the right.
+    """
     gy = 508.0
     s.ground(gy, 40.0, 330.0)
 
@@ -967,7 +968,8 @@ def _d_slm_chain(s: SVG, th: Theme) -> None:
 def _d_system_measurement(s: SVG, th: Theme) -> None:
     """Classic dual-channel frequency-response measurement: generator into
     amplifier and loudspeaker, microphone back in, the electrical reference
-    on channel 1, and Welch cross-spectra feeding H1 and coherence."""
+    on channel 1, and Welch cross-spectra feeding H1 and coherence.
+    """
 
     def box(
         x0: float, x1: float, y0: float, h: float, l1: str, l2: str, color: str
@@ -1080,7 +1082,8 @@ def _d_system_measurement(s: SVG, th: Theme) -> None:
 def _d_test_signals(s: SVG, th: Theme) -> None:
     """Labelled miniature of each stimulus: white and pink noise with their
     PSD slopes, an MLS chip stream, linear versus exponential sweeps on a
-    time-frequency sketch and an IEC 60268-1 tone burst."""
+    time-frequency sketch and an IEC 60268-1 tone burst.
+    """
     import math
 
     def tile(x: float, y: float, w: float, title: str) -> None:
@@ -1209,7 +1212,8 @@ def _d_test_signals(s: SVG, th: Theme) -> None:
 def _d_spectral_analysis(s: SVG, th: Theme) -> None:
     """The Welch estimator as a chain, with the numbers of the guide's own
     example (fs = 48 kHz, 20 s of pink noise, nperseg = 4096): 467 raw
-    segments, 442 effective averages, eps_r = 4.8 %."""
+    segments, 442 effective averages, eps_r = 4.8 %.
+    """
     cx, bw = 450.0, 680.0
     x0 = cx - bw / 2
 
@@ -1289,7 +1293,8 @@ def _d_spectral_analysis(s: SVG, th: Theme) -> None:
 def _d_miso_coherence(s: SVG, th: Theme) -> None:
     """Two correlated inputs through their paths into one output, then the
     Welch cross-spectral matrix, the conditioning and the per-source split,
-    with the guide's measured numbers (ordinary 0.32 vs partial 0.00)."""
+    with the guide's measured numbers (ordinary 0.32 vs partial 0.00).
+    """
 
     def box(
         x0: float,
@@ -1403,7 +1408,8 @@ def _d_miso_coherence(s: SVG, th: Theme) -> None:
 def _d_time_frequency(s: SVG, th: Theme) -> None:
     """The same record tiled by a short and a long STFT window at
     fs = 16 kHz: nperseg = 256 (16 ms x 62.5 Hz cells) against 1024
-    (64 ms x 15.6 Hz), with a tone and a click smeared to cell size."""
+    (64 ms x 15.6 Hz), with a tone and a click smeared to cell size.
+    """
     panels = (
         (
             100.0,
@@ -1481,7 +1487,8 @@ def _d_time_frequency(s: SVG, th: Theme) -> None:
 def _d_cepstrum_echoes(s: SVG, th: Theme) -> None:
     """Signal with an 8 ms echo, rippled spectrum, log, inverse FFT, and the
     quefrency axis with the rahmonic spikes and the lifter split, using the
-    guide's exact numbers (a = 0.5, 1/t0 = 125 Hz, +3.5/−6.0 dB)."""
+    guide's exact numbers (a = 0.5, 1/t0 = 125 Hz, +3.5/−6.0 dB).
+    """
 
     def box(x0: float, x1: float, l1: str, l2: str, l3: str, color: str) -> None:
         s.rect(x0, 64, x1 - x0, 86, th.panel, color, rx=10, sw=2)
@@ -1680,7 +1687,8 @@ def _d_echo_geometry(s: SVG, th: Theme) -> None:
 def _d_synchronous_averaging(s: SVG, th: Theme) -> None:
     """Trigger train, sliced recording, coherent average and residual, with
     the guide's numbers: T = 1/32 s at 8192 Hz, N = 40 averages, 16 dB of
-    noise reduction, and McFadden's 32.05-order node example."""
+    noise reduction, and McFadden's 32.05-order node example.
+    """
     import math
 
     s.text(
@@ -1991,7 +1999,8 @@ def _d_tsa_setup(s: SVG, th: Theme) -> None:
 def _d_correlation_delay(s: SVG, th: Theme) -> None:
     """Two microphones, the extra path c*tau, and the correlogram where the
     direct correlator smears while GCC-PHAT spikes at the guide's delay of
-    20 samples at 8192 Hz (2.44 ms, 0.84 m at 343 m/s)."""
+    20 samples at 8192 Hz (2.44 ms, 0.84 m at 343 m/s).
+    """
     gy = 300.0
     s.ground(gy, 60, 840)
 
@@ -2078,7 +2087,8 @@ def _d_correlation_delay(s: SVG, th: Theme) -> None:
 def _d_data_qualification(s: SVG, th: Theme) -> None:
     """Record to segment mean squares to the reverse arrangement count and
     the Table A.6 verdict, with the guide's numbers: N = 20 segments,
-    acceptance (64, 125), A = 91 accepted and A = 7 rejected."""
+    acceptance (64, 125), A = 91 accepted and A = 7 rejected.
+    """
     cx = 450.0
     x0, bw = 170.0, 560.0
 
@@ -2159,7 +2169,8 @@ def _d_slm_pipeline(s: SVG, th: Theme) -> None:
     """The guide's own pipeline: the two recordings that go in, the single
     sensitivity factor that makes them physical, and the three readout
     branches (display statistics, integrated levels, band spectrum) that a
-    class 1 meter reports, closed by the class verifiers."""
+    class 1 meter reports, closed by the class verifiers.
+    """
     # --- The two recordings the meter needs, from the same input chain -----
     for x0, l1, l2 in (
         (40.0, "Calibrator tone", "94 dB at 1 kHz  (IEC 60942)"),
@@ -2274,7 +2285,8 @@ def _d_calibration_dataflow(s: SVG, th: Theme) -> None:
     """The data flow of the calibration guide: the calibrator recording
     yields one factor, the measurement recording carries the samples, and
     every level function takes the factor as ``calibration_factor``. The
-    dBFS reference frame is the branch taken when no factor exists."""
+    dBFS reference frame is the branch taken when no factor exists.
+    """
     # --- The two recordings, which must come from the same untouched chain --
     for x0, l1, l2 in (
         (40.0, "Calibrator recording", "1 kHz tone through the chain"),
@@ -2359,7 +2371,8 @@ def _d_bank_dataflow(s: SVG, th: Theme) -> None:
     """The two numerical-stability strategies of the filter bank as one
     path: every band is a biquad cascade, and a low band takes the decimated
     branch first. Both branches end in the band level; ``sigbands=True``
-    also brings the band signal back to the input rate."""
+    also brings the band signal back to the input rate.
+    """
     # --- Input and the per-band decision ------------------------------------
     s.rect(290, 54, 320, 64, th.panel, th.fg, rx=12, sw=2)
     s.text(450, 84, "Input signal  $x(t)$", 18, th.fg, bold=True)

--- a/scripts/diagrams/underwater.py
+++ b/scripts/diagrams/underwater.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 def _d_hydrophone_deployment(s: SVG, th: Theme) -> None:
     """ISO 17208-1 deep-water geometry: ship transiting past a buoy-suspended
     vertical array of three hydrophones at 15/30/45 degree depression angles,
-    lateral CPA distance of at least 100 m, plus the plan-view data window."""
+    lateral CPA distance of at least 100 m, plus the plan-view data window.
+    """
     import math
 
     surf = 150.0
@@ -165,7 +166,8 @@ def _d_hydrophone_deployment(s: SVG, th: Theme) -> None:
 def _d_sofar_channel(s: SVG, th: Theme) -> None:
     """The deep sound channel: measured North Atlantic values (sound speed
     1524 m/s at the surface, minimum near 1492 m/s at the 1200 m axis,
-    1527 m/s at 4800 m) and rays oscillating about the channel axis."""
+    1527 m/s at 4800 m) and rays oscillating about the channel axis.
+    """
     import math
 
     surf, bot = 100.0, 520.0
@@ -267,7 +269,8 @@ def _d_sofar_channel(s: SVG, th: Theme) -> None:
 def _d_pile_driving_deployment(s: SVG, th: Theme) -> None:
     """ISO 18406 piling survey: the monopile and hammer, the 750 m measurement
     position, the allowed hydrophone depth band in the lower half of a 30 m
-    water column, and the additional positions at three times the water depth."""
+    water column, and the additional positions at three times the water depth.
+    """
     import math
 
     surf, bed = 170.0, 440.0  # 30 m of water over 270 px
@@ -475,7 +478,8 @@ def _d_pile_driving_deployment(s: SVG, th: Theme) -> None:
 def _d_sonar_equation(s: SVG, th: Theme) -> None:
     """The two sonar geometries the equations encode: a passive one-way path
     against ambient noise, and an active monostatic two-way path against a
-    target strength and reverberation, with the reference conventions."""
+    target strength and reverberation, with the reference conventions.
+    """
 
     def _noise_field(x1: float, x2: float, y1: float, y2: float) -> None:
         """Isotropic ambient field, drawn as a sparse stipple."""
@@ -637,7 +641,8 @@ def _d_sonar_equation(s: SVG, th: Theme) -> None:
 def _d_underwater_waveguide(s: SVG, th: Theme) -> None:
     """Range-depth section with the coordinate frame, the two boundary
     conditions, the c(z) profile, the source and receiver depths, one turning
-    ray, and what each of the four solvers computes in that same frame."""
+    ray, and what each of the four solvers computes in that same frame.
+    """
     import math
 
     surf, bot = 120.0, 400.0
@@ -768,7 +773,8 @@ def _d_underwater_waveguide(s: SVG, th: Theme) -> None:
 def _d_marine_mammal_exposure(s: SVG, th: Theme) -> None:
     """Where the spectrum is measured against where the criterion applies: the
     hydrophone at the ISO 18406 range, the animal further out, the three steps
-    between them, and the two isopleths of the dual metric."""
+    between them, and the two isopleths of the dual metric.
+    """
     surf, bed = 150.0, 366.0
     px_, hx_, ax_ = 92.0, 250.0, 430.0
 

--- a/scripts/diagrams/vibration.py
+++ b/scripts/diagrams/vibration.py
@@ -519,7 +519,8 @@ def _d_iso2631_5_setup(s: SVG, th: Theme) -> None:
 def _d_fault_kinematics(s: SVG, th: Theme) -> None:
     """Where the fault frequencies come from: the bearing in end section and
     in axial half-section (where the contact angle lives), the gear pair and
-    the ducted fan's rotating lobe pattern."""
+    the ducted fan's rotating lobe pattern.
+    """
     import math
 
     # ===== Panel 1: rolling-contact bearing, end section ====================
@@ -699,7 +700,8 @@ def _d_fault_kinematics(s: SVG, th: Theme) -> None:
 
 def _d_machine_diagnostics(s: SVG, th: Theme) -> None:
     """Condition-monitoring measurement on a motor-gearbox train: where the
-    accelerometers go, how they are mounted, and what the analyser records."""
+    accelerometers go, how they are mounted, and what the analyser records.
+    """
     gy = 262.0  # top of the baseplate
     shaft_y = 222.0
 
@@ -839,7 +841,8 @@ def _d_machine_diagnostics(s: SVG, th: Theme) -> None:
 
 def _d_mobility_rig(s: SVG, th: Theme) -> None:
     """ISO 7626 rig: free-free beam, exciter + impedance head at the driving
-    point, accelerometer at a transfer point, impact-hammer variant."""
+    point, accelerometer at a transfer point, impact-hammer variant.
+    """
     cy_top, beam_top, beam_h = 116.0, 286.0, 26.0
     beam_bot = beam_top + beam_h
     # Ceiling with soft suspension.
@@ -974,7 +977,8 @@ def _d_mobility_rig(s: SVG, th: Theme) -> None:
 
 def _d_transfer_stiffness_rig(s: SVG, th: Theme) -> None:
     """ISO 10846: isolator between the driven input mass and a blocked output
-    (direct, force transducer) or a blocking mass (indirect)."""
+    (direct, force transducer) or a blocking mass (indirect).
+    """
     for cx, head in (
         (250.0, "Direct method (Part 2)"),
         (650.0, "Indirect method (Part 3)"),
@@ -1160,7 +1164,8 @@ def _d_transfer_stiffness_rig(s: SVG, th: Theme) -> None:
 def _d_junction_rig(s: SVG, th: Theme) -> None:
     """ISO 10848 junction rig: an L- and a T-junction of concrete plates,
     structure-borne excitation on element i, accelerometers on i and j and
-    the junction length l_ij along the corner line."""
+    the junction length l_ij along the corner line.
+    """
     gy = 430.0
     dp = 170.0
     dxo, dyo = dp * 0.72, dp * 0.55
@@ -1252,7 +1257,8 @@ def _d_junction_rig(s: SVG, th: Theme) -> None:
 def _d_power_injection_rig(s: SVG, th: Theme) -> None:
     """The experimental-SEA rig: two plates joined along an edge, a shaker
     through an impedance head on one of them, accelerometers distributed over
-    both, and the drive moved for the second run of the two-drive scheme."""
+    both, and the drive moved for the second run of the two-drive scheme.
+    """
     gy = 380.0
     dp = 116.0
     dxo, dyo = dp * 0.72, dp * 0.55

--- a/scripts/figures/fields/_core.py
+++ b/scripts/figures/fields/_core.py
@@ -261,7 +261,8 @@ def _anim_speaker(
     cone, the cone tip on the ``x0`` plane, centred on ``y_mid`` for the
     given ``bore``. The tip stops ``tip_inset`` short of each bore edge
     (3 % of the bore when omitted); a "loudspeaker" caption is drawn at
-    ``label_y`` when given (``None`` skips it)."""
+    ``label_y`` when given (``None`` skips it).
+    """
     from matplotlib.patches import Polygon, Rectangle
 
     if tip_inset is None:

--- a/scripts/figures/fields/absorption_placement.py
+++ b/scripts/figures/fields/absorption_placement.py
@@ -121,7 +121,8 @@ def _ap_linings() -> tuple[float, float, float, float]:
 
 def _ap_fit_t60(t: Any, level: Any, lo: float, hi: float) -> float:
     """T60 extrapolated from a straight fit of the decay between two levels,
-    the T20/T30 practice of the measurement guides."""
+    the T20/T30 practice of the measurement guides.
+    """
     m = (level <= lo) & (level >= hi) & (t > 0.015)
     slope = float(np.polyfit(t[m], level[m], 1)[0])
     return -60.0 / slope
@@ -240,7 +241,8 @@ def animate_fdtd_absorption_placement(output_dir: str) -> None:
     cannot tell the rooms apart: the spread room decays inside the band,
     the concentrated room's decay bends and its tail leaves it, and the
     per-frame RMS panel shows the surviving field running nearly parallel
-    to the absorbing pair, in horizontal stripes."""
+    to the absorbing pair, in horizontal stripes.
+    """
     from matplotlib import patheffects
     from matplotlib.patches import Rectangle
 

--- a/scripts/figures/fields/aperture.py
+++ b/scripts/figures/fields/aperture.py
@@ -117,7 +117,8 @@ def animate_fdtd_aperture_slit(output_dir: str) -> None:
     the library gives the narrow slit's transmission coefficient. The
     shadow side of each instantaneous panel rides its own annotated
     display gain so the slit's re-radiation is visible next to the
-    standing wave facing the wall; the RMS row keeps one shared scale."""
+    standing wave facing the wall; the RMS row keeps one shared scale.
+    """
     from matplotlib import patheffects
     from matplotlib.patches import Rectangle
 

--- a/scripts/figures/fields/barrier.py
+++ b/scripts/figures/fields/barrier.py
@@ -133,7 +133,8 @@ def animate_fdtd_barrier(output_dir: str) -> None:
     """A point source behind a thin rigid barrier on reflecting ground
     (2D FDTD), at 100 Hz and 500 Hz side by side: the long wavelength
     diffracts around the edge and fills the shadow zone, the short one is
-    cast into a deep, clean shadow -- why barriers fail at low frequency."""
+    cast into a deep, clean shadow -- why barriers fail at low frequency.
+    """
     from matplotlib import patheffects
     from matplotlib.patches import Rectangle
 

--- a/scripts/figures/fields/diffusion.py
+++ b/scripts/figures/fields/diffusion.py
@@ -167,7 +167,8 @@ def animate_fdtd_diffusion(output_dir: str) -> None:
     collimated specular beam back, the diffuser's phase-step wells spray
     the same energy into a wide fan; the scattered field (total minus
     incident) and the arc diffusion coefficients make the contrast
-    quantitative."""
+    quantitative.
+    """
     from matplotlib import patheffects
     from matplotlib.patches import Polygon
 

--- a/scripts/figures/fields/dispersion.py
+++ b/scripts/figures/fields/dispersion.py
@@ -75,7 +75,8 @@ def _disp_group_speed(cells: Any, courant: float) -> Any:
 def _disp_phase_speed(cells: Any, courant: float) -> Any:
     """Exact discrete phase speed / c on the grid axis, in cells per
     wavelength: ``arcsin(S sin theta) / (S theta)``. This is the error the
-    guide's ``(1 - S^2)(k dx)^2 / 24`` approximates."""
+    guide's ``(1 - S^2)(k dx)^2 / 24`` approximates.
+    """
     theta = np.pi / np.asarray(cells, dtype=float)
     arg = np.clip(courant * np.sin(theta), -1.0, 1.0)
     return np.arcsin(arg) / theta / courant
@@ -192,7 +193,8 @@ def animate_fdtd_dispersion(output_dir: str) -> None:
     the gap in metres against the closed form. The coarse tube reaches the
     finish line milliseconds late; the fine one arrives on time. The side
     panel carries the speed-error law the three measurements are read
-    against, phase and group."""
+    against, phase and group.
+    """
     T = _translate_str
     tubes, times, courant = _dispersion_fields()
     colors = (COLOR_SECONDARY, COLOR_PRIMARY, COLOR_TERTIARY)

--- a/scripts/figures/fields/ducting.py
+++ b/scripts/figures/fields/ducting.py
@@ -128,7 +128,8 @@ def animate_fdtd_ducting(output_dir: str) -> None:
     toward the sound-speed minimum and stay trapped; launched near the
     surface the energy crosses the channel and leaks away to depth. The
     closing seconds crossfade to the time-integrated energy map, so the
-    verdict frame shows the whole path history."""
+    verdict frame shows the whole path history.
+    """
     from matplotlib import patheffects
 
     T = _translate_str

--- a/scripts/figures/fields/elastic.py
+++ b/scripts/figures/fields/elastic.py
@@ -165,7 +165,8 @@ def animate_elastic_plate_junction(output_dir: str) -> None:
     identical perpendicular plate it splits into a reflected and a
     transmitted bending wave plus a fast in-plane precursor, and the
     verdict pill quotes the closed-form junction_transmission coefficient
-    the guide computes for this corner."""
+    the guide computes for this corner.
+    """
     from matplotlib.patches import Rectangle
 
     from phonometry import vibration
@@ -565,7 +566,8 @@ def animate_elastic_coincidence(output_dir: str) -> None:
     quote the oblique mass law (Bies Eq. 7.41) each panel is judged
     against. Both panels draw the air below the plate with the same
     annotated display gain, so the transmitted field is legible next to an
-    incident wave some 45 dB louder."""
+    incident wave some 45 dB louder.
+    """
     from matplotlib import patheffects
     from matplotlib.patches import Rectangle
 

--- a/scripts/figures/fields/expansion_chamber.py
+++ b/scripts/figures/fields/expansion_chamber.py
@@ -34,7 +34,8 @@ _CHAMBER_DX = 0.0025
 
 def _expansion_chamber_freqs() -> tuple[float, float]:
     """The two CW carriers: full transmission at ``kL = pi`` and the TL
-    peak at ``kL = pi/2`` of the 0.30 m chamber (Bies Eq. (8.111))."""
+    peak at ``kL = pi/2`` of the 0.30 m chamber (Bies Eq. (8.111)).
+    """
     return 343.0 / (2.0 * _CHAMBER_L), 343.0 / (4.0 * _CHAMBER_L)
 
 
@@ -127,7 +128,8 @@ def animate_fdtd_expansion_chamber(output_dir: str) -> None:
     (the pi round trip across the chamber returns both echoes to the
     inlet in phase) and the wave is sent back up the inlet, leaving the
     outlet at less than half amplitude (the 6.5 dB four-pole TL peak).
-    No absorption anywhere: a purely reactive silencer."""
+    No absorption anywhere: a purely reactive silencer.
+    """
     T = _translate_str
     (p_pass, e_pass), (p_stop, e_stop), times, tls = _expansion_chamber_fields()
     f_pass, f_peak = _expansion_chamber_freqs()
@@ -276,7 +278,8 @@ def _anim_chamber_hardware(
 ) -> None:
     """Draw the silencer as hardware: inlet/outlet pipe walls, the chamber
     shell with its end plates, the drive loudspeaker and the anechoic
-    termination, all to scale (metres)."""
+    termination, all to scale (metres).
+    """
     from matplotlib.patches import Rectangle
 
     wall = 0.012

--- a/scripts/figures/fields/ground_effect.py
+++ b/scripts/figures/fields/ground_effect.py
@@ -151,7 +151,8 @@ def animate_fdtd_ground_effect(output_dir: str) -> None:
     and ground-reflected wavefronts interfere and the lobe pattern forms;
     the ghosted image source below the ground explains the geometry, and the
     level sampled on an 8 m arc converges to the two-path model with its
-    predicted nulls."""
+    predicted nulls.
+    """
     from matplotlib import patheffects
 
     T = _translate_str

--- a/scripts/figures/fields/metadiffuser.py
+++ b/scripts/figures/fields/metadiffuser.py
@@ -357,7 +357,8 @@ def animate_fdtd_metadiffuser(output_dir: str) -> None:
     """The 27 cm deep Schroeder QRD vs the 2 cm metadiffuser that mimics
     it, next to a flat control slab (2D FDTD at 0.25 mm, real slits, necks
     and cavities meshed): the same 2 kHz wavefront leaves the same kind of
-    scattered fan, from a panel 13.7 times thinner."""
+    scattered fan, from a panel 13.7 times thinner.
+    """
     from matplotlib import patheffects
     from matplotlib.patches import Polygon, Rectangle
 

--- a/scripts/figures/fields/pillar_hall.py
+++ b/scripts/figures/fields/pillar_hall.py
@@ -174,7 +174,8 @@ def _pillar_fields(n_frames: int = _PILLAR_FRAMES) -> tuple[Any, Any]:
 def animate_fdtd_pillar_hall(output_dir: str) -> None:
     """README banner: an 800 Hz plane wavefront sweeps through a hall of
     rigid columns (2D FDTD at 2.5 mm): every pillar diffracts the front and
-    the scattered wavelets interfere until they fill the whole hall."""
+    the scattered wavelets interfere until they fill the whole hall.
+    """
     from matplotlib.patches import Circle
 
     T = _translate_str

--- a/scripts/figures/fields/radiation_efficiency.py
+++ b/scripts/figures/fields/radiation_efficiency.py
@@ -77,7 +77,8 @@ _RE_VLIM = 1.6
 
 def _re_geometry() -> tuple[float, float, float, float]:
     """View extent ``(x0, x1, h0, h1)`` [m], x from the left of the view and
-    h measured from the plate's upper face, positive upwards."""
+    h measured from the plate's upper face, positive upwards.
+    """
     dx = _EL_DX
     x1 = (_RE_VIEW_COLS[1] - _RE_VIEW_COLS[0]) * dx
     h1 = (_RE_R0 - _RE_VIEW_ROWS[0]) * dx

--- a/scripts/figures/fields/refraction.py
+++ b/scripts/figures/fields/refraction.py
@@ -35,7 +35,8 @@ _REFR_FPS = 80
 
 def _refraction_profiles() -> tuple[Any, ...]:
     """The guide's realistic logarithmic surface-layer profiles: downwind
-    (+1 m/s) and upwind (-1 m/s) effective sound speed."""
+    (+1 m/s) and upwind (-1 m/s) effective sound speed.
+    """
     from phonometry import environment
 
     return tuple(
@@ -168,7 +169,8 @@ def animate_fdtd_refraction(output_dir: str) -> None:
     they lift off the surface and an acoustic shadow opens at the ground.
     The library's ray fans, traced through the same c(z) profiles,
     overlay the fields; the closing seconds crossfade to the
-    spreading-compensated RMS map."""
+    spreading-compensated RMS map.
+    """
     from matplotlib import patheffects
 
     from phonometry import environment

--- a/scripts/figures/fields/room_modes.py
+++ b/scripts/figures/fields/room_modes.py
@@ -90,7 +90,8 @@ def animate_fdtd_room_modes(output_dir: str) -> None:
     """On-mode vs off-mode CW drive in a rigid 5 x 3.5 m room (2D FDTD):
     on resonance the (2,1) standing-wave pattern grows until it dominates
     the field; off resonance the forced response stays weak and never
-    organises into that nodal structure."""
+    organises into that nodal structure.
+    """
     from matplotlib import patheffects
 
     T = _translate_str

--- a/scripts/figures/fields/seabed.py
+++ b/scripts/figures/fields/seabed.py
@@ -70,7 +70,8 @@ _SB_T0 = 3.0 * _SB_TAU
 
 def _sb_geometry() -> tuple[int, int, int, int, int]:
     """Visible columns and rows, the seabed row inside the visible block,
-    and the source cell in absolute grid indices."""
+    and the source cell in absolute grid indices.
+    """
     n_vis = round(_SB_RANGE / _SB_DX)
     rows_water = round(_SB_WATER / _SB_DX)
     n_rows = rows_water + round(_SB_SED / _SB_DX)
@@ -96,14 +97,14 @@ def _sb_front_angle(times: Any) -> Any:
 
 @lru_cache(maxsize=1)
 def _seabed_fields() -> tuple[Any, ...]:
-    """Two runs of one water-over-sediment scene, sand and mud, cached.
+    r"""Two runs of one water-over-sediment scene, sand and mud, cached.
 
     Identical but for ``c2`` and ``rho2``. Sponges on all four sides, so
     the only interface in the model is the seabed and nothing returns from
     the edges. The source is a one-cycle 100 Hz Gaussian-modulated burst.
 
     The measurement is the **net energy flux through the seabed**,
-    ``\\int p v_z dt`` accumulated per column on the interface face: it is
+    ``\int p v_z dt`` accumulated per column on the interface face: it is
     exactly what enters the bottom, it needs no ray tracing, and an
     evanescent skin contributes nothing to it, which is what makes the sand
     run go to zero past the critical ray instead of merely dim.
@@ -244,7 +245,8 @@ def animate_fdtd_critical_angle(output_dir: str) -> None:
     which has no critical angle, sound enters the bottom at every angle
     right out to the edge of the frame. A lower axis fills in the measured
     energy flux through the seabed behind the contact point and lands on
-    the closed form."""
+    the closed form.
+    """
     from matplotlib.patches import Rectangle
 
     from phonometry import underwater

--- a/scripts/figures/fields/side_branch.py
+++ b/scripts/figures/fields/side_branch.py
@@ -216,7 +216,8 @@ def animate_fdtd_side_branch(output_dir: str) -> None:
     (the junction end correction), and the clip reports the effective
     length c/(4 f_sim) -- the guide's build-long-and-trim procedure done
     on screen. No model TL is annotated anywhere: the lossless notch is
-    infinite at f0, while the charge bandwidth f/Q is percent-wide."""
+    infinite at f0, while the charge bandwidth f/Q is percent-wide.
+    """
     from matplotlib.patches import Rectangle
 
     T = _translate_str

--- a/scripts/figures/fields/slit_absorber.py
+++ b/scripts/figures/fields/slit_absorber.py
@@ -59,7 +59,8 @@ def _slit_absorber_cell_rows(
     dx: float, slit_cells: int, ny: int
 ) -> dict[str, tuple[int, int]]:
     """Row/column spans of the meshed cell (slit at the top of the period,
-    neck and cavity below it, mirroring ``plot_slit_absorber_geometry``)."""
+    neck and cavity below it, mirroring ``plot_slit_absorber_geometry``).
+    """
     res = _slit_absorber_design().resonator
     neck_cells = round(res.neck_length / dx)
     cav_cells = round(res.cavity_length / dx)
@@ -234,7 +235,8 @@ def animate_fdtd_slit_absorber(output_dir: str) -> None:
     library's visco-thermal effective fluids. At the design slit height
     the loss/leakage balance swallows the wave (alpha = 1, flat envelope);
     widening the slit breaks the balance and the reflection rebuilds the
-    standing wave. A zoom shows the field crawling through the slit."""
+    standing wave. A zoom shows the field crawling through the slit.
+    """
     from matplotlib.patches import Rectangle
 
     T = _translate_str
@@ -507,7 +509,8 @@ def _anim_slit_tube_walls(
 ) -> None:
     """Tube walls and drive loudspeaker for the slit-absorber clip (the
     shared ``_anim_tube_hardware`` labels its termination as a plug, but
-    here the termination IS the meshed panel, drawn by the caller)."""
+    here the termination IS the meshed panel, drawn by the caller).
+    """
     from matplotlib.patches import Rectangle
 
     wall = 0.007

--- a/scripts/figures/fields/tubes.py
+++ b/scripts/figures/fields/tubes.py
@@ -50,7 +50,8 @@ def _anim_tube_hardware(
     label_speaker: bool = True,
 ) -> None:
     """Draw the tube as hardware around the FDTD bore: walls, loudspeaker,
-    sample block, microphones and the termination, all to scale (metres)."""
+    sample block, microphones and the termination, all to scale (metres).
+    """
     from matplotlib.patches import Rectangle
 
     wall = 0.014
@@ -255,7 +256,8 @@ def animate_fdtd_impedance_tube(output_dir: str) -> None:
     the standing wave grows deep nulls (|r| ~ 1), while a 10 cm lossy
     sample in front of the same plug leaves the minima shallow: the ISO
     10534-2 microphone pair reads exactly that envelope. One concept: the
-    standing-wave ratio IS the absorption measurement."""
+    standing-wave ratio IS the absorption measurement.
+    """
     T = _translate_str
     (p_e, env_e), (p_s, env_s), times, alpha = _impedance_tube_fields()
     vmax = float(np.quantile(np.abs(p_e), 0.999))
@@ -491,7 +493,8 @@ def animate_fdtd_transmission_tube(output_dir: str) -> None:
     The empty tube passes it unchanged; a 10 cm lossy layer mid-tube splits
     it into a reflection and a weakened transmission that the four ASTM
     E2611 microphones resolve. One concept: transmission loss is what fails
-    to come out the other side."""
+    to come out the other side.
+    """
     T = _translate_str
     p_e, p_s, times, tl = _transmission_tube_fields()
     vmax = float(np.quantile(np.abs(p_e), 0.999))
@@ -588,7 +591,8 @@ def animate_standing_wave_tube(output_dir: str) -> None:
     """ISO 10534-2 impedance tube: the incident and reflected waves travel
     inside a drawn tube and their sum forms the standing-wave envelope; a
     rigid termination (deep nodes) is compared with a porous sample
-    (shallow nodes) sampled by the two wall microphones."""
+    (shallow nodes) sampled by the two wall microphones.
+    """
     from matplotlib.patches import Polygon, Rectangle
 
     T = _translate_str

--- a/scripts/figures/perception.py
+++ b/scripts/figures/perception.py
@@ -2808,7 +2808,8 @@ def generate_htlan_compression(output_dir: str) -> None:
 def generate_exposure_budget(output_dir: str) -> None:
     """The ISO 9612 Annex C budget: where the variance comes from, and what
     reduces it. Left, the Annex D day term by term; right, the expanded
-    uncertainty against the sample count for the two sampling models."""
+    uncertainty against the sample count for the two sampling models.
+    """
     print("Generating exposure_budget.png...")
     from phonometry import hearing
 

--- a/scripts/figures/room.py
+++ b/scripts/figures/room.py
@@ -66,7 +66,8 @@ def generate_schroeder_decay(output_dir: str) -> None:
     def fit_line(decay_range: tuple[float, float]) -> tuple[float, float]:
         """Least-squares (slope, intercept) over an evaluation range,
         replicating room_acoustics._fit_decay_time so the drawn line has
-        slope -60/T with the annotated T."""
+        slope -60/T with the annotated T.
+        """
         mask = (level <= -decay_range[0]) & (level >= -decay_range[1])
         slope, intercept = np.polyfit(time[mask], level[mask], 1)
         return float(slope), float(intercept)

--- a/scripts/figures/schematics.py
+++ b/scripts/figures/schematics.py
@@ -172,7 +172,8 @@ def _draw_speaker(
     ax: Any, x: float, y: float, *, size: float = 1.0, direction: int = 1
 ) -> None:
     """A loudspeaker symbol: cabinet plus cone, radiating toward
-    ``direction`` (+1 = +x, -1 = -x). ``(x, y)`` is the cone mouth centre."""
+    ``direction`` (+1 = +x, -1 = -x). ``(x, y)`` is the cone mouth centre.
+    """
     from matplotlib.patches import Polygon, Rectangle
 
     d = float(direction)
@@ -472,7 +473,8 @@ def _draw_resistor(ax: Any, x0: float, x1: float, y: float) -> None:
 
 def animate_time_weighting_ballistics(output_dir: str) -> None:
     """A tone burst through the IEC 61672-1 RC detector: the capacitor fills
-    and drains while the F/S/I meter needles follow their own ballistics."""
+    and drains while the F/S/I meter needles follow their own ballistics.
+    """
     from matplotlib.patches import FancyBboxPatch, Rectangle
 
     from phonometry import filters
@@ -752,7 +754,8 @@ def animate_time_weighting_ballistics(output_dir: str) -> None:
 
 def animate_onset_detection(output_dir: str) -> None:
     """The NT ACOU 112 detector scanning L_AF with a magnifier; the
-    OR -> LD -> P -> KI decision chain lights up once the onset is found."""
+    OR -> LD -> P -> KI decision chain lights up once the onset is found.
+    """
     from matplotlib.patches import Ellipse
 
     from phonometry import environment
@@ -933,7 +936,8 @@ def animate_onset_detection(output_dir: str) -> None:
 
 def animate_instantaneous_intensity(output_dir: str) -> None:
     """A p-p probe with p/u phasors: the instantaneous intensity arrow flips
-    while its running average settles to net flow (active) or zero (reactive)."""
+    while its running average settles to net flow (active) or zero (reactive).
+    """
     from matplotlib.patches import Circle
 
     T = _translate_str
@@ -1203,7 +1207,8 @@ def animate_instantaneous_intensity(output_dir: str) -> None:
 
 def animate_schroeder(output_dir: str) -> None:
     """Backward integration of p²(t): the tail energy fills up on one axis
-    while the decay curve and its T20/T30 fits emerge on a companion axis."""
+    while the decay curve and its T20/T30 fits emerge on a companion axis.
+    """
     from matplotlib.patches import Patch
 
     from phonometry import room
@@ -1410,7 +1415,8 @@ def animate_schroeder(output_dir: str) -> None:
 def animate_flanking_paths(output_dir: str) -> None:
     """EN 12354-1 junction schematic: energy pulses leave the source room
     over the Dd, Ff, Fd and Df paths, shrinking at the junction, and each
-    path label lights up as its pulse re-radiates into the receiving room."""
+    path label lights up as its pulse re-radiates into the receiving room.
+    """
     from matplotlib.patches import Circle, Rectangle
 
     T = _translate_str
@@ -1651,7 +1657,8 @@ def animate_intensity_scan_power(output_dir: str) -> None:
     """ISO 9614-2 sound power: a p-p probe traces the serpentine scan over
     the top face of the measurement box while the normal-intensity arrows
     appear behind it, and the partial powers of the five faces accumulate
-    into the L_W meter."""
+    into the L_W meter.
+    """
     from matplotlib.patches import Circle, Polygon
 
     T = _translate_str
@@ -1950,7 +1957,8 @@ def animate_intensity_scan_power(output_dir: str) -> None:
 def animate_sweep_deconvolution(output_dir: str) -> None:
     """ISO 18233 swept-sine measurement: the exponential sweep crosses a
     drawn room while its spectrogram builds, then the inverse filter
-    collapses the whole record into the impulse response."""
+    collapses the whole record into the impulse response.
+    """
     from matplotlib.colors import Normalize
     from matplotlib.patches import Rectangle
     from scipy.signal import fftconvolve, spectrogram
@@ -2184,7 +2192,8 @@ def animate_sweep_deconvolution(output_dir: str) -> None:
 def animate_specific_loudness(output_dir: str) -> None:
     """ISO 532-1 specific loudness: the N'(z) pattern of a 1 kHz narrowband
     sound builds along the Bark axis as the band level steps up, and the
-    area under the pattern integrates to the total loudness in sone."""
+    area under the pattern integrates to the total loudness in sone.
+    """
     T = _translate_str
     from phonometry import psychoacoustics
 
@@ -2358,7 +2367,8 @@ def animate_specific_loudness(output_dir: str) -> None:
 def animate_power_two_rooms(output_dir: str) -> None:
     """The same source in an anechoic room (ISO 3745 free field) and in a
     reverberation room (ISO 3741 diffuse build-up): both microphone
-    pressures differ, both routes converge to the same sound power L_W."""
+    pressures differ, both routes converge to the same sound power L_W.
+    """
     from matplotlib.patches import Circle, Polygon, Rectangle
 
     T = _translate_str
@@ -2664,7 +2674,8 @@ def animate_comb_filtering(output_dir: str) -> None:
     """Direct sound plus one floor reflection at a microphone: as the mic
     height changes, the delayed copy shifts and the comb filter in the
     frequency response moves with it, which is why measurement position matters
-    near reflecting surfaces."""
+    near reflecting surfaces.
+    """
     T = _translate_str
     c0 = 343.0
     xs_, hs = 0.6, 1.5  # source position (x, height)
@@ -2887,7 +2898,8 @@ def animate_dynamic_stiffness_sweep(output_dir: str) -> None:
     """EN 29052-1 resonance sweep: the load plate on its resilient specimen
     driven through fr, with the amplitude peaking and the response flipping
     from in phase with the force to a quarter cycle behind it and on to
-    antiphase, which is what the measurement actually reads."""
+    antiphase, which is what the measurement actually reads.
+    """
     from matplotlib.patches import Rectangle
 
     T = _translate_str
@@ -3244,7 +3256,8 @@ def animate_modulation_transfer(output_dir: str) -> None:
     """The IEC 60268-16 modulation transfer function drawn where it lives:
     on a speech-rate intensity envelope. Reverberation shrinks the envelope
     about its mean; steady noise lifts a floor under it. Both shrink m, the
-    m(F) curve and the band MTIs follow, and the STI falls with them."""
+    m(F) curve and the band MTIs follow, and the STI falls with them.
+    """
     T = _translate_str
 
     data = _modulation_transfer_data()
@@ -3497,7 +3510,8 @@ def animate_loudness_gating(output_dir: str) -> None:
     """The BS.1770-5 double gate deciding, block by block: the relative
     threshold is recomputed from the survivors of the first pass, so it
     slides as the programme plays and retroactively drops blocks that were
-    passing. Then the deeper -20 LU gate of the loudness range."""
+    passing. Then the deeper -20 LU gate of the loudness range.
+    """
     T = _translate_str
 
     data = _loudness_gating_data()
@@ -3818,7 +3832,8 @@ def animate_epnl_flyover(output_dir: str) -> None:
     """EPNL built in the order the standard builds it: a spectrum every
     half second, a background fitted under its fan tone, PNLT rising over
     PNL by that correction, and only at the end -- once the peak is known --
-    the 10 dB-down window, the duration correction and the EPNL."""
+    the 10 dB-down window, the duration correction and the EPNL.
+    """
     from matplotlib.patches import Polygon
 
     T = _translate_str
@@ -4143,7 +4158,8 @@ def animate_image_source_buildup(output_dir: str) -> None:
     """A circle expanding from the receiver at c t sweeps the mirror-room
     lattice; every image it reaches writes its arrival into the
     reflectogram, and the running count follows the (4 pi / 3)(c t)^3 / V
-    law whose derivative is the reflection density of the guide."""
+    law whose derivative is the reflection density of the guide.
+    """
     from matplotlib.patches import Circle, Rectangle
 
     from .theme import series_colors
@@ -4461,7 +4477,8 @@ def animate_iso717_shift(output_dir: str) -> None:
     unfavourable deviations is as large as it can be without passing 32.0 dB
     -- the iterative fit behind every single number on the ratings page,
     run once for the airborne engine and once for the impact engine, where
-    the same rule holds with the deviation's sign reversed."""
+    the same rule holds with the deviation's sign reversed.
+    """
     from matplotlib.patches import Patch
 
     T = _translate_str
@@ -4831,7 +4848,8 @@ def _block_vs_exponential_data() -> dict[str, Any]:
 @lru_cache(maxsize=1)
 def _bve_cached() -> dict[str, Any]:
     """One data build per process: 128 Fast-envelope runs are paid once,
-    not once per language x theme variant."""
+    not once per language x theme variant.
+    """
     return _block_vs_exponential_data()
 
 
@@ -4840,7 +4858,8 @@ def animate_block_vs_exponential(output_dir: str) -> None:
     exponential Fast detector answers the same number at every alignment
     because the burst duration is in its differential equation; the block
     integrator's answer swings by nearly 3 dB, because the alignment is all
-    it has. The case study's central claim, measured."""
+    it has. The case study's central claim, measured.
+    """
     T = _translate_str
 
     d = _bve_cached()
@@ -5092,7 +5111,8 @@ def animate_feedback_howl(output_dir: str) -> None:
     3.3 dB above the direct sound; four open microphones cost 6 dB and the
     same loop takes far longer to settle 8.7 dB up; 4 dB more system gain
     puts the loop gain at unity and the copies stop shrinking, which is the
-    howl. Gain before feedback is a convergence condition, not a level."""
+    howl. Gain before feedback is a convergence condition, not a level.
+    """
     from matplotlib.patches import Circle
 
     T = _translate_str

--- a/scripts/figures/theme.py
+++ b/scripts/figures/theme.py
@@ -366,8 +366,7 @@ def plot_psd(
 def measure_weighting_response(
     fs: int, curve: str, freqs: "np.ndarray | None" = None
 ) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Measure a weighting curve the way the docs figure plots it: impulse
+    """Measure a weighting curve the way the docs figure plots it: impulse
     response through the real filter path, evaluated with ``freqz`` (DTFT
     of the measured response).
 

--- a/scripts/figures/underwater.py
+++ b/scripts/figures/underwater.py
@@ -791,7 +791,8 @@ def generate_numerical_propagation(output_dir: str) -> None:
 
 def generate_seawater_absorption(output_dir: str) -> None:
     """Volume absorption of the three models, and how far the two simpler ones
-    depart from the Francois-Garrison reference."""
+    depart from the Francois-Garrison reference.
+    """
     print("Generating seawater_absorption...")
     from phonometry import underwater
 
@@ -1951,7 +1952,8 @@ def _piling_strike(fs: int = 48_000) -> "np.ndarray":
 
 def generate_marine_mammal_assessment(output_dir: str) -> None:
     """The band spectrum the chain starts from, and the same campaign judged
-    for a low-frequency cetacean and for a porpoise."""
+    for a low-frequency cetacean and for a porpoise.
+    """
     print("Generating marine_mammal_assessment...")
     from phonometry import underwater
 
@@ -1987,7 +1989,8 @@ def generate_marine_mammal_assessment(output_dir: str) -> None:
 
 def generate_marine_mammal_exposure_functions(output_dir: str) -> None:
     """The exposure function regulators apply, what the 2024 revision changed,
-    and the criteria of every in-water group side by side."""
+    and the criteria of every in-water group side by side.
+    """
     print("Generating marine_mammal_exposure_functions...")
     from phonometry import underwater
 

--- a/scripts/figures/vibration.py
+++ b/scripts/figures/vibration.py
@@ -13,10 +13,10 @@ from typing import TYPE_CHECKING, Literal
 
 
 def _sci_math(value: float, digits: int = 2) -> str:
-    """A scientific-notation reading composed as mathtext.
+    r"""A scientific-notation reading composed as mathtext.
 
     ``f"{4.4e-3:.2e}"`` writes "4.40e-03", which a figure has no business
-    showing; this returns ``$4.40\\times10^{-3}$``, where mathtext sets the
+    showing; this returns ``$4.40\times10^{-3}$``, where mathtext sets the
     proper multiplication sign and a typographic minus in the exponent.
     """
     exponent = math.floor(math.log10(abs(value)))

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Generate the Starlight API reference from the phonometry docstrings.
+"""Generate the Starlight API reference from the phonometry docstrings.
 
 Renders every public name as committed Markdown pages under
 ``site/src/content/docs/reference/api/`` (one page per public module, grouped
@@ -427,11 +426,11 @@ def render_inline(text: str, xref: dict[str, str], stats: RoleStats) -> str:
 
 
 def _math_bars_to_commands(match: re.Match[str]) -> str:
-    """Spell the vertical bars of a math span as TeX commands.
+    r"""Spell the vertical bars of a math span as TeX commands.
 
-    GFM decodes the ``\\|`` cell escape for prose and code spans but not
-    inside math, where KaTeX would then read it as ``\\|`` and typeset a
-    double bar. ``\\vert``/``\\Vert`` are the same glyphs written without
+    GFM decodes the ``\|`` cell escape for prose and code spans but not
+    inside math, where KaTeX would then read it as ``\|`` and typeset a
+    double bar. ``\vert``/``\Vert`` are the same glyphs written without
     the character the table syntax claims, so they survive the escape.
     """
     span = match.group(0).replace("\\|", "\\Vert ")
@@ -439,12 +438,12 @@ def _math_bars_to_commands(match: re.Match[str]) -> str:
 
 
 def render_cell(text: str, xref: dict[str, str], stats: RoleStats) -> str:
-    """Inline reST -> Markdown for a table cell (single line, pipes escaped).
+    r"""Inline reST -> Markdown for a table cell (single line, pipes escaped).
 
     The ``|`` escape is GFM table syntax: it is decoded back to a literal
     pipe only inside a table row, so it must never be applied to prose
     outside a table (a code span there would show the backslash literally).
-    Math is exempt: its bars become ``\\vert``/``\\Vert`` first, so the
+    Math is exempt: its bars become ``\vert``/``\Vert`` first, so the
     escaping below cannot reach into a formula.
     """
     rendered = render_inline(text, xref, stats)

--- a/scripts/generate_brand.py
+++ b/scripts/generate_brand.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Deterministic generator for the phonometry brand assets: the mark itself and
+"""Deterministic generator for the phonometry brand assets: the mark itself and
 every icon derived from it.
 
 The mark is a wavefront leaving a point source and crossing a measurement grid.

--- a/scripts/generate_diagrams.py
+++ b/scripts/generate_diagrams.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Deterministic SVG generator for the experimental-setup diagrams used in the
+"""Deterministic SVG generator for the experimental-setup diagrams used in the
 documentation. Every diagram is emitted in a light and a dark variant
 (``*_dark.svg``) with the same palette as the matplotlib figures, so the
 docs can theme-switch them exactly like the raster WebP plots.

--- a/scripts/mirror_glossary.py
+++ b/scripts/mirror_glossary.py
@@ -88,7 +88,8 @@ def _localized(value: Any) -> str:
 
 def _relative_link(to_route: str) -> str | None:
     """The mirror-relative path from the glossary to another page, if that page
-    has a mirror file."""
+    has a mirror file.
+    """
     target = DOCS / f"{to_route}.md"
     if not target.exists():
         target = DOCS / to_route / "index.md"
@@ -116,7 +117,8 @@ def _rewrite_links(body: str) -> str:
 
 def _prose() -> str:
     """The page's own prose: everything between the frontmatter and the card
-    component, with the component import dropped."""
+    component, with the component import dropped.
+    """
     text = PAGE.read_text(encoding="utf-8")
     match = re.match(r"---\n.*?\n---\n", text, re.DOTALL)
     if not match:
@@ -156,7 +158,8 @@ def _row(term: dict[str, Any], titles: dict[str, str]) -> str:
 
 def _titles() -> dict[str, str]:
     """The title of every English page, by route, so a link carries the name the
-    site gives the page instead of a hand-kept copy of it."""
+    site gives the page instead of a hand-kept copy of it.
+    """
     found: dict[str, str] = {}
     for page in SITE.rglob("*.md*"):
         route = page.relative_to(SITE).with_suffix("").as_posix()

--- a/scripts/mirror_overviews.py
+++ b/scripts/mirror_overviews.py
@@ -99,7 +99,8 @@ PLANNED: set[Path] = set()
 
 def _relative_link(from_route: str, to_route: str) -> str | None:
     """The mirror-relative path from one route's index to another page, if
-    that page has, or will have, a mirror file."""
+    that page has, or will have, a mirror file.
+    """
     alias = ROUTE_ALIASES.get(to_route)
     if alias is not None:
         target = DOCS / alias

--- a/src/phonometry/_internal/levels_math.py
+++ b/src/phonometry/_internal/levels_math.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Shared decibel-energy arithmetic helpers (private).
+"""Shared decibel-energy arithmetic helpers (private).
 
 Seeded by the library audit: many modules restated the same
 ``10 lg(sum/mean 10^(L/10))`` energy combinations inline. New code

--- a/src/phonometry/_internal/rays.py
+++ b/src/phonometry/_internal/rays.py
@@ -366,12 +366,12 @@ def _sloping_slope(boundary: _Sloping, r: NDArray[np.float64]) -> NDArray[np.flo
 
 
 class DynamicRays(NamedTuple):
-    """The dynamic ray equations to integrate alongside the trajectory.
+    r"""The dynamic ray equations to integrate alongside the trajectory.
 
     :ivar spreading: Per-ray :math:`q(0)`. With :math:`q(0) = 0` and
         :math:`p(0) = 1/c(0)` (Jensen Eq. 3.63) the pair is the geometric
-        spreading, :math:`r\\,q = J`; with :math:`p(0) = 1` and
-        :math:`q(0) = i\\omega W_0^2/2` (Eq. 3.91) it is a Gaussian beam of
+        spreading, :math:`r\,q = J`; with :math:`p(0) = 1` and
+        :math:`q(0) = i\omega W_0^2/2` (Eq. 3.91) it is a Gaussian beam of
         initial half-width :math:`W_0` and flat wavefront.
     :ivar slope: Per-ray :math:`p(0)`, in the same dtype as ``spreading``.
     :ivar profile_depths: Node coordinates of the sound-speed profile,
@@ -392,19 +392,19 @@ class DynamicRays(NamedTuple):
 
 
 class RayMarch(NamedTuple):
-    """Per-ray history of a range march, all of shape ``(n_rays, n_steps)``.
+    r"""Per-ray history of a range march, all of shape ``(n_rays, n_steps)``.
 
     :ivar positions: ``z`` at each range sample.
     :ivar times: Cumulative travel time at each range sample, zero at the start.
     :ivar arc_lengths: Cumulative arc length along the ray at each range sample,
-        zero at the start. :math:`ds/dr = 1/(\\xi c) = 1/\\cos\\theta \\ge 1`
-        with :math:`\\theta` the local ray angle, so it never falls below the
+        zero at the start. :math:`ds/dr = 1/(\xi c) = 1/\cos\theta \ge 1`
+        with :math:`\theta` the local ray angle, so it never falls below the
         range spanned and exceeds it by exactly the obliquity of the path; a
         reflection adds no path, so it stays continuous across one, like the
         time. This is the measure a volume absorption
-        :math:`e^{-\\int \\alpha\\,ds}` multiplies on (Jensen Sect. 3.6.2,
+        :math:`e^{-\int \alpha\,ds}` multiplies on (Jensen Sect. 3.6.2,
         Eq. 3.116).
-    :ivar verticals: Vertical slowness :math:`\\zeta` at each range sample.
+    :ivar verticals: Vertical slowness :math:`\zeta` at each range sample.
     :ivar reflections: Boundary reflections resolved inside each range step
         (zero in the first column, which is the launch point). Crossings of a
         profile node are not reflections and are not counted here.
@@ -417,12 +417,12 @@ class RayMarch(NamedTuple):
         for a medium with no upper boundary.
     :ivar spreadings: Ray-tube spreading :math:`q`, or ``None`` when the march
         was not asked to carry it.
-    :ivar spreading_slopes: Its conjugate :math:`p`, :math:`p = \\xi\\,dq/dr`,
+    :ivar spreading_slopes: Its conjugate :math:`p`, :math:`p = \xi\,dq/dr`,
         or ``None``. The beam half-width and wavefront curvature follow from the
         pair as Jensen Eqs. (3.89)-(3.90),
-        :math:`W = \\sqrt{-2/(\\omega\\,\\mathrm{Im}[p/q])}` and
-        :math:`K = -c\\,\\mathrm{Re}[p/q]`.
-    :ivar horizontals: Horizontal slowness :math:`\\xi` at each range sample.
+        :math:`W = \sqrt{-2/(\omega\,\mathrm{Im}[p/q])}` and
+        :math:`K = -c\,\mathrm{Re}[p/q]`.
+    :ivar horizontals: Horizontal slowness :math:`\xi` at each range sample.
         Over level boundaries it is the launch column repeated, Snell's
         invariant; a reflection off a sloping boundary rotates it (module
         docstring), so a consumer forming ray-centred coordinates must read it

--- a/src/phonometry/_internal/types.py
+++ b/src/phonometry/_internal/types.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Shared typing aliases and array/scalar coercion helpers (private).
+"""Shared typing aliases and array/scalar coercion helpers (private).
 
 Seeded by the library audit: several modules re-declared the same
 ``Real`` alias and hand-copied the "0-d array becomes a float" return

--- a/src/phonometry/_internal/utils.py
+++ b/src/phonometry/_internal/utils.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Signal processing utilities for phonometry.
-"""
+"""Signal processing utilities for phonometry."""
 
 from __future__ import annotations
 
@@ -15,8 +13,7 @@ if TYPE_CHECKING:
 
 
 def _typesignal(x: Sequence[float] | np.ndarray) -> np.ndarray:
-    """
-    Ensure signal is a float64 numpy array.
+    """Ensure signal is a float64 numpy array.
 
     Integer inputs (e.g. int16 audio from ``scipy.io.wavfile.read``) are
     converted to float64 to prevent silent overflow when the signal is
@@ -29,8 +26,7 @@ def _typesignal(x: Sequence[float] | np.ndarray) -> np.ndarray:
 
 
 def _resample_to_length(y: np.ndarray, factor: int, target_length: int) -> np.ndarray:
-    """
-    Resample signal and ensure the output matches target_length exactly.
+    """Resample signal and ensure the output matches target_length exactly.
     Handles both 1D and 2D (channels, samples) arrays.
 
     :param y: Input signal.
@@ -66,8 +62,7 @@ def _resample_to_length(y: np.ndarray, factor: int, target_length: int) -> np.nd
 def _downsamplingfactor(
     freq: list[float], fs: int, headroom: float = 1.25
 ) -> np.ndarray:
-    """
-    Compute optimal downsampling factors for filter stability.
+    """Compute optimal downsampling factors for filter stability.
 
     :param freq: Band upper-edge frequencies.
     :param fs: Sample rate.

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Shared input-validation helpers (private).
+"""Shared input-validation helpers (private).
 
 Seeded by the library audit: modules used to hand-roll the same checks with
 diverging NaN semantics and error-message styles. New code should validate

--- a/src/phonometry/_internal/warnings.py
+++ b/src/phonometry/_internal/warnings.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Warning hierarchy root (private module, public class).
+"""Warning hierarchy root (private module, public class).
 
 Every warning the library emits derives from :class:`PhonometryWarning`
 so users can filter or escalate all phonometry diagnostics with a single

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Noise-Power-Distance (NPD) event-level interpolation (ECAC Doc 29).
+"""Noise-Power-Distance (NPD) event-level interpolation (ECAC Doc 29).
 
 The ECAC Doc 29 airport-noise method describes an aircraft's noise emission with
 **Noise-Power-Distance (NPD)** tables: the event noise level (``LAmax`` or the

--- a/src/phonometry/aircraft/atmospheric_absorption.py
+++ b/src/phonometry/aircraft/atmospheric_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-One-third-octave-band atmospheric absorption for aircraft noise (SAE ARP 5534).
+"""One-third-octave-band atmospheric absorption for aircraft noise (SAE ARP 5534).
 
 Aircraft noise certification (14 CFR Part 36, ICAO Annex 16 Vol. I) works with
 one-third-octave-band spectra, and correcting a measured flyover to reference

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Aircraft noise certification: Effective Perceived Noise Level (ICAO Annex 16).
+r"""Aircraft noise certification: Effective Perceived Noise Level (ICAO Annex 16).
 
 The EPNL is the noise-certification metric for transport-category aircraft. It
 is built from a half-second spectral time history (24 one-third-octave bands,

--- a/src/phonometry/aircraft/measurement_system.py
+++ b/src/phonometry/aircraft/measurement_system.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Aircraft-noise measurement-system tolerances (IEC 61265:1995).
+"""Aircraft-noise measurement-system tolerances (IEC 61265:1995).
 
 The certification levels of :mod:`phonometry.aircraft.certification` are only
 worth what the chain that measured them is, and IEC 61265 is the standard that

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Rotorcraft noise by the hemisphere method (ECAC Doc 32 / NORAH2).
+r"""Rotorcraft noise by the hemisphere method (ECAC Doc 32 / NORAH2).
 
 The ECAC Doc 32 rotorcraft-noise method describes a helicopter's highly directive
 source with a **noise hemisphere**: one-third-octave-band sound pressure levels on

--- a/src/phonometry/aircraft/rotorcraft_propagation.py
+++ b/src/phonometry/aircraft/rotorcraft_propagation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Rotorcraft propagation, ground effect and screening (ECAC Doc 32 / NORAH2).
+r"""Rotorcraft propagation, ground effect and screening (ECAC Doc 32 / NORAH2).
 
 Between the noise hemisphere that describes a helicopter and the receiver on the
 ground lies the path, and the path knows nothing about rotorcraft. The ECAC

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Programme loudness and true-peak level (ITU-R BS.1770-5, EBU R 128).
+r"""Programme loudness and true-peak level (ITU-R BS.1770-5, EBU R 128).
 
 Implements the objective multichannel loudness measurement algorithm of
 ITU-R BS.1770-5 Annex 1 and its companions:
@@ -123,12 +122,12 @@ DEFAULT_CHANNEL_WEIGHTS: dict[int, tuple[float, ...]] = {
 
 
 def _analog_from_biquad(coeffs: tuple[float, float, float], rate: float) -> np.ndarray:
-    """Map a digital biquad polynomial to its bilinear analog prototype.
+    r"""Map a digital biquad polynomial to its bilinear analog prototype.
 
-    Substituting :math:`z^{-1} = (K - s)/(K + s)` with :math:`K = 2 f_\\mathrm{s}`
+    Substituting :math:`z^{-1} = (K - s)/(K + s)` with :math:`K = 2 f_\mathrm{s}`
     (the inverse of the bilinear transform) into
     :math:`c_0 + c_1 z^{-1} + c_2 z^{-2}` gives the analog quadratic
-    :math:`(c_0 - c_1 + c_2)\\,s^2 + 2K(c_0 - c_2)\\,s + K^2(c_0 + c_1 + c_2)`.
+    :math:`(c_0 - c_1 + c_2)\,s^2 + 2K(c_0 - c_2)\,s + K^2(c_0 + c_1 + c_2)`.
 
     :param coeffs: The digital polynomial coefficients ``(c0, c1, c2)``.
     :param rate: The sample rate the digital coefficients are valid at, Hz.

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Laboratory measurement of flanking sound transmission (ISO 10848:2006/2010).
+r"""Laboratory measurement of flanking sound transmission (ISO 10848:2006/2010).
 
 This is the **measurement** counterpart of the flanking-transmission
 *prediction* in :mod:`phonometry.building.prediction.simplified_model`. EN 12354-1 predicts the

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Impact-sound improvement of floor coverings on a small mock-up
+r"""Impact-sound improvement of floor coverings on a small mock-up
 (ISO 16251-1:2014).
 
 Laboratory method for the **improvement of impact sound insulation** ``ΔL`` of a
@@ -45,7 +44,8 @@ rating bands 100 Hz to 3150 Hz; a wider clause 6.3 spectrum (18 bands 100-5000
 Hz, optionally extended to 50 Hz) is rated on that sub-range. The statement of
 results (Clause 8 e)) also carries the spectrum adaptation term ``CI,Δ`` (ISO
 717-2:2020 Formula (A.4)) via
-:func:`phonometry.building.impact_improvement_adaptation_term`."""
+:func:`phonometry.building.impact_improvement_adaptation_term`.
+"""
 
 from __future__ import annotations
 

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Heavy and soft impact sources: rubber ball and bang machine
+r"""Heavy and soft impact sources: rubber ball and bang machine
 (ISO 16283-2:2020 Annex A, ISO 10140-5:2010 Annex F, JIS A 1418-2:2019,
 ISO 717-2:2020 Annex D).
 

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Field measurement of sound insulation: airborne (ISO 16283-1:2014), impact
+r"""Field measurement of sound insulation: airborne (ISO 16283-1:2014), impact
 (ISO 16283-2) and facade (ISO 16283-3:2016).
 
 **Field quantities (ISO 16283-1:2014).** From the energy-average sound
@@ -381,6 +380,7 @@ class FacadeInsulationResult:
     method: str = "loudspeaker"
 
     def __post_init__(self) -> None:
+        """Reject a ``method`` other than ``"loudspeaker"`` or ``"road_traffic"``."""
         if self.method not in _FACADE_CORRECTION:
             raise ValueError(
                 "'method' must be 'loudspeaker' or 'road_traffic', got "
@@ -612,8 +612,7 @@ def _render_iso16283_facade(
 def energy_average_level(
     levels: Sequence[float] | np.ndarray, axis: int = -1
 ) -> np.ndarray | float:
-    r"""
-    Energy-average sound pressure level (ISO 16283-1:2014, Formula (9)).
+    r"""Energy-average sound pressure level (ISO 16283-1:2014, Formula (9)).
 
     Combines sound pressure levels measured at several microphone
     positions into
@@ -702,8 +701,7 @@ def airborne_insulation(
     volume: float | None = None,
     t0: float = 0.5,
 ) -> AirborneInsulationResult:
-    r"""
-    Field airborne sound insulation per ISO 16283-1:2014.
+    r"""Field airborne sound insulation per ISO 16283-1:2014.
 
     Computes, per frequency band, the level difference
     :math:`D = L_1 - L_2`
@@ -776,8 +774,7 @@ def impact_insulation(
     volume: float | None = None,
     t0: float = 0.5,
 ) -> ImpactInsulationResult:
-    r"""
-    Field impact sound insulation per ISO 16283-2 (tapping machine).
+    r"""Field impact sound insulation per ISO 16283-2 (tapping machine).
 
     Computes, per frequency band, the standardized impact sound pressure
     level :math:`L'_\mathrm{nT} = L_\mathrm{i} - 10 \log_{10}(T/T_0)` (Formula (1)) and, when the
@@ -869,8 +866,7 @@ def facade_insulation(
     t0: float = 0.5,
     frequencies: Sequence[float] | np.ndarray | None = None,
 ) -> FacadeInsulationResult:
-    r"""
-    Field façade sound insulation per ISO 16283-3:2016.
+    r"""Field façade sound insulation per ISO 16283-3:2016.
 
     Computes, per frequency band, the global-method level difference
     :math:`D_{2\mathrm{m}} = L_{1,2\mathrm{m}} - L_2` (Clause 3.14), its standardized form

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound insulation measured with sound intensity (ISO 15186).
+r"""Sound insulation measured with sound intensity (ISO 15186).
 
 This is the sound-**intensity** counterpart of the sound-pressure methods in
 :mod:`phonometry.building.measurement.lab_insulation` (ISO 10140) and :mod:`phonometry.building.measurement.insulation`
@@ -67,7 +66,8 @@ to 50 Hz. The single-number weighted rating uses the ISO 717-1 core range, so
 the automatic rating (``RI,w``, ``RI,M,w``, ``DI,n,e,w``) is formed via the
 verified :func:`phonometry.building.weighted_rating` engine only when exactly
 16 one-third-octave (100-3150 Hz) or 5 octave (125-2000 Hz) values are
-supplied."""
+supplied.
+"""
 
 from __future__ import annotations
 
@@ -588,8 +588,7 @@ def intensity_sound_reduction(
     area: float,
     kc: Sequence[float] | np.ndarray | None = None,
 ) -> IntensityReductionResult:
-    r"""
-    Intensity sound reduction index per ISO 15186-1:2000 (Formula (7)).
+    r"""Intensity sound reduction index per ISO 15186-1:2000 (Formula (7)).
 
     Computes, per frequency band, the intensity sound reduction index, in dB,
 
@@ -666,8 +665,7 @@ def intensity_element_normalized_difference(
     measurement_area: float,
     n: int = 1,
 ) -> IntensityElementNormalizedResult:
-    r"""
-    Intensity element normalized level difference per ISO 15186-1 (Formula (8)).
+    r"""Intensity element normalized level difference per ISO 15186-1 (Formula (8)).
 
     Computes, per frequency band, the intensity element normalized level
     difference of a single element unit, in dB,

--- a/src/phonometry/building/measurement/lab_insulation.py
+++ b/src/phonometry/building/measurement/lab_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Laboratory sound insulation of building elements (ISO 10140).
+r"""Laboratory sound insulation of building elements (ISO 10140).
 
 This is the **laboratory** counterpart of the field ISO 16283 family in
 :mod:`phonometry.building.measurement.insulation`. In a qualified test facility flanking
@@ -412,8 +411,7 @@ def lab_airborne_insulation(
     area: float,
     volume: float,
 ) -> LabAirborneInsulationResult:
-    r"""
-    Laboratory airborne sound reduction index per ISO 10140-2:2010.
+    r"""Laboratory airborne sound reduction index per ISO 10140-2:2010.
 
     Computes, per frequency band, the sound reduction index
     :math:`R = L_1 - L_2 + 10 \log_{10}(S/A)` (Clause 3.1, Formula (2)) with the
@@ -463,8 +461,7 @@ def lab_impact_insulation(
     *,
     volume: float,
 ) -> LabImpactInsulationResult:
-    r"""
-    Laboratory impact sound pressure level per ISO 10140-3:2010.
+    r"""Laboratory impact sound pressure level per ISO 10140-3:2010.
 
     Computes, per frequency band, the normalized impact sound pressure level
     :math:`L_\mathrm{n} = L_\mathrm{i} + 10 \log_{10}(A/A_0)` (Clause 3.2, Formula (1)) with the

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Single-number weighted ratings of sound insulation and their spectrum
+r"""Single-number weighted ratings of sound insulation and their spectrum
 adaptation terms (ISO 717-1 airborne, ISO 717-2 impact).
 
 ISO 717 rates a curve, not a room. Whatever produced the band values (a field
@@ -684,8 +683,7 @@ def weighted_rating(
     values_by_band: Sequence[float] | np.ndarray,
     bands: str | None = None,
 ) -> WeightedRatingResult:
-    """
-    Single-number weighted rating and C / Ctr per ISO 717-1.
+    """Single-number weighted rating and C / Ctr per ISO 717-1.
 
     Applies the reference-curve method of Clause 4.4: the Table 3
     reference curve is shifted in 1 dB steps towards the measured curve
@@ -792,8 +790,7 @@ def weighted_impact_rating(
     values_by_band: Sequence[float] | np.ndarray,
     bands: str | None = None,
 ) -> ImpactRatingResult:
-    r"""
-    Single-number weighted impact rating and CI per ISO 717-2.
+    r"""Single-number weighted impact rating and CI per ISO 717-2.
 
     Applies the reference-curve method of Clause 4.3: the Table 3 impact
     reference curve is shifted in 1 dB steps towards the measured curve

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Structure-borne sound power of building equipment (EN 15657:2018; ISO 9611).
+r"""Structure-borne sound power of building equipment (EN 15657:2018; ISO 9611).
 
 Building service equipment (pumps, fans, boilers, sanitary appliances) injects
 **structure-borne sound power** into the building structure it is fixed to.
@@ -218,7 +217,8 @@ class StructureBornePowerResult:
     @property
     def total_level(self) -> float:
         r"""Band-summed power level :math:`10 \log_{10}(\sum 10^{0.1 L_{W\mathrm{s}}})`,
-        in dB."""
+        in dB.
+        """
         lw = np.asarray(self.power_level, dtype=np.float64)
         return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * lw))))
 

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Field survey method for sound insulation and service-equipment noise
+r"""Field survey method for sound insulation and service-equipment noise
 (ISO 10052:2021).
 
 This is the **survey (control) method**: a fast, octave-band field procedure
@@ -63,7 +62,8 @@ heavy/soft impact source uses 63 Hz to 500 Hz. The single-number weighted
 ratings reuse the verified :func:`phonometry.building.weighted_rating` (ISO
 717-1) and :func:`phonometry.building.weighted_impact_rating` (ISO 717-2)
 engines, formed only when exactly 5 octave (or 16 one-third-octave) values are
-supplied. No background correction is applied (Clause 6.2)."""
+supplied. No background correction is applied (Clause 6.2).
+"""
 
 from __future__ import annotations
 
@@ -641,8 +641,7 @@ def survey_airborne_insulation(
     volume: float | None = None,
     area: float | None = None,
 ) -> SurveyAirborneResult:
-    r"""
-    Airborne sound insulation between rooms, survey method (ISO 10052:2021).
+    r"""Airborne sound insulation between rooms, survey method (ISO 10052:2021).
 
     Computes, per octave band, the level difference :math:`D = L_1 - L_2`
     (Clause 3.2), the standardized level difference :math:`D_\mathrm{nT} = D + k`
@@ -708,8 +707,7 @@ def survey_impact_insulation(
     *,
     volume: float | None = None,
 ) -> SurveyImpactResult:
-    r"""
-    Impact sound insulation between rooms, survey method (ISO 10052:2021).
+    r"""Impact sound insulation between rooms, survey method (ISO 10052:2021).
 
     Computes, per octave band, the energy-average impact sound pressure level
     ``Li`` (Clause 3.7), the standardized impact level
@@ -745,8 +743,7 @@ def survey_facade_insulation(
     *,
     volume: float | None = None,
 ) -> SurveyFacadeResult:
-    r"""
-    Façade sound insulation, survey method (ISO 10052:2021).
+    r"""Façade sound insulation, survey method (ISO 10052:2021).
 
     Computes, per octave band, the façade level difference
     :math:`D_{2\mathrm{m}} = L_{1,2\mathrm{m}} - L_2` (Clause 3.13), the standardized façade
@@ -788,8 +785,7 @@ def survey_service_equipment_level(
     *,
     volume: float | None = None,
 ) -> SurveyServiceEquipmentResult:
-    r"""
-    Service-equipment sound pressure level, survey method (ISO 10052:2021).
+    r"""Service-equipment sound pressure level, survey method (ISO 10052:2021).
 
     Computes the service-equipment level
     :math:`L_{XY} = 10 \log_{10}[(1/3) \sum 10^{0.1 L_{XY,j}}]`

--- a/src/phonometry/building/measurement/uncertainty.py
+++ b/src/phonometry/building/measurement/uncertainty.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Measurement uncertainty in building acoustics (ISO 12999-1:2020).
+r"""Measurement uncertainty in building acoustics (ISO 12999-1:2020).
 
 This module supplies the **measurement uncertainty** of the sound-insulation
 quantities produced by the field/lab/prediction modules

--- a/src/phonometry/building/prediction/aperture_transmission.py
+++ b/src/phonometry/building/prediction/aperture_transmission.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound transmission through slits, holes and apertures (Hopkins 2007, Sound
+r"""Sound transmission through slits, holes and apertures (Hopkins 2007, Sound
 Insulation, Section 4.3.10; Gomperts 1964; Wilson & Soroka 1965).
 
 Air paths are the real limit on the sound insulation of an otherwise heavy
@@ -126,7 +125,8 @@ class ApertureTransmissionResult:
     @property
     def transmission_loss(self) -> np.ndarray:
         r"""Aperture sound reduction index :math:`R = -10 \log_{10}(\tau)` per
-        band, dB."""
+        band, dB.
+        """
         return transmission_loss_from_coefficient(self.transmission_coefficient)
 
     def plot(
@@ -162,7 +162,8 @@ class ApertureTransmissionResult:
 
 def _slit_end_correction(k_big: np.ndarray) -> np.ndarray:
     r"""End correction :math:`e = (1/\pi)(\ln(8/K) - \gamma)` (Hopkins
-    Eq. 4.100)."""
+    Eq. 4.100).
+    """
     return np.asarray((np.log(8.0 / k_big) - _EULER_GAMMA) / np.pi, dtype=np.float64)
 
 

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Suspended-ceiling plenum flanking path (Vigran 9.2.3 after Mechel 1980;
+r"""Suspended-ceiling plenum flanking path (Vigran 9.2.3 after Mechel 1980;
 ISO 140-9 / ISO 10848-2; ASTM E1414 / ASTM E413).
 
 Two offices separated by a partition that stops at the suspended ceiling share

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Detailed per-band building prediction (EN/ISO 12354-1/-2:2017).
+r"""Detailed per-band building prediction (EN/ISO 12354-1/-2:2017).
 
 This is the **detailed model** of the building-prediction chain, the per-band
 counterpart of the simplified single-number model implemented in

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Façade sound insulation and outdoor radiation prediction (EN 12354-3/-4:2000).
+r"""Façade sound insulation and outdoor radiation prediction (EN 12354-3/-4:2000).
 
 Two companion prediction models for the building envelope, both built on the
 same energy summation of element transmission factors

--- a/src/phonometry/building/prediction/installed_structure_borne.py
+++ b/src/phonometry/building/prediction/installed_structure_borne.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Installed structure-borne sound from service equipment (EN 12354-5:2009).
+r"""Installed structure-borne sound from service equipment (EN 12354-5:2009).
 
 EN 12354-5 predicts the sound pressure level in a receiving room caused by
 building service equipment that injects **structure-borne sound** into the
@@ -1000,7 +999,8 @@ class InstalledSourceResult:
     @property
     def overall_level(self) -> float:
         r"""Band-summed total level :math:`10 \log_{10}(\sum 10^{0.1 L_\mathrm{n,s}})`,
-        in dB."""
+        in dB.
+        """
         lt = np.atleast_1d(np.asarray(self.total_level, dtype=np.float64))
         return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * lt))))
 

--- a/src/phonometry/building/prediction/linings.py
+++ b/src/phonometry/building/prediction/linings.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Prediction of wall and ceiling linings: the weighted improvement an additional
+r"""Prediction of wall and ceiling linings: the weighted improvement an additional
 layer gives the element behind it (ISO 12354-1:2017 Annex D).
 
 A lining is not a floor covering. It is added to a wall or a ceiling, not laid

--- a/src/phonometry/building/prediction/masonry_cavity_wall.py
+++ b/src/phonometry/building/prediction/masonry_cavity_wall.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Wall ties in masonry cavity walls: the structural bridge across the cavity
+r"""Wall ties in masonry cavity walls: the structural bridge across the cavity
 (Hopkins 2007, Sections 3.11.3.2 and 4.3.5.4.1).
 
 A masonry cavity wall is a double leaf, and the textbook double-leaf prediction

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Predicted airborne sound reduction index of panels (Bies, Hansen & Howard
+r"""Predicted airborne sound reduction index of panels (Bies, Hansen & Howard
 2017, Engineering Noise Control 5e, Section 7.2; Sharp 1973).
 
 Where EN 12354-1 (:mod:`phonometry.building.prediction.simplified_model`) takes the

--- a/src/phonometry/building/prediction/resilient_layers.py
+++ b/src/phonometry/building/prediction/resilient_layers.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Prediction of resilient-layer performance: tapping force, floor coverings,
+r"""Prediction of resilient-layer performance: tapping force, floor coverings,
 floating floors.
 
 The measurement modules of this domain report what a resilient layer *achieved*
@@ -277,7 +276,8 @@ def covering_contact_stiffness(
 
 def _is_over_critical(stiffness: float, impedance: float, mass: float) -> bool:
     r"""``True`` for an over-critical oscillation,
-    :math:`K m \ge 4 Z_\mathrm{dp}^{2}` (Eq. 3.95)."""
+    :math:`K m \ge 4 Z_\mathrm{dp}^{2}` (Eq. 3.95).
+    """
     return stiffness * mass >= 4.0 * impedance**2
 
 
@@ -486,7 +486,8 @@ class TappingForceResult:
     @property
     def power_input_level(self) -> np.ndarray:
         r"""Power input level :math:`10 \log_{10}(W_\mathrm{in}/1~\text{pW})`, in dB
-        (Hopkins Fig. 3.33)."""
+        (Hopkins Fig. 3.33).
+        """
         return np.asarray(10.0 * np.log10(self.power_input / _POWER_REFERENCE))
 
     def plot(

--- a/src/phonometry/building/prediction/simplified_model.py
+++ b/src/phonometry/building/prediction/simplified_model.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Building acoustic performance prediction (EN 12354-1/-2:2000).
+r"""Building acoustic performance prediction (EN 12354-1/-2:2000).
 
 This is the **prediction** counterpart of the measurement modules
 (:mod:`phonometry.building.measurement.lab_insulation` for laboratory ``R``/``Ln`` and
@@ -369,11 +368,11 @@ def _check_finite(value: float, name: str) -> float:
 
 @dataclass(frozen=True)
 class _KijTerms:
-    """The terms every Annex E branch is written in.
+    r"""The terms every Annex E branch is written in.
 
-    :ivar m: :math:`M = \\log_{10}` of the mass ratio (Formula E.2).
+    :ivar m: :math:`M = \log_{10}` of the mass ratio (Formula E.2).
     :ivar ratio: The mass ratio itself, which the E.7 validity test reads.
-    :ivar lg_f_fk: :math:`\\log_{10}(f/f_k)` of the double-leaf branches.
+    :ivar lg_f_fk: :math:`\log_{10}(f/f_k)` of the double-leaf branches.
     :ivar delta1: The E.4/E.5 frequency term, zero below ``f1``.
     """
 

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Spanish building code CTE DB-HR: global indices and requirement checks.
+r"""Spanish building code CTE DB-HR: global indices and requirement checks.
 
 The *Documento Basico HR Proteccion frente al ruido* of the Spanish Codigo
 Tecnico de la Edificacion states its requirements in A-weighted global

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Harmonic distortion of electroacoustic equipment (IEC 60268-3 / AES17).
+"""Harmonic distortion of electroacoustic equipment (IEC 60268-3 / AES17).
 
 Single-tone distortion metrics of amplifiers and audio equipment, from a
 captured signal:

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Frequency-response and coherence estimators (Bendat & Piersol).
+r"""Frequency-response and coherence estimators (Bendat & Piersol).
 
 Two-channel (input/output) system identification from measured signals, using
 the Welch-averaged cross- and auto-spectral densities. Following Bendat &

--- a/src/phonometry/electroacoustics/intermodulation.py
+++ b/src/phonometry/electroacoustics/intermodulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Intermodulation distortion of audio equipment (IEC 60268-3 14.12.7-10).
+r"""Intermodulation distortion of audio equipment (IEC 60268-3 14.12.7-10).
 
 Where the harmonic metrics of :mod:`phonometry.electroacoustics.distortion`
 drive the equipment with a single tone, these drive it with two (or with a
@@ -11,7 +10,7 @@ inharmonic with the programme:
 
 * **Modulation distortion** ``d_m,2``/``d_m,3`` (14.12.7): a large low tone
   :math:`f_1` modulating a small high tone :math:`f_2`, read on the
-  sidebands at :math:`f_2 \\pm (n-1) f_1`.
+  sidebands at :math:`f_2 \pm (n-1) f_1`.
 * **Difference-frequency distortion** ``d_d,2``/``d_d,3`` (14.12.8) from two
   equal-amplitude tones, and the **total difference-frequency distortion**
   (14.12.10) of the standard 8 kHz / 11,95 kHz pair.
@@ -373,7 +372,8 @@ _DIM_SEARCH_FACTOR = 0.1
 def _dim_components(f_sine: float, f_square: float, nyquist: float) -> list[float]:
     r"""DIM difference products
     :math:`\lvert k \, f_\mathrm{square} - f_\mathrm{sine} \rvert`
-    below ``f_sine`` (Table 2)."""
+    below ``f_sine`` (Table 2).
+    """
     products: set[float] = set()
     for k in range(1, _DIM_MAX_ORDER + 1):
         for sign in (-1.0, 1.0):

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Rated loudspeaker characteristics (IEC 60268-5).
+r"""Rated loudspeaker characteristics (IEC 60268-5).
 
 A loudspeaker measurement/rating report gathers the *rated characteristics*
 IEC 60268-5:2003+A1:2007 defines around a measured on-axis response: the

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Rated microphone characteristics (IEC 60268-4).
+r"""Rated microphone characteristics (IEC 60268-4).
 
 A microphone measurement/rating report gathers the *rated characteristics*
 IEC 60268-4:2014 defines around a measured free-field frequency response: the
@@ -90,7 +89,8 @@ _MIN_POLAR_SPAN_DEG = 150.0
 
 def _sensitivity_level_db(sensitivity_v_per_pa: float) -> float:
     r"""Sensitivity level :math:`20 \log_{10}(M / 1\,\mathrm{V/Pa})`, in dB re
-    1 V/Pa (11.1)."""
+    1 V/Pa (11.1).
+    """
     return float(20.0 * np.log10(sensitivity_v_per_pa / _M_REF))
 
 

--- a/src/phonometry/electroacoustics/noise_measurements.py
+++ b/src/phonometry/electroacoustics/noise_measurements.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Noise measurements of audio equipment (AES17-2015 6.4).
+"""Noise measurements of audio equipment (AES17-2015 6.4).
 
 The two levels that say how quiet a device is, both measured through the
 AES17 measurement chain -- the standard notch (5.2.8) where a test tone has

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Radiation of a rigid circular piston set in an infinite baffle.
+r"""Radiation of a rigid circular piston set in an infinite baffle.
 
 The baffled circular piston is the canonical acoustic radiator: a flat rigid
 disc of radius ``a`` vibrating with a uniform normal velocity in an otherwise

--- a/src/phonometry/electroacoustics/swept_sine.py
+++ b/src/phonometry/electroacoustics/swept_sine.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Harmonic-distortion separation with exponential sweeps (Farina / Novak).
+r"""Harmonic-distortion separation with exponential sweeps (Farina / Novak).
 
 A single exponential sine sweep characterises the linear response and
 every harmonic distortion order of a weakly nonlinear system at once:
@@ -51,7 +50,8 @@ Chebyshev identities, :math:`\lvert H_1 \rvert = 1 + 3 a_3/4`,
 :math:`\lvert H_3 \rvert = a_3/4` (phase :math:`\pi`), and a THD(f) equal to
 the closed form :math:`\sqrt{(a_2/2)^2 + (a_3/4)^2} / (1 + 3 a_3/4)` -- which
 also matches :func:`phonometry.electroacoustics.thd` measured tone by tone on
-the same system."""
+the same system.
+"""
 
 from __future__ import annotations
 
@@ -125,8 +125,7 @@ def synchronized_sweep_signal(
     amplitude: float = 1.0,
     fade: float = 0.0,
 ) -> NDArray[np.float64]:
-    r"""
-    Generate a synchronized exponential sweep (Novak et al. 2015, Eq. 47).
+    r"""Generate a synchronized exponential sweep (Novak et al. 2015, Eq. 47).
 
     :math:`x(t) = A \sin[2\pi f_1 L \exp(t/L)]` with the rate
     :math:`L = \operatorname{round}(f_1 \tilde{T} / \ln(f_2/f_1)) / f_1`
@@ -541,8 +540,7 @@ def swept_sine_distortion(
     fade: float | None = None,
     remove_dc: bool = True,
 ) -> SweptSineDistortionResult:
-    r"""
-    Separate the harmonic responses of a swept-sine measurement.
+    r"""Separate the harmonic responses of a swept-sine measurement.
 
     Deconvolves the recorded response of a (weakly, memorylessly) nonlinear
     system to an exponential sweep and windows the impulse response of each

--- a/src/phonometry/emission/_shared.py
+++ b/src/phonometry/emission/_shared.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-What every sound-power method has in common: the A-weighting band corrections
+r"""What every sound-power method has in common: the A-weighting band corrections
 of ISO 3744:2010 Annex E, the reference area, the accuracy-grade vocabulary
 and the qualification warning.
 
@@ -51,7 +50,8 @@ class SoundPowerWarning(PhonometryWarning):
     and microphone/source-position sampling; and for ISO 9614-2 negative total
     partial power and unmet field-indicator criteria. Where a lower criterion
     is only just met the returned levels represent upper bounds and must be
-    reported as such."""
+    reported as such.
+    """
 
 
 # --- ISO 3744:2010 Annex E, A-weighting band corrections Ck (dB) ------------
@@ -99,7 +99,8 @@ def _a_weighting_corrections(frequencies: np.ndarray) -> np.ndarray:
     """A-weighting band corrections Ck for the given nominal mid-band
     frequencies (ISO 3744:2010 Annex E, Tables E.1/E.2). The octave-band
     values (Table E.2) coincide with the one-third-octave values (Table E.1)
-    at the shared mid-band frequencies, so a single lookup serves both."""
+    at the shared mid-band frequencies, so a single lookup serves both.
+    """
     nominal = [round(f) for f in frequencies]
     # Use the octave table (E.2) when every band is an octave mid-band centre,
     # otherwise the one-third-octave table (E.1); the two agree where they

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Two-microphone (p-p) sound intensity per IEC 61043:1993 and the
+r"""Two-microphone (p-p) sound intensity per IEC 61043:1993 and the
 ISO 9614-1:1993 field indicators.
 
 A p-p probe holds two pressure microphones a fixed distance ``spacing``
@@ -289,7 +288,8 @@ class FieldIndicators:
 
 def _level(value: float, reference: float) -> float:
     r"""Level :math:`10 \log_{10}(\mathrm{value}/\mathrm{reference})` in dB, with a
-    tiny-floor guard for zero values."""
+    tiny-floor guard for zero values.
+    """
     return float(10.0 * np.log10(max(value, np.finfo(float).tiny) / reference))
 
 
@@ -375,8 +375,7 @@ def sound_intensity(
     limits: list[float] | None = None,
     bias_correct: bool = False,
 ) -> IntensityResult:
-    r"""
-    Sound intensity from a two-microphone (p-p) probe (IEC 61043:1993).
+    r"""Sound intensity from a two-microphone (p-p) probe (IEC 61043:1993).
 
     The one-sided cross spectrum ``G12`` of the two microphone pressures
     is estimated with Welch-averaged, Hann-windowed segments
@@ -579,8 +578,7 @@ def _coefficient_of_variation(
 def temporal_variability_indicator(
     short_time_intensity: list[float] | np.ndarray,
 ) -> float | np.ndarray:
-    r"""
-    ISO 9614-1:1993 temporal variability indicator F1 (equation (A.1)).
+    r"""ISO 9614-1:1993 temporal variability indicator F1 (equation (A.1)).
 
     In the initial test a "typical" measurement position is chosen on an
     initial measurement surface and the normal sound intensity is sampled
@@ -699,8 +697,7 @@ def field_indicators(
     *,
     temporal_intensity: list[float] | np.ndarray | None = None,
 ) -> FieldIndicators:
-    r"""
-    ISO 9614-1:1993 Annex A field indicators F1 to F4.
+    r"""ISO 9614-1:1993 Annex A field indicators F1 to F4.
 
     Given the sound pressure level ``Lpi`` (dB) and the signed normal
     sound intensity ``Ini`` (W/m^2) measured at each of the N discrete
@@ -785,8 +782,7 @@ def field_indicators(
 def dynamic_capability_index(
     pressure_residual_intensity_index: float, bias_error_factor: float = 10.0
 ) -> float:
-    r"""
-    Dynamic capability index Ld (ISO 9614-1:1993, clause 3.12).
+    r"""Dynamic capability index Ld (ISO 9614-1:1993, clause 3.12).
 
     :math:`L_\mathrm{d} = \delta_{pI0} - K` (equation (10)), where
     :math:`\delta_{pI0}` is the

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-IEC 61043:1993 sound-intensity instrument class verification.
+r"""IEC 61043:1993 sound-intensity instrument class verification.
 
 A two-microphone (p-p) intensity chain is graded by its **pressure-residual
 intensity index** ``delta_pI0``: feed both measurement channels the same pink
@@ -168,7 +167,8 @@ def _match_band(frequency: float) -> float:
 
 def _spacing_offset(spacing: float) -> float:
     r"""Table 2 Note 1 separation term :math:`10 \log_{10}(x/25)` in dB, ``x`` in
-    mm."""
+    mm.
+    """
     if not np.isfinite(spacing) or spacing <= 0.0:
         raise ValueError("'spacing' must be a positive, finite distance in metres.")
     return float(10.0 * np.log10(spacing / REFERENCE_SPACING))
@@ -191,8 +191,7 @@ def residual_index_limits(
     spacing: float = REFERENCE_SPACING,
     frequencies: list[float] | np.ndarray | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    r"""
-    IEC 61043:1993 Table 2 minimum pressure-residual intensity index.
+    r"""IEC 61043:1993 Table 2 minimum pressure-residual intensity index.
 
     Returns the class 1 and class 2 minima the standard requires of a device
     kind, already rescaled to the microphone separation in use with the Note 1
@@ -229,8 +228,7 @@ def residual_index_limits(
 
 
 def instrument_class_from_components(probe_class: int, processor_class: int) -> int:
-    """
-    Class of an instrument assembled from a separate probe and processor.
+    """Class of an instrument assembled from a separate probe and processor.
 
     IEC 61043:1993 clause 8: when a probe and a processor are supplied
     separately, a class 1 instrument consists of a class 1 processor and a
@@ -290,8 +288,7 @@ def verify_intensity_class(
     device: str = "instrument",
     spacing: float = REFERENCE_SPACING,
 ) -> dict[str, Any]:
-    r"""
-    Verify a measured ``delta_pI0`` spectrum against IEC 61043:1993 Table 2.
+    r"""Verify a measured ``delta_pI0`` spectrum against IEC 61043:1993 Table 2.
 
     Each band's measured pressure-residual intensity index is compared with the
     class 1 and class 2 minima of Table 2 for the device kind, rescaled to the
@@ -577,7 +574,8 @@ def _plane_wave_phase_deg(
     frequency: np.ndarray, spacing: float, c: float
 ) -> np.ndarray:
     r"""Plane-wave phase difference :math:`k d` across the spacer, in
-    degrees."""
+    degrees.
+    """
     if not np.isfinite(spacing) or spacing <= 0.0:
         raise ValueError("'spacing' must be a positive, finite distance in metres.")
     if not np.isfinite(c) or c <= 0.0:
@@ -594,8 +592,7 @@ def phase_mismatch_from_residual_index(
     spacing: float,
     c: float = 343.0,
 ) -> np.ndarray:
-    r"""
-    Channel phase mismatch equivalent to a pressure-residual intensity index.
+    r"""Channel phase mismatch equivalent to a pressure-residual intensity index.
 
     In an axially propagating plane progressive wave the true phase difference
     between the two sensing points is :math:`k d = 2\pi f d / c`, and a
@@ -634,8 +631,7 @@ def residual_index_from_phase_mismatch(
     spacing: float,
     c: float = 343.0,
 ) -> np.ndarray:
-    r"""
-    Pressure-residual intensity index of a given channel phase mismatch.
+    r"""Pressure-residual intensity index of a given channel phase mismatch.
 
     The inverse of :func:`phase_mismatch_from_residual_index`:
 

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound power level of a noise source from sound pressure measurements over an
+r"""Sound power level of a noise source from sound pressure measurements over an
 enveloping measurement surface: ISO 3744:2010 (engineering, accuracy grade 2)
 and ISO 3746:2010 (survey, accuracy grade 3).
 
@@ -226,7 +225,8 @@ class SoundPowerResult:
     evaluated per band per clause 8.4). ``uncertainty`` is the expanded
     uncertainty
     :math:`U = 2\sqrt{\sigma_{\mathrm{R}0}^2 + \sigma_\mathrm{omc}^2}` (95 %, ISO 3744
-    clause 9.5)."""
+    clause 9.5).
+    """
 
     frequencies: np.ndarray | None
     sound_power_level: np.ndarray

--- a/src/phonometry/emission/sound_power_anechoic.py
+++ b/src/phonometry/emission/sound_power_anechoic.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound power level of a noise source in an anechoic or hemi-anechoic room, from
+r"""Sound power level of a noise source in an anechoic or hemi-anechoic room, from
 sound pressure measurements over an enveloping surface: ISO 3745:2012
 (precision, accuracy grade 1).
 
@@ -262,7 +261,8 @@ class PrecisionSoundPowerResult:
     :math:`U = k\sqrt{\sigma_{\mathrm{R}0}^2 + \sigma_\mathrm{omc}^2}`
     (Eq. 24/25) and ``uncertainty_bands`` the
     per-band value (``NaN`` without ``frequencies``).
-    ``sound_power_level_a`` is the A-weighted total ``LWA`` (Eq. C.1)."""
+    ``sound_power_level_a`` is the A-weighted total ``LWA`` (Eq. C.1).
+    """
 
     frequencies: np.ndarray | None
     sound_power_level: np.ndarray
@@ -595,7 +595,8 @@ def _precision_surface_level(
     corrected: np.ndarray, areas: np.ndarray | None
 ) -> np.ndarray:
     """Surface time-averaged level Lp_bar: equal-area Eq. 12 or area-weighted
-    Eq. 13 when partial areas ``Si`` are supplied."""
+    Eq. 13 when partial areas ``Si`` are supplied.
+    """
     if areas is None:
         return np.asarray(energy_mean(corrected, axis=0), dtype=np.float64)
     n_positions = corrected.shape[0]

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound power level of a noise source by sound-intensity **scanning**:
+r"""Sound power level of a noise source by sound-intensity **scanning**:
 ISO 9614-2:1996 (engineering, grade 2; survey/control, grade 3) and
 ISO 9614-3:2002 (precision, grade 1).
 
@@ -293,7 +292,8 @@ class SoundPowerIntensityResult:
 
 def _level_magnitude(values: np.ndarray) -> np.ndarray:
     r"""Magnitude level :math:`10 \log_{10}(|P_i|/P_0)` in dB, with a tiny-floor
-    guard for zeros."""
+    guard for zeros.
+    """
     guarded = np.maximum(np.abs(values), np.finfo(float).tiny)
     return np.asarray(10.0 * np.log10(guarded / _P0), dtype=np.float64)
 
@@ -609,7 +609,8 @@ def _a_weighting_omission(
     (:math:`F_{+/-} \le 3` dB, B.1.2) binds engineering-grade determinations
     only
     (optional for grade 3, Note 16). Net-negative bands are excluded already
-    as non-determinable (clause 9.2), so they are not flagged here."""
+    as non-determinable (clause 9.2), so they are not flagged here.
+    """
     if fpi is None or ld is None:
         return None
     fails = ~(ld > fpi)
@@ -630,7 +631,8 @@ def _a_weighted_total(
     Sums the determinable bands (net power :math:`P > 0`, clause 9.2) minus the
     bands omitted per clause 10.6 b (criteria 1 and/or 2 failed). When the
     screening could not be evaluated (``omitted`` is ``None``) every
-    determinable band is summed and a :class:`SoundPowerWarning` is emitted."""
+    determinable band is summed and a :class:`SoundPowerWarning` is emitted.
+    """
     determinable = ~negative_band
     if frequencies is not None:
         freqs = np.asarray(frequencies, dtype=np.float64)
@@ -684,7 +686,8 @@ class PrecisionFieldIndicators:
     magnitude of the segment intensities) and ``f_pi_signed`` the signed one
     (= F3, Eq. B.6, using the algebraic mean); by construction
     :math:`F_{pI_\mathrm{n}}^{\mathrm{signed}} \ge F_{pI_\mathrm{n}}^{\mathrm{unsigned}}`.
-    ``fs`` is the field-non-uniformity indicator (= F4, Eq. B.8)."""
+    ``fs`` is the field-non-uniformity indicator (= F4, Eq. B.8).
+    """
 
     ft: np.ndarray | None
     f_pi_unsigned: np.ndarray
@@ -710,7 +713,8 @@ class PrecisionCriteria:
     through criterion 4
     or, where evaluated, criterion 5 (C.1.6.2: a band satisfying criterion 5
     is qualified as a final result even if :math:`F_\mathrm{S}(2) \ge 2`); ``None``
-    unless both criterion 1 and criterion 2 are evaluable."""
+    unless both criterion 1 and criterion 2 are evaluable.
+    """
 
     criterion_1: np.ndarray | None
     criterion_2: np.ndarray | None
@@ -785,7 +789,8 @@ class PrecisionIntensityResult:
     where :math:`P \le 0` (``not_applicable_band`` True, clause 9.2).
     ``sound_power_level_normalized`` is ``LW0`` normalized to 23 deg C /
     101 325 Pa (Eq. 10). ``sound_power_level_a`` is the A-weighted total over
-    applicable bands (``NaN`` without ``frequencies`` and more than one band)."""
+    applicable bands (``NaN`` without ``frequencies`` and more than one band).
+    """
 
     frequencies: np.ndarray | None
     partial_power: np.ndarray

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound power level of a noise source measured in a reverberation test room:
+r"""Sound power level of a noise source measured in a reverberation test room:
 ISO 3741:2010 (precision method, accuracy grade 1).
 
 The source is placed in a hard-walled reverberation room whose reverberant
@@ -95,7 +94,8 @@ class ReverberationSoundPowerResult:
     ``sound_power_level_a`` is the A-weighted total ``LWA`` (Annex F Eq. F.2),
     computed only when ``frequencies`` are supplied (``NaN`` for several bands
     without them; equal to ``LW`` for a single band). ``method`` is ``'direct'``
-    or ``'comparison'``."""
+    or ``'comparison'``.
+    """
 
     frequencies: np.ndarray | None
     sound_power_level: np.ndarray
@@ -188,7 +188,8 @@ def _validate_meteorology(temperature: float, static_pressure: float) -> None:
     A non-finite or :math:`\le -273` degC temperature makes
     :math:`\sqrt{273 + \theta}` complex/zero, and a non-finite or non-positive
     static pressure makes :math:`\log_{10}(p_\mathrm{s}/p_{\mathrm{s}0})` undefined; both are rejected
-    with a clean ``ValueError``."""
+    with a clean ``ValueError``.
+    """
     if not np.isfinite(temperature) or temperature <= -273.0:
         raise ValueError("'temperature' must be finite and greater than -273 degC.")
     if not np.isfinite(static_pressure) or static_pressure <= 0.0:
@@ -197,7 +198,8 @@ def _validate_meteorology(temperature: float, static_pressure: float) -> None:
 
 def _speed_of_sound(temperature: float) -> float:
     r"""Speed of sound :math:`c = 20.05 \sqrt{273 + \theta}` (ISO 3741,
-    clause 9.1.4)."""
+    clause 9.1.4).
+    """
     return float(20.05 * np.sqrt(273.0 + temperature))
 
 
@@ -220,7 +222,8 @@ def _c2_correction(temperature: float, static_pressure: float) -> float:
 def _mean_level(levels: np.ndarray) -> np.ndarray:
     """Energy mean over microphone positions (rows), returning one value per
     band. A 1D input is treated as a single averaged spectrum (ISO 3741
-    Eq. 16)."""
+    Eq. 16).
+    """
     arr = np.asarray(levels, dtype=np.float64)
     if arr.ndim == 1:
         return arr
@@ -239,7 +242,8 @@ def _k1_eq14(delta: np.ndarray, frequencies: np.ndarray) -> tuple[np.ndarray, bo
     250 Hz to 5 000 Hz) ``K1`` is clamped to the criterion value (1.26 dB /
     0.46 dB) and the levels become upper bounds. ``delta`` may be per band
     ``(NB,)`` or per position and band ``(NM, NB)``; the second returned value
-    flags whether any element fell below the lower criterion."""
+    flags whether any element fell below the lower criterion.
+    """
     low = np.where((frequencies <= 200.0) | (frequencies >= 6300.0), 6.0, 10.0)
     clamped = np.maximum(delta, low)
     k1 = -10.0 * np.log10(1.0 - 10.0 ** (-0.1 * clamped))
@@ -267,7 +271,8 @@ def _background_corrected_mean(
     With 1D pre-averaged ``levels`` the per-position information is gone, so a
     single ``K1`` is computed from the averaged spectra -- an approximation of
     the per-position procedure that is exact only when every position has the
-    same source-to-background margin. Prefer per-position input."""
+    same source-to-background margin. Prefer per-position input.
+    """
     arr = np.asarray(levels, dtype=np.float64)
     raw_mean = _mean_level(levels)
     if arr.ndim == 2:
@@ -309,7 +314,8 @@ def _min_room_volume(lowest_band: float) -> float:
     """Minimum room volume for the lowest band of interest (ISO 3741 Table 1).
 
     Bands at or below 160 Hz demand a progressively larger room; from 200 Hz
-    upward the floor is 70 m^3."""
+    upward the floor is 70 m^3.
+    """
     for band, vmin in _TABLE1_MIN_VOLUME:
         if lowest_band <= band:
             return vmin
@@ -323,12 +329,13 @@ def _room_qualification_warnings(
     surface_area: float,
     frequencies: np.ndarray,
 ) -> None:
-    """Emit advisory :class:`SoundPowerWarning`\\ s when the room or the
+    r"""Emit advisory :class:`SoundPowerWarning`\ s when the room or the
     microphone sampling fails an ISO 3741 qualification criterion.
 
     The determination still proceeds and returns a result; the warnings flag
     that the room must be qualified per Annex C/D or that more microphone
-    positions are needed (ISO 3741:2010, clauses 5.2, 5.3, 8.3, 8.4.2.2)."""
+    positions are needed (ISO 3741:2010, clauses 5.2, 5.3, 8.3, 8.4.2.2).
+    """
     lowest = float(np.min(frequencies))
     vmin = _min_room_volume(lowest)
     if volume < vmin:
@@ -360,7 +367,8 @@ def _position_sampling_warnings(levels: np.ndarray, stacklevel: int) -> None:
     inter-position standard deviation above the sM criterion (1,5 dB;
     8.4.2.2, Eq. 10). These sampling criteria need no room geometry, so they
     apply to both the direct and the comparison methods. A 1D (already-averaged)
-    spectrum carries no per-position information and is skipped."""
+    spectrum carries no per-position information and is skipped.
+    """
     arr = np.asarray(levels, dtype=np.float64)
     if arr.ndim != 2:
         return
@@ -391,7 +399,8 @@ def _a_weighted_total(
     sound_power_level: np.ndarray, frequencies: np.ndarray | None
 ) -> float:
     """A-weighted total ``LWA`` (ISO 3741 Annex F Eq. F.2). ``NaN`` for several
-    bands without frequencies; equal to ``LW`` for a single band."""
+    bands without frequencies; equal to ``LW`` for a single band.
+    """
     n_bands = sound_power_level.shape[0]
     if frequencies is not None:
         try:

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Airborne sound power from surface vibration (ISO/TS 7849-1/-2:2009).
+r"""Airborne sound power from surface vibration (ISO/TS 7849-1/-2:2009).
 
 The airborne sound power a machine radiates through the structure-borne
 vibration of its outer surface is estimated from the surface vibratory velocity
@@ -272,7 +271,8 @@ class VibrationSoundPowerResult:
     @property
     def total_level(self) -> float:
         r"""Band-summed sound power level, in dB:
-        :math:`10 \log_{10} \sum_j 10^{0.1 L_{Wj}}`."""
+        :math:`10 \log_{10} \sum_j 10^{0.1 L_{Wj}}`.
+        """
         lw = np.asarray(self.sound_power_level, dtype=np.float64)
         return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * lw))))
 

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Prominence of impulsive sounds and the ``LAeq`` adjustment (NT ACOU 112:2002,
+r"""Prominence of impulsive sounds and the ``LAeq`` adjustment (NT ACOU 112:2002,
 ISO/PAS 1996-3:2022).
 
 Noise with prominent impulses is more annoying than a steady sound of the same

--- a/src/phonometry/environment/assessment/measurement.py
+++ b/src/phonometry/environment/assessment/measurement.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Determination of environmental-noise sound pressure levels (ISO 1996-2:2017).
+r"""Determination of environmental-noise sound pressure levels (ISO 1996-2:2017).
 
 The measurement companion of the ISO 1996-1 descriptors in
 :mod:`phonometry.environment`. ISO 1996-2 covers *how* the levels that feed

--- a/src/phonometry/environment/assessment/rating.py
+++ b/src/phonometry/environment/assessment/rating.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Environmental noise descriptors per ISO 1996-1:2016.
+"""Environmental noise descriptors per ISO 1996-1:2016.
 
 Day-evening-night (Lden, 3.6.4) and day-night (Ldn, 3.6.5) sound levels,
 and composite whole-day rating levels (6.5, Formulae 5-6).
@@ -17,8 +16,7 @@ if TYPE_CHECKING:
 
 
 def composite_rating_level(periods: Iterable[tuple[float, float, float]]) -> float:
-    r"""
-    Composite whole-day rating level (ISO 1996-1:2016, 6.5).
+    r"""Composite whole-day rating level (ISO 1996-1:2016, 6.5).
 
     Generalizes Formulae (5) and (6): each period contributes its rating
     level plus adjustment, weighted by its share of the 24 h day:
@@ -54,8 +52,7 @@ def lden(
     lnight: float,
     hours: tuple[float, float, float] = (12.0, 4.0, 8.0),
 ) -> float:
-    r"""
-    Day-evening-night sound level Lden (ISO 1996-1:2016, 3.6.4).
+    r"""Day-evening-night sound level Lden (ISO 1996-1:2016, 3.6.4).
 
     .. math::
 
@@ -82,8 +79,7 @@ def ldn(
     lnight: float,
     hours: tuple[float, float] = (15.0, 9.0),
 ) -> float:
-    r"""
-    Day-night sound level Ldn (ISO 1996-1:2016, 3.6.5).
+    r"""Day-night sound level Ldn (ISO 1996-1:2016, 3.6.5).
 
     .. math::
 

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Spanish noise regulation: the corrected level LKeq (Real Decreto 1367/2007).
+r"""Spanish noise regulation: the corrected level LKeq (Real Decreto 1367/2007).
 
 Real Decreto 1367/2007 develops Ley 37/2003 del Ruido on acoustic zoning,
 quality objectives and emitter limit values. Its assessment chain is built on

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Atmospheric absorption of sound: ISO 9613-1:1993.
+r"""Atmospheric absorption of sound: ISO 9613-1:1993.
 
 The attenuation of a pure tone propagating through the atmosphere is governed by
 a pure-tone attenuation coefficient ``alpha`` (in dB/m) that depends on frequency,

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Spherical-wave ground effect and advanced barrier diffraction.
+r"""Spherical-wave ground effect and advanced barrier diffraction.
 
 This module extends the tabulated ground and barrier terms of ISO 9613-2 (see
 :mod:`phonometry.environment.propagation.outdoor_propagation`) with the underlying wave
@@ -884,7 +883,8 @@ def _diffracted_over_barrier(
     k: Real,
 ) -> Complex:
     """Diffracted field over a thin (``near_edge``) or thick (``near``/``far``
-    edges) barrier for one source/receiver pair; see :func:`_screen_field`."""
+    edges) barrier for one source/receiver pair; see :func:`_screen_field`.
+    """
     if thickness is None:
         return _screen_field(source, near_edge, near_edge, receiver, k)
     return _screen_field(source, near_edge, far_edge, receiver, k)

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Outdoor sound propagation: ISO 9613-2:1996 general method of calculation.
+r"""Outdoor sound propagation: ISO 9613-2:1996 general method of calculation.
 
 This part of ISO 9613 predicts octave-band attenuation of sound propagating
 outdoors from a point source to a receiver under conditions favourable to
@@ -127,6 +126,7 @@ class Barrier:
     line_of_sight_clear: bool = False
 
     def __post_init__(self) -> None:
+        """Reject negative ``dss``/``dsr``/``a`` and a non-positive spacing ``e``."""
         if self.source_to_edge < 0.0 or self.edge_to_receiver < 0.0:
             raise ValueError("Barrier edge distances must be non-negative.")
         if self.parallel_distance < 0.0:

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Atmospheric refraction: ray tracing and the parabolic equation (PE).
+r"""Atmospheric refraction: ray tracing and the parabolic equation (PE).
 
 Sound propagation outdoors is bent by vertical gradients of the effective sound
 speed :math:`c_\mathrm{eff}(z) = c(z) + u(z)` (the adiabatic sound speed plus the

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-CNOSSOS-EU railway source emission (Directive 2002/49/EC Annex II, 2.3).
+r"""CNOSSOS-EU railway source emission (Directive 2002/49/EC Annex II, 2.3).
 
 The common noise assessment methods of the European Union describe a railway
 track as **two** incoherent source lines at the centre of the track, at

--- a/src/phonometry/environment/sources/cnossos_road.py
+++ b/src/phonometry/environment/sources/cnossos_road.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-CNOSSOS-EU road traffic source emission (Directive 2002/49/EC Annex II, 2.2).
+r"""CNOSSOS-EU road traffic source emission (Directive 2002/49/EC Annex II, 2.2).
 
 The common noise assessment methods of the European Union describe a road as an
 incoherent **source line** of point sources 0.05 m above the pavement. Each

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Wind-turbine acoustic noise (IEC 61400-11:2012+A1:2018).
+r"""Wind-turbine acoustic noise (IEC 61400-11:2012+A1:2018).
 
 Two closed-form quantities of the standard:
 
@@ -309,7 +308,8 @@ def _candidate_peak(
     tone_frequency: float | None,
 ) -> int:
     """Index of the candidate line: the spectrum maximum, or the validated
-    nearest bin to the requested frequency."""
+    nearest bin to the requested frequency.
+    """
     if tone_frequency is None:
         return int(np.argmax(lv))
     tf = float(tone_frequency)
@@ -328,7 +328,8 @@ def _screen_possible_tone(
 ) -> bool:
     """9.5.2 possible-tone screen: local maximum more than 6 dB above the
     critical-band energy average that excludes the maximum line and its two
-    adjacent lines."""
+    adjacent lines.
+    """
     screen_indices = np.nonzero(in_band)[0]
     screen_indices = screen_indices[np.abs(screen_indices - peak) > 1]
     local_max = (peak == 0 or lv[peak] >= lv[peak - 1]) and (

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-IEC 61260-1:2014 band-filter class verification.
+r"""IEC 61260-1:2014 band-filter class verification.
 
 Acceptance limits on relative attenuation transcribed from the
 official text (BS EN 61260-1:2014, **Table 1**, standard pages 15-16):
@@ -129,8 +128,7 @@ _FILTER_EDITIONS: dict[str, dict[str, Any]] = {
 
 
 def _map_breakpoint(exponent: float, fraction: float) -> float:
-    r"""
-    Map an octave-band breakpoint :math:`G^x` to a fractional-octave one.
+    r"""Map an octave-band breakpoint :math:`G^x` to a fractional-octave one.
 
     BS EN 61260-1:2014 Formula (9): the high-frequency breakpoint for
     bandwidth designator 1/b is
@@ -148,8 +146,7 @@ def _map_breakpoint(exponent: float, fraction: float) -> float:
 def class_limits(
     fraction: float, filter_class: int, omega: np.ndarray, *, edition: str = "2014"
 ) -> tuple[np.ndarray, np.ndarray]:
-    r"""
-    Acceptance limits on relative attenuation at normalized frequencies.
+    r"""Acceptance limits on relative attenuation at normalized frequencies.
 
     :param fraction: Bandwidth designator denominator b (1 for octave,
         3 for one-third octave, ...).
@@ -283,8 +280,7 @@ def _verify_band(
 def verify_filter_class(
     bank: OctaveFilterBank, num_points: int = 2**15, *, edition: str = "2014"
 ) -> dict[str, Any]:
-    """
-    Verify a filter bank against the IEC 61260 class limits.
+    """Verify a filter bank against the IEC 61260 class limits.
 
     Each band's relative attenuation (referenced to the attenuation at its
     exact mid-band frequency) is checked against every acceptance-limit class of

--- a/src/phonometry/filters/core.py
+++ b/src/phonometry/filters/core.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Core processing logic and FilterBank class for phonometry.
-"""
+"""Core processing logic and FilterBank class for phonometry."""
 
 from __future__ import annotations
 
@@ -153,8 +151,7 @@ def _validate_bank_design(
 
 
 class OctaveFilterBank:
-    """
-    A class-based representation of an Octave Filter Bank.
+    """A class-based representation of an Octave Filter Bank.
     Allows for pre-calculating and reusing filter coefficients.
     """
 
@@ -170,8 +167,7 @@ class OctaveFilterBank:
         block_processing: BlockProcessing = _DEFAULT_BLOCK_PROCESSING,
         response_plot: ResponsePlot = _DEFAULT_RESPONSE_PLOT,
     ) -> None:
-        """
-        Initialize the Octave Filter Bank.
+        """Initialize the Octave Filter Bank.
 
         :param fs: Sample rate in Hz.
         :param fraction: Bandwidth fraction (e.g., 1 for octave, 3 for 1/3 octave).
@@ -260,6 +256,7 @@ class OctaveFilterBank:
         self._steady_ic = steady_ic
 
     def __repr__(self) -> str:
+        """Design summary: fs, fraction, order, limits, filter family and band count."""
         return (
             f"OctaveFilterBank(fs={self.fs}, fraction={self.fraction}, order={self.order}, "
             f"limits={self.limits}, filter_type='{self.filter_type}', "
@@ -379,8 +376,7 @@ class OctaveFilterBank:
             list[Signal] | list[np.ndarray],
         ]
     ):
-        """
-        Apply the pre-designed filter bank to a signal.
+        """Apply the pre-designed filter bank to a signal.
 
         :param x: Input signal (1D array or 2D array [channels, samples]), or
             a :class:`phonometry.io.Signal`. A Signal recorded at another rate
@@ -495,8 +491,7 @@ class OctaveFilterBank:
         detrend: bool = True,
         zero_phase: bool = False,
     ) -> tuple[np.ndarray, list[float], np.ndarray]:
-        """
-        Short-time fractional-octave analysis: level per band over time.
+        """Short-time fractional-octave analysis: level per band over time.
 
         :param x: Input signal (1D array or 2D array [channels, samples]), or
             a :class:`phonometry.io.Signal`. It follows the same rate and
@@ -577,8 +572,7 @@ class OctaveFilterBank:
         calculate_level: bool = True,
         zero_phase: bool = False,
     ) -> tuple[np.ndarray | None, list[np.ndarray] | None]:
-        """
-        Process signal through each frequency band.
+        """Process signal through each frequency band.
 
         :param x_proc: Standardized 2D input signal [channels, samples].
         :param num_channels: Number of channels.
@@ -785,8 +779,7 @@ def octave_filter(
     | tuple[np.ndarray, list[float], list[Signal] | list[np.ndarray]]
     | tuple[np.ndarray, list[str], list[Signal] | list[np.ndarray]]
 ):
-    """
-    Filter a signal with octave or fractional octave filter bank.
+    """Filter a signal with octave or fractional octave filter bank.
 
     This method uses a filter bank with Second-Order Sections (SOS) coefficients.
     To obtain the correct coefficients, automatic subsampling is applied to the

--- a/src/phonometry/filters/design.py
+++ b/src/phonometry/filters/design.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Band-filter design and visualization: the SOS designer behind the octave and
+"""Band-filter design and visualization: the SOS designer behind the octave and
 fractional-octave banks, and the response plot the banks draw with it.
 """
 
@@ -22,8 +21,7 @@ def _cheby2_transition_ratio(order: int, attenuation: float) -> float:
 def _cheby2_stopband_edges(
     fd: float, fu: float, order: int, attenuation: float, fs: float | None = None
 ) -> tuple[float, float]:
-    """
-    Map desired -3 dB band edges (fd, fu) to the Chebyshev II stopband
+    """Map desired -3 dB band edges (fd, fu) to the Chebyshev II stopband
     edges that scipy expects as ``Wn``.
 
     Uses the analog lowpass-to-bandpass transform: the stopband keeps the
@@ -55,8 +53,7 @@ def _cheby2_stopband_edges(
 
 
 def _cheby2_headroom(fraction: float, order: int, attenuation: float) -> float:
-    """
-    Headroom factor ``f2_stop / f_upper_edge`` needed above the band's upper
+    """Headroom factor ``f2_stop / f_upper_edge`` needed above the band's upper
     edge. Constant across bands of the same fraction (bands are geometric).
     """
     g = 10 ** (3 / 10)
@@ -79,8 +76,7 @@ def _design_sos_filter(
     show: bool = False,
     plot_file: str | None = None,
 ) -> list[np.ndarray]:
-    """
-    Generate SOS coefficients for the filter bank.
+    """Generate SOS coefficients for the filter bank.
 
     :param freq: Center frequencies.
     :param freq_d: Lower edge frequencies.
@@ -157,8 +153,7 @@ def _showfilter(
     plot_file: str | None = None,
     close: bool = True,
 ) -> None:
-    """
-    Visualize filter bank frequency response.
+    """Visualize filter bank frequency response.
 
     :param sos: List of SOS coefficients.
     :param freq: Center frequencies.

--- a/src/phonometry/filters/equalizer.py
+++ b/src/phonometry/filters/equalizer.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Parametric equalizer biquads per the RBJ Audio EQ Cookbook.
+r"""Parametric equalizer biquads per the RBJ Audio EQ Cookbook.
 
 Second-order (biquad) IIR sections designed from the closed-form recipes of
 Robert Bristow-Johnson's *Audio EQ Cookbook*, the de-facto reference for
@@ -140,6 +139,7 @@ class EQSection:
     slope: float | None = None
 
     def __post_init__(self) -> None:
+        """Reject a section the cookbook cannot design (type, ``f0``, gain, Q/BW/S)."""
         _validate_section(self)
 
 
@@ -477,8 +477,7 @@ class ParametricEQ:
         stateful: bool = False,
         steady_ic: bool = False,
     ) -> None:
-        """
-        :param fs: Sample rate in Hz.
+        """:param fs: Sample rate in Hz.
         :param sections: One :class:`EQSection` or a sequence of them; the
             cascade applies them in order.
         :param stateful: If True, :meth:`filter` carries the filter state

--- a/src/phonometry/filters/frequencies.py
+++ b/src/phonometry/filters/frequencies.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Frequency calculation logic according to ANSI/IEC standards.
-"""
+"""Frequency calculation logic according to ANSI/IEC standards."""
 
 from __future__ import annotations
 
@@ -17,8 +15,7 @@ def nominal_frequencies(
     fraction: float,
     limits: list[float] | None = None,
 ) -> tuple[list[float], list[float], list[float], list[str]]:
-    """
-    Calculate frequencies according to ANSI/IEC standards.
+    """Calculate frequencies according to ANSI/IEC standards.
 
     :param fraction: Bandwidth fraction (e.g., 1, 3).
     :param limits: [f_min, f_max] limits.
@@ -48,8 +45,7 @@ def nominal_frequencies(
 
 
 def _initindex(f: float, fr: float, g: float, b: float) -> int:
-    """
-    Calculate starting index for band generation.
+    """Calculate starting index for band generation.
 
     :param f: Frequency.
     :param fr: Reference frequency.
@@ -63,8 +59,7 @@ def _initindex(f: float, fr: float, g: float, b: float) -> int:
 
 
 def _ratio(g: float, x: int, b: float) -> float:
-    """
-    Calculate ratio for center frequency.
+    """Calculate ratio for center frequency.
 
     :param g: Base ratio.
     :param x: Index.
@@ -77,8 +72,7 @@ def _ratio(g: float, x: int, b: float) -> float:
 
 
 def _bandedge(g: float, b: float) -> float:
-    """
-    Calculate band-edge ratio.
+    """Calculate band-edge ratio.
 
     :param g: Base ratio.
     :param b: Bandwidth fraction.
@@ -90,8 +84,7 @@ def _bandedge(g: float, b: float) -> float:
 def _deleteouters(
     freq: list[float], freq_d: list[float], freq_u: list[float], fs: int
 ) -> tuple[list[float], list[float], list[float]]:
-    """
-    Remove bands exceeding the Nyquist frequency.
+    """Remove bands exceeding the Nyquist frequency.
 
     :param freq: Center frequencies.
     :param freq_d: Lower edges.
@@ -120,8 +113,7 @@ def _deleteouters(
 def _genfreqs(
     limits: list[float], fraction: float, fs: int
 ) -> tuple[list[float], list[float], list[float], list[str]]:
-    """
-    Determine band frequencies within limits.
+    """Determine band frequencies within limits.
 
     :param limits: [f_min, f_max].
     :param fraction: Bandwidth fraction.
@@ -189,8 +181,7 @@ def _format_nominal_freq(f: float) -> str:
 
 
 def normalized_frequencies(fraction: int) -> list[float]:
-    """
-    Get standardized IEC center frequencies.
+    """Get standardized IEC center frequencies.
 
     :param fraction: 1 or 3 (Octave or 1/3 Octave).
     :return: List of standard frequencies.

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Weighting filters (A, B, C, D, G, AU, Z), time weighting utilities and
+r"""Weighting filters (A, B, C, D, G, AU, Z), time weighting utilities and
 the Linkwitz-Riley crossover.
 
 A/C/Z per IEC 61672-1:2013; G (infrasound) per ISO 7196:1995.
@@ -77,8 +76,7 @@ except ImportError:  # pragma: no cover - depends on install extras
 
 
 class WeightingFilter:
-    """
-    Class-based frequency weighting filter (A, B, C, D, G, AU, Z).
+    """Class-based frequency weighting filter (A, B, C, D, G, AU, Z).
     Allows pre-calculating and reusing filter coefficients.
     """
 
@@ -90,8 +88,7 @@ class WeightingFilter:
         steady_ic: bool = False,
         high_accuracy: bool | None = None,
     ) -> None:
-        """
-        Initialize the weighting filter.
+        """Initialize the weighting filter.
 
         :param fs: Sample rate in Hz.
         :param curve: 'A', 'C' (IEC 61672-1), 'B' (ANSI S1.4-1983,
@@ -339,8 +336,7 @@ class WeightingFilter:
         return _sos_state_mismatch(self.zi, x_proc)
 
     def filter(self, x: Signal | list[float] | np.ndarray) -> Signal | np.ndarray:
-        """
-        Apply the weighting filter to a signal.
+        """Apply the weighting filter to a signal.
 
         :param x: Input signal (1D or 2D [channels, samples]), or a
             :class:`phonometry.io.Signal`. A Signal recorded at another rate
@@ -397,7 +393,7 @@ def _resample_poly_fir(rate: int) -> np.ndarray:
 def _runtime_frequency_response(
     wf: WeightingFilter, frequencies: np.ndarray
 ) -> np.ndarray:
-    """Complex steady-state response of the *whole* filter path.
+    r"""Complex steady-state response of the *whole* filter path.
 
     A non-stateful ``WeightingFilter`` with ``high_accuracy`` does not apply
     its second-order sections to the input directly: it interpolates by
@@ -410,8 +406,8 @@ def _runtime_frequency_response(
 
     .. math::
 
-       G(f) = \\sum_{k=0}^{L-1} H_\\mathrm{FIR}^2(f - k f_s)\\,
-              H_\\mathrm{SOS}(f - k f_s),
+       G(f) = \sum_{k=0}^{L-1} H_\mathrm{FIR}^2(f - k f_s)\,
+              H_\mathrm{SOS}(f - k f_s),
 
     evaluated at the ``L * fs`` design rate (the transfer functions are
     periodic there, so images beyond the design Nyquist frequency need no
@@ -519,9 +515,11 @@ class TimeWeightedEnvelope:
         return np.asarray(self.mean_square, dtype=dtype)
 
     def __len__(self) -> int:
+        """Length of the leading axis: channels when 2-D, samples for one channel."""
         return int(self.mean_square.shape[0])
 
     def __getitem__(self, key: Any) -> Any:
+        """Index the mean square; the result is bare values, not another envelope."""
         return self.mean_square[key]
 
     @property
@@ -592,8 +590,7 @@ def weighting_filter(
     curve: str = "A",
     high_accuracy: bool = True,
 ) -> Signal | np.ndarray:
-    """
-    Apply a frequency weighting to a signal.
+    """Apply a frequency weighting to a signal.
 
     :param x: Input signal, or a :class:`phonometry.io.Signal` read from a
         measurement file. A calibrated Signal is weighted in pascals, so the
@@ -705,8 +702,7 @@ def time_weighting(
     mode: str = "fast",
     initial_state: str | float | np.ndarray | None = None,
 ) -> TimeWeightedEnvelope | np.ndarray:
-    """
-    Apply time weighting to a signal (Exponential averaging).
+    """Apply time weighting to a signal (Exponential averaging).
 
     :param x: Input signal (raw pressure/voltage), or a
         :class:`phonometry.io.Signal` read from a measurement file. The
@@ -767,16 +763,14 @@ def time_weighting(
 
 
 class TimeWeighting:
-    """
-    Stateful time weighting for block processing.
+    """Stateful time weighting for block processing.
 
     Wraps :func:`time_weighting` carrying the exponential integrator state
     across blocks, so concatenated block outputs equal a single continuous call.
     """
 
     def __init__(self, fs: int, mode: str = "fast") -> None:
-        """
-        :param fs: Sample rate in Hz.
+        """:param fs: Sample rate in Hz.
         :param mode: 'fast' (125 ms), 'slow' (1000 ms) or 'impulse' (35 ms / 1.5 s).
         """
         if fs <= 0:
@@ -843,8 +837,7 @@ def linkwitz_riley(
     freq: float,
     order: int = 4,
 ) -> tuple[Signal, Signal] | tuple[np.ndarray, np.ndarray]:
-    """
-    Linkwitz-Riley crossover filter (Butterworth squared).
+    """Linkwitz-Riley crossover filter (Butterworth squared).
     Splits signal into low and high bands with flat sum response.
 
     :param x: Input signal, or a :class:`phonometry.io.Signal` read from a

--- a/src/phonometry/filters/weighting_compliance.py
+++ b/src/phonometry/filters/weighting_compliance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-IEC 61672-1:2013 frequency-weighting class verification.
+r"""IEC 61672-1:2013 frequency-weighting class verification.
 
 A/C/Z frequency-weighting acceptance limits transcribed from
 BS EN 61672-1:2013, **Table 3** (standard page 22): the design-goal responses
@@ -322,8 +321,7 @@ def _analytic_weighting_db(curve: str, frequencies: np.ndarray) -> np.ndarray:
 def weighting_class_limits(
     weighting_class: int,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    IEC 61672-1:2013 Table 3 acceptance limits for a performance class.
+    """IEC 61672-1:2013 Table 3 acceptance limits for a performance class.
 
     The limits apply to every IEC 61672-1 weighting (A, C, Z); they qualify
     the deviation of the measured relative response from the design goal at
@@ -492,8 +490,7 @@ def _between_nominals_sweep(
 def verify_weighting_class(
     wf: WeightingFilter, *, sweep_points: int = 4096
 ) -> dict[str, Any]:
-    r"""
-    Verify a frequency-weighting filter against its standard's tolerances.
+    r"""Verify a frequency-weighting filter against its standard's tolerances.
 
     ``A``/``C``/``Z`` are checked against IEC 61672-1:2013 Table 3 (classes 1
     and 2). The historical ``B`` weighting is checked against ANSI S1.4-1983:

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Estimation of noise-induced hearing loss (ISO 1999:2013).
+r"""Estimation of noise-induced hearing loss (ISO 1999:2013).
 
 Implements the noise-induced permanent threshold shift (NIPTS) of a
 noise-exposed population and its combination with the age-related threshold

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Occupational noise exposure: measurement strategies and uncertainty (ISO 9612:2009).
+r"""Occupational noise exposure: measurement strategies and uncertainty (ISO 9612:2009).
 
 ISO 9612:2009 is the engineering method (accuracy grade 2) for determining a
 worker's daily noise exposure level ``LEX,8h`` from measurements of the
@@ -156,8 +155,7 @@ _C4_ADVISORY_THRESHOLD: float = 3.5
 
 
 def table_c4_contribution(n_samples: int, u1: float) -> float:
-    r"""
-    Uncertainty contribution :math:`c_1 u_1` (dB) from Table C.4
+    r"""Uncertainty contribution :math:`c_1 u_1` (dB) from Table C.4
     (job/full-day sampling).
 
     Bilinear interpolation on the sample count ``N`` and the sampling standard
@@ -193,8 +191,7 @@ def table_c4_contribution(n_samples: int, u1: float) -> float:
 
 
 def minimum_cumulative_duration_hours(n_workers: int) -> float:
-    """
-    Minimum cumulative measurement duration (h) for a homogeneous exposure group (Table 1).
+    """Minimum cumulative measurement duration (h) for a homogeneous exposure group (Table 1).
 
     :param n_workers: Number of workers ``n_G`` in the homogeneous exposure group.
     :return: The minimum cumulative measurement duration in hours. For
@@ -244,8 +241,7 @@ def _task_sampling_uncertainty(levels: Sequence[float]) -> float:
 # --------------------------------------------------------------------------- #
 @dataclass(frozen=True)
 class Task:
-    """
-    One task of a task-based measurement (ISO 9612:2009 Clause 9).
+    """One task of a task-based measurement (ISO 9612:2009 Clause 9).
 
     :param samples: Measured ``Lp,A,eqT,mi`` levels for the task, dB. At least
         three are recommended (Clause 9.3); a single conservative value is
@@ -269,6 +265,7 @@ class Task:
     instrument: InstrumentClass | None = None
 
     def __post_init__(self) -> None:
+        """Reject an empty ``samples`` tuple and a non-positive ``duration_hours``."""
         if len(self.samples) == 0:
             raise ValueError("A Task needs at least one Lp,A,eqT sample.")
         if self.duration_hours <= 0.0:
@@ -296,7 +293,8 @@ class TaskContribution:
     @property
     def variance_contribution(self) -> float:
         r"""This task's contribution to :math:`u^2(L_\mathrm{EX,8h})` (a term of
-        Eq C.3), dB²."""
+        Eq C.3), dB².
+        """
         return (
             self.c1a**2 * (self.u1a**2 + self.u2**2 + self.u3**2)
             + (self.c1b * self.u1b) ** 2
@@ -305,8 +303,7 @@ class TaskContribution:
 
 @dataclass(frozen=True)
 class ExposureResult:
-    r"""
-    Daily noise exposure level and its expanded uncertainty (ISO 9612:2009).
+    r"""Daily noise exposure level and its expanded uncertainty (ISO 9612:2009).
 
     :ivar lex_8h: A-weighted daily noise exposure level ``LEX,8h``, dB.
     :ivar combined_standard_uncertainty: Combined standard uncertainty ``u``
@@ -522,8 +519,7 @@ def task_based_exposure(
     include_duration_uncertainty: bool = True,
     warn: bool = True,
 ) -> ExposureResult:
-    """
-    Daily noise exposure level from task-based measurements (ISO 9612:2009 Clause 9).
+    """Daily noise exposure level from task-based measurements (ISO 9612:2009 Clause 9).
 
     Each task level is the energy average of its samples (Eq 7); the daily level
     is the energy sum of the task contributions (Eq 9/10). The uncertainty budget
@@ -639,8 +635,7 @@ def job_based_exposure(
     sample_duration_hours: float | None = None,
     warn: bool = True,
 ) -> ExposureResult:
-    r"""
-    Daily noise exposure level from job-based measurements (ISO 9612:2009 Clause 10).
+    r"""Daily noise exposure level from job-based measurements (ISO 9612:2009 Clause 10).
 
     The effective-day level is the energy average of ``N >= 5`` random job samples
     (Eq 11); the daily level follows Eq 12. The sampling uncertainty ``u1`` is the
@@ -694,8 +689,7 @@ def full_day_exposure(
     u3: float = _U3_DEFAULT,
     warn: bool = True,
 ) -> ExposureResult:
-    """
-    Daily noise exposure level from full-day measurements (ISO 9612:2009 Clause 11).
+    """Daily noise exposure level from full-day measurements (ISO 9612:2009 Clause 11).
 
     Three (or more) whole-day ``Lp,A,eqT`` measurements are energy-averaged (Eq 11)
     and the daily level follows Eq 13. If only three measurements are supplied and

--- a/src/phonometry/hearing/threshold.py
+++ b/src/phonometry/hearing/threshold.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Age-related hearing threshold (ISO 7029:2017) and audiometric reference zero
+r"""Age-related hearing threshold (ISO 7029:2017) and audiometric reference zero
 (ISO 389-7:2005).
 
 Implements the statistical distribution of the hearing threshold of an

--- a/src/phonometry/io/_backends.py
+++ b/src/phonometry/io/_backends.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Backend dispatch: base install for the WAV family, ``[audio]`` for the rest.
+r"""Backend dispatch: base install for the WAV family, ``[audio]`` for the rest.
 
 The base install (NumPy + SciPy) reads every *linear* WAV a measurement
 chain produces -- PCM at any depth, IEEE float, EXTENSIBLE, BWF metadata,

--- a/src/phonometry/io/_bext.py
+++ b/src/phonometry/io/_bext.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Writing the ``bext`` broadcast extension chunk (EBU Tech 3285 v2, 2011).
+r"""Writing the ``bext`` broadcast extension chunk (EBU Tech 3285 v2, 2011).
 
 No maintained Python package writes ``bext`` (wavinfo only reads it;
 python-soundfile does not expose libsndfile's ``SFC_SET_BROADCAST_INFO``),

--- a/src/phonometry/io/_blocks.py
+++ b/src/phonometry/io/_blocks.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Block streaming: feed hours of recording through a constant memory window.
+r"""Block streaming: feed hours of recording through a constant memory window.
 
 A night of environmental monitoring at 48 kHz/24-bit/2 channels grows past
 4 GiB on disk in under four hours and costs about 5.5 GiB of RAM *per

--- a/src/phonometry/io/_chunks.py
+++ b/src/phonometry/io/_chunks.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-RIFF/RF64 chunk walker for WAVE measurement files, in pure ``struct``.
+r"""RIFF/RF64 chunk walker for WAVE measurement files, in pure ``struct``.
 
 :mod:`scipy.io.wavfile` decodes the samples of every WAV variant a
 measurement chain produces (PCM 1-64 bit, IEEE float, WAVE_FORMAT_EXTENSIBLE,

--- a/src/phonometry/io/_convert.py
+++ b/src/phonometry/io/_convert.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Converting a measurement file without losing what makes it a measurement.
+r"""Converting a measurement file without losing what makes it a measurement.
 
 Generic converters treat audio as audio: they resample when convenient,
 normalise when helpful, and drop every chunk they do not recognise --

--- a/src/phonometry/io/_flac.py
+++ b/src/phonometry/io/_flac.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Carrying the ``bext`` provenance chunk inside a FLAC file.
+r"""Carrying the ``bext`` provenance chunk inside a FLAC file.
 
 FLAC is the one compressed format a measurement archive can defend
 (lossless by construction, RFC 9639), but its metadata model has no

--- a/src/phonometry/io/_resolve.py
+++ b/src/phonometry/io/_resolve.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Resolving an ``(x, fs)`` argument pair that may arrive as a ``Signal``.
+"""Resolving an ``(x, fs)`` argument pair that may arrive as a ``Signal``.
 
 A function that consumes a recording should take a
 :class:`phonometry.io.Signal` in place of the bare ``(x, fs)`` pair: the

--- a/src/phonometry/io/_sidecar.py
+++ b/src/phonometry/io/_sidecar.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-The calibration sidecar: a versioned JSON file beside the audio.
+r"""The calibration sidecar: a versioned JSON file beside the audio.
 
 No audio container carries a microphone calibration. The equipment survey
 behind this module found the same pattern everywhere: sound level meters

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-The :class:`Signal` result object: samples plus the metadata they need.
+r"""The :class:`Signal` result object: samples plus the metadata they need.
 
 A measurement WAV is only interpretable together with its sample rate, its
 calibration and its provenance, yet the ecosystem's readers return a bare

--- a/src/phonometry/io/_wav.py
+++ b/src/phonometry/io/_wav.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Base-install WAV reading: scipy decodes the samples, the walker the rest.
+r"""Base-install WAV reading: scipy decodes the samples, the walker the rest.
 
 :mod:`scipy.io.wavfile` already decodes every linear WAV variant measurement
 equipment writes -- PCM 1-64 bit (24-bit arrives as ``int32`` with the sample

--- a/src/phonometry/io/_write.py
+++ b/src/phonometry/io/_write.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Base-install WAV writing: scipy where it already serves, in-house where not.
+r"""Base-install WAV writing: scipy where it already serves, in-house where not.
 
 :func:`scipy.io.wavfile.write` covers most of what a measurement export
 needs -- PCM 16/32, IEEE float 32/64, and automatic RF64 promotion when the

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Airflow resistance of porous materials: ISO 9053-1 and ISO 9053-2.
+r"""Airflow resistance of porous materials: ISO 9053-1 and ISO 9053-2.
 
 Two standardised measurement methods share the same three quantities and units
 (ISO 9053-1:2018, Clause 3; ISO 9053-2:2020, Clause 3):

--- a/src/phonometry/materials/absorbers/four_microphone.py
+++ b/src/phonometry/materials/absorbers/four_microphone.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Four-microphone transfer-matrix method for the transmission of a specimen.
+r"""Four-microphone transfer-matrix method for the transmission of a specimen.
 
 **ASTM E2611-19**, the two-tube method: the specimen sits between an upstream
 and a downstream tube section with two microphones on each side, and the wave

--- a/src/phonometry/materials/absorbers/impedance_tube.py
+++ b/src/phonometry/materials/absorbers/impedance_tube.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Two-microphone transfer-function method in the impedance tube.
+r"""Two-microphone transfer-function method in the impedance tube.
 
 **BS EN ISO 10534-2:2001**: the complex reflection factor ``r`` at the sample
 surface is obtained from the measured transfer function ``H12`` between two

--- a/src/phonometry/materials/absorbers/layered.py
+++ b/src/phonometry/materials/absorbers/layered.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Declarative layer stacks and the transfer-matrix absorber solver.
+r"""Declarative layer stacks and the transfer-matrix absorber solver.
 
 An absorber is declared as a list of layers ordered from the sound-incidence
 side towards the termination and solved at one angle, in the same

--- a/src/phonometry/materials/absorbers/porous.py
+++ b/src/phonometry/materials/absorbers/porous.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Porous-material models and resonant sheet impedances.
+r"""Porous-material models and resonant sheet impedances.
 
 Two complementary building blocks, all in the :math:`e^{+j \omega t}`
 time convention with the forward wave carried by :math:`e^{-j k x}` (so a
@@ -251,7 +250,8 @@ class PorousMediumResult:
     @property
     def normalized_wavenumber(self) -> Complex:
         r"""Wavenumber normalised by the free-air wavenumber
-        :math:`k_0 = \omega / c`."""
+        :math:`k_0 = \omega / c`.
+        """
         k0 = 2.0 * np.pi * self.frequency / self.speed_of_sound
         return np.asarray(self.wavenumber / k0, dtype=np.complex128)
 

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Single-number rating of sound absorption (ISO 11654:1997).
+r"""Single-number rating of sound absorption (ISO 11654:1997).
 
 From one-third-octave sound absorption coefficients ``alpha_s`` measured in
 a reverberation room (ISO 354) this module forms the practical sound
@@ -143,7 +142,8 @@ def _round_half_up(value: float) -> int:
 
 def _practical_round(mean: float) -> float:
     r"""Round an octave mean per Clause 4.1: to the second decimal, then in
-    steps of 0.05, capped at 1.00 (the NOTE gives :math:`0.92 \to 0.90`)."""
+    steps of 0.05, capped at 1.00 (the NOTE gives :math:`0.92 \to 0.90`).
+    """
     hundredths = _round_half_up(mean * 100.0)  # second decimal
     fives = _round_half_up(hundredths / 5.0) * 5  # nearest 0,05
     fives = max(0, min(100, fives))  # maximise to 1,00 (Clause 4.1)
@@ -152,7 +152,8 @@ def _practical_round(mean: float) -> float:
 
 def _to_units(alpha: float) -> int:
     """Snap an absorption coefficient to the 0,05 grid as an integer
-    twentieth in ``[0, 20]`` (``1.00`` -> 20), for float-safe comparison."""
+    twentieth in ``[0, 20]`` (``1.00`` -> 20), for float-safe comparison.
+    """
     return max(0, min(20, _round_half_up(alpha * 20.0)))
 
 
@@ -243,7 +244,8 @@ class AbsorptionRatingResult:
     @property
     def rating_label(self) -> str:
         """The rating as reported in Clause 5.3, e.g. ``"0.60(M)"`` or
-        ``"0.60"`` when no shape indicator applies."""
+        ``"0.60"`` when no shape indicator applies.
+        """
         if self.shape_indicator:
             return f"{self.alpha_w:.2f}({self.shape_indicator})"
         return f"{self.alpha_w:.2f}"
@@ -347,7 +349,8 @@ def practical_absorption_coefficient(
 def _shape_indicator(measured_units: list[int], reference_units: list[int]) -> str:
     """Shape indicators of Clause 4.3: a band exceeding the shifted
     reference by 0,25 or more contributes L (250 Hz), M (500/1000 Hz) or
-    H (2000/4000 Hz)."""
+    H (2000/4000 Hz).
+    """
     excess = [
         m - r >= _SHAPE_THRESHOLD_UNITS for m, r in zip(measured_units, reference_units)
     ]

--- a/src/phonometry/materials/absorbers/slow_sound.py
+++ b/src/phonometry/materials/absorbers/slow_sound.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Slow-sound slit panels loaded with Helmholtz resonators (perfect absorbers).
+r"""Slow-sound slit panels loaded with Helmholtz resonators (perfect absorbers).
 
 A rigid panel perforated by a periodic array of thin closed slits, whose upper
 wall is loaded by an array of Helmholtz resonators (HRs), behaves as a

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound absorption in a reverberation room: BS EN ISO 354:2003.
+r"""Sound absorption in a reverberation room: BS EN ISO 354:2003.
 
 The mean reverberation time of a reverberation room is measured empty and with
 the test specimen installed. From those two reverberation times the equivalent
@@ -203,7 +202,8 @@ def _absorption_area(
 
     Shared by :func:`absorption_area` (which adds the ISO 354 clause 6.1.1
     volume advisory) and :func:`absorption_coefficient` (which advises the
-    volume once for the pair of measurements)."""
+    volume once for the pair of measurements).
+    """
     t = np.asarray(t60, dtype=np.float64)
     m_arr = np.asarray(m, dtype=np.float64)
     _validate_area_inputs(t, volume, m_arr)

--- a/src/phonometry/materials/absorbers/standing_wave.py
+++ b/src/phonometry/materials/absorbers/standing_wave.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Standing-wave-ratio method for normal-incidence absorption and impedance.
+r"""Standing-wave-ratio method for normal-incidence absorption and impedance.
 
 **BS EN ISO 10534-1:2001**, the probe-traverse method of the impedance tube: a
 loudspeaker drives one pure tone at a time, a probe microphone traverses the

--- a/src/phonometry/materials/absorbers/uncertainty.py
+++ b/src/phonometry/materials/absorbers/uncertainty.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Measurement uncertainty for sound absorption (ISO 12999-2:2020).
+r"""Measurement uncertainty for sound absorption (ISO 12999-2:2020).
 
 Companion of the sound-insulation uncertainty of :mod:`phonometry.building.measurement.uncertainty`
 (ISO 12999-1). This part gives the standard uncertainty ``u`` of the quantities
@@ -203,7 +202,8 @@ class AbsorptionUncertaintyResult:
     @property
     def reported_expanded_uncertainty(self) -> np.ndarray:
         """``U`` rounded for reporting (Clause 8): two decimals for absorption
-        coefficients, one decimal for the equivalent area and ``DLα,NRD``."""
+        coefficients, one decimal for the equivalent area and ``DLα,NRD``.
+        """
         decimals = 2 if self.quantity in _COEFFICIENT_QUANTITIES else 1
         return _round_report(self.expanded_uncertainty, decimals)
 
@@ -258,7 +258,8 @@ def _band_uncertainty(
     band_kind: str,
 ) -> AbsorptionUncertaintyResult:
     r"""Shared engine for the coefficient formulae
-    :math:`\sigma_\mathrm{R} = m \alpha + n` (values == α)."""
+    :math:`\sigma_\mathrm{R} = m \alpha + n` (values == α).
+    """
     if values.shape != frequencies.shape:
         raise ValueError(
             f"'{quantity}' values and frequencies must have the same shape; "

--- a/src/phonometry/materials/diffusers/design.py
+++ b/src/phonometry/materials/diffusers/design.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Far-field polar response and diffusion coefficient predicted from a diffuser design.
+r"""Far-field polar response and diffusion coefficient predicted from a diffuser design.
 
 Where :mod:`phonometry.materials.diffusers.scattering_diffusion` evaluates the *measured*
 directional diffusion coefficient of ISO 17497-2 from a set of reflected

--- a/src/phonometry/materials/diffusers/metadiffuser.py
+++ b/src/phonometry/materials/diffusers/metadiffuser.py
@@ -79,6 +79,7 @@ class MetadiffuserWell:
     resonators: tuple[HelmholtzResonator, ...]
 
     def __post_init__(self) -> None:
+        """Reject a non-positive ``slit_height`` and a well with no resonators."""
         require_positive(self.slit_height, "slit_height")
         if not self.resonators:
             raise ValueError("'resonators' must contain at least one resonator.")

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Random-incidence scattering coefficient in a reverberation room.
+r"""Random-incidence scattering coefficient in a reverberation room.
 
 **ISO 17497-1:2004+A1:2014.** Four reverberation times (Table 2) taken with and
 without the test sample, with a static and a rotating turntable, give two

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Directional and random-incidence diffusion coefficients in a free field.
+r"""Directional and random-incidence diffusion coefficients in a free field.
 
 **ISO 17497-2:2012.** From the set of reflected sound-pressure levels ``L_i``
 on a semicircle or hemisphere the autocorrelation diffusion coefficient

--- a/src/phonometry/materials/resilient/dynamic_stiffness.py
+++ b/src/phonometry/materials/resilient/dynamic_stiffness.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Dynamic stiffness of resilient materials under floating floors (EN 29052-1:1992).
+r"""Dynamic stiffness of resilient materials under floating floors (EN 29052-1:1992).
 
 A floating floor is a heavy floating slab resting on a resilient layer; the
 combination is a mass-spring system whose natural frequency governs the impact

--- a/src/phonometry/materials/surfaces/road_absorption.py
+++ b/src/phonometry/materials/surfaces/road_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-In-situ sound absorption of road surfaces (ISO 13472-1 / ISO 13472-2).
+r"""In-situ sound absorption of road surfaces (ISO 13472-1 / ISO 13472-2).
 
 Two complementary standardised in-situ methods are supported here. They target
 opposite ends of the absorption scale and are **not** interchangeable:

--- a/src/phonometry/metrology/calibration.py
+++ b/src/phonometry/metrology/calibration.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Calibration utilities for mapping digital signals to physical SPL levels.
-"""
+"""Calibration utilities for mapping digital signals to physical SPL levels."""
 
 from __future__ import annotations
 
@@ -73,8 +71,7 @@ def sensitivity(
     frequency: float = 1000.0,
     narrowband: bool = False,
 ) -> float:
-    r"""
-    Calculate the calibration factor (multiplier) to convert digital units
+    r"""Calculate the calibration factor (multiplier) to convert digital units
     to Pascals based on a reference recording (e.g., 1kHz @ 94dB).
 
     When ``fs`` is provided (and ``validate`` is True), the recording's

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Random-data qualification: stationarity tests and Rice crossing statistics.
+r"""Random-data qualification: stationarity tests and Rice crossing statistics.
 
 Before a record is averaged into a PSD, condensed into a Leq or fed to a GUM
 budget, Bendat & Piersol (*Random Data*, 4th ed., Sec. 10.3) require it to be
@@ -450,8 +449,7 @@ def trend_test(
     method: str = "reverse_arrangements",
     alpha: float = 0.05,
 ) -> TrendTestResult:
-    r"""
-    Nonparametric trend test on a sequence of observations or estimates.
+    r"""Nonparametric trend test on a sequence of observations or estimates.
 
     Tests the hypothesis that the sequence holds independent observations
     of one random variable -- no underlying trend -- without assuming any
@@ -566,8 +564,7 @@ def stationarity_test(
     method: str = "reverse_arrangements",
     alpha: float = 0.05,
 ) -> StationarityTestResult:
-    r"""
-    Test a record for stationarity via trends in segment statistics.
+    r"""Test a record for stationarity via trends in segment statistics.
 
     The B&P Sec. 10.3.1.1 procedure: (1) divide the record into
     ``n_segments`` equal intervals, assumed long enough for the values to
@@ -734,8 +731,7 @@ def level_crossing_rate(
     levels: NDArray[np.float64] | list[float] | None = None,
     nperseg: int | None = None,
 ) -> LevelCrossingResult:
-    r"""
-    Level-crossing rates of a record and their Rice expectations.
+    r"""Level-crossing rates of a record and their Rice expectations.
 
     Counts the crossings of each level ``a`` (both slopes, B&P Sec. 5.5.1)
     and compares them with the closed forms for Gaussian data: the
@@ -936,8 +932,7 @@ def peak_statistics(
     *,
     nperseg: int | None = None,
 ) -> PeakStatisticsResult:
-    r"""
-    Peak rate, irregularity factor and peak-height distribution of a record.
+    r"""Peak rate, irregularity factor and peak-height distribution of a record.
 
     Detects the record's local maxima and compares their rate and height
     distribution with the Rice closed forms for Gaussian data (B&P

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Measurement uncertainty by the GUM and its Monte Carlo supplement.
+r"""Measurement uncertainty by the GUM and its Monte Carlo supplement.
 
 Implements the two propagation methods of the *Guide to the Expression of
 Uncertainty in Measurement*:
@@ -76,6 +75,7 @@ class Quantity:
     name: str = ""
 
     def __post_init__(self) -> None:
+        """Reject a negative uncertainty, an unrecognised PDF or non-positive dof."""
         if self.uncertainty < 0.0:
             raise ValueError("uncertainty must be non-negative.")
         if self.distribution not in DISTRIBUTIONS:

--- a/src/phonometry/noise_control/_criterion.py
+++ b/src/phonometry/noise_control/_criterion.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Shared plumbing of the composed noise-control workflows.
+"""Shared plumbing of the composed noise-control workflows.
 
 :mod:`phonometry.noise_control.duct_path` and
 :mod:`phonometry.noise_control.room_to_room` are the two calculations in the

--- a/src/phonometry/noise_control/duct_modes.py
+++ b/src/phonometry/noise_control/duct_modes.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Higher-order acoustic modes in ducts, with the mean-flow cut-on shift.
+r"""Higher-order acoustic modes in ducts, with the mean-flow cut-on shift.
 
 Every plane-wave duct method has the same expiry date: the frequency at which
 the first higher-order mode cuts on. Below it a duct carries only plane waves,

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-End-to-end duct-borne noise calculation: fan to room, element by element.
+r"""End-to-end duct-borne noise calculation: fan to room, element by element.
 
 The classic consulting workflow of HVAC acoustics is a bookkeeping exercise.
 Start from the sound power the fan puts into the duct, walk down the path, and

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Insertion loss of a close or free-standing machine enclosure.
+r"""Insertion loss of a close or free-standing machine enclosure.
 
 Wrapping a machine in a sealed enclosure reduces the radiated noise by the
 transmission loss of its panels, *minus* a penalty for the reverberant build-up

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-HVAC duct acoustics: fan power, duct losses, plenums and flow-generated noise.
+r"""HVAC duct acoustics: fan power, duct losses, plenums and flow-generated noise.
 
 A ventilation duct network attenuates fan noise through several mechanisms
 that add up along the path, and it *regenerates* noise wherever the airflow is

--- a/src/phonometry/noise_control/room_to_room.py
+++ b/src/phonometry/noise_control/room_to_room.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Room-to-room noise reduction: source room, partition, receiving room, criterion.
+r"""Room-to-room noise reduction: source room, partition, receiving room, criterion.
 
 The other classic bookkeeping exercise of noise control, beside the duct-borne
 cascade of :mod:`phonometry.noise_control.duct_path`. A machine runs in one

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Reactive silencers by the four-pole (transmission-matrix) method.
+r"""Reactive silencers by the four-pole (transmission-matrix) method.
 
 A reactive silencer controls noise by *reflecting* it back to the source with
 impedance discontinuities -- sudden area changes and side branches -- rather

--- a/src/phonometry/psychoacoustics/loudness/_zwicker_data.py
+++ b/src/phonometry/psychoacoustics/loudness/_zwicker_data.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Numeric tables of the ISO 532-1:2017 Zwicker loudness reference algorithm.
+"""Numeric tables of the ISO 532-1:2017 Zwicker loudness reference algorithm.
 
 Every constant reproduces, digit for digit, one table of the normative
 Annex A reference implementation of ISO 532-1:2017 (program "ISO_532-1.c",

--- a/src/phonometry/psychoacoustics/loudness/contours.py
+++ b/src/phonometry/psychoacoustics/loudness/contours.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Normal equal-loudness-level contours per ISO 226:2023.
+"""Normal equal-loudness-level contours per ISO 226:2023.
 
 Implements Formula (1) (clause 4.1: SPL of a pure tone from its loudness
 level) and Formula (2) (clause 4.2: the inverse) with the Table 1 (p. 4)
@@ -84,8 +83,7 @@ def _spl_from_phon(frequency: float, phon: float) -> float:
 
 
 def equal_loudness_contour(phon: float) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Normal equal-loudness-level contour (ISO 226:2023 Formula 1).
+    """Normal equal-loudness-level contour (ISO 226:2023 Formula 1).
 
     Returns the sound pressure levels of pure tones judged equally loud as
     a 1 kHz tone at ``phon`` dB SPL, at the 29 preferred third-octave
@@ -109,8 +107,7 @@ def equal_loudness_contour(phon: float) -> tuple[np.ndarray, np.ndarray]:
 
 
 def loudness_level(spl: float, frequency: float) -> float:
-    """
-    Loudness level of a pure tone (ISO 226:2023 Formula 2).
+    """Loudness level of a pure tone (ISO 226:2023 Formula 2).
 
     :param spl: Sound pressure level of the tone in dB re 20 uPa.
     :param frequency: Tone frequency in Hz; must be one of the 29 preferred
@@ -127,8 +124,7 @@ def loudness_level(spl: float, frequency: float) -> float:
 
 
 def hearing_threshold() -> tuple[np.ndarray, np.ndarray]:
-    """
-    Threshold of hearing T_f (ISO 226:2023 Table 1).
+    """Threshold of hearing T_f (ISO 226:2023 Table 1).
 
     :return: Tuple ``(frequencies, threshold)`` in Hz and dB re 20 uPa.
     """
@@ -200,8 +196,7 @@ def equal_loudness_contours(
     phons: Sequence[float] = _DEFAULT_PHONS,
     frequencies: Sequence[float] | np.ndarray | None = None,
 ) -> EqualLoudnessContours:
-    """
-    Build the ISO 226:2023 equal-loudness-level contour family.
+    """Build the ISO 226:2023 equal-loudness-level contour family.
 
     Evaluates :func:`equal_loudness_contour` at each level in ``phons`` and
     :func:`hearing_threshold`, and bundles them into an

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Psychoacoustic loudness per ECMA-418-2:2025 (4th ed., Sottek Hearing Model).
+"""Psychoacoustic loudness per ECMA-418-2:2025 (4th ed., Sottek Hearing Model).
 
 Clean-room implementation of the loudness signal chain of ECMA-418-2:2025:
 

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Stationary loudness per ISO 532-2:2017 (Moore-Glasberg method).
+"""Stationary loudness per ISO 532-2:2017 (Moore-Glasberg method).
 
 Clean-room implementation of the spectral loudness model of ISO 532-2:2017,
 the third calculation method of the ISO 532 series (distinct from the Zwicker

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Time-varying loudness per ISO 532-3:2023 (Moore-Glasberg-Schlittenlacher).
+r"""Time-varying loudness per ISO 532-3:2023 (Moore-Glasberg-Schlittenlacher).
 
 Clean-room implementation of the time-varying loudness model of ISO 532-3:2023,
 the extension of the stationary Moore-Glasberg method of ISO 532-2:2017 to

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Zwicker loudness for stationary and time-varying sounds per ISO 532-1:2017.
+"""Zwicker loudness for stationary and time-varying sounds per ISO 532-1:2017.
 
 Clean-room Python port of the normative reference implementation given in
 Annex A of ISO 532-1:2017 (program "ISO_532-1", Annex A.4).  Two entry
@@ -718,8 +717,7 @@ def loudness_zwicker_from_spectrum(
     levels: list[float] | np.ndarray,
     field: Literal["free", "diffuse"] = "free",
 ) -> ZwickerLoudness:
-    """
-    Stationary Zwicker loudness from one-third-octave band levels.
+    """Stationary Zwicker loudness from one-third-octave band levels.
 
     Implements the method for stationary sounds of ISO 532-1:2017
     (clause 5) starting from the 28 one-third-octave band levels with
@@ -760,8 +758,7 @@ def loudness_zwicker(
     calibration_factor: float | None = None,
     time_skip: float = 0.0,
 ) -> ZwickerLoudness:
-    r"""
-    Zwicker loudness of a calibrated time signal per ISO 532-1:2017.
+    r"""Zwicker loudness of a calibrated time signal per ISO 532-1:2017.
 
     The signal is resampled to the internal 48 kHz rate if needed, split
     into 28 one-third-octave bands with the Annex A filterbank (Tables

--- a/src/phonometry/psychoacoustics/quality/annoyance.py
+++ b/src/phonometry/psychoacoustics/quality/annoyance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Psychoacoustic annoyance (PA) after Fastl & Zwicker.
+r"""Psychoacoustic annoyance (PA) after Fastl & Zwicker.
 
 Psychoacoustic annoyance combines four hearing sensations -- loudness,
 sharpness, fluctuation strength and roughness -- into a single figure that

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Fluctuation strength after Fastl & Zwicker / Osses et al.
+r"""Fluctuation strength after Fastl & Zwicker / Osses et al.
 
 Fluctuation strength ``F`` (unit: vacil) rates the slow loudness fluctuations of
 a sound. It has a band-pass dependence on modulation frequency peaking near
@@ -183,7 +182,8 @@ def _terhardt_a0_db(f: NDArray[np.float64]) -> NDArray[np.float64]:
 
 def _g_weight(z: NDArray[np.float64]) -> NDArray[np.float64]:
     """Frequency weighting g(z) (Osses 2016 §3.1): 1 up to 15 Bark, then a
-    linear taper down to 0.5 at 23.5 Bark."""
+    linear taper down to 0.5 at 23.5 Bark.
+    """
     g = np.ones_like(z)
     high = z > 15.0
     g[high] = 1.0 - 0.5 * (z[high] - 15.0) / (23.5 - 15.0)
@@ -356,7 +356,8 @@ def _modulation_depth(
 def _neighbour_covariance(h_bp: NDArray[np.float64]) -> NDArray[np.float64]:
     r"""Cross covariance :math:`\lvert k_{i-2} \cdot k_{i+2} \rvert` with the
     bands two indices away (Osses 2016 Eq. 9), with :math:`k = 1` at the
-    filter-bank edges."""
+    filter-bank edges.
+    """
     k = np.ones(_N_FILTERS)
     for i in range(_N_FILTERS):
         lo = i - 2

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Psychoacoustic fluctuation strength per ECMA-418-2:2025 (4th ed., Clause 9).
+r"""Psychoacoustic fluctuation strength per ECMA-418-2:2025 (4th ed., Clause 9).
 
 Clean-room implementation of the fluctuation-strength signal chain of
 ECMA-418-2:2025 (Clause 9, Sottek Hearing Model). The shared auditory

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Psychoacoustic roughness per ECMA-418-2:2025 (4th ed., Sottek Hearing Model).
+r"""Psychoacoustic roughness per ECMA-418-2:2025 (4th ed., Sottek Hearing Model).
 
 Clean-room implementation of the roughness signal chain of ECMA-418-2:2025
 (Clause 7). The shared auditory front-end (Clause 5: outer/middle-ear filter,

--- a/src/phonometry/psychoacoustics/quality/sharpness.py
+++ b/src/phonometry/psychoacoustics/quality/sharpness.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Sharpness per DIN 45692:2009-08.
+"""Sharpness per DIN 45692:2009-08.
 
 Sharpness rates the high-frequency emphasis of a sound in acum, computed
 as the g(z)-weighted first moment of the specific loudness pattern
@@ -124,8 +123,7 @@ def _k_din() -> float:
 def sharpness_din_from_specific(
     specific: np.ndarray, method: Literal["din", "aures", "bismarck"] = "din"
 ) -> float:
-    """
-    Sharpness in acum from a specific-loudness pattern (DIN 45692 Eq. 1).
+    """Sharpness in acum from a specific-loudness pattern (DIN 45692 Eq. 1).
 
     :param specific: Specific loudness N'(z) at 0.1 Bark steps (240 values),
         e.g. ``ZwickerLoudness.specific``.
@@ -152,8 +150,7 @@ def sharpness_din(
     method: Literal["din", "aures", "bismarck"] = "din",
     calibration_factor: float | None = None,
 ) -> float:
-    """
-    Sharpness of a signal per DIN 45692:2009 (stationary analysis).
+    """Sharpness of a signal per DIN 45692:2009 (stationary analysis).
 
     The specific loudness comes from the ISO 532-1 Zwicker stationary
     method (the DIN 45631 basis named by DIN 45692); the sharpness is its

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Prominent discrete tone assessment per ECMA-418-1:2024 (3rd edition).
+"""Prominent discrete tone assessment per ECMA-418-1:2024 (3rd edition).
 
 Implements the tone-to-noise ratio (TNR, clause 11) and prominence ratio
 (PR, clause 12) methods on Hann-windowed, RMS-averaged FFT spectra
@@ -43,7 +42,8 @@ def _warn_coarse_resolution(dfc: float, df: float, ft: float) -> None:
     The tone band is 15 % of the critical bandwidth ``dfc`` (half-width
     ``0.075*dfc``). Below ~3 bins across the half-width the tone/noise split
     is biased (ECMA-418-1 keeps the tone band within 15 % of the critical
-    bandwidth). At 250 Hz a 4 Hz bin already costs ~0.3 dB of TNR."""
+    bandwidth). At 250 Hz a 4 Hz bin already costs ~0.3 dB of TNR.
+    """
     bins = 0.075 * dfc / df
     if bins < 3.0:
         warnings.warn(
@@ -209,7 +209,8 @@ def _find_peak(freqs: np.ndarray, power: np.ndarray, tone_freq: float | None) ->
 def _tone_band(power: np.ndarray, peak: int, half_width_bins: int) -> tuple[int, int]:
     """Clause 11.2: tone-band edges at the minimal points on both sides of
     the peak within 15 % of the critical band; if the minimum falls on the
-    window edge, the nearest local minimum beyond it is used."""
+    window edge, the nearest local minimum beyond it is used.
+    """
 
     def _edge(direction: int) -> int:
         last = power.size - 1
@@ -262,8 +263,7 @@ def tone_to_noise_ratio(
     tone_freq: float | None = None,
     resolution_hz: float = 1.0,
 ) -> ToneAssessment:
-    """
-    Tone-to-noise ratio of a discrete tone (ECMA-418-1:2024, clause 11).
+    """Tone-to-noise ratio of a discrete tone (ECMA-418-1:2024, clause 11).
 
     The spectrum is Hann-windowed and RMS-averaged (clause 11.1). The tone
     level ``Lt`` is the tone-band level above the line connecting the band
@@ -387,8 +387,7 @@ def prominence_ratio(
     tone_freq: float | None = None,
     resolution_hz: float = 1.0,
 ) -> ToneAssessment:
-    """
-    Prominence ratio of a discrete tone (ECMA-418-1:2024, clause 12).
+    """Prominence ratio of a discrete tone (ECMA-418-1:2024, clause 12).
 
     Compares the level of the critical band centred on the tone (``LM``)
     with the mean of the two contiguous critical bands (``LL``, ``LU``,

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Psychoacoustic tonality per ECMA-418-2:2025 (4th ed., Sottek Hearing Model).
+r"""Psychoacoustic tonality per ECMA-418-2:2025 (4th ed., Sottek Hearing Model).
 
 Clean-room implementation of the tonality signal chain of ECMA-418-2:2025
 (Clause 6.2). The shared auditory front-end (Clause 5) and the ACF-based

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Objective audibility of tones in noise -- engineering method (ISO/PAS 20065:2016).
+r"""Objective audibility of tones in noise -- engineering method (ISO/PAS 20065:2016).
 
 ISO/PAS 20065 is the detailed engineering method that ISO 1996-2:2017 defers to
 for the audibility of prominent tones; the simplified 2007/2009 Annex C method
@@ -1079,7 +1078,8 @@ class ToneAudibilityResult:
     @property
     def audible(self) -> NDArray[np.bool_]:
         r"""Boolean mask of tones that are present, i.e. :math:`\Delta L > 0`
-        (Step 2)."""
+        (Step 2).
+        """
         return self.audibilities > 0.0
 
     @property

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Room acoustic parameters from impulse responses per ISO 3382-1:2009
+"""Room acoustic parameters from impulse responses per ISO 3382-1:2009
 (performance spaces) and ISO 3382-2:2008 (ordinary rooms).
 
 The measured impulse response (acquired e.g. with the swept-sine or MLS
@@ -452,8 +451,7 @@ def decay_curve(
     fraction: int = 1,
     zero_phase: bool = False,
 ) -> DecayCurve:
-    """
-    Schroeder decay curve of an impulse response.
+    """Schroeder decay curve of an impulse response.
 
     Backward integration of the squared impulse response
     (ISO 3382-1:2009, 5.3.3, Equation (1)), with noise truncation at the
@@ -527,8 +525,7 @@ def room_parameters(
     fraction: int = 1,
     zero_phase: bool = False,
 ) -> RoomAcousticsResult:
-    """
-    Room acoustic parameters per ISO 3382-1:2009 / ISO 3382-2:2008.
+    """Room acoustic parameters per ISO 3382-1:2009 / ISO 3382-2:2008.
 
     The impulse response (e.g. acquired with the ISO 18233 swept-sine or
     MLS methods of :mod:`phonometry.room.impulse_response`) is filtered into

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Sound absorption in enclosed spaces (EN 12354-6:2003).
+r"""Sound absorption in enclosed spaces (EN 12354-6:2003).
 
 Estimates the total equivalent sound absorption area of a room and the
 resulting reverberation time from the absorption of its surfaces and objects

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Synthetic room impulse response by the image-source method (rectangular room).
+r"""Synthetic room impulse response by the image-source method (rectangular room).
 
 A rigid-walled (or absorbing) rectangular room -- a *shoebox* -- reflects a
 point source in its six walls. Each reflection is equivalent to the free-field

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Impulse-response acquisition per BS EN ISO 18233:2006.
+r"""Impulse-response acquisition per BS EN ISO 18233:2006.
 
 This module provides the deterministic-excitation front end for the "new
 measurement methods" of ISO 18233: generate an excitation signal, play it
@@ -144,7 +143,8 @@ class ImpulseResponseResult:
     :func:`phonometry.room.decay_curve` and
     :func:`phonometry.speech.sti_from_impulse_response`. Indexing,
     ``len(result)`` and the ``size``/``ndim``/``shape``/``dtype`` attributes
-    forward to ``ir``."""
+    forward to ``ir``.
+    """
 
     ir: np.ndarray
     fs: int | None
@@ -155,9 +155,11 @@ class ImpulseResponseResult:
         return np.asarray(self.ir, dtype=dtype)
 
     def __len__(self) -> int:
+        """Number of impulse-response samples (the length of ``ir``'s last axis)."""
         return int(self.ir.shape[-1])
 
     def __getitem__(self, key: Any) -> Any:
+        """Forward indexing to ``ir``: ``result[key]`` yields ``ir[key]``."""
         return self.ir[key]
 
     @property
@@ -204,8 +206,7 @@ def sweep_signal(
     amplitude: float = 1.0,
     fade: float = 0.01,
 ) -> np.ndarray:
-    r"""
-    Generate an exponential sine sweep (ESS) with exact analytic phase.
+    r"""Generate an exponential sine sweep (ESS) with exact analytic phase.
 
     The instantaneous frequency rises exponentially from ``f1`` to ``f2``,
     :math:`f(t) = f_1 (f_2/f_1)^{t/T}`, so the time spent per octave is
@@ -282,8 +283,7 @@ def inverse_filter(
     amplitude: float = 1.0,
     fade: float = 0.01,
 ) -> np.ndarray:
-    """
-    Build the Farina inverse filter for an exponential sine sweep.
+    """Build the Farina inverse filter for an exponential sine sweep.
 
     The inverse filter is the time-reversed sweep multiplied by an amplitude
     envelope that rises by 6 dB/octave (``prop. to the instantaneous
@@ -415,8 +415,7 @@ def impulse_response(
     length: int | None = None,
     return_full: bool = False,
 ) -> ImpulseResponseResult:
-    r"""
-    Recover the broadband impulse response by sweep deconvolution.
+    r"""Recover the broadband impulse response by sweep deconvolution.
 
     Implements the linear (non-circular) deconvolution of ISO 18233:2006,
     B.5. Both signals are zero-padded to ``len(recorded)+len(reference)-1``
@@ -506,8 +505,7 @@ def impulse_response(
 
 
 def mls_signal(order: int) -> np.ndarray:
-    """
-    Generate a maximum-length sequence (MLS) of the given order.
+    """Generate a maximum-length sequence (MLS) of the given order.
 
     A Fibonacci LFSR with primitive-polynomial feedback taps produces a
     binary sequence of length ``2**order - 1`` whose circular
@@ -545,8 +543,7 @@ def mls_impulse_response(
     length: int | None = None,
     fs: int | None = None,
 ) -> ImpulseResponseResult:
-    """
-    Recover an impulse response from a periodic MLS excitation.
+    """Recover an impulse response from a periodic MLS excitation.
 
     The recording must span an integer number of MLS periods; the periods
     are averaged (raising the effective signal-to-noise ratio by 3 dB per
@@ -664,8 +661,7 @@ _SHAPED_EDGE_OCTAVES = 1.0 / 6.0
 
 
 def golay_pair(order: int) -> tuple[np.ndarray, np.ndarray]:
-    r"""
-    Generate a complementary Golay pair of length ``2**order``.
+    r"""Generate a complementary Golay pair of length ``2**order``.
 
     Built with the append recursion of Golay (1961): starting from
     ``a1 = (+1, +1)``, ``b1 = (+1, -1)``, each step appends ``b`` to ``a``
@@ -699,8 +695,7 @@ def golay_impulse_response(
     length: int | None = None,
     fs: int | None = None,
 ) -> ImpulseResponseResult:
-    r"""
-    Recover an impulse response from a complementary Golay-pair excitation.
+    r"""Recover an impulse response from a complementary Golay-pair excitation.
 
     Each code of the pair is emitted periodically (as with an MLS, record in
     the steady state: at least one settling period before acquisition); the
@@ -833,9 +828,11 @@ class ShapedSweepResult:
         return np.asarray(self.signal, dtype=dtype)
 
     def __len__(self) -> int:
+        """Number of sweep samples (the length of ``signal``'s last axis)."""
         return int(self.signal.shape[-1])
 
     def __getitem__(self, key: Any) -> Any:
+        """Forward indexing to ``signal``: ``result[key]`` yields ``signal[key]``."""
         return self.signal[key]
 
     @property
@@ -944,8 +941,7 @@ def shaped_sweep_signal(
     start_delay: float | None = None,
     fade: float = 0.01,
 ) -> ShapedSweepResult:
-    r"""
-    Synthesize a sweep with an arbitrary target magnitude spectrum.
+    r"""Synthesize a sweep with an arbitrary target magnitude spectrum.
 
     Implements the frequency-domain sweep construction of
     Mueller & Massarani ("Transfer-Function Measurement with Sweeps", JAES

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Room-noise rating curves per ANSI/ASA S12.2-2019.
+"""Room-noise rating curves per ANSI/ASA S12.2-2019.
 
 Implements the two spectrum-in rating methods of ANSI/ASA S12.2-2019, *Criteria
 for Evaluating Room Noise*:

--- a/src/phonometry/room/open_plan.py
+++ b/src/phonometry/room/open_plan.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Open-plan-office spatial metrics per ISO 3382-3:2012.
+r"""Open-plan-office spatial metrics per ISO 3382-3:2012.
 
 From a line of measurement positions across workstations (ISO 3382-3:2012,
 5.2.2) this module derives the single-number quantities of Clause 4:
@@ -225,8 +224,7 @@ def open_plan_metrics(
     spl_a_speech: list[float] | np.ndarray,
     sti_values: list[float] | np.ndarray,
 ) -> OpenPlanResult:
-    r"""
-    Open-plan-office single-number quantities per ISO 3382-3:2012.
+    r"""Open-plan-office single-number quantities per ISO 3382-3:2012.
 
     Computes the spatial decay rate ``D2,S`` and the nominal A-weighted
     speech level at 4 m ``Lp,A,S,4m`` (Clause 6.2, Equation (5)) from a

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Reverberation-time prediction from room geometry and absorption.
+r"""Reverberation-time prediction from room geometry and absorption.
 
 Predicts the reverberation time ``T`` of an enclosed space from its volume,
 boundary areas and the sound-absorption coefficients of its surfaces, through
@@ -242,7 +241,8 @@ def _reverberation_time(
     volume: float, absorption: NDArray[np.float64], speed_of_sound: float
 ) -> np.ndarray | float:
     r""":math:`T = 24 \ln 10 / c_0 \cdot V / \text{absorption}`, with a
-    positive-absorption guard."""
+    positive-absorption guard.
+    """
     if np.any(absorption <= 0.0):
         raise ValueError(
             "the total absorption is non-positive; a perfectly reflecting room "

--- a/src/phonometry/room/steady_field.py
+++ b/src/phonometry/room/steady_field.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Steady-state sound field in a room: room constant, critical distance, level.
+r"""Steady-state sound field in a room: room constant, critical distance, level.
 
 When a source of constant sound power runs in a room, the sound pressure level
 at a receiver settles to a steady value made of two parts: the **direct field**

--- a/src/phonometry/signals/cepstrum.py
+++ b/src/phonometry/signals/cepstrum.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Cepstral analysis: real/power/complex cepstrum, liftering and echo detection.
+r"""Cepstral analysis: real/power/complex cepstrum, liftering and echo detection.
 
 The **cepstrum** is the inverse Fourier transform of the logarithm of a
 spectrum. Because the log turns the convolution :math:`x = h * u` into the
@@ -246,8 +245,7 @@ def cepstrum(
     kind: str = "power",
     nfft: int | None = None,
 ) -> CepstrumResult:
-    """
-    Cepstrum of a record: power, real or complex.
+    """Cepstrum of a record: power, real or complex.
 
     * ``"power"``: inverse DFT of ``ln|X|^2`` (Milner Fig. 21 in Havelock
       Ch. 27). Even, phase-blind; an echo of reflection coefficient ``a``
@@ -355,8 +353,7 @@ def lifter(
     mode: str = "lowpass",
     nfft: int | None = None,
 ) -> LifterResult:
-    """
-    Lifter a record's log spectrum: keep quefrencies below or above a cutoff.
+    """Lifter a record's log spectrum: keep quefrencies below or above a cutoff.
 
     Liftering is filtering in the quefrency domain (Milner Sec. 4.3 in
     Havelock Ch. 27): the real cepstrum is windowed and transformed back
@@ -501,8 +498,7 @@ def echo_detection(
     max_quefrency: float | None = None,
     nfft: int | None = None,
 ) -> EchoDetectionResult:
-    r"""
-    Detect an echo as the largest power-cepstrum peak in a quefrency band.
+    r"""Detect an echo as the largest power-cepstrum peak in a quefrency band.
 
     A reflection :math:`x(t) = s(t) + a s(t - t_0)` leaves a spike of
     height ``a`` -- positive or negative with the sign of the reflection --

--- a/src/phonometry/signals/correlation.py
+++ b/src/phonometry/signals/correlation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Correlation analysis and time-delay estimation.
+r"""Correlation analysis and time-delay estimation.
 
 Auto- and cross-correlation estimators with the three standard
 normalizations, generalized cross-correlation (GCC) time-delay estimation

--- a/src/phonometry/signals/envelope.py
+++ b/src/phonometry/signals/envelope.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Envelope and instantaneous phase via the Hilbert transform.
+r"""Envelope and instantaneous phase via the Hilbert transform.
 
 Signal-envelope analysis following Bendat & Piersol, *Random Data:
 Analysis and Measurement Procedures* (4th ed., 2010), Chapter 13. The

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Regularized spectral inversion with frequency-dependent regularization.
+r"""Regularized spectral inversion with frequency-dependent regularization.
 
 Inverting a measured transfer function -- to equalize a measurement
 loudspeaker, flatten a microphone response or post-process an acquired
@@ -113,6 +112,7 @@ class InverseFilterResult:
         return np.asarray(self.inverse, dtype=dtype)
 
     def __len__(self) -> int:
+        """Number of inverse-filter samples, the ``n_fft`` of the design."""
         return int(self.inverse.shape[-1])
 
     @property
@@ -251,8 +251,7 @@ def regularized_inverse_filter(
     n_fft: int | None = None,
     delay: int | None = None,
 ) -> InverseFilterResult:
-    r"""
-    Design a regularized inverse filter for a measured impulse response.
+    r"""Design a regularized inverse filter for a measured impulse response.
 
     Computes the frequency-dependent Tikhonov inverse of Kirkeby & Nelson
     (JAES 47(7/8), 1999, Eq. (17)),

--- a/src/phonometry/signals/levels.py
+++ b/src/phonometry/signals/levels.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Integrated and statistical sound levels (Leq, LAeq, LN percentiles).
+"""Integrated and statistical sound levels (Leq, LAeq, LN percentiles).
 
 Every function here accepts a :class:`phonometry.io.Signal` in place of
 the bare ``(x, fs)`` pair: the object read from a measurement file
@@ -68,8 +67,7 @@ def leq(
     calibration_factor: float | None = None,
     dbfs: bool = False,
 ) -> float | np.ndarray:
-    """
-    Equivalent continuous sound level (Leq) over the whole signal.
+    """Equivalent continuous sound level (Leq) over the whole signal.
 
     :param x: Input signal (1D or 2D [channels, samples]) in raw pressure
         units, or a :class:`phonometry.io.Signal` read from a measurement
@@ -97,8 +95,7 @@ def laeq(
     calibration_factor: float | None = None,
     dbfs: bool = False,
 ) -> float | np.ndarray:
-    """
-    A-weighted equivalent continuous sound level (LAeq).
+    """A-weighted equivalent continuous sound level (LAeq).
 
     :param x: Input signal (1D or 2D [channels, samples]) in raw pressure
         units, or a :class:`phonometry.io.Signal` read from a measurement
@@ -127,8 +124,7 @@ def ln_levels(
     calibration_factor: float | None = None,
     dbfs: bool = False,
 ) -> dict[int, float | np.ndarray]:
-    """
-    Statistical percentile levels (LN) from the time-weighted level envelope.
+    """Statistical percentile levels (LN) from the time-weighted level envelope.
 
     L10 is the level exceeded 10% of the time (90th percentile of the level
     distribution), L90 the level exceeded 90% of the time, etc.
@@ -187,8 +183,7 @@ def lc_peak(
     dbfs: bool = False,
     oversample: int = 8,
 ) -> float | np.ndarray:
-    """
-    C-weighted peak sound level, LCpeak (IEC 61672-1:2013, subclause 5.13).
+    """C-weighted peak sound level, LCpeak (IEC 61672-1:2013, subclause 5.13).
 
     The absolute maximum of the C-weighted signal, expressed in dB. This is
     the quantity used by occupational-noise regulations (e.g. 135/137/140
@@ -237,8 +232,7 @@ def sel(
     calibration_factor: float | None = None,
     dbfs: bool = False,
 ) -> float | np.ndarray:
-    r"""
-    Sound exposure level (SEL / LAE): the event level normalized to 1 second.
+    r"""Sound exposure level (SEL / LAE): the event level normalized to 1 second.
 
     :math:`\text{SEL} = L_{\mathrm{eq},T} + 10 \log_{10}(T / 1\,\text{s})`, the
     standard single-event metric
@@ -281,8 +275,7 @@ def sound_exposure(
     duration_hours: float | None = None,
     calibration_factor: float | None = None,
 ) -> float | np.ndarray:
-    """
-    A-weighted sound exposure E in pascal-squared hours (IEC 61252, 3.1).
+    """A-weighted sound exposure E in pascal-squared hours (IEC 61252, 3.1).
 
     The time integral of the squared A-weighted sound pressure. By default
     the input is the whole event (E integrates over ``len(x)/fs``); pass
@@ -323,8 +316,7 @@ def lex_8h(
     duration_hours: float | None = None,
     calibration_factor: float | None = None,
 ) -> float | np.ndarray:
-    """
-    Normalized 8-h average sound level, LEX,8h (IEC 61252, 3.3).
+    """Normalized 8-h average sound level, LEX,8h (IEC 61252, 3.3).
 
     The daily personal noise exposure level: the steady level that, sustained
     over a nominal 8 h working day, carries the same A-weighted sound

--- a/src/phonometry/signals/multitaper.py
+++ b/src/phonometry/signals/multitaper.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Thomson multitaper spectral estimation (Percival & Walden 1993, Ch. 7).
+r"""Thomson multitaper spectral estimation (Percival & Walden 1993, Ch. 7).
 
 Thomson's multitaper estimator (Thomson 1982), as developed in Percival &
 Walden, *Spectral Analysis for Physical Applications* (1993, Chapter 7),

--- a/src/phonometry/signals/phase.py
+++ b/src/phonometry/signals/phase.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Phase utilities: minimum phase, group delay and excess phase.
+r"""Phase utilities: minimum phase, group delay and excess phase.
 
 For a causal, stable, minimum-phase system the log-magnitude and the phase
 of the frequency response form a Hilbert-transform pair (Bendat & Piersol,
@@ -128,8 +127,7 @@ def minimum_phase(
     *,
     oversample: int = 8,
 ) -> NDArray[np.complex128]:
-    r"""
-    Minimum-phase response with the magnitude of ``response``.
+    r"""Minimum-phase response with the magnitude of ``response``.
 
     Computes the phase that the Hilbert relation between log-magnitude and
     phase assigns to :math:`\lvert H(f) \rvert` (Bendat & Piersol
@@ -176,8 +174,7 @@ def group_delay(
     response: NDArray[np.complex128] | list[float],
     fs: float,
 ) -> NDArray[np.float64]:
-    r"""
-    Group delay :math:`\tau_\mathrm{g}(f) = -(1/2\pi) \, d\phi/df` of a response.
+    r"""Group delay :math:`\tau_\mathrm{g}(f) = -(1/2\pi) \, d\phi/df` of a response.
 
     The phase is unwrapped and differentiated with second-order central
     differences (one-sided at the grid ends). The estimate is exact for a
@@ -207,8 +204,7 @@ def excess_phase(
     *,
     oversample: int = 8,
 ) -> NDArray[np.float64]:
-    r"""
-    Excess phase: measured phase minus the minimum phase of
+    r"""Excess phase: measured phase minus the minimum phase of
     :math:`\lvert H \rvert`.
 
     :math:`\phi_{\mathrm{excess}} = \operatorname{unwrap}(\arg H) -
@@ -289,8 +285,7 @@ def phase_decomposition(
     *,
     oversample: int = 8,
 ) -> PhaseDecompositionResult:
-    """
-    Decompose a response into its minimum-phase and all-pass parts.
+    """Decompose a response into its minimum-phase and all-pass parts.
 
     Bundles :func:`minimum_phase`, :func:`excess_phase` and
     :func:`group_delay` on one frequency axis: the minimum phase carries

--- a/src/phonometry/signals/spectra.py
+++ b/src/phonometry/signals/spectra.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Calibrated spectral-density estimation with statistical error analysis.
+r"""Calibrated spectral-density estimation with statistical error analysis.
 
 Welch-averaged auto- and cross-spectral density estimators that report,
 alongside the spectrum itself, the statistical quality of the estimate,
@@ -332,7 +331,8 @@ def _coherence_from_spectra(
     gyy: NDArray[np.float64],
 ) -> NDArray[np.float64]:
     r"""Coherence :math:`\gamma^2 = \lvert G_{xy} \rvert^2 /
-    (G_{xx} G_{yy})` clipped to [0, 1]."""
+    (G_{xx} G_{yy})` clipped to [0, 1].
+    """
     denom = gxx * gyy
     coh = np.divide(np.abs(gxy) ** 2, denom, out=np.zeros_like(gxx), where=denom > 0.0)
     return np.asarray(np.clip(coh, 0.0, 1.0), dtype=np.float64)

--- a/src/phonometry/signals/synchronous_average.py
+++ b/src/phonometry/signals/synchronous_average.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Time synchronous averaging (TSA) of a periodic waveform in noise.
+r"""Time synchronous averaging (TSA) of a periodic waveform in noise.
 
 Time domain averaging extracts a repetitive signal of known period ``T``
 from additive noise by ensemble-averaging successive length-``T`` blocks,

--- a/src/phonometry/signals/test_signals.py
+++ b/src/phonometry/signals/test_signals.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Test signals and sample-rate utilities.
+r"""Test signals and sample-rate utilities.
 
 The signal toolbox of the metrology domain: deterministic test signals and
 the two sample-rate operations every measurement chain eventually needs,

--- a/src/phonometry/signals/time_frequency.py
+++ b/src/phonometry/signals/time_frequency.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Calibrated time-frequency analysis: STFT spectrogram and zoom FFT.
+r"""Calibrated time-frequency analysis: STFT spectrogram and zoom FFT.
 
 Fine-band time-frequency views of a record, following Bendat & Piersol,
 *Random Data: Analysis and Measurement Procedures* (4th ed., 2010):

--- a/src/phonometry/signals/windows.py
+++ b/src/phonometry/signals/windows.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Figures of merit of a spectral-analysis taper (Harris 1978).
+r"""Figures of merit of a spectral-analysis taper (Harris 1978).
 
 The window is the one choice every Fourier estimator forces and the one
 the estimators of :mod:`phonometry.signals.spectra` leave open in their

--- a/src/phonometry/simulation/elastic_fdtd.py
+++ b/src/phonometry/simulation/elastic_fdtd.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-2D elastic finite-difference time-domain (P-SV) simulation.
+r"""2D elastic finite-difference time-domain (P-SV) simulation.
 
 A staggered-grid velocity-stress leapfrog solver for the 2D elastodynamic
 equations in an isotropic linear medium, following the reference formulation
@@ -136,6 +135,7 @@ class ExplosionSource:
     amplitude: float = 1.0
 
     def __post_init__(self) -> None:
+        """Reject a non-finite ``amplitude`` gain."""
         _finite("amplitude", self.amplitude)
 
 
@@ -171,6 +171,7 @@ class ForceSource:
     amplitude: float = 1.0
 
     def __post_init__(self) -> None:
+        """Reject a non-finite gain and a ``direction`` other than ``"x"``/``"y"``."""
         _finite("amplitude", self.amplitude)
         if self.direction not in _DIRECTIONS:
             raise ValueError("direction must be 'x' or 'y'")
@@ -209,6 +210,7 @@ class Material:
     rho: float
 
     def __post_init__(self) -> None:
+        """Reject non-positive ``c_p``/``rho``, negative ``c_s`` and negative lambda."""
         c_p = _positive_finite("c_p", self.c_p)
         c_s = _finite("c_s", self.c_s)
         if c_s < 0.0:

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-2D acoustic finite-difference time-domain (FDTD) simulation.
+r"""2D acoustic finite-difference time-domain (FDTD) simulation.
 
 A staggered-grid (Yee-style) pressure-velocity leapfrog solver for the
 linear acoustic equations in a non-moving medium, following the reference
@@ -116,6 +115,7 @@ class GaussianPulse:
     amplitude: float = 1.0
 
     def __post_init__(self) -> None:
+        """Require a positive ``width`` and finite ``amplitude`` and ``t0``."""
         _positive_finite("width", self.width)
         _finite("amplitude", self.amplitude)
         if self.t0 is not None:
@@ -148,6 +148,7 @@ class CWSource:
     ramp_cycles: float = 3.0
 
     def __post_init__(self) -> None:
+        """Require a positive ``frequency`` and a non-negative ``ramp_cycles``."""
         _positive_finite("frequency", self.frequency)
         _finite("amplitude", self.amplitude)
         if not np.isfinite(self.ramp_cycles) or self.ramp_cycles < 0.0:
@@ -190,6 +191,7 @@ class SignalSource:
     amplitude: float = 1.0
 
     def __post_init__(self) -> None:
+        """Require a positive ``sample_rate`` and freeze finite 1D ``samples``."""
         _positive_finite("sample_rate", self.sample_rate)
         _finite("amplitude", self.amplitude)
         arr = np.array(self.samples, dtype=np.float64)

--- a/src/phonometry/simulation/ntff.py
+++ b/src/phonometry/simulation/ntff.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-2D near-to-far-field (NTFF) transformation over a closed contour.
+r"""2D near-to-far-field (NTFF) transformation over a closed contour.
 
 Given the steady-state pressure and outward normal velocity phasors on a
 closed contour that encloses a scatterer (or any source region), the
@@ -106,6 +105,7 @@ class ContourPhasors:
     segment: float
 
     def __post_init__(self) -> None:
+        """Check positive scalars, matched shapes and finite samples; coerce dtypes."""
         if not np.isfinite(self.frequency) or self.frequency <= 0.0:
             raise ValueError("frequency must be positive and finite")
         if not np.isfinite(self.segment) or self.segment <= 0.0:

--- a/src/phonometry/speech/objective_intelligibility.py
+++ b/src/phonometry/speech/objective_intelligibility.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Short-Time Objective Intelligibility (STOI and ESTOI).
+"""Short-Time Objective Intelligibility (STOI and ESTOI).
 
 Implements the two correlation-based objective intelligibility measures that
 predict the intelligibility of time-frequency weighted noisy speech, where the

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Speech Intelligibility Index (SII) per ANSI S3.5-1997 (R2017).
+"""Speech Intelligibility Index (SII) per ANSI S3.5-1997 (R2017).
 
 Implements all four band procedures of ANSI S3.5-1997, *American National
 Standard Methods for the Calculation of the Speech Intelligibility Index*:

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Speech Transmission Index (STI) per IEC 60268-16:2020 (Edition 5).
+"""Speech Transmission Index (STI) per IEC 60268-16:2020 (Edition 5).
 
 Implements the full-STI indirect method from impulse responses (Schroeder
 modulation transfer function), the direct STIPA method on recorded signals
@@ -413,8 +412,7 @@ def sti_from_impulse_response(
     level: Sequence[float] | np.ndarray | None = None,
     ambient: Sequence[float] | np.ndarray | None = None,
 ) -> STIResult:
-    r"""
-    Full STI from a room/system impulse response (indirect method).
+    r"""Full STI from a room/system impulse response (indirect method).
 
     The impulse response is filtered into the seven octave bands 125 Hz -
     8 kHz (IEC 61260-1 filters) and the modulation transfer function is
@@ -611,8 +609,7 @@ def stipa(
     level: Sequence[float] | np.ndarray | None = None,
     ambient: Sequence[float] | np.ndarray | None = None,
 ) -> STIResult:
-    """
-    STIPA on a recorded test signal (direct method, Annex B).
+    """STIPA on a recorded test signal (direct method, Annex B).
 
     The recording is filtered into the seven octave bands, squared and
     low-passed (~100 Hz) into intensity envelopes, and the modulation
@@ -719,8 +716,7 @@ def stipa_signal(
     level_db: float | None = None,
     seed: int | None = None,
 ) -> np.ndarray:
-    """
-    Generate an IEC 60268-16:2020 conformant STIPA test signal.
+    """Generate an IEC 60268-16:2020 conformant STIPA test signal.
 
     Pink-noise carriers are band-limited to half-octave bands centred on
     the seven octave-band frequencies (clause A.4), set to the Ed.5 male

--- a/src/phonometry/underwater/acoustics.py
+++ b/src/phonometry/underwater/acoustics.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Underwater-acoustics reference levels (ISO 18405:2017).
+r"""Underwater-acoustics reference levels (ISO 18405:2017).
 
 Underwater sound levels use a reference pressure of **1 µPa** (not the 20 µPa of
 airborne acoustics) and a reference sound exposure of **1 µPa²·s**. This module

--- a/src/phonometry/underwater/bioacoustics/audiograms.py
+++ b/src/phonometry/underwater/bioacoustics/audiograms.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Marine-mammal hearing thresholds (group audiograms and the orca audiogram).
+r"""Marine-mammal hearing thresholds (group audiograms and the orca audiogram).
 
 Two independent published descriptions of how well a marine mammal hears:
 

--- a/src/phonometry/underwater/bioacoustics/weighting.py
+++ b/src/phonometry/underwater/bioacoustics/weighting.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Regulatory auditory weighting and exposure criteria for marine mammals.
+r"""Regulatory auditory weighting and exposure criteria for marine mammals.
 
 Noise-exposure assessments weight a spectrum by a hearing-group filter before
 comparing it with a threshold. The filter is the same band-pass form in all
@@ -548,7 +547,8 @@ def _band_pass_db(
     f_khz: NDArray[np.float64], p: WeightingParameters
 ) -> NDArray[np.float64]:
     r""":math:`10 \log_{10}` of the band-pass ratio shared by ``W(f)`` and
-    ``E(f)``."""
+    ``E(f)``.
+    """
     ratio = (f_khz / p.f1_khz) ** (2.0 * p.a) / (
         (1.0 + (f_khz / p.f1_khz) ** 2) ** p.a * (1.0 + (f_khz / p.f2_khz) ** 2) ** p.b
     )

--- a/src/phonometry/underwater/propagation/closed_form.py
+++ b/src/phonometry/underwater/propagation/closed_form.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Underwater sound propagation: propagation loss (closed-form).
+r"""Underwater sound propagation: propagation loss (closed-form).
 
 Propagation loss ``PL``, :math:`N_\mathrm{PL}` (dB) is the difference between
 the source level in a given direction and the mean-square sound pressure level

--- a/src/phonometry/underwater/propagation/numerical.py
+++ b/src/phonometry/underwater/propagation/numerical.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Numerical models of underwater sound propagation (range-independent water,
+"""Numerical models of underwater sound propagation (range-independent water,
 with an optionally sloping bottom for the ray-based solvers).
 
 Four complementary numerical solvers for the acoustic field in a
@@ -208,12 +207,12 @@ def _seabed_grazing_deg(
     xi: NDArray[np.float64],
     c_bottom: float,
 ) -> NDArray[np.float64]:
-    """The grazing angle Snell's invariant fixes at the seabed, in degrees.
+    r"""The grazing angle Snell's invariant fixes at the seabed, in degrees.
 
-    :math:`\\cos\\varphi = \\xi\\,c(D)`: the same at every touch of one ray,
+    :math:`\cos\varphi = \xi\,c(D)`: the same at every touch of one ray,
     because the direction a ray crosses a depth with is set by the invariant
     and not by how many times it has bounced. A ray that turns above the
-    seabed has :math:`\\xi\\,c(D) > 1` (clipped to a grazing angle of zero);
+    seabed has :math:`\xi\,c(D) > 1` (clipped to a grazing angle of zero);
     its bottom count stays zero, so the coefficient it never earned is never
     applied.
     """
@@ -536,7 +535,7 @@ def normal_modes(
 
 @dataclass(frozen=True)
 class RayTraceResult:
-    """Ray-tracing solution through a sound-speed profile.
+    r"""Ray-tracing solution through a sound-speed profile.
 
     :ivar launch_angles: Launch angles from the horizontal, in degrees.
     :ivar ranges: Per-ray horizontal ranges, in metres, shape
@@ -549,25 +548,25 @@ class RayTraceResult:
         column it stands in, exceeds it by the obliquity of the path, and a
         reflection leaves it continuous. This, and not the range, is the
         measure seawater absorption acts along: Jensen Sect. 3.6.2 carries a
-        volume loss :math:`\\alpha` into the ray solution by perturbing the
-        eikonal and lands on :math:`e^{-\\int_0^s \\alpha(s')\\,ds'}`
+        volume loss :math:`\alpha` into the ray solution by perturbing the
+        eikonal and lands on :math:`e^{-\int_0^s \alpha(s')\,ds'}`
         (Eq. 3.116), an integral over the path actually flown, so a caller
         hanging amplitudes on these rays multiplies by
-        :math:`e^{-\\alpha s}` with the :math:`s` read off here.
+        :math:`e^{-\alpha s}` with the :math:`s` read off here.
     :ivar surface_reflections: Per-ray cumulative count of sea-surface
         reflections by each range sample, same shape (zero at the source).
     :ivar bottom_reflections: The same count for the seabed. The two counts,
         and not the reflection coefficients themselves, are the whole of the
         per-bounce record an amplitude carrier needs from the geometry.
         Jensen Sect. 3.6.3 treats a boundary interaction as multiplying the
-        ray amplitude by :math:`|\\mathcal{R}(\\theta)|` and adding
-        :math:`\\arg \\mathcal{R}(\\theta)` to its phase (Eqs. 3.125-3.126),
-        with :math:`\\theta` the local angle of incidence; and in a
+        ray amplitude by :math:`|\mathcal{R}(\theta)|` and adding
+        :math:`\arg \mathcal{R}(\theta)` to its phase (Eqs. 3.125-3.126),
+        with :math:`\theta` the local angle of incidence; and in a
         range-independent medium that angle is the *same* at every touch of
         the same flat boundary, because the direction a ray crosses a depth
-        with is fixed by Snell's invariant, :math:`\\cos\\theta = \\xi\\,c`,
+        with is fixed by Snell's invariant, :math:`\cos\theta = \xi\,c`,
         not by how many times it has bounced. Any boundary coefficient
-        therefore enters a path's amplitude only as :math:`\\mathcal{R}^n`
+        therefore enters a path's amplitude only as :math:`\mathcal{R}^n`
         with the :math:`n` read off here, which is how
         :func:`gaussian_beams` charges its lossy seabed and how
         :func:`eigenrays` charges each arrival; ``ray_trace`` itself carries
@@ -911,7 +910,7 @@ def _march_arrival_rays(
     receiver_range: float,
     n_steps: int,
 ) -> RayMarch:
-    """March candidate eigenrays so the last sample lands on the receiver.
+    r"""March candidate eigenrays so the last sample lands on the receiver.
 
     Geometry and amplitude in one call, which the marcher's own doctrine
     requires (see :mod:`phonometry._internal.rays`): asking for the dynamic
@@ -920,7 +919,7 @@ def _march_arrival_rays(
     off one while the root was found on the other would answer for a slightly
     different path. Every march of the search therefore carries the pair, with
     the *real* point-source initial conditions of Jensen Eq. (3.63),
-    :math:`q(0) = 0`, :math:`p(0) = 1/c(0)`, under which :math:`r\\,q = J`
+    :math:`q(0) = 0`, :math:`p(0) = 1/c(0)`, under which :math:`r\,q = J`
     (Eq. 3.64) and the classical amplitude of Eq. (3.65) is a read-off. The
     receiver range is the last sample of the march by construction, so nothing
     is interpolated at the point everything is asserted at.
@@ -944,10 +943,10 @@ def _march_arrival_rays(
 
 
 def _caustic_crossings(spreadings: NDArray[np.float64]) -> NDArray[np.int_]:
-    """The KMAH index per ray: sign changes of the real spreading history.
+    r"""The KMAH index per ray: sign changes of the real spreading history.
 
     With the initial conditions of Eq. (3.63) the pair is real, so
-    :math:`q \\propto J` (Eq. 3.64) and every caustic is a sign change of
+    :math:`q \propto J` (Eq. 3.64) and every caustic is a sign change of
     ``q`` along the row: "the number of times J(s) vanishes in [0, s]"
     (Eq. 3.79). The launch sample is q = 0 by those initial conditions and is
     not a caustic, which is why zeros are dropped before the signs are
@@ -1437,7 +1436,7 @@ def eigenrays(
 
 @dataclass(frozen=True)
 class GaussianBeamResult:
-    """Gaussian beam solution of a range-independent waveguide.
+    r"""Gaussian beam solution of a range-independent waveguide.
 
     The propagation-loss field is on the same footing as
     :class:`ParabolicEquationResult`'s: same shape, same reference, so the two
@@ -1458,7 +1457,7 @@ class GaussianBeamResult:
         none in 80200 cells.
 
         The source column is **not** one of the infinities, and is not to be
-        read. :func:`parabolic_equation` divides by :math:`\\sqrt{r}` and so
+        read. :func:`parabolic_equation` divides by :math:`\sqrt{r}` and so
         genuinely diverges at ``r = 0``; the beam sum does not, and hands back a
         finite number there instead, 13.6 dB in the case above. It means
         nothing, and neither does anything else within about three initial beam
@@ -1466,7 +1465,7 @@ class GaussianBeamResult:
         no near field. The plausible size of these numbers is the point worth
         knowing about them.
     :ivar pressure: The complex field the loss was taken from, same shape, in
-        the module's own :math:`e^{-i\\omega t}` convention (the conjugate of
+        the module's own :math:`e^{-i\omega t}` convention (the conjugate of
         the one Jensen Eq. (3.88) is printed in) and normalised to unit
         pressure at 1 m, so ``propagation_loss = -20 lg|pressure|``.
     :ivar launch_angles: Launch angle of each beam's central ray, from the
@@ -1492,7 +1491,7 @@ class GaussianBeamResult:
     :ivar absorption_model: The seawater absorption model applied along the
         beams, or ``None`` when the run propagated without volume absorption
         (the default).
-    :ivar absorption_coefficient: The absorption coefficient :math:`\\alpha`
+    :ivar absorption_coefficient: The absorption coefficient :math:`\alpha`
         actually applied, in dB/km (0.0 when ``absorption_model`` is ``None``),
         as :func:`~phonometry.underwater.propagation.closed_form.seawater_absorption`
         evaluated it at the source frequency and depth. Recorded so a run's
@@ -1711,13 +1710,13 @@ def _default_beam_widths(
 def _image_ladder(
     n_wrap: int,
 ) -> list[tuple[int, float, int, int]]:
-    """The receiver's images in the folded column, as boundary-touch counts.
+    r"""The receiver's images in the folded column, as boundary-touch counts.
 
     The marcher folds a reflected ray back into the water column, which is the
     right thing for the geometry and only half the story for a beam: what folds
     is the *central ray*, while the beam's transverse profile keeps its full
     unfolded extent. A beam of half-width :math:`W` crossing the column at
-    :math:`\\theta` to the horizontal spans :math:`W/\\cos\\theta` in depth at
+    :math:`\theta` to the horizontal spans :math:`W/\cos\theta` in depth at
     fixed range, so any beam steep enough, or wide enough, straddles a boundary
     and its folded copies overlap. Summing only the copy nearest the receiver
     throws the rest away, and it does so silently and in one direction: measured
@@ -1734,7 +1733,7 @@ def _image_ladder(
     planes stand at even multiples of ``D`` and the bottom planes at odd ones,
     and *counting* them is all that happens here. The counts are returned
     rather than the product, because the bottom's coefficient need not be a
-    number: a lossy seabed's :math:`\\mathcal{R}` depends on the grazing angle
+    number: a lossy seabed's :math:`\mathcal{R}` depends on the grazing angle
     and so differs beam by beam, while the count of planes between an image and
     the receiver is geometry and differs only rung by rung.
     :func:`_beam_influence` raises each beam's own coefficient to these
@@ -1754,7 +1753,7 @@ def _image_ladder(
     :func:`_fold_images`, whose rung ``(l, side)`` is the rotation of the
     receiver by ``2 l`` facet angles about the local apex. The counts carry
     over unchanged because the fan's plane-crossing structure is the stack's:
-    the image at angle :math:`2l\\beta \\pm \\gamma` stands behind exactly
+    the image at angle :math:`2l\beta \pm \gamma` stands behind exactly
     ``l`` bottom planes and ``l`` (or ``l - 1``) surface planes, the same
     words the level ladder counts, which is also where the sign consistency
     condition (an even number of facets in the half turn) comes from.
@@ -1776,7 +1775,7 @@ def _image_ladder(
 
 
 class _BeamSamples(NamedTuple):
-    """Each beam read at the marching column that brackets a receiver range.
+    r"""Each beam read at the marching column that brackets a receiver range.
 
     All the ``(n_beams, n_ranges)`` fields are the march's own history indexed
     at the column nearest each requested range, so the influence sum is
@@ -1786,7 +1785,7 @@ class _BeamSamples(NamedTuple):
     a sloping bottom rotates it at each bounce; over a level bottom every row
     is its launch value repeated.
 
-    :ivar weight: :math:`A(\\theta_0)` of Eq. (3.92) times the reflection
+    :ivar weight: :math:`A(\theta_0)` of Eq. (3.92) times the reflection
         coefficients the central ray has accumulated by that column.
     :ivar phase: The argument of ``spreading``, unwrapped along the ray, which
         is the branch the square root of Eq. (3.88) is taken on.
@@ -1835,16 +1834,16 @@ def _fold_images(
     side: float,
     zr: NDArray[np.float64],
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Receiver images of one ladder rung, per (column, receiver depth).
+    r"""Receiver images of one ladder rung, per (column, receiver depth).
 
     Where the column's facet is level this is the flat ladder's image,
     ``z = 2 l D + side z_r`` at the receiver's own range, to the last bit.
     Where it slopes, the surface plane and the extended facet plane meet at a
     local apex, and the compositions of their two mirrors are the dihedral
     fan about it: the rung ``(l, side)`` image sits at polar angle
-    :math:`2 l \\beta + \\mathrm{side}\\,\\gamma` on the receiver's own circle
-    of radius :math:`\\rho` about that apex, with :math:`\\beta` the facet
-    angle and :math:`(\\rho, \\gamma)` the receiver's polar coordinates. For
+    :math:`2 l \beta + \mathrm{side}\,\gamma` on the receiver's own circle
+    of radius :math:`\rho` about that apex, with :math:`\beta` the facet
+    angle and :math:`(\rho, \gamma)` the receiver's polar coordinates. For
     a single facet that is the exact unfolding (it is how the ideal wedge's
     closed-form image fan is built), which is what lets the tail sum keep the
     flat ladder's accuracy on a slope; a polyline of several facets makes it
@@ -1884,7 +1883,7 @@ def _fold_margins(
     wrap: int,
     side: float,
 ) -> tuple[NDArray[np.float64], NDArray[np.bool_]]:
-    """Per-column admission floor and validity of one ladder rung.
+    r"""Per-column admission floor and validity of one ladder rung.
 
     The floor is a lower bound on the *transverse* distance from the rung's
     images to the beams, compared against the beams' reach so a rung no beam
@@ -1905,10 +1904,10 @@ def _fold_margins(
     there and back, so a rung whose images stand on wedge geometry beyond
     anything the caller described is refused by every beam at once.
 
-    Validity is the fan closing on itself: a wedge of angle :math:`\\beta`
-    has :math:`2\\pi/\\beta` distinct images in the whole circle, so a rung
-    rotated past :math:`\\pi` re-enters from the other side and would count
-    an image twice; it is dropped, and at exactly :math:`\\pi` (the seam,
+    Validity is the fan closing on itself: a wedge of angle :math:`\beta`
+    has :math:`2\pi/\beta` distinct images in the whole circle, so a rung
+    rotated past :math:`\pi` re-enters from the other side and would count
+    an image twice; it is dropped, and at exactly :math:`\pi` (the seam,
     where the two directions land on the same image) only the positive wrap
     keeps it. Level columns have no fan to close and every rung is valid.
     """

--- a/src/phonometry/underwater/propagation/seabed_reflection.py
+++ b/src/phonometry/underwater/propagation/seabed_reflection.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Plane-wave reflection at the seabed (fluid-fluid Rayleigh model).
+r"""Plane-wave reflection at the seabed (fluid-fluid Rayleigh model).
 
 A plane wave in the water column (density :math:`\rho_1`, sound speed
 ``c1``) striking a fluid sediment half-space (:math:`\rho_2`, ``c2``)

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Speed of sound in sea water (empirical equations).
+r"""Speed of sound in sea water (empirical equations).
 
 Four coexisting equations for the sound speed ``c`` as a function of
 temperature, salinity and depth/pressure, selectable through ``model``:

--- a/src/phonometry/underwater/propagation/weston_regimes.py
+++ b/src/phonometry/underwater/propagation/weston_regimes.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Weston's shallow-water propagation regimes (flux theory).
+r"""Weston's shallow-water propagation regimes (flux theory).
 
 A source in a shallow-water waveguide loses energy in four successive range
 regimes, each with its own power law. The boundaries between them follow from

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-The sonar equation (passive and active), in decibels.
+r"""The sonar equation (passive and active), in decibels.
 
 Combines the sonar performance terms -- source level ``SL``, propagation loss
 ``PL``, noise level ``NL``, directivity index ``DI``, detection threshold ``DT``,

--- a/src/phonometry/underwater/sources/ambient_noise.py
+++ b/src/phonometry/underwater/sources/ambient_noise.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Ocean ambient-noise spectrum levels (Wenz framework).
+r"""Ocean ambient-noise spectrum levels (Wenz framework).
 
 Deep-water ambient-noise **spectrum levels** (dB re 1 µPa²/Hz) from the two
 physically grounded components of the Wenz curves:

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Radiated underwater sound from percussive pile driving (ISO 18406:2017).
+r"""Radiated underwater sound from percussive pile driving (ISO 18406:2017).
 
 Percussive pile driving radiates a train of impulsive acoustic pulses, one per
 hammer strike. ISO 18406 characterises them with:

--- a/src/phonometry/underwater/sources/ship_radiated_noise.py
+++ b/src/phonometry/underwater/sources/ship_radiated_noise.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Ship radiated noise and equivalent monopole source level (ISO 17208-1/-2).
+r"""Ship radiated noise and equivalent monopole source level (ISO 17208-1/-2).
 
 A surface ship measured in deep water is characterised by its **radiated noise
 level** and then by an **equivalent monopole source level** referred to a point

--- a/src/phonometry/underwater/sources/ship_traffic_noise.py
+++ b/src/phonometry/underwater/sources/ship_traffic_noise.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Predicted source-level spectrum of shipping traffic (semi-empirical models).
+"""Predicted source-level spectrum of shipping traffic (semi-empirical models).
 
 When no measured spectrum is available, the underwater radiated-noise source
 level of a ship can be *estimated* from readily available traffic parameters

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Human exposure to whole-body and hand-transmitted vibration.
+r"""Human exposure to whole-body and hand-transmitted vibration.
 
 The measurement chain of the ISO human-vibration family is implemented from the
 standards' own analog definitions, clean-room:

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Whole-body vibration containing multiple shocks (ISO 2631-5:2018).
+r"""Whole-body vibration containing multiple shocks (ISO 2631-5:2018).
 
 Implements the normative Clause 5 spinal-response model and the Annex C
 assessment of adverse health effects for the vertical (``z``) axis.
@@ -319,7 +318,8 @@ def compression_dose(daily_dose_value: float, *, mz: float = MZ_MALE) -> float:
 
 def static_stress(mz: float = MZ_MALE) -> float:
     r"""Static compressive stress :math:`S_\text{stat} = m_\mathrm{z} \cdot 9.81`
-    (Annex C), MPa."""
+    (Annex C), MPa.
+    """
     return mz * GRAVITY
 
 

--- a/src/phonometry/vibration/machinery/diagnostics.py
+++ b/src/phonometry/vibration/machinery/diagnostics.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Kinematic fault frequencies of rotating machinery (Norton & Karczub Ch. 8).
+r"""Kinematic fault frequencies of rotating machinery (Norton & Karczub Ch. 8).
 
 Condition monitoring starts with arithmetic, not with signal processing: every
 rolling-contact bearing, gear pair, induction motor and bladed rotor excites a

--- a/src/phonometry/vibration/structural/experimental_sea.py
+++ b/src/phonometry/vibration/structural/experimental_sea.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Experimental statistical energy analysis: coupling loss factors from measured
+r"""Experimental statistical energy analysis: coupling loss factors from measured
 energies (Norton & Karczub Ch. 6).
 
 Statistical energy analysis (SEA) has two routes to the coupling loss factor

--- a/src/phonometry/vibration/structural/junction_transmission.py
+++ b/src/phonometry/vibration/structural/junction_transmission.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Bending-wave transmission coefficients for rigid plate junctions
+r"""Bending-wave transmission coefficients for rigid plate junctions
 (Hopkins 2007, *Sound Insulation*, Section 5.2.1.3; Cremer et al. 1973;
 Craik 1981, 1996).
 

--- a/src/phonometry/vibration/structural/mechanical_mobility.py
+++ b/src/phonometry/vibration/structural/mechanical_mobility.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Mechanical mobility and the frequency-response-function family (ISO 7626-1:2011).
+r"""Mechanical mobility and the frequency-response-function family (ISO 7626-1:2011).
 
 Mechanical **mobility** is the complex ratio of a velocity response to the
 excitation force that produces it, :math:`Y_{ij} = v_i / F_j` (ISO 7626-1,

--- a/src/phonometry/vibration/structural/point_mobility.py
+++ b/src/phonometry/vibration/structural/point_mobility.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Point mobilities and impedances of infinite structures (Cremer, Heckl &
+r"""Point mobilities and impedances of infinite structures (Cremer, Heckl &
 Petersson 2005, Chapter 5, Table 5.1).
 
 The **point mobility** ``Y`` of a structure is the complex ratio of the

--- a/src/phonometry/vibration/structural/radiation_efficiency.py
+++ b/src/phonometry/vibration/structural/radiation_efficiency.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Radiation efficiency of a plate in bending (Hopkins 2007, Sound Insulation,
+r"""Radiation efficiency of a plate in bending (Hopkins 2007, Sound Insulation,
 Section 2.9; Leppington et al. 1982; Maidanik 1962).
 
 The **radiation efficiency** ``sigma`` of a vibrating plate relates the

--- a/src/phonometry/vibration/structural/transfer_stiffness.py
+++ b/src/phonometry/vibration/structural/transfer_stiffness.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-r"""
-Dynamic transfer stiffness of resilient elements (ISO 10846-1/-2/-3).
+r"""Dynamic transfer stiffness of resilient elements (ISO 10846-1/-2/-3).
 
 The vibro-acoustic transfer property of a resilient element (a vibration
 isolator, mount, bellows or hose) is its **dynamic transfer stiffness**: the
@@ -50,7 +49,8 @@ family (ISO 10846-1, Annex A / Table A.2):
 mechanical impedance and effective mass through
 :func:`phonometry.vibration.convert_frf` (``"dynamic_stiffness"`` <->
 ``"impedance"`` <-> ``"apparent_mass"``). This module feeds the structure-borne
-source and building prediction standards (ISO 9611, EN 15657, EN 12354-5)."""
+source and building prediction standards (ISO 9611, EN 15657, EN 12354-5).
+"""
 
 from __future__ import annotations
 
@@ -325,7 +325,8 @@ class TransferStiffnessResult:
     @property
     def loss_factor(self) -> np.ndarray:
         r"""Loss factor :math:`\eta = \operatorname{Im}/\operatorname{Re}`
-        per frequency (3.8)."""
+        per frequency (3.8).
+        """
         return loss_factor(self.transfer_stiffness)
 
     def to(self, target: str) -> np.ndarray:

--- a/tests/aircraft/test_epnl_report.py
+++ b/tests/aircraft/test_epnl_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ICAO Annex 16 EPNL report (``.report()`` -> PDF).
+"""Tests for the ICAO Annex 16 EPNL report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for a computed flyover, unknown engines are

--- a/tests/aircraft/test_rotorcraft_norah2.py
+++ b/tests/aircraft/test_rotorcraft_norah2.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-End-to-end validation of the rotorcraft event chain against the NORAH2
+"""End-to-end validation of the rotorcraft event chain against the NORAH2
 reference implementation (EASA.2020.FC.06 prototype, V2.0.74 public release).
 
 The prototype's ARP verification cases carry, per single-event operation, the

--- a/tests/broadcast/test_ebu_material_oracle.py
+++ b/tests/broadcast/test_ebu_material_oracle.py
@@ -95,7 +95,8 @@ def _load(name: str) -> tuple[np.ndarray, float]:
 )
 def test_gated_integrated_loudness_from_series(key: str, case: str) -> None:
     """The BS.1770-5 two-stage gate over the committed 400 ms momentary
-    series must land on the EBU-published -23,0 LUFS."""
+    series must land on the EBU-published -23,0 LUFS.
+    """
     integrated, _ = _integrated_from_blocks(_SERIES[f"{key}_momentary"])
     assert integrated == pytest.approx(-23.0, abs=0.1), case
 

--- a/tests/broadcast/test_program_loudness.py
+++ b/tests/broadcast/test_program_loudness.py
@@ -373,7 +373,8 @@ def test_tech3341_true_peak_tones(
 @pytest.mark.parametrize("offset", range(4), ids=[f"case{20 + o}" for o in range(4)])
 def test_tech3341_true_peak_intersample_offsets(offset: int) -> None:
     """Cases 20-23: one fs/4 period inside an fs/6 tone, decimated with a
-    0-3 sample offset at the 4 fs synthesis rate; all read 0.0 dBTP."""
+    0-3 sample offset at the 4 fs synthesis rate; all read 0.0 dBTP.
+    """
     fs4 = 4 * FS
     n = round(1.0 * fs4)
     frequency = np.full(n, FS / 6.0)
@@ -393,7 +394,8 @@ def test_tech3341_true_peak_intersample_offsets(offset: int) -> None:
 
 def test_true_peak_under_read_bound() -> None:
     """The worst-phase under-read obeys 20 lg cos(pi fnorm / n) (Annex 2
-    Attachment 1) at fnorm = 0.25 with the default 4x oversampling."""
+    Attachment 1) at fnorm = 0.25 with the default 4x oversampling.
+    """
     t = np.arange(FS) / FS
     worst = 0.0
     for phase in np.linspace(0.0, np.pi / 2.0, 9):
@@ -450,7 +452,8 @@ def test_tech3342_repetition_invariance() -> None:
 
 def test_loudness_range_reference_percentile_indexing() -> None:
     """loudness_range follows the Tech 3342 reference implementation on a
-    hand-computable short-term vector (no gating active)."""
+    hand-computable short-term vector (no gating active).
+    """
     stl = np.linspace(-40.0, -20.0, 21)  # 1 LU steps; mean power ~ -24.2
     # Relative threshold ~ -44.2 gates nothing; indices round(20*p/100):
     # low = stl[2] = -38, high = stl[19] = -21.

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the EBU R 128 programme-loudness report (``.report()`` -> PDF).
+"""Tests for the EBU R 128 programme-loudness report (``.report()`` -> PDF).
 
 These tests assert both structural facts (a valid single-page PDF is written
 for a measured programme, unknown engines/tolerances are rejected, a compliant
@@ -213,7 +212,8 @@ def test_verdict_follows_displayed_rounding_at_boundary() -> None:
 
 def test_fiche_pins_displayed_numbers(tmp_path) -> None:
     """The rendered fiche shows the QC tolerance, its R 128 item and the
-    0.1 LU rounded measured loudness."""
+    0.1 LU rounded measured loudness.
+    """
     result = _case1_result()
     out = tmp_path / "pins.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=-23.0))

--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -579,7 +579,8 @@ def test_the_bare_names_are_gone():
 
 def test_annex_b_uncorrelated_single_number_uncertainties() -> None:
     """Formula (B.2) on the Table B.1 spectrum gives u(Rw+C50-5000) = 0,6 dB
-    and u(Rw+Ctr,50-5000) = 0,8 dB."""
+    and u(Rw+Ctr,50-5000) = 0,8 dB.
+    """
     import reference_data as ref
 
     from phonometry.building.measurement.insulation import (
@@ -620,7 +621,8 @@ def test_annex_b_correlated_rw_uncertainty() -> None:
 
 def test_annex_b_correlated_adaptation_sum_uncertainties() -> None:
     """Formulae (B.3)-(B.5): u(Rw+C50-5000) = 2,1 dB and
-    u(Rw+Ctr,50-5000) = 2,6 dB (unrounded 2,05 / 2,63)."""
+    u(Rw+Ctr,50-5000) = 2,6 dB (unrounded 2,05 / 2,63).
+    """
     import reference_data as ref
 
     from phonometry.building.measurement.insulation import (

--- a/tests/building/measurement/test_facade_field_report.py
+++ b/tests/building/measurement/test_facade_field_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 16283-3 field facade report (``.report()`` -> PDF).
+"""Tests for the ISO 16283-3 field facade report (``.report()`` -> PDF).
 
 The fiche's numbers are verified against the standard's own definitions using
 hand-computable syntheses: with ``T = T0 = 0,5 s`` the standardization term

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 16283-3:2016 field façade sound insulation and its ISO 717-1
+"""Tests for ISO 16283-3:2016 field façade sound insulation and its ISO 717-1
 weighted rating.
 
 Validation strategy: the standard's own formulas and closed-form

--- a/tests/building/measurement/test_floor_covering_improvement.py
+++ b/tests/building/measurement/test_floor_covering_improvement.py
@@ -266,7 +266,8 @@ def test_ci_delta_validation() -> None:
 
 def test_clause_63_18_band_spectrum_rates_on_sub_range() -> None:
     """A clause 6.3 spectrum (18 bands 100-5000 Hz) now yields ΔLw and CI,Δ
-    from its 100-3150 Hz sub-range."""
+    from its 100-3150 Hz sub-range.
+    """
     dl16 = np.asarray(ref.ISO717_2_ANNEX_C2_DELTA_L)
     dl18 = np.concatenate([dl16, [22.0, 21.0]])  # 4 k / 5 kHz extensions
     bare = np.full(18, 75.0)

--- a/tests/building/measurement/test_impact_insulation.py
+++ b/tests/building/measurement/test_impact_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 16283-2 field impact sound insulation and ISO 717-2
+"""Tests for ISO 16283-2 field impact sound insulation and ISO 717-2
 weighted impact ratings (CI).
 
 Validation strategy: the standards' own numbers, not self-consistency.

--- a/tests/building/measurement/test_insulation.py
+++ b/tests/building/measurement/test_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 16283-1:2014 field airborne sound insulation and
+"""Tests for ISO 16283-1:2014 field airborne sound insulation and
 ISO 717-1 weighted ratings (C / Ctr).
 
 Validation strategy: the standards' own numbers, not self-consistency.
@@ -345,7 +344,8 @@ def test_field_rating_pipeline_dnt_w() -> None:
 
 def test_extended_annex_c2_enlarged_range() -> None:
     """ISO 717-1:2020 Annex C Table C.2: Rw(C;Ctr;C50-5000;Ctr,50-5000)
-    = 30 (-2; -3; -2; -4) dB."""
+    = 30 (-2; -3; -2; -4) dB.
+    """
     import reference_data as ref
 
     freqs = [
@@ -446,7 +446,8 @@ def test_extended_requires_core_bands() -> None:
 
 def test_one_decimal_rating_annex_b() -> None:
     """ISO 12999-1:2020 Annex B: the 0,1 dB shift yields Rw = 57,4 dB and the
-    one-decimal sums Rw + C50-5000 = 56,4 / Rw + Ctr,50-5000 = 51,1 dB."""
+    one-decimal sums Rw + C50-5000 = 56,4 / Rw + Ctr,50-5000 = 51,1 dB.
+    """
     import reference_data as ref
 
     res = building.weighted_rating_extended(
@@ -472,7 +473,8 @@ def test_one_decimal_rating_annex_b() -> None:
 
 def test_impact_extended_ci_50_2500() -> None:
     """CI,50-2500 sums 50-2500 Hz (A.2.1 NOTE); flat extensions with low
-    energy leave it equal to the core CI."""
+    energy leave it equal to the core CI.
+    """
     import reference_data as ref
 
     freqs = [
@@ -496,7 +498,8 @@ def test_impact_extended_ci_50_2500() -> None:
 
 def test_impact_one_decimal_reference_floor() -> None:
     """The 0,1 dB variant reproduces the printed uncertainty constants of
-    ISO 717-2:2020 A.2.2: Ln,r,0,w = 77,6 dB and CI,r,0 = -10,3 dB."""
+    ISO 717-2:2020 A.2.2: Ln,r,0,w = 77,6 dB and CI,r,0 = -10,3 dB.
+    """
     import reference_data as ref
 
     res = building.weighted_impact_rating_extended(

--- a/tests/building/measurement/test_intensity_insulation.py
+++ b/tests/building/measurement/test_intensity_insulation.py
@@ -222,7 +222,8 @@ def test_combine_subareas_validation() -> None:
 
 def test_combine_subareas_negative_direction_rule() -> None:
     """Clause 6.4.6: a reverse-flow subarea enters Formula (11) with -Smi
-    while Sm keeps the unsigned area sum (Formula (12))."""
+    while Sm keeps the unsigned area sum (Formula (12)).
+    """
     # Forward 9 m2 at 50 dB, reverse 1 m2 at 40 dB (~10 % reverse power).
     lin, sm = building.combine_subareas([[50.0], [40.0]], [9.0, -1.0])
     expected = 10.0 * np.log10((9.0 * 10**5.0 - 1.0 * 10**4.0) / 10.0)

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 10140 laboratory test report (``.report()`` -> PDF).
+"""Tests for the ISO 10140 laboratory test report (``.report()`` -> PDF).
 
 The fiche's numbers are verified against the standards' own definitions
 using hand-computable syntheses. For the airborne fiche, choosing the free
@@ -237,7 +236,6 @@ def test_missing_rating_rejected(tmp_path) -> None:
 
 def test_rating_without_per_band_data_rejected(tmp_path) -> None:
     """A manually built rating lacking the per-band arrays is rejected."""
-
     # A backward-compatibly constructed rating (band_centers / measured /
     # shifted_reference default to None) would otherwise crash the table.
     bare_rating = building.WeightedRatingResult(
@@ -266,7 +264,8 @@ def test_manual_impact_result_renders(tmp_path) -> None:
 
 def test_report_rejects_band_count_mismatch(tmp_path) -> None:
     """A rating whose per-band arrays are shorter than the curve raises a clear
-    ValueError (not an uncaught IndexError)."""
+    ValueError (not an uncaught IndexError).
+    """
     import dataclasses
 
     res = _airborne_result()

--- a/tests/building/measurement/test_iso15186_element_report.py
+++ b/tests/building/measurement/test_iso15186_element_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 15186-1 element-normalized intensity report (``.report()``).
+"""Tests for the ISO 15186-1 element-normalized intensity report (``.report()``).
 
 The element-normalized level difference ``DI,n,e`` (Clause 3.9, Formula (8)) is
 a level difference rated by the same ISO 717-1 machinery as the pressure ``R``,
@@ -204,7 +203,6 @@ def test_non_iso_band_count_rejected(tmp_path) -> None:
     ISO 717-1 rates; a hand-crafted rating whose per-band arrays all match an
     8-band curve would otherwise satisfy the shared renderer's shape checks.
     """
-
     centers = np.array([100, 125, 160, 200, 250, 315, 400, 500], dtype=float)
     curve = np.linspace(20.0, 40.0, 8)
     rating = building.WeightedRatingResult(
@@ -224,7 +222,6 @@ def test_non_iso_band_count_rejected(tmp_path) -> None:
 
 def test_rating_without_per_band_data_rejected(tmp_path) -> None:
     """A manually built rating lacking the per-band arrays is rejected."""
-
     bare_rating = building.WeightedRatingResult(
         rating=30, c=-2, ctr=-3, unfavourable_sum=0.0
     )

--- a/tests/building/measurement/test_iso15186_report.py
+++ b/tests/building/measurement/test_iso15186_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 15186-1 intensity sound-insulation report (``.report()``).
+"""Tests for the ISO 15186-1 intensity sound-insulation report (``.report()``).
 
 The intensity sound reduction index ``RI`` is an ordinary sound reduction
 index rated by the same ISO 717-1 machinery as the pressure ``R``, so the
@@ -259,7 +258,6 @@ def test_non_iso_band_count_rejected(tmp_path) -> None:
     ISO 717-1 rates; a hand-crafted rating whose per-band arrays all match an
     8-band curve would otherwise satisfy the shared renderer's shape checks.
     """
-
     centers = np.array([100, 125, 160, 200, 250, 315, 400, 500], dtype=float)
     curve = np.linspace(20.0, 40.0, 8)
     rating = building.WeightedRatingResult(
@@ -281,7 +279,6 @@ def test_non_iso_band_count_rejected(tmp_path) -> None:
 
 def test_rating_without_per_band_data_rejected(tmp_path) -> None:
     """A manually built rating lacking the per-band arrays is rejected."""
-
     bare_rating = building.WeightedRatingResult(
         rating=30, c=-2, ctr=-3, unfavourable_sum=0.0
     )

--- a/tests/building/measurement/test_iso16251_report.py
+++ b/tests/building/measurement/test_iso16251_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 16251-1 floor-covering impact-improvement report (``.report()``).
+"""Tests for the ISO 16251-1 floor-covering impact-improvement report (``.report()``).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for an impact-improvement measurement, the

--- a/tests/building/measurement/test_iso16283_report.py
+++ b/tests/building/measurement/test_iso16283_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 16283 field test report (``.report()`` -> PDF).
+"""Tests for the ISO 16283 field test report (``.report()`` -> PDF).
 
 The fiche's numbers are verified against the standards' own definitions
 using hand-computable syntheses: with ``T = T0 = 0,5 s`` the reverberation

--- a/tests/building/measurement/test_iso717_report.py
+++ b/tests/building/measurement/test_iso717_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 717 Annex C rating report (``.report()`` -> PDF).
+"""Tests for the ISO 717 Annex C rating report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural
 facts: a non-empty file that starts with the ``%PDF`` magic bytes is written

--- a/tests/building/measurement/test_lab_insulation.py
+++ b/tests/building/measurement/test_lab_insulation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 10140 laboratory sound insulation.
+"""Tests for ISO 10140 laboratory sound insulation.
 
 Validation strategy: closed-form identities from the standards' own
 formulae, and consistency with the verified ISO 717-1/2 rating engine.

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -168,7 +168,6 @@ def test_plot_returns_axes() -> None:
 
 def test_blocked_force_level_formula_15() -> None:
     """L_Fb,eq = L_Ws,low - 10 lg(Re{Y}/Y0), dB re 1e-6 N."""
-
     lfb = building.equivalent_blocked_force_level(61.7, 5.34e-6)
     assert float(lfb) == pytest.approx(61.7 - 10.0 * math.log10(5.34e-6))
     # A complex plate mobility uses its real part (Formula 16).
@@ -180,7 +179,6 @@ def test_blocked_force_level_formula_15() -> None:
 
 def test_characteristic_reception_plate_power_formula_17() -> None:
     """L_Wsn = L_Fb,eq + 10 lg(Y_R,inf,low/Y0), Y_R,inf,low = 5e-6 m/(N.s)."""
-
     lfb = building.equivalent_blocked_force_level(61.7, 5.34e-6)
     lwsn = building.characteristic_reception_plate_power(lfb)
     assert float(lwsn) == pytest.approx(61.7 + 10.0 * math.log10(5.0e-6 / 5.34e-6))
@@ -216,7 +214,6 @@ def test_free_velocity_level_formula_18_real_mobility() -> None:
     the injected power is P = v_f**2 / Y, so v_f**2 = P*Y and
     L_vf = 10 lg(P*Y/(1e-9)**2) with P in watts.
     """
-
     p_watt = 1e-12 * 10.0 ** (70.0 / 10.0)
     y = 1.0e-2
     expected = 10.0 * math.log10(p_watt * y / 1e-9**2)
@@ -233,7 +230,6 @@ def test_formulas_15_18_19_are_mutually_consistent() -> None:
     Synthesize a source of known free velocity and blocked force measured on
     ideal low- and high-mobility plates, then recover the source mobility.
     """
-
     y_source = 2.5e-4  # true |Y_S|, m/(N s)
     v_free = 3.2e-6  # true free velocity, m/s
     f_blocked = v_free / y_source
@@ -254,7 +250,6 @@ def test_source_mobility_formula_19_round_trip() -> None:
     has |Y_S| = v_f/F_b; expressing both as levels re 1e-9 m/s and 1e-6 N
     must return exactly that ratio.
     """
-
     v_f, f_b = 1.0e-4, 2.0e-2  # m/s, N -> |Y_S| = 5e-3 m/(N.s)
     lvf = 20.0 * math.log10(v_f / 1.0e-9)
     lfb = 20.0 * math.log10(f_b / 1.0e-6)

--- a/tests/building/measurement/test_structure_borne_power_report.py
+++ b/tests/building/measurement/test_structure_borne_power_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the EN 15657 structure-borne sound power ``.report()`` fiche.
+"""Tests for the EN 15657 structure-borne sound power ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 standard, independent of the library's own combination path. A source on a

--- a/tests/building/measurement/test_survey_insulation_report.py
+++ b/tests/building/measurement/test_survey_insulation_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 10052 survey-method field reports (``.report()`` -> PDF).
+"""Tests for the ISO 10052 survey-method field reports (``.report()`` -> PDF).
 
 ISO 10052 carries no worked numeric example, so the fiches are exercised with
 closed-form syntheses like the sibling report tests: with the reverberation

--- a/tests/building/prediction/test_detailed_model_report.py
+++ b/tests/building/prediction/test_detailed_model_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 12354-1/-2:2017 detailed prediction fiches (``.report()``).
+"""Tests for the ISO 12354-1/-2:2017 detailed prediction fiches (``.report()``).
 
 Both fiches are pinned to the per-band worked example the two parts share
 (ISO 12354-1 Annex L / ISO 12354-2 Annex G, the heavy homogeneous building

--- a/tests/building/prediction/test_facade.py
+++ b/tests/building/prediction/test_facade.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the EN 12354-3/-4:2000 façade prediction module
+"""Tests for the EN 12354-3/-4:2000 façade prediction module
 (:mod:`phonometry.building.prediction.facade`).
 
 The primary oracles are the two worked examples of the standard: Annex F of
@@ -195,7 +194,8 @@ def test_annex_g_rprime_cap() -> None:
 
 def test_rprime_cap_off_by_default() -> None:
     """The 40 dB cap is an Annex G example footnote, not Formula (2)/(3):
-    by default R' is the bare energy sum, uncapped."""
+    by default R' is the bare energy sum, uncapped.
+    """
     res = building.radiated_sound_power(
         [building.FacadeElement(name="wall", area=100.0, r=[60.0])],
         lp_in=90.0,

--- a/tests/building/prediction/test_installed_structure_borne.py
+++ b/tests/building/prediction/test_installed_structure_borne.py
@@ -322,7 +322,8 @@ def test_annex_i3_cistern_coupling_terms() -> None:
 
 def test_annex_i3_cistern_full_chain_table_i9() -> None:
     """Table I.9 end-to-end: all four paths, the Formula (17) total and the
-    29 dB(A) receiving-room value, within the +/-0,15 dB table rounding."""
+    29 dB(A) receiving-room value, within the +/-0,15 dB table rounding.
+    """
     import reference_data as ref
 
     tol = ref.EN12354_5_ANNEX_I_TOL

--- a/tests/building/prediction/test_installed_structure_borne_report.py
+++ b/tests/building/prediction/test_installed_structure_borne_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the EN 12354-5 installed structure-borne prediction ``.report()``.
+"""Tests for the EN 12354-5 installed structure-borne prediction ``.report()``.
 
 The fiche is a prediction, not a measurement, and the sheet says so. The
 rendered values are checked against a clean-room oracle derived from the

--- a/tests/building/prediction/test_resilient_layers.py
+++ b/tests/building/prediction/test_resilient_layers.py
@@ -341,7 +341,8 @@ def test_force_pulse_transform_matches_the_closed_form_spectrum() -> None:
 
 def test_over_critical_pulse_stays_positive() -> None:
     """H printed p. 279: "For over-critical oscillations, the force pulse decays
-    to zero and takes only positive values"."""
+    to zero and takes only positive values".
+    """
     stiffness, impedance = _plate("chipboard", 0.022)
     time = np.linspace(0.0, 0.02, 5000)
     pulse = building.force_pulse(time, stiffness, impedance)
@@ -527,7 +528,8 @@ def test_critical_case_is_inclusive_and_finite() -> None:
 
 def test_troughs_occur_at_odd_multiples_of_the_cut_off() -> None:
     """H printed p. 514: "deep troughs in the force spectra above the cut-off
-    frequency; these occur at frequencies n fco where n = 3, 5, 7, etc."."""
+    frequency; these occur at frequencies n fco where n = 3, 5, 7, etc.".
+    """
     impedance = _plate("concrete", 0.14)[1]
     stiffness = building.covering_contact_stiffness(2.8e8 * 0.005, 0.005)
     result = building.tapping_force_spectrum([1.0], stiffness, impedance)
@@ -568,7 +570,8 @@ def test_covering_improvement_is_zero_below_the_cut_off() -> None:
     """H printed p. 514: "Below fco the soft floor covering does not
     significantly alter the force input compared to the bare slab; hence it
     does not improve the impact sound insulation ... Below fco, DeltaL is
-    approximately 0 dB"."""
+    approximately 0 dB".
+    """
     plate_stiffness, impedance = _plate("concrete", 0.14)
     thickness = 0.005
     covering = building.covering_contact_stiffness(2.8e8 * thickness, thickness)
@@ -580,7 +583,8 @@ def test_covering_improvement_is_zero_below_the_cut_off() -> None:
 
 def test_two_line_estimate_rises_12_db_per_octave() -> None:
     """H printed p. 514: "the curves will tend towards a straight slope of
-    12 dB/octave (equivalent to 40 dB/decade) for f >= fco"."""
+    12 dB/octave (equivalent to 40 dB/decade) for f >= fco".
+    """
     plate_stiffness, impedance = _plate("concrete", 0.14)
     thickness = 0.005
     covering = building.covering_contact_stiffness(2.8e8 * thickness, thickness)
@@ -765,7 +769,8 @@ def test_covering_bands_are_the_iec_61260_base_ten_bands(
 
 def test_covering_improvement_result_carries_both_cut_offs() -> None:
     """The bare slab's own cut-off (about 7 kHz) is reported alongside the
-    covering's, since above it the bare force falls too (H printed p. 514)."""
+    covering's, since above it the bare force falls too (H printed p. 514).
+    """
     plate_stiffness, impedance = _plate("concrete", 0.14)
     thickness = 0.005
     covering = building.covering_contact_stiffness(2.8e8 * thickness, thickness)
@@ -828,7 +833,8 @@ def test_weighted_improvement_matches_the_printed_32_2_db() -> None:
 def test_asphalt_branch_is_the_40_lg_law() -> None:
     """ISO 12354-2:2017 Formula (C.3), ``DeltaL = 40 lg(f/fo)`` for asphalt and
     dry floating floors; H Eq. (4.119) is the same law from Cremer's
-    infinite-plate derivation, "12 dB per octave" (V printed p. 308)."""
+    infinite-plate derivation, "12 dB per octave" (V printed p. 308).
+    """
     freqs = np.array([100.0, 200.0, 400.0, 800.0])
     result = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=50.0, model="cremer"
@@ -839,7 +845,8 @@ def test_asphalt_branch_is_the_40_lg_law() -> None:
 
 def test_en12354_branch_is_the_30_lg_law() -> None:
     """ISO 12354-2:2017 Formula (C.1) / H Eq. (4.124): 30 lg(f/fo), i.e. the
-    "9 dB per octave" of V printed p. 308, and 0 dB at and below ``fo``."""
+    "9 dB per octave" of V printed p. 308, and 0 dB at and below ``fo``.
+    """
     freqs = np.array([25.0, 50.0, 100.0, 200.0])
     result = building.floating_floor_improvement_spectrum(
         freqs, resonance_frequency=50.0

--- a/tests/building/prediction/test_simplified_model_report.py
+++ b/tests/building/prediction/test_simplified_model_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the EN/ISO 12354-1/-2 predicted-insulation reports (``.report()``).
+"""Tests for the EN/ISO 12354-1/-2 predicted-insulation reports (``.report()``).
 
 The prediction fiches are pinned to the standards' own worked examples, run
 through the tested prediction code: EN 12354-1 Annex H.3 (airborne, a

--- a/tests/building/prediction/test_wall_linings.py
+++ b/tests/building/prediction/test_wall_linings.py
@@ -245,7 +245,8 @@ def test_table_d1_63_to_80_boundary() -> None:
 def test_table_d1_1600_hz_overlap_takes_the_conservative_value() -> None:
     """ISO 12354-1:2017 Table D.1 prints 1 600 Hz in two rows with different
     values, "630 to 1 600 -> -10" and "1 600 <= f0 <= 5 000 -> -5"; see
-    docs/ERRATA.md. The library takes the more conservative -10 dB."""
+    docs/ERRATA.md. The library takes the more conservative -10 dB.
+    """
     assert building.weighted_lining_improvement(1600.0, 45.0) == -10.0
     assert building.weighted_lining_improvement(2000.0, 45.0) == -5.0
 
@@ -366,7 +367,8 @@ def test_anchor_and_glued_area_corrections_d5_and_d6() -> None:
 
 def test_stud_system_formula_d7() -> None:
     """ISO 12354-1:2017 Formula (D.7), printed p. 41: ``-20 lg(fo) + 48``,
-    ``-22 lg(fo) + 51``, ``-24 lg(fo) + 54``, each ">= -4"."""
+    ``-22 lg(fo) + 51``, ``-24 lg(fo) + 54``, each ">= -4".
+    """
     studs = building.lining_improvement(100.0, system="studs")
     assert studs.ratings == pytest.approx((48.0 - 40.0, 51.0 - 44.0, 54.0 - 48.0))
     assert building.lining_improvement(5000.0, system="studs").delta_rw == -4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,7 @@ os.environ.setdefault("MPLBACKEND", "Agg")
 
 
 def pytest_configure(config):
-    """
-    Configure environment variables for the test session.
+    """Configure environment variables for the test session.
     We disable Numba JIT to allow coverage tools to trace inside the kernels.
     """
     # Disable JIT by default for tests to ensure 100% coverage reporting.

--- a/tests/electroacoustics/test_electroacoustics_signal_overloads.py
+++ b/tests/electroacoustics/test_electroacoustics_signal_overloads.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Every electroacoustic measurement takes a ``Signal`` in place of ``(x, fs)``.
+"""Every electroacoustic measurement takes a ``Signal`` in place of ``(x, fs)``.
 
 Same contract as ``signals``, ``filters`` and ``signals.levels``, held by
 ``phonometry.io._resolve``: the object supplies the rate when ``fs`` is

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the IEC 60268-5 loudspeaker rated characteristics and their
+"""Tests for the IEC 60268-5 loudspeaker rated characteristics and their
 ``.report()`` fiche (characteristics model + PDF rendering).
 
 The two computed characteristics are checked against IEC 60268-5's own

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the IEC 60268-4 microphone rated characteristics and their
+"""Tests for the IEC 60268-4 microphone rated characteristics and their
 ``.report()`` fiche (characteristics model + PDF rendering).
 
 The four computed characteristics are checked against IEC 60268-4's own

--- a/tests/electroacoustics/test_sound_reinforcement.py
+++ b/tests/electroacoustics/test_sound_reinforcement.py
@@ -42,7 +42,8 @@ LEVEL_AT_LISTENER = 80.0
 
 def test_stability_margin_default_is_10_db() -> None:
     """Long p. 698: "This text uses a middle value of 10 dB for an equalised
-    system" (12 dB unequalised, 6 dB carefully equalised)."""
+    system" (12 dB unequalised, 6 dB carefully equalised).
+    """
     assert electroacoustics.DEFAULT_STABILITY_MARGIN == 10.0
 
 

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-p-p sound intensity (IEC 61043:1993) and ISO 9614-1:1993 field indicators.
+"""p-p sound intensity (IEC 61043:1993) and ISO 9614-1:1993 field indicators.
 
 Physics anchors:
 - Plane progressive wave: I = p_rms^2 / (rho*c), so Lp - LI =
@@ -29,7 +28,8 @@ def _plane_wave_pair(
     seed: int = 42,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Band-limited noise observed at two points; the second is a pure
-    (fractional, circular) delay of the first: p2(t) = p1(t - delay)."""
+    (fractional, circular) delay of the first: p2(t) = p1(t - delay).
+    """
     rng = np.random.default_rng(seed)
     n = int(FS * seconds)
     freqs = np.fft.rfftfreq(n, 1.0 / FS)
@@ -65,7 +65,8 @@ def test_plane_progressive_wave_broadband() -> None:
 def test_bias_correct_undoes_finite_difference_underread() -> None:
     """bias_correct=True lifts each in-band bin by (k*dr)/sin(k*dr)
     (IEC 61043:1993, 7.3). For a single tone the corrected total therefore
-    equals the raw total times that factor; at low frequency it is ~1."""
+    equals the raw total times that factor; at low frequency it is ~1.
+    """
     spacing, f0 = 0.05, 500.0
     t = np.arange(int(FS * 2)) / FS
     delay = spacing / C
@@ -95,7 +96,8 @@ def test_bias_correct_near_null_does_not_explode() -> None:
     intensity that is almost nulled; the un-clamped reciprocal
     (k*dr)/sin(k*dr) would blow up by ~30x there and let a few near-null bins
     dominate the total. Clamping the correction at k*dr = pi/2 keeps the
-    corrected total finite and bounded by the constant pi/2 factor."""
+    corrected total finite and bounded by the constant pi/2 factor.
+    """
     spacing = SPACING  # 12 mm -> first null at 343/0.024 = 14.3 kHz
     f0 = 14000.0  # k*dr ~ 0.98*pi, deep in the near-null region
     t = np.arange(int(FS * 2)) / FS
@@ -121,7 +123,8 @@ def test_bias_correct_near_null_does_not_explode() -> None:
 def test_bias_correct_below_cutoff_matches_analytic() -> None:
     """Below the pi/2 cutoff the clamped correction equals the exact
     reciprocal, so bias_correct recovers the unbiased plane-wave intensity
-    A^2/(2*rho*c) (behaviour unchanged from the un-clamped correction)."""
+    A^2/(2*rho*c) (behaviour unchanged from the un-clamped correction).
+    """
     spacing, f0 = SPACING, 4000.0  # k*dr = 0.88 rad < pi/2
     t = np.arange(int(FS * 5.0)) / FS
     amp = np.sqrt(2.0)  # 1 Pa rms
@@ -186,7 +189,8 @@ def test_standing_wave_high_pressure_intensity_index() -> None:
 
 def test_1khz_tone_exact_analytic_intensity() -> None:
     """Pure tone with exact phase lag k*dr: the cross-spectral estimator
-    must return (A^2/(2*rho*c)) * sin(k*dr)/(k*dr) exactly."""
+    must return (A^2/(2*rho*c)) * sin(k*dr)/(k*dr) exactly.
+    """
     t = np.arange(int(FS * 5.0)) / FS
     f0 = 1000.0
     amp = np.sqrt(2.0)  # 1 Pa rms
@@ -271,7 +275,8 @@ def test_validation_errors() -> None:
 
 def test_field_indicators_uniform_field() -> None:
     """Uniform positive intensity: F4 = 0 and F2 = F3; a plane-wave-like
-    surface gives F2 = 10*lg(rho*c/400) = 0,14 dB."""
+    surface gives F2 = 10*lg(rho*c/400) = 0,14 dB.
+    """
     i_n = np.full(8, 1.0 / (RHO * C))  # plane-wave intensity for 1 Pa^2
     lp = np.full(8, 93.98)  # 1 Pa^2 mean-square pressure
     ind = emission.field_indicators(lp, i_n)
@@ -309,7 +314,8 @@ def test_field_indicators_validation() -> None:
 
 def test_field_indicators_per_band_matches_per_column_scalars() -> None:
     """2D (positions, bands) input returns per-band arrays, one indicator
-    triple per column, identical to the scalar call on that column."""
+    triple per column, identical to the scalar call on that column.
+    """
     rng = np.random.default_rng(9614)
     freqs = np.array([125.0, 250.0, 500.0, 1000.0])
     lp = 74.0 + rng.normal(0.0, 0.8, (8, 4))
@@ -369,7 +375,8 @@ def test_field_indicators_plot_draws_indicators_and_ld() -> None:
 
 def test_dynamic_capability_index() -> None:
     """Ld = delta_pI0 - K (ISO 9614-1 equation (10)); adequate when
-    Ld > F2 (criterion 1, equation (B.1))."""
+    Ld > F2 (criterion 1, equation (B.1)).
+    """
     assert emission.dynamic_capability_index(18.0) == pytest.approx(8.0)
     assert emission.dynamic_capability_index(
         18.0, bias_error_factor=7.0

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-IEC 61043:1993 sound-intensity instrument class verification.
+"""IEC 61043:1993 sound-intensity instrument class verification.
 
 Oracles (independent of the implementation):
 

--- a/tests/emission/test_iso3741_report.py
+++ b/tests/emission/test_iso3741_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 3741 reverberation-room sound-power ``.report()`` fiche.
+"""Tests for the ISO 3741 reverberation-room sound-power ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 standard, independent of the library's own computation path. A steady source

--- a/tests/emission/test_iso3744_report.py
+++ b/tests/emission/test_iso3744_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 3744 / ISO 3745 sound-power determination ``.report()`` fiche.
+"""Tests for the ISO 3744 / ISO 3745 sound-power determination ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 standard, independent of the library's own combination path. For a uniform

--- a/tests/emission/test_iso4871_report.py
+++ b/tests/emission/test_iso4871_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 4871:1996 noise-emission declaration and its ``.report()``
+"""Tests for the ISO 4871:1996 noise-emission declaration and its ``.report()``
 fiche (declaration model + PDF rendering).
 
 The declaration model is checked against ISO 4871's own definitions and Annex B
@@ -279,7 +278,8 @@ def test_single_number_report_renders_one_page(tmp_path) -> None:
 def test_dual_number_report_follows_annex_b2_layout(tmp_path) -> None:
     """The dual-number table states only L and K (Annex B.2): no derived
     L_WAd row, whose mix of separately rounded addends and a once-rounded sum
-    is not part of the dual layout."""
+    is not part of the dual layout.
+    """
     pytest.importorskip("reportlab")
     decl = _annex_b_declaration()
     out = tmp_path / "iso4871_dual_layout.pdf"
@@ -292,7 +292,8 @@ def test_dual_number_report_follows_annex_b2_layout(tmp_path) -> None:
 
 def test_dual_number_verification_row_uses_rounded_sum(tmp_path) -> None:
     """A dual-number fiche verifies against L_WA + K_WA of the separately
-    rounded declared values (93 + 2 = 95 for 93,4/2,4), not round(95,8) = 96."""
+    rounded declared values (93 + 2 = 95 for 93,4/2,4), not round(95,8) = 96.
+    """
     pytest.importorskip("reportlab")
     mode = emission.OperatingModeDeclaration(
         "Operating mode 1", 93.4, 2.4, verification_level=95.0

--- a/tests/emission/test_iso7849_report.py
+++ b/tests/emission/test_iso7849_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO/TS 7849 sound-power-from-vibration ``.report()`` fiche.
+"""Tests for the ISO/TS 7849 sound-power-from-vibration ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 standard, independent of the library's own combination path. A machine casing

--- a/tests/emission/test_iso9614_3_report.py
+++ b/tests/emission/test_iso9614_3_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 9614-3 precision sound-power-by-intensity ``.report()`` fiche.
+"""Tests for the ISO 9614-3 precision sound-power-by-intensity ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 standard, independent of the library's own combination path. A machine is

--- a/tests/emission/test_iso9614_report.py
+++ b/tests/emission/test_iso9614_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 9614-2 sound-power-by-intensity ``.report()`` fiche.
+"""Tests for the ISO 9614-2 sound-power-by-intensity ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 standard, independent of the library's own combination path. A machine is

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Sound power from pressure over an enveloping surface: ISO 3744:2010
+"""Sound power from pressure over an enveloping surface: ISO 3744:2010
 (engineering) and ISO 3746:2010 (survey).
 
 Physics anchors:
@@ -82,7 +81,8 @@ def test_k1_zero_above_15db() -> None:
 def test_k1_applies_equation_16_at_exactly_15db() -> None:
     """dL == 15 dB stays inside '6 dB <= dLp <= 15 dB' (ISO 3744:2010, 8.2.3),
     so Eq. (16) applies: K1 = -10*lg(1-10^-1,5) = 0,1395... dB; K1 = 0 only
-    for dLp strictly above 15 dB."""
+    for dLp strictly above 15 dB.
+    """
     k1 = emission.background_noise_correction(np.array([75.0]), np.array([60.0]))
     assert k1[0] == pytest.approx(-10.0 * np.log10(1.0 - 10.0**-1.5), abs=1e-9)
     assert k1[0] == pytest.approx(0.13955, abs=1e-4)
@@ -90,7 +90,8 @@ def test_k1_applies_equation_16_at_exactly_15db() -> None:
 
 def test_k1_survey_applies_equation_at_exactly_10db() -> None:
     """Survey: dL == 10 dB stays inside '3 dB <= dLp <= 10 dB' (ISO 3746:2010,
-    8.3.3), so the correction applies: K1 = -10*lg(1-10^-1) = 0,4576 dB."""
+    8.3.3), so the correction applies: K1 = -10*lg(1-10^-1) = 0,4576 dB.
+    """
     k1 = emission.background_noise_correction(
         np.array([70.0]), np.array([60.0]), grade="survey"
     )
@@ -271,7 +272,8 @@ def test_directivity_index_uniform_field_is_zero() -> None:
 def test_directivity_index_uniform_field_with_background_is_zero() -> None:
     """With background correction and a uniform field (large dL so K1 ~ 0),
     the apparent DI stays ~0 at every position; it must NOT be inflated by the
-    surface-area term 10*lg(S/S0) (~22 dB at r = 5 m). ISO 3744 Eq. 7 / Eq. 16."""
+    surface-area term 10*lg(S/S0) (~22 dB at r = 5 m). ISO 3744 Eq. 7 / Eq. 16.
+    """
     src = np.full((10, 1), 80.0)
     bg = np.full((10, 1), 40.0)  # dL = 40 dB -> K1 ~ 4e-4 dB
     res = emission.sound_power_pressure(
@@ -284,7 +286,8 @@ def test_directivity_index_background_corrects_each_position() -> None:
     """Per Eq. 7 both the per-position level and the surface mean are
     background-corrected by the same broadband K1, which cancels in the
     difference: DI_i = (Lp_i - K1) - (mean - K1) = Lp_i - mean. The DI must
-    NOT carry a residual +K1 offset (ISO 3744 Eq. 7, notes sec. 9)."""
+    NOT carry a residual +K1 offset (ISO 3744 Eq. 7, notes sec. 9).
+    """
     src = np.array(
         [[82.0], [78.0], [80.0], [79.0], [81.0], [80.0], [83.0], [77.0], [80.0], [80.0]]
     )
@@ -305,7 +308,8 @@ def test_directivity_index_background_corrects_each_position() -> None:
 def test_directivity_index_per_band_localises_a_hot_band() -> None:
     """ISO 3744 clause 8.6: DI is per band, shape (NM, NB). A position that is
     hotter only in one band must show a positive DI in that band and ~0 in the
-    others; the other positions stay ~0 outside that band."""
+    others; the other positions stay ~0 outside that band.
+    """
     n_pos, n_bands = 10, 4
     levels = np.full((n_pos, n_bands), 70.0)
     levels[3, 2] += 12.0  # position 3 hot only in band 2
@@ -322,7 +326,8 @@ def test_directivity_index_per_band_localises_a_hot_band() -> None:
 
 def test_directivity_index_per_band_equals_level_minus_energy_mean() -> None:
     """DIi*(k) reduces to the raw per-band level minus the per-band energy mean
-    (the uniform per-band K1 cancels; ISO 3744 Eq. 7)."""
+    (the uniform per-band K1 cancels; ISO 3744 Eq. 7).
+    """
     rng = np.random.default_rng(0)
     levels = 70.0 + rng.uniform(-3.0, 3.0, size=(10, 3))
     res = emission.sound_power_pressure(levels, "hemisphere", radius=2.0)
@@ -332,7 +337,8 @@ def test_directivity_index_per_band_equals_level_minus_energy_mean() -> None:
 
 def test_background_levels_single_spectrum_broadcasts() -> None:
     """A single background spectrum (NB,) or (1, NB) is broadcast to every
-    position and gives the same K1 as the equivalent full (NM, NB) array."""
+    position and gives the same K1 as the equivalent full (NM, NB) array.
+    """
     levels = np.tile(np.array([90.0, 92.0, 95.0]), (10, 1))
     bg_spectrum = np.array([70.0, 71.0, 72.0])
     res_1d = emission.sound_power_pressure(
@@ -372,7 +378,8 @@ def test_k2_per_band_from_absorption_area() -> None:
 
 def test_k2_per_band_eq_a7_from_mean_absorption() -> None:
     """Eq. A.7: A = alpha*Sv per band -> K2 per band, and matches the scalar
-    branch band by band."""
+    branch band by band.
+    """
     alpha = np.array([0.1, 0.2, 0.4])
     sv = 500.0
     k2 = emission.environmental_correction(
@@ -405,7 +412,8 @@ def test_k2_scalar_still_returns_float() -> None:
 
 def test_per_band_k2_flows_into_sound_power() -> None:
     """A per-band K2 (from per-band reverberation time) is applied band by band
-    in the full determination."""
+    in the full determination.
+    """
     levels = np.tile(np.array([90.0, 92.0, 95.0]), (10, 1))
     t = np.array([1.0, 2.0, 4.0])
     volume = 2000.0  # large enough that per-band K2 stays under the 4 dB limit
@@ -424,7 +432,8 @@ def test_per_band_k2_flows_into_sound_power() -> None:
 
 def test_sound_power_level_a_multiband_without_frequencies_is_nan() -> None:
     """Multi-band input without 'frequencies' cannot be A-weighted, so the
-    A-weighted field is NaN (A-weighting needs the band centre frequencies)."""
+    A-weighted field is NaN (A-weighting needs the band centre frequencies).
+    """
     levels = np.tile(np.array([90.0, 92.0, 95.0]), (10, 1))
     res = emission.sound_power_pressure(levels, "hemisphere", radius=2.0)
     assert np.isnan(res.sound_power_level_a)

--- a/tests/emission/test_sound_power_intensity.py
+++ b/tests/emission/test_sound_power_intensity.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Sound power by sound-intensity scanning: ISO 9614-2:1996.
+"""Sound power by sound-intensity scanning: ISO 9614-2:1996.
 
 Physics / standard anchors:
 - Partial power Pi = <In,i>*Si (Eq. 5/12); total P = sum Pi (Eq. 6);
@@ -96,7 +95,8 @@ def test_small_negative_partial_power_no_warning() -> None:
 def test_f_plus_minus_warning_suppressed_under_survey_grade() -> None:
     """Criterion 2 is optional for the survey grade (B.1.2): F+/- > 3 dB must
     not emit the 'engineering grade not achieved' warning when grade='survey',
-    while the engineering grade still warns for the same data."""
+    while the engineering grade still warns for the same data.
+    """
     import warnings
 
     areas = np.array([0.5, 0.5, 0.5, 0.5])
@@ -249,7 +249,8 @@ def test_sweep_reversal_fails_criterion_3() -> None:
     """An equal-magnitude opposite-sign segment between the two sweeps has
     |ΔL| ~ 0 from the magnitudes alone, yet is grossly non-repeatable. With the
     band still determinable (positive total power) and criteria 1/2 satisfied,
-    the reversed segment must force criterion 3 (and thus the grade) to fail."""
+    the reversed segment must force criterion 3 (and thus the grade) to fail.
+    """
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     scan1 = np.full((4, 1), 5.0e-4)
     scan2 = scan1.copy()
@@ -284,7 +285,8 @@ def test_sweep_reversal_fails_criterion_3() -> None:
 
 def test_partial_sweep_reversal_only_affects_flipped_segment() -> None:
     """Only the segment whose flow reverses gets +inf repeatability; the aligned
-    segments keep their finite |ΔL|."""
+    segments keep their finite |ΔL|.
+    """
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     scan1 = np.full((4, 1), 5.0e-4)
     scan2 = scan1.copy()
@@ -297,7 +299,8 @@ def test_partial_sweep_reversal_only_affects_flipped_segment() -> None:
 
 def test_exact_zero_partial_power_does_not_trigger_reversal() -> None:
     """An exact-zero partial power carries no direction and must not be treated
-    as a reversal (no spurious +inf repeatability)."""
+    as a reversal (no spurious +inf repeatability).
+    """
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     scan1 = np.full((4, 1), 5.0e-4)
     scan2 = scan1.copy()
@@ -308,7 +311,8 @@ def test_exact_zero_partial_power_does_not_trigger_reversal() -> None:
 
 def test_short_frequencies_raises_value_error_not_index_error() -> None:
     """A 'frequencies' array shorter than the band count raises the public
-    ValueError up front, not an IndexError during classification."""
+    ValueError up front, not an IndexError during classification.
+    """
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     intensity = np.column_stack([np.full(4, 5.0e-4), np.full(4, 5.0e-4)])
     levels = np.full((4, 2), 90.0)
@@ -429,7 +433,8 @@ def test_a_weighted_total_omits_band_failing_criterion_2_engineering() -> None:
 def test_survey_grade_does_not_omit_on_criterion_2() -> None:
     """Criterion 2 is optional for grade 3 (Note 16), so a survey
     determination keeps a band with F+/- > 3 dB in LWA:
-    10*lg(10^9,28206 + 10^9,60206) = 97,7192 dB."""
+    10*lg(10^9,28206 + 10^9,60206) = 97,7192 dB.
+    """
     areas = np.ones(4)
     intensity = np.column_stack(
         [np.full(4, 1.0e-3), np.array([5.0e-3, -1.0e-3, 1.0e-3, -1.0e-3])]
@@ -450,7 +455,8 @@ def test_survey_grade_does_not_omit_on_criterion_2() -> None:
 
 def test_a_weighting_screening_unavailable_warns_and_sums_all() -> None:
     """Without FpI/Ld the clause 10.6 b screening cannot run: every
-    determinable band is summed and a warning notes the missing screening."""
+    determinable band is summed and a warning notes the missing screening.
+    """
     areas = np.ones(4)
     intensity = np.column_stack([np.full(4, 1.0e-3), np.full(4, 5.0e-4)])
     with pytest.warns(emission.SoundPowerWarning, match="10.6 b"):

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Precision-grade sound power: ISO 3745:2012 (anechoic / hemi-anechoic) and
+"""Precision-grade sound power: ISO 3745:2012 (anechoic / hemi-anechoic) and
 ISO 9614-3:2002 (sound-intensity scanning, precision).
 
 Physics / standard anchors:
@@ -284,7 +283,8 @@ def test_area_weighted_equals_equal_area_for_equal_areas() -> None:
 
 def test_anechoic_a_weighted_uncertainty_is_half_db_base() -> None:
     """The A-weighted sigma_R0 is 0,5 dB in both rooms; U = 2*0,5 = 1,0 dB
-    with no operating uncertainty (Eq. 24/25)."""
+    with no operating uncertainty (Eq. 24/25).
+    """
     res = sound_power_anechoic(np.full((40, 1), 70.0), "sphere", radius=1.0)
     assert res.uncertainty == pytest.approx(1.0, abs=1e-9)
 
@@ -342,7 +342,8 @@ def test_anechoic_bands_above_10khz_survive_without_lwa() -> None:
     """ISO 3745 covers one-third octaves up to 20 kHz (sigma_R0 Tables 2/3),
     but the ISO 3744 Annex E A-weighting table stops at 10 kHz: a 12,5 kHz
     band must not abort the determination -- the per-band LW and uncertainty
-    stay defined and only the A-weighted total is NaN."""
+    stay defined and only the A-weighted total is NaN.
+    """
     freqs = np.array([10000.0, 12500.0])
     res = sound_power_anechoic(
         np.full((40, freqs.size), 70.0), "sphere", radius=1.0, frequencies=freqs
@@ -525,7 +526,8 @@ def test_criterion_4_fails_on_highly_nonuniform_field() -> None:
 
 def test_criterion_2_dynamic_capability() -> None:
     """delta_pI0 = 14 dB, K = 10 -> Ld = 4; criterion 2 passes iff
-    F_pIn(signed) <= 4 dB."""
+    F_pIn(signed) <= 4 dB.
+    """
     # Build a field with a small, controllable F_pIn(signed).
     i_n = np.full((4, 1), 2.0e-6)
     # Choose Lp so that F_pIn(signed) = Lp_bar - 10*lg(In/I0) is ~2 dB (< 4).
@@ -606,7 +608,8 @@ def test_qualified_combines_criteria_1_to_4() -> None:
 
 def test_criterion_5_qualifies_band_despite_failed_criterion_4() -> None:
     """C.1.6.2: if criterion 5 holds, the band is qualified as a final result
-    even if FS(2) >= 2 (criterion 4 fails)."""
+    even if FS(2) >= 2 (criterion 4 fails).
+    """
     # A strongly non-uniform positive field: FS > 2 (criterion 4 fails).
     i_n = np.array([[1.0e-8], [1.0e-8], [1.0e-8], [1.0e-8], [1.0e-8], [1.0e-4]])
     li = 10.0 * np.log10(np.mean(i_n) / _P0)

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Sound power in a reverberation test room: ISO 3741:2010 (precision, grade 1).
+"""Sound power in a reverberation test room: ISO 3741:2010 (precision, grade 1).
 
 Physics / normative anchors (ISO 3741:2010):
 - Direct method, Eq. (20):
@@ -140,7 +139,8 @@ def test_comparison_reference_conditions_c2_near_zero() -> None:
 
 def test_comparison_fewer_than_six_positions_warns() -> None:
     """2D per-position test-source levels below the 6-position minimum warn
-    in the comparison method too (no V/S check -- no room geometry)."""
+    in the comparison method too (no V/S check -- no room geometry).
+    """
     levels = np.array([[80.0], [80.1], [79.9]])  # 3 positions, tight spread
     lp_rss = np.array([70.0])
     lw_ref = np.array([90.0])
@@ -293,7 +293,8 @@ def test_background_shape_mismatch_raises() -> None:
 
 def test_preaveraged_1d_levels_keep_single_k1_path() -> None:
     """1D pre-averaged spectra carry no per-position data: a single K1 from
-    the averaged spectra applies (documented approximation of 9.1.2)."""
+    the averaged spectra applies (documented approximation of 9.1.2).
+    """
     freqs = np.array([1000.0])
     t60 = np.array([1.5])
     res = emission.sound_power_reverberation(
@@ -311,7 +312,8 @@ def test_preaveraged_1d_levels_keep_single_k1_path() -> None:
 
 def test_comparison_method_corrects_test_source_per_position() -> None:
     """The comparison method applies the same per-position Eq. 14/15/16 chain
-    to the source under test before Eq. (21)."""
+    to the source under test before Eq. (21).
+    """
     freqs = np.array([1000.0])
     levels = np.array([[70.0], [68.0], [66.0], [72.0], [71.0], [69.0]])
     background = np.array([[58.0], [60.0], [59.0], [60.0], [62.0], [58.0]])
@@ -459,7 +461,8 @@ def test_qualified_room_emits_no_warning() -> None:
 # --------------------------------------------------------------------------
 def test_comparison_wrong_frequency_length_raises_clean_error() -> None:
     """Wrong-length 'frequencies' with 'background_levels' must raise a clean
-    ValueError (shape check ahead of the background broadcasting)."""
+    ValueError (shape check ahead of the background broadcasting).
+    """
     levels = np.array([80.0, 81.0, 82.0])
     levels_ref = np.array([70.0, 71.0, 72.0])
     lw_ref = np.array([90.0, 91.0, 92.0])
@@ -477,7 +480,8 @@ def test_comparison_wrong_frequency_length_raises_clean_error() -> None:
 
 def test_comparison_wrong_shape_raises_without_sampling_warning() -> None:
     """Malformed shapes raise ValueError before any position-sampling advisory
-    (warn-after-validate: a fewer-than-6-positions input must not warn first)."""
+    (warn-after-validate: a fewer-than-6-positions input must not warn first).
+    """
     # 3 positions (< 6) x 2 bands, but levels_ref spans 3 bands -> mismatch.
     levels = np.array([[80.0, 81.0], [80.1, 81.1], [79.9, 80.9]])
     levels_ref = np.array([70.0, 71.0, 72.0])
@@ -493,7 +497,8 @@ def test_comparison_wrong_shape_raises_without_sampling_warning() -> None:
 # --------------------------------------------------------------------------
 def test_comparison_reports_applied_background_correction() -> None:
     """The comparison method reports the ST K1 actually applied per band (Eq.
-    14), and reporting the field does not alter the computed LW."""
+    14), and reporting the field does not alter the computed LW.
+    """
     freqs = np.array([1000.0])
     lw_ref = np.array([90.0])
     lp_rss = np.array([70.0])

--- a/tests/environment/assessment/test_impulse_prominence.py
+++ b/tests/environment/assessment/test_impulse_prominence.py
@@ -111,7 +111,8 @@ def test_plot_returns_axes() -> None:
 def test_onset_rate_gate_zeroes_non_qualifying_impulses() -> None:
     """Clause 8 applies the adjustment only for onset rates above 10 dB/s
     (clause 4.5): a 5 dB/s level rise (P = 5.30 for LD = 40 dB) must not
-    yield KI > 0."""
+    yield KI > 0.
+    """
     with pytest.warns(nt.ImpulseProminenceWarning, match="10 dB/s"):
         res = nt.impulse_prominence([5.0], [40.0])
     assert res.qualifies.tolist() == [False]
@@ -121,7 +122,8 @@ def test_onset_rate_gate_zeroes_non_qualifying_impulses() -> None:
 
 def test_onset_rate_gate_governing_from_qualifying_only() -> None:
     """A non-qualifying event with the highest P cannot govern: the KI comes
-    from the strongest QUALIFYING impulse."""
+    from the strongest QUALIFYING impulse.
+    """
     with pytest.warns(nt.ImpulseProminenceWarning):
         res = nt.impulse_prominence([8.0, 30.0], [60.0, 20.0])
     assert res.qualifies.tolist() == [False, True]

--- a/tests/environment/assessment/test_impulse_prominence_report.py
+++ b/tests/environment/assessment/test_impulse_prominence_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the impulsive-sound prominence report (``.report()`` -> PDF).
+"""Tests for the impulsive-sound prominence report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for an impulse set, unknown engines and

--- a/tests/environment/assessment/test_measurement.py
+++ b/tests/environment/assessment/test_measurement.py
@@ -237,7 +237,8 @@ def test_repeated_measurements() -> None:
 def test_repeated_measurements_spread_levels() -> None:
     """Spread levels: the primary Formulae (17)+(19) route stays sane
     (3.944 dB for [50, 60, 70]) while the Note 2 approximation inflates to
-    12.183 dB and triggers the spread warning."""
+    12.183 dB and triggers the spread warning.
+    """
     with pytest.warns(EnvironmentalMeasurementWarning, match="Formula \\(20\\)"):
         res = environment.uncertainty_from_repeated_measurements([50.0, 60.0, 70.0])
     assert res.standard_uncertainty == pytest.approx(3.944, abs=2e-3)

--- a/tests/environment/assessment/test_rating.py
+++ b/tests/environment/assessment/test_rating.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Environmental noise descriptors (ISO 1996-1:2016).
+"""Environmental noise descriptors (ISO 1996-1:2016).
 
 Lden (3.6.4): 10*lg{(1/24)*[t_day*10^(0,1*Lday) + t_evening*10^(0,1*(Levening+5))
 + t_night*10^(0,1*(Lnight+10))]} with default periods 12/4/8 h.
@@ -17,7 +16,8 @@ from phonometry import environment
 
 def test_lden_constant_level_analytic() -> None:
     """Constant level L in all periods: Lden = L + 10*lg[(12 + 4*10^0.5 +
-    8*10)/24] for the default 12/4/8 h split."""
+    8*10)/24] for the default 12/4/8 h split.
+    """
     expected_offset = 10 * np.log10((12 + 4 * 10**0.5 + 8 * 10) / 24)
     assert environment.lden(60.0, 60.0, 60.0) == pytest.approx(
         60.0 + expected_offset, abs=1e-9

--- a/tests/environment/propagation/test_air_absorption.py
+++ b/tests/environment/propagation/test_air_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 9613-1:1993 atmospheric sound absorption.
+"""Tests for ISO 9613-1:1993 atmospheric sound absorption.
 
 Normative anchors (ISO 9613-1:1993):
 - Eq. (3): frO = (pa/pr)[24 + 4,04e4 h (0,02+h)/(0,391+h)]  (oxygen relaxation).
@@ -214,7 +213,8 @@ def test_iso9613_2_table2_grid_exact_midbands() -> None:
     across the eight octave bands, evaluated at the exact base-10 midbands
     (the table's own convention). Every cell agrees to half a unit of its
     last printed digit except the documented 15 degC / 80 % / 1 kHz print
-    quirk (printed 4,1 vs exact 4,151)."""
+    quirk (printed 4,1 vs exact 4,151).
+    """
     import reference_data as ref
 
     for (temp, rh), row in ref.ISO9613_2_TABLE2.items():

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the spherical-wave ground effect and advanced barrier diffraction.
+"""Tests for the spherical-wave ground effect and advanced barrier diffraction.
 
 Clean-room anchors:
 - Attenborough & Van Renterghem, *Predicting Outdoor Sound* 2e (2021):

--- a/tests/environment/propagation/test_outdoor_propagation.py
+++ b/tests/environment/propagation/test_outdoor_propagation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 9613-2:1996 outdoor sound propagation (general method).
+"""Tests for ISO 9613-2:1996 outdoor sound propagation (general method).
 
 Normative anchors (ISO 9613-2:1996):
 - Eq. (3): LfT(DW) = Lw + Dc - A.

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 9613-2 outdoor-propagation prediction reports (``.report()``).
+"""Tests for the ISO 9613-2 outdoor-propagation prediction reports (``.report()``).
 
 Two prediction fiches share the ISO 9613-2 family renderer: the octave-band
 attenuation breakdown (:class:`OutdoorAttenuation`), which boxes the A-weighted

--- a/tests/environment/propagation/test_refraction.py
+++ b/tests/environment/propagation/test_refraction.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for atmospheric refraction: ray tracing and the parabolic equation.
+"""Tests for atmospheric refraction: ray tracing and the parabolic equation.
 
 Clean-room anchors:
 - Salomons, *Computational Atmospheric Acoustics* (Springer, 2001): Eq. (4.3)

--- a/tests/environment/sources/test_cnossos_rail.py
+++ b/tests/environment/sources/test_cnossos_rail.py
@@ -379,7 +379,8 @@ def test_every_committed_catalogue_row_is_exercised_unmasked() -> None:
 def test_workbook_exercises_every_physical_source() -> None:
     """Rolling, impact, squeal, traction, aerodynamic and the bridge term all
     have to be switched on somewhere in the committed extract, or the end-to-end
-    agreement would be measuring less than it appears to."""
+    agreement would be measuring less than it appears to.
+    """
     cases = ref.cnossos_rail_workbook_cases()
     assert any(c["condition"] == "constant" for c in cases)  # rolling
     assert any(float(c["joint_density_per_m"]) > 0.0 for c in cases)  # impact
@@ -692,7 +693,8 @@ def test_idling_excludes_rolling_and_uses_the_idling_flow_term() -> None:
 
 def test_minimum_speed_floor_and_impact_exclusion() -> None:
     """2.3.2: a 50 km/h floor on the roughness, 30 km/h for a tram, and no
-    impact noise below it."""
+    impact noise below it.
+    """
     plain = _reference_track(impact_roughness=None)
     slow = railway_source_power(
         RailwayVehicle(_reference_stock(), flow_rate=10.0, speed=20.0), plain

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -161,7 +161,8 @@ def test_two_tone_band_anchors_to_highest_tone_line() -> None:
     49.5 dB @ 520 Hz on a 30 dB floor (df = 2 Hz): the 49.5 dB line falls
     outside 10 dB of the 60 dB maximum (candidate-anchored it would count),
     L_pt = 10 lg(10^5.2 + 10^6) = 60.639 dB, L_pn = 30 + 10 lg(CBW(480)/3),
-    L_a at 500 Hz, giving dL_a = 17.066 dB at 500 Hz (hand-derived)."""
+    L_a at 500 Hz, giving dL_a = 17.066 dB at 500 Hz (hand-derived).
+    """
     df = 2.0
     freqs = np.arange(420.0, 540.0 + df, df)
     levels = np.full(freqs.size, 30.0)
@@ -179,7 +180,8 @@ def test_two_tone_band_anchors_to_highest_tone_line() -> None:
 def test_no_identified_tone_is_flagged() -> None:
     """A broad 33 dB bump on a 30 dB floor produces no classified tone line
     (9.5.4): the result must say so instead of fabricating a tone, and such
-    spectra are excluded from the 9.5.1 bin averaging."""
+    spectra are excluded from the 9.5.1 bin averaging.
+    """
     df = 2.0
     freqs = np.arange(380.0, 620.0 + df, df)
     levels = np.full(freqs.size, 30.0)
@@ -192,7 +194,8 @@ def test_no_identified_tone_is_flagged() -> None:
 
 def test_possible_tone_screen_rejects_non_local_maximum() -> None:
     """9.5.2: a candidate that is not a local maximum is not a possible tone,
-    even when strong lines exist elsewhere in the band."""
+    even when strong lines exist elsewhere in the band.
+    """
     df = 2.0
     freqs = np.arange(420.0, 580.0 + df, df)
     levels = np.full(freqs.size, 30.0)

--- a/tests/environment/sources/test_wind_turbine_tonality_report.py
+++ b/tests/environment/sources/test_wind_turbine_tonality_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the wind-turbine tonal audibility report (``.report()`` -> PDF).
+"""Tests for the wind-turbine tonal audibility report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written, unknown engines and languages are rejected,

--- a/tests/filters/test_b_au_d_weightings.py
+++ b/tests/filters/test_b_au_d_weightings.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Clean-room oracles for the B, AU and D frequency weightings.
+"""Clean-room oracles for the B, AU and D frequency weightings.
 
 B is pinned to ANSI S1.4-1983: the Table IV design goals (B column), the
 Table V tolerance masks and the Appendix C analytic form. AU is pinned to
@@ -176,7 +175,8 @@ def test_au_table2_poles_reproduce_table1_nominals() -> None:
 
 def test_au_pins_nominal_values() -> None:
     """Pin the realized AU response at 31.5 Hz, 1 kHz, 8 kHz and the
-    subclause 2.2 explicit values at 25/31.5/40 kHz (nominal A + U)."""
+    subclause 2.2 explicit values at 25/31.5/40 kHz (nominal A + U).
+    """
     wf = filters.WeightingFilter(96000, "AU")
     freqs = [_exact(f) for f in (31.5, 1000.0, 8000.0, 25000.0, 31500.0, 40000.0)]
     resp = _response_db(wf, freqs)

--- a/tests/filters/test_compliance.py
+++ b/tests/filters/test_compliance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the IEC 61260 filter class verifier (2014 classes 1/2 and the
+"""Tests for the IEC 61260 filter class verifier (2014 classes 1/2 and the
 1995 / ANSI S1.11-2004 edition that adds class 0).
 """
 
@@ -109,7 +108,8 @@ def test_coarse_grid_breakpoints_evaluated_exactly() -> None:
     """The Table 1 breakpoints are evaluated with sosfreqz at their exact
     frequencies, not interpolated off the grid: even the permitted 16-point
     floor reproduces the dense-grid verdict and binding margin (interpolation
-    used to yield garbage margins around -190 dB there)."""
+    used to yield garbage margins around -190 dB there).
+    """
     bank = filters.OctaveFilterBank(
         fs=48000,
         fraction=3,
@@ -247,7 +247,8 @@ def test_1995_rejects_out_of_range_class_and_bad_edition() -> None:
 def test_map_breakpoint_reproduces_table_f1() -> None:
     """IEC 61260-1:2014 Table F.1: the Formula (9) mapping reproduces every
     printed one-third-octave (b = 3) breakpoint and reciprocal to the five
-    printed decimals."""
+    printed decimals.
+    """
     from reference_data import IEC61260_TABLE_F1
 
     from phonometry.filters.compliance import _map_breakpoint

--- a/tests/filters/test_design.py
+++ b/tests/filters/test_design.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for filter design helpers and response plotting utilities.
-"""
+"""Tests for filter design helpers and response plotting utilities."""
 
 from unittest.mock import patch
 
@@ -30,8 +28,7 @@ def _edge_gains_db(
 
 @pytest.mark.parametrize("fraction", [1, 3])
 def test_cheby2_minus3db_at_band_edges(fraction: float) -> None:
-    """
-    Verify cheby2 places its -3 dB points at the ANSI band edges.
+    """Verify cheby2 places its -3 dB points at the ANSI band edges.
 
     **Purpose:**
     ``Wn`` in Chebyshev II is the STOPBAND edge. Passing the band edges
@@ -59,8 +56,7 @@ def test_cheby2_minus3db_at_band_edges(fraction: float) -> None:
 
 
 def test_cheby2_broadband_levels_match_butter() -> None:
-    """
-    Verify cheby2 band levels agree with butter for broadband noise.
+    """Verify cheby2 band levels agree with butter for broadband noise.
 
     **Purpose:**
     With the stopband placed on the band edges, cheby2 underestimated
@@ -91,8 +87,7 @@ def test_cheby2_broadband_levels_match_butter() -> None:
 
 @pytest.mark.parametrize("fraction", [1, 3])
 def test_bessel_minus3db_at_band_edges(fraction: float) -> None:
-    """
-    Verify bessel places its -3 dB points at the ANSI band edges.
+    """Verify bessel places its -3 dB points at the ANSI band edges.
 
     **Purpose:**
     ``norm="phase"`` shifted the -3 dB crossings inward (~-10 dB at the
@@ -242,7 +237,6 @@ def test_cheby2_default_bank_meets_class1(fraction: float) -> None:
     (>= 70 dB for Omega >= G^4). The default was raised to 72 dB, which the
     audit demonstrated passes class 1 with the same +0.400 dB passband margin.
     """
-
     bank = filters.OctaveFilterBank(
         fs=48000,
         fraction=fraction,
@@ -257,7 +251,8 @@ def test_cheby2_default_bank_meets_class1(fraction: float) -> None:
 def test_functional_octavefilter_cheby2_default_meets_class1() -> None:
     """The functional octave_filter() wrapper defaults attenuation to 72 dB so a
     cheby2 call meets IEC 61260-1 class 1, matching OctaveFilterBank (F1 follow-up:
-    the wrapper previously still defaulted to 60 dB)."""
+    the wrapper previously still defaulted to 60 dB).
+    """
     import inspect
 
     default_att = (

--- a/tests/filters/test_g_weighting.py
+++ b/tests/filters/test_g_weighting.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-G frequency weighting for infrasound (ISO 7196:1995).
+"""G frequency weighting for infrasound (ISO 7196:1995).
 
 Clause 4: the G frequency response is the pole-zero configuration of
 Table 1 (transcribed below from the official PDF, p. 2), with 0 dB gain at
@@ -39,7 +38,8 @@ def test_g_gain_is_0db_at_10hz() -> None:
 def test_g_matches_iso7196_table2(freq: float, expected_db: float) -> None:
     """Digital response vs the Table 2 values (given at nominal one-third-
     octave frequencies; evaluated at the exact base-10 frequencies
-    10^(n/10), the same convention as IEC 61672-1 Annex D)."""
+    10^(n/10), the same convention as IEC 61672-1 Annex D).
+    """
     exact = 10 ** (round(10 * np.log10(freq)) / 10)
     # Worst measured deviation vs Table 2 is 0.047 dB; 0.1 keeps ~2x headroom
     # (was 0.3, ~6x looser) while staying well inside the +/-1 dB tolerance.
@@ -91,7 +91,8 @@ def test_g_stateful_holds_its_reference_at_low_fs() -> None:
     while stateful filtering ran at the input rate, so an SOS built for
     fs * 24 was applied at fs = 2000 and the reference read -36 dB. The
     existing stateful test could not see it: at 48 kHz the oversample
-    factor is one and both paths coincide."""
+    factor is one and both paths coincide.
+    """
     fs = 2000
     t = np.arange(fs * 8) / fs
     x = np.sin(2 * np.pi * 10.0 * t)
@@ -116,7 +117,8 @@ def test_g_weighting_consistent_at_low_sample_rates() -> None:
     """The G response must not depend on fs: at low rates (infrasound
     recorders) 315 Hz approaches Nyquist and the un-prewarped bilinear
     design would otherwise warp; the fs-aware oversampling keeps every
-    rate within a few hundredths of a dB of the 48 kHz design."""
+    rate within a few hundredths of a dB of the 48 kHz design.
+    """
 
     def gain_at(fs: int, freq: float) -> float:
         t = np.arange(int(fs * 8)) / fs

--- a/tests/filters/test_iec61260_report.py
+++ b/tests/filters/test_iec61260_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the IEC 61260-1 filter-class-compliance report (``.report()`` -> PDF).
+"""Tests for the IEC 61260-1 filter-class-compliance report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 ``filter_class_compliance`` carries the bank data and agrees with

--- a/tests/filters/test_iec_compliance.py
+++ b/tests/filters/test_iec_compliance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-IEC 61672-1:2013 tone-burst response compliance.
+"""IEC 61672-1:2013 tone-burst response compliance.
 
 Reference values and acceptance limits transcribed from the official text:
 BS EN 61672-1:2013, **Table 4** ("Reference 4 kHz toneburst responses and
@@ -93,8 +92,7 @@ def test_slow_tone_burst_iec_table4(
 
 
 def test_delta_ref_equation7_consistency() -> None:
-    """
-    Sanity-check the transcription: Table 4 values follow Equation (7),
+    """Sanity-check the transcription: Table 4 values follow Equation (7),
     ``delta_ref = 10*lg(1 - exp(-Tb/tau))`` (tau_F = 0.125 s, tau_S = 1 s),
     within the standard's own rounding (0.1 dB, plus its -0.1-quirk rows).
     """
@@ -152,8 +150,7 @@ def test_sel_tone_burst_iec_table4(
 
 
 def test_delta_ref_equation8_consistency() -> None:
-    """
-    Sanity-check the transcription: the ``LAE - LA`` column of Table 4 follows
+    """Sanity-check the transcription: the ``LAE - LA`` column of Table 4 follows
     Equation (8), ``delta_ref = 10*lg(Tb/T0)`` with ``T0 = 1 s``.
 
     The counterpart of :func:`test_delta_ref_equation7_consistency` for the

--- a/tests/filters/test_iec_weighting_table3.py
+++ b/tests/filters/test_iec_weighting_table3.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-IEC 61672-1:2013 frequency weighting compliance (Table 3).
+"""IEC 61672-1:2013 frequency weighting compliance (Table 3).
 
 Nominal A/C/Z weightings and class 1 acceptance limits transcribed from the
 official text: BS EN 61672-1:2013, **Table 3** ("Frequency weightings and

--- a/tests/filters/test_multichannel.py
+++ b/tests/filters/test_multichannel.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Multichannel processing validation tests.
-"""
+"""Multichannel processing validation tests."""
 
 import numpy as np
 
@@ -9,8 +7,7 @@ from phonometry import filters
 
 
 def test_multichannel() -> None:
-    """
-    Validate processing of signals with multiple channels (e.g., stereo).
+    """Validate processing of signals with multiple channels (e.g., stereo).
 
     **Purpose:**
     Verify that the `octave_filter` function can independently process multiple audio channels

--- a/tests/filters/test_nominal_frequencies.py
+++ b/tests/filters/test_nominal_frequencies.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for IEC 61260-1 nominal frequency helpers and opt-in nominal label support.
-"""
+"""Tests for IEC 61260-1 nominal frequency helpers and opt-in nominal label support."""
 
 import numpy as np
 import pytest
@@ -149,7 +147,8 @@ def test_normalizedfreq_fraction1_and_invalid_fraction() -> None:
 
 def test_annex_e34_worked_rounding_examples() -> None:
     """IEC 61260-1:2014 E.3.4: 41,567 -> 41,6 (MSD 4, three significant
-    figures) and 8 785,2 -> 8 800 (MSD 8, two significant figures)."""
+    figures) and 8 785,2 -> 8 800 (MSD 8, two significant figures).
+    """
     from reference_data import IEC61260_E34_EXAMPLES
 
     from phonometry.filters.frequencies import _iec_e3_round

--- a/tests/filters/test_parametric_filters.py
+++ b/tests/filters/test_parametric_filters.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for parametric filters: Weighting (A, C), Time Weighting and Linkwitz-Riley.
-"""
+"""Tests for parametric filters: Weighting (A, C), Time Weighting and Linkwitz-Riley."""
 
 import numpy as np
 import pytest
@@ -10,8 +8,7 @@ from phonometry import filters, metrology
 
 
 def test_calibration_logic() -> None:
-    """
-    Verify that calibration correctly maps digital RMS to target SPL.
+    """Verify that calibration correctly maps digital RMS to target SPL.
 
     **Purpose:**
     Confirm that the `sensitivity` function produces a multiplier that accurately
@@ -48,8 +45,7 @@ def test_calibration_logic() -> None:
 
 
 def test_dbfs_logic() -> None:
-    """
-    Verify dBFS mode returns RMS relative to 1.0.
+    """Verify dBFS mode returns RMS relative to 1.0.
 
     **Purpose:**
     Ensure the `dbfs=True` option correctly calculates decibels relative to full scale (0 dBFS = RMS of 1.0).
@@ -77,8 +73,7 @@ def test_dbfs_logic() -> None:
 
 
 def test_peak_mode_logic() -> None:
-    """
-    Verify that Peak mode returns the absolute maximum of the filtered band.
+    """Verify that Peak mode returns the absolute maximum of the filtered band.
 
     **Purpose:**
     Addressing Issue #10 regarding consistency with professional software (peak-holding).
@@ -107,8 +102,7 @@ def test_peak_mode_logic() -> None:
 
 
 def test_a_weighting_response() -> None:
-    """
-    Verify A-weighting frequency response.
+    """Verify A-weighting frequency response.
 
     **Purpose:**
     Confirm that the A-weighting filter matches the standardized IEC 61672-1:2013 gains at key frequencies.
@@ -141,8 +135,7 @@ def test_a_weighting_response() -> None:
 
 
 def test_c_weighting_response() -> None:
-    """
-    Verify C-weighting frequency response.
+    """Verify C-weighting frequency response.
 
     **Purpose:**
     Confirm that the C-weighting filter matches the standardized IEC 61672-1:2013 gains.
@@ -204,8 +197,7 @@ def test_weighting_filter_class_direct_use() -> None:
 
 
 def test_time_weighting_fast() -> None:
-    """
-    Verify Fast (125ms) time weighting response to a step.
+    r"""Verify Fast (125ms) time weighting response to a step.
 
     **Purpose:**
     Validate the exponential integration constant ($\tau$) for time ballistics.
@@ -230,9 +222,7 @@ def test_time_weighting_fast() -> None:
 
 
 def test_time_weighting_initial_state_first() -> None:
-    """
-    Verify that initial_state='first' starts the integrator from the first energy value.
-    """
+    """Verify that initial_state='first' starts the integrator from the first energy value."""
     fs = 1000
     x = np.ones(fs)
 
@@ -242,9 +232,7 @@ def test_time_weighting_initial_state_first() -> None:
 
 
 def test_time_weighting_initial_state_custom() -> None:
-    """
-    Verify custom initial_state matches the recursive equation with y[-1] set.
-    """
+    """Verify custom initial_state matches the recursive equation with y[-1] set."""
     fs = 1000
     tau = 0.125
     alpha = 1 - np.exp(-1 / (fs * tau))
@@ -293,9 +281,7 @@ def test_time_weighting_initial_state_array_per_channel() -> None:
 
 
 def test_time_weighting_initial_state_multichannel_first() -> None:
-    """
-    Verify initial_state='first' is applied independently per channel.
-    """
+    """Verify initial_state='first' is applied independently per channel."""
     fs = 1000
     x = np.vstack([np.ones(fs), 2 * np.ones(fs)])
 
@@ -306,9 +292,7 @@ def test_time_weighting_initial_state_multichannel_first() -> None:
 
 
 def test_time_weighting_initial_state_invalid() -> None:
-    """
-    Verify invalid initial_state names are rejected.
-    """
+    """Verify invalid initial_state names are rejected."""
     fs = 1000
     x = np.ones(fs)
 
@@ -361,8 +345,7 @@ def test_time_weighting_impulse_initial_state_first_1d() -> None:
 
 
 def test_linkwitz_riley_sum() -> None:
-    """
-    Verify that the sum of Linkwitz-Riley bands is flat.
+    """Verify that the sum of Linkwitz-Riley bands is flat.
 
     **Purpose:**
     The defining characteristic of an LR4 crossover is that the combined response of the
@@ -392,8 +375,7 @@ def test_linkwitz_riley_sum() -> None:
 
 
 def test_weighting_z_bypass() -> None:
-    """
-    Verify Z-weighting is a bypass.
+    """Verify Z-weighting is a bypass.
 
     **Purpose:**
     Confirm that 'Z' (Zero weighting) does not modify the signal.
@@ -411,8 +393,7 @@ def test_weighting_z_bypass() -> None:
 
 
 def test_time_weighting_int16_no_overflow() -> None:
-    """
-    Verify integer input does not overflow when squared internally.
+    """Verify integer input does not overflow when squared internally.
 
     **Purpose:**
     int16 audio (e.g. from ``scipy.io.wavfile.read``) previously overflowed
@@ -436,8 +417,7 @@ def test_time_weighting_int16_no_overflow() -> None:
 
 
 def test_sensitivity_int16_matches_float() -> None:
-    """
-    Verify calibration works with integer reference recordings.
+    """Verify calibration works with integer reference recordings.
 
     **Purpose:**
     ``sensitivity`` previously squared the raw integer array,
@@ -477,8 +457,7 @@ def _measured_gain_db(wf: filters.WeightingFilter, fs: int, f0: float) -> float:
 
 @pytest.mark.parametrize("fs", [44100, 48000])
 def test_a_weighting_class1_high_frequencies(fs: int) -> None:
-    """
-    Verify A-weighting stays within IEC 61672-1 class 1 tolerances at HF.
+    """Verify A-weighting stays within IEC 61672-1 class 1 tolerances at HF.
 
     **Purpose:**
     The plain bilinear design compresses the response near Nyquist: at
@@ -545,8 +524,7 @@ def _analytic_c_weight_db(f: float) -> float:
 
 @pytest.mark.parametrize("fs", [44100, 48000])
 def test_c_weighting_class1_high_frequencies(fs: int) -> None:
-    """
-    Verify C-weighting stays within IEC 61672-1 class 1 tolerances at HF.
+    """Verify C-weighting stays within IEC 61672-1 class 1 tolerances at HF.
 
     **Purpose:**
     Same oversampled design path as the A curve; dedicated regression so a
@@ -571,8 +549,7 @@ def test_weighting_filter_empty_signal_high_accuracy() -> None:
 
 
 def test_a_weighting_positive_gain_region() -> None:
-    """
-    Verify the A-curve is POSITIVE between 1.25 and 5 kHz (IEC 61672-1 Table 2).
+    """Verify the A-curve is POSITIVE between 1.25 and 5 kHz (IEC 61672-1 Table 2).
 
     **Purpose:**
     The A-weighting models equal-loudness sensitivity: the ear is MORE

--- a/tests/filters/test_performance.py
+++ b/tests/filters/test_performance.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests that the filter-bank design work is reused rather than repeated.
-"""
+"""Tests that the filter-bank design work is reused rather than repeated."""
 
 import time
 from typing import Any
@@ -36,8 +34,7 @@ def design_counter(monkeypatch: pytest.MonkeyPatch) -> _DesignCounter:
 
 
 def test_filterbank_reuse_skips_redesign(design_counter: _DesignCounter) -> None:
-    """
-    Verify that reusing OctaveFilterBank designs its coefficients exactly once.
+    """Verify that reusing OctaveFilterBank designs its coefficients exactly once.
 
     **Purpose:**
     The class-based API exists so that the SOS design runs at construction and
@@ -81,8 +78,7 @@ def test_filterbank_reuse_skips_redesign(design_counter: _DesignCounter) -> None
 
 
 def test_octave_filter_cache_reuses_the_bank(design_counter: _DesignCounter) -> None:
-    """
-    Verify that repeated ``octave_filter`` calls share one design.
+    """Verify that repeated ``octave_filter`` calls share one design.
 
     **Purpose:**
     ``_cached_filter_bank`` is what makes the functional API affordable in a
@@ -106,8 +102,7 @@ def test_octave_filter_cache_reuses_the_bank(design_counter: _DesignCounter) -> 
 
 
 def test_filterbank_reuse_is_not_slower() -> None:
-    """
-    Report the wall-clock cost of both paths, without gating on it.
+    """Report the wall-clock cost of both paths, without gating on it.
 
     **Purpose:**
     The timings are what a reader of this file wants to see, and they are worth

--- a/tests/filters/test_signal_overloads.py
+++ b/tests/filters/test_signal_overloads.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Every public filter takes a ``phonometry.io.Signal`` in place of ``(x, fs)``.
+"""Every public filter takes a ``phonometry.io.Signal`` in place of ``(x, fs)``.
 
 The contract is the one ``signals.levels`` established and
 ``phonometry.io._resolve`` now holds for the whole library: the

--- a/tests/filters/test_spectrogram.py
+++ b/tests/filters/test_spectrogram.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for OctaveFilterBank.spectrogram() short-time band levels.
-"""
+"""Tests for OctaveFilterBank.spectrogram() short-time band levels."""
 
 import numpy as np
 import pytest

--- a/tests/filters/test_weighting_class_verifier.py
+++ b/tests/filters/test_weighting_class_verifier.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the IEC 61672-1:2013 frequency-weighting class verifier
+"""Tests for the IEC 61672-1:2013 frequency-weighting class verifier
 (``verify_weighting_class`` / ``weighting_class_limits``).
 
 The design-goal responses and class 1 limits in the verifier's Table 3
@@ -157,7 +156,8 @@ def test_frequencies_above_nyquist_are_dropped() -> None:
 def test_low_fs_verdict_is_flagged_range_limited() -> None:
     """Dropping Table 3 rows that carry finite lower limits (class 1 has them
     up to 16 kHz) must flag the verdict as range-limited: a 16 kHz-sampled
-    system cannot demonstrate full class-1 conformance over 10 Hz-20 kHz."""
+    system cannot demonstrate full class-1 conformance over 10 Hz-20 kHz.
+    """
     result = filters.verify_weighting_class(filters.WeightingFilter(16000, "A"))
     assert result["range_limited"] is True
     result_full = filters.verify_weighting_class(filters.WeightingFilter(48000, "A"))
@@ -169,7 +169,8 @@ def test_deviation_evaluated_at_exact_base10_frequency() -> None:
     nominal label (Table 3 NOTE; IEC 61672-3 subclause 13.3), not at the
     label itself: the reported deviation at "16 kHz" follows a tone at
     15 848.9 Hz and not one at 16 000 Hz, which the A curve puts about
-    0.1 dB lower."""
+    0.1 dB lower.
+    """
     wf = filters.WeightingFilter(96000, "A")
     band = next(
         b for b in filters.verify_weighting_class(wf)["bands"] if b["freq"] == 16000.0
@@ -208,7 +209,8 @@ def test_verdict_measures_the_resampled_path(fs: int, label: float) -> None:
 def test_notch_between_nominals_fails_the_sweep() -> None:
     """Adversarial 5.5.7 case: an iirnotch at 900 Hz (between the 800 and
     1000 Hz nominals) leaves every nominal-frequency verdict at class 1 but
-    must fail the between-nominals sweep, so no class can be assigned."""
+    must fail the between-nominals sweep, so no class can be assigned.
+    """
     import numpy as np
     from scipy import signal as sg
 

--- a/tests/filters/test_zero_phase.py
+++ b/tests/filters/test_zero_phase.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for zero-phase (sosfiltfilt) filtering in OctaveFilterBank.
-"""
+"""Tests for zero-phase (sosfiltfilt) filtering in OctaveFilterBank."""
 
 import numpy as np
 import pytest
@@ -70,7 +68,8 @@ def test_zero_phase_passband_level_matches() -> None:
 def test_zero_phase_broadband_band_narrowing() -> None:
     """Forward-backward filtering narrows the effective passband, lowering the
     measured broadband band level ~0.2-0.3 dB per band (a pure center tone,
-    tested above, does not exercise this). Characterizes the documented bias."""
+    tested above, does not exercise this). Characterizes the documented bias.
+    """
     bank = filters.OctaveFilterBank(fs=FS, fraction=1, limits=[100, 8000])
     x = np.random.default_rng(7).standard_normal(FS * 4)
     spl_fwd, _ = bank.filter(x)

--- a/tests/hearing/test_iso9612_report.py
+++ b/tests/hearing/test_iso9612_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 9612:2009 occupational noise-exposure ``.report()`` fiche.
+"""Tests for the ISO 9612:2009 occupational noise-exposure ``.report()`` fiche.
 
 The rendered values are checked against a hand-derivable oracle independent of
 the library: two 4 h tasks at 85 dB and 75 dB give

--- a/tests/hearing/test_noise_induced_hearing_loss_report.py
+++ b/tests/hearing/test_noise_induced_hearing_loss_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 1999:2013 hearing-loss prediction ``.report()`` fiches.
+"""Tests for the ISO 1999:2013 hearing-loss prediction ``.report()`` fiches.
 
 The two occupational-hearing-loss result types render one-page statistical
 prediction fiches: NIPTS (noise-induced permanent threshold shift, clause 6.3)

--- a/tests/io/test_io_signal_structure.py
+++ b/tests/io/test_io_signal_structure.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Narrowing a ``Signal`` without losing what makes it one.
+"""Narrowing a ``Signal`` without losing what makes it one.
 
 Indexing a Signal yields its samples, which is what makes the object a
 drop-in for the array it stands for. The cost is that ``sig[0]`` and

--- a/tests/iso12354_building.py
+++ b/tests/iso12354_building.py
@@ -162,7 +162,6 @@ def airborne_paths(situ: dict, delta_r: object) -> list:
     :return: The twelve :class:`~phonometry.BandPath` objects, labelled as
         Table L.1 labels its columns (``D1``, ``1d``, ``11``, ...).
     """
-
     kij = junction_indices()
     paths = []
     for tag, name in enumerate_flanking():
@@ -215,7 +214,6 @@ def impact_paths(situ: dict, delta_l: object) -> list:
     :return: The four :class:`~phonometry.BandPath` objects, labelled as
         Table G.1 labels its columns (``Df1`` to ``Df4``).
     """
-
     kij = junction_indices()
     return [
         building.impact_flanking_path(

--- a/tests/materials/absorbers/test_absorption_rating.py
+++ b/tests/materials/absorbers/test_absorption_rating.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 11654:1997 single-number sound absorption rating (alpha_w).
+"""Tests for ISO 11654:1997 single-number sound absorption rating (alpha_w).
 
 Validation strategy: the standard's own numbers, not self-consistency.
 

--- a/tests/materials/absorbers/test_airflow_resistance.py
+++ b/tests/materials/absorbers/test_airflow_resistance.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 9053-1:2018 (static) and ISO 9053-2:2020 (alternating) airflow
+"""Tests for ISO 9053-1:2018 (static) and ISO 9053-2:2020 (alternating) airflow
 resistance.
 
 Normative anchors:

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Impedance-tube material characterisation (ISO 10534-1/-2, ASTM E2611-19).
+"""Impedance-tube material characterisation (ISO 10534-1/-2, ASTM E2611-19).
 
 No worked numeric example exists in either standard, so the tests anchor on
 physics identities:

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 10534-2 impedance-tube test report (``.report()`` -> PDF).
+"""Tests for the ISO 10534-2 impedance-tube test report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural
 facts: a valid single-page PDF is written for a two-microphone measurement,

--- a/tests/materials/absorbers/test_iso11654_report.py
+++ b/tests/materials/absorbers/test_iso11654_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 11654 absorption-rating report (``.report()`` -> PDF).
+"""Tests for the ISO 11654 absorption-rating report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural
 facts: a valid single-page PDF is written for a weighted absorption rating,

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 354 sound-absorption test report (``.report()`` -> PDF).
+"""Tests for the ISO 354 sound-absorption test report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural
 facts: a valid single-page PDF is written for a reverberation-room measurement,

--- a/tests/materials/absorbers/test_iso9053_report.py
+++ b/tests/materials/absorbers/test_iso9053_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 9053-1:2018 static airflow-resistance report (``.report()``).
+"""Tests for the ISO 9053-1:2018 static airflow-resistance report (``.report()``).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written, the displayed key quantities match the

--- a/tests/materials/absorbers/test_porous.py
+++ b/tests/materials/absorbers/test_porous.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Porous-material models and multilayer absorber prediction.
+"""Porous-material models and multilayer absorber prediction.
 
 Oracle strategy (no free fitting anywhere):
 
@@ -715,7 +714,8 @@ class TestResonantSheets:
 
     def test_effectively_grazing_angle_rejected(self) -> None:
         """Angles within ~1e-6 of pi/2 would drive an air layer's kx to
-        exactly zero (inf * 0 = nan); they are rejected up front."""
+        exactly zero (inf * 0 = nan); they are rejected up front.
+        """
         f = np.array([1000.0])
         layers = [AirLayer(0.05)]
         with pytest.raises(ValueError, match="angle"):

--- a/tests/materials/absorbers/test_slow_sound.py
+++ b/tests/materials/absorbers/test_slow_sound.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Slow-sound slit + Helmholtz-resonator perfect absorbers (Jimenez et al.).
+"""Slow-sound slit + Helmholtz-resonator perfect absorbers (Jimenez et al.).
 
 Oracle strategy (clean-room from the documented transfer-matrix formulas of
 Jimenez, Groby, Pagneux and Romero-Garcia, Appl. Sci. 2017, 7, 618, and the

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for BS EN ISO 354:2003 sound absorption in a reverberation room.
+"""Tests for BS EN ISO 354:2003 sound absorption in a reverberation room.
 
 Normative anchors (ISO 354:2003):
 - Eq. (5)/(7): A = 55,3*V/(c*T) - 4*V*m  (empty room A1 / with specimen A2).
@@ -171,7 +170,8 @@ def test_temperature2_defaults_to_temperature1() -> None:
 
 def test_speed_of_sound2_defaults_to_speed_of_sound1() -> None:
     """Overriding only c1 must apply the same speed to the second measurement
-    (c2 defaults to c1), mirroring the temperature2 -> temperature1 default."""
+    (c2 defaults to c1), mirroring the temperature2 -> temperature1 default.
+    """
     v, s = 200.0, 10.0
     c = 340.0
     only_c1 = materials.absorption_coefficient(5.0, 3.0, v, s, speed_of_sound1=c)

--- a/tests/materials/diffusers/test_diffuser_design.py
+++ b/tests/materials/diffusers/test_diffuser_design.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Diffuser-design far-field prediction tests (Cox & D'Antonio Fraunhofer model).
+"""Diffuser-design far-field prediction tests (Cox & D'Antonio Fraunhofer model).
 
 The predictor has no numeric worked example to anchor on, so every test rests
 on a closed-form geometry identity or an exact-by-physics behaviour:

--- a/tests/materials/diffusers/test_iso17497_report.py
+++ b/tests/materials/diffusers/test_iso17497_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 17497-1/-2 scattering and diffusion reports (``.report()``).
+"""Tests for the ISO 17497-1/-2 scattering and diffusion reports (``.report()``).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for each fiche (scattering ``s(f)``, the

--- a/tests/materials/diffusers/test_metadiffuser.py
+++ b/tests/materials/diffusers/test_metadiffuser.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Metadiffuser panels against the published designs (Sci. Rep. 7:5389, 2017).
+"""Metadiffuser panels against the published designs (Sci. Rep. 7:5389, 2017).
 
 The oracles are the printed numbers of the paper and its supplementary
 material, computed here through an independent implementation of the same

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Scattering (ISO 17497-1) and diffusion (ISO 17497-2) coefficient tests.
+"""Scattering (ISO 17497-1) and diffusion (ISO 17497-2) coefficient tests.
 
 Neither part of ISO 17497 has a numeric worked example, so the tests anchor
 on algebraic and physical identities, on a committed model-generated arc for

--- a/tests/materials/resilient/test_iso9052_report.py
+++ b/tests/materials/resilient/test_iso9052_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the EN 29052-1 / ISO 9052-1 dynamic-stiffness report (``.report()``).
+"""Tests for the EN 29052-1 / ISO 9052-1 dynamic-stiffness report (``.report()``).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written, the displayed key quantities match the

--- a/tests/materials/surfaces/test_road_absorption.py
+++ b/tests/materials/surfaces/test_road_absorption.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-In-situ road-surface sound absorption (ISO 13472-1 / ISO 13472-2).
+"""In-situ road-surface sound absorption (ISO 13472-1 / ISO 13472-2).
 
 Neither standard gives a computable narrow-band worked example, so the tests
 anchor on physics identities and the numeric oracles captured in the Step-0

--- a/tests/materials/test_geometry_plots.py
+++ b/tests/materials/test_geometry_plots.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Geometry drawings of materials devices (``_plot/geometry/``).
+"""Geometry drawings of materials devices (``_plot/geometry/``).
 
 Smoke coverage plus the contracts that matter: every renderer returns the
 axes it drew on with an equal aspect, results retain the geometry their

--- a/tests/metrology/test_calibration_validation.py
+++ b/tests/metrology/test_calibration_validation.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Calibration-tone stability validation (IEC 60942:2017).
+"""Calibration-tone stability validation (IEC 60942:2017).
 
 IEC 60942:2017 (EN IEC 60942:2018) 5.3.3: the short-term level fluctuation is
 measured with time-weighting F over 60 s, sampling at least 30 times; the
@@ -95,7 +94,8 @@ def test_multichannel_stable_at_different_levels_no_warning() -> None:
 
 def test_default_limit_follows_iec_60942_2017_table2() -> None:
     """~0.13 dB fluctuation: over the 0.07 dB class 1 limit at 1 kHz, but
-    within the 0.20 dB limit for a 31.5-63 Hz nominal frequency (Table 2)."""
+    within the 0.20 dB limit for a 31.5-63 Hz nominal frequency (Table 2).
+    """
     x = _cal_tone(am_depth=0.015)
     with pytest.warns(metrology.CalibrationWarning, match="Table 2"):
         metrology.sensitivity(x, fs=FS)
@@ -116,7 +116,8 @@ def test_asymmetric_fluctuation_uses_max_min_vs_mean() -> None:
 
 def test_narrowband_rejects_broadband_noise() -> None:
     """A noisy calibrator take biases the broadband-RMS factor low by
-    ``-10*lg(1 + 1/SNR)``; the narrowband tone estimator recovers it."""
+    ``-10*lg(1 + 1/SNR)``; the narrowband tone estimator recovers it.
+    """
     tone = _cal_tone(seconds=3.0)
     tone_power = float(np.mean(tone**2))
     rng = np.random.default_rng(0)
@@ -152,7 +153,8 @@ def test_narrowband_requires_fs() -> None:
 
 def test_table2_row_boundaries() -> None:
     """IEC 60942:2017 Table 2: 160 Hz belongs to the 0.07 dB row and 63 Hz
-    to the 0.20 dB row; the open interval between them gets 0.10 dB."""
+    to the 0.20 dB row; the open interval between them gets 0.10 dB.
+    """
     from phonometry.metrology.calibration import _class1_fluctuation_limit
 
     assert _class1_fluctuation_limit(63.0) == pytest.approx(0.20)

--- a/tests/metrology/test_iec61043_report.py
+++ b/tests/metrology/test_iec61043_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the IEC 61043 class-verification report (``.report()`` -> PDF).
+"""Tests for the IEC 61043 class-verification report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a compliant chain renders a valid single-page COMPLIES fiche, the Spanish

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -213,7 +213,8 @@ def test_correlated_budget_requires_explicit_coverage_factor() -> None:
     the GUM defines no correlated form: with finite input dof the effective
     dof are undefined (NaN) and expanded() demands an explicit coverage
     factor, instead of a meaningless (possibly ~1e-5) effective dof that
-    explodes the coverage factor or an invented normal fallback."""
+    explodes the coverage factor or an invented normal fallback.
+    """
     qs = [u.Quantity(10.0, 0.1, dof=5), u.Quantity(10.0, 0.1, dof=5)]
     r = np.array([[1.0, 0.999], [0.999, 1.0]])
     with pytest.warns(u.UncertaintyWarning, match="Welch-Satterthwaite"):
@@ -233,7 +234,8 @@ def test_correlated_budget_requires_explicit_coverage_factor() -> None:
 
 def test_correlated_budget_with_infinite_dof_stays_normal() -> None:
     """All-infinite input dof: the output is treated as normal regardless of
-    correlation, so veff stays infinite and no warning fires."""
+    correlation, so veff stays infinite and no warning fires.
+    """
     qs = [u.Quantity(10.0, 0.1), u.Quantity(10.0, 0.1)]
     r = np.array([[1.0, 0.5], [0.5, 1.0]])
     result = u.combine_uncertainty(lambda a, b: a + b, qs, correlation=r)
@@ -246,7 +248,8 @@ def test_sensitivity_step_stays_local_on_nonlinear_model() -> None:
     """The finite-difference step is the input uncertainty with only a
     64-ULP floor: for a large-magnitude input with structure at the
     uncertainty scale, a sqrt(eps)*|x| step (~15 units at 1e9) would probe
-    far outside the uncertainty region and bias the sensitivity."""
+    far outside the uncertainty region and bias the sensitivity.
+    """
     x0, ux = 1.0e9, 1.0e-3
 
     def model(x):
@@ -260,7 +263,8 @@ def test_sensitivity_step_stays_local_on_nonlinear_model() -> None:
 
 def test_identity_correlation_keeps_welch_satterthwaite() -> None:
     """An explicit identity matrix is the uncorrelated case: the finite input
-    dof still propagate (no fallback, no warning)."""
+    dof still propagate (no fallback, no warning).
+    """
     qs = [u.Quantity(0.0, 1.0, dof=10) for _ in range(4)]
     result = u.combine_uncertainty(_add4, qs, correlation=np.eye(4))
     assert result.effective_dof == pytest.approx(40.0, abs=1e-6)
@@ -270,7 +274,8 @@ def test_sensitivity_step_survives_tiny_relative_uncertainty() -> None:
     """M10 regression: xi = 1e9 with u = 1e-6 used to underflow the 1e-9
     perturbation below np.spacing(1e9) = 1.2e-7, zeroing both sensitivities
     and reporting uc = 0. The step max(u, sqrt(eps)|x|) recovers the exact
-    uc = sqrt(2) * 1e-6."""
+    uc = sqrt(2) * 1e-6.
+    """
     qs = [u.Quantity(1e9, 1e-6), u.Quantity(1e9, 1e-6)]
     result = u.combine_uncertainty(lambda a, b: a + b, qs)
     np.testing.assert_allclose(result.sensitivities, 1.0, rtol=1e-6)
@@ -280,7 +285,8 @@ def test_sensitivity_step_survives_tiny_relative_uncertainty() -> None:
 def test_flat_direction_warns_but_computes() -> None:
     """A model genuinely flat along one input (here b, multiplied by zero)
     warns that its uncertainty does not propagate, and the rest of the budget
-    is unaffected."""
+    is unaffected.
+    """
     qs = [u.Quantity(3.0, 0.1), u.Quantity(4.0, 0.2)]
     with pytest.warns(u.UncertaintyWarning, match="does not change"):
         result = u.combine_uncertainty(lambda a, b: a + 0.0 * b, qs)
@@ -316,7 +322,8 @@ def _h1_budget() -> u.UncertaintyResult:
 def test_gum_h1_end_to_end_combined_uncertainty() -> None:
     """GUM H.1.4/H.1.6: l = 50 000 838 nm, uc = 32 nm (31.71 unrounded),
     contributions (25, 9.7, 0, 0, 2.9, 16.7) nm, veff = 16.7 (printed
-    truncated to 16)."""
+    truncated to 16).
+    """
     from reference_data import (
         GUM_H1_CONTRIBUTIONS,
         GUM_H1_UC,
@@ -333,7 +340,8 @@ def test_gum_h1_end_to_end_combined_uncertainty() -> None:
 
 def test_gum_h1_expanded_uncertainty_99() -> None:
     """GUM H.1.6: U99 = 93 nm at k(0.99, veff=16) = 2.92; interpolating at
-    the untruncated veff = 16.66 (G.4.2 NOTE 1) gives 92.1 nm."""
+    the untruncated veff = 16.66 (G.4.2 NOTE 1) gives 92.1 nm.
+    """
     from reference_data import GUM_H1_U99
 
     result = _h1_budget()
@@ -382,7 +390,8 @@ def test_gum_h2_correlated_measurement() -> None:
 
 def test_monte_carlo_matches_supplement1_table2_gaussian() -> None:
     """Supplement 1 Table 2 (clause 9.2.2): four standard Gaussian Xi ->
-    u(y) = 2.00 and the 95 % symmetric interval [-3.92, 3.92]."""
+    u(y) = 2.00 and the 95 % symmetric interval [-3.92, 3.92].
+    """
     from reference_data import GUMS1_TABLE2_INTERVAL_95
 
     qs = [u.Quantity(0.0, 1.0) for _ in range(4)]

--- a/tests/noise_control/test_enclosure_report.py
+++ b/tests/noise_control/test_enclosure_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the machine-enclosure insertion-loss ``.report()`` fiche.
+"""Tests for the machine-enclosure insertion-loss ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 Bies, Hansen & Howard model (Engineering Noise Control 5th ed., section 7.4.2),

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -154,7 +154,6 @@ def test_norton_model_has_no_insertion_loss_ceiling() -> None:
 
 def test_required_transmission_loss_inverts_the_equation() -> None:
     """``enclosure_required_transmission_loss`` is the exact inverse."""
-
     target = np.array([10.0, 20.0, 30.0])
     required = noise_control.enclosure_required_transmission_loss(target, 6.0, 5.0, 0.3)
     assert np.allclose(required.insertion_loss, target)
@@ -167,7 +166,6 @@ def test_required_transmission_loss_inverts_the_equation() -> None:
 
 def test_required_transmission_loss_callable_and_result_shape() -> None:
     """A callable target and the frequency labelling behave as in the forward call."""
-
     freqs = np.array([125.0, 250.0, 500.0])
     res = noise_control.enclosure_required_transmission_loss(
         lambda f: 5.0 + 10.0 * np.log10(f / 125.0), 6.0, 5.0, 0.3, frequencies=freqs

--- a/tests/noise_control/test_hvac_report.py
+++ b/tests/noise_control/test_hvac_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the HVAC duct-noise-spectrum ``.report()`` fiche.
+"""Tests for the HVAC duct-noise-spectrum ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle independent of the
 library's own path. For a regenerated-noise spectrum the band sound power level

--- a/tests/noise_control/test_silencer_report.py
+++ b/tests/noise_control/test_silencer_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the reactive-silencer transmission-loss ``.report()`` fiche.
+"""Tests for the reactive-silencer transmission-loss ``.report()`` fiche.
 
 The rendered values are checked against a clean-room oracle derived from the
 simple-expansion-chamber closed form (Bies, Hansen & Howard, Engineering Noise

--- a/tests/psychoacoustics/loudness/test_contours.py
+++ b/tests/psychoacoustics/loudness/test_contours.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Normal equal-loudness-level contours (ISO 226:2023).
+"""Normal equal-loudness-level contours (ISO 226:2023).
 
 Formula (1) (clause 4.1, p. 2) derives the SPL of a pure tone from its
 loudness level; Formula (2) (clause 4.2, p. 3) is the inverse. Both use the
@@ -97,7 +96,8 @@ def test_validity_limits() -> None:
 
 def test_untabulated_frequency_raises() -> None:
     """Table 1 defines parameters only at the 29 preferred frequencies; the
-    standard specifies no interpolation between them."""
+    standard specifies no interpolation between them.
+    """
     with pytest.raises(ValueError, match="frequency"):
         psychoacoustics.loudness_level(60.0, 440.0)
 

--- a/tests/psychoacoustics/loudness/test_ecma.py
+++ b/tests/psychoacoustics/loudness/test_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-ECMA-418-2:2025 (Sottek Hearing Model) loudness conformance tests.
+"""ECMA-418-2:2025 (Sottek Hearing Model) loudness conformance tests.
 
 The primary oracle is the standard's own calibration (Clause 5.1.8): a
 1 kHz sinusoid at 40 dB SPL yields 1 sone_HMS via the Clause 8 method. The

--- a/tests/psychoacoustics/loudness/test_moore_glasberg.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-ISO 532-2:2017 (Moore-Glasberg) stationary loudness conformance tests.
+"""ISO 532-2:2017 (Moore-Glasberg) stationary loudness conformance tests.
 
 The primary oracle is Annex B of the standard, which tabulates the calculated
 loudness (sone) and loudness level (phon) for a set of reference signals:

--- a/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-ISO 532-3:2023 (Moore-Glasberg-Schlittenlacher) time-varying loudness tests.
+"""ISO 532-3:2023 (Moore-Glasberg-Schlittenlacher) time-varying loudness tests.
 
 The algorithmic reference for steady tones is Annex C.1 of the standard, which
 tabulates the maximum long-term loudness (sone) and loudness level (phon) of
@@ -232,7 +231,6 @@ def test_annex_c3_multi_tone(
 
 def test_steady_matches_iso532_2_stationary() -> None:
     """A long steady tone converges to the ISO 532-2 stationary loudness."""
-
     stationary = psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, 60.0)])
     res = psychoacoustics.loudness_moore_glasberg_time(_tone(1000.0, 60.0), FS)
     # Both models share the excitation/specific-loudness machinery (different

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Zwicker loudness (ISO 532-1:2017) conformance tests.
+"""Zwicker loudness (ISO 532-1:2017) conformance tests.
 
 Expected values and tolerances come from the results workbooks of the
 freely downloadable ISO 532-1:2017 electronic attachment (Annex B),
@@ -164,7 +163,8 @@ def test_stationary_time_skip() -> None:
     leading silence and the filterbank onset do not dilute the mean square.
     A tone with 150 ms of leading silence (like the shipped WAVs) reads low
     without the skip and recovers the steady-tone value with it; invalid
-    skips raise."""
+    skips raise.
+    """
     lead = np.zeros(int(FS * 0.15))
     x = np.concatenate([lead, _tone(1000.0, 60.0, seconds=1.0, pad_ms=0.0)])
     n_all = psychoacoustics.loudness_zwicker(x, FS, stationary=True).loudness
@@ -186,7 +186,8 @@ def test_stationary_time_skip() -> None:
 
 def test_1khz_60db_anchor() -> None:
     """Definitional anchor: a 1 kHz tone at 40 phon is 1 sone; 60 dB -> 4 sone
-    (each 10 phon doubles loudness)."""
+    (each 10 phon doubles loudness).
+    """
     res = psychoacoustics.loudness_zwicker(
         _tone(1000.0, 60.0, seconds=2.0, pad_ms=0.0), FS, stationary=True
     )
@@ -220,7 +221,8 @@ def _read_wav_fullscale(path: str) -> tuple[np.ndarray, int]:
 
 def _read_wav_pa(path: pathlib.Path, peak_rms_db: float) -> tuple[np.ndarray, int]:
     """Read a 16-bit ISO test WAV and calibrate its peak short-time RMS to
-    the level stated in Annex B (the WAVs carry no absolute scale)."""
+    the level stated in Annex B (the WAVs carry no absolute scale).
+    """
     x, fs = _read_wav_fullscale(str(path))
     win = max(1, int(fs * 0.002))
     sq = np.convolve(x**2, np.ones(win) / win, mode="same")
@@ -324,7 +326,8 @@ def test_annex_b4_tone_pulses(case: str, num: int, level: float) -> None:
     this test enforces sample by sample, plus the Nmax header value.
     (The workbook header N5 values are not reproducible from their own
     published traces with the Annex A percentile formula and are therefore
-    not asserted.)"""
+    not asserted.)
+    """
     exp = EXPECTED[case]
     x, fs = _read_wav_pa(DATA / f"iso532_1_test_signal_{num}.wav", level)
     res = psychoacoustics.loudness_zwicker(x, fs, stationary=False)
@@ -351,7 +354,8 @@ def test_n5_n10_use_full_rate_series(monkeypatch) -> None:
     four phases, spreading N5 by up to ~3 % across the phases (Annex B
     TS 10, 0.7513..0.7752); the full-rate percentile (0.7628) is
     phase-unambiguous and sits inside that envelope. The 500 Hz
-    ``loudness_vs_time`` output is unchanged (public contract)."""
+    ``loudness_vs_time`` output is unchanged (public contract).
+    """
     import sys
 
     from phonometry.psychoacoustics.loudness.zwicker import _SR_LEVEL, _SR_LOUDNESS
@@ -458,7 +462,8 @@ def test_non_finite_inputs_rejected() -> None:
 
 def test_pathological_resampling_ratio_rejected() -> None:
     """gcd(48000, 44101) = 1 would demand a 48000/44101 polyphase filter;
-    reject instead of hanging."""
+    reject instead of hanging.
+    """
     x = np.ones(1000)
     with pytest.raises(ValueError, match="resampl"):
         psychoacoustics.loudness_zwicker(x, 44101)
@@ -474,7 +479,8 @@ def test_diffuse_field_differs() -> None:
 
 def test_minimal_length_validation() -> None:
     """Signals shorter than one 500 Hz output sample raise cleanly instead
-    of crashing on an empty percentile buffer."""
+    of crashing on an empty percentile buffer.
+    """
     too_short = np.ones(48)
     with pytest.raises(ValueError, match="too short"):
         psychoacoustics.loudness_zwicker(too_short, FS)
@@ -488,7 +494,8 @@ def test_specific_pattern_matches_reported_max() -> None:
     """The returned pattern is taken at the same decimated instant as the
     reported Nmax. For a steady tone the temporal weighting converges, so
     the pattern integral must match Nmax there (for transients the
-    instantaneous pattern legitimately exceeds the weighted maximum)."""
+    instantaneous pattern legitimately exceeds the weighted maximum).
+    """
     res = psychoacoustics.loudness_zwicker(
         _tone(1000.0, 70.0, seconds=2.0, pad_ms=0.0), FS
     )

--- a/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-ECMA-418-2:2025 (Sottek Hearing Model) fluctuation-strength conformance tests.
+"""ECMA-418-2:2025 (Sottek Hearing Model) fluctuation-strength conformance tests.
 
 The primary oracle is the standard's own calibration (Clause 9, intro and
 9.1.11): a 1 kHz carrier, 100 % amplitude-modulated (m = 1) at 4 Hz and a

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-ECMA-418-2:2025 (Sottek Hearing Model) roughness conformance tests.
+"""ECMA-418-2:2025 (Sottek Hearing Model) roughness conformance tests.
 
 The primary oracle is the standard's own calibration (Clause 7, intro and
 7.1.7): a 1 kHz carrier, 100 % amplitude-modulated (m = 1) at 70 Hz and a

--- a/tests/psychoacoustics/quality/test_sharpness.py
+++ b/tests/psychoacoustics/quality/test_sharpness.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Sharpness (DIN 45692:2009-08) conformance tests.
+"""Sharpness (DIN 45692:2009-08) conformance tests.
 
 Clause 6: the standard test signal is critical-band-wide narrowband noise
 at 1 kHz (920-1080 Hz) with 60 dB overall level -> S = 1.00 acum, and every
@@ -113,7 +112,8 @@ def test_k_in_normative_range() -> None:
 @pytest.mark.parametrize(("fc", "f_lo", "f_hi", "target"), A2_CASES)
 def test_table_a2_targets(fc: float, f_lo: float, f_hi: float, target: float) -> None:
     """Table A.2 target sharpness for critical-band-wide noises at 4 sone,
-    within the clause 6 tolerance (5 % or 0.05 acum)."""
+    within the clause 6 tolerance (5 % or 0.05 acum).
+    """
     level = _level_for_4_sone(f_lo, f_hi)
     s = sharpness_din(_narrowband(f_lo, f_hi, level), FS)
     tol = max(0.05, 0.05 * target)
@@ -123,7 +123,8 @@ def test_table_a2_targets(fc: float, f_lo: float, f_hi: float, target: float) ->
 @pytest.mark.parametrize(("f_lo", "target"), A3_CASES)
 def test_table_a3_targets(f_lo: float, target: float) -> None:
     """Table A.3 target sharpness for broadband noises (fu .. 10 kHz) at
-    4 sone, within the clause 6 tolerance (5 % or 0.05 acum)."""
+    4 sone, within the clause 6 tolerance (5 % or 0.05 acum).
+    """
     level = _level_for_4_sone(f_lo, 10000.0)
     s = sharpness_din(_narrowband(f_lo, 10000.0, level), FS)
     tol = max(0.05, 0.05 * target)
@@ -143,7 +144,8 @@ def test_annex_b_variants() -> None:
     DIN 45692 Formulas (B.1)/(B.2). The clause 6 reference sound then lands
     NEAR (not exactly at) 1 acum -- a non-circular check of the published
     formulas, unlike the normative method whose k is derived from this very
-    signal. Measured: ~0.96 acum (Aures), ~1.02 acum (von Bismarck)."""
+    signal. Measured: ~0.96 acum (Aures), ~1.02 acum (von Bismarck).
+    """
     spec = loudness_zwicker(reference_sound(), FS, stationary=True).specific
     for method in ("aures", "bismarck"):
         s = sharpness_din_from_specific(spec, method=method)
@@ -160,7 +162,8 @@ def test_annex_b_variants() -> None:
 def test_annex_b_literal_factor() -> None:
     """Formulas (B.1)/(B.2) print S = 0,11 * moment; the implementation must
     use the literal 0.11, not a self-derived per-variant constant (which
-    would shift every Aures result ~4 % against other implementations)."""
+    would shift every Aures result ~4 % against other implementations).
+    """
     from phonometry.psychoacoustics.quality.sharpness import _K_ANNEX_B
 
     assert _K_ANNEX_B == 0.11

--- a/tests/psychoacoustics/quality/test_tonality.py
+++ b/tests/psychoacoustics/quality/test_tonality.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Prominent discrete tones: TNR and PR per ECMA-418-1:2024.
+"""Prominent discrete tones: TNR and PR per ECMA-418-1:2024.
 
 Anchors transcribed from the official PDF:
 - Clause 10 Formula (2) EXAMPLE: dfc = 162,2 Hz at 1 kHz; 117,3 Hz at 500 Hz.
@@ -45,7 +44,8 @@ def _tone_in_noise(
 
 def test_critical_band_examples() -> None:
     """Clause 10 and 12.2 worked examples from the standard text (shared
-    oracles in tests/reference_data/, also used by the CI report)."""
+    oracles in tests/reference_data/, also used by the CI report).
+    """
     _, _, dfc_1k = _critical_band(1000.0)
     assert dfc_1k == pytest.approx(ECMA418_1_DFC_1KHZ, abs=0.05)
     _, _, dfc_500 = _critical_band(500.0)
@@ -63,7 +63,8 @@ def test_proximity_spacing_examples() -> None:
 
 def test_tnr_of_synthetic_tone_matches_analytic() -> None:
     """White noise with PSD N0 masks a tone with power Pt:
-    TNR = 10*lg(Pt / (N0 * dfc))."""
+    TNR = 10*lg(Pt / (N0 * dfc)).
+    """
     tone_rms, noise_rms = 0.1, 0.05
     x = _tone_in_noise(1000.0, tone_rms, noise_rms)
     n0 = noise_rms**2 / (FS / 2)  # white-noise PSD
@@ -131,7 +132,8 @@ def test_pr_criteria_and_noise_only() -> None:
 
 def test_pr_low_frequency_truncated_band() -> None:
     """ft <= 171.4 Hz uses the 20 Hz-truncated lower band rescaled to
-    100 Hz (Formula 24) - the result must still be finite and sensible."""
+    100 Hz (Formula 24) - the result must still be finite and sensible.
+    """
     x = _tone_in_noise(120.0, 0.3, 0.02)
     result = psychoacoustics.prominence_ratio(x, FS, tone_freq=120.0)
     assert result.frequency == pytest.approx(120.0, abs=1.0)
@@ -143,7 +145,8 @@ def test_pr_low_frequency_truncated_band() -> None:
 
 def test_tnr_proximate_tones_combine() -> None:
     """Clause 11.6: two tones 30 Hz apart at 1 kHz (always proximate at
-    1 kHz+) are assessed as one tone with their combined level."""
+    1 kHz+) are assessed as one tone with their combined level.
+    """
     rng = np.random.default_rng(99)
     # 16 s (was 30 s): the 0.1 dB tolerance needs more spectral averaging than
     # the 8 s default (measured error: 0.18 dB at 8 s, 0.025 dB at 16 s).
@@ -189,7 +192,8 @@ def test_too_coarse_resolution_raises() -> None:
 
 def test_coarse_resolution_warns_at_low_frequency() -> None:
     """At 250 Hz (dfc ~ 115 Hz) a 4 Hz bin gives < 3 bins across the tone
-    half-width, biasing the ratio; the function warns (it does not raise)."""
+    half-width, biasing the ratio; the function warns (it does not raise).
+    """
     x = _tone_in_noise(250.0, 0.2, 0.02)
     with pytest.warns(UserWarning, match="bins"):
         psychoacoustics.tone_to_noise_ratio(x, FS, tone_freq=250.0, resolution_hz=4.0)
@@ -200,7 +204,8 @@ def test_coarse_resolution_warns_at_low_frequency() -> None:
 def test_range_edge_warns() -> None:
     """A tone at exactly 89.1 Hz snaps to the 89.0 Hz bin at 1 Hz resolution
     and lands just below the range of interest, flipping the prominence
-    verdict despite a huge ratio; the function warns about the edge."""
+    verdict despite a huge ratio; the function warns about the edge.
+    """
     x = _tone_in_noise(89.1, 0.2, 0.002)
     with pytest.warns(UserWarning, match="range-of-interest edge"):
         res = psychoacoustics.tone_to_noise_ratio(x, FS, tone_freq=89.1)
@@ -209,7 +214,8 @@ def test_range_edge_warns() -> None:
 
 def test_numeric_noise_power_warns() -> None:
     """Silence and DC produce formally finite TNR/PR values with no meaning;
-    the function warns that the band power is at numeric-noise level."""
+    the function warns that the band power is at numeric-noise level.
+    """
     silence = np.zeros(FS * 2)
     with pytest.warns(UserWarning, match="numeric-noise"):
         psychoacoustics.tone_to_noise_ratio(silence, FS, tone_freq=1000.0)

--- a/tests/psychoacoustics/quality/test_tonality_ecma.py
+++ b/tests/psychoacoustics/quality/test_tonality_ecma.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-ECMA-418-2:2025 (Sottek Hearing Model) tonality conformance tests.
+"""ECMA-418-2:2025 (Sottek Hearing Model) tonality conformance tests.
 
 The primary oracle is the standard's own calibration (Clause 6.2.8): a 1 kHz
 tone at 40 dB SPL yields 1 tu_HMS. That is the only tonality reference value

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -651,7 +651,8 @@ def test_assess_tones_rejects_non_positive_frequency() -> None:
 # ---------------------------------------------------------------------------
 def test_table_e2_lg_and_av_columns() -> None:
     """Every Table E.2 LG (Formula (12)) and av (Formula (13)) value chains
-    from the printed LS and fT to <= 0.03 dB (2-decimal print rounding)."""
+    from the printed LS and fT to <= 0.03 dB (2-decimal print rounding).
+    """
     for (ft, ls, _lt, _dl), lg_p, av_p in zip(
         ref.ISO20065_ANNEX_E_TONES, ref.ISO20065_E2_LG, ref.ISO20065_E2_AV
     ):
@@ -664,7 +665,8 @@ def test_table_e2_lg_and_av_columns() -> None:
 def test_table_e2_band_limits_are_line_snapped() -> None:
     """The printed Table E.2 f1/f2 are the first/last FFT lines inside the
     analytic Formula (4)/(5) band: each printed limit lies within one line
-    spacing inside the analytic corner."""
+    spacing inside the analytic corner.
+    """
     df = ref.ISO20065_LINE_SPACING
     for (ft, _ls, _lt, _dl), (f1_p, f2_p) in zip(
         ref.ISO20065_ANNEX_E_TONES, ref.ISO20065_E2_BAND_LIMITS
@@ -678,7 +680,8 @@ def test_table_e2_uncertainty_of_the_137hz_tone() -> None:
     """analyze_spectrum reports the Clause 6 extended uncertainty; on the
     E.1 spectrum the decisive 137.3 Hz tone reproduces the printed
     U = 2.79 dB. The flanking tones' critical bands extend beyond the
-    truncated E.1 table, so their U reproduces within 0.1 dB only."""
+    truncated E.1 table, so their U reproduces within 0.1 dB only.
+    """
     res = psychoacoustics.analyze_spectrum(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
     )
@@ -696,7 +699,8 @@ def test_table_e2_uncertainty_of_the_137hz_tone() -> None:
 def test_table_e2_fg_uncertainty() -> None:
     """The '2 FG' row of Table E.2: with the N summated tone levels as the K
     summands (the Clause 6 reading for combined tones) and the decisive
-    tone's noise lines, U reproduces the printed 3.21 dB."""
+    tone's noise lines, U reproduces the printed 3.21 dB.
+    """
     from phonometry.psychoacoustics.quality.tone_audibility import (
         _mean_narrowband_level_lines,
     )
@@ -733,7 +737,8 @@ def test_uncertainty_constants_and_validation() -> None:
 # ---------------------------------------------------------------------------
 def test_table_e4_decisive_chain() -> None:
     """Each Table E.4 decisive row chains LS/LT -> LG, av, dL to the printed
-    values (<= 0.03 dB residual from the 2-decimal intermediates)."""
+    values (<= 0.03 dB residual from the 2-decimal intermediates).
+    """
     for ft, dl_p, ls, lt, lg_p, av_p, _u in ref.ISO20065_E4_DECISIVE_ROWS:
         assert psychoacoustics.critical_band_level(
             ls, ft, ref.ISO20065_LINE_SPACING
@@ -747,7 +752,8 @@ def test_table_e4_decisive_chain() -> None:
 def test_table_e4_mean_audibility_uncertainty() -> None:
     """Annex E Step 4: the extended uncertainty of the mean audibility over
     the five spectra (Formulae (28)/(29)) reproduces the printed 1.38 dB and
-    respects the printed 1.4 dB check margin for fewer than 12 spectra."""
+    respects the printed 1.4 dB check margin for fewer than 12 spectra.
+    """
     u_j = [row[6] for row in ref.ISO20065_E4_DECISIVE_ROWS]
     u_mean = psychoacoustics.mean_audibility_uncertainty(
         ref.ISO20065_DECISIVE_AUDIBILITIES, u_j
@@ -764,7 +770,8 @@ def test_table_e3_decisive_audibilities_and_mean() -> None:
     and FG audibilities (Clause 5.3.8 Step 4) and matches the printed bold
     values; their Formula (20) energy mean is the printed 6.96 dB. (The
     narrow-band lines of spectra 2-5 are not printed, so E.3 cannot be
-    chained from levels; this locks the printed record's consistency.)"""
+    chained from levels; this locks the printed record's consistency.)
+    """
     decisives = []
     for j in sorted(ref.ISO20065_E3_TONES):
         candidates = [dl for _f, dl in ref.ISO20065_E3_TONES[j]]
@@ -786,7 +793,8 @@ def test_table_e3_decisive_audibilities_and_mean() -> None:
 def test_din_anhang_i_decisive_tone_from_spectrum() -> None:
     """Tabelle I.9 -> I.10 row k = 2 (j = 24): the from-levels chain
     reproduces the printed LS = 41.71, LT = 68.10, LG = 57.68, av = -2.10
-    and decisive dL = 12.52 dB (2-decimal print rounding)."""
+    and decisive dL = 12.52 dB (2-decimal print rounding).
+    """
     ft, dl_p, ls_p, lt_p, lg_p, av_p, _u = ref.DIN45681_I10_DECISIVE
     df = ref.DIN45681_LINE_SPACING
     ls = psychoacoustics.mean_narrowband_level(
@@ -809,7 +817,8 @@ def test_din_anhang_i_decisive_tone_from_spectrum() -> None:
 def test_din_anhang_i_decisive_tone_uncertainty() -> None:
     """Tabelle I.10 row k = 2: the Clause 6 / Anhang G extended uncertainty of
     the decisive tone reproduces the printed u = 3.18 dB from the K = 4 tone
-    lines and the M noise lines of the final Formula (6) iteration."""
+    lines and the M noise lines of the final Formula (6) iteration.
+    """
     from phonometry.psychoacoustics.quality.tone_audibility import (
         _mean_narrowband_level_lines,
     )
@@ -827,7 +836,8 @@ def test_din_anhang_i_decisive_tone_uncertainty() -> None:
 
 def test_din_anhang_i_analyze_spectrum_end_to_end() -> None:
     """analyze_spectrum on the Tabelle I.9 lines finds exactly the decisive
-    298.8 Hz tone with the printed audibility and uncertainty."""
+    298.8 Hz tone with the printed audibility and uncertainty.
+    """
     res = psychoacoustics.analyze_spectrum(
         ref.DIN45681_I9_LEVELS,
         ref.DIN45681_I9_FREQUENCIES,
@@ -849,7 +859,8 @@ def test_din_anhang_i_two_tone_rule_matches_5fg_row() -> None:
     1000 Hz) are printed combined ("5 FG"): the Formula (18)/(19) decision
     must NOT separate them -- the only printed outcome of the two-tone rule.
     The FG chain then reproduces the printed dL = 3.22 dB from the printed
-    combined LT = 55.95 dB at the more audible member (732.1 Hz)."""
+    combined LT = 55.95 dB at the more audible member (732.1 Hz).
+    """
     ft4, dl4, _ls4, _lt4 = ref.DIN45681_I10_K4
     ft5, dl5, ls5, _lt5 = ref.DIN45681_I10_K5
     assert psychoacoustics.resolve_tones_separately(ft4, ft5, dl4, dl5) is False
@@ -867,7 +878,8 @@ def test_din_anhang_i_two_tone_rule_matches_5fg_row() -> None:
 
 def test_din_anhang_i11_rows_j45_j48_chain() -> None:
     """Tabelle I.11 rows j = 45 / j = 48: the Formulae (12)-(14) chain from
-    the printed LS/LT reproduces the printed LG, av and dL columns."""
+    the printed LS/LT reproduces the printed LG, av and dL columns.
+    """
     df = ref.DIN45681_LINE_SPACING
     for ft, dl_p, ls_p, lt_p, lg_p, av_p, _u in (
         ref.DIN45681_I11_J45,
@@ -887,7 +899,8 @@ def test_din_tabelle_i6_6fg_plain_sum_reproduces_printed_audibility() -> None:
     plain Formula (17) energy sum of the three tone levels (82.87 dB) through
     the chain at 592.2 Hz. (The row's printed LT cell, 81.11 dB, follows the
     Anmerkung-2 shared-line dedupe instead and contradicts the printed dL;
-    only the dL chain is pinned, see reference_data.)"""
+    only the dL chain is pinned, see reference_data.)
+    """
     ft, dl_p, ls_p, _av_p = ref.DIN45681_I6_6FG
     lt = psychoacoustics.energy_sum_level(
         ref.DIN45681_I6_6FG_TONE_LEVELS, effective_bandwidth_factor=1.0
@@ -900,7 +913,8 @@ def test_din_tabelle_i6_6fg_plain_sum_reproduces_printed_audibility() -> None:
 
 def test_din_anhang_i3_mean_audibility_maps_to_kt_4() -> None:
     """Anhang I.3 Steps 3/5: the printed mean audibility 6.38 dB maps to
-    KT = 4 dB (DIN Abschnitt 6 Tabelle 1 == ISO 1996-2:2017 Table J.1)."""
+    KT = 4 dB (DIN Abschnitt 6 Tabelle 1 == ISO 1996-2:2017 Table J.1).
+    """
     from phonometry import environment
 
     assert (
@@ -914,7 +928,8 @@ def test_din_anhang_i3_mean_audibility_maps_to_kt_4() -> None:
 def test_din_tabelle_a1_critical_bandwidths() -> None:
     """Tabelle A.1: Formula (2) reproduces every printed (integer-rounded)
     critical bandwidth from 100 Hz to 13.5 kHz, except the 250 Hz print
-    quirk recorded in reference_data (printed 105 vs Formula (2) 104.47)."""
+    quirk recorded in reference_data (printed 105 vs Formula (2) 104.47).
+    """
     for ft, dfc_printed in ref.DIN45681_A1_BANDWIDTHS:
         computed = psychoacoustics.critical_bandwidth_engineering(ft)
         if ft == 250.0:

--- a/tests/psychoacoustics/test_erb_scale.py
+++ b/tests/psychoacoustics/test_erb_scale.py
@@ -58,7 +58,8 @@ def test_erb_bandwidth_at_1_khz_is_about_130_hz() -> None:
 
 def test_935_to_1065_hz_spans_one_erb() -> None:
     """Moore p. 76: "an increase in frequency from 935 to 1065 Hz corresponds
-    to one ERB_N"."""
+    to one ERB_N".
+    """
     span = 1065.0 - 935.0
     centre = 0.5 * (935.0 + 1065.0)
     erb = float(np.asarray(psychoacoustics.erb_bandwidth(centre))[()])

--- a/tests/psychoacoustics/test_iso1996_tone_report.py
+++ b/tests/psychoacoustics/test_iso1996_tone_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the tonal audibility assessment report (``.report()`` -> PDF).
+"""Tests for the tonal audibility assessment report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for a detected-tone result, unknown engines
@@ -180,7 +179,6 @@ def test_absent_tone_reports_zero_adjustment(tmp_path) -> None:
     A synthetic near-threshold tone keeps K low; the prominence note and boxed
     K stay consistent with the decisive audibility.
     """
-
     # One tone barely above the masking threshold: LT chosen so ΔL_ta is small.
     result = psychoacoustics.assess_tones([500.0], [40.0], [30.0], 2.0)
     out = tmp_path / "weak.pdf"

--- a/tests/psychoacoustics/test_iso532_report.py
+++ b/tests/psychoacoustics/test_iso532_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 532-1 Zwicker loudness report (``.report()`` -> PDF).
+"""Tests for the ISO 532-1 Zwicker loudness report (``.report()`` -> PDF).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for a stationary loudness result, unknown
@@ -175,7 +174,6 @@ def test_time_varying_fiche_reports_nmax_percentiles_and_nt(tmp_path) -> None:
     time-varying sounds and names the reported maximum "loudness (Nmax)";
     the fiche must not label it as the stationary total loudness N.
     """
-
     fs = 48000
     t = np.arange(fs) / fs
     x = (

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-The psychoacoustic models take a ``Signal`` in place of ``(x, fs)``.
+"""The psychoacoustic models take a ``Signal`` in place of ``(x, fs)``.
 
 Same contract as the rest of the library, held by
 ``phonometry.io._resolve``. This is the surface where it matters most, and

--- a/tests/reference_data/environment.py
+++ b/tests/reference_data/environment.py
@@ -1880,7 +1880,8 @@ def cnossos_rail_workbook_cases() -> list[dict[str, str]]:
 
 def cnossos_rail_2015_wavelength_tables() -> dict[tuple[str, str], tuple[float, ...]]:
     """The 2015 catalogue spectra given against wavelength, keyed by
-    ``(table, id)``: wheel and rail roughness, contact filter, impact."""
+    ``(table, id)``: wheel and rail roughness, contact filter, impact.
+    """
     return {
         (row["table"], row["id"]): tuple(
             float(row[w]) for w in CNOSSOS_RAIL_2015_WAVELENGTHS
@@ -1893,7 +1894,8 @@ def cnossos_rail_2015_frequency_tables() -> dict[
     tuple[str, str, str], tuple[float, ...]
 ]:
     """The 2015 catalogue spectra given against frequency, keyed by
-    ``(table, id, source)``: transfer functions, traction, aerodynamic."""
+    ``(table, id, source)``: transfer functions, traction, aerodynamic.
+    """
     return {
         (row["table"], row["id"], row["source"]): tuple(
             float(row[b]) for b in CNOSSOS_RAIL_BANDS
@@ -2152,7 +2154,8 @@ def cnossos_road_workbook_cases() -> list[dict[str, str]]:
 def cnossos_road_2015_coefficients() -> dict[str, dict[str, tuple[float, ...]]]:
     """Table F-1 as published in (EU) 2015/996, keyed by category then ``AR``,
     ``BR``, ``AP``, ``BP``. This is the superseded database the workbook was
-    computed with, not the one the library ships."""
+    computed with, not the one the library ships.
+    """
     table: dict[str, dict[str, tuple[float, ...]]] = {}
     for row in _cnossos_road_rows("road_coefficients_2015.csv"):
         table.setdefault(row["category"], {})[row["coefficient"]] = tuple(
@@ -2165,7 +2168,8 @@ def cnossos_road_2015_surfaces() -> dict[
     str, tuple[str, dict[str, tuple[float, ...]], dict[str, float]]
 ]:
     """Table F-4 as published in (EU) 2015/996, keyed by the ``NLxx`` surface
-    identifier the workbook uses: ``(description, alpha, beta)``."""
+    identifier the workbook uses: ``(description, alpha, beta)``.
+    """
     names: dict[str, str] = {}
     alpha: dict[str, dict[str, tuple[float, ...]]] = {}
     beta: dict[str, dict[str, float]] = {}

--- a/tests/result_factories.py
+++ b/tests/result_factories.py
@@ -261,7 +261,8 @@ def _band_uncertainty() -> ph.building.BandUncertainty:
 
 def _intensity_wide() -> ph.emission.IntensityResult:
     """IntensityResult with band centres spanning two decades (100 Hz-10 kHz)
-    so the log-axis bar-width scaling can be checked at the extremes."""
+    so the log-axis bar-width scaling can be checked at the extremes.
+    """
     freqs = np.array([100.0, 1000.0, 10000.0])
     n = freqs.size
     return ph.emission.IntensityResult(
@@ -441,7 +442,8 @@ def _field_indicators() -> ph.emission.FieldIndicators:
 
 def _room_with_one_invalid_band() -> ph.room.RoomAcousticsResult:
     """A RoomAcousticsResult whose middle band is flagged invalid on every
-    decay-time series (built directly so the test is deterministic)."""
+    decay-time series (built directly so the test is deterministic).
+    """
     freq = np.array([250.0, 500.0, 1000.0])
     ones = np.ones(3)
     valid = np.array([True, False, True])  # 500 Hz band invalid

--- a/tests/room/test_acoustics.py
+++ b/tests/room/test_acoustics.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 3382-1:2009 / ISO 3382-2:2008 room acoustic parameters.
+"""Tests for ISO 3382-1:2009 / ISO 3382-2:2008 room acoustic parameters.
 
 Validation strategy (closed forms, not self-consistency). For a purely
 exponential energy decay p^2(t) = exp(-a*t) with a = 6*ln(10)/T:
@@ -41,7 +40,8 @@ def multitone_ir(
     t60: float, seconds: float, freqs: list[float], fs: int = FS
 ) -> np.ndarray:
     """One sine carrier per octave band, all sharing the same exponential
-    energy envelope, so every band-filtered envelope is exp(-A60*t/t60)."""
+    energy envelope, so every band-filtered envelope is exp(-A60*t/t60).
+    """
     t = np.arange(round(seconds * fs)) / fs
     env = np.exp(-0.5 * A60 * t / t60)
     out = np.zeros_like(t)
@@ -128,7 +128,8 @@ def test_zero_phase_reduces_short_decay_group_delay_bias() -> None:
     filtering removes the filter group delay, which otherwise inflates the
     apparent decay time of a short low-frequency decay. On a deterministic
     125 Hz damped sinusoid (T = 0.2 s) the zero-phase T20/T30 sit closer to
-    the true value than the causal fit."""
+    the true value than the causal fit.
+    """
     t60, fc = 0.2, 125.89254118
     n = int(1.2 * FS)
     t = np.arange(n) / FS
@@ -236,7 +237,8 @@ def test_decay_validity_thresholds_account_for_tail_compensation() -> None:
     the truncated tail (Schroeder Eq. (3), C != 0), whose residual bias is
     positive, so a flagged-valid T20 at dyn=35 / T30 at dyn=45 exceeds the
     5 % JND (ISO 3382-2 Table A.1). Flags must tighten to ~46 dB (T20) and
-    ~54 dB (T30), where the bias falls below the JND."""
+    ~54 dB (T30), where the bias falls below the JND.
+    """
 
     def noisy_exp(sigma: float, seed: int) -> np.ndarray:
         rng = np.random.default_rng(seed)

--- a/tests/room/test_crowd_noise.py
+++ b/tests/room/test_crowd_noise.py
@@ -55,7 +55,8 @@ def test_long_direct_field_60_db_at_1_2_m() -> None:
 
 def test_long_self_noise_63_db_for_one_talker() -> None:
     """Long p. 665: "With 20 metric sabins, our self-generated reverberant-field
-    noise is 63 dB"."""
+    noise is 63 dB".
+    """
     lp = float(np.asarray(room.crowd_noise_level(1, LONG_HARD_ABSORPTION))[()])
     assert round(lp) == 63
 
@@ -69,14 +70,16 @@ def test_long_signal_to_noise_is_minus_3_db() -> None:
 
 def test_long_twenty_talkers_reach_76_db() -> None:
     """Long p. 665: "If there are 20 tables in the room ... the reverberant
-    noise level rises to 76 dB"."""
+    noise level rises to 76 dB".
+    """
     lp = float(np.asarray(room.crowd_noise_level(20, LONG_HARD_ABSORPTION))[()])
     assert round(lp) == 76
 
 
 def test_long_absorptive_ceiling_adds_170_sabins() -> None:
     """Long p. 665: an alpha 0.9 ceiling over 13.7 x 13.7 m "adds 170 metric
-    sabins"."""
+    sabins".
+    """
     added = LONG_CEILING_ALPHA * LONG_TREATED_ROOM_SIDE**2
     assert round(added, -1) == 170.0
 

--- a/tests/room/test_golay.py
+++ b/tests/room/test_golay.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for complementary Golay-pair impulse-response acquisition.
+"""Tests for complementary Golay-pair impulse-response acquisition.
 
 Validation strategy (closed-form, not self-consistency):
 - The complementary property is an algebraic identity: the sum of the two

--- a/tests/room/test_impulse_response.py
+++ b/tests/room/test_impulse_response.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 18233:2006 impulse-response acquisition.
+"""Tests for ISO 18233:2006 impulse-response acquisition.
 
 Validation strategy (closed-form, not self-consistency):
 - Ideal chain (recorded == excitation) -> band-limited delta at t=0.
@@ -118,7 +117,8 @@ def test_farina_method_recovers_iir_response_in_band() -> None:
 def test_farina_rejects_zero_padded_reference() -> None:
     """A reference zero-padded to the recording length (the correct input
     for method='spectral') silently rebuilds a wrong inverse filter for
-    Farina; it must raise instead. The unpadded sweep is unaffected."""
+    Farina; it must raise instead. The unpadded sweep is unaffected.
+    """
     b, a = signal.butter(4, [200.0, 2000.0], btype="band", fs=FS)
     f1, f2, secs = 20.0, 20000.0, 2.0
     x = room.sweep_signal(FS, f1, f2, secs)
@@ -260,7 +260,8 @@ def test_mls_recovers_iir_response_in_band() -> None:
 
 def test_mls_short_period_aliasing_warns() -> None:
     """An IR longer than one MLS period folds back circularly (A.1); the
-    recovered IR keeps undecayed energy at the period end, which is warned."""
+    recovered IR keeps undecayed energy at the period end, which is warned.
+    """
     order = 12  # L = 4095 samples (~85 ms at 48 kHz)
     a = room.mls_signal(order)
     length = a.size
@@ -313,7 +314,8 @@ def test_mls_snr_improves_with_averaging() -> None:
 
 def test_mls_multi_period_recording_averages_internally() -> None:
     """A >1-period recording exercises the internal reshape/mean averaging
-    branch and recovers a known filter, beating a single noisy period."""
+    branch and recovers a known filter, beating a single noisy period.
+    """
     order = 14
     a = room.mls_signal(order)
     length = a.size

--- a/tests/room/test_iso3382_3_report.py
+++ b/tests/room/test_iso3382_3_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 3382-3:2012 open-plan office acoustics report (``.report()``).
+"""Tests for the ISO 3382-3:2012 open-plan office acoustics report (``.report()``).
 
 The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for an open-plan result, the four

--- a/tests/room/test_iso3382_report.py
+++ b/tests/room/test_iso3382_report.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the ISO 3382-1/-2 room acoustic parameters report (``.report()``).
+"""Tests for the ISO 3382-1/-2 room acoustic parameters report (``.report()``).
 
 The report is a rendering feature, so these tests assert only structural
 facts: a valid single-page PDF is written for a room-acoustics result, the

--- a/tests/room/test_open_plan.py
+++ b/tests/room/test_open_plan.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for ISO 3382-3:2012 open-plan-office spatial metrics.
+"""Tests for ISO 3382-3:2012 open-plan-office spatial metrics.
 
 Validation strategy: exact analytic constructions (not self-consistency).
 
@@ -126,7 +125,8 @@ def test_exactly_one_in_range_gives_nan_decay() -> None:
 
     A single in-range point cannot define a decay slope, so the module
     degrades gracefully to NaN (as documented) rather than crashing, while
-    the distance-based STI regression still resolves rD."""
+    the distance-based STI regression still resolves rD.
+    """
     r = np.array([0.5, 1.0, 4.0, 18.0])  # only 4 m lies in [2, 16] m
     lp = np.array([60.0, 58.0, 50.0, 40.0])
     sti = 0.6 - 0.02 * r

--- a/tests/room/test_room_signal_overloads.py
+++ b/tests/room/test_room_signal_overloads.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-The room measurements take a ``Signal`` in place of ``(ir, fs)``.
+"""The room measurements take a ``Signal`` in place of ``(ir, fs)``.
 
 Same contract as the rest of the library, held by
 ``phonometry.io._resolve``. What is particular here is that the room

--- a/tests/room/test_shaped_sweep.py
+++ b/tests/room/test_shaped_sweep.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the arbitrary-magnitude sweep synthesis (Mueller & Massarani
+"""Tests for the arbitrary-magnitude sweep synthesis (Mueller & Massarani
 2001, Secs. 4.2-4.3).
 
 Validation strategy (closed-form, not self-consistency):

--- a/tests/signals/test_correlation.py
+++ b/tests/signals/test_correlation.py
@@ -234,7 +234,8 @@ def test_gcc_phat_sharpens_the_peak_of_a_colored_signal() -> None:
     """The plain correlator smears the delta by the signal autocorrelation
     (Knapp & Carter Eq. 9); PHAT prewhitens and restores a sharp peak.
     The coloring keeps some power everywhere (a Butterworth roll-off, not
-    a brick wall) - K&C's condition for the PHAT phase to stay defined."""
+    a brick wall) - K&C's condition for the PHAT phase to stay defined.
+    """
     from scipy import signal as sp_signal
 
     delay = 20
@@ -256,7 +257,8 @@ def test_ml_weighting_suppresses_empty_bands_where_phat_jitters() -> None:
     """K&C: PHAT weights 1/|Gxy| regardless of coherence, so bands without
     signal contribute unit-magnitude random phase; the ML (HT) weighting
     scales them by γ²/(1-γ²) and stays accurate on a band-limited signal
-    observed through noisy sensors."""
+    observed through noisy sensors.
+    """
     s = _bandlimited(11, 0.4 * FS)
     noise_a = ph.signals.noise_signal(FS, N / FS, color="white", rms=0.1, seed=311)
     noise_b = ph.signals.noise_signal(FS, N / FS, color="white", rms=0.1, seed=312)
@@ -279,7 +281,8 @@ def test_ml_weighting_suppresses_empty_bands_where_phat_jitters() -> None:
 
 def test_fractional_delay_direct_parabolic_accuracy() -> None:
     """Parabolic interpolation on a 0.4·fs band-limited pair: |err| < 0.1
-    sample (the parabola only approximates the sinc-shaped peak)."""
+    sample (the parabola only approximates the sinc-shaped peak).
+    """
     x = _bandlimited(12, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
     res = ph.signals.time_delay(x, y, FS, method="direct")
@@ -288,7 +291,8 @@ def test_fractional_delay_direct_parabolic_accuracy() -> None:
 
 def test_fractional_delay_direct_upsampled_accuracy() -> None:
     """Band-limited local upsampling ×16 fixes the parabola bias:
-    |err| < 2e-3 samples on the same pair."""
+    |err| < 2e-3 samples on the same pair.
+    """
     x = _bandlimited(12, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
     res = ph.signals.time_delay(x, y, FS, method="direct", upsample=16)
@@ -297,7 +301,8 @@ def test_fractional_delay_direct_upsampled_accuracy() -> None:
 
 def test_phase_slope_handles_polarity_inversion() -> None:
     """A polarity-inverted path (α < 0) has θ(0) = π; referencing the
-    phase to DC keeps the Eq. 5.101b slope unbiased."""
+    phase to DC keeps the Eq. 5.101b slope unbiased.
+    """
     x = _white(22)
     y = -np.roll(x, 5)
     res = ph.signals.time_delay(x, y, FS, method="phase", nperseg=2048)
@@ -306,7 +311,8 @@ def test_phase_slope_handles_polarity_inversion() -> None:
 
 def test_ml_weighting_requires_averaged_coherence() -> None:
     """K&C Eq. 45b exists only for |γ|² < 1: a single-segment coherence
-    is identically one, so the estimator refuses to run."""
+    is identically one, so the estimator refuses to run.
+    """
     x = _white(23, n=2048)
     y = np.roll(x, 5)
     with pytest.raises(ValueError, match="averaged coherence"):
@@ -325,7 +331,8 @@ def test_time_delay_rejects_constant_records() -> None:
 
 def test_fractional_delay_phase_slope_accuracy() -> None:
     """The Eq. 5.101b phase-slope estimate is exact to <1e-3 samples for a
-    clean fractional delay (the phase of a pure delay is exactly linear)."""
+    clean fractional delay (the phase of a pure delay is exactly linear).
+    """
     x = _bandlimited(13, 0.4 * FS)
     y = _fractional_delay(x, 12.25)
     res = ph.signals.time_delay(x, y, FS, method="phase", nperseg=2048)
@@ -382,7 +389,8 @@ def test_delay_scatter_is_consistent_with_the_eq_8_129_prediction() -> None:
     models the peak of the continuous correlation function, so it is an
     order-of-magnitude tool; the observed scatter sits below the
     prediction (the ±2σ interval of Eq. 8.130 is conservative) and within
-    a factor of a few of it."""
+    a factor of a few of it.
+    """
     bandwidth = 1000.0
     delays = []
     predicted = 0.0
@@ -415,7 +423,8 @@ def test_no_bandwidth_means_no_error_fields() -> None:
 def test_single_ir_subsample_delay_accuracy() -> None:
     """Documented accuracy on a smooth band-limited pulse: a few
     hundredths of a sample with the parabola alone, ~1e-3 samples at the
-    default upsample=8, below 1e-5 at x32."""
+    default upsample=8, below 1e-5 at x32.
+    """
     ir = _bandlimited_pulse(4096, 700.35, 0.15)
     got = ph.signals.impulse_response_delay(ir, FS) * FS
     assert got == pytest.approx(700.35, abs=1e-3)
@@ -445,7 +454,8 @@ def test_ir_pair_delay_and_alignment() -> None:
 
 def test_single_ir_delay_near_the_record_start() -> None:
     """A peak close to the boundary keeps a full-size (clamped) upsampling
-    window instead of a shrunken one."""
+    window instead of a shrunken one.
+    """
     ir = _bandlimited_pulse(4096, 5.25, 0.15)
     got = ph.signals.impulse_response_delay(ir, FS) * FS
     assert got == pytest.approx(5.25, abs=5e-3)
@@ -453,7 +463,8 @@ def test_single_ir_delay_near_the_record_start() -> None:
 
 def test_peak_coefficient_guard_for_out_of_record_delays() -> None:
     """The phase-slope delay is not bounded by a search window; a delay
-    beyond the record length must yield a zero coefficient, not a crash."""
+    beyond the record length must yield a zero coefficient, not a crash.
+    """
     from phonometry.signals.correlation import _delay_error
 
     x = _white(25, n=4096)

--- a/tests/signals/test_envelope.py
+++ b/tests/signals/test_envelope.py
@@ -163,7 +163,8 @@ def test_envelope_rejects_invalid_inputs() -> None:
 
 def test_short_record_antialiased_decimation_is_supported() -> None:
     """scipy's FIR decimator runs through resample_poly, so even the
-    32-sample minimum record decimates without a length cushion."""
+    32-sample minimum record decimates without a length cushion.
+    """
     x = np.sin(0.3 * np.arange(32))
     res = ph.signals.envelope(x, FS, decimation_factor=8)
     assert res.envelope.size == 4

--- a/tests/signals/test_estimate_overloads.py
+++ b/tests/signals/test_estimate_overloads.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Every signal-analysis estimate takes a ``Signal`` in place of ``(x, fs)``.
+"""Every signal-analysis estimate takes a ``Signal`` in place of ``(x, fs)``.
 
 Same contract as ``signals.levels`` and ``filters``, held by
 ``phonometry.io._resolve``: the object supplies the rate when ``fs`` is

--- a/tests/signals/test_inversion.py
+++ b/tests/signals/test_inversion.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for the regularized spectral inversion (Kirkeby & Nelson 1999,
+"""Tests for the regularized spectral inversion (Kirkeby & Nelson 1999,
 Mueller & Massarani 2001).
 
 Validation strategy (closed-form, not self-consistency):

--- a/tests/signals/test_levels.py
+++ b/tests/signals/test_levels.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for integrated and statistical sound levels (Leq, LAeq, LN).
-"""
+"""Tests for integrated and statistical sound levels (Leq, LAeq, LN)."""
 
 import inspect
 import pathlib
@@ -76,7 +74,6 @@ def test_laeq_100hz_attenuated() -> None:
 
 def test_ln_levels_constant_signal_all_equal() -> None:
     """For a steady tone, L10 == L90 and L50 == Leq (within envelope ripple)."""
-
     x = _tone(1000, seconds=3.0)
     out = signals.ln_levels(x, FS, n=(10, 50, 90))
     assert set(out.keys()) == {10, 50, 90}
@@ -88,7 +85,6 @@ def test_ln_levels_constant_signal_all_equal() -> None:
 
 def test_ln_levels_ordering() -> None:
     """L10 (exceeded 10% of time) >= L50 >= L90 for a fluctuating signal."""
-
     rng = np.random.default_rng(0)
     x = rng.standard_normal(FS * 3) * np.linspace(0.1, 1.0, FS * 3)
     out = signals.ln_levels(x, FS)
@@ -161,7 +157,6 @@ def _faded(x: np.ndarray, ramp: float = 0.05) -> np.ndarray:
 
 def test_lc_peak_steady_1khz() -> None:
     """C weighting is ~0 dB at 1 kHz: LCpeak of a steady sine = 20*log10(A/p0)."""
-
     x = _faded(_tone(1000, seconds=1.0, amp=1.0))
     assert signals.lc_peak(x, FS) == pytest.approx(20 * np.log10(1.0 / 2e-5), abs=0.15)
 
@@ -284,7 +279,6 @@ def test_lc_peak_recovers_inter_sample_peak_8k_48k() -> None:
     (audit N2 I-1: up to -1.15 dB worst-case over phase, -0.69 dB at phase 0).
     Oversampled peak detection recovers the analytic sinusoid crest.
     """
-
     x = _faded(_tone(8000, seconds=1.0))
     err = signals.lc_peak(x, FS) - _lcpeak_analytic_steady(x, FS)
     assert abs(err) < 0.5, f"LCpeak under-reads by {err:+.3f} dB (inter-sample loss)"
@@ -292,7 +286,6 @@ def test_lc_peak_recovers_inter_sample_peak_8k_48k() -> None:
 
 def test_lc_peak_oversample_keyword_controls_recovery() -> None:
     """oversample=1 reproduces the legacy on-grid under-read; the default fixes it."""
-
     x = _faded(_tone(8000, seconds=1.0))
     ref = _lcpeak_analytic_steady(x, FS)
     legacy_err = signals.lc_peak(x, FS, oversample=1) - ref
@@ -308,7 +301,6 @@ def test_lc_peak_oversample_keyword_controls_recovery() -> None:
 
 def test_sel_steady_signal_normalizes_to_one_second() -> None:
     """SEL = Leq + 10*log10(T / 1 s) for a steady signal of duration T."""
-
     x = _tone(1000, seconds=4.0)
     assert signals.sel(x, FS) == pytest.approx(
         signals.leq(x) + 10 * np.log10(4.0), abs=1e-6
@@ -345,7 +337,6 @@ def _tone_at_level(
 
 def test_sound_exposure_anchor_90db_8h_is_3p2_pa2h() -> None:
     """BS EN 61252:1995 Annex A / §3.3 NOTE 4: 3.2 Pa²h <-> exactly 90 dB."""
-
     x = _tone_at_level(90.0)
     assert signals.sound_exposure(x, FS, duration_hours=8.0) == pytest.approx(
         3.2, rel=0.01
@@ -360,7 +351,6 @@ def test_lex_8h_anchor_90db() -> None:
 
 def test_lex_8h_half_workday_subtracts_3db() -> None:
     """LEX,8h = LAeq,T + 10*log10(T/8h): a 4 h exposure at 90 dB -> 86.99 dB."""
-
     x = _tone_at_level(90.0)
     assert signals.lex_8h(x, FS, duration_hours=4.0) == pytest.approx(
         90.0 + 10 * np.log10(4 / 8), abs=0.05
@@ -369,7 +359,6 @@ def test_lex_8h_half_workday_subtracts_3db() -> None:
 
 def test_sound_exposure_1_pa2h_is_nearly_85db() -> None:
     """§3.3 NOTE 4: 1 Pa²h corresponds to a LEX,8h of nearly 85 dB (84.95)."""
-
     x = _tone_at_level(84.9485)
     assert signals.sound_exposure(x, FS, duration_hours=8.0) == pytest.approx(
         1.0, rel=0.01
@@ -379,7 +368,6 @@ def test_sound_exposure_1_pa2h_is_nearly_85db() -> None:
 
 def test_sound_exposure_defaults_to_recording_duration() -> None:
     """Without duration_hours, x IS the whole event: E = integral over len(x)."""
-
     x = _tone_at_level(90.0, seconds=2.0)
     expected = (2e-5 * 10 ** (90 / 20)) ** 2 * (2.0 / 3600.0)  # Pa² * hours
     assert signals.sound_exposure(x, FS) == pytest.approx(expected, rel=0.01)
@@ -536,7 +524,6 @@ def test_ln_levels_and_sel_accept_every_weighting_filter_curve(curve: str) -> No
     'A', 'C', 'G', 'Z'; the real accepted set is whatever `weighting_filter`
     takes. Only an unknown letter raises.
     """
-
     x = _tone(1000, seconds=2.0)
     assert np.isfinite(signals.ln_levels(x, FS, n=(50,), weighting=curve)[50])
     assert np.isfinite(signals.sel(x, FS, weighting=curve))

--- a/tests/signals/test_parametrized_signals.py
+++ b/tests/signals/test_parametrized_signals.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Parametric tests using pytest best practices for signal processing verification.
-"""
+"""Parametric tests using pytest best practices for signal processing verification."""
 
 import numpy as np
 import pytest
@@ -17,8 +15,7 @@ from phonometry import filters
     ],
 )
 def test_band_count_estimates(fraction: float, expected_bands: int) -> None:
-    """
-    Verify that the filter bank generates the expected number of frequency bands.
+    """Verify that the filter bank generates the expected number of frequency bands.
 
     **Purpose:**
     Ensure that the band generation logic (`_genfreqs`) correctly interprets the fraction
@@ -47,8 +44,7 @@ def test_band_count_estimates(fraction: float, expected_bands: int) -> None:
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_input_dtypes(dtype: np.dtype) -> None:
-    """
-    Ensure the library correctly handles different floating-point precisions.
+    """Ensure the library correctly handles different floating-point precisions.
 
     **Purpose:**
     Audio data can come in float32 (common in WAV files/real-time) or float64.
@@ -74,8 +70,7 @@ def test_input_dtypes(dtype: np.dtype) -> None:
 
 @pytest.mark.parametrize("channels", [1, 2, 4])
 def test_multichannel_shapes(channels: int) -> None:
-    """
-    Verify the library handles different channel counts (Mono, Stereo, Multichannel).
+    """Verify the library handles different channel counts (Mono, Stereo, Multichannel).
 
     **Purpose:**
     The library claims to support multichannel input. The output shape must reflect the input channels.
@@ -113,8 +108,7 @@ def test_multichannel_shapes(channels: int) -> None:
 )
 @pytest.mark.parametrize("target_freq", [63, 1000, 8000])
 def test_frequency_isolation(target_freq: float, filter_type: str) -> None:
-    """
-    Critical Audio Test: Verify spectral isolation of pure tones.
+    """Critical Audio Test: Verify spectral isolation of pure tones.
 
     **Purpose:**
     This is the core functional test of a filter bank. A pure sine wave at 1000 Hz should
@@ -176,8 +170,7 @@ def test_frequency_isolation(target_freq: float, filter_type: str) -> None:
     "filter_type", ["butter", "cheby1", "cheby2", "ellip", "bessel"]
 )
 def test_impulse_response_decay(filter_type: str) -> None:
-    """
-    Verify filter stability using the Impulse Response (IR).
+    """Verify filter stability using the Impulse Response (IR).
 
     **Purpose:**
     Stable filters must have a decaying impulse response. If the energy does not decay,
@@ -213,8 +206,7 @@ def test_impulse_response_decay(filter_type: str) -> None:
 
 
 def test_filterbank_class_direct() -> None:
-    """
-    Verify direct usage of OctaveFilterBank class.
+    """Verify direct usage of OctaveFilterBank class.
 
     **Purpose:**
     Confirm that the class can be instantiated and used independently of the wrapper function.
@@ -243,8 +235,7 @@ def test_filterbank_class_direct() -> None:
 
 
 def test_impulse_kernel_python_fallback_matches_numba() -> None:
-    """
-    Verify the pure-Python kernel matches the (possibly jitted) default.
+    """Verify the pure-Python kernel matches the (possibly jitted) default.
 
     **Purpose:**
     numba is an optional dependency; without it, time_weighting 'impulse'
@@ -263,7 +254,6 @@ def test_impulse_kernel_python_fallback_matches_numba() -> None:
 
 def test_time_weighting_class_blocks_match_continuous() -> None:
     """Block-wise TimeWeighting must equal one-shot time_weighting."""
-
     fs = 48000
     rng = np.random.default_rng(5)
     x = rng.standard_normal(fs)
@@ -307,7 +297,6 @@ def test_time_weighting_class_invalid_params() -> None:
 
 def test_time_weighting_class_impulse_blocks_match_continuous() -> None:
     """Impulse mode uses a distinct asymmetric kernel: verify state carrying."""
-
     fs = 48000
     rng = np.random.default_rng(7)
     x = rng.standard_normal((2, fs))

--- a/tests/signals/test_signal_theory_limits.py
+++ b/tests/signals/test_signal_theory_limits.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Stress tests and signal processing theory verification.
+"""Stress tests and signal processing theory verification.
 Focuses on edge cases that might be problematic in DSP.
 """
 
@@ -11,8 +10,7 @@ from phonometry import filters
 
 
 def test_nyquist_frequency_content() -> None:
-    """
-    Theory: A signal exactly at fs/2 (Nyquist) is ambiguous in digital systems.
+    """Theory: A signal exactly at fs/2 (Nyquist) is ambiguous in digital systems.
     Verification: Pass a Nyquist-frequency signal through the filter bank.
     Expectation: The library should not crash, and energy should be handled gracefully (attenuated).
     """
@@ -27,8 +25,7 @@ def test_nyquist_frequency_content() -> None:
 
 
 def test_aliasing_behavior() -> None:
-    """
-    Theory: Frequencies above fs/2 appear as aliased lower frequencies.
+    """Theory: Frequencies above fs/2 appear as aliased lower frequencies.
     Verification: Pass a signal at fs * 0.75 (above Nyquist).
     Expectation: The filter bank should treat the aliased frequency (fs * 0.25) correctly.
     """
@@ -48,8 +45,7 @@ def test_aliasing_behavior() -> None:
 
 
 def test_extreme_high_order_stability() -> None:
-    """
-    Theory: Very high order IIR filters can become numerically unstable even with SOS.
+    """Theory: Very high order IIR filters can become numerically unstable even with SOS.
     Verification: Request order 50 and 100 (extreme).
     Expectation: SOS should maintain stability (no NaNs), but we check output sanity.
     """
@@ -63,8 +59,7 @@ def test_extreme_high_order_stability() -> None:
 
 
 def test_dc_offset_rejection() -> None:
-    """
-    Theory: Band-pass filters should reject DC (0 Hz).
+    """Theory: Band-pass filters should reject DC (0 Hz).
     Verification: Pass a constant signal (x = 1.0) with detrend=True.
     Expectation: The signal should be centered around 0 before filtering,
     leading to extremely low energy levels.
@@ -85,9 +80,7 @@ def test_dc_offset_rejection() -> None:
 
 
 def test_extreme_sampling_rates() -> None:
-    """
-    Verification: Test extremely low and extremely high sampling rates.
-    """
+    """Verification: Test extremely low and extremely high sampling rates."""
     # Extremely low (e.g. 100Hz)
     fs_low = 100
     x_low = np.zeros(fs_low)
@@ -102,9 +95,7 @@ def test_extreme_sampling_rates() -> None:
 
 
 def test_huge_calibration_factor() -> None:
-    """
-    Verification: Sensitivity factor of 1e10 (extreme scaling).
-    """
+    """Verification: Sensitivity factor of 1e10 (extreme scaling)."""
     fs = 8000
     x = np.random.default_rng(42).standard_normal(fs)
     spl, _ = filters.octave_filter(
@@ -114,8 +105,7 @@ def test_huge_calibration_factor() -> None:
 
 
 def test_multichannel_mismatched_lengths() -> None:
-    """
-    Verification: Pass a 2D array where channels have different sizes (not possible in numpy,
+    """Verification: Pass a 2D array where channels have different sizes (not possible in numpy,
     but we check if it handles non-standard list of lists if we support it).
     Actually, _typesignal ensures it's an array.
     """
@@ -129,8 +119,7 @@ def test_multichannel_mismatched_lengths() -> None:
 
 
 def test_sos_stability_at_low_freq_high_fs() -> None:
-    """
-    Theory: Filtering at 16Hz with fs=192kHz is extremely difficult.
+    """Theory: Filtering at 16Hz with fs=192kHz is extremely difficult.
     Verification: Check stability for this case.
     """
     fs = 192000

--- a/tests/simulation/test_fdtd_ntff.py
+++ b/tests/simulation/test_fdtd_ntff.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Near-to-far-field (NTFF) transformation: analytic and full-wave oracles.
+"""Near-to-far-field (NTFF) transformation: analytic and full-wave oracles.
 
 The contour capture and the 2D Kirchhoff-Helmholtz integral are checked in
 three tiers, each independent of the code under test:

--- a/tests/simulation/test_fdtd_plane_wave.py
+++ b/tests/simulation/test_fdtd_plane_wave.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Plane-wave machinery of the 2-D FDTD solver.
+"""Plane-wave machinery of the 2-D FDTD solver.
 
 Anchors on exact plane-wave physics: the one-way initial packet must stay
 plane, travel at the phase speed toward its direction and leave (almost) no

--- a/tests/simulation/test_fdtd_virtual_tube.py
+++ b/tests/simulation/test_fdtd_virtual_tube.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Virtual impedance-tube experiments: FDTD end to end through the standards.
+"""Virtual impedance-tube experiments: FDTD end to end through the standards.
 
 A narrow rigid-walled FDTD domain is a plane-wave tube. A one-way packet is
 launched at a sample modelled as an equivalent fluid (density, speed and a

--- a/tests/speech/test_speech_signal_overloads.py
+++ b/tests/speech/test_speech_signal_overloads.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-The speech measurements take a ``Signal`` in place of ``(x, fs)``.
+"""The speech measurements take a ``Signal`` in place of ``(x, fs)``.
 
 Same contract as the rest of the library, held by
 ``phonometry.io._resolve``: the object supplies the rate when ``fs`` is

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Speech Transmission Index per IEC 60268-16:2020 (Edition 5).
+"""Speech Transmission Index per IEC 60268-16:2020 (Edition 5).
 
 Validation vectors:
 - Weighting-factor test (Ed.5 A.2.2): band pairs with TI=1 give exact STI
@@ -51,7 +50,8 @@ def _uniform_mtf(m: float) -> np.ndarray:
 
 def _decay_ir(t60: float, fs: int, seed: int = 0) -> np.ndarray:
     """Noise-carrier impulse response with exponential energy decay:
-    p(t) ~ e^(-13.8 t / T60), i.e. -60 dB at t = T60."""
+    p(t) ~ e^(-13.8 t / T60), i.e. -60 dB at t = T60.
+    """
     rng = np.random.default_rng(seed)
     n = int(2.0 * t60 * fs)
     t = np.arange(n) / fs
@@ -60,7 +60,8 @@ def _decay_ir(t60: float, fs: int, seed: int = 0) -> np.ndarray:
 
 def _analytic_decay_sti(t60: float) -> float:
     """Expected STI from the closed-form Schroeder MTF of an exponential
-    decay, identical in all bands: m(F) = 1/sqrt(1 + (2 pi F T/13,8)^2)."""
+    decay, identical in all bands: m(F) = 1/sqrt(1 + (2 pi F T/13,8)^2).
+    """
     m = 1.0 / np.sqrt(1.0 + (2.0 * np.pi * _MOD_FREQS * t60 / 13.8) ** 2)
     return _sti_from_mtf(np.tile(m, (_NUM_BANDS, 1))).sti
 
@@ -254,7 +255,8 @@ def test_stipa_loopback_ideal_channel(stipa_18s_seed1234: np.ndarray):
 def test_stipa_short_recording_warns(stipa_18s_seed1234: np.ndarray):
     """A recording shorter than the recommended 15 s biases the recovered
     modulation depths (and STI) low; stipa should warn (IEC 60268-16 STIPA
-    practice recommends 15 s to 25 s)."""
+    practice recommends 15 s to 25 s).
+    """
     short = speech.stipa_signal(FS, seconds=5.0, seed=1234)
     with pytest.warns(UserWarning, match="15"):
         speech.stipa(short, FS)
@@ -444,7 +446,8 @@ def _c32_signal(m: float, fs: int, seconds: float) -> np.ndarray:
 def test_stipa_direct_method_modulation_depth_staircase(i: int) -> None:
     """Ed.5 C.3.2: the full stipa() audio path (octave bank, intensity
     envelopes, sine/cosine correlation, TI chain) must reproduce the
-    published STI staircase for the Formula (C.1) signal within +/-0,05."""
+    published STI staircase for the Formula (C.1) signal within +/-0,05.
+    """
     m = i / 10.0
     x = _c32_signal(m, FS, seconds=16.0)
     res = speech.stipa(x, FS)

--- a/tests/speech/test_stipa_certified.py
+++ b/tests/speech/test_stipa_certified.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-End-to-end STIPA verification against the IEC 60268-16:2020 (rev 5)
+"""End-to-end STIPA verification against the IEC 60268-16:2020 (rev 5)
 certified test bench signals from stipa.info (Embedded Acoustics BV).
 
 The bench is 49 mono 48 kHz WAV files, 133 MB of PCM that does not compress
@@ -89,7 +88,8 @@ _FULL_BENCH_PRESENT = _BENCH.is_full_set
 
 def _decode(relative: str) -> np.ndarray:
     """Reconstruct an extracted signal: ``order`` cumulative sums of the
-    stored difference, checked against the SHA-256 of the original samples."""
+    stored difference, checked against the SHA-256 of the original samples.
+    """
     entry = _MANIFEST[relative]
     with zipfile.ZipFile(_EXTRACT) as archive:
         blob = archive.read(entry["member"])
@@ -143,7 +143,8 @@ def _available(cases: Mapping[Any, str]) -> list[Any]:
 
 def _stipa_quiet(x: np.ndarray) -> speech.STIResult:
     """stipa() with the expected verification-bench warnings silenced
-    (dead bands and junk m > 1,3 in the two-band C.4.2 signals)."""
+    (dead bands and junk m > 1,3 in the two-band C.4.2 signals).
+    """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         return speech.stipa(x, FS)
@@ -195,7 +196,8 @@ _C33_FILES = {
 
 def _schroeder_m(rt60: float) -> np.ndarray:
     """Closed-form MTF of an exponential intensity decay of 60 dB in RT60:
-    I(t) ~ e^(-a t), a = 6 ln(10)/RT60, m(F) = 1/sqrt(1 + (2 pi F/a)^2)."""
+    I(t) ~ e^(-a t), a = 6 ln(10)/RT60, m(F) = 1/sqrt(1 + (2 pi F/a)^2).
+    """
     a = 6.0 * np.log(10.0) / rt60
     return np.asarray(1.0 / np.sqrt(1.0 + (2.0 * np.pi * _MOD_FREQS / a) ** 2))
 
@@ -323,7 +325,8 @@ _COMMITTED = (
 
 def test_committed_extract_inventory() -> None:
     """The committed extract must hold exactly the 27 declared signals and
-    every one of them must decode to the digest of the original samples."""
+    every one of them must decode to the digest of the original samples.
+    """
     assert set(_MANIFEST) == set(_COMMITTED), (
         "the extract no longer matches the documented selection "
         "(see tests/data/stipa/README.md)"

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Advanced tests for input validation, edge cases, and robustness.
-"""
+"""Advanced tests for input validation, edge cases, and robustness."""
 
 import numpy as np
 import pytest
@@ -10,8 +8,7 @@ from phonometry import filters
 
 
 def test_fraction_validation() -> None:
-    """
-    Test the filter's behavior with standard and non-standard fractional bandwidths.
+    """Test the filter's behavior with standard and non-standard fractional bandwidths.
 
     **Purpose:**
     Verify that the `octave_filter` function can handle both standard (1/1, 1/3 octave)
@@ -49,8 +46,7 @@ def test_fraction_validation() -> None:
 
 
 def test_invalid_inputs() -> None:
-    """
-    Test input validation logic for invalid parameters.
+    """Test input validation logic for invalid parameters.
 
     **Purpose:**
     Ensure that the function robustly rejects invalid input configurations that could lead
@@ -104,8 +100,7 @@ def test_invalid_inputs() -> None:
 
 
 def test_short_signal() -> None:
-    """
-    Test processing of a signal shorter than the downsampling factor.
+    """Test processing of a signal shorter than the downsampling factor.
 
     **Purpose:**
     The library uses multirate processing (downsampling) to stabilize low-frequency filters.
@@ -134,8 +129,7 @@ def test_short_signal() -> None:
 
 
 def test_nan_handling() -> None:
-    """
-    Test the behavior when the input signal contains NaN values.
+    """Test the behavior when the input signal contains NaN values.
 
     **Purpose:**
     Determine if NaNs in the input propagate to the output.
@@ -159,8 +153,7 @@ def test_nan_handling() -> None:
 
 
 def test_silence() -> None:
-    """
-    Test the filter's output for a completely silent input signal.
+    """Test the filter's output for a completely silent input signal.
 
     **Purpose:**
     Verify that a zero-input signal results in an appropriately low SPL (decibel) reading.
@@ -182,8 +175,7 @@ def test_silence() -> None:
 
 
 def test_nyquist_limit() -> None:
-    """
-    Test handling of requested frequency bands that exceed the Nyquist limit.
+    """Test handling of requested frequency bands that exceed the Nyquist limit.
 
     **Purpose:**
     The Nyquist theorem states valid frequencies are < fs/2. Requesting bands above this
@@ -211,8 +203,7 @@ def test_nyquist_limit() -> None:
 
 
 def test_high_order_stability() -> None:
-    """
-    Test the numerical stability of high-order filters.
+    """Test the numerical stability of high-order filters.
 
     **Purpose:**
     High-order IIR filters (e.g., order > 10) are prone to numerical instability if implemented

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Advanced audio processing tests including Pink Noise spectral analysis.
-"""
+"""Advanced audio processing tests including Pink Noise spectral analysis."""
 
 from typing import cast
 
@@ -11,9 +9,7 @@ from phonometry import filters
 
 
 def generate_pink_noise(samples: int) -> np.ndarray:
-    """
-    Generate pink noise (1/f noise) using the Voss-McCartney algorithm.
-    """
+    """Generate pink noise (1/f noise) using the Voss-McCartney algorithm."""
     num_cols = 16
     rng = np.random.default_rng(42)  # Seeded for reproducibility
     array = np.empty((samples, num_cols))
@@ -35,8 +31,7 @@ def generate_pink_noise(samples: int) -> np.ndarray:
 
 
 def test_pink_noise_flatness() -> None:
-    """
-    Verify that Pink Noise produces a flat spectrum on a fractional octave analyzer.
+    """Verify that Pink Noise produces a flat spectrum on a fractional octave analyzer.
 
     **Purpose:**
     Pink noise has equal energy per octave (or fractional octave). This is a fundamental property used

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,6 @@
 #  Copyright (c) 2020. Jose Manuel Requena Plens
 
-"""
-Basic test and usage example for phonometry.
-"""
+"""Basic test and usage example for phonometry."""
 
 import numpy as np
 
@@ -15,8 +13,7 @@ def test_package_version_is_public() -> None:
 
 
 def test_octave_filter_basic() -> None:
-    """
-    Basic sanity check for the octave filter.
+    """Basic sanity check for the octave filter.
 
     **Purpose:**
     Ensure the function runs without errors for a simple, standard use case and returns
@@ -51,8 +48,7 @@ def test_octave_filter_basic() -> None:
 
 
 def test_octave_filter_sigbands() -> None:
-    """
-    Test the retrieval of time-domain filtered signals (`sigbands=True`).
+    """Test the retrieval of time-domain filtered signals (`sigbands=True`).
 
     **Purpose:**
     Verify that the user can retrieve the actual time-domain waveform for each frequency band,

--- a/tests/test_check_errata_evidence.py
+++ b/tests/test_check_errata_evidence.py
@@ -129,7 +129,8 @@ def test_an_incomplete_citation_does_not_satisfy_the_check(
 ) -> None:
     """All three parts are required: the page index resolves in any copy of the
     edition, the printed folio is what a reader holding the paper looks for,
-    and without the designation neither resolves in any library."""
+    and without the designation neither resolves in any library.
+    """
     incomplete = _WITH_PAGE.replace(
         "Verified on PDF page 8 (printed p. 6) of Some standard:2020.", without
     )

--- a/tests/test_check_subscript_slope.py
+++ b/tests/test_check_subscript_slope.py
@@ -1,10 +1,10 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""The subscript-slope gate, held against the shapes this corpus writes.
+r"""The subscript-slope gate, held against the shapes this corpus writes.
 
 ``scripts/check_subscript_slope.py`` reads mathematics as it is typed rather
 than as it renders, and the two ways of writing an upright subscript are the
 whole difficulty: the command may wrap the whole comma-separated run
-(``L_\\mathrm{n,w,eq}``) or one component of it (``\\alpha_{\\mathrm{s},i}``).
+(``L_\mathrm{n,w,eq}``) or one component of it (``\alpha_{\mathrm{s},i}``).
 A first version read the wrapped run component by component, decided that its
 ``w`` was italic, and reported four pages that were correctly set. These tests
 fix both readings, the silence between files that the file scope depends on,
@@ -67,7 +67,7 @@ def test_component_of_a_compound_subscript_is_read(tmp_path):
 
 
 def test_a_run_inside_one_wrapper_is_upright_throughout(tmp_path):
-    """``L_\\mathrm{n,w,eq}`` sets three upright components, not one."""
+    r"""``L_\mathrm{n,w,eq}`` sets three upright components, not one."""
     path = _write(
         tmp_path,
         "impact.md",

--- a/tests/test_conformance_report.py
+++ b/tests/test_conformance_report.py
@@ -144,7 +144,8 @@ def test_scattering_insitu_precision_reference_data_matches_oracles() -> None:
 def test_filter_binding_detail_matches_library_margin() -> None:
     """The report re-derives the binding measured value and limit with the
     public ``class_limits``; guard that its class-1 margin never diverges from
-    the authoritative ``verify_filter_class`` (single source of truth)."""
+    the authoritative ``verify_filter_class`` (single source of truth).
+    """
     from phonometry import filters
     from phonometry.filters.compliance import verify_filter_class
 

--- a/tests/test_device_geometry_plots.py
+++ b/tests/test_device_geometry_plots.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Geometry drawings of measurement and control devices (``_plot/geometry/``).
+"""Geometry drawings of measurement and control devices (``_plot/geometry/``).
 
 Covers the device renderers added after the materials batch: reactive
 silencers, the image-source room plan, the barrier section, microphone

--- a/tests/test_errors_and_edge_cases.py
+++ b/tests/test_errors_and_edge_cases.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for error handling and edge cases across all modules.
-"""
+"""Tests for error handling and edge cases across all modules."""
 
 import numpy as np
 import pytest
@@ -11,8 +9,7 @@ from phonometry.filters.frequencies import nominal_frequencies
 
 
 def test_octave_filter_bank_invalid_init() -> None:
-    """
-    Verify that OctaveFilterBank raises appropriate errors for invalid parameters.
+    """Verify that OctaveFilterBank raises appropriate errors for invalid parameters.
 
     **Purpose:**
     Ensure that the class constructor robustly validates all input arguments to prevent
@@ -50,8 +47,7 @@ def test_octave_filter_bank_invalid_init() -> None:
 
 
 def test_weighting_filter_invalid() -> None:
-    """
-    Verify error handling for invalid weighting curves.
+    """Verify error handling for invalid weighting curves.
 
     **Purpose:**
     Ensure that only the supported curves (A, B, C, D, G, AU, Z) are accepted.
@@ -71,8 +67,7 @@ def test_weighting_filter_invalid() -> None:
 
 
 def test_time_weighting_invalid() -> None:
-    """
-    Verify error handling for invalid time weighting modes.
+    """Verify error handling for invalid time weighting modes.
 
     **Purpose:**
     Ensure that only standardized ballistic modes (Fast, Slow, Impulse) are accepted.
@@ -90,8 +85,7 @@ def test_time_weighting_invalid() -> None:
 
 
 def test_linkwitz_riley_invalid() -> None:
-    """
-    Verify error handling for Linkwitz-Riley order.
+    """Verify error handling for Linkwitz-Riley order.
 
     **Purpose:**
     Linkwitz-Riley filters require an even order to ensure correct phase alignment.
@@ -109,8 +103,7 @@ def test_linkwitz_riley_invalid() -> None:
 
 
 def test_calculate_sensitivity_silent() -> None:
-    """
-    Verify error handling for silent reference signal.
+    """Verify error handling for silent reference signal.
 
     **Purpose:**
     Prevent division by zero during calibration when the reference signal is empty or silent.
@@ -127,8 +120,7 @@ def test_calculate_sensitivity_silent() -> None:
 
 
 def test_octave_filter_vs_class_consistency() -> None:
-    """
-    Verify that octave_filter function and OctaveFilterBank class yield identical results.
+    """Verify that octave_filter function and OctaveFilterBank class yield identical results.
 
     **Purpose:**
     Ensure that the functional wrapper correctly proxies all arguments to the underlying
@@ -171,8 +163,7 @@ def test_octave_filter_vs_class_consistency() -> None:
 
 
 def test_single_sample_signal() -> None:
-    """
-    Verify handling of extremely short signals.
+    """Verify handling of extremely short signals.
 
     **Purpose:**
     Ensure the library doesn't crash when provided with a single-sample signal,
@@ -192,8 +183,7 @@ def test_single_sample_signal() -> None:
 
 
 def test_multichannel_consistency() -> None:
-    """
-    Verify that processing 2 channels together is same as processing them separately.
+    """Verify that processing 2 channels together is same as processing them separately.
 
     **Purpose:**
     Confirm that the multichannel implementation correctly isolates channels and does

--- a/tests/test_figure_i18n_comma.py
+++ b/tests/test_figure_i18n_comma.py
@@ -102,11 +102,11 @@ def test_legitimate_decimals_still_take_the_comma(text: str, expected: str) -> N
 
 
 def test_every_replacement_template_of_the_pattern_table_compiles() -> None:
-    """One bad escape in one template silences the whole Spanish edition.
+    r"""One bad escape in one template silences the whole Spanish edition.
 
     ``lookup`` walks the pattern list until something matches, and
     ``re.sub`` compiles the *replacement* as it goes, so a template with a
-    stray ``\\l`` (a mathtext ``\\lambda`` written with one backslash instead
+    stray ``\l`` (a mathtext ``\lambda`` written with one backslash instead
     of two) raises for every string that reaches that row -- which is every
     string the exact table and the earlier patterns do not answer. The
     Spanish pass of a whole render run then dies on a label that has nothing

--- a/tests/test_graph_measurements.py
+++ b/tests/test_graph_measurements.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Guards for the measurement methods used by generate_graphs.py.
+"""Guards for the measurement methods used by generate_graphs.py.
 
 The published weighting-curves figure once showed A/C ~2.4 dB low (never
 crossing 0 dB) because the impulse sat at sample 0 and the high-accuracy
@@ -68,8 +67,7 @@ def test_graph_c_curve_matches_analytic() -> None:
 
 
 def test_graph_a_curve_shows_positive_bump() -> None:
-    """
-    The exact failure mode that shipped: an A curve that never crosses 0 dB.
+    """The exact failure mode that shipped: an A curve that never crosses 0 dB.
 
     The A-weighting is positive between ~1.1 and ~6.2 kHz with a maximum of
     +1.27 dB at ~2.5 kHz (IEC 61672-1 Table 2). The plotted curve must show it.
@@ -94,8 +92,7 @@ def test_graph_curves_anchor_at_1khz() -> None:
 
 
 def test_graph_b_curve_matches_published_table() -> None:
-    """
-    The B trace of the special-curves figure, against its published table.
+    """The B trace of the special-curves figure, against its published table.
 
     Oracle: ANSI S1.4-1983 Table IV design goals (B column) with the Table V
     Type 0 tolerance, evaluated at the exact base-10 frequency behind each
@@ -114,8 +111,7 @@ def test_graph_b_curve_matches_published_table() -> None:
 
 
 def test_graph_d_curve_matches_published_table() -> None:
-    """
-    The D trace of the special-curves figure, including the annotated hump.
+    """The D trace of the special-curves figure, including the annotated hump.
 
     Oracle: the IEC 537:1976 one-third-octave table republished in NASA
     CR-3406 Table SLD-I, whose maximum is the +11.5 dB at 3.15 kHz the
@@ -132,8 +128,7 @@ def test_graph_d_curve_matches_published_table() -> None:
 
 
 def test_graph_au_trace_is_a_plus_the_u_lowpass() -> None:
-    """
-    AU must sit on the A reference through the audible range, then cut.
+    """AU must sit on the A reference through the audible range, then cut.
 
     Oracle: IEC 61012:1990 Table 1, the nominal relative response of the U
     weighting as a separate unit with its per-row tolerance. AU is A

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -1,7 +1,6 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 
-"""
-Tests ensuring the package treats matplotlib as the optional dependency it is.
+"""Tests ensuring the package treats matplotlib as the optional dependency it is.
 
 Three promises are kept here. Importing phonometry must not force a specific
 (e.g. non-interactive) backend, so the package can be used during interactive

--- a/tests/test_mutually_required_groups.py
+++ b/tests/test_mutually_required_groups.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Every parameter group that has to travel together is refused when it does not.
+"""Every parameter group that has to travel together is refused when it does not.
 
 Twenty public functions take a group of arguments that the signature used to
 present as independently optional: some are "exactly one of", some are "all or

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Packaging guarantees: PEP 561 typing marker shipped with the package, and
+"""Packaging guarantees: PEP 561 typing marker shipped with the package, and
 the generated PyPI long description in sync with the GitHub README.
 
 The long description also has a property the README does not: PyPI freezes it

--- a/tests/test_rays.py
+++ b/tests/test_rays.py
@@ -443,15 +443,15 @@ def _capped_layer_paths(
     angle_deg: float,
     ranges: np.ndarray,
 ) -> tuple[np.ndarray, float]:
-    """``z(r)`` in closed form for a gradient layer under a homogeneous cap.
+    r"""``z(r)`` in closed form for a gradient layer under a homogeneous cap.
 
     In the layer the ray is the usual circular arc, and the angle from the
     horizontal is what writes it down without solving anything: differentiating
-    Snell's law :math:`\\cos\\theta = c\\,\\xi` along the ray gives
-    :math:`d\\theta/dr = -\\xi g/\\cos\\theta`, hence
-    :math:`\\sin\\theta(r) = \\sin\\theta_0 - \\xi g r`, and Snell's law itself
-    then gives :math:`z - z_\\mathrm{s} = (\\cos\\theta - \\cos\\theta_0)/
-    (\\xi g)`. Above the cap the sound speed is constant and the ray is the
+    Snell's law :math:`\cos\theta = c\,\xi` along the ray gives
+    :math:`d\theta/dr = -\xi g/\cos\theta`, hence
+    :math:`\sin\theta(r) = \sin\theta_0 - \xi g r`, and Snell's law itself
+    then gives :math:`z - z_\mathrm{s} = (\cos\theta - \cos\theta_0)/
+    (\xi g)`. Above the cap the sound speed is constant and the ray is the
     straight line it arrives as. No integrator and no ray-tube quantity anywhere
     in it, which is what makes the family below an oracle rather than a
     restatement.

--- a/tests/test_secondary_geometry_plots.py
+++ b/tests/test_secondary_geometry_plots.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Geometry drawings of the secondary set-ups (``_plot/geometry/``).
+"""Geometry drawings of the secondary set-ups (``_plot/geometry/``).
 
 Facade elevation, double wall, plate junctions, the in-situ absorption
 set-up, the dynamic-stiffness rig, the diffusion goniometer, the baffled

--- a/tests/test_signal_contract_exemptions.py
+++ b/tests/test_signal_contract_exemptions.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-The last packages on the ``Signal`` contract, and the four exemptions.
+"""The last packages on the ``Signal`` contract, and the four exemptions.
 
 Everything in ``phonometry`` that consumes a recording now takes the object
 the reader returns in place of the ``(x, fs)`` pair. This file covers the

--- a/tests/test_signal_return_contract.py
+++ b/tests/test_signal_return_contract.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-The return side of the ``Signal`` contract: what a transform hands back.
+"""The return side of the ``Signal`` contract: what a transform hands back.
 
 Until now the contract ran one way. A :class:`~phonometry.io.Signal` went
 into a transform and a bare array came out, so a chain of them lost the rate

--- a/tests/test_transition_stub.py
+++ b/tests/test_transition_stub.py
@@ -1,6 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-The PyOctaveBand transition stub that lives under ``stub/``.
+"""The PyOctaveBand transition stub that lives under ``stub/``.
 
 Almost nothing in the tree looks at it. It is not installed by the test
 environment, it is not imported by the library, `mypy` was pointed at ``src``

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""
-Tests for internal utility helpers.
-"""
+"""Tests for internal utility helpers."""
 
 import numpy as np
 

--- a/tests/underwater/propagation/test_bathymetry.py
+++ b/tests/underwater/propagation/test_bathymetry.py
@@ -234,13 +234,13 @@ def test_a_ray_reflected_past_the_vertical_ends_in_nan() -> None:
 
 
 def test_a_vertex_reflects_specularly_off_one_of_its_facets() -> None:
-    """A ray aimed exactly at a polyline vertex still reflects cleanly.
+    r"""A ray aimed exactly at a polyline vertex still reflects cleanly.
 
     A vertex has no tangent of its own and the faceted model needs none: the
     reflection uses the facet holding the located crossing, whichever side
     the bisection's last halving landed on. What is guaranteed, and asserted,
     is that the bounce is specular off one of the two adjoining facets (here
-    :math:`-\\theta_0` off the level one or :math:`-(\\theta_0 + 2\\beta)`
+    :math:`-\theta_0` off the level one or :math:`-(\theta_0 + 2\beta)`
     off the sloping one), counted once, with the march finite throughout;
     a wrong tangent, a double bounce or a corrupted crossing would all show.
     """
@@ -270,13 +270,13 @@ def test_a_vertex_reflects_specularly_off_one_of_its_facets() -> None:
 
 
 def test_a_ray_nearly_parallel_to_the_slope_survives_the_graze() -> None:
-    """A grazing contact with the slope neither spins nor corrupts the march.
+    r"""A grazing contact with the slope neither spins nor corrupts the march.
 
     The ray is launched within a tenth of a degree of the downslope facet's
     own angle, meets it near-tangentially where the Newton polish has no
     slope difference to divide by, and must come out specular all the same:
     finite, forward, exactly one bottom touch, and leaving at
-    :math:`2\\beta - \\theta_0`, a tenth of a degree on the *other* side of
+    :math:`2\beta - \theta_0`, a tenth of a degree on the *other* side of
     the facet, so it separates from the deepening bottom as slowly as it
     closed in on it.
     """
@@ -650,7 +650,8 @@ def test_eigenrays_declines_a_sloping_trace() -> None:
 
 def test_the_seabed_pair_and_a_slope_are_rejected_together() -> None:
     """One grazing angle per beam is a level-bottom fact, and the solver
-    refuses to pretend otherwise rather than quietly mis-charging bounces."""
+    refuses to pretend otherwise rather than quietly mis-charging bounces.
+    """
     seabed = FluidSeabed(density=1800.0, sound_speed=1700.0)
     with pytest.raises(ValueError, match="lossy fluid seabed"):
         gaussian_beams(

--- a/tests/underwater/propagation/test_eigenrays.py
+++ b/tests/underwater/propagation/test_eigenrays.py
@@ -271,7 +271,8 @@ def test_a_lossy_seabed_charges_R_at_each_arrivals_own_angle_as_printed() -> Non
 
 def test_the_cap_keeps_the_earliest_arrivals_and_says_so() -> None:
     """``max_arrivals`` truncates the sorted tail and warns, changing nothing
-    about the arrivals it keeps."""
+    about the arrivals it keeps.
+    """
     trace, full = _guide_arrivals()
     with pytest.warns(PhonometryWarning, match="11 eigenrays.*6 earliest"):
         capped = eigenrays(

--- a/tests/underwater/propagation/test_gaussian_beams.py
+++ b/tests/underwater/propagation/test_gaussian_beams.py
@@ -852,7 +852,8 @@ def test_the_perfect_default_is_the_seabed_machinery_off_state() -> None:
 
 def test_a_malformed_seabed_is_rejected() -> None:
     """A ``FluidSeabed`` cannot half-arrive, so what is left to reject is a
-    nonphysical one, each field with its own message."""
+    nonphysical one, each field with its own message.
+    """
     iso = ([0.0, 1000.0], [_C, _C])
     airy = FluidSeabed(density=-1.0, sound_speed=1700.0)
     still = FluidSeabed(density=1800.0, sound_speed=0.0)

--- a/tests/vibration/human/test_human_vibration.py
+++ b/tests/vibration/human/test_human_vibration.py
@@ -123,7 +123,8 @@ def _tolerance_region(freq: float, name: str) -> int:
 
 def test_table_5_tolerance_envelope() -> None:
     """|H| stays inside the Table 5 envelope of the printed design goal
-    at every Annex B one-third-octave band, for all nine weightings."""
+    at every Annex B one-third-octave band, for all nine weightings.
+    """
     for name, rows in ISO8041_1_ANNEX_B_FACTORS.items():
         for n, printed in rows:
             freq = _fc(n)

--- a/tests/vibration/structural/test_mechanical_mobility.py
+++ b/tests/vibration/structural/test_mechanical_mobility.py
@@ -90,7 +90,8 @@ def test_reciprocals_multiply_to_one() -> None:
 
 def test_rigid_mass_decade_identity_at_1000_rad_s() -> None:
     """At omega = 1000 rad/s a rigid 1 kg mass spans exact decades:
-    accelerance 1 1/kg <-> mobility 1e-3 m/(N.s) <-> compliance 1e-6 m/N."""
+    accelerance 1 1/kg <-> mobility 1e-3 m/(N.s) <-> compliance 1e-6 m/N.
+    """
     f = 1000.0 / (2.0 * math.pi)
     y = vibration.convert_frf(1.0, f, "apparent_mass", "mobility")
     h = vibration.convert_frf(1.0, f, "apparent_mass", "receptance")

--- a/tests/vibration/structural/test_transfer_stiffness.py
+++ b/tests/vibration/structural/test_transfer_stiffness.py
@@ -156,7 +156,8 @@ def test_result_helper_warns_above_transmissibility_limit() -> None:
 
 def test_indirect_bias_at_the_validity_limit_is_within_1_db() -> None:
     """At |T| = 0.1 (DeltaL1,2 = 20 dB) the undamped mass-spring model gives
-    k_indirect = 1.1 k: a 0.83 dB (10 %) bias, inside the 1 dB (12 %) bound."""
+    k_indirect = 1.1 k: a 0.83 dB (10 %) bias, inside the 1 dB (12 %) bound.
+    """
     k, m = 1e6, 1.0
     f = math.sqrt(11.0 * k / m) / (2.0 * math.pi)  # omega^2 m = 11 k -> T = -0.1
     t = complex(vibration.base_transmissibility(f, m, k))
@@ -171,7 +172,8 @@ def test_indirect_bias_at_the_validity_limit_is_within_1_db() -> None:
 
 def test_linearity_criterion_10_db_step() -> None:
     """ISO 10846-2/-3, 7.6: input spectra 10 dB apart must give transfer-
-    stiffness levels within 1.5 dB - exact equality for a linear element."""
+    stiffness levels within 1.5 dB - exact equality for a linear element.
+    """
     u_a, step = 1e-6 + 0j, 10.0 ** (-10.0 / 20.0)
     k = 1e6 + 3e4j
     lk_a = float(


### PR DESCRIPTION
## What and why

The docstring rules join the linter: summary on the first line, closing quotes on their own, raw strings where a docstring carries backslashes, and a one-line docstring on every magic method. 873 sites moved mechanically without changing a word; 37 docstrings became raw strings under one invariant, that the value Python stores in `__doc__` stays byte-identical, checked by parsing the tree before and after; 21 magic methods now say what they reject, count or forward. The invariant check caught the one real defect: a test docstring wrote `\tau` and `\approx` in a cooked string, so its stored value held a tab and a bell character where the source shows mathematics. The raw prefix is the repair, and that is the only docstring whose value moved.

The rules that judge prose rather than shape are measured out in `pyproject.toml` with their counts: D401 (imperative mood, 999), D205 (fold the multi-line opening sentence, 516 of 528 deliberate), D403 (capitalise `dBFS`), D400 (its nine sites are four questions and five sentences that finish on the next line), and D210 in tests only, where a docstring may open with the clause it checks quoted verbatim.

## Validation

No new computation. Every `__doc__` value was compared by AST between the old and new tree; the only difference anywhere is the escape repair described above. The regenerated artifacts (API reference, llms, conformance) came out byte-identical, and all 42 animation fingerprints stayed put.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files you touched
- [x] `mypy src scripts`
- [x] `bandit -r src` (any finding fails, including Low)
- [x] `pytest -q` (8958 passed, 16 skipped)

Regenerated where this change touches them:

- [x] `make conformance`: byte-identical, nothing to commit
- [x] `make api-docs`: byte-identical, nothing to commit
- [x] `make llms`: byte-identical, nothing to commit

Always:

- [x] CHANGELOG entry under `[Unreleased]`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Standardized docstring formatting across the codebase, ensuring consistent summary placement and closing quote positioning.</li>
<li>Converted docstrings containing backslashes (e.g., for mathtext or regex) to raw strings to maintain byte-identical content.</li>
<li>Updated magic methods to include descriptive docstrings, particularly for __post_init__, __len__, and __getitem__.</li>
<li>Configured Ruff linting rules in pyproject.toml to enforce docstring shape while explicitly ignoring rules that would require rewriting prose or changing documentation voice.</li>
<li>Adjusted linting exceptions for tests to allow specific docstring formatting required for quoted clauses.</li>
</ul></div>