### PR TITLE
Say the message once, in the exception itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Every exception message is assigned to a variable and raised by name:
+  2148 sites, `msg = ...` then `raise SomethingError(msg)`. What it buys is
+  the traceback: the line the interpreter prints for the raise is
+  `raise ClauseError(msg)`, not the first of several wrapped lines of a long
+  clause citation, so the message appears once, in the exception itself, and
+  the frame stays one line. The one site left alone is a guard in the code
+  that draws `anim_fdtd_side_branch`, where the rewrite would move the clip's
+  recorded fingerprint and demand a re-render that draws the same frames; it
+  says so next to the `noqa`.
+
 - Docstrings hold one shape now. The summary sits on the first line, the
   closing quotes take their own, and 873 docstrings moved to say so without
   changing by a word. Where a docstring carries backslashes (matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ select = [
     "ICN",                  # the conventional alias for a well-known package
     "N812",                 # an alias must not disguise a function as a class
     "INP", "T20",           # both already clean in `src`, and kept that way
+    "EM",                   # the message lives in a variable, so a traceback
+                            # shows `raise ClauseError(msg)` and the text once,
+                            # not a two-line message split across the frame
     "D105",                 # a magic method still explains itself
     "D2", "D301",           # docstring shape: where the summary sits and how
                             # quotes and backslashes are spelled. Shape only;

--- a/scripts/api_taxonomy.py
+++ b/scripts/api_taxonomy.py
@@ -467,10 +467,11 @@ def module_section(module: str) -> Section:
     """
     section = _MODULE_TO_SECTION.get(module)
     if section is None:
-        raise KeyError(
+        msg = (
             f"module {module!r} is not mapped to any API-reference section; "
             "add it to the matching Section in scripts/api_taxonomy.py"
         )
+        raise KeyError(msg)
     return section
 
 
@@ -486,24 +487,27 @@ def _build_module_index() -> dict[str, Section]:
         allowed = _SECTION_SUBPACKAGES[section.key]
         for module in section.modules:
             if module in index:
-                raise ValueError(
+                msg = (
                     f"module {module!r} is assigned to both "
                     f"{index[module].key!r} and {section.key!r}"
                 )
+                raise ValueError(msg)
             parent = _parent_subpackage(module)
             if parent not in allowed:
-                raise ValueError(
+                msg = (
                     f"module {module!r} (subpackage {parent!r}) does not "
                     f"belong to section {section.key!r}, which only accepts "
                     f"subpackages {allowed!r}"
                 )
+                raise ValueError(msg)
             index[module] = section
     for name, module in OBJECT_MODULE_OVERRIDES.items():
         if module not in index:
-            raise ValueError(
+            msg = (
                 f"OBJECT_MODULE_OVERRIDES[{name!r}] points to unmapped "
                 f"module {module!r}"
             )
+            raise ValueError(msg)
     return index
 
 
@@ -535,10 +539,11 @@ def public_names() -> dict[str, ModuleType]:
         for member in getattr(package, "__all__", ()):
             previous = owners.get(member)
             if previous is not None:
-                raise ValueError(
+                msg = (
                     f"{member!r} is published by both {previous.__name__} and "
                     f"{package.__name__}; one name, one owner"
                 )
+                raise ValueError(msg)
             owners[member] = package
     # The names the top level holds itself, which is every one it publishes
     # that no package does. `Signal` is not among them: it is published at the

--- a/scripts/check_conformance_claims.py
+++ b/scripts/check_conformance_claims.py
@@ -136,11 +136,12 @@ def expected_counts(root: pathlib.Path = ROOT) -> dict[str, int]:
     report = report_path(root)
     match = HEADLINE.search(_read(report))
     if match is None:
-        raise ValueError(
+        msg = (
             f"{_label(report, root)}: headline not found. The report format "
             "changed; update HEADLINE here and in "
             "site/src/data/conformance-stats.mjs."
         )
+        raise ValueError(msg)
     return {name: int(value) for name, value in match.groupdict().items()}
 
 
@@ -209,12 +210,13 @@ def claims_in(line: str) -> list[Claim]:
             if previous is None:
                 seen[(start, end)] = claim
             elif previous.field != field:
-                raise ValueError(
+                msg = (
                     f"ambiguous conformance claim {line[start:end]!r}: "
                     f"read as {previous.field!r} by {previous.phrase!r} and as "
                     f"{field!r} by {match.group(0)!r}. Tighten one of the "
                     "patterns in CLAIMS."
                 )
+                raise ValueError(msg)
     return [seen[key] for key in sorted(seen)]
 
 
@@ -236,10 +238,11 @@ def rewrite_line(line: str, expected: Mapping[str, int]) -> tuple[str, list[Clai
     reach = len(body)
     for claim in reversed(stale):
         if claim.end > reach:
-            raise ValueError(
+            msg = (
                 f"overlapping conformance claims in {body!r}; the writer cannot "
                 "rewrite spans that intersect."
             )
+            raise ValueError(msg)
         reach = claim.start
         body = body[: claim.start] + str(expected[claim.field]) + body[claim.end :]
     return body + ending, stale

--- a/scripts/check_figure_language.py
+++ b/scripts/check_figure_language.py
@@ -214,7 +214,8 @@ def read_baseline(path: pathlib.Path) -> dict[str, set[str]]:
             continue
         stem, _, raw = line.partition(": ")
         if not raw:
-            raise SystemExit(f"{path}:{number}: expected 'stem: \"string\"'")
+            msg = f"{path}:{number}: expected 'stem: \"string\"'"
+            raise SystemExit(msg)
         entries.setdefault(stem, set()).add(json.loads(raw))
     return entries
 

--- a/scripts/check_stub_metadata.py
+++ b/scripts/check_stub_metadata.py
@@ -62,7 +62,8 @@ def _metadata_of_wheel(path: pathlib.Path) -> Message:
             name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
         ]
         if len(names) != 1:
-            raise SystemExit(f"{path.name}: expected one METADATA, found {names}")
+            msg = f"{path.name}: expected one METADATA, found {names}"
+            raise SystemExit(msg)
         return message_from_string(archive.read(names[0]).decode("utf-8"))
 
 
@@ -72,10 +73,12 @@ def _metadata_of_sdist(path: pathlib.Path) -> Message:
         # The top-level PKG-INFO, not one belonging to a vendored tree.
         names = [name for name in names if name.count("/") == 1]
         if len(names) != 1:
-            raise SystemExit(f"{path.name}: expected one PKG-INFO, found {names}")
+            msg = f"{path.name}: expected one PKG-INFO, found {names}"
+            raise SystemExit(msg)
         handle = archive.extractfile(names[0])
         if handle is None:
-            raise SystemExit(f"{path.name}: {names[0]} is not a regular file")
+            msg = f"{path.name}: {names[0]} is not a regular file"
+            raise SystemExit(msg)
         return message_from_string(handle.read().decode("utf-8"))
 
 
@@ -85,10 +88,11 @@ def _phonometry_requirement(metadata: Message, label: str) -> Requirement:
     ]
     named = [item for item in declared if item.name == "phonometry"]
     if len(named) != 1:
-        raise SystemExit(
+        msg = (
             f"{label}: expected exactly one phonometry requirement, "
             f"found {[str(item) for item in named]}"
         )
+        raise SystemExit(msg)
     return named[0]
 
 
@@ -124,10 +128,11 @@ def _problems(requirement: Requirement, label: str) -> list[str]:
 def main() -> int:
     artifacts = sorted(_DIST.glob("*.whl")) + sorted(_DIST.glob("*.tar.gz"))
     if not artifacts:
-        raise SystemExit(
+        msg = (
             f"no built artifacts in {_DIST.relative_to(_ROOT)}; "
             f"run 'python -m build stub/' first"
         )
+        raise SystemExit(msg)
 
     problems: list[str] = []
     for artifact in artifacts:

--- a/scripts/conformance/domains/broadcast_wave.py
+++ b/scripts/conformance/domains/broadcast_wave.py
@@ -90,7 +90,8 @@ def _bext_payload(blob: bytes) -> bytes:
         if chunk_id == b"bext":
             return blob[pos + 8 : pos + 8 + size]
         pos += 8 + size + size % 2
-    raise ValueError("no bext chunk in the written file")
+    msg = "no bext chunk in the written file"
+    raise ValueError(msg)
 
 
 def _write_and_capture(
@@ -107,7 +108,8 @@ def _write_and_capture(
         reread = read(path).provenance
         payload = _bext_payload(path.read_bytes())
     if reread is None:
-        raise ValueError("written bext did not read back")
+        msg = "written bext did not read back"
+        raise ValueError(msg)
     return payload, reread
 
 

--- a/scripts/conformance/domains/psychoacoustics.py
+++ b/scripts/conformance/domains/psychoacoustics.py
@@ -105,10 +105,11 @@ def _iso532_b5_signal(
         str(_DATA / "iso532_1" / "Annex B.5" / f"Test signal {num} *.wav")
     )
     if not matches:
-        raise FileNotFoundError(
+        msg = (
             f"No ISO 532-1 Annex B.5 WAV found for Test signal {num} "
             "(see tests/data/iso532_1/README.md)."
         )
+        raise FileNotFoundError(msg)
     # WAV/RIFF is little-endian, so the dtype is fixed to '<i2'; a multi-channel
     # file keeps only channel 0.
     with wave.open(matches[0]) as handle:
@@ -120,7 +121,8 @@ def _iso532_b5_signal(
     signal = raw.astype(np.float64) / 32768.0 * (2.0 * math.sqrt(2.0))
     field = str(entry["field"])
     if field not in ("free", "diffuse"):
-        raise ValueError(f"unexpected sound field {field!r} in the workbook")
+        msg = f"unexpected sound field {field!r} in the workbook"
+        raise ValueError(msg)
     return (
         signal,
         int(fs),

--- a/scripts/diagrams/canvas.py
+++ b/scripts/diagrams/canvas.py
@@ -318,50 +318,55 @@ def _math_tokens(run: str, s: str, script: bool = False) -> list[tuple[str, str]
         ch = run[i]
         if ch in "_^":
             if script:
-                raise ValueError(
+                msg = (
                     f"nested script {run[i:]!r} inside a script of {s!r}: "
                     "the composer sets a single script level"
                 )
+                raise ValueError(msg)
             kind = "sub" if ch == "_" else "sup"
             if i + 1 == len(run):
-                raise ValueError(
-                    f"empty script {ch!r} at the end of a math run in {s!r}"
-                )
+                msg = f"empty script {ch!r} at the end of a math run in {s!r}"
+                raise ValueError(msg)
             if run[i + 1] == "{":
                 end = run.find("}", i + 2)
                 if end < 0:
-                    raise ValueError(f"unclosed script brace {run[i:]!r} in {s!r}")
+                    msg = f"unclosed script brace {run[i:]!r} in {s!r}"
+                    raise ValueError(msg)
                 if end == i + 2:
-                    raise ValueError(f"empty script {run[i : end + 1]!r} in {s!r}")
+                    msg = f"empty script {run[i : end + 1]!r} in {s!r}"
+                    raise ValueError(msg)
                 out.append((kind, run[i + 2 : end]))
                 i = end + 1
             else:
                 nxt = run[i + 2 : i + 3]
                 if nxt == "(":
-                    raise ValueError(
+                    msg = (
                         f"ambiguous script {run[i : i + 2]!r} before '(' in "
                         f"{s!r}: brace the script and keep the argument "
                         f"outside, as {ch}{{{run[i + 1]}}}(...)"
                     )
+                    raise ValueError(msg)
                 if nxt.isalnum():
                     j = i + 2
                     while j < len(run) and run[j].isalnum():
                         j += 1
-                    raise ValueError(
+                    msg = (
                         f"ambiguous script {run[i:j]!r} in {s!r}: only "
                         f"{run[i + 1]!r} would attach to {ch!r}, brace the "
                         f"whole script as {ch}{{...}}"
                     )
+                    raise ValueError(msg)
                 if nxt == "," and i + 3 < len(run) and run[i + 3].isalnum():
                     j = i + 3
                     while j < len(run) and (run[j].isalnum() or run[j] == ","):
                         j += 1
-                    raise ValueError(
+                    msg = (
                         f"ambiguous comma {run[i:j]!r} in {s!r}: glued to "
                         f"the script it reads as part of the subscript, "
                         f"write {ch}{{{run[i + 1]},...}} or space the "
                         "comma off"
                     )
+                    raise ValueError(msg)
                 out.append((kind, run[i + 1 : i + 2]))
                 i += 2
         elif ch.isalpha():
@@ -437,7 +442,8 @@ def _math_runs(s: str) -> list[tuple[str, bool, float, float]]:
     """
     segments = s.split("$")
     if len(segments) % 2 == 0:
-        raise ValueError(f"unbalanced $ markup in {s!r}")
+        msg = f"unbalanced $ markup in {s!r}"
+        raise ValueError(msg)
     chunks: list[tuple[str, bool, float, float]] = []
 
     def add(
@@ -455,10 +461,11 @@ def _math_runs(s: str) -> list[tuple[str, bool, float, float]]:
             add(segment)
             continue
         if "\\" in segment:
-            raise ValueError(
+            msg = (
                 f"backslash in math run {segment!r} of {s!r}: there are no "
                 "commands here, write the glyph itself (θ, √, ·, …)"
             )
+            raise ValueError(msg)
         for kind, payload in _math_tokens(segment, s):
             if kind in ("var", "up"):
                 add(payload, italic=kind == "var")
@@ -496,17 +503,19 @@ def _label_runs(
     """
     if "$" in s:
         if mono:
-            raise ValueError(
+            msg = (
                 f"mono cannot carry composed mathematics: {s!r} would "
                 "drop its $...$ styling; write the label without mono "
                 "or without markup"
             )
+            raise ValueError(msg)
         if italic:
-            raise ValueError(
+            msg = (
                 f"whole-string italic cannot carry composed mathematics: "
                 f"{s!r} styles its own italics run by run; drop the italic "
                 "or the markup"
             )
+            raise ValueError(msg)
         return [
             Run(text, (False, bold, run_italic), shift, scale)
             for text, run_italic, shift, scale in _math_runs(s)

--- a/scripts/diagrams/outline.py
+++ b/scripts/diagrams/outline.py
@@ -135,15 +135,17 @@ def assert_capabilities() -> None:
         return
     raqm = getattr(ft2font, "__libraqm_version__", None)
     if not raqm:
-        raise RuntimeError(
+        msg = (
             "matplotlib was built without libraqm: combining marks would "
             "shape with their own advance and the plates would mis-set "
             "every T̂/L̄/x̃ label"
         )
+        raise RuntimeError(msg)
     for chain in _FACES.values():
         for path in chain:
             if not path.is_file():
-                raise RuntimeError(f"font file missing from the chain: {path}")
+                msg = f"font file missing from the chain: {path}"
+                raise RuntimeError(msg)
     _capabilities_checked = True
 
 
@@ -202,11 +204,13 @@ def segment(text: str, face_key: FaceKey) -> list[FaceRun]:
                 None,
             )
             if ch is not None:
-                raise ValueError(f"no face in the chain draws {ch!r} of {text!r}")
-            raise ValueError(
+                msg = f"no face in the chain draws {ch!r} of {text!r}"
+                raise ValueError(msg)
+            msg = (
                 f"no single face in the chain covers the cluster "
                 f"{cluster!r} of {text!r}"
             )
+            raise ValueError(msg)
         if runs and runs[-1].path == path:
             runs[-1] = FaceRun(runs[-1].text + cluster, path)
         else:

--- a/scripts/fdtd_gpu.py
+++ b/scripts/fdtd_gpu.py
@@ -47,14 +47,16 @@ def _positive_finite(name: str, value: float) -> float:
     """Validate that *value* is a strictly positive finite scalar."""
     out = float(value)
     if not np.isfinite(out) or out <= 0.0:
-        raise ValueError(f"{name} must be positive and finite")
+        msg = f"{name} must be positive and finite"
+        raise ValueError(msg)
     return out
 
 
 def _integer(name: str, value: int) -> int:
     """Validate that *value* is an integral scalar (bool is rejected)."""
     if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
-        raise ValueError(f"{name} must be an integer")  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        msg = f"{name} must be an integer"
+        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
     return int(value)
 
 
@@ -62,14 +64,16 @@ def _resolve_cfl(cfl: float) -> float:
     """Validate the Courant number into a float strictly inside (0, 1)."""
     out = float(cfl)
     if not np.isfinite(out) or not 0.0 < out < 1.0:
-        raise ValueError("cfl must lie in (0, 1)")
+        msg = "cfl must lie in (0, 1)"
+        raise ValueError(msg)
     return out
 
 
 def _positive_map(name: str, field: Field2D) -> None:
     """Validate that every cell of *field* is strictly positive and finite."""
     if not np.all(np.isfinite(field)) or bool(np.any(field <= 0.0)):
-        raise ValueError(f"{name} must be strictly positive and finite everywhere")
+        msg = f"{name} must be strictly positive and finite everywhere"
+        raise ValueError(msg)
 
 
 def _sponge_profile(
@@ -96,12 +100,14 @@ def _resolve_c_map(c: float | Field2D, shape: tuple[int, int] | None) -> Field2D
     """Broadcast/validate the sound-speed spec into a positive 2D map."""
     if np.isscalar(c):
         if shape is None:
-            raise ValueError("shape is required when c is a scalar")
+            msg = "shape is required when c is a scalar"
+            raise ValueError(msg)
         c_map = np.full(shape, float(np.real(c)), dtype=np.float64)
     else:
         c_map = np.asarray(c, dtype=np.float64)
     if c_map.ndim != 2:
-        raise ValueError("c must be a 2D (ny, nx) map")
+        msg = "c must be a 2D (ny, nx) map"
+        raise ValueError(msg)
     _positive_map("c", c_map)
     return c_map
 
@@ -114,7 +120,8 @@ def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
         else np.asarray(rho, dtype=np.float64)
     )
     if rho_map.shape != (ny, nx):
-        raise ValueError("rho map must match the shape of c")
+        msg = "rho map must match the shape of c"
+        raise ValueError(msg)
     _positive_map("rho", rho_map)
     return rho_map
 
@@ -125,11 +132,14 @@ def _resolve_sponge(
     """Validate the sponge configuration exactly as the library does."""
     width = _integer("sponge_width", sponge_width)
     if width < 0:
-        raise ValueError("sponge_width must be non-negative")
+        msg = "sponge_width must be non-negative"
+        raise ValueError(msg)
     if width >= min(nx, ny):
-        raise ValueError("sponge_width must be narrower than the smallest grid side")
+        msg = "sponge_width must be narrower than the smallest grid side"
+        raise ValueError(msg)
     if not 0.0 < sponge_reflection < 1.0:
-        raise ValueError("sponge_reflection must lie strictly between 0 and 1")
+        msg = "sponge_reflection must lie strictly between 0 and 1"
+        raise ValueError(msg)
     return width, float(sponge_reflection)
 
 
@@ -139,13 +149,16 @@ def _resolve_damping(
     """Validate the damping spec into a non-negative 0D or ``(ny, nx)`` array."""
     damping_map = np.asarray(damping, dtype=np.float64)
     if damping_map.ndim not in (0, 2):
-        raise ValueError("damping must be a scalar or an (ny, nx) map")
+        msg = "damping must be a scalar or an (ny, nx) map"
+        raise ValueError(msg)
     if not np.all(np.isfinite(damping_map)) or np.any(damping_map < 0.0):
-        raise ValueError("damping must be non-negative and finite")
+        msg = "damping must be non-negative and finite"
+        raise ValueError(msg)
     if damping_map.ndim == 2 and damping_map.shape != (ny, nx):
-        raise ValueError(
+        msg = (
             f"damping map shape {damping_map.shape} does not match the grid {(ny, nx)}"
         )
+        raise ValueError(msg)
     return damping_map
 
 
@@ -159,7 +172,8 @@ def _resolve_sponge_sides(sponge_sides: Any) -> tuple[str, ...]:
         sides = tuple(sponge_sides)
     unknown = set(sides) - set(_SIDES)
     if unknown:
-        raise ValueError(f"unknown sponge sides: {sorted(unknown)}")
+        msg = f"unknown sponge sides: {sorted(unknown)}"
+        raise ValueError(msg)
     return sides
 
 
@@ -171,14 +185,14 @@ def _edge_impedance_profile(
     if z.ndim == 0:
         z = np.full(n_edge, float(z), dtype=np.float64)
     if z.shape != (n_edge,):
-        raise ValueError(
+        msg = (
             f"impedance for side {side!r} must be a scalar or a 1D "
             f"array of length {n_edge}"
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(z)) or bool(np.any(z <= 0.0)):
-        raise ValueError(
-            f"impedance for side {side!r} must be strictly positive and finite"
-        )
+        msg = f"impedance for side {side!r} must be strictly positive and finite"
+        raise ValueError(msg)
     return z
 
 
@@ -199,16 +213,16 @@ def _resolve_edge_impedance(
         return {}
     unknown = set(edge_impedance) - set(_SIDES)
     if unknown:
-        raise ValueError(f"unknown impedance sides: {sorted(unknown)}")
+        msg = f"unknown impedance sides: {sorted(unknown)}"
+        raise ValueError(msg)
     absorbing = set(sponge_sides) if sponge_width > 0 else set()
     profiles: dict[str, Field2D] = {}
     for side in _SIDES:  # deterministic order
         if side not in edge_impedance:
             continue
         if side in absorbing:
-            raise ValueError(
-                f"side {side!r} cannot be both absorbing and an impedance boundary"
-            )
+            msg = f"side {side!r} cannot be both absorbing and an impedance boundary"
+            raise ValueError(msg)
         n_edge = ny if side in ("left", "right") else nx
         profiles[side] = _edge_impedance_profile(side, edge_impedance[side], n_edge)
     return profiles
@@ -222,11 +236,14 @@ def _resolve_obstacle_mask(
         return None
     mask = np.asarray(obstacle_mask)
     if mask.shape != (ny, nx):
-        raise ValueError("obstacle_mask must match the grid shape")
+        msg = "obstacle_mask must match the grid shape"
+        raise ValueError(msg)
     if mask.dtype != np.bool_:
-        raise ValueError("obstacle_mask must be a boolean array")
+        msg = "obstacle_mask must be a boolean array"
+        raise ValueError(msg)
     if bool(mask.all()):
-        raise ValueError("obstacle_mask must leave open cells")
+        msg = "obstacle_mask must leave open cells"
+        raise ValueError(msg)
     return mask
 
 
@@ -451,11 +468,14 @@ class GpuFDTD2D:
         :param wavelength: Optional carrier wavelength [m].
         """
         if direction not in _SIDE_TRAVEL:
-            raise ValueError("'direction' must be 'down', 'up', 'left' or 'right'.")
+            msg = "'direction' must be 'down', 'up', 'left' or 'right'."
+            raise ValueError(msg)
         if width <= 0.0:
-            raise ValueError("'width' must be positive.")
+            msg = "'width' must be positive."
+            raise ValueError(msg)
         if wavelength is not None and wavelength <= 0.0:
-            raise ValueError("'wavelength' must be positive.")
+            msg = "'wavelength' must be positive."
+            raise ValueError(msg)
 
         def profile(coord: NDArray[np.floating]) -> Field2D:
             envelope = amplitude * np.exp(-(((coord - center) / width) ** 2))

--- a/scripts/fdtd_gpu_remote.py
+++ b/scripts/fdtd_gpu_remote.py
@@ -208,12 +208,15 @@ def build_job(
     )
     sample_stride = fdtd_gpu._integer("sample_stride", sample_stride)
     if sample_stride < 1:
-        raise ValueError("sample_stride must be >= 1")
+        msg = "sample_stride must be >= 1"
+        raise ValueError(msg)
     if sample_dtype not in ("float64", "float32"):
-        raise ValueError("sample_dtype must be 'float64' or 'float32'")
+        msg = "sample_dtype must be 'float64' or 'float32'"
+        raise ValueError(msg)
     sample_arr = np.unique(np.asarray(sample_steps, dtype=np.int64))
     if sample_arr.size and (int(sample_arr.min()) < 0 or int(sample_arr.max()) > steps):
-        raise ValueError("sample_steps must lie within [0, steps]")
+        msg = "sample_steps must lie within [0, steps]"
+        raise ValueError(msg)
     # None is the "not given" sentinel (all four sides when a sponge is
     # active, as the library); an explicit iterable, including the empty
     # tuple, is resolved and stored literally.
@@ -251,9 +254,11 @@ def build_job(
     if init_scale_x is not None:
         w = np.asarray(init_scale_x, dtype=np.float64)
         if w.ndim != 1 or w.shape[0] != nx:
-            raise ValueError(f"init_scale_x must be a 1D array of length nx = {nx}")
+            msg = f"init_scale_x must be a 1D array of length nx = {nx}"
+            raise ValueError(msg)
         if not np.all(np.isfinite(w)):
-            raise ValueError("init_scale_x must be finite everywhere")
+            msg = "init_scale_x must be finite everywhere"
+            raise ValueError(msg)
         job["init_scale_x"] = w
     return job
 
@@ -300,7 +305,8 @@ def _scp(sources: list[str], dest: str, timeout: float) -> None:
         check=False,
     )
     if proc.returncode != 0:
-        raise RemoteRunError(f"scp failed: {proc.stderr.strip()}")
+        msg = f"scp failed: {proc.stderr.strip()}"
+        raise RemoteRunError(msg)
 
 
 def remote_available(config: RemoteConfig) -> bool:
@@ -334,9 +340,8 @@ def run_remote(
         np.savez_compressed(job_path, **job)
         mkdir = _ssh(config, f"mkdir -p {q_dir}", timeout=30.0)
         if mkdir.returncode != 0:
-            raise RemoteRunError(
-                f"cannot create {job_dir} on {config.target}: {mkdir.stderr.strip()}"
-            )
+            msg = f"cannot create {job_dir} on {config.target}: {mkdir.stderr.strip()}"
+            raise RemoteRunError(msg)
         try:
             _scp(
                 [
@@ -355,11 +360,11 @@ def run_remote(
             try:
                 run = _ssh(config, docker_cmd, timeout=timeout)
             except subprocess.TimeoutExpired as exc:
-                raise RemoteRunError(f"remote job exceeded {timeout:.0f} s") from exc
+                msg = f"remote job exceeded {timeout:.0f} s"
+                raise RemoteRunError(msg) from exc
             if run.returncode != 0:
-                raise RemoteRunError(
-                    f"remote docker run failed: {run.stderr.strip()[-800:]}"
-                )
+                msg = f"remote docker run failed: {run.stderr.strip()[-800:]}"
+                raise RemoteRunError(msg)
             frames_path = Path(tmp) / "frames.npz"
             _scp(
                 [f"{config.target}:{q_dir}/frames.npz"], str(frames_path), timeout=300.0

--- a/scripts/figures/fields/side_branch.py
+++ b/scripts/figures/fields/side_branch.py
@@ -159,8 +159,12 @@ def _side_branch_fields() -> tuple[Any, ...]:
     resonances = noise_control.quarter_wave_resonator(
         f_grid, duct_area=0.01, length=0.3, branch_area=2e-3
     ).resonances
+    # The message stays inline: this function is hashed into the recorded
+    # fingerprint of anim_fdtd_side_branch, and moving a literal that a
+    # closed stub can never raise would mark the committed clip stale and
+    # demand a re-render that draws the same frames.
     if resonances is None:  # never for a closed stub; narrows the type
-        raise RuntimeError("quarter_wave_resonator returned no resonances")
+        raise RuntimeError("quarter_wave_resonator returned no resonances")  # noqa: EM101
     f0 = float(resonances[0])
     f_sim = _sbr_ring_down()
 

--- a/scripts/figures/registry.py
+++ b/scripts/figures/registry.py
@@ -1164,9 +1164,8 @@ def generate_posters(output_dir: str) -> None:
 
     webms = sorted(glob.glob(os.path.join(output_dir, "anim_*.webm")))
     if not webms:
-        raise RuntimeError(
-            f"no anim_*.webm files found in {output_dir}; run `make animations` first"
-        )
+        msg = f"no anim_*.webm files found in {output_dir}; run `make animations` first"
+        raise RuntimeError(msg)
     for webm in webms:
         poster = _extract_poster(webm, _poster_ss_for(webm))
         print(f"  {os.path.basename(webm)} -> {os.path.basename(poster)}")
@@ -1252,7 +1251,8 @@ _ANIM_FIELDS: dict[str, Callable[[], Any]] = {
 # A clip rename must not silently drop its field builder; fail fast.
 if not _ANIM_FIELDS.keys() <= _ANIMATIONS.keys():
     _unknown_field = sorted(_ANIM_FIELDS.keys() - _ANIMATIONS.keys())
-    raise RuntimeError(f"animation names not in _ANIMATIONS: {_unknown_field}")
+    msg = f"animation names not in _ANIMATIONS: {_unknown_field}"
+    raise RuntimeError(msg)
 
 
 def _render_anim_variant(clip: str, output_dir: str, lang: str, dark: bool) -> None:
@@ -1295,9 +1295,8 @@ def _render_anim_variants(clip: str, output_dir: str) -> None:
         proc.join()
     failed = [p.exitcode for p in procs if p.exitcode]
     if failed:
-        raise RuntimeError(
-            f"{clip}: {len(failed)} variant(s) failed (exit codes {failed})"
-        )
+        msg = f"{clip}: {len(failed)} variant(s) failed (exit codes {failed})"
+        raise RuntimeError(msg)
 
 
 def _stamp_clips(clips: list[str], output_dir: str) -> None:
@@ -1353,15 +1352,17 @@ def generate_animations(
     import shutil
 
     if shutil.which("ffmpeg") is None:
-        raise RuntimeError(
+        msg = (
             "ffmpeg was not found on PATH; it is required to encode the "
             "animation WebM/GIF outputs. Install ffmpeg and retry."
         )
+        raise RuntimeError(msg)
     if names:
         unknown = sorted(set(names) - _ANIMATIONS.keys())
         if unknown:
             available = ", ".join(sorted(_ANIMATIONS))
-            raise SystemExit(f"unknown animation(s) {unknown}; available: {available}")
+            msg = f"unknown animation(s) {unknown}; available: {available}"
+            raise SystemExit(msg)
         clips = list(names)
     else:
         clips = list(_ANIMATIONS)
@@ -1443,7 +1444,8 @@ _FIGURE_WEIGHTS: dict[str, float] = {
 _REGISTRY_NAMES = frozenset(f.__name__.removeprefix("generate_") for f in _FIGURE_FUNCS)
 if not (_GROUPED_FIGURES | _FIGURE_WEIGHTS.keys()) <= _REGISTRY_NAMES:
     _unknown = sorted((_GROUPED_FIGURES | _FIGURE_WEIGHTS.keys()) - _REGISTRY_NAMES)
-    raise RuntimeError(f"figure names not in _FIGURE_FUNCS: {_unknown}")
+    msg = f"figure names not in _FIGURE_FUNCS: {_unknown}"
+    raise RuntimeError(msg)
 
 
 def _run_figure_task(
@@ -1600,7 +1602,8 @@ _ANIM_WEIGHTS: dict[str, float] = {
 # A clip rename must not silently drop its scheduling weight; fail fast.
 if not _ANIM_WEIGHTS.keys() <= _ANIMATIONS.keys():
     _unknown_anim = sorted(_ANIM_WEIGHTS.keys() - _ANIMATIONS.keys())
-    raise RuntimeError(f"animation names not in _ANIMATIONS: {_unknown_anim}")
+    msg = f"animation names not in _ANIMATIONS: {_unknown_anim}"
+    raise RuntimeError(msg)
 
 
 def _run_anim_task(clip: str, img_dir: str) -> str:
@@ -1686,7 +1689,8 @@ def _select_figures(names: list[str] | None) -> list[Callable[[str], None]]:
         name = raw.removeprefix("generate_")
         if name not in by_name:
             available = ", ".join(sorted(by_name))
-            raise SystemExit(f"unknown figure {raw!r}; available: {available}")
+            msg = f"unknown figure {raw!r}; available: {available}"
+            raise SystemExit(msg)
         selected.append(by_name[name])
     return selected
 
@@ -1786,10 +1790,11 @@ def main(argv: list[str] | None = None) -> None:
             import shutil
 
             if shutil.which("ffmpeg") is None:
-                raise RuntimeError(
+                msg = (
                     "ffmpeg was not found on PATH; it is required to encode "
                     "the animation WebM/GIF outputs. Install ffmpeg and retry."
                 )
+                raise RuntimeError(msg)
             clips = list(_ANIMATIONS)
             print(
                 f"--- Generating animations ({len(clips)} clips "

--- a/scripts/figures/signals.py
+++ b/scripts/figures/signals.py
@@ -348,7 +348,8 @@ def generate_decomposition_plot(output_dir: str) -> None:
     _, _, xb_cheby2 = bank_cheby2.filter(y, sigbands=True)
 
     if xb_butter is None or xb_cheby2 is None:
-        raise ValueError("Signal bands should not be None")
+        msg = "Signal bands should not be None"
+        raise ValueError(msg)
 
     num_plots = len(xb_butter) + 2  # +1 for original, +1 for impulse response
     _fig, axes = plt.subplots(num_plots, 1, figsize=(10, 2.2 * num_plots), sharex=False)

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -533,9 +533,12 @@ def attribute_module(name: str, obj: object) -> str:
     if isinstance(module, str) and _is_public_module(module):
         return module
     if isinstance(module, str):
-        raise LookupError(  # noqa: TRY004 - a private-module lookup is a configuration error, not a type error
+        msg = (
             f"public name {name!r} is defined in private module {module!r}; "
             "add it to OBJECT_MODULE_OVERRIDES in scripts/api_taxonomy.py"
+        )
+        raise LookupError(  # noqa: TRY004 - a private-module lookup is a configuration error, not a type error
+            msg
         )
     # Module-level constant: find the taxonomy module that defines it.
     hits: list[str] = []
@@ -548,10 +551,11 @@ def attribute_module(name: str, obj: object) -> str:
                 hits.append(candidate)
     if len(hits) == 1:
         return hits[0]
-    raise LookupError(
+    msg = (
         f"constant {name!r} matches modules {hits!r}; add it to "
         "OBJECT_MODULE_OVERRIDES in scripts/api_taxonomy.py"
     )
+    raise LookupError(msg)
 
 
 _SENTINEL = object()
@@ -775,9 +779,8 @@ def build_model() -> tuple[list[ModuleDoc], dict[str, str], list[str]]:
     mapped = {m for s in SECTIONS.values() for m in s.modules}
     stale = sorted(mapped - set(by_module))
     if stale:
-        raise ValueError(
-            f"taxonomy modules with no public names (remove or fix): {stale}"
-        )
+        msg = f"taxonomy modules with no public names (remove or fix): {stale}"
+        raise ValueError(msg)
 
     pages: list[ModuleDoc] = []
     xref: dict[str, str] = {}
@@ -806,7 +809,8 @@ def build_model() -> tuple[list[ModuleDoc], dict[str, str], list[str]]:
 
     slugs = {(page.section.key, page.slug) for page in pages}
     if len(slugs) != len(pages):
-        raise ValueError("slug collision between module pages")
+        msg = "slug collision between module pages"
+        raise ValueError(msg)
 
     return pages, xref, issues
 

--- a/scripts/generate_brand.py
+++ b/scripts/generate_brand.py
@@ -176,7 +176,8 @@ def ribbon_outline(ribbon: Ribbon) -> tuple[Point, list[Segment]]:
     point of the bottom one, and the malformed tip would show in both emitters.
     """
     if ribbon.width[-1] != 0.0:
-        raise ValueError("a ribbon has to taper to zero width at its tip")
+        msg = "a ribbon has to taper to zero width at its tip"
+        raise ValueError(msg)
     spine, width = ribbon.spine, ribbon.width
     nrm = _normals(spine)
     upper = [

--- a/scripts/generate_llms.py
+++ b/scripts/generate_llms.py
@@ -153,10 +153,11 @@ def _conformance_counts() -> tuple[int, int, int]:
         source,
     )
     if match is None:
-        raise SystemExit(
+        msg = (
             "docs/CONFORMANCE.md: headline not found. Regenerate it with "
             "`make conformance`."
         )
+        raise SystemExit(msg)
     return int(match[1]), int(match[2]), int(match[3])
 
 
@@ -562,10 +563,11 @@ def build_llms_txt(version: str, shard_slugs: tuple[str, ...]) -> str:
         if entry is None:
             # These are listed by hand, so an unresolvable one is always a
             # bug; the About page went missing this way once, silently.
-            raise SystemExit(
+            msg = (
                 f"generate_llms.py: START_ROUTES names {route}, "
                 "which has no mirror page"
             )
+            raise SystemExit(msg)
         lines.append(entry)
     lines += [
         f"- [Guides index]({SITE_URL}/start/guides/)",

--- a/scripts/generate_pypi_readme.py
+++ b/scripts/generate_pypi_readme.py
@@ -124,10 +124,11 @@ def pypi_readme(readme: str, tag: str) -> str:
     def collapse(match: re.Match[str]) -> str:
         imgs = _IMG.findall(match.group(0))
         if len(imgs) != 1:
-            raise ValueError(
+            msg = (
                 "expected exactly one <img> fallback inside each <picture> "
                 "element of README.md"
             )
+            raise ValueError(msg)
         img = imgs[0].replace(' loading="lazy"', "")
         swapped = re.sub(r'(src="[^"]+)\.gif"', r'\1_poster.jpg"', img)
         if swapped != img:

--- a/scripts/job_runner.py
+++ b/scripts/job_runner.py
@@ -126,7 +126,8 @@ def run_job(job: Any) -> dict[str, Any]:
     steps = int(job["steps"])
     stride = int(job["sample_stride"]) if "sample_stride" in job else 1
     if stride < 1:
-        raise ValueError("sample_stride must be >= 1")
+        msg = "sample_stride must be >= 1"
+        raise ValueError(msg)
     dtype = np.dtype(str(job["sample_dtype"]) if "sample_dtype" in job else "float64")
     # Deduplicate defensively (build_job already stores unique steps, but
     # the archive may come from elsewhere): ascending order, one recorded

--- a/scripts/mirror_glossary.py
+++ b/scripts/mirror_glossary.py
@@ -60,9 +60,8 @@ def _load() -> list[dict[str, Any]]:
     """The glossary array, read through node."""
     node = shutil.which("node")
     if node is None:
-        raise SystemExit(
-            "scripts/mirror_glossary.py needs node to read site/src/data/glossary.mjs"
-        )
+        msg = "scripts/mirror_glossary.py needs node to read site/src/data/glossary.mjs"
+        raise SystemExit(msg)
     program = _DUMP % json.dumps(DATA.as_uri())
     # Fixed argv, no shell: the only variable is a path this repo owns.
     result = subprocess.run(
@@ -72,7 +71,8 @@ def _load() -> list[dict[str, Any]]:
         check=False,
     )
     if result.returncode != 0:
-        raise SystemExit(f"could not read {DATA}: {result.stderr.strip()}")
+        msg = f"could not read {DATA}: {result.stderr.strip()}"
+        raise SystemExit(msg)
     data: list[dict[str, Any]] = json.loads(result.stdout)
     return data
 
@@ -122,7 +122,8 @@ def _prose() -> str:
     text = PAGE.read_text(encoding="utf-8")
     match = re.match(r"---\n.*?\n---\n", text, re.DOTALL)
     if not match:
-        raise SystemExit(f"{PAGE}: page without frontmatter")
+        msg = f"{PAGE}: page without frontmatter"
+        raise SystemExit(msg)
     body = text[match.end() :]
     body = re.sub(r"^import .*$", "", body, flags=re.MULTILINE)
     body = body.split("<Glossary")[0]

--- a/scripts/mirror_overviews.py
+++ b/scripts/mirror_overviews.py
@@ -56,14 +56,16 @@ def _frontmatter(text: str, page: Path) -> tuple[dict[str, str], str]:
     """The title of a page, and its body."""
     match = re.match(r"---\n(.*?)\n---\n", text, re.DOTALL)
     if not match:
-        raise SystemExit(f"{page}: overview without frontmatter")
+        msg = f"{page}: overview without frontmatter"
+        raise SystemExit(msg)
     found = re.search(
         r"""^title:\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)'|(\S.*?))\s*$""",
         match.group(1),
         re.MULTILINE,
     )
     if not found:
-        raise SystemExit(f"{page}: overview without a title")
+        msg = f"{page}: overview without a title"
+        raise SystemExit(msg)
     title = (found.group(1) or found.group(2) or found.group(3)).replace('\\"', '"')
     return {"title": title}, text[match.end() :]
 
@@ -169,7 +171,8 @@ def render(page: Path) -> tuple[Path, str]:
     fields, body = _frontmatter(page.read_text(encoding="utf-8"), page)
     title = fields.get("title")
     if not title:
-        raise SystemExit(f"{page}: overview without a title")
+        msg = f"{page}: overview without a title"
+        raise SystemExit(msg)
     up = "../" * len(Path(route).parts)
     head = f"← [Documentation index]({up}README.md)\n\n# {title}\n\n"
     body = _rewrite_links(_strip_components(body), route) + "\n"

--- a/src/phonometry/__init__.py
+++ b/src/phonometry/__init__.py
@@ -126,7 +126,8 @@ def __getattr__(name: str) -> object:
     elif name in _NAMES:
         value = getattr(import_module(_NAMES[name], __name__), name)
     else:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
     globals()[name] = value
     return value
 

--- a/src/phonometry/_i18n.py
+++ b/src/phonometry/_i18n.py
@@ -28,10 +28,11 @@ _VALID_LANGUAGES = ("en", "es")
 def check_language(language: str) -> Language:
     """Return ``language`` if supported, else raise a clear :class:`ValueError`."""
     if language not in _VALID_LANGUAGES:
-        raise ValueError(
+        msg = (
             f"Unknown language {language!r}; supported languages are "
             f"{_VALID_LANGUAGES}."
         )
+        raise ValueError(msg)
     return language  # type: ignore[return-value]
 
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -26,7 +26,8 @@ def require_positive(value: float, name: str) -> float:
     :raises ValueError: for a non-finite or non-positive value.
     """
     if not math.isfinite(value) or value <= 0.0:
-        raise ValueError(f"'{name}' must be positive.")
+        msg = f"'{name}' must be positive."
+        raise ValueError(msg)
     return float(value)
 
 
@@ -39,7 +40,8 @@ def require_non_negative(value: float, name: str) -> float:
     :raises ValueError: for a non-finite or negative value.
     """
     if not math.isfinite(value) or value < 0.0:
-        raise ValueError(f"'{name}' must be non-negative.")
+        msg = f"'{name}' must be non-negative."
+        raise ValueError(msg)
     return float(value)
 
 
@@ -52,7 +54,8 @@ def require_fraction(value: float, name: str) -> float:
     :raises ValueError: for a non-finite value or one outside ``[0, 1)``.
     """
     if not math.isfinite(value) or value < 0.0 or value >= 1.0:
-        raise ValueError(f"'{name}' must be in the range [0, 1).")
+        msg = f"'{name}' must be in the range [0, 1)."
+        raise ValueError(msg)
     return float(value)
 
 
@@ -66,7 +69,8 @@ def require_choice(value: str, name: str, options: tuple[str, ...]) -> str:
     :raises ValueError: for a value not in *options*.
     """
     if value not in options:
-        raise ValueError(f"'{name}' must be one of {options}; got {value!r}.")
+        msg = f"'{name}' must be one of {options}; got {value!r}."
+        raise ValueError(msg)
     return value
 
 
@@ -81,11 +85,14 @@ def require_positive_array(x: ArrayLike, name: str) -> np.ndarray:
     """
     arr = np.atleast_1d(np.asarray(x, dtype=np.float64))
     if arr.ndim != 1 or arr.size == 0:
-        raise ValueError(f"'{name}' must be a non-empty 1-D array.")
+        msg = f"'{name}' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     if np.any(arr <= 0.0):
-        raise ValueError(f"'{name}' must be strictly positive.")
+        msg = f"'{name}' must be strictly positive."
+        raise ValueError(msg)
     return arr
 
 
@@ -103,9 +110,11 @@ def require_finite_array(x: ArrayLike, name: str) -> np.ndarray:
     """
     arr = np.atleast_1d(np.asarray(x, dtype=np.float64))
     if arr.ndim != 1 or arr.size == 0:
-        raise ValueError(f"'{name}' must be a non-empty 1-D array.")
+        msg = f"'{name}' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must contain only finite values.")
+        msg = f"'{name}' must contain only finite values."
+        raise ValueError(msg)
     return arr
 
 
@@ -122,8 +131,9 @@ def require_1d_signal(x: ArrayLike, name: str = "signal") -> np.ndarray:
     """
     arr = np.asarray(x, dtype=np.float64)
     if arr.ndim != 1:
-        raise ValueError(
+        msg = (
             f"{name} must be a 1-D time series; got shape {arr.shape}. "
             "Process multichannel signals one channel at a time."
         )
+        raise ValueError(msg)
     return arr

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -472,10 +472,11 @@ def _require_extended_curve(
     result: ExtendedWeightedRatingResult | ExtendedImpactRatingResult,
 ) -> None:
     if result.band_centers is None or result.measured is None:
-        raise ValueError(
+        msg = (
             "This extended rating result carries no band curve to plot (it "
             "was constructed without band_centers/measured data)."
         )
+        raise ValueError(msg)
 
 
 def _plot_extended_rating(

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -465,7 +465,8 @@ def theme_line(
     from matplotlib.colors import to_rgb
 
     if not 0.0 <= quiet <= 1.0:
-        raise ValueError("'quiet' must be in 0-1.")
+        msg = "'quiet' must be in 0-1."
+        raise ValueError(msg)
     hue = to_rgb(color)
     page = _page_color(ax, background)
     weight = max(quiet, _line_weight(hue, page, ratio))
@@ -959,10 +960,11 @@ def _require_rating_curve(
         or result.measured is None
         or result.shifted_reference is None
     ):
-        raise ValueError(
+        msg = (
             "This rating result carries no band curve to plot (it was "
             "constructed without measured/reference data)."
         )
+        raise ValueError(msg)
 
 
 def _facade_x_axis(

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -242,10 +242,11 @@ def plot_modulation_distortion(
         or result.carrier_amplitude is None
         or result.f_high is None
     ):
-        raise ValueError(
+        msg = (
             "this result carries no sideband spectrum data to plot; obtain it "
             "from modulation_distortion()."
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     tiny = np.finfo(np.float64).tiny
     carrier = float(result.carrier_amplitude)
@@ -879,7 +880,8 @@ def _plot_one_quantity(
 
     if quantity not in table:
         allowed = ", ".join(repr(q) for q in table)
-        raise ValueError(f"unknown quantity {quantity!r}; choose one of {allowed}.")
+        msg = f"unknown quantity {quantity!r}; choose one of {allowed}."
+        raise ValueError(msg)
     drawer, polar, attr = table[quantity]
     if attr is not None and getattr(result, attr) is None:
         raise ValueError(missing[quantity])

--- a/src/phonometry/_plot/emission.py
+++ b/src/phonometry/_plot/emission.py
@@ -200,10 +200,11 @@ def plot_intensity(
     from .._i18n import format_number, localize_axes
 
     if result.frequency is None:
-        raise ValueError(
+        msg = (
             "plot() needs per-band intensity data; call sound_intensity(...) "
             "with a 'fraction' to obtain it."
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequency, dtype=np.float64)
     lp = np.asarray(result.pressure_level, dtype=np.float64)
@@ -281,10 +282,11 @@ def plot_field_indicators(
 
     f2 = np.atleast_1d(np.asarray(result.f2, dtype=np.float64))
     if result.frequency is None or f2.size < 2:
-        raise ValueError(
+        msg = (
             "plot() needs per-band indicators; call field_indicators(...) with "
             "2D (positions, bands) arrays and 'frequencies'."
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequency, dtype=np.float64)
     f3 = np.atleast_1d(np.asarray(result.f3, dtype=np.float64))

--- a/src/phonometry/_plot/filters.py
+++ b/src/phonometry/_plot/filters.py
@@ -147,10 +147,11 @@ def plot_filter_class(
         # symmetric window is empty. Unreachable through the public verifier,
         # which never designs such a band; kept so a future designer that does
         # fails clearly instead of on a cryptic reduction.
-        raise ValueError(
+        msg = (
             "Cannot plot the filter class corridor: the mid-band frequency is at "
             "or above the analysis Nyquist, so the f/f_m window is empty."
         )
+        raise ValueError(msg)
     finite_upper = np.isfinite(upper)
 
     # Scale the axis to the mask, not to the measured curve: a steep bank

--- a/src/phonometry/_plot/geometry/building.py
+++ b/src/phonometry/_plot/geometry/building.py
@@ -113,12 +113,15 @@ def plot_aperture_geometry(
 
     _check_language(language)
     if depth <= 0.0:
-        raise ValueError("'depth' must be positive.")
+        msg = "'depth' must be positive."
+        raise ValueError(msg)
     if (width is None) == (radius is None):
-        raise ValueError("Give exactly one of 'width' or 'radius'.")
+        msg = "Give exactly one of 'width' or 'radius'."
+        raise ValueError(msg)
     opening = float(width) if width is not None else 2.0 * float(radius or 0.0)
     if opening <= 0.0:
-        raise ValueError("The aperture size must be positive.")
+        msg = "The aperture size must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     wall_h = max(4.0 * opening, 1.1 * depth)
@@ -194,10 +197,11 @@ def plot_aperture_result_geometry(
                 language=language,
                 **kwargs,
             )
-    raise ValueError(
+    msg = (
         "This result does not retain its geometry; call "
         "plot_aperture_geometry(depth, ...) with the original arguments."
     )
+    raise ValueError(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -226,14 +230,16 @@ def plot_facade_elements(
     _check_language(language)
     tiles = list(elements)
     if not tiles:
-        raise ValueError("'elements' must contain at least one element.")
+        msg = "'elements' must contain at least one element."
+        raise ValueError(msg)
     areas: list[float] = []
     for element in tiles:
         area = getattr(element, "area", None)
         if area is None:
             areas.append(0.1)  # nominal tile for dn_e-rated elements
         elif float(area) <= 0.0:
-            raise ValueError("Element areas must be positive.")
+            msg = "Element areas must be positive."
+            raise ValueError(msg)
         else:
             areas.append(float(area))
     if ax is None:
@@ -291,10 +297,11 @@ def plot_facade_result_geometry(
 ) -> Axes:
     """Facade elevation for a prediction that retained its ``elements``."""
     if getattr(result, "elements", None) is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its elements; call "
             "plot_facade_elements(elements) with the original sequence."
         )
+        raise ValueError(msg)
     return plot_facade_elements(result.elements, ax=ax, language=language, **kwargs)
 
 
@@ -333,7 +340,8 @@ def plot_double_wall_geometry(
     """
     _check_language(language)
     if mass1 <= 0.0 or mass2 <= 0.0 or gap <= 0.0:
-        raise ValueError("'mass1', 'mass2' and 'gap' must be positive.")
+        msg = "'mass1', 'mass2' and 'gap' must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     t1 = mass1 / _LEAF_DENSITY
@@ -383,10 +391,11 @@ def plot_double_wall_result_geometry(
 ) -> Axes:
     """Double-wall drawing for a result that retained its geometry."""
     if result.mass1 is None or result.mass2 is None or result.gap is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its double-wall geometry; call "
             "plot_double_wall_geometry(mass1, mass2, gap)."
         )
+        raise ValueError(msg)
     return plot_double_wall_geometry(
         result.mass1,
         result.mass2,

--- a/src/phonometry/_plot/geometry/electroacoustics.py
+++ b/src/phonometry/_plot/geometry/electroacoustics.py
@@ -120,9 +120,11 @@ def plot_piston_geometry(
     """
     _check_language(language)
     if radius <= 0.0:
-        raise ValueError("'radius' must be positive.")
+        msg = "'radius' must be positive."
+        raise ValueError(msg)
     if (angles is None) != (directivity is None):
-        raise ValueError("Give 'angles' and 'directivity' together.")
+        msg = "Give 'angles' and 'directivity' together."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     a = float(radius)
@@ -149,7 +151,8 @@ def plot_piston_geometry(
         ang = np.asarray(angles, dtype=np.float64)
         d_lin = np.abs(np.asarray(directivity, dtype=np.float64))
         if ang.shape != d_lin.shape:
-            raise ValueError("'angles' and 'directivity' must match.")
+            msg = "'angles' and 'directivity' must match."
+            raise ValueError(msg)
         peak = float(d_lin.max())
         if peak > 0.0:
             scale = 2.8 * a / peak
@@ -188,9 +191,8 @@ def plot_piston_result_geometry(
         ka = np.atleast_1d(np.asarray(result.ka, dtype=np.float64))
         n_rows = int(directivity.shape[0])
         if not -n_rows <= frequency_index < n_rows or ka.size < n_rows:
-            raise ValueError(
-                f"'frequency_index' must index the {n_rows} computed frequencies."
-            )
+            msg = f"'frequency_index' must index the {n_rows} computed frequencies."
+            raise ValueError(msg)
         row = directivity[frequency_index]
         angles = np.asarray(result.angles, dtype=np.float64)
         lobe = row
@@ -250,7 +252,8 @@ def plot_sound_reinforcement_geometry(
         float(listener_distance),
     )
     if not all(np.isfinite(v) and v > 0.0 for v in lengths):
-        raise ValueError("The three distances must be positive and finite.")
+        msg = "The three distances must be positive and finite."
+        raise ValueError(msg)
     d_tm, d_hm, d_hl = lengths
     if ax is None:
         ax = _new_axes()

--- a/src/phonometry/_plot/geometry/emission.py
+++ b/src/phonometry/_plot/geometry/emission.py
@@ -158,9 +158,11 @@ def plot_microphone_positions(
     _check_language(language)
     pts = np.asarray(positions, dtype=np.float64)
     if pts.ndim != 2 or pts.shape[1] != 3 or pts.shape[0] == 0:
-        raise ValueError("'positions' must have shape (N, 3) with N >= 1.")
+        msg = "'positions' must have shape (N, 3) with N >= 1."
+        raise ValueError(msg)
     if radius is not None and radius <= 0.0:
-        raise ValueError("'radius' must be positive when given.")
+        msg = "'radius' must be positive when given."
+        raise ValueError(msg)
     r = (
         float(radius)
         if radius is not None
@@ -261,7 +263,8 @@ def plot_pp_probe_geometry(
 
     _check_language(language)
     if spacing <= 0.0:
-        raise ValueError("'spacing' must be positive.")
+        msg = "'spacing' must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     dr = float(spacing)
@@ -340,8 +343,9 @@ def plot_intensity_result_geometry(
 ) -> Axes:
     """Probe drawing for a result that retained its spacer."""
     if result.spacing is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its microphone spacing; call "
             "plot_pp_probe_geometry(spacing)."
         )
+        raise ValueError(msg)
     return plot_pp_probe_geometry(result.spacing, ax=ax, language=language, **kwargs)

--- a/src/phonometry/_plot/geometry/environment.py
+++ b/src/phonometry/_plot/geometry/environment.py
@@ -93,14 +93,17 @@ def plot_barrier_geometry(
     """
     _check_language(language)
     if min(source_height, barrier_height, receiver_height) < 0.0:
-        raise ValueError("Heights must be non-negative.")
+        msg = "Heights must be non-negative."
+        raise ValueError(msg)
     if barrier_distance <= 0.0 or receiver_distance <= barrier_distance:
-        raise ValueError(
+        msg = (
             "'barrier_distance' must be positive and 'receiver_distance' "
             "greater than it."
         )
+        raise ValueError(msg)
     if thickness is not None and thickness <= 0.0:
-        raise ValueError("'thickness' must be positive when given.")
+        msg = "'thickness' must be positive when given."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     e = 0.0 if thickness is None else float(thickness)
@@ -226,10 +229,11 @@ def plot_barrier_result_geometry(
         or result.receiver_distance is None
         or result.receiver_height is None
     ):
-        raise ValueError(
+        msg = (
             "This result does not retain its geometry; call "
             "plot_barrier_geometry(...) with the original arguments."
         )
+        raise ValueError(msg)
     return plot_barrier_geometry(
         ax=ax,
         source_height=result.source_height,

--- a/src/phonometry/_plot/geometry/materials.py
+++ b/src/phonometry/_plot/geometry/materials.py
@@ -125,7 +125,8 @@ def _layer_kind_and_thickness(layer: Any, total: float) -> tuple[str, float, str
         return "plate", float(layer.thickness), "Microperforated plate"
     if name == "MembraneLayer":
         return "membrane", _MEMBRANE_DRAW_FRACTION * total, "Membrane"
-    raise TypeError(f"Unsupported layer type: {name!r}.")
+    msg = f"Unsupported layer type: {name!r}."
+    raise TypeError(msg)
 
 
 def _stack_total_depth(layers: Sequence[Any]) -> float:
@@ -186,7 +187,8 @@ def plot_absorber_stack(
     _check_language(language)
     stack = list(layers) if isinstance(layers, Sequence) else [layers]
     if not stack:
-        raise ValueError("'layers' must contain at least one layer.")
+        msg = "'layers' must contain at least one layer."
+        raise ValueError(msg)
     total = _stack_total_depth(stack)
     if total <= 0.0:
         total = 0.05
@@ -387,10 +389,12 @@ def plot_slit_absorber_geometry(
     """
     _check_language(language)
     if slit_height <= 0.0 or lattice_step <= 0.0 or period <= 0.0:
-        raise ValueError("'slit_height', 'lattice_step' and 'period' must be positive.")
+        msg = "'slit_height', 'lattice_step' and 'period' must be positive."
+        raise ValueError(msg)
     chain = list(resonators) if isinstance(resonators, Sequence) else [resonators]
     if not chain:
-        raise ValueError("'resonators' must contain at least one resonator.")
+        msg = "'resonators' must contain at least one resonator."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     n = len(chain)
@@ -486,16 +490,21 @@ def plot_qrd_geometry(
     _check_language(language)
     d = np.asarray(depths, dtype=np.float64)
     if d.ndim != 1 or d.size == 0:
-        raise ValueError("'depths' must be a non-empty 1-D sequence.")
+        msg = "'depths' must be a non-empty 1-D sequence."
+        raise ValueError(msg)
     if np.any(d < 0.0):
-        raise ValueError("'depths' must be non-negative.")
+        msg = "'depths' must be non-negative."
+        raise ValueError(msg)
     if well_width <= 0.0:
-        raise ValueError("'well_width' must be positive.")
+        msg = "'well_width' must be positive."
+        raise ValueError(msg)
     if periods < 1:
-        raise ValueError("'periods' must be >= 1.")
+        msg = "'periods' must be >= 1."
+        raise ValueError(msg)
     fin = well_width / 12.0 if fin_width is None else float(fin_width)
     if fin < 0.0:
-        raise ValueError("'fin_width' must be non-negative.")
+        msg = "'fin_width' must be non-negative."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     n = int(d.size)
@@ -708,11 +717,14 @@ def plot_impedance_tube_geometry(
 
     _check_language(language)
     if spacing <= 0.0 or x1 <= spacing:
-        raise ValueError("'spacing' must be positive and 'x1' > 'spacing'.")
+        msg = "'spacing' must be positive and 'x1' > 'spacing'."
+        raise ValueError(msg)
     if diameter is not None and diameter <= 0.0:
-        raise ValueError("'diameter' must be positive when given.")
+        msg = "'diameter' must be positive when given."
+        raise ValueError(msg)
     if sample_thickness is not None and sample_thickness <= 0.0:
-        raise ValueError("'sample_thickness' must be positive when given.")
+        msg = "'sample_thickness' must be positive when given."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     bore = _nominal_bore(diameter, 1.5 * spacing)
@@ -822,13 +834,14 @@ def plot_transmission_tube_geometry(
 
     _check_language(language)
     if min(l1, s1, l2, s2, thickness) <= 0.0:
-        raise ValueError("'l1', 's1', 'l2', 's2' and 'thickness' must be positive.")
+        msg = "'l1', 's1', 'l2', 's2' and 'thickness' must be positive."
+        raise ValueError(msg)
     if diameter is not None and diameter <= 0.0:
-        raise ValueError("'diameter' must be positive when given.")
+        msg = "'diameter' must be positive when given."
+        raise ValueError(msg)
     if l2 <= thickness:
-        raise ValueError(
-            "'l2' is measured from the front face and must exceed 'thickness'."
-        )
+        msg = "'l2' is measured from the front face and must exceed 'thickness'."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     bore = _nominal_bore(diameter, 1.5 * max(s1, s2))
@@ -930,10 +943,11 @@ def plot_layered_absorber_geometry(
 ) -> Axes:
     """Stack drawing for a result that retained its ``layers``."""
     if result.layers is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its layers; call "
             "plot_absorber_stack(layers) with the original layer sequence."
         )
+        raise ValueError(msg)
     return plot_absorber_stack(result.layers, ax=ax, language=language, **kwargs)
 
 
@@ -951,10 +965,11 @@ def plot_slit_absorber_result_geometry(
         or result.lattice_step is None
         or result.period is None
     ):
-        raise ValueError(
+        msg = (
             "This result does not retain its geometry; call "
             "plot_slit_absorber_geometry(...) with the original arguments."
         )
+        raise ValueError(msg)
     return plot_slit_absorber_geometry(
         result.resonators,
         ax=ax,
@@ -1034,13 +1049,16 @@ def plot_metadiffuser_panel_geometry(
     """
     _check_language(language)
     if depth <= 0.0 or period <= 0.0:
-        raise ValueError("'depth' and 'period' must be positive.")
+        msg = "'depth' and 'period' must be positive."
+        raise ValueError(msg)
     cells = list(wells)
     if len(cells) < 2:
-        raise ValueError("'wells' must contain at least two wells.")
+        msg = "'wells' must contain at least two wells."
+        raise ValueError(msg)
     for well in cells:
         if well is not None and well.slit_height >= period:
-            raise ValueError("every slit height must be smaller than the period.")
+            msg = "every slit height must be smaller than the period."
+            raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     n_wells = len(cells)
@@ -1133,11 +1151,12 @@ def plot_metadiffuser_geometry(
 ) -> Axes:
     """Panel drawing for a metadiffuser result that retained its geometry."""
     if result.wells is None or result.depth is None or result.period is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its geometry; call "
             "plot_metadiffuser_panel_geometry(...) with the original "
             "arguments."
         )
+        raise ValueError(msg)
     return plot_metadiffuser_panel_geometry(
         result.wells,
         ax=ax,
@@ -1157,10 +1176,11 @@ def plot_diffuser_geometry(
 ) -> Axes:
     """QRD well profile for a polar response that retained its geometry."""
     if result.depths is None or result.well_width is None:
-        raise ValueError(
+        msg = (
             "This response does not retain its well geometry; call "
             "plot_qrd_geometry(depths, well_width) instead."
         )
+        raise ValueError(msg)
     return plot_qrd_geometry(
         result.depths,
         result.well_width,
@@ -1180,10 +1200,11 @@ def plot_impedance_tube_result_geometry(
 ) -> Axes:
     """Tube drawing for an ISO 10534-2 result that retained its geometry."""
     if result.spacing is None or result.x1 is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its tube geometry; call "
             "plot_impedance_tube_geometry(...) with the original arguments."
         )
+        raise ValueError(msg)
     return plot_impedance_tube_geometry(
         ax=ax,
         spacing=result.spacing,
@@ -1210,11 +1231,12 @@ def plot_transfer_matrix_geometry(
         or result.s2 is None
         or result.thickness is None
     ):
-        raise ValueError(
+        msg = (
             "This matrix does not retain its tube geometry; call "
             "plot_transmission_tube_geometry(...) with the original "
             "arguments."
         )
+        raise ValueError(msg)
     return plot_transmission_tube_geometry(
         ax=ax,
         l1=result.l1,
@@ -1259,11 +1281,11 @@ def plot_insitu_geometry(
     """
     _check_language(language)
     if mic_height <= 0.0 or source_height <= mic_height:
-        raise ValueError(
-            "'source_height' must exceed 'mic_height' and both be positive."
-        )
+        msg = "'source_height' must exceed 'mic_height' and both be positive."
+        raise ValueError(msg)
     if sampled_radius is not None and sampled_radius <= 0.0:
-        raise ValueError("'sampled_radius' must be positive when given.")
+        msg = "'sampled_radius' must be positive when given."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     half = max(source_height, sampled_radius or 0.0) * 1.2
@@ -1344,10 +1366,11 @@ def plot_insitu_result_geometry(
 ) -> Axes:
     """Set-up drawing for a result that retained its geometry."""
     if result.source_height is None or result.mic_height is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its set-up heights; call "
             "plot_insitu_geometry(source_height=..., mic_height=...)."
         )
+        raise ValueError(msg)
     return plot_insitu_geometry(
         ax=ax,
         source_height=result.source_height,
@@ -1386,9 +1409,8 @@ def plot_dynamic_stiffness_rig(
     """
     _check_language(language)
     if specimen_side <= 0.0 or specimen_thickness <= 0.0 or load_mass <= 0.0:
-        raise ValueError(
-            "'specimen_side', 'specimen_thickness' and 'load_mass' must be positive."
-        )
+        msg = "'specimen_side', 'specimen_thickness' and 'load_mass' must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     side = float(specimen_side)
@@ -1474,11 +1496,14 @@ def plot_goniometer_geometry(
     """
     _check_language(language)
     if source_distance <= 0.0 or receiver_radius <= 0.0:
-        raise ValueError("'source_distance' and 'receiver_radius' must be positive.")
+        msg = "'source_distance' and 'receiver_radius' must be positive."
+        raise ValueError(msg)
     if not 0.0 < angular_step <= 90.0:
-        raise ValueError("'angular_step' must be in (0, 90] degrees.")
+        msg = "'angular_step' must be in (0, 90] degrees."
+        raise ValueError(msg)
     if sample_width <= 0.0:
-        raise ValueError("'sample_width' must be positive.")
+        msg = "'sample_width' must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     angles = np.radians(np.arange(-90.0, 90.0 + 0.5 * angular_step, angular_step))

--- a/src/phonometry/_plot/geometry/noise_control.py
+++ b/src/phonometry/_plot/geometry/noise_control.py
@@ -114,7 +114,8 @@ _SILENCER_KINDS = (
 def _duct_diameter(area: float) -> float:
     """Equivalent circular diameter of a duct cross-section."""
     if area <= 0.0:
-        raise ValueError("Cross-section areas must be positive.")
+        msg = "Cross-section areas must be positive."
+        raise ValueError(msg)
     return float(2.0 * np.sqrt(area / np.pi))
 
 
@@ -153,11 +154,11 @@ def _draw_chamber(
     d_p = _duct_diameter(pipe_area)
     d_c = _duct_diameter(chamber_area)
     if chamber_area <= pipe_area:
-        raise ValueError("'chamber_area' must exceed 'pipe_area'.")
+        msg = "'chamber_area' must exceed 'pipe_area'."
+        raise ValueError(msg)
     if inlet_extension + outlet_extension > length:
-        raise ValueError(
-            "'inlet_extension' + 'outlet_extension' must not exceed 'length'."
-        )
+        msg = "'inlet_extension' + 'outlet_extension' must not exceed 'length'."
+        raise ValueError(msg)
     stub = max(0.5 * length, 1.5 * d_c)
     # Chamber shell.
     from matplotlib.patches import Rectangle
@@ -261,19 +262,22 @@ def _branch_dimensions(
     """Resolve (branch diameter, branch length, cavity side) per kind."""
     if kind == _KIND_HELMHOLTZ:
         if neck_area is None or neck_length is None or cavity_volume is None:
-            raise ValueError(
+            msg = (
                 "A Helmholtz resonator drawing needs 'neck_area', "
                 "'neck_length' and 'cavity_volume'."
             )
+            raise ValueError(msg)
         if cavity_volume <= 0.0 or neck_length <= 0.0:
-            raise ValueError("'cavity_volume' and 'neck_length' must be positive.")
+            msg = "'cavity_volume' and 'neck_length' must be positive."
+            raise ValueError(msg)
         return (
             _duct_diameter(neck_area),
             neck_length,
             float(cavity_volume ** (1.0 / 3.0)),
         )
     if length is None or branch_area is None:
-        raise ValueError("A quarter-wave drawing needs 'length' and 'branch_area'.")
+        msg = "A quarter-wave drawing needs 'length' and 'branch_area'."
+        raise ValueError(msg)
     if length <= 0.0:
         raise ValueError(_LENGTH_POSITIVE)
     return _duct_diameter(branch_area), length, 0.0
@@ -383,19 +387,18 @@ def _validate_chamber_geometry(
 ) -> None:
     """Chamber parameter validation, before any figure exists."""
     if length is None or chamber_area is None or pipe_area is None:
-        raise ValueError(
-            "A chamber drawing needs 'length', 'chamber_area' and 'pipe_area'."
-        )
+        msg = "A chamber drawing needs 'length', 'chamber_area' and 'pipe_area'."
+        raise ValueError(msg)
     if length <= 0.0:
         raise ValueError(_LENGTH_POSITIVE)
     _duct_diameter(pipe_area)
     _duct_diameter(chamber_area)
     if chamber_area <= pipe_area:
-        raise ValueError("'chamber_area' must exceed 'pipe_area'.")
+        msg = "'chamber_area' must exceed 'pipe_area'."
+        raise ValueError(msg)
     if inlet_extension + outlet_extension > length:
-        raise ValueError(
-            "'inlet_extension' + 'outlet_extension' must not exceed 'length'."
-        )
+        msg = "'inlet_extension' + 'outlet_extension' must not exceed 'length'."
+        raise ValueError(msg)
 
 
 def _validate_branch_geometry(
@@ -409,20 +412,24 @@ def _validate_branch_geometry(
 ) -> None:
     """Side-branch parameter validation, before any figure exists."""
     if duct_area is None:
-        raise ValueError("A side-branch drawing needs 'duct_area'.")
+        msg = "A side-branch drawing needs 'duct_area'."
+        raise ValueError(msg)
     _duct_diameter(duct_area)
     if kind == _KIND_HELMHOLTZ:
         if neck_area is None or neck_length is None or cavity_volume is None:
-            raise ValueError(
+            msg = (
                 "A Helmholtz resonator drawing needs 'neck_area', "
                 "'neck_length' and 'cavity_volume'."
             )
+            raise ValueError(msg)
         if neck_length <= 0.0 or cavity_volume <= 0.0:
-            raise ValueError("'cavity_volume' and 'neck_length' must be positive.")
+            msg = "'cavity_volume' and 'neck_length' must be positive."
+            raise ValueError(msg)
         _duct_diameter(neck_area)
         return
     if length is None or branch_area is None:
-        raise ValueError("A quarter-wave drawing needs 'length' and 'branch_area'.")
+        msg = "A quarter-wave drawing needs 'length' and 'branch_area'."
+        raise ValueError(msg)
     if length <= 0.0:
         raise ValueError(_LENGTH_POSITIVE)
     _duct_diameter(branch_area)
@@ -471,9 +478,8 @@ def plot_silencer_geometry(
     """
     _check_language(language)
     if kind not in _SILENCER_KINDS:
-        raise ValueError(
-            f"Unknown silencer kind {kind!r}; expected one of {_SILENCER_KINDS}."
-        )
+        msg = f"Unknown silencer kind {kind!r}; expected one of {_SILENCER_KINDS}."
+        raise ValueError(msg)
     chamber = kind in (_KIND_EXPANSION, _KIND_EXTENDED)
     if chamber:
         _validate_chamber_geometry(
@@ -539,10 +545,11 @@ def plot_silencer_result_geometry(
     if result.chain is not None:
         return plot_silencer_chain_geometry(result.chain, ax=ax, language=language)
     if result.geometry is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its geometry; call "
             "plot_silencer_geometry(kind, ...) with the original arguments."
         )
+        raise ValueError(msg)
     return plot_silencer_geometry(
         result.kind,
         ax=ax,
@@ -801,11 +808,12 @@ def plot_silencer_chain_geometry(
     _check_language(language)
     segments, branches, total = _chain_layout(chain.elements)
     if not segments:
-        raise ValueError(
+        msg = (
             "This chain has no duct of positive length, so it declares no "
             "geometry to draw: a shunt element holds an impedance and no "
             "shape. Add the duct runs its branches sit on."
         )
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     d_max = max(_duct_diameter(area) for _, _, area in segments)
@@ -858,11 +866,11 @@ def plot_plenum_geometry(
 
     _check_language(language)
     if exit_area <= 0.0 or line_of_sight <= 0.0 or wall_area <= 0.0:
-        raise ValueError(
-            "'exit_area', 'line_of_sight' and 'wall_area' must be positive."
-        )
+        msg = "'exit_area', 'line_of_sight' and 'wall_area' must be positive."
+        raise ValueError(msg)
     if not 0.0 <= angle < 0.5 * np.pi:
-        raise ValueError("'angle' must be in [0, pi/2).")
+        msg = "'angle' must be in [0, pi/2)."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     r = float(line_of_sight)

--- a/src/phonometry/_plot/geometry/room.py
+++ b/src/phonometry/_plot/geometry/room.py
@@ -103,7 +103,8 @@ def plot_image_source_geometry(
 
     order_cap = min(int(result.max_order), 3) if max_order is None else int(max_order)
     if order_cap < 1:
-        raise ValueError("'max_order' must be >= 1.")
+        msg = "'max_order' must be >= 1."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     lx, ly = float(result.dimensions[0]), float(result.dimensions[1])
@@ -212,7 +213,8 @@ def plot_open_plan_geometry(
     _check_language(language)
     pos = np.sort(np.asarray(positions, dtype=np.float64).ravel())
     if pos.size < 2 or np.any(pos <= 0.0):
-        raise ValueError("'positions' needs at least two positive distances.")
+        msg = "'positions' needs at least two positive distances."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     span = float(pos.max())
@@ -293,10 +295,11 @@ def plot_open_plan_result_geometry(
 ) -> Axes:
     """Measurement-line drawing for a result that retained its positions."""
     if result.positions_m is None:
-        raise ValueError(
+        msg = (
             "This result does not retain its microphone positions; call "
             "plot_open_plan_geometry(positions)."
         )
+        raise ValueError(msg)
     return plot_open_plan_geometry(
         result.positions_m,
         ax=ax,

--- a/src/phonometry/_plot/geometry/simulation.py
+++ b/src/phonometry/_plot/geometry/simulation.py
@@ -143,7 +143,8 @@ def plot_fdtd_domain(
     if probes is not None:
         pts = np.asarray(probes, dtype=np.float64)
         if pts.ndim != 2 or pts.shape[1] != 2:
-            raise ValueError("'probes' must have shape (N, 2).")
+            msg = "'probes' must have shape (N, 2)."
+            raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     ny, nx = sim.p.shape

--- a/src/phonometry/_plot/geometry/vibration.py
+++ b/src/phonometry/_plot/geometry/vibration.py
@@ -79,9 +79,11 @@ def plot_junction_geometry(
     """
     _check_language(language)
     if junction not in ("L", "T1", "T2", "X"):
-        raise ValueError("'junction' must be 'L', 'T1', 'T2' or 'X'.")
+        msg = "'junction' must be 'L', 'T1', 'T2' or 'X'."
+        raise ValueError(msg)
     if thickness1 <= 0.0 or thickness2 <= 0.0:
-        raise ValueError("Thicknesses must be positive.")
+        msg = "Thicknesses must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     h1, h2 = float(thickness1), float(thickness2)
@@ -122,10 +124,11 @@ def plot_junction_result_geometry(
 ) -> Axes:
     """Junction drawing for a result that retained its thicknesses."""
     if result.thickness1 is None or result.thickness2 is None:
-        raise ValueError(
+        msg = (
             "This result does not retain the plate thicknesses; call "
             "plot_junction_geometry(junction, thickness1, thickness2)."
         )
+        raise ValueError(msg)
     return plot_junction_geometry(
         result.junction,
         result.thickness1,
@@ -162,7 +165,8 @@ def plot_plate_geometry(
     """
     _check_language(language)
     if length_x <= 0.0 or length_y <= 0.0:
-        raise ValueError("'length_x' and 'length_y' must be positive.")
+        msg = "'length_x' and 'length_y' must be positive."
+        raise ValueError(msg)
     if ax is None:
         ax = _new_axes()
     a, b = float(length_x), float(length_y)

--- a/src/phonometry/_plot/hearing.py
+++ b/src/phonometry/_plot/hearing.py
@@ -261,10 +261,11 @@ def plot_occupational_exposure(
     from .._i18n import format_number, localize_axes
 
     if not result.tasks:
-        raise ValueError(
+        msg = (
             "plot() needs per-task contributions; only task_based_exposure() "
             "results carry them (the job/full-day strategies do not)."
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     contributions = [t.lex_8h_contribution for t in result.tasks]
     labels = [t.label for t in result.tasks]

--- a/src/phonometry/_plot/io.py
+++ b/src/phonometry/_plot/io.py
@@ -45,11 +45,12 @@ def _db_waveform(y: np.ndarray, calibrated: bool) -> np.ndarray:
         have no reference to count decibels from.
     """
     if not calibrated:
-        raise ValueError(
+        msg = (
             "scale='db' needs a calibrated Signal: without a "
             "calibration_factor the samples are digital full-scale units "
             "and there is no reference to count decibels from"
         )
+        raise ValueError(msg)
     # Deferred, not tidiness: signals.levels imports io, so reaching for
     # the reference pressure at module level here is an import cycle that
     # takes down `import phonometry` outright.
@@ -124,7 +125,8 @@ def plot_signal(
     from .._i18n import localize_axes
 
     if scale not in ("linear", "db"):
-        raise ValueError(f"scale must be 'linear' or 'db'; got {scale!r}")
+        msg = f"scale must be 'linear' or 'db'; got {scale!r}"
+        raise ValueError(msg)
 
     factor = result.calibration_factor
     calibrated = factor is not None

--- a/src/phonometry/_plot/materials.py
+++ b/src/phonometry/_plot/materials.py
@@ -642,10 +642,11 @@ def plot_absorption_uncertainty(
     :raises ValueError: The result is a single-number quantity (no bands).
     """
     if result.frequencies.size == 0:
-        raise ValueError(
+        msg = (
             "plot() needs a per-band result; single-number quantities "
             "(alpha_w, DLalpha) have no spectrum to plot."
         )
+        raise ValueError(msg)
     from .._i18n import decimal_comma, localize_axes
 
     ax = ax if ax is not None else _new_axes()

--- a/src/phonometry/_plot/metrology.py
+++ b/src/phonometry/_plot/metrology.py
@@ -150,10 +150,11 @@ def plot_monte_carlo(
     from .._i18n import decimal_comma, fmt_minus, localize_axes
 
     if result.samples is None:
-        raise ValueError(
+        msg = (
             "plot() needs the Monte Carlo output samples; call "
             "monte_carlo(..., keep_samples=True) to retain them."
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     samples = np.asarray(result.samples, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY_LIGHT)
@@ -401,7 +402,8 @@ def plot_peak_statistics(
         ax.set_title(_t("Peak-height distribution (Bendat & Piersol 5.5.4)", language))
     peaks = result.peak_values
     if peaks.size == 0:
-        raise ValueError("The record has no local maxima to plot.")
+        msg = "The record has no local maxima to plot."
+        raise ValueError(msg)
     exceedance = 1.0 - np.arange(1, peaks.size + 1) / peaks.size
     z = np.linspace(float(peaks[0]), float(peaks[-1]), 400)
     ax.plot(

--- a/src/phonometry/_plot/psychoacoustics.py
+++ b/src/phonometry/_plot/psychoacoustics.py
@@ -206,10 +206,11 @@ def plot_zwicker_loudness_time(
     from .._i18n import format_number, localize_axes
 
     if result.time is None or result.loudness_vs_time is None:
-        raise ValueError(
+        msg = (
             "plot_zwicker_loudness_time() needs a time-varying result with "
             "'time' and 'loudness_vs_time'."
         )
+        raise ValueError(msg)
     ax_time = ax if ax is not None else _new_axes()
     time = np.asarray(result.time, dtype=np.float64)
     lvt = np.asarray(result.loudness_vs_time, dtype=np.float64)

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -321,7 +321,8 @@ def plot_impulse_response(
     h = np.asarray(result.ir, dtype=np.float64)
     n = h.shape[-1]
     if n == 0:
-        raise ValueError("impulse response is empty; nothing to plot.")
+        msg = "impulse response is empty; nothing to plot."
+        raise ValueError(msg)
     time, xlabel = _time_axis(n, result.fs, language=language)
     peak = float(np.max(np.abs(h)))
     tiny = np.finfo(np.float64).tiny
@@ -600,11 +601,12 @@ def plot_open_plan(
         (``d2s`` / ``lp_as_4m`` are NaN).
     """
     if not (np.isfinite(result.d2s) and np.isfinite(result.lp_as_4m)):
-        raise ValueError(
+        msg = (
             "plot() needs the spatial-decay regression; this result's d2s / "
             "lp_as_4m are NaN (fewer than two positions in the 2 m to 16 m "
             "range)."
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     import matplotlib.ticker as mticker
 
@@ -696,7 +698,8 @@ def plot_excitation(
     x = np.asarray(signal, dtype=np.float64)
     n = x.shape[-1]
     if n == 0:
-        raise ValueError("excitation signal is empty; nothing to plot.")
+        msg = "excitation signal is empty; nothing to plot."
+        raise ValueError(msg)
     t = np.arange(n) / float(fs)
     color = kwargs.pop("color", _C_PRIMARY)
 

--- a/src/phonometry/_plot/simulation.py
+++ b/src/phonometry/_plot/simulation.py
@@ -248,10 +248,11 @@ def plot_fdtd_snapshot(
     :raises ValueError: If the result holds no snapshots.
     """
     if result.snapshots is None or result.snapshot_times is None:
-        raise ValueError(
+        msg = (
             "the result holds no snapshots; rerun the "
             "simulation with snapshot_every set"
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     t_txt = _snapshot_time_text(result.snapshot_times, frame, language)
     return _render_snapshot(
@@ -361,10 +362,11 @@ def plot_elastic_snapshot(
     :raises ValueError: If the result holds no snapshots.
     """
     if result.snapshots is None or result.snapshot_times is None:
-        raise ValueError(
+        msg = (
             "the result holds no snapshots; rerun the "
             "simulation with snapshot_every set"
         )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     t_txt = _snapshot_time_text(result.snapshot_times, frame, language)
     return _render_snapshot(

--- a/src/phonometry/_plot/vibration.py
+++ b/src/phonometry/_plot/vibration.py
@@ -902,7 +902,8 @@ def plot_fault_frequencies(
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     if freqs.size == 0:
-        raise ValueError("the result carries no fault lines to plot.")
+        msg = "the result carries no fault lines to plot."
+        raise ValueError(msg)
 
     f_max = max_frequency
     spectrum_f = spectrum_a = None

--- a/src/phonometry/_report/_insulation_fiche.py
+++ b/src/phonometry/_report/_insulation_fiche.py
@@ -258,18 +258,18 @@ def render_insulation_fiche(
     # result, and it must carry the per-band arrays the table and plot consume
     # (np.asarray(None) would otherwise yield a 0-d array and crash the table).
     if rating.quantity != ("impact" if is_impact else "airborne"):
-        raise ValueError(
-            "The ISO 717 rating quantity does not match the reported result."
-        )
+        msg = "The ISO 717 rating quantity does not match the reported result."
+        raise ValueError(msg)
     if (
         rating.band_centers is None
         or rating.measured is None
         or rating.shifted_reference is None
     ):
-        raise ValueError(
+        msg = (
             "The report needs the ISO 717 per-band rating data ('band_centers', "
             "'measured' and 'shifted_reference') on the rating."
         )
+        raise ValueError(msg)
 
     rating_symbol = spec["rating_symbol"]
     curve = np.asarray(getattr(result, curve_attr), dtype=np.float64)
@@ -277,11 +277,12 @@ def render_insulation_fiche(
     measured = np.asarray(rating.measured, dtype=np.float64)
     shifted = np.asarray(rating.shifted_reference, dtype=np.float64)
     if not (curve.shape == centers.shape == measured.shape == shifted.shape):
-        raise ValueError(
+        msg = (
             "The report needs matching per-band lengths: the rating's "
             "'band_centers', 'measured' and 'shifted_reference' and the "
             "result's per-band curve must all have the same length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title_text = t(spec["title"], language)

--- a/src/phonometry/_report/_layout.py
+++ b/src/phonometry/_report/_layout.py
@@ -275,7 +275,8 @@ def render_figure_drawing(
         if os.path.exists(svg_path):
             os.remove(svg_path)
     if drawing is None or not drawing.width:
-        raise ValueError("Could not convert the report plot to vector graphics.")
+        msg = "Could not convert the report plot to vector graphics."
+        raise ValueError(msg)
     scale = target_width / drawing.width
     drawing.scale(scale, scale)
     drawing.width = drawing.width * scale

--- a/src/phonometry/_report/_sound_power_fiche.py
+++ b/src/phonometry/_report/_sound_power_fiche.py
@@ -173,12 +173,13 @@ def headline_level(result: Any, level_a: float | None = None) -> float:
     """
     if level_a is not None:
         if not math.isfinite(float(level_a)):
-            raise ValueError(
+            msg = (
                 "the screened A-weighted level is not defined: no band "
                 "survived the qualification, so there is no determination to "
                 "report. Re-run the measurement rather than reporting the "
                 "total over the bands the criteria rejected."
             )
+            raise ValueError(msg)
         return float(level_a)
     lwa = float(result.sound_power_level_a)
     return lwa if math.isfinite(lwa) else total_power_level(result)

--- a/src/phonometry/_report/broadcast.py
+++ b/src/phonometry/_report/broadcast.py
@@ -255,10 +255,11 @@ def render_program_loudness_report(
     """
     del verbose  # uniform signature; the fiche has one stacked body layout
     if tolerance not in _TOLERANCES_LU:
-        raise ValueError(
+        msg = (
             f"Unknown tolerance rule {tolerance!r}; use 'qc' (+-0.2 LU, EBU "
             "R 128 item i) or 'live' (+-1.0 LU, item h)."
         )
+        raise ValueError(msg)
     tolerance_lu = _TOLERANCES_LU[tolerance]
     try:
         from reportlab.lib import colors

--- a/src/phonometry/_report/iec60268_5.py
+++ b/src/phonometry/_report/iec60268_5.py
@@ -217,7 +217,8 @@ def _drawing_from_figure(fig: Any, target_width: float, language: str = "en") ->
         if os.path.exists(svg_path):
             os.remove(svg_path)
     if drawing is None or not drawing.width:
-        raise ValueError("Could not convert the report plot to vector graphics.")
+        msg = "Could not convert the report plot to vector graphics."
+        raise ValueError(msg)
     scale = target_width / drawing.width
     drawing.scale(scale, scale)
     drawing.width = drawing.width * scale

--- a/src/phonometry/_report/iec61043.py
+++ b/src/phonometry/_report/iec61043.py
@@ -357,10 +357,11 @@ def render_iec61043_report(
         flow.append(fiche_paragraph(t(strip, language), strip_style))
     if metadata is not None and metadata.required_class is not None:
         if metadata.required_class not in (1, 2):
-            raise ValueError(
+            msg = (
                 f"required_class={metadata.required_class} is not an IEC 61043 "
                 "residual-index class; the standard defines classes 1 and 2."
             )
+            raise ValueError(msg)
         text, passed = _verdict(result, metadata.required_class, language)
         flow.extend(verdict_flow(text, passed, styles, language))
     flow.extend(footer_flow(metadata, language))

--- a/src/phonometry/_report/iec61260.py
+++ b/src/phonometry/_report/iec61260.py
@@ -291,12 +291,13 @@ def render_iec61260_report(
         )
     if metadata is not None and metadata.required_class is not None:
         if metadata.required_class not in result.available_classes():
-            raise ValueError(
+            msg = (
                 f"required_class={metadata.required_class} does not exist in "
                 f"the {result.edition} edition this result was verified "
                 f"against (available classes: {result.available_classes()}); "
                 "class 0 requires edition='1995'."
             )
+            raise ValueError(msg)
         text, passed = _verdict(result, metadata.required_class, language)
         flow.extend(verdict_flow(text, passed, styles, language))
     flow.extend(footer_flow(metadata, language))

--- a/src/phonometry/_report/iso10534.py
+++ b/src/phonometry/_report/iso10534.py
@@ -324,10 +324,11 @@ def render_iso10534_report(
     freqs = np.asarray(result.frequency, dtype=np.float64)
     alpha = np.asarray(result.absorption, dtype=np.float64)
     if freqs.shape != alpha.shape:
-        raise ValueError(
+        msg = (
             "render_iso10534_report() needs 'frequency' and 'absorption' of "
             "equal length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Impedance-tube sound absorption and impedance", language)

--- a/src/phonometry/_report/iso10848.py
+++ b/src/phonometry/_report/iso10848.py
@@ -93,10 +93,11 @@ def _part_designation(part: int) -> str:
     try:
         return _PART_DESIGNATIONS[int(part)]
     except (KeyError, ValueError) as exc:
-        raise ValueError(
+        msg = (
             "'part' must be 2, 3 or 4 (the ISO 10848 part governing the "
             f"tested construction); got {part!r}."
-        ) from exc
+        )
+        raise ValueError(msg) from exc
 
 
 def _dnf_spec(standard: str, language: str) -> dict[str, str]:
@@ -158,10 +159,11 @@ def _require_rating(
     renderer.
     """
     if rating is None:
-        raise ValueError(
+        msg = (
             "The flanking-descriptor report needs its ISO 717 single-number "
             "rating (16 one-third-octave or 5 octave bands)."
         )
+        raise ValueError(msg)
     return rating
 
 
@@ -411,10 +413,11 @@ def render_vibration_reduction_report(
         installed.
     """
     if result.frequencies is None:
-        raise ValueError(
+        msg = (
             "The Kij report needs the band centre frequencies; build the result "
             "with vibration_reduction_index(..., frequency=...)."
         )
+        raise ValueError(msg)
     try:
         from reportlab.lib import colors
         from reportlab.lib.styles import ParagraphStyle

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -337,10 +337,11 @@ def render_iso11654_report(
     measured = np.asarray(result.measured, dtype=np.float64)
     shifted = np.asarray(result.shifted_reference, dtype=np.float64)
     if not centers.shape == measured.shape == shifted.shape:
-        raise ValueError(
+        msg = (
             "render_iso11654_report() needs 'band_centers', 'measured' and "
             "'shifted_reference' of equal length."
         )
+        raise ValueError(msg)
     # Unfavourable deviation: measured practical coefficient below the curve.
     deviations = np.maximum(shifted - measured, 0.0)
 

--- a/src/phonometry/_report/iso12354.py
+++ b/src/phonometry/_report/iso12354.py
@@ -411,11 +411,12 @@ def _detailed_path_rows(
 def _detailed_rating(result: Any) -> Any:
     """Return the result's ISO 717 rating, refusing an unrated spectrum."""
     if result.rating is None:
-        raise ValueError(
+        msg = (
             "A detailed prediction report needs the ISO 717 single-number "
             "rating: build the result on bands covering 100 Hz to 3150 Hz "
             "(one-third octave) or 125 Hz to 2000 Hz (octave)."
         )
+        raise ValueError(msg)
     return result.rating
 
 
@@ -562,12 +563,13 @@ def render_iso12354_facade_report(
         installed.
     """
     if result.d_2m_nt_w is None or result.r_tr_s_w is None or result.c_tr is None:
-        raise ValueError(
+        msg = (
             "A facade prediction report needs the ISO 717-1 single-number "
             "ratings: build the result on the 5 octave or 16 one-third-octave "
             "bands (pass matching per-band element data and 'bands' to "
             "facade_sound_reduction)."
         )
+        raise ValueError(msg)
     from ..building.measurement.insulation import weighted_rating
 
     shares = _facade_energy_shares(result) if verbose else {}

--- a/src/phonometry/_report/iso15186.py
+++ b/src/phonometry/_report/iso15186.py
@@ -106,12 +106,14 @@ def _qualification_columns(
             continue
         arr = np.asarray(values, dtype=np.float64)
         if arr.shape != (n_bands,):
-            raise ValueError(
+            msg = (
                 f"'{name}' must carry one value per reported band "
                 f"({n_bands}); got shape {arr.shape}."
             )
+            raise ValueError(msg)
         if not np.all(np.isfinite(arr)):
-            raise ValueError(f"'{name}' must contain only finite values.")
+            msg = f"'{name}' must contain only finite values."
+            raise ValueError(msg)
         columns.append((header, arr, 1))
     return columns
 

--- a/src/phonometry/_report/iso16251.py
+++ b/src/phonometry/_report/iso16251.py
@@ -349,10 +349,11 @@ def render_iso16251_report(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     delta_l = np.asarray(result.improvement, dtype=np.float64)
     if freqs.shape != delta_l.shape:
-        raise ValueError(
+        msg = (
             "render_iso16251_report() needs 'frequencies' and 'improvement' of "
             "equal length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Floor-covering impact sound improvement", language)

--- a/src/phonometry/_report/iso17497.py
+++ b/src/phonometry/_report/iso17497.py
@@ -292,10 +292,11 @@ def render_scattering_report(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     s = np.asarray(result.scattering, dtype=np.float64)
     if freqs.shape != s.shape:
-        raise ValueError(
+        msg = (
             "render_scattering_report() needs 'frequencies' and 'scattering' "
             "of equal length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Surface scattering measurement", language)
@@ -436,10 +437,11 @@ def render_diffusion_spectrum_report(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     d = np.asarray(result.diffusion, dtype=np.float64)
     if freqs.shape != d.shape:
-        raise ValueError(
+        msg = (
             "render_diffusion_spectrum_report() needs 'frequencies' and "
             "'diffusion' of equal length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Surface diffusion measurement", language)
@@ -550,10 +552,11 @@ def render_diffusion_polar_report(
     angles = np.asarray(result.angles, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
     if angles.shape != levels.shape:
-        raise ValueError(
+        msg = (
             "render_diffusion_polar_report() needs 'angles' and 'levels' of "
             "equal length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Surface diffusion measurement", language)

--- a/src/phonometry/_report/iso354.py
+++ b/src/phonometry/_report/iso354.py
@@ -233,9 +233,10 @@ def render_iso354_report(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     alpha_s = np.asarray(result.alpha_s, dtype=np.float64)
     if freqs.shape != alpha_s.shape:
-        raise ValueError(
+        msg = (
             "render_iso354_report() needs 'frequencies' and 'alpha_s' of equal length."
         )
+        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Sound absorption measurement", language)

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -89,11 +89,12 @@ def _symbol_markup(symbol: str) -> str:
     """
     match = _SYMBOL_RE.match(symbol)
     if match is None:
-        raise ValueError(
+        msg = (
             f"Invalid ISO 717 quantity symbol {symbol!r}; expected a leading "
             "capital letter (optionally primed) followed by its subscript, "
             "e.g. 'Rw', 'R'w', 'DnT,w', 'L'nT,w'."
         )
+        raise ValueError(msg)
     stem, subscript = match.groups()
     return f"{stem}<sub>{subscript}</sub>"
 
@@ -394,18 +395,20 @@ def _validated_curves(
     measured = result.measured
     shifted = result.shifted_reference
     if centers is None or measured is None or shifted is None:
-        raise ValueError(
+        msg = (
             "render_iso717_report() needs 'band_centers', 'measured' and "
             "'shifted_reference' on the result."
         )
+        raise ValueError(msg)
     centers = np.asarray(centers, dtype=np.float64)
     measured = np.asarray(measured, dtype=np.float64)
     shifted = np.asarray(shifted, dtype=np.float64)
     if not centers.shape == measured.shape == shifted.shape:
-        raise ValueError(
+        msg = (
             "render_iso717_report() needs 'band_centers', 'measured' and "
             "'shifted_reference' of equal length."
         )
+        raise ValueError(msg)
 
     # Unfavourable deviation: reference above measurement (airborne) or
     # measurement above the reference (impact, the opposite sign).

--- a/src/phonometry/_report/iso9613.py
+++ b/src/phonometry/_report/iso9613.py
@@ -308,10 +308,11 @@ def _resolve_levels(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     lw = np.atleast_1d(np.asarray(emission.sound_power_level, dtype=np.float64))
     if lw.shape != freqs.shape:
-        raise ValueError(
+        msg = (
             "source_emission.sound_power_level must have one value per frequency "
             f"band (got {lw.size}, expected {freqs.size})."
         )
+        raise ValueError(msg)
     receiver = _compose_receiver_level(
         lw,
         emission.directivity_index,

--- a/src/phonometry/_report/metadata.py
+++ b/src/phonometry/_report/metadata.py
@@ -207,10 +207,11 @@ class ReportMetadata:
         if value is None:
             return
         if not ok(float(value)):
-            raise ValueError(
+            msg = (
                 f"ReportMetadata.{name} must be {description} when given; "
                 f"got {value!r}."
             )
+            raise ValueError(msg)
 
     def __post_init__(self) -> None:
         """Validate the supplied numeric fields by physical range."""
@@ -236,24 +237,27 @@ class ReportMetadata:
             # (a bool is an int in Python, so it is excluded explicitly) and
             # anything not strictly positive.
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-                raise ValueError(
+                msg = (
                     f"ReportMetadata.{name} must be a positive integer when "
                     f"given; got {value!r}."
                 )
+                raise ValueError(msg)
         if self.required_class is not None and self.required_class not in (0, 1, 2):
-            raise ValueError(
+            msg = (
                 "ReportMetadata.required_class must be 0, 1 or 2 when given; "
                 f"got {self.required_class!r}."
             )
+            raise ValueError(msg)
         if self.tube_shape is not None and self.tube_shape not in (
             "circular",
             "rectangular",
             "square",
         ):
-            raise ValueError(
+            msg = (
                 "ReportMetadata.tube_shape must be 'circular', 'rectangular' "
                 f"or 'square' when given; got {self.tube_shape!r}."
             )
+            raise ValueError(msg)
 
     def is_empty(self) -> bool:
         """Return ``True`` when no field is set (an all-``None`` instance)."""

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -64,7 +64,8 @@ def lateral_attenuation(elevation_deg: float, lateral_m: float) -> float:
     ell = float(lateral_m)
     beta = float(elevation_deg)
     if not np.isfinite(ell) or ell < 0.0 or not np.isfinite(beta):
-        raise ValueError("'lateral_m' must be non-negative and inputs finite.")
+        msg = "'lateral_m' must be non-negative and inputs finite."
+        raise ValueError(msg)
     gamma = 1.089 * (1.0 - np.exp(-0.00274 * ell)) if ell <= 914.0 else 1.0
     if beta < 0.0:
         lam = 10.857
@@ -87,14 +88,14 @@ def engine_installation_correction(
     """
     phi = float(depression_deg)
     if not np.isfinite(phi):
-        raise ValueError("'depression_deg' must be finite.")
+        msg = "'depression_deg' must be finite."
+        raise ValueError(msg)
     key = mounting.strip().lower()
     if key in ("propeller", "prop"):
         return 0.0
     if key not in _INSTALLATION:
-        raise ValueError(
-            f"'mounting' must be 'wing', 'fuselage' or 'propeller', got {mounting!r}."
-        )
+        msg = f"'mounting' must be 'wing', 'fuselage' or 'propeller', got {mounting!r}."
+        raise ValueError(msg)
     a, b, c = _INSTALLATION[key]
     phi_eff = np.radians(max(phi, 0.0))  # for φ<0, ΔI(φ)=ΔI(0)
     num = (a * np.cos(phi_eff) ** 2 + np.sin(phi_eff) ** 2) ** b
@@ -115,7 +116,8 @@ def duration_correction(reference_speed: float, segment_speed: float) -> float:
     vref = float(reference_speed)
     vseg = float(segment_speed)
     if not (np.isfinite(vref) and vref > 0.0 and np.isfinite(vseg) and vseg > 0.0):
-        raise ValueError("'reference_speed' and 'segment_speed' must be positive.")
+        msg = "'reference_speed' and 'segment_speed' must be positive."
+        raise ValueError(msg)
     return float(10.0 * np.log10(vref / vseg))
 
 
@@ -135,7 +137,8 @@ def noise_fraction(q: float, segment_length: float, scaled_distance: float) -> f
     lam = float(segment_length)
     dl = float(scaled_distance)
     if not (np.isfinite(lam) and lam > 0.0 and np.isfinite(dl) and dl > 0.0):
-        raise ValueError("'segment_length' and 'scaled_distance' must be positive.")
+        msg = "'segment_length' and 'scaled_distance' must be positive."
+        raise ValueError(msg)
     # Relative distances from the perpendicular foot Sp to the segment ends,
     # scaled by dλ: to the start S1 (−q) and to the end S2 (λ−q). The full
     # infinite path (α1→−∞, α2→+∞) then gives F=1, i.e. ΔF=0.
@@ -179,9 +182,11 @@ def impedance_adjustment(
     t = float(temperature)
     p = float(pressure)
     if not (np.isfinite(t) and np.isfinite(p) and p > 0.0):
-        raise ValueError("'pressure' must be positive and inputs finite.")
+        msg = "'pressure' must be positive and inputs finite."
+        raise ValueError(msg)
     if t <= -273.15:
-        raise ValueError("'temperature' must be above absolute zero (−273.15 °C).")
+        msg = "'temperature' must be above absolute zero (−273.15 °C)."
+        raise ValueError(msg)
     delta = p / _P0_KPA
     theta = (t + 273.15) / (_T0_C + 273.15)
     zc = _ZC_STD * delta / np.sqrt(theta)
@@ -247,10 +252,12 @@ def start_of_roll_directivity(
     psi = float(azimuth_deg)
     dsor = float(distance_m)
     if not (np.isfinite(psi) and np.isfinite(dsor) and dsor > 0.0):
-        raise ValueError("'distance_m' must be positive and inputs finite.")
+        msg = "'distance_m' must be positive and inputs finite."
+        raise ValueError(msg)
     key = engine.strip().lower()
     if key not in ("jet", "turbofan", "turboprop", "prop", "propeller"):
-        raise ValueError(f"'engine' must be 'jet' or 'turboprop', got {engine!r}.")
+        msg = f"'engine' must be 'jet' or 'turboprop', got {engine!r}."
+        raise ValueError(msg)
     if psi < 90.0:  # ahead of / abeam the aircraft: no rearward directivity
         return 0.0
     psi = min(psi, 180.0)
@@ -288,19 +295,25 @@ def _clean_table(
     d = np.asarray(distances, dtype=np.float64).ravel()
     lv = np.asarray(levels, dtype=np.float64)
     if p.size < 2 or d.size < 2:
-        raise ValueError("'powers' and 'distances' must each have at least two values.")
+        msg = "'powers' and 'distances' must each have at least two values."
+        raise ValueError(msg)
     if lv.shape != (p.size, d.size):
-        raise ValueError("'levels' must have shape (len(powers), len(distances)).")
+        msg = "'levels' must have shape (len(powers), len(distances))."
+        raise ValueError(msg)
     if not (
         np.all(np.isfinite(p)) and np.all(np.isfinite(d)) and np.all(np.isfinite(lv))
     ):
-        raise ValueError("'powers', 'distances' and 'levels' must be finite.")
+        msg = "'powers', 'distances' and 'levels' must be finite."
+        raise ValueError(msg)
     if np.any(d <= 0.0):
-        raise ValueError("'distances' must be strictly positive (slant range in m).")
+        msg = "'distances' must be strictly positive (slant range in m)."
+        raise ValueError(msg)
     if np.any(np.diff(p) <= 0.0):
-        raise ValueError("'powers' must be strictly increasing.")
+        msg = "'powers' must be strictly increasing."
+        raise ValueError(msg)
     if np.any(np.diff(d) <= 0.0):
-        raise ValueError("'distances' must be strictly increasing.")
+        msg = "'distances' must be strictly increasing."
+        raise ValueError(msg)
     return p, d, lv
 
 
@@ -369,10 +382,12 @@ def npd_level(
     p, d, lv = _clean_table(powers, distances, levels)
     dq = np.atleast_1d(np.asarray(distance, dtype=np.float64))
     if dq.size == 0 or not np.all(np.isfinite(dq)) or np.any(dq <= 0.0):
-        raise ValueError("'distance' must be finite and strictly positive.")
+        msg = "'distance' must be finite and strictly positive."
+        raise ValueError(msg)
     pq = float(power)
     if not np.isfinite(pq):
-        raise ValueError("'power' must be finite.")
+        msg = "'power' must be finite."
+        raise ValueError(msg)
 
     logd_tab = np.log10(d)
     logdq = np.log10(dq)
@@ -601,15 +616,17 @@ def _validate_path(
     """Coerce and validate a flight path to a finite ``(N, 5)`` array."""
     pts = np.asarray(path, dtype=np.float64)
     if pts.ndim != 2 or pts.shape[1] != 5 or pts.shape[0] < 2:
-        raise ValueError(
-            "'path' must have shape (N, 5) with N >= 2 (x,y,z,power,speed)."
-        )
+        msg = "'path' must have shape (N, 5) with N >= 2 (x,y,z,power,speed)."
+        raise ValueError(msg)
     if not np.all(np.isfinite(pts)):
-        raise ValueError("'path' must contain only finite values.")
+        msg = "'path' must contain only finite values."
+        raise ValueError(msg)
     if np.any(pts[:, 3] < 0.0):
-        raise ValueError("'path' power settings (column 4) must be non-negative.")
+        msg = "'path' power settings (column 4) must be non-negative."
+        raise ValueError(msg)
     if np.any(pts[:, 4] < 0.0):
-        raise ValueError("'path' speeds (column 5) must be non-negative.")
+        msg = "'path' speeds (column 5) must be non-negative."
+        raise ValueError(msg)
     return pts
 
 
@@ -622,9 +639,8 @@ def _validate_ground_roll(
         return None
     gr = np.asarray(ground_roll, dtype=bool).ravel()
     if gr.shape != (n_points - 1,):
-        raise ValueError(
-            f"'ground_roll' must have length {n_points - 1} (one per segment)."
-        )
+        msg = f"'ground_roll' must have length {n_points - 1} (one per segment)."
+        raise ValueError(msg)
     return gr
 
 
@@ -637,7 +653,8 @@ def _validate_bank(
         return None
     bk = np.asarray(bank, dtype=np.float64).ravel()
     if bk.shape != (n_points - 1,):
-        raise ValueError(f"'bank' must have length {n_points - 1} (one per segment).")
+        msg = f"'bank' must have length {n_points - 1} (one per segment)."
+        raise ValueError(msg)
     return bk
 
 
@@ -720,7 +737,8 @@ def _segment_speed(v1: float, v2: float, frac: float, on_roll: bool) -> float:
     else:
         v_seg = float(np.sqrt(max(v1**2 + frac * (v2**2 - v1**2), 0.0)))
     if v_seg <= 0.0:
-        raise ValueError("segment with zero mean speed (stationary segment in 'path').")
+        msg = "segment with zero mean speed (stationary segment in 'path')."
+        raise ValueError(msg)
     return v_seg
 
 
@@ -1102,7 +1120,8 @@ def _grid_segment_level(
     else:
         v_seg = np.sqrt(np.maximum(v1**2 + frac * (v2**2 - v1**2), 0.0))
     if np.any(v_seg <= 0.0):
-        raise ValueError("segment with zero mean speed (stationary segment in 'path').")
+        msg = "segment with zero mean speed (stationary segment in 'path')."
+        raise ValueError(msg)
     dv = 10.0 * np.log10(ctx.vref / v_seg)
     d_lambda = _D0_M * 10.0 ** ((le_d - lm_d) / 10.0)
     df = _grid_noise_fraction(q, length, d_lambda, roll_behind, roll_ahead)
@@ -1136,7 +1155,8 @@ def _grid_event_levels(
     mount_key = mounting.strip().lower()
     engine_installation_correction(0.0, mounting)  # validate 'mounting' once
     if not (np.isfinite(vref) and vref > 0.0):
-        raise ValueError("'reference_speed' must be positive.")
+        msg = "'reference_speed' must be positive."
+        raise ValueError(msg)
     ctx = _GridContext(
         obs,
         p,
@@ -1223,10 +1243,12 @@ def event_level(
     pts = _validate_path(path)
     obs = np.asarray(observer, dtype=np.float64).ravel()
     if obs.shape != (3,) or not np.all(np.isfinite(obs)):
-        raise ValueError("'observer' must be a finite (x, y, z) point.")
+        msg = "'observer' must be a finite (x, y, z) point."
+        raise ValueError(msg)
     key = metric.strip().lower()
     if key not in ("exposure", "maximum"):
-        raise ValueError("'metric' must be 'exposure' or 'maximum'.")
+        msg = "'metric' must be 'exposure' or 'maximum'."
+        raise ValueError(msg)
     gr = _validate_ground_roll(segments.ground_roll, pts.shape[0])
     lr = _validate_ground_roll(segments.landing_roll, pts.shape[0])
     bk = _validate_bank(segments.bank, pts.shape[0])
@@ -1305,12 +1327,14 @@ def noise_contour(
     gx = np.asarray(x, dtype=np.float64).ravel()
     gy = np.asarray(y, dtype=np.float64).ravel()
     if gx.size < 2 or gy.size < 2:
-        raise ValueError("'x' and 'y' must each have at least two grid points.")
+        msg = "'x' and 'y' must each have at least two grid points."
+        raise ValueError(msg)
     # Validate and clean the shared inputs once, not per grid point.
     pts = _validate_path(path)
     key = metric.strip().lower()
     if key not in ("exposure", "maximum"):
-        raise ValueError("'metric' must be 'exposure' or 'maximum'.")
+        msg = "'metric' must be 'exposure' or 'maximum'."
+        raise ValueError(msg)
     gr = _validate_ground_roll(segments.ground_roll, pts.shape[0])
     lr = _validate_ground_roll(segments.landing_roll, pts.shape[0])
     bk = _validate_bank(segments.bank, pts.shape[0])

--- a/src/phonometry/aircraft/anp_fleet.py
+++ b/src/phonometry/aircraft/anp_fleet.py
@@ -86,9 +86,10 @@ def _operation_code(operation: str) -> str:
     """Normalise an operation label to the ANP code ``"A"``/``"D"``."""
     key = str(operation).strip().lower()
     if key not in _OPERATION:
-        raise ValueError(
+        msg = (
             f"'operation' must be 'departure'/'D' or 'arrival'/'A', got {operation!r}."
         )
+        raise ValueError(msg)
     return _OPERATION[key]
 
 
@@ -108,14 +109,14 @@ def _pick(name: str, tables: Mapping[str, str]) -> str:
     """
     matches = [f for f in tables if name in f.lower()]
     if len(matches) > 1:
-        raise ValueError(
+        msg = (
             f"ambiguous ANP table for {name!r}: {sorted(matches)}. Keep a single "
             f"file per table in the export directory."
         )
+        raise ValueError(msg)
     if not matches:
-        raise FileNotFoundError(
-            f"no ANP table matching {name!r} found (looked in: {sorted(tables)})."
-        )
+        msg = f"no ANP table matching {name!r} found (looked in: {sorted(tables)})."
+        raise FileNotFoundError(msg)
     return tables[matches[0]]
 
 
@@ -127,10 +128,12 @@ def _distances_m(header: Iterable[str]) -> NDArray[np.float64]:
         if c.startswith("L_") and c.endswith("ft"):
             dist_ft.append(float(c[2:-2]))
     if len(dist_ft) < 2:
-        raise ValueError("NPD table has fewer than two 'L_<ft>ft' distance columns.")
+        msg = "NPD table has fewer than two 'L_<ft>ft' distance columns."
+        raise ValueError(msg)
     distances = np.asarray(dist_ft, dtype=np.float64) * _FT_M
     if np.any(np.diff(distances) <= 0.0):
-        raise ValueError("NPD 'L_<ft>ft' distance columns must be strictly increasing.")
+        msg = "NPD 'L_<ft>ft' distance columns must be strictly increasing."
+        raise ValueError(msg)
     distances.flags.writeable = False  # shared across every AnpNpdCurves
     return distances
 
@@ -335,10 +338,11 @@ class AnpDatabase:
         :raises KeyError: If the identifier is not in the database.
         """
         if aircraft_id not in self._aircraft:
-            raise KeyError(
+            msg = (
                 f"aircraft {aircraft_id!r} not in this ANP database "
                 f"(available: {self.aircraft_ids})."
             )
+            raise KeyError(msg)
         m = self._aircraft[aircraft_id]
         lat = m.get("Lateral Directivity Identifier", "").strip().lower()
         return AnpAircraft(
@@ -366,18 +370,21 @@ class AnpDatabase:
         :raises ValueError: If the metric or operation is unknown.
         """
         if metric not in _METRICS:
-            raise ValueError(f"'metric' must be one of {_METRICS}, got {metric!r}.")
+            msg = f"'metric' must be one of {_METRICS}, got {metric!r}."
+            raise ValueError(msg)
         op = _operation_code(operation)
         m = self._aircraft.get(aircraft_id)
         if m is None:
-            raise KeyError(f"aircraft {aircraft_id!r} not in this ANP database.")
+            msg = f"aircraft {aircraft_id!r} not in this ANP database."
+            raise KeyError(msg)
         npd_id = m.get("NPD_ID", "")
         key = (npd_id, metric, op)
         if key not in self._npd:
-            raise KeyError(
+            msg = (
                 f"no {metric} NPD data for aircraft {aircraft_id!r} "
                 f"(NPD_ID {npd_id!r}), operation {op!r}."
             )
+            raise KeyError(msg)
         powers, levels = self._npd[key]
         return AnpNpdCurves(
             aircraft_id=aircraft_id,
@@ -418,10 +425,11 @@ class AnpDatabase:
             exist with none of them named ``"DEFAULT"``.
         """
         if aircraft_id not in self._aircraft:
-            raise KeyError(
+            msg = (
                 f"aircraft {aircraft_id!r} not in this ANP database "
                 f"(available: {self.aircraft_ids})."
             )
+            raise KeyError(msg)
         op = _operation_code(operation)
         stage = int(stage_length)
         ids = sorted(
@@ -437,30 +445,33 @@ class AnpDatabase:
                     if a == aircraft_id and o == op
                 }
             )
-            raise KeyError(
+            msg = (
                 f"no fixed-point profile for aircraft {aircraft_id!r}, operation "
                 f"{op!r}, stage length {stage_length} (available stage lengths: "
                 f"{avail}). Aircraft with only procedural-step profiles are not "
                 f"supported by this bridge."
             )
+            raise KeyError(msg)
         if profile_id is not None:
             pid = str(profile_id)
             if pid not in ids:
-                raise KeyError(
+                msg = (
                     f"no fixed-point profile {pid!r} for aircraft "
                     f"{aircraft_id!r}, operation {op!r}, stage length "
                     f"{stage_length} (available profiles: {ids})."
                 )
+                raise KeyError(msg)
         elif "DEFAULT" in ids:
             pid = "DEFAULT"
         elif len(ids) == 1:
             pid = ids[0]
         else:
-            raise ValueError(
+            msg = (
                 f"aircraft {aircraft_id!r}, operation {op!r}, stage length "
                 f"{stage_length} has several fixed-point profiles and none is "
                 f"'DEFAULT': {ids}. Pass profile_id= to choose one."
             )
+            raise ValueError(msg)
         path = self._profiles[(aircraft_id, op, pid, stage)]
         # Ground-roll segments run along the runway: both endpoints at field
         # elevation. Tabulated ground points sit at exactly 0 m and the lowest
@@ -501,11 +512,12 @@ class AnpDatabase:
         # so the two metrics must share power settings. They always do in the ANP
         # database; this guards a malformed user-supplied export.
         if not np.array_equal(sel.powers, lmax.powers):
-            raise ValueError(
+            msg = (
                 f"SEL and LAmax NPD power settings differ for aircraft "
                 f"{aircraft_id!r}, operation {operation!r}: {sel.powers} vs "
                 f"{lmax.powers}."
             )
+            raise ValueError(msg)
         return acft, prof, sel.powers, sel.distances, sel.levels, lmax.levels
 
     def event_level(
@@ -614,10 +626,12 @@ def _read_tables(path: Path | str | None) -> dict[str, str]:
 
     directory = pathlib.Path(path)
     if not directory.is_dir():
-        raise NotADirectoryError(f"ANP database path {path!r} is not a directory.")
+        msg = f"ANP database path {path!r} is not a directory."
+        raise NotADirectoryError(msg)
     files_found = sorted(directory.glob("*.csv")) + sorted(directory.glob("*.CSV"))
     if not files_found:
-        raise FileNotFoundError(f"no .csv ANP tables found in {path!r}.")
+        msg = f"no .csv ANP tables found in {path!r}."
+        raise FileNotFoundError(msg)
     return {f.name: f.read_text(encoding="utf-8-sig") for f in files_found}
 
 
@@ -630,7 +644,8 @@ def _parse_npd(
     """Parse the NPD table into ``{(npd_id, metric, op): (powers, levels)}``."""
     rows = _rows(text)
     if not rows:
-        raise ValueError("empty NPD table.")
+        msg = "empty NPD table."
+        raise ValueError(msg)
     level_cols = [c for c in rows[0] if c.startswith("L_") and c.endswith("ft")]
     distances = _distances_m(rows[0].keys())
     grouped: dict[tuple[str, str, str], list[tuple[float, list[float]]]] = {}
@@ -689,12 +704,13 @@ def _parse_profiles(
         numbers = [p[0] for p in pts]
         if numbers != list(range(numbers[0], numbers[0] + len(numbers))):
             acft, op, pid, stage = key
-            raise ValueError(
+            msg = (
                 f"fixed-point profile for aircraft {acft!r}, operation {op!r}, "
                 f"profile {pid!r}, stage length {stage} has duplicate or "
                 f"non-consecutive point numbers {numbers}; the table is "
                 f"malformed."
             )
+            raise ValueError(msg)
         path = np.asarray([p[1] for p in pts], dtype=np.float64)
         path.flags.writeable = False  # exposed by reference on AnpProfile
         profiles[key] = path

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -105,9 +105,11 @@ _PNL_FACTOR = 10.0 / np.log10(2.0)
 def _validate_spectrum(spl: NDArray[np.float64] | list[float]) -> NDArray[np.float64]:
     sig = np.asarray(spl, dtype=np.float64)
     if sig.shape != (24,):
-        raise ValueError("'spl' must contain the 24 one-third-octave-band levels.")
+        msg = "'spl' must contain the 24 one-third-octave-band levels."
+        raise ValueError(msg)
     if not np.all(np.isfinite(sig)):
-        raise ValueError("'spl' must be finite.")
+        msg = "'spl' must be finite."
+        raise ValueError(msg)
     return sig
 
 
@@ -345,7 +347,8 @@ def tone_correction(
     :raises ValueError: If the spectrum is not 24 finite levels.
     """
     if not 0 <= int(start_band) <= 3:
-        raise ValueError("'start_band' must be between 0 (50 Hz) and 3 (100 Hz).")
+        msg = "'start_band' must be between 0 (50 Hz) and 3 (100 Hz)."
+        raise ValueError(msg)
     _, excess = _tone_background(spl, start=int(start_band))
     factors = [_tone_factor(float(excess[i]), float(NOY_BANDS[i])) for i in range(24)]
     return float(max(factors))
@@ -428,7 +431,8 @@ def epnl_from_pnlt(
     """
     p = np.atleast_1d(np.asarray(pnlt, dtype=np.float64))
     if p.ndim != 1 or p.size < 1 or not np.all(np.isfinite(p)):
-        raise ValueError("'pnlt' must be a non-empty finite 1-D sequence.")
+        msg = "'pnlt' must be a non-empty finite 1-D sequence."
+        raise ValueError(msg)
     dt_raw = np.asarray(dt, dtype=np.float64)
     dt_arr = (
         np.full(p.shape, float(dt_raw.reshape(-1)[0])) if dt_raw.size == 1 else dt_raw
@@ -438,18 +442,19 @@ def epnl_from_pnlt(
         or np.any(dt_arr <= 0.0)
         or not np.all(np.isfinite(dt_arr))
     ):
-        raise ValueError("'dt' must be positive and match 'pnlt' in length.")
+        msg = "'dt' must be positive and match 'pnlt' in length."
+        raise ValueError(msg)
     if reference_time <= 0.0 or not np.isfinite(reference_time):
-        raise ValueError("'reference_time' must be a positive, finite number.")
+        msg = "'reference_time' must be a positive, finite number."
+        raise ValueError(msg)
 
     km = int(np.argmax(p))
     delta_b = 0.0
     if tone_corrections is not None:
         c = np.atleast_1d(np.asarray(tone_corrections, dtype=np.float64))
         if c.shape != p.shape or not np.all(np.isfinite(c)):
-            raise ValueError(
-                "'tone_corrections' must match 'pnlt' in length and be finite."
-            )
+            msg = "'tone_corrections' must match 'pnlt' in length and be finite."
+            raise ValueError(msg)
         t_mid = np.cumsum(dt_arr) - 0.5 * dt_arr
         window = c[np.abs(t_mid - t_mid[km]) <= 1.0 + 1e-9]
         delta_b = max(0.0, float(np.mean(window)) - float(c[km]))
@@ -542,9 +547,8 @@ class EPNLResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.annex16_epnl import render_annex16_epnl_report
 
         return render_annex16_epnl_report(
@@ -586,16 +590,19 @@ def effective_perceived_noise_level(
     """
     arr = np.asarray(spectra, dtype=np.float64)
     if arr.ndim != 2 or arr.shape[1] != 24 or arr.shape[0] < 1:
-        raise ValueError("'spectra' must have shape (K, 24).")
+        msg = "'spectra' must have shape (K, 24)."
+        raise ValueError(msg)
     if not np.all(np.isfinite(arr)):
-        raise ValueError("'spectra' must be finite.")
+        msg = "'spectra' must be finite."
+        raise ValueError(msg)
     start_band = _PROCEDURE_START_BAND.get(procedure)
     if start_band is None:
-        raise ValueError(
+        msg = (
             f"Unknown procedure {procedure!r}; use 'aeroplane' (tone "
             "correction from 80 Hz) or 'helicopter' (from 50 Hz, ICAO "
             "Annex 16 Vol I App. 2 4.3.1 Step 1)."
         )
+        raise ValueError(msg)
 
     pnl = np.array([perceived_noise_level(row) for row in arr])
     corr = np.array([tone_correction(row, start_band=start_band) for row in arr])

--- a/src/phonometry/aircraft/measurement_system.py
+++ b/src/phonometry/aircraft/measurement_system.py
@@ -59,12 +59,14 @@ def _iec61265_directional_limit(frequency: float, angle: float) -> float:
         None,
     )
     if row is None:
-        raise ValueError(
+        msg = (
             "'frequency' is not an IEC 61265 tabulated one-third-octave band "
             "(50 Hz-1.6 kHz, then 2, 2.5, 3.15, 4, 5, 6.3, 8, 10 kHz)."
         )
+        raise ValueError(msg)
     if angle <= 0.0 or angle > _IEC61265_ANGLES[-1]:
-        raise ValueError("'angle' must lie in (0, 150] degrees.")
+        msg = "'angle' must lie in (0, 150] degrees."
+        raise ValueError(msg)
     col = next(i for i, a in enumerate(_IEC61265_ANGLES) if a >= angle)
     return row[col]
 
@@ -163,7 +165,8 @@ def _linearity_checks(linearity: dict[str, float]) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     for kind, dev in linearity.items():
         if kind not in _LINEARITY_LIMITS:
-            raise ValueError("linearity keys must be 'reference' or 'other'.")
+            msg = "linearity keys must be 'reference' or 'other'."
+            raise ValueError(msg)
         limit = _LINEARITY_LIMITS[kind]
         checks.append(
             {

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -313,9 +313,8 @@ def _grid_axis(
     s = require_positive(step, name)
     n = round((stop - start) / s)
     if n < 1 or abs((stop - start) / s - n) > 1e-9:
-        raise ValueError(
-            f"'{name}' must divide the {stop - start:g} degree span evenly."
-        )
+        msg = f"'{name}' must divide the {stop - start:g} degree span evenly."
+        raise ValueError(msg)
     return np.linspace(start, stop, n + 1)
 
 
@@ -403,17 +402,20 @@ def hover_ring_hemisphere(
     brg = np.atleast_1d(np.asarray(bearings, dtype=np.float64))
     lv = np.asarray(levels, dtype=np.float64)
     if brg.ndim != 1 or brg.size < 2:
-        raise ValueError("'bearings' must be 1-D with at least two ring directions.")
+        msg = "'bearings' must be 1-D with at least two ring directions."
+        raise ValueError(msg)
     if not np.all(np.isfinite(brg)) or np.any(np.diff(brg) <= 0.0):
-        raise ValueError("'bearings' must be finite and strictly increasing.")
+        msg = "'bearings' must be finite and strictly increasing."
+        raise ValueError(msg)
     if brg[0] < -180.0 or brg[-1] > 180.0:
-        raise ValueError("'bearings' must lie within [-180, 180] degrees.")
+        msg = "'bearings' must lie within [-180, 180] degrees."
+        raise ValueError(msg)
     if lv.shape != (brg.size, freqs.size):
-        raise ValueError(
-            "'levels' must have shape (B, F) matching 'bearings' and 'frequencies'."
-        )
+        msg = "'levels' must have shape (B, F) matching 'bearings' and 'frequencies'."
+        raise ValueError(msg)
     if not np.all(np.isfinite(lv)):
-        raise ValueError("'levels' must be finite.")
+        msg = "'levels' must be finite."
+        raise ValueError(msg)
     dist = require_positive(distance, "distance")
     key = require_choice(mapping, "mapping", ("constant_phi", "bearing"))
     az = _grid_axis(-90.0, 90.0, azimuth_step, "azimuth_step")
@@ -487,7 +489,8 @@ def hover_derived_hemisphere(
     elif math.isfinite(offset_db):
         offset = float(offset_db)
     else:
-        raise ValueError("'offset_db' must be finite.")
+        msg = "'offset_db' must be finite."
+        raise ValueError(msg)
     return RotorcraftHemisphere(
         frequencies=np.asarray(hemisphere.frequencies, dtype=np.float64).copy(),
         azimuth=np.asarray(hemisphere.azimuth, dtype=np.float64).copy(),
@@ -559,14 +562,15 @@ def flight_condition_weights(
     v = np.atleast_1d(np.asarray(airspeeds, dtype=np.float64))
     g = np.atleast_1d(np.asarray(path_angles, dtype=np.float64))
     if v.ndim != 1 or v.shape != g.shape or v.size < 1:
-        raise ValueError(
-            "'airspeeds' and 'path_angles' must be 1-D of equal, non-zero size."
-        )
+        msg = "'airspeeds' and 'path_angles' must be 1-D of equal, non-zero size."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(v)) and np.all(np.isfinite(g))):
-        raise ValueError("'airspeeds' and 'path_angles' must be finite.")
+        msg = "'airspeeds' and 'path_angles' must be finite."
+        raise ValueError(msg)
     ffc = require_positive(scaling_factor, "scaling_factor")
     if not np.isfinite(airspeed) or not np.isfinite(path_angle):
-        raise ValueError("'airspeed' and 'path_angle' must be finite.")
+        msg = "'airspeed' and 'path_angle' must be finite."
+        raise ValueError(msg)
     if v.size == 1:
         return [(0, 1.0)]
 
@@ -623,9 +627,11 @@ def _simplex_from_table(
     """The first triangle of a lookup table enveloping ``q``, or ``None``."""
     tri = np.asarray(triangles, dtype=np.intp)
     if tri.ndim != 2 or tri.shape[1] != 3 or tri.size == 0:
-        raise ValueError("'triangles' must have shape (T, 3).")
+        msg = "'triangles' must have shape (T, 3)."
+        raise ValueError(msg)
     if tri.min() < 0 or tri.max() >= n:
-        raise ValueError("'triangles' indices must address the database conditions.")
+        msg = "'triangles' indices must address the database conditions."
+        raise ValueError(msg)
     for row in tri:
         p0, p1, p2 = pts[row]
         m = np.column_stack([p1 - p0, p2 - p0])
@@ -692,16 +698,17 @@ def _common_frequencies(
 ) -> NDArray[np.float64]:
     """The shared band grid of a hemisphere set (validated)."""
     if len(hemispheres) == 0:
-        raise ValueError("'hemispheres' must not be empty.")
+        msg = "'hemispheres' must not be empty."
+        raise ValueError(msg)
     n = np.atleast_1d(np.asarray(airspeeds, dtype=np.float64)).size
     if len(hemispheres) != n:
-        raise ValueError(
-            "'hemispheres' and the flight conditions must have equal length."
-        )
+        msg = "'hemispheres' and the flight conditions must have equal length."
+        raise ValueError(msg)
     freqs = np.asarray(hemispheres[0].frequencies, dtype=np.float64)
     for h in hemispheres[1:]:
         if not np.array_equal(np.asarray(h.frequencies, dtype=np.float64), freqs):
-            raise ValueError("All hemispheres must share one band grid.")
+            msg = "All hemispheres must share one band grid."
+            raise ValueError(msg)
     return freqs
 
 
@@ -979,9 +986,11 @@ def _per_point(
     if arr.ndim == 0:
         arr = np.full(n, float(arr))
     if arr.shape != (n,):
-        raise ValueError(f"'{name}' must be a scalar or match the track length.")
+        msg = f"'{name}' must be a scalar or match the track length."
+        raise ValueError(msg)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return arr
 
 
@@ -993,13 +1002,17 @@ def _validated_track(
     t = np.asarray(times, dtype=np.float64)
     p = np.asarray(positions, dtype=np.float64)
     if t.ndim != 1 or t.size < 2:
-        raise ValueError("'times' must be 1-D with at least two points.")
+        msg = "'times' must be 1-D with at least two points."
+        raise ValueError(msg)
     if p.shape != (t.size, 3):
-        raise ValueError("'positions' must have shape (N, 3) matching 'times'.")
+        msg = "'positions' must have shape (N, 3) matching 'times'."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(t)) and np.all(np.isfinite(p))):
-        raise ValueError("'times' and 'positions' must be finite.")
+        msg = "'times' and 'positions' must be finite."
+        raise ValueError(msg)
     if np.any(np.diff(t) <= 0.0):
-        raise ValueError("'times' must be strictly increasing.")
+        msg = "'times' must be strictly increasing."
+        raise ValueError(msg)
     return t, p
 
 
@@ -1008,7 +1021,8 @@ def _reference_distance(hemispheres: Sequence[RotorcraftHemisphere]) -> float:
     rref = float(hemispheres[0].distance)
     for h in hemispheres[1:]:
         if float(h.distance) != rref:
-            raise ValueError("All hemispheres must share one reference distance.")
+            msg = "All hemispheres must share one reference distance."
+            raise ValueError(msg)
     return require_positive(rref, "hemisphere distance")
 
 
@@ -1269,10 +1283,11 @@ def _setup_resistivity(
     if np.ndim(flow_resistivity) == 0:
         return _resolve_flow_resistivity(float(np.asarray(flow_resistivity)))
     if dem is not None:
-        raise ValueError(
+        msg = (
             "With 'terrain', 'flow_resistivity' must be a single "
             "value or class (per-path maps are not supported)."
         )
+        raise ValueError(msg)
     return require_positive_array(
         np.asarray(flow_resistivity, dtype=np.float64).ravel(), "flow_resistivity"
     )
@@ -1285,16 +1300,19 @@ def _setup_ground_elevation(
     """The scalar (or per-receiver) ground elevation of an event run."""
     if np.isscalar(ground_elevation):
         if not np.isfinite(ground_elevation):
-            raise ValueError("'ground_elevation' must be finite.")
+            msg = "'ground_elevation' must be finite."
+            raise ValueError(msg)
         return float(ground_elevation)  # type: ignore[arg-type]
     arr = np.asarray(ground_elevation, dtype=np.float64).ravel()
     if not np.all(np.isfinite(arr)):
-        raise ValueError("'ground_elevation' must be finite.")
+        msg = "'ground_elevation' must be finite."
+        raise ValueError(msg)
     if dem is not None:
-        raise ValueError(
+        msg = (
             "With 'terrain', 'ground_elevation' comes from the "
             "elevation model and must be left scalar."
         )
+        raise ValueError(msg)
     return arr
 
 
@@ -1317,10 +1335,11 @@ def _require_dem_coverage(
         or np.min(y) < ty[0]
         or np.max(y) > ty[-1]
     ):
-        raise ValueError(
+        msg = (
             f"'terrain' must cover the whole {what} (x in "
             f"[{tx[0]:g}, {tx[-1]:g}], y in [{ty[0]:g}, {ty[-1]:g}])."
         )
+        raise ValueError(msg)
 
 
 def _validated_terrain(
@@ -1332,7 +1351,8 @@ def _validated_terrain(
     if terrain is None:
         return None
     if len(terrain) != 3:
-        raise ValueError("'terrain' must be an (x, y, z) elevation model.")
+        msg = "'terrain' must be an (x, y, z) elevation model."
+        raise ValueError(msg)
     tx = np.asarray(terrain[0], dtype=np.float64).ravel()
     ty = np.asarray(terrain[1], dtype=np.float64).ravel()
     tz = np.asarray(terrain[2], dtype=np.float64)
@@ -1342,13 +1362,14 @@ def _validated_terrain(
         or np.any(np.diff(tx) <= 0)
         or np.any(np.diff(ty) <= 0)
     ):
-        raise ValueError(
-            "'terrain' x and y must be strictly increasing with >= 2 points."
-        )
+        msg = "'terrain' x and y must be strictly increasing with >= 2 points."
+        raise ValueError(msg)
     if tz.shape != (ty.size, tx.size) or not np.all(np.isfinite(tz)):
-        raise ValueError("'terrain' z must be finite with shape (len(y), len(x)).")
+        msg = "'terrain' z must be finite with shape (len(y), len(x))."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(tx)) and np.all(np.isfinite(ty))):
-        raise ValueError("'terrain' coordinates must be finite.")
+        msg = "'terrain' coordinates must be finite."
+        raise ValueError(msg)
     return tx, ty, tz
 
 
@@ -1675,12 +1696,14 @@ def rotorcraft_event_level(
     )
     rx = np.asarray(receiver, dtype=np.float64).ravel()
     if rx.size != 2 or not np.all(np.isfinite(rx)):
-        raise ValueError("'receiver' must be a finite (x, y) ground position.")
+        msg = "'receiver' must be a finite (x, y) ground position."
+        raise ValueError(msg)
     if not (np.isscalar(setup.sigma) and np.isscalar(setup.ground_elevation)):
-        raise ValueError(
+        msg = (
             "A single receiver takes scalar 'flow_resistivity' and "
             "'ground_elevation'; arrays are for the contour grid."
         )
+        raise ValueError(msg)
     if setup.terrain is not None:
         _require_dem_coverage(setup.terrain, rx[:1], rx[1:2], "receiver")
         local = float(_dem_height(setup.terrain, rx[:1], rx[1:2])[0])
@@ -1797,9 +1820,8 @@ def rotorcraft_noise_contour(
         or gy.size < 2
         or not (np.all(np.isfinite(gx)) and np.all(np.isfinite(gy)))
     ):
-        raise ValueError(
-            "'x' and 'y' must each be finite with at least two grid points."
-        )
+        msg = "'x' and 'y' must each be finite with at least two grid points."
+        raise ValueError(msg)
     key = require_choice(metric, "metric", ("exposure", "maximum"))
     xx, yy = np.meshgrid(gx, gy)
     n_g = xx.size
@@ -1811,10 +1833,11 @@ def rotorcraft_noise_contour(
             continue
         shape = np.asarray(value).shape
         if shape not in ((n_g,), (gy.size, gx.size)):
-            raise ValueError(
+            msg = (
                 f"A per-receiver '{name}' must carry one value per grid "
                 "point, shape (len(y), len(x))."
             )
+            raise ValueError(msg)
     if setup.terrain is not None:
         _require_dem_coverage(setup.terrain, gx, gy, "receiver grid")
         local = _dem_height(setup.terrain, xx.ravel(), yy.ravel())

--- a/src/phonometry/aircraft/rotorcraft_propagation.py
+++ b/src/phonometry/aircraft/rotorcraft_propagation.py
@@ -264,9 +264,8 @@ def _resolve_flow_resistivity(flow_resistivity: float | str) -> float:
         key = flow_resistivity.strip().upper()
         if key not in _FLOW_RESISTIVITY:
             valid = ", ".join(sorted(_FLOW_RESISTIVITY))
-            raise ValueError(
-                f"'flow_resistivity' class must be one of {valid}, got {flow_resistivity!r}."
-            )
+            msg = f"'flow_resistivity' class must be one of {valid}, got {flow_resistivity!r}."
+            raise ValueError(msg)
         return _FLOW_RESISTIVITY[key]
     return require_positive(flow_resistivity, "flow_resistivity")
 
@@ -422,11 +421,14 @@ def _validated_section(
     d = np.atleast_1d(np.asarray(distances, dtype=np.float64))
     z = np.atleast_1d(np.asarray(heights, dtype=np.float64))
     if d.ndim != 1 or d.shape != z.shape or d.size < 2:
-        raise ValueError("'distances' and 'heights' must be 1-D of equal size >= 2.")
+        msg = "'distances' and 'heights' must be 1-D of equal size >= 2."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(d)) and np.all(np.isfinite(z))):
-        raise ValueError("'distances' and 'heights' must be finite.")
+        msg = "'distances' and 'heights' must be finite."
+        raise ValueError(msg)
     if np.any(np.diff(d) <= 0.0):
-        raise ValueError("'distances' must be strictly increasing.")
+        msg = "'distances' must be strictly increasing."
+        raise ValueError(msg)
     return d, z
 
 
@@ -469,7 +471,8 @@ def mean_flow_resistivity(
     d = require_positive_array(lengths, "lengths")
     sig = require_positive_array(resistivities, "resistivities")
     if d.shape != sig.shape:
-        raise ValueError("'lengths' and 'resistivities' must have equal shape.")
+        msg = "'lengths' and 'resistivities' must have equal shape."
+        raise ValueError(msg)
     return float(10.0 ** (np.sum(d * np.log10(sig)) / np.sum(d)))
 
 
@@ -521,7 +524,8 @@ def diffraction_attenuation(
     """
     f = require_positive_array(frequencies, "frequencies")
     if not np.isfinite(path_difference):
-        raise ValueError("'path_difference' must be finite.")
+        msg = "'path_difference' must be finite."
+        raise ValueError(msg)
     h0 = require_non_negative(edge_height, "edge_height")
     e = require_non_negative(edge_span, "edge_span")
     lam = _C / f
@@ -643,13 +647,14 @@ def terrain_screening_adjustment(
         and np.isfinite(rcv[0])
         and np.isfinite(rcv[1])
     ):
-        raise ValueError("'source' and 'receiver' must be finite (d, z) points.")
+        msg = "'source' and 'receiver' must be finite (d, z) points."
+        raise ValueError(msg)
     if src[0] >= rcv[0]:
-        raise ValueError(
-            "'source' must lie at a smaller section distance than 'receiver'."
-        )
+        msg = "'source' must lie at a smaller section distance than 'receiver'."
+        raise ValueError(msg)
     if d[0] > src[0] + 1e-9 or d[-1] < rcv[0] - 1e-9:
-        raise ValueError("The terrain section must cover [source d, receiver d].")
+        msg = "The terrain section must cover [source d, receiver d]."
+        raise ValueError(msg)
     sigma_seg = _segment_resistivities(flow_resistivity, d.size - 1)
     d, z, sigma_seg = _cropped_section(d, z, sigma_seg, src[0], rcv[0])
     adjustment, screened, delta, points = _screening_core(f, src, rcv, d, z, sigma_seg)
@@ -677,9 +682,8 @@ def _segment_resistivities(
         return np.full(n_segments, _resolve_flow_resistivity(float(flow_resistivity)))  # type: ignore[arg-type]
     arr = require_positive_array(flow_resistivity, "flow_resistivity")
     if arr.shape != (n_segments,):
-        raise ValueError(
-            "Per-segment 'flow_resistivity' must have one value per profile segment."
-        )
+        msg = "Per-segment 'flow_resistivity' must have one value per profile segment."
+        raise ValueError(msg)
     return arr
 
 

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -181,11 +181,12 @@ def k_weighting_coefficients(
     """
     fs = require_positive(float(fs), "fs")
     if fs < 16000.0:
-        raise ValueError(
+        msg = (
             "the K-weighting redesign requires fs >= 16000 Hz; below that "
             "the bilinear warping no longer preserves the specified response "
             f"within the metering tolerance; got fs={fs:g}."
         )
+        raise ValueError(msg)
     if fs == _TABLE_RATE:
         return (
             (np.array(_STAGE1_B48), np.array(_STAGE1_A48)),
@@ -318,16 +319,17 @@ def k_weighting_response(
     nyquist = fs / 2.0
     if frequencies is None:
         if n < 1:
-            raise ValueError(f"n must be a positive integer; got {n}.")
+            msg = f"n must be a positive integer; got {n}."
+            raise ValueError(msg)
         freqs = np.logspace(np.log10(10.0), np.log10(nyquist), int(n))
     else:
         freqs = np.asarray(frequencies, dtype=np.float64).ravel()
         if freqs.size == 0:
-            raise ValueError("'frequencies' cannot be empty.")
+            msg = "'frequencies' cannot be empty."
+            raise ValueError(msg)
         if np.any(freqs <= 0.0) or np.any(freqs > nyquist):
-            raise ValueError(
-                f"every frequency must lie in (0, fs/2] = (0, {nyquist:g}] Hz."
-            )
+            msg = f"every frequency must lie in (0, fs/2] = (0, {nyquist:g}] Hz."
+            raise ValueError(msg)
     shelf_db = 20.0 * np.log10(np.abs(signal.freqz(b1, a1, worN=freqs, fs=fs)[1]))
     highpass_db = 20.0 * np.log10(np.abs(signal.freqz(b2, a2, worN=freqs, fs=fs)[1]))
     return KWeightingResponse(
@@ -364,11 +366,11 @@ def channel_weight(
     theta = np.abs(np.asarray(azimuth, dtype=np.float64))
     phi = np.abs(np.asarray(elevation, dtype=np.float64))
     if not (np.all(np.isfinite(theta)) and np.all(np.isfinite(phi))):
-        raise ValueError("azimuth and elevation must be finite.")
+        msg = "azimuth and elevation must be finite."
+        raise ValueError(msg)
     if np.any(theta > 360.0) or np.any(phi > 90.0):
-        raise ValueError(
-            "azimuth must be within +/-360 deg and elevation within +/-90 deg."
-        )
+        msg = "azimuth must be within +/-360 deg and elevation within +/-90 deg."
+        raise ValueError(msg)
     theta = np.where(theta > 180.0, 360.0 - theta, theta)
     side = (theta >= 60.0) & (theta <= 120.0) & (phi < 30.0)
     return as_float_or_array(np.where(side, 1.41, 1.0))
@@ -380,23 +382,27 @@ def _resolve_weights(n_channels: int, weights: ArrayLike | None) -> np.ndarray:
         try:
             return np.array(DEFAULT_CHANNEL_WEIGHTS[n_channels])
         except KeyError:
-            raise ValueError(
+            msg = (
                 f"no default channel weighting for {n_channels} channels: "
                 "Table 3 covers mono, stereo, 3/2 multichannel (L/R/C/Ls/Rs) "
                 "and 5.1 (L/R/C/LFE/Ls/Rs). Pass explicit weights (see "
                 "channel_weight for the Annex 3 position-dependent values; "
                 "use 0.0 to exclude an LFE channel)."
-            ) from None
+            )
+            raise ValueError(msg) from None
     w = np.asarray(weights, dtype=np.float64)
     if w.ndim != 1 or w.size != n_channels:
-        raise ValueError(
+        msg = (
             f"weights must be a 1D sequence with one entry per channel "
             f"({n_channels}); got shape {w.shape}."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(w)):
-        raise ValueError("channel weights must be finite.")
+        msg = "channel weights must be finite."
+        raise ValueError(msg)
     if np.any(w < 0.0):
-        raise ValueError("channel weights must be non-negative.")
+        msg = "channel weights must be non-negative."
+        raise ValueError(msg)
     return w
 
 
@@ -550,7 +556,8 @@ def true_peak_level(
         or not isinstance(oversample, (int, np.integer))
         or oversample < 1
     ):
-        raise ValueError("oversample must be an integer >= 1.")
+        msg = "oversample must be an integer >= 1."
+        raise ValueError(msg)
     x_proc = _typesignal(resolve_samples(x, calibrate=False))
     if x_proc.shape[-1] == 0:
         raise ValueError(_EMPTY_SIGNAL)
@@ -615,7 +622,8 @@ def _prepare_signal(
     if x_proc.shape[-1] == 0:
         raise ValueError(_EMPTY_SIGNAL)
     if not np.all(np.isfinite(x_proc)):
-        raise ValueError("Input signal 'x' must be finite (no NaN/inf samples).")
+        msg = "Input signal 'x' must be finite (no NaN/inf samples)."
+        raise ValueError(msg)
     return x_proc, _resolve_weights(x_proc.shape[0], weights)
 
 
@@ -739,9 +747,8 @@ class ProgramLoudnessResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.broadcast import render_program_loudness_report
 
         return render_program_loudness_report(
@@ -811,11 +818,12 @@ def program_loudness(
     momentary_step = require_positive(float(momentary_step), "momentary_step")
     short_term_step = require_positive(float(short_term_step), "short_term_step")
     if momentary_step > 0.1 or short_term_step > 0.1:
-        raise ValueError(
+        msg = (
             "momentary_step and short_term_step must be <= 0.1 s: EBU Tech "
             "3341 requires a meter update rate of at least 10 Hz, and Tech "
             "3342 needs it for the LRA input."
         )
+        raise ValueError(msg)
 
     csum = _power_cumsum(k_weighting(x_proc, fs))
     n_block, block_step = _block_geometry(fs)

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -102,9 +102,8 @@ def _validate_report_request(engine: str, language: str) -> None:
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
 
 
 #: Reference equivalent sound absorption area ``A0`` for the normalized
@@ -152,11 +151,14 @@ def _as_1d(values: float | Sequence[float] | np.ndarray, name: str) -> np.ndarra
     """Coerce to a finite 1-D float array."""
     data = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if data.ndim != 1:
-        raise ValueError(f"'{name}' must be one-dimensional (one value per band).")
+        msg = f"'{name}' must be one-dimensional (one value per band)."
+        raise ValueError(msg)
     if data.size == 0:
-        raise ValueError(f"'{name}' must not be empty.")
+        msg = f"'{name}' must not be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(data)):
-        raise ValueError(f"'{name}' must contain only finite values.")
+        msg = f"'{name}' must contain only finite values."
+        raise ValueError(msg)
     return data
 
 
@@ -164,7 +166,8 @@ def _positive(value: float, name: str) -> float:
     """Validate a positive, finite scalar."""
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -174,7 +177,8 @@ def _positive_array(
     """Validate a 1-D array of positive, finite values."""
     data = _as_1d(values, name)
     if np.any(data <= 0.0):
-        raise ValueError(f"'{name}' must contain positive values.")
+        msg = f"'{name}' must contain positive values."
+        raise ValueError(msg)
     return data
 
 
@@ -198,7 +202,8 @@ def velocity_level_difference(
     lv_i = _as_1d(source_level, "source_level")
     lv_j = _as_1d(receive_level, "receive_level")
     if lv_i.size != lv_j.size:
-        raise ValueError("'source_level' and 'receive_level' must share their length.")
+        msg = "'source_level' and 'receive_level' must share their length."
+        raise ValueError(msg)
     return np.asarray(lv_i - lv_j, dtype=np.float64)
 
 
@@ -222,7 +227,8 @@ def direction_averaged_level_difference(
     a = _as_1d(dv_ij, "dv_ij")
     b = _as_1d(dv_ji, "dv_ji")
     if a.size != b.size:
-        raise ValueError("'dv_ij' and 'dv_ji' must share their length.")
+        msg = "'dv_ij' and 'dv_ji' must share their length."
+        raise ValueError(msg)
     return np.asarray(0.5 * (a + b), dtype=np.float64)
 
 
@@ -289,7 +295,8 @@ def _broadcast(values: np.ndarray, n_bands: int, name: str) -> np.ndarray:
     if values.size == 1:
         return np.full(n_bands, values[0], dtype=np.float64)
     if values.size != n_bands:
-        raise ValueError(f"'{name}' must have one value per band (or a single value).")
+        msg = f"'{name}' must have one value per band (or a single value)."
+        raise ValueError(msg)
     return values
 
 
@@ -338,9 +345,8 @@ class VibrationReductionResult:
             the frequencies do not open on complete octave triples.
         """
         if self.k_ij.size % 3 != 0:
-            raise ValueError(
-                "octave_bands() needs a band count that is a multiple of three."
-            )
+            msg = "octave_bands() needs a band count that is a multiple of three."
+            raise ValueError(msg)
         groups = self.k_ij.reshape(-1, 3)
         oct_k = -10.0 * np.log10(np.mean(10.0 ** (-groups / 10.0), axis=1))
         oct_f: np.ndarray | None = None
@@ -433,12 +439,13 @@ def _validate_octave_triples(freq_groups: np.ndarray) -> None:
             and abs(high - mid * third) <= 0.06 * (mid * third)
         )
         if not aligned:
-            raise ValueError(
+            msg = (
                 "octave_bands() needs whole octave triples: the group "
                 f"({low:g}, {mid:g}, {high:g}) Hz is not the three "
                 "one-third-octave bands of one octave. Start the input at "
                 "the lower third of an octave band."
             )
+            raise ValueError(msg)
 
 
 def _detect_band_type(frequencies: np.ndarray | None) -> str:
@@ -534,22 +541,23 @@ def vibration_reduction_index(
 
     freq = None if frequency is None else _positive_array(frequency, "frequency")
     if freq is not None and freq.size != dv.size:
-        raise ValueError("'frequency' must share the band count of the level input.")
+        msg = "'frequency' must share the band count of the level input."
+        raise ValueError(msg)
 
     ts_given = (structural_reverberation_time_i is not None) + (
         structural_reverberation_time_j is not None
     )
     if ts_given == 1:
-        raise ValueError(
-            "Supply both structural reverberation times (i and j) or neither."
-        )
+        msg = "Supply both structural reverberation times (i and j) or neither."
+        raise ValueError(msg)
 
     if ts_given == 2:
         if freq is None:
-            raise ValueError(
+            msg = (
                 "'frequency' is required when structural reverberation times are "
                 "supplied (Formula (12))."
             )
+            raise ValueError(msg)
         a_i = equivalent_absorption_length(
             s_i,
             structural_reverberation_time_i,  # type: ignore[arg-type]
@@ -634,7 +642,8 @@ def vibration_reduction_index_from_flanking(
     a0 = _positive(reference_area, "reference_area")
     sizes = {dn_f.size, r_i.size, r_j.size, a_i.size, a_j.size}
     if len(sizes) != 1:
-        raise ValueError("All per-band inputs must share the same length.")
+        msg = "All per-band inputs must share the same length."
+        raise ValueError(msg)
     k_ij = (
         dn_f
         - 0.5 * (r_i + r_j)
@@ -664,10 +673,11 @@ class FlankingLevelDifferenceResult:
     ) -> Axes:
         """Plot ``Dn,f`` against the shifted ISO 717-1 reference curve."""
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
+            raise ValueError(msg)
         return self.rating.plot(ax=ax, language=language, **kwargs)
 
     def report(
@@ -713,10 +723,11 @@ class FlankingLevelDifferenceResult:
         """
         _validate_report_request(engine, language)
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "The Dn,f report needs the ISO 717-1 single-number rating; "
                 "supply 16 one-third-octave or 5 octave bands."
             )
+            raise ValueError(msg)
         from ..._report.iso10848 import render_flanking_level_difference_report
 
         return render_flanking_level_difference_report(
@@ -746,10 +757,11 @@ class FlankingImpactLevelResult:
     ) -> Axes:
         """Plot ``Ln,f`` against the shifted ISO 717-2 reference curve."""
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
+            raise ValueError(msg)
         return self.rating.plot(ax=ax, language=language, **kwargs)
 
     def report(
@@ -795,10 +807,11 @@ class FlankingImpactLevelResult:
         """
         _validate_report_request(engine, language)
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "The Ln,f report needs the ISO 717-2 single-number rating; "
                 "supply 16 one-third-octave or 5 octave bands."
             )
+            raise ValueError(msg)
         from ..._report.iso10848 import render_flanking_impact_level_report
 
         return render_flanking_impact_level_report(
@@ -841,9 +854,8 @@ def normalized_flanking_level_difference(
     area = _positive_array(absorption_area, "absorption_area")
     a0 = _positive(reference_area, "reference_area")
     if not (l1.size == l2.size == area.size):
-        raise ValueError(
-            "'source_level', 'receive_level' and 'absorption_area' must share their length."
-        )
+        msg = "'source_level', 'receive_level' and 'absorption_area' must share their length."
+        raise ValueError(msg)
     d_n_f = l1 - l2 - 10.0 * np.log10(area / a0)
     rating = _maybe_rating(d_n_f, bands)
     return FlankingLevelDifferenceResult(d_n_f=d_n_f, rating=rating)
@@ -878,9 +890,8 @@ def normalized_flanking_impact_level(
     area = _positive_array(absorption_area, "absorption_area")
     a0 = _positive(reference_area, "reference_area")
     if l2.size != area.size:
-        raise ValueError(
-            "'receive_level' and 'absorption_area' must share their length."
-        )
+        msg = "'receive_level' and 'absorption_area' must share their length."
+        raise ValueError(msg)
     l_n_f = l2 + 10.0 * np.log10(area / a0)
     rating: ImpactRatingResult | None = None
     if l_n_f.size in (16, 5):

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -106,7 +106,8 @@ _RATING_FREQS = (
 def _finite(values: float | Sequence[float] | np.ndarray, name: str) -> np.ndarray:
     a = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if not np.all(np.isfinite(a)):
-        raise ValueError(f"'{name}' must contain only finite values.")
+        msg = f"'{name}' must contain only finite values."
+        raise ValueError(msg)
     return a
 
 
@@ -127,9 +128,11 @@ def acceleration_level(
     """
     a = _finite(acceleration, "acceleration")
     if np.any(a <= 0.0):
-        raise ValueError("'acceleration' must be positive.")
+        msg = "'acceleration' must be positive."
+        raise ValueError(msg)
     if reference <= 0.0:
-        raise ValueError("'reference' must be positive.")
+        msg = "'reference' must be positive."
+        raise ValueError(msg)
     return 20.0 * np.log10(a / reference)
 
 
@@ -150,9 +153,8 @@ def background_corrected_level(
     lp = _finite(signal_and_background, "signal_and_background")
     lb = _finite(background, "background")
     if lp.shape != lb.shape:
-        raise ValueError(
-            "'signal_and_background' and 'background' must share their shape."
-        )
+        msg = "'signal_and_background' and 'background' must share their shape."
+        raise ValueError(msg)
     margin = lp - lb
     diff = 10.0 ** (lp / 10.0) - 10.0 ** (lb / 10.0)
     with np.errstate(invalid="ignore", divide="ignore"):
@@ -262,9 +264,8 @@ class FloorCoveringImprovementResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso16251 import render_iso16251_report
 
         return render_iso16251_report(
@@ -346,21 +347,24 @@ def impact_improvement(
     freqs = _finite(frequencies, "frequencies")
     n_bands = freqs.shape[0]
     if l0.shape != l1.shape:
-        raise ValueError("'bare' and 'with_covering' must share their shape.")
+        msg = "'bare' and 'with_covering' must share their shape."
+        raise ValueError(msg)
     if l0.ndim not in (1, 2) or l0.shape[-1] != n_bands:
-        raise ValueError(
+        msg = (
             "'bare'/'with_covering' must be (bands,) or (positions, bands) "
             "matching 'frequencies'."
         )
+        raise ValueError(msg)
 
     limited_pos = np.zeros(l0.shape, dtype=bool)
     if background is not None:
         lb = _finite(background, "background")
         if lb.shape not in ((n_bands,), l0.shape):
-            raise ValueError(
+            msg = (
                 "'background' must be (bands,) or match the (positions, bands) "
                 "shape of 'bare'/'with_covering'."
             )
+            raise ValueError(msg)
         lb = np.broadcast_to(lb, l0.shape)
         # Formula (2) per position, then Formula (3), then Formula (4).
         l0, lim0 = background_corrected_level(l0, lb)
@@ -403,7 +407,8 @@ def improvement_octave_bands(
     dl = _finite(improvement, "improvement")
     freqs = _finite(frequencies, "frequencies")
     if dl.shape != freqs.shape:
-        raise ValueError("'improvement' and 'frequencies' must share their shape.")
+        msg = "'improvement' and 'frequencies' must share their shape."
+        raise ValueError(msg)
     octave_freqs: list[float] = []
     octave_values: list[float] = []
     by_freq = {round(float(f), 3): float(d) for f, d in zip(freqs, dl)}
@@ -412,10 +417,11 @@ def improvement_octave_bands(
         try:
             vals = [by_freq[round(t, 3)] for t in _nearest(thirds, by_freq)]
         except KeyError:
-            raise ValueError(
+            msg = (
                 f"Octave {centre:g} Hz is missing one of its one-third-octave "
                 "bands; provide complete triplets."
-            ) from None
+            )
+            raise ValueError(msg) from None
         octave_freqs.append(centre)
         octave_values.append(
             -10.0 * np.log10(np.mean([10.0 ** (-v / 10.0) for v in vals]))

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -370,13 +370,15 @@ def impact_force_exposure_level(
     # this record is a force in newtons. See phonometry.io._resolve.
     f = require_finite_array(resolve_samples(force, calibrate=False), "force")
     if f.size < 2:
-        raise ValueError("'force' must be a 1-D record of at least two samples.")
+        msg = "'force' must be a 1-D record of at least two samples."
+        raise ValueError(msg)
     fs = require_positive(sample_rate, "sample_rate")
     f0 = require_positive(reference_force, "reference_force")
     tref = require_positive(reference_time, "reference_time")
     energy = float(np.trapezoid((f / f0) ** 2, dx=1.0 / fs))
     if energy <= 0.0:
-        raise ValueError("'force' must carry non-zero energy.")
+        msg = "'force' must carry non-zero energy."
+        raise ValueError(msg)
     return float(10.0 * np.log10(energy / tref))
 
 
@@ -438,10 +440,11 @@ def check_heavy_impact_source(
     measured = require_finite_array(force_exposure_level, "force_exposure_level")
     n = len(spec.frequencies)
     if measured.shape != (n,):
-        raise ValueError(
+        msg = (
             f"'force_exposure_level' must hold {n} octave-band values "
             f"(31,5 Hz to 500 Hz)."
         )
+        raise ValueError(msg)
     nominal = np.asarray(spec.force_exposure_level, dtype=np.float64)
     tol = np.asarray(spec.tolerance, dtype=np.float64)
     deviation = measured - nominal
@@ -500,7 +503,8 @@ def fast_reverberation_correction(
     """
     t = require_finite_array(reverberation_time, "reverberation_time")
     if np.any(t <= 0.0):
-        raise ValueError("'reverberation_time' must be positive and finite.")
+        msg = "'reverberation_time' must be positive and finite."
+        raise ValueError(msg)
     t0 = require_positive(reference_time, "reference_time")
     c = t / _FAST_FACTOR
     c0 = np.full_like(c, t0 / _FAST_FACTOR)
@@ -587,12 +591,14 @@ def standardized_maximum_impact_level(
     if t.size == 1:
         t = np.full(li.shape, float(t[0]))
     if t.shape != li.shape:
-        raise ValueError("'reverberation_time' must be a scalar or match 'level'.")
+        msg = "'reverberation_time' must be a scalar or match 'level'."
+        raise ValueError(msg)
     freqs: np.ndarray | None = None
     if frequency is not None:
         freqs = require_finite_array(frequency, "frequency")
         if freqs.shape != li.shape:
-            raise ValueError("'frequency' must match 'level'.")
+            msg = "'frequency' must match 'level'."
+            raise ValueError(msg)
     correction = fast_reverberation_correction(t, reference_time=reference_time)
     volume_term = float(10.0 * np.log10(v / v0))
     return StandardizedMaximumImpactResult(
@@ -627,7 +633,8 @@ def heavy_impact_octave_levels(level: ArrayLike) -> np.ndarray:
     """
     x = require_finite_array(level, "level")
     if x.size % 3 != 0:
-        raise ValueError("'level' must be a 1-D array whose length is a multiple of 3.")
+        msg = "'level' must be a 1-D array whose length is a multiple of 3."
+        raise ValueError(msg)
     return np.asarray(
         10.0 * np.log10(np.sum(10.0 ** (x.reshape(-1, 3) / 10.0), axis=1)),
         dtype=np.float64,
@@ -711,25 +718,28 @@ def a_weighted_maximum_impact_level(
     if band is None:
         band = {12: "third", 4: "octave"}.get(x.size, "")
         if not band:
-            raise ValueError(
+            msg = (
                 "'level' must hold 12 one-third-octave values (50-630 Hz) or "
                 "4 octave values (63-500 Hz); pass 'band' to disambiguate."
             )
+            raise ValueError(msg)
     chosen = require_choice(band, "band", ("third", "octave"))
     table = HEAVY_IMPACT_A_WEIGHTING[chosen]
     bands = np.asarray(sorted(table), dtype=np.float64)
     if x.shape != bands.shape:
-        raise ValueError(
+        msg = (
             f"'level' must hold {bands.size} values for band={chosen!r} "
             f"({bands[0]:g} Hz to {bands[-1]:g} Hz)."
         )
+        raise ValueError(msg)
     if frequency is not None:
         given = require_finite_array(frequency, "frequency")
         if given.shape != bands.shape or not np.allclose(given, bands):
-            raise ValueError(
+            msg = (
                 f"'frequency' must be the ISO 717-2 Annex D rating bands for "
                 f"band={chosen!r}: {[float(b) for b in bands]}."
             )
+            raise ValueError(msg)
     a_weighting = np.asarray([table[float(b)] for b in bands], dtype=np.float64)
     corrected = x + a_weighting
     unrounded = float(10.0 * np.log10(np.sum(10.0 ** (corrected / 10.0))))

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -382,10 +382,11 @@ class FacadeInsulationResult:
     def __post_init__(self) -> None:
         """Reject a ``method`` other than ``"loudspeaker"`` or ``"road_traffic"``."""
         if self.method not in _FACADE_CORRECTION:
-            raise ValueError(
+            msg = (
                 "'method' must be 'loudspeaker' or 'road_traffic', got "
                 f"{self.method!r}."
             )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -496,37 +497,40 @@ def _render_iso16283(
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
     kind = type(result).__name__
     quantities, chain_attrs = _FIELD_QUANTITIES[kind]
     if quantity not in quantities:
         expected = " or ".join(repr(q) for q in quantities)
-        raise ValueError(f"Unknown field quantity {quantity!r}; expected {expected}.")
+        msg = f"Unknown field quantity {quantity!r}; expected {expected}."
+        raise ValueError(msg)
     curve = getattr(result, quantity)
     if curve is None:
-        raise ValueError(
+        msg = (
             f"The result carries no {quantity!r} curve; build it with the "
             "'area'/'volume' arguments so the normalized quantity is "
             "computed."
         )
+        raise ValueError(msg)
     curve = np.asarray(curve, dtype=np.float64)
     if curve.shape != (len(_FREQ_THIRD_OCTAVE),):
-        raise ValueError(
+        msg = (
             "The field report rates the 16 core one-third-octave bands "
             f"(100 Hz to 3150 Hz, ISO 16283 Clause 5); got {curve.shape} "
             "band values."
         )
+        raise ValueError(msg)
     if verbose:
         missing = [a for a in chain_attrs if getattr(result, a) is None]
         if missing:
-            raise ValueError(
+            msg = (
                 "verbose=True needs the per-band measurement chain "
                 f"({', '.join(chain_attrs)}); {', '.join(missing)} "
                 "missing. Build the result with airborne_insulation() / "
                 "impact_insulation() so they are populated."
             )
+            raise ValueError(msg)
     if kind == "ImpactInsulationResult":
         rating: WeightedRatingResult | ImpactRatingResult = weighted_impact_rating(
             curve
@@ -574,26 +578,28 @@ def _render_iso16283_facade(
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
     if quantity not in _FACADE_FIELD_QUANTITIES:
         expected = " or ".join(repr(q) for q in _FACADE_FIELD_QUANTITIES)
-        raise ValueError(f"Unknown facade quantity {quantity!r}; expected {expected}.")
+        msg = f"Unknown facade quantity {quantity!r}; expected {expected}."
+        raise ValueError(msg)
     curve = getattr(result, quantity)
     if curve is None:
-        raise ValueError(
+        msg = (
             f"The result carries no {quantity!r} curve; build it with the "
             "'volume' (and, for R', 'surface_level'/'area') arguments so the "
             "quantity is computed."
         )
+        raise ValueError(msg)
     curve = np.asarray(curve, dtype=np.float64)
     if curve.shape != (len(_FREQ_THIRD_OCTAVE),):
-        raise ValueError(
+        msg = (
             "The facade field report rates the 16 core one-third-octave bands "
             f"(100 Hz to 3150 Hz, ISO 16283-3 Clause 5); got {curve.shape} "
             "band values."
         )
+        raise ValueError(msg)
     rating = weighted_rating(curve)
 
     from ..._report.iso16283 import render_iso16283_facade_report
@@ -628,9 +634,11 @@ def energy_average_level(
     """
     data = np.asarray(levels, dtype=np.float64)
     if data.size == 0:
-        raise ValueError("'levels' must not be empty.")
+        msg = "'levels' must not be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(data)):
-        raise ValueError("'levels' must contain only finite values.")
+        msg = "'levels' must contain only finite values."
+        raise ValueError(msg)
     return as_float_or_array(energy_mean(data, axis=axis))
 
 
@@ -647,11 +655,14 @@ def _as_band_levels(levels: Sequence[float] | np.ndarray, name: str) -> np.ndarr
     elif data.ndim == 2:
         out = np.asarray(energy_average_level(data, axis=0), dtype=np.float64)
     else:
-        raise ValueError(f"'{name}' must be 1-D or 2-D (positions x bands).")
+        msg = f"'{name}' must be 1-D or 2-D (positions x bands)."
+        raise ValueError(msg)
     if out.size == 0:
-        raise ValueError(f"'{name}' must not be empty.")
+        msg = f"'{name}' must not be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(out)):
-        raise ValueError(f"'{name}' must contain only finite values.")
+        msg = f"'{name}' must contain only finite values."
+        raise ValueError(msg)
     return out
 
 
@@ -663,11 +674,14 @@ def _validate_reverberation(t: np.ndarray, t0: float) -> None:
     ISO 16283 part.
     """
     if t.ndim != 1:
-        raise ValueError("'t2' must be one-dimensional (one value per band).")
+        msg = "'t2' must be one-dimensional (one value per band)."
+        raise ValueError(msg)
     if not np.all(np.isfinite(t)) or np.any(t <= 0.0):
-        raise ValueError("'t2' must contain positive, finite values.")
+        msg = "'t2' must contain positive, finite values."
+        raise ValueError(msg)
     if t0 <= 0.0:
-        raise ValueError("'t0' must be positive.")
+        msg = "'t0' must be positive."
+        raise ValueError(msg)
 
 
 @overload
@@ -738,18 +752,21 @@ def airborne_insulation(
     t = np.asarray(t2, dtype=np.float64)
 
     if not (l1_bands.shape == l2_bands.shape == t.shape):
-        raise ValueError("'l1', 'l2' and 't2' must share the same band count.")
+        msg = "'l1', 'l2' and 't2' must share the same band count."
+        raise ValueError(msg)
     _validate_reverberation(t, t0)
 
     d = l1_bands - l2_bands
     dnt = d + 10.0 * np.log10(t / t0)
 
     if (area is None) != (volume is None):
-        raise ValueError("'area' and 'volume' must be given together to compute R'.")
+        msg = "'area' and 'volume' must be given together to compute R'."
+        raise ValueError(msg)
     r_prime: np.ndarray | None = None
     if area is not None and volume is not None:
         if area <= 0.0 or volume <= 0.0:
-            raise ValueError("'area' and 'volume' must be positive.")
+            msg = "'area' and 'volume' must be positive."
+            raise ValueError(msg)
         absorption = 0.16 * volume / t
         r_prime = d + 10.0 * np.log10(area / absorption)
 
@@ -806,7 +823,8 @@ def impact_insulation(
     t = np.asarray(t2, dtype=np.float64)
 
     if li_bands.shape != t.shape:
-        raise ValueError("'li' and 't2' must share the same band count.")
+        msg = "'li' and 't2' must share the same band count."
+        raise ValueError(msg)
     _validate_reverberation(t, t0)
 
     l_n_t = li_bands - 10.0 * np.log10(t / t0)
@@ -814,7 +832,8 @@ def impact_insulation(
     l_n: np.ndarray | None = None
     if volume is not None:
         if volume <= 0.0:
-            raise ValueError("'volume' must be positive.")
+            msg = "'volume' must be positive."
+            raise ValueError(msg)
         absorption = 0.16 * volume / t
         l_n = li_bands + 10.0 * np.log10(absorption / _A0_IMPACT)
 
@@ -839,19 +858,23 @@ def _validate_facade_geometry(
     receiving-room volume together.
     """
     if volume is not None and volume <= 0.0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     if area is not None and area <= 0.0:
-        raise ValueError("'area' must be positive.")
+        msg = "'area' must be positive."
+        raise ValueError(msg)
     if area is not None and surface_level is None:
-        raise ValueError(
+        msg = (
             "'area' requires 'surface_level' to compute the apparent sound "
             "reduction index R'."
         )
+        raise ValueError(msg)
     if surface_level is not None and area is not None and volume is None:
-        raise ValueError(
+        msg = (
             "'volume' is required with 'surface_level' and 'area' to compute "
             "the apparent sound reduction index R'."
         )
+        raise ValueError(msg)
 
 
 def facade_insulation(
@@ -926,16 +949,16 @@ def facade_insulation(
         stays ``None``.
     """
     if method not in _FACADE_CORRECTION:
-        raise ValueError(
-            f"'method' must be 'loudspeaker' or 'road_traffic', got {method!r}."
-        )
+        msg = f"'method' must be 'loudspeaker' or 'road_traffic', got {method!r}."
+        raise ValueError(msg)
 
     l1_bands = _as_band_levels(l1_2m, "l1_2m")
     l2_bands = _as_band_levels(l2, "l2")
     t = np.asarray(t2, dtype=np.float64)
 
     if not (l1_bands.shape == l2_bands.shape == t.shape):
-        raise ValueError("'l1_2m', 'l2' and 't2' must share the same band count.")
+        msg = "'l1_2m', 'l2' and 't2' must share the same band count."
+        raise ValueError(msg)
     _validate_reverberation(t, t0)
 
     d_2m = l1_bands - l2_bands
@@ -954,7 +977,8 @@ def facade_insulation(
     if surface_level is not None and area is not None and absorption is not None:
         surf_bands = _as_band_levels(surface_level, "surface_level")
         if surf_bands.shape != l2_bands.shape:
-            raise ValueError("'surface_level' must share the band count of 'l2'.")
+            msg = "'surface_level' must share the band count of 'l2'."
+            raise ValueError(msg)
         r_prime = (
             surf_bands
             - l2_bands
@@ -966,10 +990,11 @@ def facade_insulation(
         np.asarray(frequencies, dtype=np.float64) if frequencies is not None else None
     )
     if freqs is not None and freqs.shape != d_2m.shape:
-        raise ValueError(
+        msg = (
             "'frequencies' must have one value per band; got "
             f"{freqs.size} for {d_2m.size} bands."
         )
+        raise ValueError(msg)
     return FacadeInsulationResult(
         d_2m=d_2m,
         d_2m_nt=d_2m_nt,

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -132,23 +132,24 @@ def _validate_intensity_report(
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
     if rating is None:
-        raise ValueError(
+        msg = (
             f"The {label} report needs the ISO 717-1 single-number rating; it "
             "is formed only for exactly 16 one-third-octave (100 Hz to "
             "3150 Hz) or 5 octave (125 Hz to 2000 Hz) bands. Build the result "
             "with that band count."
         )
+        raise ValueError(msg)
     n_bands = int(np.asarray(curve).size)
     if n_bands not in (16, 5):
-        raise ValueError(
+        msg = (
             f"The {label} report supports only 16 one-third-octave (100 Hz to "
             "3150 Hz) or 5 octave (125 Hz to 2000 Hz) bands; the result "
             f"carries {n_bands}."
         )
+        raise ValueError(msg)
     return rating
 
 
@@ -191,10 +192,11 @@ class IntensityReductionResult:
         :class:`~matplotlib.axes.Axes`.
         """
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
+            raise ValueError(msg)
         return self.rating.plot(ax=ax, **kwargs)
 
     def report(
@@ -315,10 +317,11 @@ class IntensityElementNormalizedResult:
         :class:`~matplotlib.axes.Axes`.
         """
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
+            raise ValueError(msg)
         return self.rating.plot(ax=ax, **kwargs)
 
     def report(
@@ -415,7 +418,8 @@ def _positive_area(value: float, name: str) -> float:
     """Return ``value`` as a positive, finite area, or raise."""
     v = float(value)
     if not np.isfinite(v) or v <= 0.0:
-        raise ValueError(f"'{name}' must be positive.")
+        msg = f"'{name}' must be positive."
+        raise ValueError(msg)
     return v
 
 
@@ -464,9 +468,11 @@ def adaptation_term_kc(
     """
     f = np.asarray(freq, dtype=np.float64)
     if f.ndim != 1:
-        raise ValueError("'freq' must be one-dimensional.")
+        msg = "'freq' must be one-dimensional."
+        raise ValueError(msg)
     if not np.all(np.isfinite(f)) or np.any(f <= 0.0):
-        raise ValueError("'freq' must contain positive, finite values.")
+        msg = "'freq' must contain positive, finite values."
+        raise ValueError(msg)
 
     if boundary_area is None and volume is None:
         ratio = _KC_APPROX_COEFF / f
@@ -476,10 +482,11 @@ def adaptation_term_kc(
         wavelength = _SPEED_OF_SOUND / f
         ratio = sb2 * wavelength / (8.0 * v2)
     else:
-        raise ValueError(
+        msg = (
             "Supply both 'boundary_area' and 'volume' for Formula (B.1), or "
             "neither for the Formula (B.2) approximation."
         )
+        raise ValueError(msg)
     return 10.0 * np.log10(1.0 + ratio)
 
 
@@ -508,9 +515,11 @@ def surface_pressure_intensity_indicator(
     p = np.asarray(lp, dtype=np.float64)
     i = np.asarray(l_in, dtype=np.float64)
     if p.shape != i.shape:
-        raise ValueError("'lp' and 'l_in' must share their shape.")
+        msg = "'lp' and 'l_in' must share their shape."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(p)) and np.all(np.isfinite(i))):
-        raise ValueError("Levels must contain only finite values.")
+        msg = "Levels must contain only finite values."
+        raise ValueError(msg)
     return p - i
 
 
@@ -554,28 +563,31 @@ def combine_subareas(
     """
     levels = np.asarray(l_in, dtype=np.float64)
     if levels.ndim != 2:
-        raise ValueError("'l_in' must be a two-dimensional (subareas, bands) array.")
+        msg = "'l_in' must be a two-dimensional (subareas, bands) array."
+        raise ValueError(msg)
     areas = np.asarray(measurement_area, dtype=np.float64)
     if areas.ndim != 1 or areas.size != levels.shape[0]:
-        raise ValueError(
-            "'measurement_area' must give one area per subarea (row of 'l_in')."
-        )
+        msg = "'measurement_area' must give one area per subarea (row of 'l_in')."
+        raise ValueError(msg)
     if not np.all(np.isfinite(levels)):
-        raise ValueError("'l_in' must contain only finite values.")
+        msg = "'l_in' must contain only finite values."
+        raise ValueError(msg)
     if not np.all(np.isfinite(areas)) or not np.all(np.abs(areas) > 0.0):
-        raise ValueError(
+        msg = (
             "'measurement_area' must contain non-zero, finite areas (negative "
             "marks a reverse-flow subarea, Clause 6.4.6)."
         )
+        raise ValueError(msg)
 
     sm = float(np.sum(np.abs(areas)))
     energy = np.sum(areas[:, None] * 10.0 ** (0.1 * levels), axis=0)
     if np.any(energy <= 0.0):
-        raise ValueError(
+        msg = (
             "The signed subarea energy sum of Formula (11) is not positive in "
             "at least one band: the negative-direction subareas cancel or "
             "exceed the forward flow, so no combined intensity level exists."
         )
+        raise ValueError(msg)
     l_in_total = 10.0 * np.log10(energy / sm)
     return l_in_total, sm
 
@@ -627,7 +639,8 @@ def intensity_sound_reduction(
     lp1_bands = _as_band_levels(lp1, "lp1")
     l_in_bands = _as_band_levels(l_in, "l_in")
     if lp1_bands.shape != l_in_bands.shape:
-        raise ValueError("'lp1' and 'l_in' must share the same band count.")
+        msg = "'lp1' and 'l_in' must share the same band count."
+        raise ValueError(msg)
     sm = _positive_area(measurement_area, "measurement_area")
     s = _positive_area(area, "area")
 
@@ -637,9 +650,11 @@ def intensity_sound_reduction(
     if kc is not None:
         kc_bands = np.asarray(kc, dtype=np.float64)
         if kc_bands.shape != r_i.shape:
-            raise ValueError("'kc' must share the band count of the levels.")
+            msg = "'kc' must share the band count of the levels."
+            raise ValueError(msg)
         if not np.all(np.isfinite(kc_bands)):
-            raise ValueError("'kc' must contain only finite values.")
+            msg = "'kc' must contain only finite values."
+            raise ValueError(msg)
         r_i_modified = r_i + kc_bands
 
     rating = weighted_rating(r_i) if r_i.size in (16, 5) else None
@@ -707,10 +722,12 @@ def intensity_element_normalized_difference(
     lp1_bands = _as_band_levels(lp1, "lp1")
     l_in_bands = _as_band_levels(l_in, "l_in")
     if lp1_bands.shape != l_in_bands.shape:
-        raise ValueError("'lp1' and 'l_in' must share the same band count.")
+        msg = "'lp1' and 'l_in' must share the same band count."
+        raise ValueError(msg)
     sm = _positive_area(measurement_area, "measurement_area")
     if int(n) != n or n < 1:
-        raise ValueError("'n' must be a positive integer.")
+        msg = "'n' must be a positive integer."
+        raise ValueError(msg)
     if n > 1:
         warnings.warn(
             "ISO 15186-1:2000 Formula (8) as printed subtracts 10 lg(N); "

--- a/src/phonometry/building/measurement/lab_insulation.py
+++ b/src/phonometry/building/measurement/lab_insulation.py
@@ -120,10 +120,11 @@ class LabAirborneInsulationResult:
         :class:`~matplotlib.axes.Axes`.
         """
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
+            raise ValueError(msg)
         return self.rating.plot(ax=ax, **kwargs)
 
     def report(
@@ -206,10 +207,11 @@ class LabImpactInsulationResult:
         :class:`~matplotlib.axes.Axes`.
         """
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
+            raise ValueError(msg)
         return self.rating.plot(ax=ax, **kwargs)
 
     def report(
@@ -287,17 +289,17 @@ def _render_iso10140(
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
     rating = result.rating
     if rating is None:
-        raise ValueError(
+        msg = (
             "The laboratory report needs the ISO 717 single-number rating; "
             "it is formed only for exactly 16 one-third-octave (100 Hz to "
             "3150 Hz) or 5 octave (125 Hz to 2000 Hz) bands. Build the result "
             "with that band count."
         )
+        raise ValueError(msg)
 
     from ..._report.iso10140 import render_iso10140_report
 
@@ -321,13 +323,17 @@ def _absorption_area(
     """
     t = np.asarray(t2, dtype=np.float64)
     if t.ndim != 1:
-        raise ValueError("'t2' must be one-dimensional (one value per band).")
+        msg = "'t2' must be one-dimensional (one value per band)."
+        raise ValueError(msg)
     if t.size != n_bands:
-        raise ValueError("'t2' must share the band count of the level input.")
+        msg = "'t2' must share the band count of the level input."
+        raise ValueError(msg)
     if not np.all(np.isfinite(t)) or np.any(t <= 0.0):
-        raise ValueError("'t2' must contain positive, finite values.")
+        msg = "'t2' must contain positive, finite values."
+        raise ValueError(msg)
     if not np.isfinite(volume) or volume <= 0.0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     return _SABINE * volume / t
 
 
@@ -376,11 +382,11 @@ def background_correction(
     lsb = np.asarray(signal_and_background, dtype=np.float64)
     lb = np.asarray(background, dtype=np.float64)
     if lsb.shape != lb.shape:
-        raise ValueError(
-            "'signal_and_background' and 'background' must share their shape."
-        )
+        msg = "'signal_and_background' and 'background' must share their shape."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(lsb)) and np.all(np.isfinite(lb))):
-        raise ValueError("Levels must contain only finite values.")
+        msg = "Levels must contain only finite values."
+        raise ValueError(msg)
 
     margin = lsb - lb
     # Formula (4) for the 6 < margin < 15 band; unchanged at margin >= 15.
@@ -442,9 +448,11 @@ def lab_airborne_insulation(
     l1_bands = _as_band_levels(l1, "l1")
     l2_bands = _as_band_levels(l2, "l2")
     if l1_bands.shape != l2_bands.shape:
-        raise ValueError("'l1' and 'l2' must share the same band count.")
+        msg = "'l1' and 'l2' must share the same band count."
+        raise ValueError(msg)
     if not np.isfinite(area) or area <= 0.0:
-        raise ValueError("'area' must be positive.")
+        msg = "'area' must be positive."
+        raise ValueError(msg)
 
     absorption = _absorption_area(t2, volume, int(l1_bands.size))
     r = l1_bands - l2_bands + 10.0 * np.log10(area / absorption)

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -544,19 +544,19 @@ def _render_iso717(
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
     if (
         result.band_centers is None
         or result.measured is None
         or result.shifted_reference is None
     ):
-        raise ValueError(
+        msg = (
             "report() needs the per-band data ('band_centers', 'measured', "
             "'shifted_reference'); build the rating with weighted_rating() or "
             "weighted_impact_rating() so they are populated."
         )
+        raise ValueError(msg)
     from ..._report.iso717 import render_iso717_report
 
     return render_iso717_report(
@@ -602,9 +602,8 @@ def _resolve_band_set(
     """
     if bands == "third-octave" or (bands is None and n == 16):
         if n != 16:
-            raise ValueError(
-                f"One-third-octave rating needs 16 bands (100-3150 Hz), got {n}."
-            )
+            msg = f"One-third-octave rating needs 16 bands (100-3150 Hz), got {n}."
+            raise ValueError(msg)
         return (
             _REF_THIRD_OCTAVE,
             _MAX_UNFAVOURABLE_THIRD,
@@ -614,7 +613,8 @@ def _resolve_band_set(
         )
     if bands == "octave" or (bands is None and n == 5):
         if n != 5:
-            raise ValueError(f"Octave rating needs 5 bands (125-2000 Hz), got {n}.")
+            msg = f"Octave rating needs 5 bands (125-2000 Hz), got {n}."
+            raise ValueError(msg)
         return (
             _REF_OCTAVE,
             _MAX_UNFAVOURABLE_OCTAVE,
@@ -623,11 +623,13 @@ def _resolve_band_set(
             _SPECTRUM2_OCTAVE,
         )
     if bands is not None:
-        raise ValueError("'bands' must be 'third-octave', 'octave' or None.")
-    raise ValueError(
+        msg = "'bands' must be 'third-octave', 'octave' or None."
+        raise ValueError(msg)
+    msg = (
         "Expected 16 one-third-octave (100-3150 Hz) or 5 octave "
         f"(125-2000 Hz) values, got {n}."
     )
+    raise ValueError(msg)
 
 
 def _best_shift(
@@ -657,7 +659,8 @@ def _best_shift(
     """
     scale = round(1.0 / step)
     if scale < 1 or abs(scale * step - 1.0) > 1e-12:
-        raise ValueError("'step' must divide 1 dB exactly (e.g. 1.0 or 0.1).")
+        msg = "'step' must divide 1 dB exactly (e.g. 1.0 or 0.1)."
+        raise ValueError(msg)
     # Start below any feasible shift, then climb while the bound holds.
     n = (int(np.floor(np.min(measured - reference))) - 1) * scale
     while True:
@@ -743,9 +746,10 @@ def _resolve_impact_band_set(
     """
     if bands == "third-octave" or (bands is None and n == 16):
         if n != 16:
-            raise ValueError(
+            msg = (
                 f"One-third-octave impact rating needs 16 bands (100-3150 Hz), got {n}."
             )
+            raise ValueError(msg)
         return (
             _REF_IMPACT_THIRD_OCTAVE,
             _MAX_UNFAVOURABLE_THIRD,
@@ -755,9 +759,8 @@ def _resolve_impact_band_set(
         )
     if bands == "octave" or (bands is None and n == 5):
         if n != 5:
-            raise ValueError(
-                f"Octave impact rating needs 5 bands (125-2000 Hz), got {n}."
-            )
+            msg = f"Octave impact rating needs 5 bands (125-2000 Hz), got {n}."
+            raise ValueError(msg)
         return (
             _REF_IMPACT_OCTAVE,
             _MAX_UNFAVOURABLE_OCTAVE,
@@ -766,11 +769,13 @@ def _resolve_impact_band_set(
             5,
         )
     if bands is not None:
-        raise ValueError("'bands' must be 'third-octave', 'octave' or None.")
-    raise ValueError(
+        msg = "'bands' must be 'third-octave', 'octave' or None."
+        raise ValueError(msg)
+    msg = (
         "Expected 16 one-third-octave (100-3150 Hz) or 5 octave "
         f"(125-2000 Hz) values, got {n}."
     )
+    raise ValueError(msg)
 
 
 def _impact_ci(measured: np.ndarray, rating: int, n_bands: int) -> int:
@@ -902,11 +907,11 @@ def weighted_impact_improvement(
     """
     dl = np.asarray(delta_l, dtype=np.float64)
     if dl.shape != (16,):
-        raise ValueError(
-            "'delta_l' must give the 16 one-third-octave values 100-3150 Hz."
-        )
+        msg = "'delta_l' must give the 16 one-third-octave values 100-3150 Hz."
+        raise ValueError(msg)
     if not np.all(np.isfinite(dl)):
-        raise ValueError("'delta_l' must contain only finite values.")
+        msg = "'delta_l' must contain only finite values."
+        raise ValueError(msg)
     ln_r = np.asarray(_IMPACT_REFERENCE_FLOOR, dtype=np.float64) - dl
     ln_r_w = weighted_impact_rating(ln_r).rating
     return _IMPACT_REFERENCE_FLOOR_RATING - ln_r_w
@@ -935,11 +940,11 @@ def impact_improvement_adaptation_term(
     """
     dl = np.asarray(delta_l, dtype=np.float64)
     if dl.shape != (16,):
-        raise ValueError(
-            "'delta_l' must give the 16 one-third-octave values 100-3150 Hz."
-        )
+        msg = "'delta_l' must give the 16 one-third-octave values 100-3150 Hz."
+        raise ValueError(msg)
     if not np.all(np.isfinite(dl)):
-        raise ValueError("'delta_l' must contain only finite values.")
+        msg = "'delta_l' must contain only finite values."
+        raise ValueError(msg)
     ln_r = np.asarray(_IMPACT_REFERENCE_FLOOR, dtype=np.float64) - dl
     ci_r = weighted_impact_rating(ln_r).ci
     return _IMPACT_REFERENCE_FLOOR_CI - ci_r
@@ -1094,26 +1099,28 @@ def _validated_extended_input(
         raise ValueError(_VALUES_FINITE_MSG)
     if frequencies is None:
         if data.size != len(_FREQ_THIRD_OCTAVE):
-            raise ValueError(
+            msg = (
                 "Without 'frequencies' the input must be the 16 core "
                 "one-third-octave bands 100-3150 Hz; pass the band centre "
                 "frequencies for an enlarged range."
             )
+            raise ValueError(msg)
         freqs = np.asarray(_FREQ_THIRD_OCTAVE, dtype=np.float64)
     else:
         freqs = np.asarray(frequencies, dtype=np.float64)
         if freqs.shape != data.shape:
-            raise ValueError(
-                "'frequencies' must have one value per band of 'values_by_band'."
-            )
+            msg = "'frequencies' must have one value per band of 'values_by_band'."
+            raise ValueError(msg)
         if not np.all(np.isfinite(freqs)) or np.any(freqs <= 0.0):
-            raise ValueError("'frequencies' must contain positive values.")
+            msg = "'frequencies' must contain positive values."
+            raise ValueError(msg)
     core_idx = _match_bands(freqs, _FREQ_THIRD_OCTAVE)
     if core_idx is None:
-        raise ValueError(
+        msg = (
             "The input must contain the 16 core one-third-octave bands "
             "100-3150 Hz (ISO 717 rates the single number on that range)."
         )
+        raise ValueError(msg)
     return _round_half_up_tenths(data), freqs, core_idx
 
 

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -179,11 +179,13 @@ def structure_borne_power_level(
     reference_velocity = require_positive(reference_velocity, "reference_velocity")
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     lv = np.asarray(velocity_level, dtype=np.float64)
     eta = np.asarray(loss_factor, dtype=np.float64)
     if not np.all(np.isfinite(eta)) or np.any(eta <= 0.0):
-        raise ValueError("'loss_factor' must contain positive, finite values.")
+        msg = "'loss_factor' must contain positive, finite values."
+        raise ValueError(msg)
     offset = 10.0 * np.log10(reference_velocity**2 / REFERENCE_SOUND_POWER)
     lw = 10.0 * np.log10(2.0 * np.pi * f * eta * mass_per_area * area) + lv + offset
     return np.asarray(lw, dtype=np.float64)
@@ -283,9 +285,8 @@ class StructureBornePowerResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.en15657 import render_structure_borne_power_report
 
         return render_structure_borne_power_report(
@@ -335,7 +336,8 @@ def reception_plate_power(
     elif reverberation_time is not None:
         eta = np.asarray(plate_loss_factor(freq, reverberation_time), dtype=np.float64)
     else:
-        raise ValueError("provide either 'loss_factor' or 'reverberation_time'.")
+        msg = "provide either 'loss_factor' or 'reverberation_time'."
+        raise ValueError(msg)
     lw = structure_borne_power_level(lv, freq, mass_per_area, area, eta)
     return StructureBornePowerResult(
         power_level=np.asarray(lw, dtype=np.float64),
@@ -375,7 +377,8 @@ def equivalent_blocked_force_level(
         or not np.all(np.isfinite(y.imag))
         or np.any(y_re <= 0.0)
     ):
-        raise ValueError("'plate_mobility' must be finite with a positive real part.")
+        msg = "'plate_mobility' must be finite with a positive real part."
+        raise ValueError(msg)
     return np.asarray(lw - 10.0 * np.log10(y_re / REFERENCE_MOBILITY), dtype=np.float64)
 
 
@@ -442,7 +445,8 @@ def equivalent_free_velocity_level(
         or not np.all(np.isfinite(y.imag))
         or np.any(y_re <= 0.0)
     ):
-        raise ValueError("'plate_mobility' must be finite with a positive real part.")
+        msg = "'plate_mobility' must be finite with a positive real part."
+        raise ValueError(msg)
     term = np.abs(y) ** 2 / (y_re * REFERENCE_MOBILITY)
     return np.asarray(lw + 10.0 * np.log10(term) + 60.0, dtype=np.float64)
 

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -99,9 +99,8 @@ def _validate_report_request(engine: str, language: str) -> None:
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
 
 
 #: Refusal raised by every survey-result ``plot()`` when the measured band set
@@ -210,7 +209,8 @@ def _finite_bands(
     """Return ``values`` as a finite float array, or raise."""
     a = np.asarray(values, dtype=np.float64)
     if not np.all(np.isfinite(a)):
-        raise ValueError(f"'{name}' must contain only finite values.")
+        msg = f"'{name}' must contain only finite values."
+        raise ValueError(msg)
     return a
 
 
@@ -218,7 +218,8 @@ def _positive(value: float, name: str) -> float:
     """Return ``value`` as a positive, finite float, or raise."""
     v = float(value)
     if not np.isfinite(v) or v <= 0.0:
-        raise ValueError(f"'{name}' must be positive.")
+        msg = f"'{name}' must be positive."
+        raise ValueError(msg)
     return v
 
 
@@ -249,7 +250,8 @@ def reverberation_index(
     """
     tt = _finite_bands(t, "t")
     if np.any(tt <= 0.0):
-        raise ValueError("'t' must contain positive values.")
+        msg = "'t' must contain positive values."
+        raise ValueError(msg)
     return 10.0 * np.log10(tt / _positive(t0, "t0"))
 
 
@@ -294,10 +296,11 @@ def estimate_reverberation_index(
     """
     v = _positive(volume, "volume")
     if v > _TABLE3_VOLUME_LIMITS[-1]:
-        raise ValueError(
+        msg = (
             f"'volume' must be at most {_TABLE3_VOLUME_LIMITS[-1]:g} m³ "
             "(the Table 4 range)."
         )
+        raise ValueError(msg)
     # V < 15, 15 <= V < 35, 35 <= V < 60, 60 <= V <= 150 (last is inclusive).
     idx = next(
         (i for i, hi in enumerate(_TABLE3_VOLUME_LIMITS) if v < hi),
@@ -316,10 +319,11 @@ def estimate_reverberation_index(
             rng = f"{limits[idx - 1]:g} <= V <= {limits[idx]:g}"
         else:
             rng = f"{limits[idx - 1]:g} <= V < {limits[idx]:g}"
-        raise ValueError(
+        msg = (
             f"'room' {room!r} is not tabulated for the volume range "
             f"{rng} (m³); available: {available}."
         )
+        raise ValueError(msg)
     row = entries[key]
     return float(row[5]) if weighted else np.asarray(row[:5], dtype=np.float64)
 
@@ -404,16 +408,16 @@ class SurveyAirborneResult:
         """
         _validate_report_request(engine, language)
         if quantity not in ("dnt", "r_prime"):
-            raise ValueError(
-                f"Unknown survey quantity {quantity!r}; expected 'dnt' or 'r_prime'."
-            )
+            msg = f"Unknown survey quantity {quantity!r}; expected 'dnt' or 'r_prime'."
+            raise ValueError(msg)
         rating = self.rating if quantity == "dnt" else self.r_prime_rating
         if rating is None:
-            raise ValueError(
+            msg = (
                 "The survey airborne report needs the ISO 717-1 single-number "
                 "rating; supply 5 octave or 16 one-third-octave bands "
                 "(and, for R', the 'area' and 'volume' arguments)."
             )
+            raise ValueError(msg)
         from ..._report.iso10052 import render_survey_airborne_report
 
         return render_survey_airborne_report(
@@ -489,10 +493,11 @@ class SurveyImpactResult:
         """
         _validate_report_request(engine, language)
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "The survey impact report needs the ISO 717-2 single-number "
                 "rating; supply 5 octave or 16 one-third-octave bands."
             )
+            raise ValueError(msg)
         from ..._report.iso10052 import render_survey_impact_report
 
         return render_survey_impact_report(
@@ -568,10 +573,11 @@ class SurveyFacadeResult:
         """
         _validate_report_request(engine, language)
         if self.rating is None:
-            raise ValueError(
+            msg = (
                 "The survey facade report needs the ISO 717-1 single-number "
                 "rating; supply 5 octave or 16 one-third-octave bands."
             )
+            raise ValueError(msg)
         from ..._report.iso10052 import render_survey_facade_report
 
         return render_survey_facade_report(
@@ -605,10 +611,11 @@ def _validate_index(k: Sequence[float] | np.ndarray, n_bands: int) -> np.ndarray
     """Coerce the reverberation index to a finite per-band array."""
     kk = _finite_bands(k, "reverberation_index")
     if kk.shape != (n_bands,):
-        raise ValueError(
+        msg = (
             "'reverberation_index' must give one value per band, matching the "
             "level inputs."
         )
+        raise ValueError(msg)
     return kk
 
 
@@ -673,14 +680,16 @@ def survey_airborne_insulation(
     l1_bands = _as_band_levels(l1, "l1")
     l2_bands = _as_band_levels(l2, "l2")
     if l1_bands.shape != l2_bands.shape:
-        raise ValueError("'l1' and 'l2' must share the same band count.")
+        msg = "'l1' and 'l2' must share the same band count."
+        raise ValueError(msg)
     k = _validate_index(reverberation_index, int(l1_bands.size))
 
     d = l1_bands - l2_bands
     d_nt = d + k
 
     if area is not None and volume is None:
-        raise ValueError("'area' requires 'volume' to compute R'.")
+        msg = "'area' requires 'volume' to compute R'."
+        raise ValueError(msg)
 
     d_n: np.ndarray | None = None
     r_prime: np.ndarray | None = None
@@ -765,7 +774,8 @@ def survey_facade_insulation(
     out = _as_band_levels(l1_2m, "l1_2m")
     l2_bands = _as_band_levels(l2, "l2")
     if out.shape != l2_bands.shape:
-        raise ValueError("'l1_2m' and 'l2' must share the same band count.")
+        msg = "'l1_2m' and 'l2' must share the same band count."
+        raise ValueError(msg)
     k = _validate_index(reverberation_index, int(out.size))
 
     d_2m = out - l2_bands
@@ -811,18 +821,20 @@ def survey_service_equipment_level(
     """
     m = _finite_bands(measurements, "measurements")
     if m.ndim not in (1, 2) or m.shape[0] != 3:
-        raise ValueError(
+        msg = (
             "'measurements' must give exactly three measurement positions "
             "(three scalars, or a (3, bands) array)."
         )
+        raise ValueError(msg)
     l_xy = np.asarray(energy_average_level(m, axis=0), dtype=np.float64)
 
     k = _finite_bands(reverberation_index, "reverberation_index")
     if k.shape != l_xy.shape:
-        raise ValueError(
+        msg = (
             "'reverberation_index' must match the shape of the per-position "
             "average (scalar, or one value per band)."
         )
+        raise ValueError(msg)
 
     l_xy_nt = l_xy - k
     l_xy_n: np.ndarray | None = None

--- a/src/phonometry/building/measurement/uncertainty.py
+++ b/src/phonometry/building/measurement/uncertainty.py
@@ -471,9 +471,8 @@ def _canonical(quantity: str) -> str:
     key = _ALIASES.get(key, key)
     if key not in _SINGLE:
         valid = ", ".join(sorted(set(_SINGLE) | set(_ALIASES)))
-        raise ValueError(
-            f"Unknown single-number quantity {quantity!r}. Valid: {valid}."
-        )
+        msg = f"Unknown single-number quantity {quantity!r}. Valid: {valid}."
+        raise ValueError(msg)
     return key
 
 
@@ -498,17 +497,20 @@ def band_uncertainty(
         frequencies, columns = _BAND_TABLES[(measurand, upper_limit)]
     except KeyError:
         if upper_limit:
-            raise ValueError(
+            msg = (
                 f"No σR95 upper limit tabulated for measurand {measurand!r} "
                 "(only airborne, Annex D)."
-            ) from None
+            )
+            raise ValueError(msg) from None
         valid = ", ".join(sorted({m for m, _ in _BAND_TABLES}))
-        raise ValueError(f"Unknown measurand {measurand!r}. Valid: {valid}.") from None
+        msg = f"Unknown measurand {measurand!r}. Valid: {valid}."
+        raise ValueError(msg) from None
     if situation not in columns:
-        raise ValueError(
+        msg = (
             f"Situation {situation!r} is not tabulated for measurand {measurand!r} "
             f"(available: {', '.join(sorted(columns))})."
         )
+        raise ValueError(msg)
     return BandUncertainty(
         measurand=measurand,
         situation=situation,
@@ -547,17 +549,19 @@ def single_number_uncertainty(
     situations, sigma_r95 = _SINGLE[key]
     if upper_limit:
         if situation != "A":
-            raise ValueError("σR95 upper limit is defined for situation A only.")
+            msg = "σR95 upper limit is defined for situation A only."
+            raise ValueError(msg)
         if sigma_r95 is None:
-            raise ValueError(f"No σR95 upper limit tabulated for {quantity!r}.")
+            msg = f"No σR95 upper limit tabulated for {quantity!r}."
+            raise ValueError(msg)
         return sigma_r95
     if situation not in _SITUATION_INDEX:
-        raise ValueError(f"Unknown situation {situation!r}. Valid: A, B, C.")
+        msg = f"Unknown situation {situation!r}. Valid: A, B, C."
+        raise ValueError(msg)
     value = situations[_SITUATION_INDEX[situation]]
     if value is None:
-        raise ValueError(
-            f"Situation {situation!r} is not tabulated for descriptor {quantity!r}."
-        )
+        msg = f"Situation {situation!r} is not tabulated for descriptor {quantity!r}."
+        raise ValueError(msg)
     return value
 
 
@@ -595,10 +599,11 @@ def insulation_coverage_factor(
             return k
     kind = "one-sided" if one_sided else "two-sided"
     valid = ", ".join(f"{level:g}" for level in table)
-    raise ValueError(
+    msg = (
         f"Confidence level {confidence!r} is not tabulated for the {kind} test. "
         f"Valid: {valid}."
     )
+    raise ValueError(msg)
 
 
 def insulation_expanded_uncertainty(
@@ -617,7 +622,8 @@ def insulation_expanded_uncertainty(
     :raises ValueError: Negative ``u`` or an untabulated confidence level.
     """
     if u < 0:
-        raise ValueError("Standard uncertainty u must be non-negative.")
+        msg = "Standard uncertainty u must be non-negative."
+        raise ValueError(msg)
     k = max(insulation_coverage_factor(coverage, one_sided), 1.0)
     return k * u
 
@@ -672,9 +678,11 @@ def combine_uncertainties(*components: float) -> float:
     :raises ValueError: No components, or a negative component.
     """
     if not components:
-        raise ValueError("At least one uncertainty component is required.")
+        msg = "At least one uncertainty component is required."
+        raise ValueError(msg)
     if any(c < 0 for c in components):
-        raise ValueError("Uncertainty components must be non-negative.")
+        msg = "Uncertainty components must be non-negative."
+        raise ValueError(msg)
     return sqrt(sum(c * c for c in components))
 
 
@@ -701,9 +709,11 @@ def prediction_input_uncertainty(
     :raises ValueError: Non-positive ``n`` or a negative standard deviation.
     """
     if n < 1:
-        raise ValueError("n must be a positive integer.")
+        msg = "n must be a positive integer."
+        raise ValueError(msg)
     if sigma_reproducibility < 0 or sigma_product < 0:
-        raise ValueError("Standard deviations must be non-negative.")
+        msg = "Standard deviations must be non-negative."
+        raise ValueError(msg)
     return sqrt((sigma_reproducibility**2 + sigma_product**2) / n + sigma_product**2)
 
 
@@ -719,9 +729,11 @@ def reduce_by_independent_measurements(u: float, m: int) -> float:
     :raises ValueError: Non-positive ``m`` or negative ``u``.
     """
     if m < 1:
-        raise ValueError("m must be a positive integer.")
+        msg = "m must be a positive integer."
+        raise ValueError(msg)
     if u < 0:
-        raise ValueError("Standard uncertainty u must be non-negative.")
+        msg = "Standard uncertainty u must be non-negative."
+        raise ValueError(msg)
     return u / sqrt(m)
 
 
@@ -754,20 +766,23 @@ def single_number_uncertainty_uncorrelated(
     u_arr = np.asarray(band_uncertainties, dtype=float)
     d_arr = np.asarray(reference_differences, dtype=float)
     if u_arr.ndim != 1 or d_arr.ndim != 1:
-        raise ValueError("Inputs must be one-dimensional sequences.")
+        msg = "Inputs must be one-dimensional sequences."
+        raise ValueError(msg)
     if u_arr.size == 0:
-        raise ValueError("At least one band is required.")
+        msg = "At least one band is required."
+        raise ValueError(msg)
     if u_arr.shape != d_arr.shape:
-        raise ValueError(
-            "band_uncertainties and reference_differences differ in length."
-        )
+        msg = "band_uncertainties and reference_differences differ in length."
+        raise ValueError(msg)
     if np.any(u_arr < 0):
-        raise ValueError("Band uncertainties must be non-negative.")
+        msg = "Band uncertainties must be non-negative."
+        raise ValueError(msg)
     if not np.all(np.isfinite(u_arr)) or not np.all(np.isfinite(d_arr)):
-        raise ValueError(
+        msg = (
             "band_uncertainties and reference_differences must contain only "
             "finite values."
         )
+        raise ValueError(msg)
     energies = np.power(10.0, d_arr / 10.0)
     weights = energies / energies.sum()
     return float(sqrt(np.sum((weights * u_arr) ** 2)))

--- a/src/phonometry/building/prediction/aperture_transmission.py
+++ b/src/phonometry/building/prediction/aperture_transmission.py
@@ -96,7 +96,8 @@ def transmission_loss_from_coefficient(tau: ArrayLike) -> np.ndarray:
     """
     t = np.asarray(tau, dtype=np.float64)
     if np.any(t <= 0.0):
-        raise ValueError("'tau' must be positive.")
+        msg = "'tau' must be positive."
+        raise ValueError(msg)
     return np.asarray(-10.0 * np.log10(t), dtype=np.float64)
 
 
@@ -196,9 +197,11 @@ def slit_transmission_coefficient(
     position = require_choice(position, "position", tuple(_POSITION_N))
     f = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequency' must be a non-empty 1-D array.")
+        msg = "'frequency' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
 
     m = _FIELD_M[field]
     n = _POSITION_N[position]
@@ -261,7 +264,8 @@ def slit_resonance_frequencies(
     w = require_positive(width, "width")
     c0 = require_positive(speed_of_sound, "speed_of_sound")
     if orders < 1:
-        raise ValueError("'orders' must be at least 1.")
+        msg = "'orders' must be at least 1."
+        raise ValueError(msg)
     out = np.empty(orders, dtype=np.float64)
     for i in range(orders):
         z = i + 1
@@ -272,11 +276,12 @@ def slit_resonance_frequencies(
             e = (np.log(8.0 / k_big) - _EULER_GAMMA) / np.pi
             effective_depth = d + 2.0 * e * w
             if effective_depth <= 0.0:
-                raise ValueError(
+                msg = (
                     "slit too wide relative to its depth: the effective depth "
                     "d + 2e is non-positive, so no resonance exists (the "
                     "Gomperts slit model requires 'width' << wavelength)."
                 )
+                raise ValueError(msg)
             f_new = z * c0 / (2.0 * effective_depth)
             if abs(f_new - f) < 1e-9 * f:
                 f = f_new
@@ -307,9 +312,11 @@ def circular_aperture_transmission_coefficient(
     c0 = require_positive(speed_of_sound, "speed_of_sound")
     f = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequency' must be a non-empty 1-D array.")
+        msg = "'frequency' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
 
     k = 2.0 * np.pi * f / c0
     x = 2.0 * k * a
@@ -355,20 +362,25 @@ def composite_transmission_loss(
     """
     s = np.atleast_1d(np.asarray(areas, dtype=np.float64))
     if s.ndim != 1 or s.size == 0:
-        raise ValueError("'areas' must be a non-empty 1-D array.")
+        msg = "'areas' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(s <= 0.0) or not np.all(np.isfinite(s)):
-        raise ValueError("'areas' must be positive and finite.")
+        msg = "'areas' must be positive and finite."
+        raise ValueError(msg)
     r = np.asarray(reduction_indices, dtype=np.float64)
     if r.ndim == 1:
         if r.shape[0] != s.shape[0]:
-            raise ValueError("'reduction_indices' length must match 'areas'.")
+            msg = "'reduction_indices' length must match 'areas'."
+            raise ValueError(msg)
         tau = 10.0 ** (-r / 10.0)
         total_1d = float(np.sum(s * tau) / np.sum(s))
         return np.asarray(-10.0 * np.log10(total_1d), dtype=np.float64)
     if r.ndim == 2:
         if r.shape[0] != s.shape[0]:
-            raise ValueError("'reduction_indices' first axis must match 'areas'.")
+            msg = "'reduction_indices' first axis must match 'areas'."
+            raise ValueError(msg)
         tau = 10.0 ** (-r / 10.0)
         total_2d = np.sum(s[:, None] * tau, axis=0) / np.sum(s)
         return np.asarray(-10.0 * np.log10(total_2d), dtype=np.float64)
-    raise ValueError("'reduction_indices' must be 1-D or 2-D.")
+    msg = "'reduction_indices' must be 1-D or 2-D."
+    raise ValueError(msg)

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -179,12 +179,13 @@ def _require_transmission_factor(tau: np.ndarray) -> None:
     """
     worst = float(np.max(tau))
     if worst > 1.0:
-        raise ValueError(
+        msg = (
             f"the ceiling/plenum transmission factor reaches {worst:.3g}, above "
             "unity: the one-dimensional model is outside its validity range. "
             "Check that 'reduction_index_source' and 'reduction_index_receiving' "
             "exceed the geometry term 10 lg(eps^2 LR/(4h))."
         )
+        raise ValueError(msg)
 
 
 def _require_split(value: float, name: str) -> float:
@@ -196,7 +197,8 @@ def _require_split(value: float, name: str) -> float:
     """
     ratio = require_positive(value, name)
     if ratio > 1.0:
-        raise ValueError(f"'{name}' must be a power split in (0, 1].")
+        msg = f"'{name}' must be a power split in (0, 1]."
+        raise ValueError(msg)
     return ratio
 
 
@@ -226,14 +228,17 @@ def normalized_ceiling_attenuation(
     l1 = require_finite_array(level_source, "level_source")
     l2 = require_finite_array(level_receiving, "level_receiving")
     if l1.shape != l2.shape:
-        raise ValueError("'level_source' and 'level_receiving' must share their shape.")
+        msg = "'level_source' and 'level_receiving' must share their shape."
+        raise ValueError(msg)
     area = require_finite_array(absorption_area, "absorption_area")
     if area.size == 1:
         area = np.full(l1.shape, float(area[0]))
     if area.shape != l1.shape:
-        raise ValueError("'absorption_area' must be a scalar or match the levels.")
+        msg = "'absorption_area' must be a scalar or match the levels."
+        raise ValueError(msg)
     if np.any(area <= 0.0):
-        raise ValueError("'absorption_area' must be positive.")
+        msg = "'absorption_area' must be positive."
+        raise ValueError(msg)
     a0 = require_positive(reference_area, "reference_area")
     return np.asarray(l1 - l2 - 10.0 * np.log10(area / a0), dtype=np.float64)
 
@@ -304,16 +309,18 @@ def ceiling_attenuation_class(
     )
     values = require_finite_array(attenuation, "attenuation")
     if values.shape != bands.shape:
-        raise ValueError(
+        msg = (
             f"'attenuation' must hold {bands.size} one-third-octave values "
             f"(125 Hz to 4000 Hz)."
         )
+        raise ValueError(msg)
     if frequency is not None:
         given = require_finite_array(frequency, "frequency")
         if given.shape != bands.shape or not np.allclose(given, bands):
-            raise ValueError(
+            msg = (
                 "'frequency' must be the 16 ASTM E413 contour bands 125 Hz to 4000 Hz."
             )
+            raise ValueError(msg)
     # Clause 5.2: the contour is fitted to integer-rounded data.
     rounded = np.asarray(np.floor(values + 0.5), dtype=np.float64)
 
@@ -484,10 +491,11 @@ def plenum_flanking_reduction_index(
     rs = require_finite_array(reduction_index_source, "reduction_index_source")
     rr = require_finite_array(reduction_index_receiving, "reduction_index_receiving")
     if rs.shape != rr.shape:
-        raise ValueError(
+        msg = (
             "'reduction_index_source' and 'reduction_index_receiving' must "
             "share their shape."
         )
+        raise ValueError(msg)
     lr = require_positive(ceiling_length, "ceiling_length")
     h = require_positive(plenum_height, "plenum_height")
     ls = (
@@ -503,14 +511,14 @@ def plenum_flanking_reduction_index(
     if frequency is not None:
         freqs = require_finite_array(frequency, "frequency")
         if freqs.shape != rs.shape:
-            raise ValueError("'frequency' must match the reduction indices.")
+            msg = "'frequency' must match the reduction indices."
+            raise ValueError(msg)
 
     tau_s = 10.0 ** (-rs / 10.0)
     tau_r = 10.0 ** (-rr / 10.0)
     if (attenuation_source is None) != (attenuation_receiving is None):
-        raise ValueError(
-            "'attenuation_source' and 'attenuation_receiving' must be given together."
-        )
+        msg = "'attenuation_source' and 'attenuation_receiving' must be given together."
+        raise ValueError(msg)
     if attenuation_source is None or attenuation_receiving is None:
         geometry = float(10.0 * np.log10(eps**2 * lr / (4.0 * h)))
         tau = eps**2 * tau_s * tau_r * lr / (4.0 * h)
@@ -533,11 +541,11 @@ def plenum_flanking_reduction_index(
     ms = require_finite_array(attenuation_source, "attenuation_source")
     mr = require_finite_array(attenuation_receiving, "attenuation_receiving")
     if ms.shape != rs.shape or mr.shape != rs.shape:
-        raise ValueError(
-            "the attenuation coefficients must match the reduction indices."
-        )
+        msg = "the attenuation coefficients must match the reduction indices."
+        raise ValueError(msg)
     if np.any(ms <= 0.0) or np.any(mr <= 0.0):
-        raise ValueError("the attenuation coefficients must be positive.")
+        msg = "the attenuation coefficients must be positive."
+        raise ValueError(msg)
     # Eq. (9.17): the receiving side also loses power back into the room.
     mr_eff = mr + sr * tau_r / h
     # Vigran's Eq. (9.18) prints the *unprimed* mR in this denominator while

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -193,17 +193,19 @@ def _band_array(
     """Coerce *values* to ``n_bands`` finite floats, broadcasting a scalar."""
     data = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if data.ndim != 1 or data.size == 0:
-        raise ValueError(f"'{name}' must be a non-empty 1-D array.")
+        msg = f"'{name}' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if not np.all(np.isfinite(data)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     if positive and np.any(data <= 0.0):
-        raise ValueError(f"'{name}' must be strictly positive.")
+        msg = f"'{name}' must be strictly positive."
+        raise ValueError(msg)
     if data.size == 1:
         return np.full(n_bands, data[0], dtype=np.float64)
     if data.size != n_bands:
-        raise ValueError(
-            f"'{name}' must have one value per band ({n_bands}) or a single value."
-        )
+        msg = f"'{name}' must have one value per band ({n_bands}) or a single value."
+        raise ValueError(msg)
     return data
 
 
@@ -244,9 +246,8 @@ def _check_report_request(engine: str, language: str) -> None:
 
     check_language(language)
     if engine != "reportlab":
-        raise ValueError(
-            f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        )
+        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+        raise ValueError(msg)
 
 
 # --------------------------------------------------------------------------- #
@@ -585,12 +586,14 @@ def perimeter_absorption_coefficient(
     fc = require_positive_array(critical_frequencies, "critical_frequencies")
     kij = np.atleast_1d(np.asarray(vibration_reduction_indices, dtype=np.float64))
     if kij.shape != fc.shape:
-        raise ValueError(
+        msg = (
             "'critical_frequencies' and 'vibration_reduction_indices' must "
             "have the same length (one value per connected element)."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(kij)):
-        raise ValueError("'vibration_reduction_indices' must be finite.")
+        msg = "'vibration_reduction_indices' must be finite."
+        raise ValueError(msg)
     return float(np.sum(np.sqrt(fc / REFERENCE_FREQUENCY) * 10.0 ** (-kij / 10.0)))
 
 
@@ -641,7 +644,8 @@ def in_situ_total_loss_factor(
     sigma = _band_array(radiation_factor, f.size, "radiation_factor", positive=True)
     perimeter_sum = float(perimeter_absorption)
     if not np.isfinite(perimeter_sum) or perimeter_sum < 0.0:
-        raise ValueError("'perimeter_absorption' must be finite and non-negative.")
+        msg = "'perimeter_absorption' must be finite and non-negative."
+        raise ValueError(msg)
 
     radiation = 2.0 * rho0 * c0 * sigma / (2.0 * np.pi * f * m)
     perimeter = c0 / (np.pi**2 * s * np.sqrt(f * fc)) * perimeter_sum
@@ -1791,10 +1795,11 @@ def detailed_impact_prediction(
 
     f = require_positive_array(frequencies, "frequencies")
     if direct_level is None and not flanking_paths:
-        raise ValueError(
+        msg = (
             "'detailed_impact_prediction' needs a 'direct_level', at least one "
             "flanking path, or both."
         )
+        raise ValueError(msg)
     paths: tuple[BandPath, ...] = tuple(flanking_paths)
     if direct_level is not None:
         direct = BandPath(

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -90,7 +90,8 @@ def _as_array(value: float | Sequence[float] | np.ndarray, name: str) -> np.ndar
     """Return *value* as a 1-D float array, raising on non-finite entries."""
     arr = np.atleast_1d(np.asarray(value, dtype=np.float64))
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must contain only finite numbers.")
+        msg = f"'{name}' must contain only finite numbers."
+        raise ValueError(msg)
     return arr
 
 
@@ -124,15 +125,17 @@ class FacadeElement:
             k for k in ("r", "dn_e", "insertion_loss") if getattr(self, k) is not None
         ]
         if len(given) != 1:
-            raise ValueError(
+            msg = (
                 f"Element '{self.name}': give exactly one of r / dn_e / insertion_loss."
             )
+            raise ValueError(msg)
         return given[0]
 
     def tau(self, total_area: float, n_bands: int) -> np.ndarray:
         """Transmission factor ``τ`` of this element for the whole façade area."""
         if total_area <= 0:
-            raise ValueError("'total_area' (façade area S) must be positive.")
+            msg = "'total_area' (façade area S) must be positive."
+            raise ValueError(msg)
         kind = self._kind()
         raw = getattr(self, kind)  # the one non-None quantity, per _kind()
         label = f"{self.name} ({kind})"
@@ -141,13 +144,15 @@ class FacadeElement:
             weight = _A0 / total_area
         else:
             if self.area is None or self.area <= 0:
-                raise ValueError(f"Element '{self.name}': 'area' must be positive.")
+                msg = f"Element '{self.name}': 'area' must be positive."
+                raise ValueError(msg)
             level = _as_array(raw, label)
             weight = self.area / total_area
         if level.size == 1:
             level = np.full(n_bands, float(level[0]))
         if level.size != n_bands:
-            raise ValueError(f"Element '{self.name}': expected {n_bands} bands.")
+            msg = f"Element '{self.name}': expected {n_bands} bands."
+            raise ValueError(msg)
         return weight * 10.0 ** (-level / 10.0)
 
 
@@ -159,7 +164,8 @@ def _band_count(elements: Sequence[FacadeElement]) -> int:
         sizes.add(_as_array(getattr(el, kind), f"{el.name} ({kind})").size)
     sizes.discard(1)
     if len(sizes) > 1:
-        raise ValueError("Elements have inconsistent band counts.")
+        msg = "Elements have inconsistent band counts."
+        raise ValueError(msg)
     return sizes.pop() if sizes else 1
 
 
@@ -275,9 +281,8 @@ class FacadePredictionResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso12354 import render_iso12354_facade_report
 
         return render_iso12354_facade_report(
@@ -334,14 +339,15 @@ def _apparent_reduction(
 ) -> tuple[np.ndarray, dict[str, np.ndarray]]:
     r""":math:`R' = -10 \log_{10}(\sum \tau)` (F. 10 / Part 4 F. 3), plus ``Rp``."""
     if not elements:
-        raise ValueError("At least one façade element is required.")
+        msg = "At least one façade element is required."
+        raise ValueError(msg)
     if total_area <= 0:
-        raise ValueError("'area' (total façade area S) must be positive.")
+        msg = "'area' (total façade area S) must be positive."
+        raise ValueError(msg)
     names = [el.name for el in elements]
     if len(set(names)) != len(names):
-        raise ValueError(
-            "Façade element names must be unique (they key the per-element results)."
-        )
+        msg = "Façade element names must be unique (they key the per-element results)."
+        raise ValueError(msg)
     n = _band_count(elements)
     # Sum over the element list (not a name-keyed dict), so no element is ever
     # silently dropped, then key the per-element index by the unique names.
@@ -393,13 +399,15 @@ def facade_sound_reduction(
     delta = float(delta_l_fs)
     v = float(volume)
     if v <= 0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     r_prime, element_r = _apparent_reduction(elements, float(area))
     if frequencies is not None and len(frequencies) != r_prime.size:
-        raise ValueError(
+        msg = (
             f"'frequencies' has {len(frequencies)} entries but the elements imply "
             f"{r_prime.size} bands."
         )
+        raise ValueError(msg)
     r_45 = r_prime + 1.0
     r_tr_s = r_prime.copy()
     d_2m_nt = r_prime + delta + 10.0 * log10(v / (6.0 * _T0 * float(area)))
@@ -461,12 +469,14 @@ def radiated_sound_power(
     if lp.size == 1:
         lp = np.full(r_prime.size, float(lp[0]))
     if lp.size != r_prime.size:
-        raise ValueError("'lp_in' must match the element band count.")
+        msg = "'lp_in' must match the element band count."
+        raise ValueError(msg)
     if octave_bands is not None and len(octave_bands) != r_prime.size:
-        raise ValueError(
+        msg = (
             f"'octave_bands' has {len(octave_bands)} entries but the elements imply "
             f"{r_prime.size} bands."
         )
+        raise ValueError(msg)
     l_w = lp + float(c_d) - r_prime + 10.0 * log10(float(area) / _S0)
 
     l_w_dba: float | None = None
@@ -503,7 +513,8 @@ def outdoor_attenuation(width: float, height: float, distance: float) -> float:
     """
     w, h, d = float(width), float(height), float(distance)
     if min(w, h, d) <= 0:
-        raise ValueError("width, height and distance must be positive.")
+        msg = "width, height and distance must be positive."
+        raise ValueError(msg)
     area = w * h
     if d > max(w, h):
         return float(-10.0 * log10(_S0 / (pi * d * d)))  # (E.2b)
@@ -569,13 +580,16 @@ def facade_shape_level_difference(
         rows = _DELTA_LFS[shape]
     except KeyError:
         valid = ", ".join(sorted(_DELTA_LFS))
-        raise ValueError(f"Unknown facade shape {shape!r}. Valid: {valid}.") from None
+        msg = f"Unknown facade shape {shape!r}. Valid: {valid}."
+        raise ValueError(msg) from None
     h = float(line_of_sight)
     aw = float(absorption)
     if not (np.isfinite(h) and h >= 0.0):
-        raise ValueError("'line_of_sight' must be a non-negative height in m.")
+        msg = "'line_of_sight' must be a non-negative height in m."
+        raise ValueError(msg)
     if not (np.isfinite(aw) and 0.0 <= aw <= 1.0):
-        raise ValueError("'absorption' must be an αw between 0 and 1.")
+        msg = "'absorption' must be an αw between 0 and 1."
+        raise ValueError(msg)
     if h < 1.5:
         row_index = 0
     elif h <= 2.5:
@@ -584,10 +598,11 @@ def facade_shape_level_difference(
         row_index = 2
     row = rows[row_index]
     if row is None:
-        raise ValueError(
+        msg = (
             f"Figure C.2 marks shape {shape!r} as 'does not apply' for a "
             f"line-of-sight height of {h:g} m."
         )
+        raise ValueError(msg)
     return float(np.interp(aw, _DLFS_ALPHAS, row))
 
 
@@ -612,7 +627,6 @@ def outdoor_level(
     try:
         diff = lw - at  # NumPy broadcasting (scalar vs array is allowed)
     except ValueError as exc:
-        raise ValueError(
-            "'l_w' and 'attenuation' must have broadcast-compatible shapes."
-        ) from exc
+        msg = "'l_w' and 'attenuation' must have broadcast-compatible shapes."
+        raise ValueError(msg) from exc
     return float(10.0 * np.log10(np.sum(10.0 ** (diff / 10.0))))

--- a/src/phonometry/building/prediction/installed_structure_borne.py
+++ b/src/phonometry/building/prediction/installed_structure_borne.py
@@ -108,10 +108,11 @@ def _positive_real_part(values: ArrayLike, name: str) -> np.ndarray:
         or not np.all(np.isfinite(arr.imag))
         or np.any(re <= 0.0)
     ):
-        raise ValueError(
+        msg = (
             f"'{name}' must be finite with a positive real part (a passive "
             "receiver dissipates power)."
         )
+        raise ValueError(msg)
     return arr
 
 
@@ -127,7 +128,8 @@ def _positive_values(values: ArrayLike, name: str) -> np.ndarray:
     """
     arr = np.asarray(values, dtype=np.float64)
     if not np.all(np.isfinite(arr)) or np.any(arr <= 0.0):
-        raise ValueError(f"'{name}' must be finite and strictly positive.")
+        msg = f"'{name}' must be finite and strictly positive."
+        raise ValueError(msg)
     return arr
 
 
@@ -136,7 +138,8 @@ def _nonzero_magnitude(values: ArrayLike, name: str) -> np.ndarray:
     arr = np.asarray(values, dtype=np.complex128)
     mag = np.abs(arr)
     if not np.all(np.isfinite(mag)) or not np.all(mag > 0.0):
-        raise ValueError(f"'{name}' must be finite and non-zero.")
+        msg = f"'{name}' must be finite and non-zero."
+        raise ValueError(msg)
     return arr
 
 
@@ -462,14 +465,14 @@ def _table_d1_arguments(
         )
     needs_frequency = structure in _TABLE_D1_FREQUENCY_DEPENDENT
     if needs_frequency and frequency is None:
-        raise ValueError(
-            f"Table D.1 row {structure!r} depends on frequency; pass 'frequency'."
-        )
+        msg = f"Table D.1 row {structure!r} depends on frequency; pass 'frequency'."
+        raise ValueError(msg)
     if not needs_frequency and frequency is not None:
-        raise ValueError(
+        msg = (
             f"Table D.1 row {structure!r} is frequency-independent; do not "
             "pass 'frequency'."
         )
+        raise ValueError(msg)
     return {k: float(supplied[k]) for k in required}  # type: ignore[arg-type]
 
 
@@ -810,7 +813,8 @@ def multi_junction_adjustment(junctions: int) -> float:
     :raises ValueError: for fewer than one junction.
     """
     if junctions < 1:
-        raise ValueError("'junctions' must be at least 1.")
+        msg = "'junctions' must be at least 1."
+        raise ValueError(msg)
     return _MULTI_JUNCTION_ADJUSTMENT[min(junctions, 3)]
 
 
@@ -899,7 +903,8 @@ def installed_power_from_reception_plate(
     lw = np.asarray(reception_plate_level, dtype=np.float64)
     y_i = np.abs(np.asarray(receiver_mobility, dtype=np.complex128))
     if not np.all(np.isfinite(y_i)) or np.any(y_i <= 0.0):
-        raise ValueError("'receiver_mobility' must be finite and non-zero.")
+        msg = "'receiver_mobility' must be finite and non-zero."
+        raise ValueError(msg)
     return np.asarray(lw + 10.0 * np.log10(y_i / plate_mobility), dtype=np.float64)
 
 
@@ -1064,9 +1069,8 @@ class InstalledSourceResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.en12354_5 import render_installed_structure_borne_report
 
         return render_installed_structure_borne_report(
@@ -1096,9 +1100,8 @@ def _widest_band_count(n_bands: int, paths: list[dict[str, Any]]) -> int:
     for k, p in enumerate(paths):
         missing = [key for key in _REQUIRED_PATH_KEYS if key not in p]
         if missing:
-            raise ValueError(
-                f"path {k} is missing required key(s): {', '.join(missing)}."
-            )
+            msg = f"path {k} is missing required key(s): {', '.join(missing)}."
+            raise ValueError(msg)
         for key in _PER_BAND_PATH_KEYS:
             n_bands = max(
                 n_bands, np.atleast_1d(np.asarray(p[key], dtype=np.float64)).size
@@ -1119,10 +1122,11 @@ def _path_pressure_levels(
         for key in _PER_BAND_PATH_KEYS:
             values = np.atleast_1d(np.asarray(p[key], dtype=np.float64))
             if values.size not in (1, n_bands):
-                raise ValueError(
+                msg = (
                     f"path {k}: {key!r} has {values.size} bands, expected 1 "
                     f"or {n_bands} to match the other per-band inputs."
                 )
+                raise ValueError(msg)
         rows.append(
             np.broadcast_to(
                 structure_borne_pressure_level_path(
@@ -1168,7 +1172,8 @@ def installed_source_prediction(
         count.
     """
     if not paths:
-        raise ValueError("'paths' must contain at least one transmission path.")
+        msg = "'paths' must contain at least one transmission path."
+        raise ValueError(msg)
     lw_inst = np.atleast_1d(
         np.asarray(
             installed_structure_borne_power_level(
@@ -1183,10 +1188,11 @@ def installed_source_prediction(
     # broadcast across the bands.
     n_bands = _widest_band_count(lw_inst.size, paths)
     if lw_inst.size not in (1, n_bands):
-        raise ValueError(
+        msg = (
             f"the source levels carry {lw_inst.size} bands, expected 1 or "
             f"{n_bands} to match the transmission paths."
         )
+        raise ValueError(msg)
     path_levels = _path_pressure_levels(lw_inst, paths, n_bands)
     total = total_structure_borne_pressure_level(path_levels)
     freq = (
@@ -1195,10 +1201,11 @@ def installed_source_prediction(
         else np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     )
     if freq is not None and freq.size != n_bands:
-        raise ValueError(
+        msg = (
             f"frequencies carries {freq.size} values, expected {n_bands} to "
             "match the per-band inputs."
         )
+        raise ValueError(msg)
     return InstalledSourceResult(
         path_levels=path_levels,
         total_level=np.asarray(total, dtype=np.float64),

--- a/src/phonometry/building/prediction/linings.py
+++ b/src/phonometry/building/prediction/linings.py
@@ -214,10 +214,11 @@ def lining_resonance_frequency(
     m1 = require_positive(base_mass_per_area, "base_mass_per_area")
     m2 = require_positive(lining_mass_per_area, "lining_mass_per_area")
     if (dynamic_stiffness is None) == (cavity_depth is None):
-        raise ValueError(
+        msg = (
             "Give exactly one of 'dynamic_stiffness' (Formula D.1) or "
             "'cavity_depth' (Formula D.2)."
         )
+        raise ValueError(msg)
     if dynamic_stiffness is not None:
         stiffness = require_positive(dynamic_stiffness, "dynamic_stiffness")
     else:
@@ -281,13 +282,15 @@ def weighted_lining_improvement(
     f0 = require_positive(resonance_frequency, "resonance_frequency")
     rw = float(base_rating)
     if not np.isfinite(rw):
-        raise ValueError("'base_rating' must be finite.")
+        msg = "'base_rating' must be finite."
+        raise ValueError(msg)
     low, high = _TABLE_D1_RANGE
     if not low <= f0 <= high:
-        raise ValueError(
+        msg = (
             f"'resonance_frequency' must lie in [{low:g}, {high:g}] Hz; "
             "ISO 12354-1 Table D.1 is not tabulated outside it."
         )
+        raise ValueError(msg)
     rw_low, rw_high = _TABLE_D1_RW_RANGE
     if not rw_low <= rw <= rw_high:
         warnings.warn(
@@ -433,13 +436,15 @@ def lining_improvement(
         ]
     if glued_area is not None:
         if system == "studs":
-            raise ValueError(
+            msg = (
                 "'glued_area' applies to the glued exterior systems of "
                 "Formulae (D.3)/(D.4); Formula (D.7) has no glued area."
             )
+            raise ValueError(msg)
         area = require_positive(glued_area, "glued_area")
         if area > 100.0:
-            raise ValueError("'glued_area' is a percentage and cannot exceed 100.")
+            msg = "'glued_area' is a percentage and cannot exceed 100."
+            raise ValueError(msg)
         slope, offset = _ANNEX_D_GLUE
         ratings = [value + slope * area + offset for value in ratings]
     return LiningImprovementResult(
@@ -481,9 +486,8 @@ def lining_improvement_in_situ(
     delta_lab = float(laboratory_improvement)
     rw = float(base_rating_in_situ)
     if not np.isfinite(delta_lab) or not np.isfinite(rw):
-        raise ValueError(
-            "'laboratory_improvement' and 'base_rating_in_situ' must be finite."
-        )
+        msg = "'laboratory_improvement' and 'base_rating_in_situ' must be finite."
+        raise ValueError(msg)
     f0 = require_positive(resonance_frequency, "resonance_frequency")
     slope, offset = _ANNEX_D8_A
     a = min(0.0, slope * float(np.log10(f0)) + offset)

--- a/src/phonometry/building/prediction/masonry_cavity_wall.py
+++ b/src/phonometry/building/prediction/masonry_cavity_wall.py
@@ -128,9 +128,8 @@ def wall_tie_stiffness(tie: str) -> tuple[float, float]:
     try:
         return WALL_TIE_STIFFNESS[tie]
     except KeyError:
-        raise ValueError(
-            f"Unknown wall tie {tie!r}; choose one of {sorted(WALL_TIE_STIFFNESS)}."
-        ) from None
+        msg = f"Unknown wall tie {tie!r}; choose one of {sorted(WALL_TIE_STIFFNESS)}."
+        raise ValueError(msg) from None
 
 
 def wall_tie_stiffness_per_area(ties_per_area: float, tie: str | float) -> float:
@@ -242,7 +241,8 @@ def wall_tie_coupling_loss_factor(
     """
     f = require_finite_array(frequency, "frequency")
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive and finite.")
+        msg = "'frequency' must be positive and finite."
+        raise ValueError(msg)
     m1 = require_positive(mass1, "mass1")
     require_positive(mass2, "mass2")
     n = require_positive(ties_per_area, "ties_per_area")

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -226,7 +226,8 @@ def _resolve_field_correction(band: str, override: float | None) -> float:
         return field_incidence_correction(band)
     value = float(override)
     if not np.isfinite(value) or value < 0.0:
-        raise ValueError("'field_correction' must be finite and non-negative.")
+        msg = "'field_correction' must be finite and non-negative."
+        raise ValueError(msg)
     return value
 
 
@@ -418,10 +419,11 @@ def single_panel_transmission_loss(
     elif bending_stiffness is not None:
         fc = coincidence_frequency(m2, bending_stiffness, speed_of_sound=c0)
     else:
-        raise ValueError(
+        msg = (
             "provide 'critical_frequency' or 'bending_stiffness' to locate the "
             "coincidence frequency."
         )
+        raise ValueError(msg)
 
     def _tl_normal(freq: np.ndarray) -> np.ndarray:
         return mass_law_transmission_loss(
@@ -503,24 +505,27 @@ def _resolve_plateau_panel(
         density_per_mm, table_height, table_ratio = PLATEAU_MATERIALS[key]
         if mass_per_area is None:
             if thickness_mm is None:
-                raise ValueError(
+                msg = (
                     "give 'thickness_mm' with 'material', or pass "
                     "'mass_per_area' directly."
                 )
+                raise ValueError(msg)
             mass_per_area = density_per_mm * require_positive(
                 thickness_mm, "thickness_mm"
             )
         plateau_height = table_height if plateau_height is None else plateau_height
         frequency_ratio = table_ratio if frequency_ratio is None else frequency_ratio
     if mass_per_area is None or plateau_height is None or frequency_ratio is None:
-        raise ValueError(
+        msg = (
             "the plateau construction needs 'mass_per_area', 'plateau_height' "
             "and 'frequency_ratio'; give a tabulated 'material' (with "
             "'thickness_mm') or all three explicitly."
         )
+        raise ValueError(msg)
     ratio = require_positive(frequency_ratio, "frequency_ratio")
     if ratio <= 1.0:
-        raise ValueError("'frequency_ratio' must be greater than 1.")
+        msg = "'frequency_ratio' must be greater than 1."
+        raise ValueError(msg)
     return (
         require_positive(mass_per_area, "mass_per_area"),
         require_positive(plateau_height, "plateau_height"),
@@ -639,10 +644,11 @@ def plateau_transmission_loss(
     # 10 lg(1 + (pi f m''/rho0 c0)^2) = height + correction.
     target = 10.0 ** ((height + correction) / 10.0) - 1.0
     if target <= 0.0:
-        raise ValueError(
+        msg = (
             "the plateau height sits below the mass law at every frequency; "
             "check 'plateau_height' and 'field_correction'."
         )
+        raise ValueError(msg)
     f_a = rho0 * c0 * math.sqrt(target) / (math.pi * m2)
     f_b = ratio * f_a
 
@@ -758,7 +764,8 @@ def corrugated_plate_stiffness(
     wavelength = require_positive(corrugation_wavelength, "corrugation_wavelength")
     e = require_positive(youngs_modulus, "youngs_modulus")
     if not -1.0 < poisson_ratio < 1.0:
-        raise ValueError("'poisson_ratio' must lie in (-1, 1).")
+        msg = "'poisson_ratio' must lie in (-1, 1)."
+        raise ValueError(msg)
     nu = float(poisson_ratio)
     shape = (math.pi * amplitude / wavelength) ** 2
     flat = e * h**3 / 12.0
@@ -818,7 +825,8 @@ def orthotropic_plate_resonance(
     i = int(mode_x)
     n = int(mode_z)
     if i < 1 or n < 1:
-        raise ValueError("'mode_x' and 'mode_z' must be integers >= 1.")
+        msg = "'mode_x' and 'mode_z' must be integers >= 1."
+        raise ValueError(msg)
     a = require_positive(length_x, "length_x")
     b = require_positive(length_z, "length_z")
     m2 = require_positive(mass_per_area, "mass_per_area")
@@ -1107,9 +1115,8 @@ def orthotropic_transmission_loss(
     fc1 = require_positive(critical_frequency_lower, "critical_frequency_lower")
     fc2 = require_positive(critical_frequency_upper, "critical_frequency_upper")
     if fc2 <= fc1:
-        raise ValueError(
-            "'critical_frequency_upper' must exceed 'critical_frequency_lower'."
-        )
+        msg = "'critical_frequency_upper' must exceed 'critical_frequency_lower'."
+        raise ValueError(msg)
     eta = require_positive(loss_factor, "loss_factor")
     c0 = require_positive(speed_of_sound, "speed_of_sound")
     rho0 = require_positive(air_density, "air_density")
@@ -1118,17 +1125,19 @@ def orthotropic_transmission_loss(
     if area is not None:
         require_positive(area, "area")
     elif not 0.0 < limiting_angle < 90.0:
-        raise ValueError("'limiting_angle' must lie in (0, 90) degrees.")
+        msg = "'limiting_angle' must lie in (0, 90) degrees."
+        raise ValueError(msg)
     f = _band_axis(frequency)
     z0 = rho0 * c0
 
     if chosen == "heckl":
         if fc2 <= 4.0 * fc1:
-            raise ValueError(
+            msg = (
                 "the Heckl construction needs 'critical_frequency_upper' above "
                 "four times 'critical_frequency_lower' so its points stay "
                 "ordered; use method='integral' for a narrow coincidence range."
             )
+            raise ValueError(msg)
         tl = _heckl_transmission_loss(
             f,
             m2,
@@ -1223,7 +1232,8 @@ def mass_spring_mass_resonance(
         )
         stiffness = float(np.real(bulk.flat[0])) / d
         if stiffness <= 0.0:
-            raise ValueError("'cavity_medium' bulk modulus must be positive.")
+            msg = "'cavity_medium' bulk modulus must be positive."
+            raise ValueError(msg)
     reduced = (m1 + m2) / (m1 * m2)
     return float(np.sqrt((stiffness + ties) * reduced) / (2.0 * np.pi))
 

--- a/src/phonometry/building/prediction/resilient_layers.py
+++ b/src/phonometry/building/prediction/resilient_layers.py
@@ -244,7 +244,8 @@ def plate_contact_stiffness(
     e = require_positive(youngs_modulus, "youngs_modulus")
     r = require_positive(radius, "radius")
     if not -1.0 < poisson_ratio < 1.0:
-        raise ValueError("'poisson_ratio' must lie in (-1, 1).")
+        msg = "'poisson_ratio' must lie in (-1, 1)."
+        raise ValueError(msg)
     return float(2.0 * r * e / (1.0 - poisson_ratio**2))
 
 
@@ -391,7 +392,8 @@ def force_pulse(
     )
     t = np.asarray(time, dtype=np.float64)
     if not np.all(np.isfinite(t)) or np.any(t < 0.0):
-        raise ValueError("'time' must contain only finite, non-negative values.")
+        msg = "'time' must contain only finite, non-negative values."
+        raise ValueError(msg)
     decay = k / (2.0 * z)
     omega0_sq = k / m
     if _is_over_critical(k, z, m):
@@ -1031,20 +1033,20 @@ def floating_floor_improvement_spectrum(
     f_limit: float | None = None
     if model == "cremer_hammer":
         if limiting_frequency is None:
-            raise ValueError(
-                "'limiting_frequency' is required by model='cremer_hammer'."
-            )
+            msg = "'limiting_frequency' is required by model='cremer_hammer'."
+            raise ValueError(msg)
         f_limit = require_positive(limiting_frequency, "limiting_frequency")
         improvement = improvement + np.where(
             above, 10.0 * np.log10(1.0 + (f / f_limit) ** 2), 0.0
         )
     delta_lw: float | None = None
     if (mass_per_area is None) != (dynamic_stiffness is None):
-        raise ValueError(
+        msg = (
             "'mass_per_area' and 'dynamic_stiffness' are the two halves of the "
             "weighted improvement 'delta_lw'; give both or neither, since one "
             "alone would return it as None without saying why"
         )
+        raise ValueError(msg)
     if mass_per_area is not None and dynamic_stiffness is not None:
         # The weighted fit follows the construction the law belongs to:
         # Formula (C.4) for the sand-cement screeds of the 30 lg law, and

--- a/src/phonometry/building/prediction/simplified_model.py
+++ b/src/phonometry/building/prediction/simplified_model.py
@@ -256,9 +256,8 @@ class AirbornePredictionResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso12354 import render_iso12354_airborne_report
 
         return render_iso12354_airborne_report(
@@ -348,9 +347,8 @@ class ImpactPredictionResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso12354 import render_iso12354_impact_report
 
         return render_iso12354_impact_report(
@@ -362,7 +360,8 @@ def _check_finite(value: float, name: str) -> float:
     """Return ``value`` as a float, raising if it is not finite."""
     v = float(value)
     if not isfinite(v):
-        raise ValueError(f"'{name}' must be a finite number.")
+        msg = f"'{name}' must be a finite number."
+        raise ValueError(msg)
     return v
 
 
@@ -430,13 +429,14 @@ def _kij_lightweight_double_homogeneous(path: PathKind, t: _KijTerms) -> float:
     # the 2-4 path are more than three times heavier than a leaf
     # (m2/m1 > 3), i.e. for a per-path mass_ratio = m'\u22a5,i/m'i < 1/3.
     if t.ratio >= 1.0 / 3.0:
-        raise ValueError(
+        msg = (
             "The E.7 double-leaf branch (K24) is given only for "
             "mass_ratio = m'\u22a5,i/m'i < 1/3 (the homogeneous element "
             "carries the 2-4 path, so the ratio is leaf mass over "
             "homogeneous-element mass and the printed condition "
             "m2/m1 > 3 reads mass_ratio < 1/3)."
         )
+        raise ValueError(msg)
     # Per-path form (ISO 12354-1:2017 E.3.5); the 2000 print recasts the
     # same relation as 3,0 - 14,1 M + 5,7 M^2 in the Figure E.9 x-axis
     # variable lg(m2/m1), against its own Annex E definition of M (see
@@ -457,19 +457,19 @@ def _kij_corner(path: PathKind, t: _KijTerms) -> float:
     """Corner junction (E.9): one path, K12 = K21."""
     if path == "corner":
         return max(15.0 * abs(t.m) - 3.0, -2.0)
-    raise ValueError(
-        "A 'corner' junction has the single path K12 = K21; use path='corner'."
-    )
+    msg = "A 'corner' junction has the single path K12 = K21; use path='corner'."
+    raise ValueError(msg)
 
 
 def _kij_thickness_change(path: PathKind, t: _KijTerms) -> float:
     """Change of thickness in line (E.10): one path, K12 = K21."""
     if path == "through":
         return 5.0 * t.m * t.m - 5.0
-    raise ValueError(
+    msg = (
         "A 'thickness_change' junction has the single in-line path "
         "K12 = K21; use path='through'."
     )
+    raise ValueError(msg)
 
 
 #: One branch of EN 12354-1 Annex E per junction type. A branch returns
@@ -573,21 +573,26 @@ def junction_vibration_reduction(
     """
     ratio = _check_finite(mass_ratio, "mass_ratio")
     if ratio <= 0.0:
-        raise ValueError("'mass_ratio' must be positive.")
+        msg = "'mass_ratio' must be positive."
+        raise ValueError(msg)
     if _check_finite(frequency, "frequency") <= 0.0:
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     if _check_finite(f1, "f1") <= 0.0:
-        raise ValueError("'f1' must be positive.")
+        msg = "'f1' must be positive."
+        raise ValueError(msg)
     if path not in ("through", "corner", "double_leaf"):
-        raise ValueError("'path' must be 'through', 'corner' or 'double_leaf'.")
+        msg = "'path' must be 'through', 'corner' or 'double_leaf'."
+        raise ValueError(msg)
     branch = _KIJ_BRANCHES.get(junction_type)
     if branch is None:
-        raise ValueError(
+        msg = (
             "'junction_type' must be one of 'rigid_cross', 'rigid_t', "
             "'flexible_t', 'lightweight_facade', "
             "'lightweight_double_homogeneous', 'lightweight_double_coupled', "
             "'corner', 'thickness_change'."
         )
+        raise ValueError(msg)
     terms = _KijTerms(
         m=log10(ratio),
         ratio=ratio,
@@ -597,10 +602,11 @@ def junction_vibration_reduction(
     )
     kij = branch(path, terms)
     if kij is None:
-        raise ValueError(
+        msg = (
             f"Junction type {junction_type!r} has no 'double_leaf' (K24) "
             "branch in EN 12354-1 Annex E."
         )
+        raise ValueError(msg)
     return kij
 
 
@@ -626,7 +632,8 @@ def junction_min_vibration_reduction(
     si = _check_finite(s_i, "s_i")
     sj = _check_finite(s_j, "s_j")
     if lf <= 0.0 or si <= 0.0 or sj <= 0.0:
-        raise ValueError("'coupling_length', 's_i' and 's_j' must be positive.")
+        msg = "'coupling_length', 's_i' and 's_j' must be positive."
+        raise ValueError(msg)
     return 10.0 * log10(lf * _L0 * (1.0 / si + 1.0 / sj))
 
 
@@ -660,7 +667,8 @@ def _coupling_term(separating_area: float, coupling_length: float) -> float:
     ss = _check_finite(separating_area, "separating_area")
     lf = _check_finite(coupling_length, "coupling_length")
     if ss <= 0.0 or lf <= 0.0:
-        raise ValueError("'separating_area' and 'coupling_length' must be positive.")
+        msg = "'separating_area' and 'coupling_length' must be positive."
+        raise ValueError(msg)
     return 10.0 * log10(ss / (_L0 * lf))
 
 
@@ -712,7 +720,8 @@ def flanking_path(
         or any value is non-finite.
     """
     if kind not in ("Ff", "Df", "Fd"):
-        raise ValueError("'kind' must be 'Ff', 'Df' or 'Fd'.")
+        msg = "'kind' must be 'Ff', 'Df' or 'Fd'."
+        raise ValueError(msg)
     rs = _check_finite(r_source, "r_source")
     rr = _check_finite(r_receive, "r_receive")
     kij = _check_finite(k_ij, "k_ij")
@@ -899,7 +908,8 @@ def equivalent_impact_level(mass_per_area: float) -> float:
     """
     m = _check_finite(mass_per_area, "mass_per_area")
     if m <= 0.0:
-        raise ValueError("'mass_per_area' must be positive.")
+        msg = "'mass_per_area' must be positive."
+        raise ValueError(msg)
     if not (_LN_EQ_MASS_MIN <= m <= _LN_EQ_MASS_MAX):
         warnings.warn(
             f"mass_per_area = {m:g} kg/m² lies outside the 100-600 kg/m² "
@@ -928,7 +938,8 @@ def impact_flanking_correction(separating_mass: float, flanking_mass: float) -> 
     sm = _check_finite(separating_mass, "separating_mass")
     fm = _check_finite(flanking_mass, "flanking_mass")
     if sm <= 0.0 or fm <= 0.0:
-        raise ValueError("'separating_mass' and 'flanking_mass' must be positive.")
+        msg = "'separating_mass' and 'flanking_mass' must be positive."
+        raise ValueError(msg)
     # Nearest-neighbour selection on the discrete Table 1 grid. Both mass axes
     # are ascending, and ``min`` returns the first index reaching the smallest
     # distance, so a mass exactly halfway between two tabulated values (e.g.
@@ -989,7 +1000,8 @@ def standardized_impact_level(l_prime_n_w: float, volume: float) -> float:
     lnw = _check_finite(l_prime_n_w, "l_prime_n_w")
     v = _check_finite(volume, "volume")
     if v <= 0.0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     return lnw - 10.0 * log10(_IMPACT_STANDARDIZATION * v)
 
 
@@ -1022,7 +1034,9 @@ def standardized_level_difference(
     v = _check_finite(volume, "volume")
     ss = _check_finite(separating_area, "separating_area")
     if v <= 0.0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     if ss <= 0.0:
-        raise ValueError("'separating_area' must be positive.")
+        msg = "'separating_area' must be positive."
+        raise ValueError(msg)
     return rw + 10.0 * log10(_AIRBORNE_STANDARDIZATION * v / ss)

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -304,7 +304,8 @@ def _finite(value: float, name: str) -> float:
     """Return ``value`` as a float, rejecting non-finite input."""
     scalar = float(value)
     if not math.isfinite(scalar):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return scalar
 
 
@@ -312,7 +313,8 @@ def _positive(value: float, name: str) -> float:
     """Return ``value`` as a float, rejecting non-positive or non-finite input."""
     scalar = float(value)
     if not math.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -325,7 +327,8 @@ def _round_half_up(value: float, decimals: int = 0) -> float:
 def _normalise(value: str, aliases: Mapping[str, str], name: str) -> str:
     """Lower-case ``value``, normalise separators and resolve aliases."""
     if not isinstance(value, str):
-        raise ValueError(f"'{name}' must be a string; got {value!r}.")  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        msg = f"'{name}' must be a string; got {value!r}."
+        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
     key = value.strip().lower().replace(" ", "_").replace("-", "_")
     return aliases.get(key, key)
 
@@ -382,11 +385,12 @@ def _match_bands(frequencies: np.ndarray) -> np.ndarray:
     for target in DB_HR_FREQUENCIES:
         hits = np.nonzero(np.abs(frequencies - target) <= _BAND_TOLERANCE * target)[0]
         if hits.size != 1:
-            raise ValueError(
+            msg = (
                 "The input must contain exactly one band at each of the "
                 "eighteen DB-HR one-third-octave centre frequencies "
                 f"100 Hz to 5 kHz; {target:g} Hz matched {hits.size} bands."
             )
+            raise ValueError(msg)
         indices.append(int(hits[0]))
     return np.asarray(indices, dtype=np.intp)
 
@@ -420,23 +424,27 @@ def db_hr_global_index(
     """
     key = str(spectrum).strip().lower()
     if key not in DB_HR_NORMALISED_SPECTRA:
-        raise ValueError(
+        msg = (
             "'spectrum' must be one of "
             f"{sorted(DB_HR_NORMALISED_SPECTRA)}; got {spectrum!r}."
         )
+        raise ValueError(msg)
     values = np.asarray(band_values, dtype=np.float64)
     if values.ndim != 1:
-        raise ValueError("'band_values' must be one-dimensional.")
+        msg = "'band_values' must be one-dimensional."
+        raise ValueError(msg)
     if not np.all(np.isfinite(values)):
-        raise ValueError("'band_values' must contain finite values.")
+        msg = "'band_values' must contain finite values."
+        raise ValueError(msg)
 
     if frequencies is None:
         if values.size != len(DB_HR_FREQUENCIES):
-            raise ValueError(
+            msg = (
                 "Without 'frequencies' the input must be the eighteen DB-HR "
                 "one-third-octave bands 100 Hz to 5 kHz; got "
                 f"{values.size} values."
             )
+            raise ValueError(msg)
         freqs = np.asarray(DB_HR_FREQUENCIES, dtype=np.float64)
         # Copy so a later mutation of the caller's array cannot rewrite the
         # values this result reports.
@@ -444,11 +452,11 @@ def db_hr_global_index(
     else:
         given = np.asarray(frequencies, dtype=np.float64)
         if given.shape != values.shape:
-            raise ValueError(
-                "'frequencies' must have one value per band of 'band_values'."
-            )
+            msg = "'frequencies' must have one value per band of 'band_values'."
+            raise ValueError(msg)
         if not np.all(np.isfinite(given)) or np.any(given <= 0.0):
-            raise ValueError("'frequencies' must contain positive values.")
+            msg = "'frequencies' must contain positive values."
+            raise ValueError(msg)
         index = _match_bands(given)
         freqs = given[index]
         selected = values[index]
@@ -545,12 +553,13 @@ def d2m_nt_a(
     """
     key = str(spectrum).strip().lower()
     if key not in ("pink", "railway"):
-        raise ValueError(
+        msg = (
             "Formula (A.5) evaluates 'D2m,nT,A' for pink noise or, on a "
             "railway-dominant site, the Table A.4 railway spectrum; "
             f"got {spectrum!r}. Road-traffic and aircraft noise are assessed "
             "as 'D2m,nT,Atr' through Formula (A.6): use d2m_nt_atr()."
         )
+        raise ValueError(msg)
     return db_hr_global_index(
         level_difference, key, frequencies=frequencies, name="D2m,nT,A"
     )
@@ -586,12 +595,13 @@ def d2m_nt_atr(
     """
     key = str(spectrum).strip().lower()
     if key not in ("traffic", "aircraft"):
-        raise ValueError(
+        msg = (
             "Formula (A.6) evaluates 'D2m,nT,Atr' for road-traffic noise or, "
             "on an aircraft-dominant site, the Table A.2 aircraft spectrum; "
             f"got {spectrum!r}. Railway noise is assessed as 'D2m,nT,A' "
             "through Formula (A.5): use d2m_nt_a()."
         )
+        raise ValueError(msg)
     return db_hr_global_index(
         level_difference, key, frequencies=frequencies, name=_D2M_NT_ATR
     )
@@ -653,11 +663,12 @@ class DbHrRequirement:
         confident, inverted verdict.
         """
         if self.direction not in ("min", "max"):
-            raise ValueError(
+            msg = (
                 "'direction' must be 'min' (the quantity must reach the "
                 "limit) or 'max' (it must not exceed it); got "
                 f"{self.direction!r}."
             )
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -745,17 +756,19 @@ def db_hr_facade_requirement(
     use = _normalise(building_use, _USE_ALIASES, "building_use")
     room = _normalise(room_type, _ROOM_ALIASES, "room_type")
     if (use, room) not in _FACADE_ROWS:
-        raise ValueError(
+        msg = (
             "Unknown (building_use, room_type) combination "
             f"{(building_use, room_type)!r}; Table 2.1 holds "
             f"{sorted(_FACADE_ROWS)}."
         )
+        raise ValueError(msg)
     noise = str(dominant_noise).strip().lower()
     if noise not in ("road", "railway", "aircraft"):
-        raise ValueError(
+        msg = (
             "'dominant_noise' must be 'road', 'railway' or 'aircraft'; got "
             f"{dominant_noise!r}."
         )
+        raise ValueError(msg)
     if quiet_facade:
         value -= _QUIET_FACADE_REDUCTION
 
@@ -890,11 +903,12 @@ def db_hr_airborne_requirement(
     source = str(source_room).strip().lower()
     key = (receiving, source)
     if key not in _AIRBORNE_ROWS:
-        raise ValueError(
+        msg = (
             "Unknown (receiving_room, source_room) combination "
             f"{(receiving_room, source_room)!r}; DB-HR 2.1.1 covers "
             f"{sorted(_AIRBORNE_ROWS)}."
         )
+        raise ValueError(msg)
     if not shared_opening:
         quantity, limit, reference, description = _AIRBORNE_ROWS[key]
         requirements = [
@@ -910,10 +924,11 @@ def db_hr_airborne_requirement(
         ]
         return tuple(requirements)
     if key not in _SHARED_OPENING_ROWS:
-        raise ValueError(
+        msg = (
             "DB-HR 2.1.1 states no shared-opening variant for "
             f"{(receiving_room, source_room)!r}."
         )
+        raise ValueError(msg)
     opening_limit, enclosure_limit, reference = _SHARED_OPENING_ROWS[key]
     opening_note = (
         "shared door or window"
@@ -970,10 +985,11 @@ def db_hr_party_wall_requirement(quantity: str = "D2m,nT,Atr") -> DbHrRequiremen
     """
     key = str(quantity).strip()
     if key not in _PARTY_WALL_ROUTES:
-        raise ValueError(
+        msg = (
             "'quantity' must be 'D2m,nT,Atr' (per leaf, 40 dBA) or 'DnT,A' "
             f"(both leaves together, 50 dBA); got {quantity!r}."
         )
+        raise ValueError(msg)
     limit, description = _PARTY_WALL_ROUTES[key]
     return DbHrRequirement(
         quantity=key,
@@ -1013,11 +1029,12 @@ def db_hr_impact_requirement(receiving_room: str, source_room: str) -> DbHrRequi
     """
     key = (str(receiving_room).strip().lower(), str(source_room).strip().lower())
     if key not in _IMPACT_ROWS:
-        raise ValueError(
+        msg = (
             "DB-HR 2.1.2 states no impact requirement for "
             f"{(receiving_room, source_room)!r}; it covers "
             f"{sorted(_IMPACT_ROWS)}."
         )
+        raise ValueError(msg)
     limit, reference = _IMPACT_ROWS[key]
     return DbHrRequirement(
         quantity="L'nT,w",
@@ -1096,10 +1113,11 @@ def db_hr_reverberation_requirement(
     if key == "classroom" and furnished:
         key = "classroom_seated"
     if key not in _REVERBERATION_ROWS:
-        raise ValueError(
+        msg = (
             "'room_use' must be 'classroom', 'restaurant' or 'common_area' "
             f"(or a documented alias); got {room_use!r}."
         )
+        raise ValueError(msg)
     limit, reference, description = _REVERBERATION_ROWS[key]
     return DbHrRequirement(
         quantity="T",
@@ -1150,7 +1168,8 @@ def assess_db_hr(
     """
     pairs = list(items)
     if not pairs:
-        raise ValueError("At least one (value, requirement) pair is required.")
+        msg = "At least one (value, requirement) pair is required."
+        raise ValueError(msg)
     return DbHrAssessment(
         checks=tuple(check_db_hr_requirement(value, req) for value, req in pairs)
     )

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -77,7 +77,8 @@ _HARMONIC_SEARCH_FACTOR = 0.1
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -85,7 +86,8 @@ def _validate_notch_q(notch_q: float) -> float:
     """Validate the effective notch quality factor (AES17 5.2.8: 1.2 <= Q <= 3)."""
     q = float(notch_q)
     if not 1.2 <= q <= 3.0:
-        raise ValueError("'notch_q' must be within the AES17 range [1.2, 3].")
+        msg = "'notch_q' must be within the AES17 range [1.2, 3]."
+        raise ValueError(msg)
     return q
 
 
@@ -107,14 +109,17 @@ def _validate_signal(
     """
     sig = np.asarray(signal, dtype=np.float64)
     if sig.ndim != 1:
-        raise ValueError("'signal' must be one-dimensional.")
+        msg = "'signal' must be one-dimensional."
+        raise ValueError(msg)
     if sig.size < _MIN_SIGNAL_SAMPLES:
-        raise ValueError(
+        msg = (
             f"'signal' must contain at least {_MIN_SIGNAL_SAMPLES} samples to "
             "resolve a fundamental and its harmonics."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(sig)):
-        raise ValueError("'signal' must be finite.")
+        msg = "'signal' must be finite."
+        raise ValueError(msg)
     return apply_calibration(signal, sig) if calibrate else sig
 
 
@@ -169,7 +174,8 @@ def _harmonic_amplitudes(
         else float(fundamental)
     )
     if f0 <= 0.0:
-        raise ValueError("Could not determine a positive fundamental frequency.")
+        msg = "Could not determine a positive fundamental frequency."
+        raise ValueError(msg)
     search = f0 * _HARMONIC_SEARCH_FACTOR
     nyquist = fs / 2.0
     amps = []
@@ -235,15 +241,18 @@ def thd(
     sig = _validate_signal(signal)
     fs_v = _positive(fs, "fs")
     if kind not in ("F", "R"):
-        raise ValueError("'kind' must be 'F' or 'R'.")
+        msg = "'kind' must be 'F' or 'R'."
+        raise ValueError(msg)
     _f0, amps = _harmonic_amplitudes(sig, fs_v, fundamental, n_harmonics, window)
     if amps.size == 0 or amps[0] <= 0.0:
-        raise ValueError("No fundamental component found in the signal.")
+        msg = "No fundamental component found in the signal."
+        raise ValueError(msg)
     if amps.size < 2:
-        raise ValueError(
+        msg = (
             "No harmonic of the fundamental lies below the Nyquist frequency; "
             "the THD is undefined (raise fs or lower the fundamental)."
         )
+        raise ValueError(msg)
     harmonic_rms = float(np.sqrt(np.sum(amps[1:] ** 2)))
     if kind == "F":
         return float(harmonic_rms / amps[0])
@@ -285,11 +294,13 @@ def harmonic_distortion(
     fs_v = _positive(fs, "fs")
     f0 = _positive(fundamental, "fundamental")
     if order < 2:
-        raise ValueError("'order' must be at least 2.")
+        msg = "'order' must be at least 2."
+        raise ValueError(msg)
     n = max(n_harmonics, order)
     _, amps = _harmonic_amplitudes(sig, fs_v, f0, n, window)
     if amps.size < order or amps[0] <= 0.0:
-        raise ValueError("The requested harmonic order exceeds the Nyquist limit.")
+        msg = "The requested harmonic order exceeds the Nyquist limit."
+        raise ValueError(msg)
     total_rms = float(np.sqrt(np.sum(amps**2)))
     return float(amps[order - 1] / total_rms)
 
@@ -306,7 +317,8 @@ def _notched_residual(
     from scipy import signal as sp_signal
 
     if f0 >= fs / 2.0:
-        raise ValueError("'fundamental' must be below the Nyquist frequency (fs / 2).")
+        msg = "'fundamental' must be below the Nyquist frequency (fs / 2)."
+        raise ValueError(msg)
     b, a = sp_signal.iirnotch(f0, notch_q * _FILTFILT_NOTCH_Q_FACTOR, fs)
     return np.asarray(sp_signal.filtfilt(b, a, signal), dtype=np.float64)
 
@@ -429,7 +441,8 @@ def thd_plus_noise(
         sig, residual, fs_v, f0, float(notch_q), bandwidth
     )
     if total_rms <= 0.0:
-        raise ValueError("Signal has no energy.")
+        msg = "Signal has no energy."
+        raise ValueError(msg)
     ratio = residual_rms / total_rms
     if as_db:
         return float(20.0 * np.log10(ratio)) if ratio > 0.0 else -np.inf
@@ -530,7 +543,8 @@ def itu_r_468_weighting(frequencies: ArrayLike) -> NDArray[np.float64]:
     """
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if not np.all(np.isfinite(f)) or np.any(f < 0.0):
-        raise ValueError("'frequencies' must be finite and non-negative.")
+        msg = "'frequencies' must be finite and non-negative."
+        raise ValueError(msg)
     table_f = np.array([row[0] for row in _ITU_R_468_TABLE])
     table_db = np.array([row[1] for row in _ITU_R_468_TABLE])
     log_f = np.log10(np.maximum(f, np.finfo(np.float64).tiny))
@@ -609,7 +623,8 @@ def weighted_thd(
     sig = _validate_signal(signal)
     fs_v = _positive(fs, "fs")
     if weighting not in ("468", "A", "C"):
-        raise ValueError("'weighting' must be '468', 'A' or 'C'.")
+        msg = "'weighting' must be '468', 'A' or 'C'."
+        raise ValueError(msg)
     _validate_notch_q(notch_q)
     if fundamental is None:
         freqs, amp = _amplitude_spectrum(sig, fs_v, window)
@@ -620,7 +635,8 @@ def weighted_thd(
     sl = _steady_slice(sig.size, fs_v, f0, float(notch_q))
     total_rms = float(np.sqrt(np.mean(sig[sl] ** 2)))
     if total_rms <= 0.0:
-        raise ValueError("Signal has no energy.")
+        msg = "Signal has no energy."
+        raise ValueError(msg)
     if weighting == "468":
         weighted_rms = _weighted_rms_468(np.asarray(residual[sl]), fs_v)
     else:
@@ -709,7 +725,8 @@ def harmonic_analysis(
     fs_v = _positive(fs, "fs")
     f0, amps = _harmonic_amplitudes(sig, fs_v, fundamental, n_harmonics, window)
     if amps.size == 0 or amps[0] <= 0.0:
-        raise ValueError("No fundamental component found in the signal.")
+        msg = "No fundamental component found in the signal."
+        raise ValueError(msg)
     freqs = np.array([(k + 1) * f0 for k in range(amps.size)], dtype=np.float64)
     thd_f = thd(sig, fs_v, f0, kind="F", n_harmonics=n_harmonics, window=window)
     thd_r = thd(sig, fs_v, f0, kind="R", n_harmonics=n_harmonics, window=window)

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -54,15 +54,17 @@ def _validate_pair(
     xa = np.asarray(x, dtype=np.float64)
     ya = np.asarray(y, dtype=np.float64)
     if xa.ndim != 1 or ya.ndim != 1:
-        raise ValueError("'x' and 'y' must be one-dimensional.")
+        msg = "'x' and 'y' must be one-dimensional."
+        raise ValueError(msg)
     if xa.size != ya.size:
-        raise ValueError("'x' and 'y' must have the same length.")
+        msg = "'x' and 'y' must have the same length."
+        raise ValueError(msg)
     if xa.size < _MIN_SAMPLES:
-        raise ValueError(
-            f"Signals too short for a spectral estimate: {xa.size} samples."
-        )
+        msg = f"Signals too short for a spectral estimate: {xa.size} samples."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(xa)) and np.all(np.isfinite(ya))):
-        raise ValueError("'x' and 'y' must be finite.")
+        msg = "'x' and 'y' must be finite."
+        raise ValueError(msg)
     return apply_calibration(x, xa), apply_calibration(y, ya)
 
 
@@ -164,12 +166,15 @@ def transfer_function(
     xa, ya = _validate_pair(x, y)
     fs_v = _positive(fs, "fs")
     if estimator not in ("H1", "H2"):
-        raise ValueError("'estimator' must be 'H1' or 'H2'.")
+        msg = "'estimator' must be 'H1' or 'H2'."
+        raise ValueError(msg)
     if not 0.0 <= float(overlap) < 1.0:
-        raise ValueError("'overlap' must be in [0, 1).")
+        msg = "'overlap' must be in [0, 1)."
+        raise ValueError(msg)
     seg = _default_nperseg(xa.size, fs_v) if nperseg is None else int(nperseg)
     if seg < _MIN_SAMPLES or seg > xa.size:
-        raise ValueError("'nperseg' must be between 32 and the signal length.")
+        msg = "'nperseg' must be between 32 and the signal length."
+        raise ValueError(msg)
 
     freqs, gxy, gxx, gyy = _spectra(xa, ya, fs_v, seg, float(overlap))
     if estimator == "H1":
@@ -238,10 +243,12 @@ def coherence(
     xa, ya = _validate_pair(x, y)
     fs_v = _positive(fs, "fs")
     if not 0.0 <= float(overlap) < 1.0:
-        raise ValueError("'overlap' must be in [0, 1).")
+        msg = "'overlap' must be in [0, 1)."
+        raise ValueError(msg)
     seg = _default_nperseg(xa.size, fs_v) if nperseg is None else int(nperseg)
     if seg < _MIN_SAMPLES or seg > xa.size:
-        raise ValueError("'nperseg' must be between 32 and the signal length.")
+        msg = "'nperseg' must be between 32 and the signal length."
+        raise ValueError(msg)
     freqs, gxy, gxx, gyy = _spectra(xa, ya, fs_v, seg, float(overlap))
     denom = gxx * gyy
     coh = np.divide(np.abs(gxy) ** 2, denom, out=np.zeros_like(gxx), where=denom > 0.0)

--- a/src/phonometry/electroacoustics/intermodulation.py
+++ b/src/phonometry/electroacoustics/intermodulation.py
@@ -196,7 +196,8 @@ def modulation_distortion(
     half = min(_IMD_SEARCH_BINS * df, fl / 4.0)
     carrier = _tone_amplitude(freqs, amp, fh, half)
     if carrier <= 0.0:
-        raise ValueError("No carrier component found at 'f_high'.")
+        msg = "No carrier component found at 'f_high'."
+        raise ValueError(msg)
     sidebands = {
         n: tuple(
             _imd_component(freqs, amp, fh + sign * (n - 1) * fl, half, exclude=(fl, fh))
@@ -275,15 +276,18 @@ def difference_frequency_distortion(
     fa = _positive(f1, "f1")
     fb = _positive(f2, "f2")
     if fa >= fb:
-        raise ValueError("'f1' must be lower than 'f2'.")
+        msg = "'f1' must be lower than 'f2'."
+        raise ValueError(msg)
     if order not in (2, 3):
-        raise ValueError("'order' must be 2 or 3.")
+        msg = "'order' must be 2 or 3."
+        raise ValueError(msg)
     freqs, amp = _amplitude_spectrum(sig, fs_v, window)
     df = float(freqs[1] - freqs[0]) if freqs.size > 1 else 0.0
     half = min(_IMD_SEARCH_BINS * df, (fb - fa) / 4.0)
     ref = _tone_amplitude(freqs, amp, fa, half) + _tone_amplitude(freqs, amp, fb, half)
     if ref <= 0.0:
-        raise ValueError("No primary tones found at 'f1'/'f2'.")
+        msg = "No primary tones found at 'f1'/'f2'."
+        raise ValueError(msg)
     if order == 2:
         value = _imd_component(freqs, amp, fb - fa, half, exclude=(fa, fb))
     else:
@@ -340,7 +344,8 @@ def total_difference_frequency_distortion(
     fa = _positive(f1, "f1")
     fb = _positive(f2, "f2")
     if fa >= fb:
-        raise ValueError("'f1' must be lower than 'f2'.")
+        msg = "'f1' must be lower than 'f2'."
+        raise ValueError(msg)
     freqs, amp = _amplitude_spectrum(sig, fs_v, window)
     df = float(freqs[1] - freqs[0]) if freqs.size > 1 else 0.0
     p_lo, p_hi = fb - fa, 2 * fa - fb  # f0 - delta and f0 + delta
@@ -352,7 +357,8 @@ def total_difference_frequency_distortion(
         half = min(half, spacing / 4.0)
     ref = _tone_amplitude(freqs, amp, fa, half) + _tone_amplitude(freqs, amp, fb, half)
     if ref <= 0.0:
-        raise ValueError("No primary tones found at 'f1'/'f2'.")
+        msg = "No primary tones found at 'f1'/'f2'."
+        raise ValueError(msg)
     a_lo = _imd_component(freqs, amp, p_lo, half, exclude=(fa, fb))
     a_hi = _imd_component(freqs, amp, p_hi, half, exclude=(fa, fb))
     return float(np.sqrt(a_lo**2 + a_hi**2) / ref)
@@ -431,7 +437,8 @@ def dynamic_intermodulation_distortion(
     # here follows the 14.12.9.1 definition.
     ref = _tone_amplitude(freqs, amp, fsine, search)
     if ref <= 0.0:
-        raise ValueError("No 15 kHz sine component found.")
+        msg = "No 15 kHz sine component found."
+        raise ValueError(msg)
     power = 0.0
     for f in _dim_components(fsine, fsq, fs_v / 2.0):
         power += _tone_amplitude(freqs, amp, f, search) ** 2

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -81,15 +81,17 @@ def _as_curve(
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     v = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if f.ndim != 1 or v.ndim != 1 or f.shape != v.shape:
-        raise ValueError(
-            f"'{name}' frequencies and values must be 1-D and equal length."
-        )
+        msg = f"'{name}' frequencies and values must be 1-D and equal length."
+        raise ValueError(msg)
     if f.size < 2:
-        raise ValueError(f"'{name}' needs at least two frequency points.")
+        msg = f"'{name}' needs at least two frequency points."
+        raise ValueError(msg)
     if np.any(f <= 0.0) or not np.all(np.isfinite(f)):
-        raise ValueError(f"'{name}' frequencies must be positive and finite.")
+        msg = f"'{name}' frequencies must be positive and finite."
+        raise ValueError(msg)
     if not np.all(np.isfinite(v)):
-        raise ValueError(f"'{name}' values must be finite.")
+        msg = f"'{name}' values must be finite."
+        raise ValueError(msg)
     order = np.argsort(f)
     return f[order], v[order]
 
@@ -435,9 +437,8 @@ class LoudspeakerCharacteristics:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         del verbose  # uniform signature; the fiche has a single layout
         from .._report.iec60268_5 import render_iec60268_5_report
 
@@ -486,10 +487,11 @@ def _polar_from_piston(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64], float, float | None]:
     """Derive (angles_deg, relative_db, frequency, DI) from a piston result."""
     if piston.angles is None or piston.directivity is None:
-        raise ValueError(
+        msg = (
             "'directivity.piston' must be a radiating-piston result computed with "
             "'angles' so it carries a directivity pattern."
         )
+        raise ValueError(msg)
     freqs = np.asarray(piston.frequencies, dtype=np.float64)
     target = (
         float(polar_frequency)
@@ -522,7 +524,8 @@ def _resolve_sensitivity_band(
         return (f_peak / _OCTAVE_HALF, f_peak * _OCTAVE_HALF)
     lo, hi = float(sensitivity_band[0]), float(sensitivity_band[1])
     if not 0.0 < lo < hi:
-        raise ValueError("'sensitivity_band' must be a positive (lo, hi) with lo < hi.")
+        msg = "'sensitivity_band' must be a positive (lo, hi) with lo < hi."
+        raise ValueError(msg)
     return (lo, hi)
 
 
@@ -537,7 +540,8 @@ def _characteristic_sensitivity_level(
     """Band-mean on-axis level referred to 1 W into ``R`` at 1 m (20.3/20.4)."""
     in_band = (f >= band[0]) & (f <= band[1])
     if not np.any(in_band):
-        raise ValueError("'sensitivity_band' selects no on-axis response samples.")
+        msg = "'sensitivity_band' selects no on-axis response samples."
+        raise ValueError(msg)
     band_level = _energetic_mean_db(spl[in_band])
     # The drive-voltage and distance corrections; U_p = sqrt(R) drives 1 W into R.
     return float(
@@ -553,7 +557,8 @@ def _resolve_impedance(
         return None, None
     imp_f, imp_z = _as_curve(impedance[0], impedance[1], "impedance")
     if np.any(imp_z <= 0.0):
-        raise ValueError("'impedance' modulus must be positive.")
+        msg = "'impedance' modulus must be positive."
+        raise ValueError(msg)
     return imp_f, imp_z
 
 
@@ -569,7 +574,8 @@ def _resolve_distortion(
         thd_f = np.asarray(distortion.thd_frequencies, dtype=np.float64)
         thd_p = np.asarray(distortion.thd, dtype=np.float64) * 100.0
     if np.any(thd_p < 0.0):
-        raise ValueError("'distortion' THD values must be non-negative.")
+        msg = "'distortion' THD values must be non-negative."
+        raise ValueError(msg)
     return thd_f, thd_p
 
 
@@ -588,9 +594,11 @@ def _resolve_polar(
     p_ang = np.atleast_1d(np.asarray(polar[0], dtype=np.float64))
     p_db = np.atleast_1d(np.asarray(polar[1], dtype=np.float64))
     if p_ang.ndim != 1 or p_ang.shape != p_db.shape:
-        raise ValueError("'polar' angles and levels must be 1-D and equal length.")
+        msg = "'polar' angles and levels must be 1-D and equal length."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(p_ang)) and np.all(np.isfinite(p_db))):
-        raise ValueError("'polar' angles and levels must be finite.")
+        msg = "'polar' angles and levels must be finite."
+        raise ValueError(msg)
     return p_ang, p_db, polar_frequency, directivity.index_db
 
 

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -147,10 +147,11 @@ def _effective_range(
     within = np.abs(rel_db) <= tolerance
     anchor = int(np.argmin(np.abs(np.log2(f / f_ref))))
     if not within[anchor]:
-        raise ValueError(
+        msg = (
             "the response deviates beyond 'tolerance_db' at the reference "
             "frequency, so no effective frequency range contains it."
         )
+        raise ValueError(msg)
     lo_idx = anchor
     while lo_idx > 0 and within[lo_idx - 1]:
         lo_idx -= 1
@@ -488,9 +489,8 @@ class MicrophoneCharacteristics:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         del verbose  # uniform signature; the fiche has a single layout
         from .._report.iec60268_4 import render_iec60268_4_report
 
@@ -546,16 +546,16 @@ def _resolve_noise_level(
 ) -> float | None:
     """Resolve the equivalent noise level, computing it from a voltage (17.2)."""
     if noise.voltage is not None and noise.equivalent_level_db is not None:
-        raise ValueError(
-            "give either 'noise.voltage' or 'noise.equivalent_level_db', not both."
-        )
+        msg = "give either 'noise.voltage' or 'noise.equivalent_level_db', not both."
+        raise ValueError(msg)
     if noise.voltage is not None:
         u_n = require_positive(noise.voltage, "noise.voltage")
         return float(20.0 * np.log10((u_n / sensitivity_v_per_pa) / _P_REF))
     if noise.equivalent_level_db is not None and not np.isfinite(
         noise.equivalent_level_db
     ):
-        raise ValueError("'noise.equivalent_level_db' must be finite.")
+        msg = "'noise.equivalent_level_db' must be finite."
+        raise ValueError(msg)
     return noise.equivalent_level_db
 
 
@@ -567,7 +567,8 @@ def _resolve_distortion(
         return None, None
     spl, thd = _as_curve(distortion[0], distortion[1], "distortion")
     if np.any(thd < 0.0):
-        raise ValueError("'distortion' THD values must be non-negative.")
+        msg = "'distortion' THD values must be non-negative."
+        raise ValueError(msg)
     return spl, thd
 
 
@@ -583,20 +584,25 @@ def _resolve_polar(
     """
     index_db = directivity.index_db
     if index_db is not None and not np.isfinite(index_db):
-        raise ValueError("'directivity.index_db' must be finite.")
+        msg = "'directivity.index_db' must be finite."
+        raise ValueError(msg)
     polar = directivity.polar
     if polar is None:
         return None, None, index_db
     p_ang = np.atleast_1d(np.asarray(polar[0], dtype=np.float64))
     p_db = np.atleast_1d(np.asarray(polar[1], dtype=np.float64))
     if p_ang.ndim != 1 or p_ang.shape != p_db.shape:
-        raise ValueError("'polar' angles and levels must be 1-D and equal length.")
+        msg = "'polar' angles and levels must be 1-D and equal length."
+        raise ValueError(msg)
     if p_ang.size < 2:
-        raise ValueError("'polar' needs at least two angle points.")
+        msg = "'polar' needs at least two angle points."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(p_ang)) and np.all(np.isfinite(p_db))):
-        raise ValueError("'polar' angles and levels must be finite.")
+        msg = "'polar' angles and levels must be finite."
+        raise ValueError(msg)
     if np.any(p_ang < 0.0) or np.any(p_ang > 360.0):
-        raise ValueError("'polar' angles must lie within 0..360 degrees.")
+        msg = "'polar' angles must lie within 0..360 degrees."
+        raise ValueError(msg)
     order = np.argsort(p_ang)
     p_ang, p_db = p_ang[order], p_db[order]
     di = index_db
@@ -656,9 +662,8 @@ def microphone_characteristics(
     f_ref = require_positive(reference_frequency, "reference_frequency")
     tol = require_positive(tolerance_db, "tolerance_db")
     if not float(f[0]) <= f_ref <= float(f[-1]):
-        raise ValueError(
-            "'reference_frequency' must lie within the measured frequency band."
-        )
+        msg = "'reference_frequency' must lie within the measured frequency band."
+        raise ValueError(msg)
     rel = _normalized_response(f, resp, f_ref)
     effective = _effective_range(f, rel, tol, f_ref)
     level = _sensitivity_level_db(m_mv / 1000.0)
@@ -668,7 +673,8 @@ def microphone_characteristics(
     max_spl: float | None = None
     if overload.spl_db is not None:
         if not np.isfinite(overload.spl_db):
-            raise ValueError("'overload.spl_db' must be finite.")
+            msg = "'overload.spl_db' must be finite."
+            raise ValueError(msg)
         max_spl = float(overload.spl_db)
     elif d_spl is not None and d_thd is not None:
         max_spl = _overload_spl(d_spl, d_thd, thd_limit)

--- a/src/phonometry/electroacoustics/noise_measurements.py
+++ b/src/phonometry/electroacoustics/noise_measurements.py
@@ -167,7 +167,8 @@ def dynamic_range(
     sl = _steady_slice(sig.size, fs_v, f0, float(notch_q))
     weighted = _ccir_rms_weighted_rms(np.asarray(residual[sl]), fs_v, bandwidth)
     if weighted <= 0.0:
-        raise ValueError("Residual has no energy; cannot form a dynamic range.")
+        msg = "Residual has no energy; cannot form a dynamic range."
+        raise ValueError(msg)
     return float(20.0 * np.log10(reference / weighted))
 
 

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -110,7 +110,8 @@ def piston_resistance(x: ArrayLike) -> np.ndarray | float:
     """
     arr = np.asarray(x, dtype=np.float64)
     if np.any(arr < 0.0) or not np.all(np.isfinite(arr)):
-        raise ValueError("'x' must be non-negative and finite.")
+        msg = "'x' must be non-negative and finite."
+        raise ValueError(msg)
     with np.errstate(invalid="ignore", divide="ignore"):
         out = 1.0 - 2.0 * special.j1(arr) / arr
     # J1(x)/x -> 1/2 as x -> 0, so R1 -> 0; the input is validated finite, so
@@ -133,7 +134,8 @@ def piston_reactance(x: ArrayLike) -> np.ndarray | float:
     """
     arr = np.asarray(x, dtype=np.float64)
     if np.any(arr < 0.0) or not np.all(np.isfinite(arr)):
-        raise ValueError("'x' must be non-negative and finite.")
+        msg = "'x' must be non-negative and finite."
+        raise ValueError(msg)
     with np.errstate(invalid="ignore", divide="ignore"):
         out = 2.0 * special.struve(1, arr) / arr
     # H1(x)/x -> 0 as x -> 0 (H1 ~ 2 x^2 / 3 pi), so X1 -> 0; the 0/0 at x = 0
@@ -157,9 +159,11 @@ def piston_directivity(ka: ArrayLike, theta: ArrayLike) -> np.ndarray | float:
     ka_arr = np.asarray(ka, dtype=np.float64)
     theta_arr = np.asarray(theta, dtype=np.float64)
     if np.any(ka_arr < 0.0) or not np.all(np.isfinite(ka_arr)):
-        raise ValueError("'ka' must be non-negative and finite.")
+        msg = "'ka' must be non-negative and finite."
+        raise ValueError(msg)
     if not np.all(np.isfinite(theta_arr)):
-        raise ValueError("'theta' must be finite.")
+        msg = "'theta' must be finite."
+        raise ValueError(msg)
     u = ka_arr * np.sin(theta_arr)
     with np.errstate(invalid="ignore", divide="ignore"):
         out = 2.0 * special.j1(u) / u
@@ -250,18 +254,22 @@ def piston_directivity_pattern(
     """
     ka_arr = np.atleast_1d(np.asarray(ka, dtype=np.float64))
     if ka_arr.ndim != 1 or ka_arr.size == 0:
-        raise ValueError("'ka' must be a non-empty scalar or 1-D array.")
+        msg = "'ka' must be a non-empty scalar or 1-D array."
+        raise ValueError(msg)
     if np.any(ka_arr < 0.0) or not np.all(np.isfinite(ka_arr)):
-        raise ValueError("'ka' must be non-negative and finite.")
+        msg = "'ka' must be non-negative and finite."
+        raise ValueError(msg)
 
     if angles is None:
         angle_arr = _DEFAULT_DIRECTIVITY_ANGLES.copy()
     else:
         angle_arr = np.atleast_1d(np.asarray(angles, dtype=np.float64))
         if angle_arr.ndim != 1 or angle_arr.size == 0:
-            raise ValueError("'angles' must be a non-empty 1-D array.")
+            msg = "'angles' must be a non-empty 1-D array."
+            raise ValueError(msg)
         if not np.all(np.isfinite(angle_arr)):
-            raise ValueError("'angles' must be finite.")
+            msg = "'angles' must be finite."
+            raise ValueError(msg)
 
     directivity = np.asarray(
         piston_directivity(ka_arr[:, None], angle_arr[None, :]),
@@ -418,9 +426,11 @@ def radiating_piston(
     rho = require_positive(density, "density")
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(f <= 0.0) or not np.all(np.isfinite(f)):
-        raise ValueError("'frequencies' must be positive and finite.")
+        msg = "'frequencies' must be positive and finite."
+        raise ValueError(msg)
 
     omega = 2.0 * np.pi * f
     k = omega / c
@@ -437,9 +447,11 @@ def radiating_piston(
     if angles is not None:
         angle_arr = np.atleast_1d(np.asarray(angles, dtype=np.float64))
         if angle_arr.ndim != 1 or angle_arr.size == 0:
-            raise ValueError("'angles' must be a non-empty 1-D array.")
+            msg = "'angles' must be a non-empty 1-D array."
+            raise ValueError(msg)
         if not np.all(np.isfinite(angle_arr)):
-            raise ValueError("'angles' must be finite.")
+            msg = "'angles' must be finite."
+            raise ValueError(msg)
         directivity = np.asarray(
             piston_directivity(ka[:, None], angle_arr[None, :]),
             dtype=np.float64,

--- a/src/phonometry/electroacoustics/sound_reinforcement.py
+++ b/src/phonometry/electroacoustics/sound_reinforcement.py
@@ -108,7 +108,8 @@ def open_microphone_correction(open_microphones: int) -> float:
     """
     n = int(open_microphones)
     if n != open_microphones or n < 1:
-        raise ValueError("'open_microphones' must be an integer of at least 1.")
+        msg = "'open_microphones' must be an integer of at least 1."
+        raise ValueError(msg)
     return 10.0 * math.log10(n)
 
 
@@ -140,7 +141,8 @@ def feedback_loop_gain(
         float(microphone_directivity),
     )
     if not all(math.isfinite(v) for v in values):
-        raise ValueError("Levels and the directivity index must be finite.")
+        msg = "Levels and the directivity index must be finite."
+        raise ValueError(msg)
     l_hm, l_hl, d_m = values
     return l_hm - l_hl + d_m
 
@@ -246,10 +248,12 @@ def feedback_stability(
     """
     z_s = float(open_loop_gain)
     if not math.isfinite(z_s):
-        raise ValueError("'open_loop_gain' must be finite.")
+        msg = "'open_loop_gain' must be finite."
+        raise ValueError(msg)
     margin_required = float(stability_margin)
     if not math.isfinite(margin_required) or margin_required < 0.0:
-        raise ValueError("'stability_margin' must be finite and non-negative.")
+        msg = "'stability_margin' must be finite and non-negative."
+        raise ValueError(msg)
 
     g_s = feedback_loop_gain(
         level_loudspeaker_at_microphone,

--- a/src/phonometry/electroacoustics/swept_sine.py
+++ b/src/phonometry/electroacoustics/swept_sine.py
@@ -86,15 +86,18 @@ _DEFAULT_MAX_IR_LENGTH = 8192
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
 def _validate_sweep_band(fs: float, f1: float, f2: float) -> None:
     if f2 <= f1:
-        raise ValueError("'f2' must be greater than 'f1'.")
+        msg = "'f2' must be greater than 'f1'."
+        raise ValueError(msg)
     if f2 > fs / 2.0:
-        raise ValueError("'f2' must not exceed the Nyquist frequency fs/2.")
+        msg = "'f2' must not exceed the Nyquist frequency fs/2."
+        raise ValueError(msg)
 
 
 def _sweep_rate(f1: float, f2: float, seconds: float) -> float:
@@ -108,11 +111,12 @@ def _sweep_rate(f1: float, f2: float, seconds: float) -> float:
     """
     k = round(f1 * seconds / float(np.log(f2 / f1)))
     if k < 1:
-        raise ValueError(
+        msg = (
             "'seconds' is too short to synchronize the sweep: "
             "f1*seconds/ln(f2/f1) rounds to zero periods. Lengthen the "
             "sweep or raise 'f1'."
         )
+        raise ValueError(msg)
     return k / f1
 
 
@@ -162,7 +166,8 @@ def synchronized_sweep_signal(
     seconds_v = _positive(seconds, "seconds")
     amplitude_v = _positive(amplitude, "amplitude")
     if not 0.0 <= fade < 0.5:
-        raise ValueError("fade must be in [0, 0.5)")
+        msg = "fade must be in [0, 0.5)"
+        raise ValueError(msg)
     rate = _sweep_rate(f1_v, float(f2), seconds_v)
     duration = rate * np.log(float(f2) / f1_v)
     n = int(np.ceil(duration * fs_v))
@@ -388,13 +393,14 @@ def _thd_curves(
         f_max = min(f_max, upper_band / 2.0)
     grid = (frequencies >= f1) & (frequencies <= f_max)
     if not np.any(grid):
-        raise ValueError(
+        msg = (
             f"no excitation-frequency bin has a measurable order-2 "
             f"product: the THD grid [{f1:.6g}, {f_max:.6g}] Hz is empty at "
             f"the {frequencies[1]:.6g}-Hz window resolution. Lower 'f1' "
             "(the order-2 product must stay below Nyquist) or raise "
             "'ir_length' for a finer grid."
         )
+        raise ValueError(msg)
     thd_freqs = frequencies[grid]
     fundamental = np.abs(responses[0][grid])
     ratios = np.zeros((max(n_orders - 1, 0), thd_freqs.size), dtype=np.float64)
@@ -425,9 +431,11 @@ def _validated_recording(
 ) -> NDArray[np.float64]:
     rec = np.asarray(recorded, dtype=np.float64)
     if rec.ndim != 1:
-        raise ValueError("'recorded' must be one-dimensional.")
+        msg = "'recorded' must be one-dimensional."
+        raise ValueError(msg)
     if not np.all(np.isfinite(rec)):
-        raise ValueError("'recorded' must be finite.")
+        msg = "'recorded' must be finite."
+        raise ValueError(msg)
     return rec
 
 
@@ -466,23 +474,26 @@ def _harmonic_window(
     if ir_length is not None:
         window = int(ir_length)
         if window < _MIN_IR_LENGTH:
-            raise ValueError(f"'ir_length' must be at least {_MIN_IR_LENGTH} samples.")
+            msg = f"'ir_length' must be at least {_MIN_IR_LENGTH} samples."
+            raise ValueError(msg)
     else:
         window = _default_ir_length(min_spacing)
         if window < _MIN_IR_LENGTH:
-            raise ValueError(
+            msg = (
                 f"the harmonic windows would be {window} samples long "
                 f"(minimum {_MIN_IR_LENGTH}); the two closest arrivals are "
                 f"only {min_spacing} samples apart. Lengthen the sweep or "
                 "lower 'n_harmonics'."
             )
+            raise ValueError(msg)
     if window > min_spacing:
-        raise ValueError(
+        msg = (
             f"'ir_length' ({window}) exceeds the {min_spacing}-sample "
             f"spacing between orders {n_orders - 1} and {n_orders}; the "
             "windows would overlap. Shorten 'ir_length', lengthen the "
             "sweep or lower 'n_harmonics'."
         )
+        raise ValueError(msg)
     return window
 
 
@@ -612,18 +623,21 @@ def swept_sine_distortion(
     seconds_v = _positive(seconds, "seconds")
     amplitude_v = _positive(amplitude, "amplitude")
     if method not in ("synchronized", "farina"):
-        raise ValueError("'method' must be 'synchronized' or 'farina'.")
+        msg = "'method' must be 'synchronized' or 'farina'."
+        raise ValueError(msg)
     n_orders = int(n_harmonics)
     if n_orders < 2:
-        raise ValueError("'n_harmonics' must be at least 2.")
+        msg = "'n_harmonics' must be at least 2."
+        raise ValueError(msg)
 
     rate, duration, sweep_samples = _sweep_timing(method, fs_v, f1_v, f2_v, seconds_v)
     if rec.size < sweep_samples:
-        raise ValueError(
+        msg = (
             f"'recorded' has {rec.size} samples but the sweep lasts "
             f"{sweep_samples}; record at least the whole sweep (plus the "
             "system decay)."
         )
+        raise ValueError(msg)
 
     orders = np.arange(1, n_orders + 1, dtype=np.float64)
     delays_samples = rate * np.log(orders) * fs_v

--- a/src/phonometry/emission/_shared.py
+++ b/src/phonometry/emission/_shared.py
@@ -109,16 +109,18 @@ def _a_weighting_corrections(frequencies: np.ndarray) -> np.ndarray:
     ck = []
     for freq in nominal:
         if freq not in table:
-            raise ValueError(
+            msg = (
                 f"No ISO 3744 Annex E A-weighting value for {freq} Hz; "
                 "expected a nominal octave or one-third-octave mid-band "
                 "frequency (50 Hz to 10 kHz)."
             )
+            raise ValueError(msg)
         ck.append(table[freq])
     return np.asarray(ck, dtype=np.float64)
 
 
 def _check_grade(grade: str) -> Grade:
     if grade not in ("engineering", "survey"):
-        raise ValueError("'grade' must be 'engineering' or 'survey'.")
+        msg = "'grade' must be 'engineering' or 'survey'."
+        raise ValueError(msg)
     return cast(Grade, grade)

--- a/src/phonometry/emission/declaration.py
+++ b/src/phonometry/emission/declaration.py
@@ -106,23 +106,26 @@ class OperatingModeDeclaration:
     def __post_init__(self) -> None:
         """Validate the levels, the uncertainties and the pressure pairing."""
         if not str(self.mode).strip():
-            raise ValueError("OperatingModeDeclaration.mode must be a non-empty label.")
+            msg = "OperatingModeDeclaration.mode must be a non-empty label."
+            raise ValueError(msg)
         for name in ("sound_power_level", "verification_level"):
             value = getattr(self, name)
             if value is not None and not math.isfinite(float(value)):
-                raise ValueError(
+                msg = (
                     f"OperatingModeDeclaration.{name} must be finite when given; "
                     f"got {value!r}."
                 )
+                raise ValueError(msg)
         for name in ("sound_power_uncertainty", "emission_pressure_uncertainty"):
             value = getattr(self, name)
             if value is not None and not (
                 math.isfinite(float(value)) and float(value) >= 0.0
             ):
-                raise ValueError(
+                msg = (
                     f"OperatingModeDeclaration.{name} must be finite and "
                     f"non-negative when given; got {value!r}."
                 )
+                raise ValueError(msg)
         if (self.emission_pressure_level is None) != (
             self.emission_pressure_uncertainty is None
         ):
@@ -131,18 +134,20 @@ class OperatingModeDeclaration:
                 if self.emission_pressure_uncertainty is None
                 else "emission_pressure_level"
             )
-            raise ValueError(
+            msg = (
                 "emission_pressure_level and emission_pressure_uncertainty must "
                 f"be given together (ISO 4871 dual-number form); '{missing}' is "
                 "missing."
             )
+            raise ValueError(msg)
         if self.emission_pressure_level is not None and not math.isfinite(
             float(self.emission_pressure_level)
         ):
-            raise ValueError(
+            msg = (
                 "OperatingModeDeclaration.emission_pressure_level must be finite "
                 f"when given; got {self.emission_pressure_level!r}."
             )
+            raise ValueError(msg)
 
     @property
     def declared_sound_power_level(self) -> int:
@@ -258,19 +263,19 @@ class NoiseEmissionDeclaration:
         """Coerce the sequences to tuples and validate the form and mode count."""
         modes = tuple(self.modes)
         if not modes:
-            raise ValueError(
-                "NoiseEmissionDeclaration requires at least one operating mode."
-            )
+            msg = "NoiseEmissionDeclaration requires at least one operating mode."
+            raise ValueError(msg)
         standards = (
             (self.basic_standards,)
             if isinstance(self.basic_standards, str)
             else tuple(self.basic_standards)
         )
         if self.form not in ("dual-number", "single-number"):
-            raise ValueError(
+            msg = (
                 "NoiseEmissionDeclaration.form must be 'dual-number' or "
                 f"'single-number'; got {self.form!r}."
             )
+            raise ValueError(msg)
         object.__setattr__(self, "modes", modes)
         object.__setattr__(self, "basic_standards", standards)
 
@@ -319,9 +324,8 @@ class NoiseEmissionDeclaration:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso4871 import render_iso4871_report
 
         return render_iso4871_report(

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -236,10 +236,11 @@ class FieldIndicators:
             :func:`temporal_variability_indicator` directly).
         """
         if self.f1 is None:
-            raise ValueError(
+            msg = (
                 "This result carries no F1; call field_indicators(..., "
                 "temporal_intensity=...) or temporal_variability_indicator()."
             )
+            raise ValueError(msg)
         f1 = np.asarray(self.f1, dtype=np.float64)
         ok = f1 <= float(limit)
         return bool(ok) if ok.ndim == 0 else ok
@@ -334,33 +335,39 @@ def _band_integrals(
 def _validate_probe_signals(x1: np.ndarray, x2: np.ndarray) -> None:
     """Reject microphone signals that are not a matched pair of 1D pressures."""
     if x1.ndim != 1 or x2.ndim != 1:
-        raise ValueError("sound_intensity expects 1D pressure signals.")
+        msg = "sound_intensity expects 1D pressure signals."
+        raise ValueError(msg)
     if x1.size != x2.size:
-        raise ValueError(
-            f"Microphone signals must have the same length, got {x1.size} and {x2.size}."
-        )
+        msg = f"Microphone signals must have the same length, got {x1.size} and {x2.size}."
+        raise ValueError(msg)
 
 
 def _validate_probe_medium(fs: int, spacing: float, rho: float, c: float) -> None:
     """Reject a non-physical sample rate, probe spacing or medium."""
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     if spacing <= 0:
-        raise ValueError("Microphone 'spacing' must be positive.")
+        msg = "Microphone 'spacing' must be positive."
+        raise ValueError(msg)
     if rho <= 0:
-        raise ValueError("Air density 'rho' must be positive.")
+        msg = "Air density 'rho' must be positive."
+        raise ValueError(msg)
     if c <= 0:
-        raise ValueError("Speed of sound 'c' must be positive.")
+        msg = "Speed of sound 'c' must be positive."
+        raise ValueError(msg)
 
 
 def _validate_band_options(fraction: int | None, limits: list[float] | None) -> None:
     """Reject an unsupported band fraction or an ill-ordered frequency range."""
     if fraction is not None and fraction not in (1, 3):
-        raise ValueError("'fraction' must be None, 1 (octave) or 3 (one-third octave).")
+        msg = "'fraction' must be None, 1 (octave) or 3 (one-third octave)."
+        raise ValueError(msg)
     if limits is not None and (
         len(limits) != 2 or limits[0] <= 0 or limits[1] <= limits[0]
     ):
-        raise ValueError("'limits' must be [f_min, f_max] with 0 < f_min < f_max.")
+        msg = "'limits' must be [f_min, f_max] with 0 < f_min < f_max."
+        raise ValueError(msg)
 
 
 def sound_intensity(
@@ -452,9 +459,8 @@ def sound_intensity(
     _validate_probe_medium(fs, spacing, rho, c)
     _validate_band_options(fraction, limits)
     if x1.size < 32:
-        raise ValueError(
-            f"Signals too short for a spectral estimate: {x1.size} samples."
-        )
+        msg = f"Signals too short for a spectral estimate: {x1.size} samples."
+        raise ValueError(msg)
 
     # Hann-windowed Welch/CSD averaging through the shared spectral core
     # (50% overlap, detrend off); the shared default segment length targets
@@ -567,7 +573,8 @@ def _coefficient_of_variation(
     # A NaN or infinite sample slips past the positivity test below and turns
     # the whole indicator into a silent NaN, so it is rejected up front.
     if not np.all(np.isfinite(samples)):
-        raise ValueError("The normal intensity samples must all be finite.")
+        msg = "The normal intensity samples must all be finite."
+        raise ValueError(msg)
     mean = float(np.mean(samples))
     if mean <= 0.0:
         raise ValueError(non_positive_message)
@@ -615,15 +622,17 @@ def temporal_variability_indicator(
     """
     samples = np.atleast_1d(np.asarray(short_time_intensity, dtype=np.float64))
     if samples.ndim not in (1, 2):
-        raise ValueError(
+        msg = (
             "temporal_variability_indicator expects 1D (samples,) or 2D "
             "(samples, bands) arrays."
         )
+        raise ValueError(msg)
     if samples.shape[0] < 2:
-        raise ValueError(
+        msg = (
             "At least two short-time samples are required for F1 "
             "(ISO 9614-1 Annex A Note 9 recommends M = 10)."
         )
+        raise ValueError(msg)
     if samples.ndim == 1:
         return _coefficient_of_variation(samples, non_positive_message=_F1_NON_POSITIVE)
     return np.asarray(
@@ -679,10 +688,11 @@ def _temporal_indicator_for(
     f1 = temporal_variability_indicator(temporal_intensity)
     f1_size = 1 if np.ndim(f1) == 0 else np.size(f1)
     if f1_size != n_bands:
-        raise ValueError(
+        msg = (
             f"'temporal_intensity' must carry one column per band, got "
             f"{f1_size} for {n_bands} band(s)."
         )
+        raise ValueError(msg)
     if scalar_surface and np.ndim(f1) != 0:
         return float(np.asarray(f1).reshape(()))
     if not scalar_surface and np.ndim(f1) == 0:
@@ -743,26 +753,30 @@ def field_indicators(
     lp = np.atleast_1d(np.asarray(pressure_levels, dtype=np.float64))
     i_n = np.atleast_1d(np.asarray(normal_intensity, dtype=np.float64))
     if lp.ndim not in (1, 2) or i_n.ndim not in (1, 2):
-        raise ValueError(
+        msg = (
             "field_indicators expects 1D (positions,) or 2D (positions, bands) arrays."
         )
+        raise ValueError(msg)
     if lp.shape != i_n.shape:
-        raise ValueError(
+        msg = (
             f"'pressure_levels' and 'normal_intensity' must have the same "
             f"shape, got {lp.shape} and {i_n.shape}."
         )
+        raise ValueError(msg)
     if lp.shape[0] < 2:
-        raise ValueError("At least two measurement positions are required.")
+        msg = "At least two measurement positions are required."
+        raise ValueError(msg)
 
     n_bands = lp.shape[1] if lp.ndim == 2 else 1
     freqs: np.ndarray | None = None
     if frequencies is not None:
         freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
         if freqs.size != n_bands:
-            raise ValueError(
+            msg = (
                 f"'frequencies' must have one entry per band, got {freqs.size} "
                 f"for {n_bands} band(s)."
             )
+            raise ValueError(msg)
 
     f1 = _temporal_indicator_for(
         temporal_intensity, n_bands, scalar_surface=lp.ndim == 1
@@ -799,5 +813,6 @@ def dynamic_capability_index(
     :return: Ld in decibels.
     """
     if bias_error_factor <= 0:
-        raise ValueError("'bias_error_factor' must be positive.")
+        msg = "'bias_error_factor' must be positive."
+        raise ValueError(msg)
     return float(pressure_residual_intensity_index - bias_error_factor)

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -155,13 +155,15 @@ def _match_band(frequency: float) -> float:
         :data:`_BAND_MATCH_TOLERANCE` of ``frequency``.
     """
     if not np.isfinite(frequency) or frequency <= 0.0:
-        raise ValueError("Band centre frequencies must be finite and positive.")
+        msg = "Band centre frequencies must be finite and positive."
+        raise ValueError(msg)
     nearest = min(_THIRD_OCTAVE_BANDS, key=lambda f: abs(np.log(f / frequency)))
     if abs(nearest / frequency - 1.0) > _BAND_MATCH_TOLERANCE:
-        raise ValueError(
+        msg = (
             f"{frequency:g} Hz is not an IEC 61043 Table 2 band; the table "
             "covers the one-third-octave bands from 50 Hz to 6.3 kHz."
         )
+        raise ValueError(msg)
     return nearest
 
 
@@ -170,7 +172,8 @@ def _spacing_offset(spacing: float) -> float:
     mm.
     """
     if not np.isfinite(spacing) or spacing <= 0.0:
-        raise ValueError("'spacing' must be a positive, finite distance in metres.")
+        msg = "'spacing' must be a positive, finite distance in metres."
+        raise ValueError(msg)
     return float(10.0 * np.log10(spacing / REFERENCE_SPACING))
 
 
@@ -178,10 +181,11 @@ def _check_device(device: str) -> tuple[int, int]:
     """Validate a device kind and return its Table 2 column indices."""
     columns = _DEVICE_COLUMNS.get(device)
     if columns is None:
-        raise ValueError(
+        msg = (
             "'device' must be 'probe', 'processor' or 'instrument' "
             f"(IEC 61043 Table 2 columns), got {device!r}."
         )
+        raise ValueError(msg)
     return columns
 
 
@@ -244,10 +248,11 @@ def instrument_class_from_components(probe_class: int, processor_class: int) -> 
         class 2X of clause 4 is not modelled here.
     """
     if probe_class not in (1, 2) or processor_class not in (1, 2):
-        raise ValueError(
+        msg = (
             "'probe_class' and 'processor_class' must be 1 or 2; the "
             "non-real-time class 2X of IEC 61043 clause 4 is not modelled."
         )
+        raise ValueError(msg)
     return max(int(probe_class), int(processor_class))
 
 
@@ -330,23 +335,28 @@ def verify_intensity_class(
     measured = np.atleast_1d(np.asarray(residual_index, dtype=np.float64))
     supplied = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if measured.ndim != 1 or supplied.ndim != 1:
-        raise ValueError("verify_intensity_class expects 1D per-band arrays.")
+        msg = "verify_intensity_class expects 1D per-band arrays."
+        raise ValueError(msg)
     if measured.size != supplied.size:
-        raise ValueError(
+        msg = (
             f"'residual_index' and 'frequencies' must have the same length, "
             f"got {measured.size} and {supplied.size}."
         )
+        raise ValueError(msg)
     if measured.size == 0:
-        raise ValueError("At least one measurement band is required.")
+        msg = "At least one measurement band is required."
+        raise ValueError(msg)
     if not np.all(np.isfinite(measured)):
-        raise ValueError("'residual_index' must be finite.")
+        msg = "'residual_index' must be finite."
+        raise ValueError(msg)
 
     freqs = np.asarray([_match_band(float(f)) for f in supplied], dtype=np.float64)
     if np.unique(freqs).size != freqs.size:
-        raise ValueError(
+        msg = (
             "'frequencies' repeats an IEC 61043 Table 2 band; supply one "
             "measured value per band."
         )
+        raise ValueError(msg)
 
     _, class1, class2 = residual_index_limits(
         device, spacing=spacing, frequencies=freqs
@@ -431,7 +441,8 @@ class IntensityInstrumentComplianceResult:
         """
         cls = self.reference_class() if device_class is None else int(device_class)
         if cls not in (1, 2):
-            raise ValueError("'device_class' must be 1 or 2.")
+            msg = "'device_class' must be 1 or 2."
+            raise ValueError(msg)
         return min(float(band[f"margin_class{cls}_db"]) for band in self.bands)
 
     def failing_bands(self, device_class: int | None = None) -> list[float]:
@@ -442,7 +453,8 @@ class IntensityInstrumentComplianceResult:
         """
         cls = self.reference_class() if device_class is None else int(device_class)
         if cls not in (1, 2):
-            raise ValueError("'device_class' must be 1 or 2.")
+            msg = "'device_class' must be 1 or 2."
+            raise ValueError(msg)
         key = f"margin_class{cls}_db"
         return [float(b["freq"]) for b in self.bands if float(b[key]) < 0.0]
 
@@ -512,9 +524,8 @@ class IntensityInstrumentComplianceResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iec61043 import render_iec61043_report
 
         return render_iec61043_report(
@@ -577,12 +588,15 @@ def _plane_wave_phase_deg(
     degrees.
     """
     if not np.isfinite(spacing) or spacing <= 0.0:
-        raise ValueError("'spacing' must be a positive, finite distance in metres.")
+        msg = "'spacing' must be a positive, finite distance in metres."
+        raise ValueError(msg)
     if not np.isfinite(c) or c <= 0.0:
-        raise ValueError("'c' must be a positive, finite speed of sound.")
+        msg = "'c' must be a positive, finite speed of sound."
+        raise ValueError(msg)
     freq = np.asarray(frequency, dtype=np.float64)
     if np.any(~np.isfinite(freq)) or np.any(freq <= 0.0):
-        raise ValueError("'frequency' must be finite and positive.")
+        msg = "'frequency' must be finite and positive."
+        raise ValueError(msg)
     return np.asarray(360.0 * freq * spacing / c, dtype=np.float64)
 
 
@@ -620,7 +634,8 @@ def phase_mismatch_from_residual_index(
     """
     index = np.asarray(residual_index, dtype=np.float64)
     if np.any(~np.isfinite(index)):
-        raise ValueError("'residual_index' must be finite.")
+        msg = "'residual_index' must be finite."
+        raise ValueError(msg)
     kd_deg = _plane_wave_phase_deg(np.asarray(frequency, dtype=np.float64), spacing, c)
     return np.asarray(kd_deg * 10.0 ** (-index / 10.0), dtype=np.float64)
 
@@ -662,6 +677,7 @@ def residual_index_from_phase_mismatch(
     """
     phi = np.asarray(phase_mismatch, dtype=np.float64)
     if np.any(~np.isfinite(phi)) or np.any(phi <= 0.0):
-        raise ValueError("'phase_mismatch' must be finite and positive, in degrees.")
+        msg = "'phase_mismatch' must be finite and positive, in degrees."
+        raise ValueError(msg)
     kd_deg = _plane_wave_phase_deg(np.asarray(frequency, dtype=np.float64), spacing, c)
     return np.asarray(10.0 * np.log10(kd_deg / phi), dtype=np.float64)

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -300,9 +300,8 @@ class SoundPowerResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso3744 import render_sound_power_report
 
         return render_sound_power_report(
@@ -355,10 +354,11 @@ class SoundPowerResult:
 
         lwa = float(self.sound_power_level_a)
         if not np.isfinite(lwa):
-            raise ValueError(
+            msg = (
                 "declare() needs a finite A-weighted sound power level; supply "
                 "'frequencies' to sound_power_pressure(...) so LWA is defined."
             )
+            raise ValueError(msg)
         k = float(self.uncertainty if uncertainty is None else uncertainty)
         return NoiseEmissionDeclaration(
             modes=(
@@ -439,10 +439,11 @@ def _require_room_pair(
     if (first is None) == (second is None):
         return
     missing = second_name if second is None else first_name
-    raise ValueError(
+    msg = (
         f"{first_name} and {second_name} must be given together "
         f"({equation}); '{missing}' is missing."
     )
+    raise ValueError(msg)
 
 
 def _room_absorption_area(
@@ -476,14 +477,14 @@ def _room_absorption_area(
     if reverberation_time is not None and volume is not None:
         t = np.asarray(reverberation_time, dtype=np.float64)
         if volume <= 0 or np.any(t <= 0.0):
-            raise ValueError("reverberation_time and volume must be > 0.")
+            msg = "reverberation_time and volume must be > 0."
+            raise ValueError(msg)
         return 0.16 * volume / t
     if mean_absorption_coefficient is not None and room_surface is not None:
         alpha = np.asarray(mean_absorption_coefficient, dtype=np.float64)
         if room_surface <= 0 or np.any(alpha <= 0.0) or np.any(alpha > 1.0):
-            raise ValueError(
-                "mean_absorption_coefficient must be in (0, 1] and room_surface > 0."
-            )
+            msg = "mean_absorption_coefficient must be in (0, 1] and room_surface > 0."
+            raise ValueError(msg)
         return alpha * room_surface
     return None
 
@@ -535,7 +536,8 @@ def environmental_correction(
             return 0.0  # no room data at all: the field is treated as free
     a = np.asarray(absorption_area, dtype=np.float64)
     if np.any(a <= 0.0):
-        raise ValueError("absorption_area must be positive.")
+        msg = "absorption_area must be positive."
+        raise ValueError(msg)
     k2 = 10.0 * np.log10(1.0 + 4.0 * surface_area / a)
     return as_float_or_array(k2)
 
@@ -563,11 +565,12 @@ def _hemisphere_position_table(
     if reflecting_planes == 2:  # positions 14,15,18 of Table B.2
         return _TABLE_B2, (13, 14, 17)
     # positions 14,21,22 of Table B.2 (extended array not transcribed)
-    raise NotImplementedError(
+    msg = (
         "Survey coordinates for a source adjacent to three reflecting "
         "planes require the extended ISO 3746:2010 Table B.2 positions "
         "21 and 22 (see Figure B.4)."
     )
+    raise NotImplementedError(msg)
 
 
 def measurement_positions(
@@ -596,15 +599,18 @@ def measurement_positions(
     :return: ``(N, 3)`` microphone coordinates, in metres.
     """
     if surface != "hemisphere":
-        raise ValueError(
+        msg = (
             "measurement_positions provides coordinates for 'hemisphere' only; "
             "parallelepiped positions are defined by area subdivision "
             "(ISO 3744:2010 Annex C)."
         )
+        raise ValueError(msg)
     if radius <= 0:
-        raise ValueError("A positive 'radius' is required for a hemisphere.")
+        msg = "A positive 'radius' is required for a hemisphere."
+        raise ValueError(msg)
     if reflecting_planes not in (1, 2, 3):
-        raise ValueError("'reflecting_planes' must be 1, 2 or 3.")
+        msg = "'reflecting_planes' must be 1, 2 or 3."
+        raise ValueError(msg)
     grade = _check_grade(grade)
     table, index = _hemisphere_position_table(grade, reflecting_planes, tones)
     return np.asarray(table[list(index)] * radius, dtype=np.float64)
@@ -654,23 +660,25 @@ def _measurement_surface(
     """
     if surface == "hemisphere":
         if radius is None or radius <= 0:
-            raise ValueError("A positive 'radius' is required for a hemisphere.")
+            msg = "A positive 'radius' is required for a hemisphere."
+            raise ValueError(msg)
         return (
             _hemisphere_area(radius, reflecting_planes),
             _MIN_HEMI_POSITIONS[grade][reflecting_planes],
         )
     if surface == "box":
         if dimensions is None or distance is None:
-            raise ValueError("'dimensions' and 'distance' are required for a box.")
+            msg = "'dimensions' and 'distance' are required for a box."
+            raise ValueError(msg)
         if len(dimensions) != 3 or any(v <= 0 for v in dimensions) or distance <= 0:
-            raise ValueError(
-                "'dimensions' must be 3 positive values and 'distance' > 0."
-            )
+            msg = "'dimensions' must be 3 positive values and 'distance' > 0."
+            raise ValueError(msg)
         return (
             _box_area(dimensions, distance, reflecting_planes),
             _MIN_BOX_POSITIONS[grade],
         )
-    raise ValueError("'surface' must be 'hemisphere' or 'box'.")
+    msg = "'surface' must be 'hemisphere' or 'box'."
+    raise ValueError(msg)
 
 
 def _surface_background_correction(
@@ -699,11 +707,12 @@ def _surface_background_correction(
     if bg.shape == (1, n_bands) and n_positions != 1:
         bg = np.broadcast_to(bg, (n_positions, n_bands))
     if bg.shape != levels.shape:
-        raise ValueError(
+        msg = (
             "'background_levels' must match 'levels_positions' shape, or be "
             "a single spectrum of shape (NB,) or (1, NB) broadcast to all "
             "positions."
         )
+        raise ValueError(msg)
     return background_noise_correction(mean_level, energy_mean(bg, axis=0), grade)
 
 
@@ -732,10 +741,11 @@ def _surface_environmental_correction(
     )
     k2_arr = np.atleast_1d(np.asarray(k2_value, dtype=np.float64))
     if k2_arr.shape not in ((1,), (n_bands,)):
-        raise ValueError(
+        msg = (
             "per-band environmental inputs (absorption_area / reverberation_time"
             " / mean_absorption_coefficient) must match the number of bands."
         )
+        raise ValueError(msg)
     if np.any(k2_arr > _K2_LIMIT[grade]):
         warnings.warn(
             f"K2 up to {float(np.max(k2_arr)):.1f} dB exceeds the {grade} "
@@ -767,7 +777,8 @@ def _a_weighted_total(
         return None, (float(lw[0]) if n_bands == 1 else float("nan"))
     freqs = np.asarray(frequencies, dtype=np.float64)
     if freqs.shape[0] != n_bands:
-        raise ValueError("'frequencies' length must match the number of bands.")
+        msg = "'frequencies' length must match the number of bands."
+        raise ValueError(msg)
     return freqs, energy_sum(lw + _a_weighting_corrections(freqs))
 
 
@@ -823,22 +834,25 @@ def sound_power_pressure(
     grade = _check_grade(grade)
     levels = np.atleast_2d(np.asarray(levels_positions, dtype=np.float64))
     if levels.ndim != 2:
-        raise ValueError("'levels_positions' must be a 2D (positions, bands) array.")
+        msg = "'levels_positions' must be a 2D (positions, bands) array."
+        raise ValueError(msg)
     n_positions = levels.shape[0]
 
     # --- measurement surface area -----------------------------------------
     if reflecting_planes not in (1, 2, 3):
-        raise ValueError("'reflecting_planes' must be 1, 2 or 3.")
+        msg = "'reflecting_planes' must be 1, 2 or 3."
+        raise ValueError(msg)
     area, min_positions = _measurement_surface(
         surface, radius, dimensions, distance, reflecting_planes, grade
     )
 
     if n_positions < min_positions:
-        raise ValueError(
+        msg = (
             f"{grade} {surface} with {reflecting_planes} reflecting plane(s) "
             f"requires at least {min_positions} microphone positions, got "
             f"{n_positions} (ISO 3744/3746:2010 clause 8)."
         )
+        raise ValueError(msg)
 
     # --- energy average and background correction K1 ----------------------
     mean_level = energy_mean(levels, axis=0)

--- a/src/phonometry/emission/sound_power_anechoic.py
+++ b/src/phonometry/emission/sound_power_anechoic.py
@@ -333,9 +333,8 @@ class PrecisionSoundPowerResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso3744 import render_sound_power_report
 
         return render_sound_power_report(
@@ -353,10 +352,11 @@ def _precision_table(surface: PrecisionSurface, array: PrecisionArray) -> np.nda
         raise ValueError(_SURFACE_CHOICE_MSG)
     norms = np.linalg.norm(table, axis=1)
     if np.any(np.abs(norms - 1.0) > _UNIT_NORM_TOL):
-        raise ValueError(
+        msg = (
             "Microphone coordinate table is not a set of unit vectors within "
             f"{_UNIT_NORM_TOL:g}; a transcription error is present."
         )
+        raise ValueError(msg)
     return table
 
 
@@ -387,11 +387,14 @@ def precision_positions(
     if surface not in ("sphere", "hemisphere"):
         raise ValueError(_SURFACE_CHOICE_MSG)
     if array not in ("general", "broadband"):
-        raise ValueError("'array' must be 'general' or 'broadband'.")
+        msg = "'array' must be 'general' or 'broadband'."
+        raise ValueError(msg)
     if radius <= 0:
-        raise ValueError("A positive 'radius' is required.")
+        msg = "A positive 'radius' is required."
+        raise ValueError(msg)
     if count not in (20, 40):
-        raise ValueError("'count' must be 20 (primary array) or 40 (full array).")
+        msg = "'count' must be 20 (primary array) or 40 (full array)."
+        raise ValueError(msg)
     table = _precision_table(surface, array)
     return np.asarray(table[:count] * radius, dtype=np.float64)
 
@@ -436,10 +439,11 @@ def precision_background_correction(
     bg = np.asarray(background_levels, dtype=np.float64)
     freqs = np.asarray(frequencies, dtype=np.float64)
     if src.shape[-1] != freqs.shape[0] or bg.shape[-1] != freqs.shape[0]:
-        raise ValueError(
+        msg = (
             "The last axis of 'source_levels'/'background_levels' must match "
             "the number of 'frequencies'."
         )
+        raise ValueError(msg)
     low = _k1_lower_criterion(freqs)  # (NB,)
     delta = src - bg
     clamped = np.maximum(delta, low)
@@ -498,11 +502,14 @@ def meteorological_corrections(
     :return: :class:`MeteorologicalCorrection`.
     """
     if static_pressure <= 0.0:
-        raise ValueError("'static_pressure' must be positive (kPa).")
+        msg = "'static_pressure' must be positive (kPa)."
+        raise ValueError(msg)
     if temperature <= -273.0:
-        raise ValueError("'temperature' must be above -273 degrees Celsius.")
+        msg = "'temperature' must be above -273 degrees Celsius."
+        raise ValueError(msg)
     if radius <= 0.0:
-        raise ValueError("'radius' must be positive.")
+        msg = "'radius' must be positive."
+        raise ValueError(msg)
     theta_k = 273.0 + temperature
     p_term = -10.0 * np.log10(static_pressure / _PS0_KPA)
     c1 = float(p_term + 5.0 * np.log10(theta_k / _THETA0_K))
@@ -512,7 +519,8 @@ def meteorological_corrections(
     else:
         a0 = np.asarray(air_absorption_coefficient, dtype=np.float64) * radius
         if np.any(a0 < 0.0):
-            raise ValueError("'air_absorption_coefficient' must be non-negative.")
+            msg = "'air_absorption_coefficient' must be non-negative."
+            raise ValueError(msg)
         c3_arr = a0 * (1.0053 - 0.0012 * a0) ** 1.6
         c3 = as_float_or_array(c3_arr)
     return MeteorologicalCorrection(c1=c1, c2=c2, c3=c3)
@@ -530,10 +538,11 @@ def _sigma_r0_3745(nominal: int, room: PrecisionRoom) -> float:
         return 1.5 if room == "hemi-anechoic" else 1.0
     if 12500 <= nominal <= 20000:
         return 2.0
-    raise ValueError(
+    msg = (
         f"No ISO 3745:2012 sigma_R0 for {nominal} Hz; expected a nominal "
         "one-third-octave mid-band from 50 Hz to 20 kHz."
     )
+    raise ValueError(msg)
 
 
 def precision_uncertainty(
@@ -554,9 +563,11 @@ def precision_uncertainty(
     :return: ``U`` in decibels, scalar or per band matching ``sigma_r0``.
     """
     if coverage_factor <= 0.0:
-        raise ValueError("'coverage_factor' must be positive.")
+        msg = "'coverage_factor' must be positive."
+        raise ValueError(msg)
     if sigma_omc < 0.0:
-        raise ValueError("'sigma_omc' must be non-negative.")
+        msg = "'sigma_omc' must be non-negative."
+        raise ValueError(msg)
     sigma_tot = np.hypot(np.asarray(sigma_r0, dtype=np.float64), sigma_omc)
     u = coverage_factor * sigma_tot
     return as_float_or_array(u)
@@ -575,19 +586,21 @@ def _precision_k1(
     if background_levels is None:
         return np.zeros_like(levels)
     if freqs is None:
-        raise ValueError(
+        msg = (
             "'frequencies' are required with 'background_levels' to select "
             "the frequency-dependent K1 criterion (ISO 3745:2012 9.4.2)."
         )
+        raise ValueError(msg)
     n_positions, n_bands = levels.shape
     bg = np.atleast_2d(np.asarray(background_levels, dtype=np.float64))
     if bg.shape == (1, n_bands) and n_positions != 1:
         bg = np.broadcast_to(bg, (n_positions, n_bands))
     if bg.shape != levels.shape:
-        raise ValueError(
+        msg = (
             "'background_levels' must match 'levels_positions' shape, or be "
             "a single spectrum of shape (NB,) or (1, NB)."
         )
+        raise ValueError(msg)
     return precision_background_correction(levels, bg, freqs)
 
 
@@ -602,9 +615,11 @@ def _precision_surface_level(
     n_positions = corrected.shape[0]
     seg = np.asarray(areas, dtype=np.float64)
     if seg.shape != (n_positions,):
-        raise ValueError("'areas' must have one value per microphone position.")
+        msg = "'areas' must have one value per microphone position."
+        raise ValueError(msg)
     if np.any(seg <= 0.0):
-        raise ValueError("All 'areas' must be positive.")
+        msg = "All 'areas' must be positive."
+        raise ValueError(msg)
     return np.asarray(
         weighted_energy_mean(corrected, seg[:, None], axis=0), dtype=np.float64
     )
@@ -734,10 +749,12 @@ def sound_power_anechoic(
     if surface not in ("sphere", "hemisphere"):
         raise ValueError(_SURFACE_CHOICE_MSG)
     if radius <= 0:
-        raise ValueError("A positive 'radius' is required.")
+        msg = "A positive 'radius' is required."
+        raise ValueError(msg)
     levels = np.atleast_2d(np.asarray(levels_positions, dtype=np.float64))
     if levels.ndim != 2:
-        raise ValueError("'levels_positions' must be a 2D (positions, bands) array.")
+        msg = "'levels_positions' must be a 2D (positions, bands) array."
+        raise ValueError(msg)
     n_positions, n_bands = levels.shape
 
     area = (4.0 if surface == "sphere" else 2.0) * np.pi * radius**2
@@ -745,7 +762,8 @@ def sound_power_anechoic(
 
     freqs = None if frequencies is None else np.asarray(frequencies, dtype=np.float64)
     if freqs is not None and freqs.shape[0] != n_bands:
-        raise ValueError("'frequencies' length must match the number of bands.")
+        msg = "'frequencies' length must match the number of bands."
+        raise ValueError(msg)
 
     # --- per-position background correction K1i (Eq. 11) ------------------
     k1 = _precision_k1(levels, background_levels, freqs)

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -164,11 +164,12 @@ def _table2_s(nominal: int, band_type: BandType) -> float:
             6300: 2.5,
         }
     if nominal not in table:
-        raise ValueError(
+        msg = (
             f"No ISO 9614-2 Table 2 standard deviation for {nominal} Hz "
             f"({band_type}); expected a nominal band centre in the qualified "
             "range (Table 2)."
         )
+        raise ValueError(msg)
     return table[nominal]
 
 
@@ -280,9 +281,8 @@ class SoundPowerIntensityResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso9614 import render_intensity_power_report
 
         return render_intensity_power_report(
@@ -303,10 +303,11 @@ def _as_2d(name: str, arr: np.ndarray, n_seg: int, n_bands: int) -> np.ndarray:
     if a.shape == (1, n_seg) and n_bands != n_seg:
         a = a.T  # a 1D (N_seg,) input arrives as (1, N_seg)
     if a.shape != (n_seg, n_bands):
-        raise ValueError(
+        msg = (
             f"'{name}' must have shape ({n_seg}, {n_bands}) matching "
             f"'normal_intensity', got {a.shape}."
         )
+        raise ValueError(msg)
     return a
 
 
@@ -322,21 +323,24 @@ def _validate_scan(
     areas as ``(N_seg,)``.
     """
     if band_type not in ("octave", "third"):
-        raise ValueError("'band_type' must be 'octave' or 'third'.")
+        msg = "'band_type' must be 'octave' or 'third'."
+        raise ValueError(msg)
 
     intensity = np.atleast_2d(np.asarray(normal_intensity, dtype=np.float64))
     seg = np.asarray(areas, dtype=np.float64)
     if seg.ndim != 1:
-        raise ValueError("'areas' must be a 1D array of segment areas.")
+        msg = "'areas' must be a 1D array of segment areas."
+        raise ValueError(msg)
     n_seg = seg.shape[0]
     # A 1D (N_seg,) intensity arrives from atleast_2d as (1, N_seg): transpose.
     if intensity.shape == (1, n_seg) and n_seg != 1:
         intensity = intensity.T
     if intensity.shape[0] != n_seg:
-        raise ValueError(
+        msg = (
             f"'normal_intensity' first axis ({intensity.shape[0]}) must match "
             f"the number of segment 'areas' ({n_seg})."
         )
+        raise ValueError(msg)
     if frequencies is not None and np.asarray(frequencies).shape != (
         intensity.shape[1],
     ):
@@ -344,7 +348,8 @@ def _validate_scan(
         # rather than an IndexError from the Table 2 lookup during classification.
         raise ValueError(_FREQUENCIES_BAND_COUNT_MSG)
     if np.any(seg <= 0.0):
-        raise ValueError("All segment 'areas' must be positive.")
+        msg = "All segment 'areas' must be positive."
+        raise ValueError(msg)
     if n_seg < 4:
         warnings.warn(
             f"Only {n_seg} segment(s); ISO 9614-2:1996 clause 8.2 requires at "
@@ -562,10 +567,11 @@ def _classify(
         s_sur = s_eng
     else:
         if frequencies is None:
-            raise ValueError(
+            msg = (
                 "The achieved grade needs the criterion-3 limit s: provide "
                 "'frequencies' (Table 2 lookup) or 'repeatability_limit'."
             )
+            raise ValueError(msg)
         nominal = [round(float(f)) for f in np.asarray(frequencies)]
         s_eng = np.array([_table2_s(f, band_type) for f in nominal], dtype=np.float64)
         s_sur = np.full(n_bands, _S_SURVEY, dtype=np.float64)
@@ -766,16 +772,18 @@ def _check_report_bands(
     if residual_index is not None:
         index = np.atleast_1d(np.asarray(residual_index, dtype=np.float64))
         if index.size not in (1, n_bands):
-            raise ValueError(
+            msg = (
                 f"'residual_index' must be a scalar or span the {n_bands} "
                 f"bands of the determination; got {index.size} values."
             )
+            raise ValueError(msg)
     for name, values in arrays:
         if values.shape != (n_bands,):
-            raise ValueError(
+            msg = (
                 f"'{name}' must span the {n_bands} bands of the determination; "
                 f"got shape {values.shape}."
             )
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -894,9 +902,8 @@ class PrecisionIntensityResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         n_bands = int(np.asarray(self.sound_power_level).size)
         _check_report_bands(indicators, criteria, residual_index, n_bands)
 
@@ -955,13 +962,15 @@ def precision_field_indicators(
     i_n = np.atleast_2d(np.asarray(segment_intensity, dtype=np.float64))
     lp = np.atleast_2d(np.asarray(segment_pressure_levels, dtype=np.float64))
     if i_n.shape != lp.shape:
-        raise ValueError(
+        msg = (
             "'segment_intensity' and 'segment_pressure_levels' must have the "
             f"same shape, got {i_n.shape} and {lp.shape}."
         )
+        raise ValueError(msg)
     n_seg = i_n.shape[0]
     if n_seg < 2:
-        raise ValueError("At least two segments are required for the indicators.")
+        msg = "At least two segments are required for the indicators."
+        raise ValueError(msg)
 
     lp_bar = energy_mean(lp, axis=0)  # Eq. B.4
     li_unsigned = 10.0 * np.log10(np.mean(np.abs(i_n), axis=0) / _I0)  # Eq. B.5
@@ -985,12 +994,12 @@ def precision_field_indicators(
     if time_window_intensity is not None:
         win = np.atleast_2d(np.asarray(time_window_intensity, dtype=np.float64))
         if win.shape[-1] != i_n.shape[-1]:
-            raise ValueError(
-                "'time_window_intensity' last axis must match the number of bands."
-            )
+            msg = "'time_window_intensity' last axis must match the number of bands."
+            raise ValueError(msg)
         m = win.shape[0]
         if m < 2:
-            raise ValueError("At least two time windows are required for FT.")
+            msg = "At least two time windows are required for FT."
+            raise ValueError(msg)
         mean_t = np.mean(win, axis=0)
         with np.errstate(divide="ignore", invalid="ignore"):
             ft = np.asarray(
@@ -1014,10 +1023,11 @@ def _sigma_r0_9614_3(nominal: int) -> float:
         return 1.0
     if nominal == 6300:
         return 2.0
-    raise ValueError(
+    msg = (
         f"No ISO 9614-3:2002 Table 1 sigma_R0 for {nominal} Hz; expected a "
         "nominal one-third-octave mid-band from 50 Hz to 6300 Hz."
     )
+    raise ValueError(msg)
 
 
 def precision_qualification(
@@ -1072,10 +1082,11 @@ def precision_qualification(
             nominal = [round(float(f)) for f in np.asarray(frequencies)]
             s = np.array([_sigma_r0_9614_3(f) for f in nominal], dtype=np.float64)
         else:
-            raise ValueError(
+            msg = (
                 "Criterion 1 needs the limit s: provide 'frequencies' (Table 1) "
                 "or 'repeatability_limit'."
             )
+            raise ValueError(msg)
         criterion_1 = np.asarray(np.abs(l1 - l2) <= s / 2.0, dtype=bool)
 
     # Criterion 2: Ld >= F_pIn(signed), Ld = delta_pI0 - K.
@@ -1172,7 +1183,8 @@ def sound_power_intensity_precision(
     raw_intensity = np.asarray(partial_intensity, dtype=np.float64)
     seg = np.asarray(areas, dtype=np.float64)
     if seg.ndim != 1:
-        raise ValueError("'areas' must be a 1D array of partial surface areas.")
+        msg = "'areas' must be a 1D array of partial surface areas."
+        raise ValueError(msg)
     n_seg = seg.shape[0]
     # A 1-D input is unambiguously ``(N,)`` segments with one band -> ``(N, 1)``;
     # a 2-D input is taken as ``(segments, bands)`` as given. Keying off the
@@ -1183,16 +1195,20 @@ def sound_power_intensity_precision(
     else:
         intensity = np.atleast_2d(raw_intensity)
     if intensity.shape[0] != n_seg:
-        raise ValueError(
+        msg = (
             f"'partial_intensity' first axis ({intensity.shape[0]}) must match "
             f"the number of 'areas' ({n_seg})."
         )
+        raise ValueError(msg)
     if np.any(seg <= 0.0):
-        raise ValueError("All 'areas' must be positive.")
+        msg = "All 'areas' must be positive."
+        raise ValueError(msg)
     if temperature <= -273.15:
-        raise ValueError("'temperature' must be above -273,15 degrees Celsius.")
+        msg = "'temperature' must be above -273,15 degrees Celsius."
+        raise ValueError(msg)
     if barometric_pressure <= 0.0:
-        raise ValueError("'barometric_pressure' must be positive (Pa).")
+        msg = "'barometric_pressure' must be positive (Pa)."
+        raise ValueError(msg)
     n_bands = intensity.shape[1]
     if frequencies is not None and np.asarray(frequencies).shape != (n_bands,):
         raise ValueError(_FREQUENCIES_BAND_COUNT_MSG)

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -172,9 +172,8 @@ class ReverberationSoundPowerResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso3741 import render_reverberation_power_report
 
         return render_reverberation_power_report(
@@ -191,9 +190,11 @@ def _validate_meteorology(temperature: float, static_pressure: float) -> None:
     with a clean ``ValueError``.
     """
     if not np.isfinite(temperature) or temperature <= -273.0:
-        raise ValueError("'temperature' must be finite and greater than -273 degC.")
+        msg = "'temperature' must be finite and greater than -273 degC."
+        raise ValueError(msg)
     if not np.isfinite(static_pressure) or static_pressure <= 0.0:
-        raise ValueError("'static_pressure' must be finite and positive.")
+        msg = "'static_pressure' must be finite and positive."
+        raise ValueError(msg)
 
 
 def _speed_of_sound(temperature: float) -> float:
@@ -229,7 +230,8 @@ def _mean_level(levels: np.ndarray) -> np.ndarray:
         return arr
     if arr.ndim == 2:
         return energy_mean(arr, axis=0)
-    raise ValueError("'levels' must be a 1D spectrum or a 2D (positions, bands) array.")
+    msg = "'levels' must be a 1D spectrum or a 2D (positions, bands) array."
+    raise ValueError(msg)
 
 
 def _k1_eq14(delta: np.ndarray, frequencies: np.ndarray) -> tuple[np.ndarray, bool]:
@@ -280,10 +282,11 @@ def _background_corrected_mean(
         if bg.ndim == 1:
             bg = np.broadcast_to(bg, arr.shape)
         if bg.shape != arr.shape:
-            raise ValueError(
+            msg = (
                 "'background_levels' must match the per-position 'levels' "
                 "shape or be a single (bands,) spectrum."
             )
+            raise ValueError(msg)
         k1i, clamped = _k1_eq14(arr - bg, frequencies)
         corrected = energy_mean(arr - k1i, axis=0)
     else:
@@ -461,18 +464,22 @@ def sound_power_reverberation(
     :return: :class:`ReverberationSoundPowerResult`.
     """
     if volume <= 0 or surface_area <= 0:
-        raise ValueError("'volume' and 'surface_area' must be positive.")
+        msg = "'volume' and 'surface_area' must be positive."
+        raise ValueError(msg)
     _validate_meteorology(temperature, static_pressure)
     mean_level = _mean_level(levels)
     n_bands = mean_level.shape[0]
     freqs = np.asarray(frequencies, dtype=np.float64)
     t60_arr = np.broadcast_to(np.asarray(t60, dtype=np.float64), (n_bands,)).copy()
     if freqs.shape != (n_bands,):
-        raise ValueError("'frequencies' length must match the number of bands.")
+        msg = "'frequencies' length must match the number of bands."
+        raise ValueError(msg)
     if np.any(t60_arr <= 0.0):
-        raise ValueError("'t60' values must be positive.")
+        msg = "'t60' values must be positive."
+        raise ValueError(msg)
     if np.any(freqs <= 0.0):
-        raise ValueError("'frequencies' must be positive.")
+        msg = "'frequencies' must be positive."
+        raise ValueError(msg)
 
     _room_qualification_warnings(levels, t60_arr, volume, surface_area, freqs)
 
@@ -559,13 +566,13 @@ def sound_power_comparison(
     lw_rss = np.asarray(lw_ref, dtype=np.float64)
     n_bands = lp_st.shape[0]
     if lp_rss.shape != (n_bands,) or lw_rss.shape != (n_bands,):
-        raise ValueError(
-            "'levels', 'levels_ref' and 'lw_ref' must span the same bands."
-        )
+        msg = "'levels', 'levels_ref' and 'lw_ref' must span the same bands."
+        raise ValueError(msg)
 
     freqs = None if frequencies is None else np.asarray(frequencies, dtype=np.float64)
     if freqs is not None and freqs.shape != (n_bands,):
-        raise ValueError("'frequencies' length must match the number of bands.")
+        msg = "'frequencies' length must match the number of bands."
+        raise ValueError(msg)
 
     # Microphone-sampling advisories (<6 positions, sM > 1,5 dB) apply to the
     # per-position measurement of the source under test, exactly as in the
@@ -576,13 +583,13 @@ def sound_power_comparison(
     k1_st = np.zeros(n_bands, dtype=np.float64)
     if background_levels is not None:
         if freqs is None:
-            raise ValueError("'frequencies' are required to apply 'background_levels'.")
+            msg = "'frequencies' are required to apply 'background_levels'."
+            raise ValueError(msg)
         lp_st, k1_st = _background_corrected_mean(levels, background_levels, freqs)
     if background_levels_ref is not None:
         if freqs is None:
-            raise ValueError(
-                "'frequencies' are required to apply 'background_levels_ref'."
-            )
+            msg = "'frequencies' are required to apply 'background_levels_ref'."
+            raise ValueError(msg)
         lp_rss, _ = _background_corrected_mean(levels_ref, background_levels_ref, freqs)
 
     c2 = _c2_correction(temperature, static_pressure)

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -126,7 +126,8 @@ def velocity_level_from_acceleration(
     a = np.asarray(peak_acceleration, dtype=np.float64)
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     v_rms = np.abs(a) / (2.0 * np.pi * f * np.sqrt(2.0))
     return np.asarray(20.0 * np.log10(v_rms / reference), dtype=np.float64)
 
@@ -150,7 +151,8 @@ def mean_velocity_level(levels: ArrayLike, areas: ArrayLike | None = None) -> fl
     else:
         s = np.asarray(areas, dtype=np.float64)
         if s.shape != lv.shape:
-            raise ValueError("'areas' must match the shape of 'levels'.")
+            msg = "'areas' must match the shape of 'levels'."
+            raise ValueError(msg)
         mean_energy = float(np.sum(s * energy) / np.sum(s))
     return float(10.0 * np.log10(mean_energy))
 
@@ -359,9 +361,8 @@ class VibrationSoundPowerResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso7849 import render_vibration_power_report
 
         return render_vibration_power_report(
@@ -394,7 +395,8 @@ def sound_power_from_vibration(
     if frequencies is not None:
         freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
         if freq.shape != lv.shape:
-            raise ValueError("'frequencies' must match the shape of 'velocity_level'.")
+            msg = "'frequencies' must match the shape of 'velocity_level'."
+            raise ValueError(msg)
     return VibrationSoundPowerResult(
         velocity_level=lv,
         sound_power_level=np.asarray(lw, dtype=np.float64),

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -189,9 +189,8 @@ class ImpulseProminenceResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso1996_impulse import render_impulse_prominence_report
 
         return render_impulse_prominence_report(
@@ -224,9 +223,11 @@ def predicted_prominence(
     orate = np.asarray(onset_rate, dtype=np.float64)
     ld = np.asarray(level_difference, dtype=np.float64)
     if not (np.all(np.isfinite(orate)) and np.all(np.isfinite(ld))):
-        raise ValueError("onset_rate and level_difference must be finite.")
+        msg = "onset_rate and level_difference must be finite."
+        raise ValueError(msg)
     if np.any(orate <= 0.0) or np.any(ld <= 0.0):
-        raise ValueError("onset_rate and level_difference must be positive.")
+        msg = "onset_rate and level_difference must be positive."
+        raise ValueError(msg)
     k1, k2 = PROMINENCE_COEFFS
     return k1 * np.log10(orate) + k2 * np.log10(ld)
 
@@ -277,19 +278,22 @@ def impulse_prominence(
         positive and finite.
     """
     if not math.isfinite(assessment_period_min) or assessment_period_min <= 0.0:
-        raise ValueError(
+        msg = (
             f"assessment_period_min must be positive and finite; got "
             f"{assessment_period_min}."
         )
+        raise ValueError(msg)
     orate = np.asarray(onset_rates, dtype=np.float64).ravel()
     ld = np.asarray(level_differences, dtype=np.float64).ravel()
     if orate.size == 0:
-        raise ValueError("at least one impulse is required.")
+        msg = "at least one impulse is required."
+        raise ValueError(msg)
     if orate.shape != ld.shape:
-        raise ValueError(
+        msg = (
             f"onset_rates and level_differences must have the same shape; "
             f"got {orate.shape} and {ld.shape}."
         )
+        raise ValueError(msg)
     per_impulse = predicted_prominence(orate, ld)
     qualifies = orate > ONSET_RATE_LIMIT
     if not np.all(qualifies):
@@ -346,15 +350,19 @@ def rating_level(
     ki = np.atleast_1d(np.asarray(adjustment, dtype=np.float64))
     dt = np.atleast_1d(np.asarray(durations, dtype=np.float64))
     if not le.shape == ki.shape == dt.shape:
-        raise ValueError("laeq, adjustment and durations must have equal length.")
+        msg = "laeq, adjustment and durations must have equal length."
+        raise ValueError(msg)
     if le.size == 0:
-        raise ValueError("at least one sub-interval is required.")
+        msg = "at least one sub-interval is required."
+        raise ValueError(msg)
     if not (
         np.all(np.isfinite(le)) and np.all(np.isfinite(ki)) and np.all(np.isfinite(dt))
     ):
-        raise ValueError("laeq, adjustment and durations must be finite.")
+        msg = "laeq, adjustment and durations must be finite."
+        raise ValueError(msg)
     if not math.isfinite(reference_time) or reference_time <= 0.0 or np.any(dt <= 0.0):
-        raise ValueError("reference_time and durations must be positive.")
+        msg = "reference_time and durations must be positive."
+        raise ValueError(msg)
     energy = np.sum(dt * 10.0 ** ((le + ki) / 10.0))
     return float(10.0 * np.log10(energy / reference_time))
 
@@ -565,14 +573,15 @@ def sound_pressure_level_history(
     fs = resolve_fs(signal, fs, name="signal")
     x = np.asarray(resolve_samples(signal), dtype=np.float64).ravel()
     if not math.isfinite(fs) or fs <= 0.0:
-        raise ValueError("fs must be positive.")
+        msg = "fs must be positive."
+        raise ValueError(msg)
     lo, hi = SAMPLE_INTERVAL_RANGE
     if not lo <= dt <= hi:
-        raise ValueError(
-            f"dt must be within {lo * 1e3:g}-{hi * 1e3:g} ms (Clause 4); got {dt * 1e3:g} ms."
-        )
+        msg = f"dt must be within {lo * 1e3:g}-{hi * 1e3:g} ms (Clause 4); got {dt * 1e3:g} ms."
+        raise ValueError(msg)
     if x.size == 0:
-        raise ValueError("signal must not be empty.")
+        msg = "signal must not be empty."
+        raise ValueError(msg)
 
     weighted = np.asarray(weighting_filter(x, round(fs), curve="A"), dtype=np.float64)
     # Warm-start the F integrator at the first window's mean square so a steady
@@ -719,9 +728,11 @@ def detect_onsets(
     """
     lev = np.asarray(levels, dtype=np.float64).ravel()
     if not math.isfinite(dt) or dt <= 0.0:
-        raise ValueError("dt must be positive.")
+        msg = "dt must be positive."
+        raise ValueError(msg)
     if lev.size < 2:
-        raise ValueError("at least two level samples are required.")
+        msg = "at least two level samples are required."
+        raise ValueError(msg)
     times = np.arange(lev.size) * dt
     gradient = np.diff(lev) / dt
 

--- a/src/phonometry/environment/assessment/measurement.py
+++ b/src/phonometry/environment/assessment/measurement.py
@@ -93,14 +93,16 @@ class EnvironmentalMeasurementWarning(PhonometryWarning):
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return scalar
 
 
@@ -285,13 +287,17 @@ def tonal_seeking_survey(
     lev = np.asarray(levels, dtype=np.float64)
     freq = np.asarray(frequencies, dtype=np.float64)
     if lev.ndim != 1 or freq.ndim != 1:
-        raise ValueError("'levels' and 'frequencies' must be one-dimensional.")
+        msg = "'levels' and 'frequencies' must be one-dimensional."
+        raise ValueError(msg)
     if lev.size != freq.size:
-        raise ValueError("'levels' and 'frequencies' must share their length.")
+        msg = "'levels' and 'frequencies' must share their length."
+        raise ValueError(msg)
     if lev.size < 3:
-        raise ValueError("Need at least three bands to test the neighbours.")
+        msg = "Need at least three bands to test the neighbours."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(lev)) and np.all(np.isfinite(freq))):
-        raise ValueError("'levels' and 'frequencies' must be finite.")
+        msg = "'levels' and 'frequencies' must be finite."
+        raise ValueError(msg)
     flags = np.zeros(lev.size, dtype=np.bool_)
     for i in range(1, lev.size - 1):
         threshold = _survey_threshold(freq[i])
@@ -362,7 +368,8 @@ def residual_sound_correction(
     lres = _finite(residual_level, "residual_level")
     margin = lp - lres
     if margin <= 0.0:
-        raise ValueError("'residual_level' must be below 'measured_level' to correct.")
+        msg = "'residual_level' must be below 'measured_level' to correct."
+        raise ValueError(msg)
     corrected = 10.0 * np.log10(10.0 ** (lp / 10.0) - 10.0 ** (lres / 10.0))
     reliable = margin > 3.0
     if not reliable:
@@ -412,7 +419,8 @@ def gaussian_residual_level(
     """
     median = _finite(l50, "l50")
     if (l90 is None) == (l95 is None):
-        raise ValueError("Supply exactly one of 'l90' or 'l95'.")
+        msg = "Supply exactly one of 'l90' or 'l95'."
+        raise ValueError(msg)
     if l90 is not None:
         spread = median - _finite(l90, "l90")
         divisor = _GAUSS_DIVISOR_L90
@@ -422,12 +430,14 @@ def gaussian_residual_level(
         divisor = _GAUSS_DIVISOR_L95
         name = "l95"
     else:  # unreachable: the check above guarantees exactly one is supplied
-        raise ValueError("Supply exactly one of 'l90' or 'l95'.")
+        msg = "Supply exactly one of 'l90' or 'l95'."
+        raise ValueError(msg)
     if spread < 0.0:
-        raise ValueError(
+        msg = (
             f"'{name}' exceeds 'l50': the exceedance percentiles satisfy "
             "L50 >= L90 >= L95, so the arguments look swapped."
         )
+        raise ValueError(msg)
     return float(median + _GAUSS_CONSTANT * (spread / divisor) ** 2)
 
 
@@ -450,19 +460,22 @@ def combined_standard_uncertainty(
     """
     items = list(contributions)
     if not items:
-        raise ValueError("'contributions' must not be empty.")
+        msg = "'contributions' must not be empty."
+        raise ValueError(msg)
     products = []
     for item in items:
         if isinstance(item, (tuple, list, np.ndarray)):
             pair = np.asarray(item, dtype=np.float64)
             if pair.shape != (2,):
-                raise ValueError("Each pair must be (uncertainty, sensitivity).")
+                msg = "Each pair must be (uncertainty, sensitivity)."
+                raise ValueError(msg)
             products.append(pair[0] * pair[1])
         else:
             products.append(float(item))
     arr = np.asarray(products, dtype=np.float64)
     if not np.all(np.isfinite(arr)):
-        raise ValueError("'contributions' must be finite.")
+        msg = "'contributions' must be finite."
+        raise ValueError(msg)
     return float(np.sqrt(np.sum(arr**2)))
 
 
@@ -491,9 +504,11 @@ def expanded_uncertainty(
     """
     u = _finite(standard_uncertainty, "standard_uncertainty")
     if u < 0.0:
-        raise ValueError("'standard_uncertainty' must be non-negative.")
+        msg = "'standard_uncertainty' must be non-negative."
+        raise ValueError(msg)
     if confidence not in _COVERAGE_FACTORS:
-        raise ValueError(f"'confidence' must be one of {sorted(_COVERAGE_FACTORS)}.")
+        msg = f"'confidence' must be one of {sorted(_COVERAGE_FACTORS)}."
+        raise ValueError(msg)
     return float(_COVERAGE_FACTORS[confidence] * u)
 
 
@@ -523,9 +538,11 @@ def residual_correction_uncertainty(
     u_lp = _finite(measured_uncertainty, "measured_uncertainty")
     u_res = _finite(residual_uncertainty, "residual_uncertainty")
     if lp - lres <= 0.0:
-        raise ValueError("'residual_level' must be below 'measured_level'.")
+        msg = "'residual_level' must be below 'measured_level'."
+        raise ValueError(msg)
     if u_lp < 0.0 or u_res < 0.0:
-        raise ValueError("Uncertainties must be non-negative.")
+        msg = "Uncertainties must be non-negative."
+        raise ValueError(msg)
     m = 10.0 ** (-0.1 * (lp - lres))
     c_lp = 1.0 / (1.0 - m)
     c_res = -m / (1.0 - m)
@@ -589,9 +606,11 @@ def uncertainty_from_repeated_measurements(
 
     lev = np.asarray(levels, dtype=np.float64)
     if lev.ndim != 1 or lev.size < 2:
-        raise ValueError("'levels' must be a 1-D array of at least two values.")
+        msg = "'levels' must be a 1-D array of at least two values."
+        raise ValueError(msg)
     if not np.all(np.isfinite(lev)):
-        raise ValueError("'levels' must be finite.")
+        msg = "'levels' must be finite."
+        raise ValueError(msg)
     n = int(lev.size)
     energies = 10.0 ** (0.1 * lev)
     mean_energy = float(np.mean(energies))

--- a/src/phonometry/environment/assessment/rating.py
+++ b/src/phonometry/environment/assessment/rating.py
@@ -35,13 +35,16 @@ def composite_rating_level(periods: Iterable[tuple[float, float, float]]) -> flo
     """
     periods = list(periods)
     if not periods:
-        raise ValueError("At least one period is required.")
+        msg = "At least one period is required."
+        raise ValueError(msg)
     hours = np.array([h for _, h, _ in periods], dtype=np.float64)
     if not np.all(np.isfinite(hours)) or np.any(hours <= 0):
-        raise ValueError("Every period duration must be a positive, finite number.")
+        msg = "Every period duration must be a positive, finite number."
+        raise ValueError(msg)
     total = float(np.sum(hours))
     if abs(total - 24.0) > 1e-9:
-        raise ValueError(f"Period durations must sum to 24 h; got {total!r}.")
+        msg = f"Period durations must sum to 24 h; got {total!r}."
+        raise ValueError(msg)
     acc = sum(h / 24.0 * 10 ** (0.1 * (level + k)) for level, h, k in periods)
     return float(10 * np.log10(acc))
 

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -291,7 +291,8 @@ def _finite(value: float, name: str) -> float:
     """Return ``value`` as a float, rejecting non-finite input."""
     scalar = float(value)
     if not math.isfinite(scalar):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return scalar
 
 
@@ -299,14 +300,16 @@ def _positive(value: float, name: str) -> float:
     """Return ``value`` as a float, rejecting non-positive or non-finite input."""
     scalar = float(value)
     if not math.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
 def _normalise(value: str, aliases: Mapping[str, str], name: str) -> str:
     """Lower-case ``value``, replace spaces by underscores and resolve aliases."""
     if not isinstance(value, str):
-        raise ValueError(f"'{name}' must be a string; got {value!r}.")  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        msg = f"'{name}' must be a string; got {value!r}."
+        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
     key = value.strip().lower().replace(" ", "_").replace("-", "_")
     return aliases.get(key, key)
 
@@ -315,9 +318,8 @@ def _check_period(period: str) -> str:
     """Validate an evaluation-period name."""
     key = str(period).strip().lower()
     if key not in RD1367_EVALUATION_PERIODS:
-        raise ValueError(
-            f"'period' must be one of 'day', 'evening', 'night'; got {period!r}."
-        )
+        msg = f"'period' must be one of 'day', 'evening', 'night'; got {period!r}."
+        raise ValueError(msg)
     return key
 
 
@@ -395,23 +397,29 @@ def _validate_kt_spectrum(band_levels: np.ndarray, freqs: np.ndarray) -> None:
     :raises ValueError: For a shape, a value or an order the procedure needs.
     """
     if band_levels.ndim != 1 or freqs.ndim != 1:
-        raise ValueError("'levels' and 'frequencies' must be one-dimensional.")
+        msg = "'levels' and 'frequencies' must be one-dimensional."
+        raise ValueError(msg)
     if band_levels.shape != freqs.shape:
-        raise ValueError(
+        msg = (
             "'levels' and 'frequencies' must have the same length; got "
             f"{band_levels.size} and {freqs.size}."
         )
+        raise ValueError(msg)
     if band_levels.size < 3:
-        raise ValueError(
+        msg = (
             "At least three one-third-octave bands are needed: the procedure "
             "compares a band against its two neighbours."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(band_levels)):
-        raise ValueError("'levels' must contain finite values.")
+        msg = "'levels' must contain finite values."
+        raise ValueError(msg)
     if not np.all(np.isfinite(freqs)) or np.any(freqs <= 0.0):
-        raise ValueError("'frequencies' must contain positive, finite values.")
+        msg = "'frequencies' must contain positive, finite values."
+        raise ValueError(msg)
     if np.any(np.diff(freqs) <= 0.0):
-        raise ValueError("'frequencies' must be strictly ascending.")
+        msg = "'frequencies' must be strictly ascending."
+        raise ValueError(msg)
 
 
 def _band_tonal_corrections(
@@ -586,10 +594,11 @@ def total_correction(kt: float = 0.0, kf: float = 0.0, ki: float = 0.0) -> float
     for value, name in ((kt, "kt"), (kf, "kf"), (ki, "ki")):
         scalar = _finite(value, name)
         if not any(math.isclose(scalar, step) for step in RD1367_CORRECTION_VALUES):
-            raise ValueError(
+            msg = (
                 f"'{name}' must be 0, 3 or 6 dB, the only values the Annex IV "
                 f"A.3.3 tables grade; got {value!r}."
             )
+            raise ValueError(msg)
         total += scalar
     return min(total, RD1367_MAX_CORRECTION)
 
@@ -685,7 +694,8 @@ def evaluation_period_level(
     """
     items = list(phases)
     if not items:
-        raise ValueError("At least one noise phase is required.")
+        msg = "At least one noise phase is required."
+        raise ValueError(msg)
     durations = np.array([p.hours for p in items], dtype=np.float64)
     levels = np.array([p.lkeq for p in items], dtype=np.float64)
     total = float(np.sum(durations))
@@ -694,10 +704,11 @@ def evaluation_period_level(
     else:
         period = _positive(hours, "hours")
         if abs(total - period) > 1e-9:
-            raise ValueError(
+            msg = (
                 "The phase durations must sum to the period duration "
                 f"(sum Ti = T); got {total!r} h for T = {period!r} h."
             )
+            raise ValueError(msg)
     return float(10.0 * np.log10(np.sum(durations * 10.0 ** (levels / 10.0)) / period))
 
 
@@ -723,20 +734,24 @@ def long_term_corrected_level(
     """
     levels = np.asarray(daily_levels, dtype=np.float64).ravel()
     if levels.size == 0:
-        raise ValueError("At least one daily level is required.")
+        msg = "At least one daily level is required."
+        raise ValueError(msg)
     if not np.all(np.isfinite(levels)):
-        raise ValueError("'daily_levels' must contain finite values.")
+        msg = "'daily_levels' must contain finite values."
+        raise ValueError(msg)
     if weights is None:
         counts = np.ones_like(levels)
     else:
         counts = np.asarray(weights, dtype=np.float64).ravel()
         if counts.shape != levels.shape:
-            raise ValueError(
+            msg = (
                 "'weights' must have one value per daily level; got "
                 f"{counts.size} for {levels.size} levels."
             )
+            raise ValueError(msg)
         if not np.all(np.isfinite(counts)) or np.any(counts <= 0.0):
-            raise ValueError("'weights' must contain positive, finite values.")
+            msg = "'weights' must contain positive, finite values."
+            raise ValueError(msg)
     return float(
         10.0 * np.log10(np.sum(counts * 10.0 ** (levels / 10.0)) / np.sum(counts))
     )
@@ -798,10 +813,11 @@ def _area_key(area_type: str, table: Mapping[str, Any]) -> str:
     """Resolve and validate an acoustic area type against a table."""
     key = _normalise(area_type, _AREA_ALIASES, "area_type")
     if key not in table:
-        raise ValueError(
+        msg = (
             "'area_type' must be one of "
             f"{sorted(table)} (or a documented alias); got {area_type!r}."
         )
+        raise ValueError(msg)
     return key
 
 
@@ -828,9 +844,8 @@ def outdoor_quality_objectives(
     key = _area_key(area_type, _OUTDOOR_OBJECTIVES)
     state = str(urbanisation).strip().lower()
     if state not in ("existing", "new"):
-        raise ValueError(
-            f"'urbanisation' must be 'existing' or 'new'; got {urbanisation!r}."
-        )
+        msg = f"'urbanisation' must be 'existing' or 'new'; got {urbanisation!r}."
+        raise ValueError(msg)
     offset = 0.0 if state == "existing" else -5.0
     suffix = (
         "existing urbanised areas"
@@ -854,10 +869,11 @@ def _indoor_key(
     use = _normalise(building_use, _USE_ALIASES, "building_use")
     room = _normalise(room_type, _ROOM_ALIASES, "room_type")
     if (use, room) not in table:
-        raise ValueError(
+        msg = (
             "Unknown (building_use, room_type) combination "
             f"{(building_use, room_type)!r}; the table holds {sorted(table)}."
         )
+        raise ValueError(msg)
     return use, room
 
 
@@ -895,10 +911,11 @@ def vibration_quality_objective(building_use: str) -> float:
     """
     use = _normalise(building_use, _USE_ALIASES, "building_use")
     if use not in _VIBRATION_OBJECTIVES:
-        raise ValueError(
+        msg = (
             "'building_use' must be one of "
             f"{sorted(_VIBRATION_OBJECTIVES)}; got {building_use!r}."
         )
+        raise ValueError(msg)
     return _VIBRATION_OBJECTIVES[use]
 
 
@@ -1135,20 +1152,21 @@ def _validate_annual_inputs(
     :raises ValueError: For a fractional or out-of-range count of days.
     """
     if int(year_days) != year_days or int(year_days) <= 0:
-        raise ValueError(
-            f"'year_days' must be a positive whole number; got {year_days!r}."
-        )
+        msg = f"'year_days' must be a positive whole number; got {year_days!r}."
+        raise ValueError(msg)
     if operating_days is None:
         return
     if int(operating_days) != operating_days:
-        raise ValueError(
+        msg = (
             f"'operating_days' must be a whole number of days; got {operating_days!r}."
         )
+        raise ValueError(msg)
     if not 0 < int(operating_days) <= int(year_days):
-        raise ValueError(
+        msg = (
             "'operating_days' must be a positive integer no larger than "
             f"'year_days'; got {operating_days!r} of {year_days!r}."
         )
+        raise ValueError(msg)
     _finite(closed_level, "closed_level")
 
 
@@ -1208,7 +1226,8 @@ def _assess_period(
     :raises ValueError: If the period carries no noise phases.
     """
     if not phases:
-        raise ValueError(f"Period {name!r} has no noise phases.")
+        msg = f"Period {name!r} has no noise phases."
+        raise ValueError(msg)
     level = evaluation_period_level(phases, hours=duration)
     reported = round_reported_level(level)
     annual = _annual_index(
@@ -1286,7 +1305,8 @@ def assess_activity(
         inconsistent durations, or invalid annual parameters.
     """
     if not measurements:
-        raise ValueError("At least one evaluation period must be supplied.")
+        msg = "At least one evaluation period must be supplied."
+        raise ValueError(msg)
     durations = _period_durations(period_hours)
     _validate_annual_inputs(operating_days, year_days, closed_level)
 
@@ -1306,22 +1326,24 @@ def assess_activity(
         if name in measurements
     ]
     if not assessments:
-        raise ValueError(
+        msg = (
             "None of the supplied keys is an evaluation period; expected "
             f"any of {RD1367_EVALUATION_PERIODS}."
         )
+        raise ValueError(msg)
     if new_activity and all(p.long_term_pass is None for p in assessments):
         # Article 25.1 b i is mandatory for a new activity, so an assessment
         # that never evaluates it cannot conclude anything about compliance.
         # Checked after the structural validation so the more specific error
         # about the measurements themselves wins.
-        raise ValueError(
+        msg = (
             "A new activity is assessed against all three criteria of Article "
             "25.1 b, so the annual index LK,x is required: supply "
             "'long_term_levels' or 'operating_days'. For the inspection of an "
             "activity already in operation, which Article 25.2 subjects only "
             "to the daily and phase criteria, pass new_activity=False."
         )
+        raise ValueError(msg)
     return ActivityAssessment(
         periods=tuple(assessments), limits=limits, new_activity=new_activity
     )

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -135,13 +135,17 @@ def _validate(
 ) -> None:
     """Raise on non-physical inputs; warn on out-of-tabulated-range inputs."""
     if np.any(freqs <= 0.0):
-        raise ValueError("'frequencies' must be positive.")
+        msg = "'frequencies' must be positive."
+        raise ValueError(msg)
     if temperature <= -_KELVIN:
-        raise ValueError("'temperature' must be above absolute zero (-273,15 degC).")
+        msg = "'temperature' must be above absolute zero (-273,15 degC)."
+        raise ValueError(msg)
     if not 0.0 <= relative_humidity <= 100.0:
-        raise ValueError("'relative_humidity' must be within [0, 100] %.")
+        msg = "'relative_humidity' must be within [0, 100] %."
+        raise ValueError(msg)
     if pressure <= 0.0:
-        raise ValueError("'pressure' must be positive.")
+        msg = "'pressure' must be positive."
+        raise ValueError(msg)
 
     lo_t, hi_t = _TEMPERATURE_RANGE
     if not lo_t <= temperature <= hi_t:
@@ -332,9 +336,8 @@ class AtmosphericAttenuation:
         if self.distance is not None and (
             not np.isfinite(self.distance) or self.distance < 0.0
         ):
-            raise ValueError(
-                "'distance' must be a finite, non-negative number of metres."
-            )
+            msg = "'distance' must be a finite, non-negative number of metres."
+            raise ValueError(msg)
 
     @property
     def total_attenuation(self) -> NDArray[np.float64] | None:

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -165,7 +165,8 @@ def _normalized_ground_impedance(
     from ...materials.absorbers.porous import PorousMediumResult
 
     if (impedance is None) == (flow_resistivity is None):
-        raise ValueError("provide exactly one of 'impedance' or 'flow_resistivity'.")
+        msg = "provide exactly one of 'impedance' or 'flow_resistivity'."
+        raise ValueError(msg)
     if flow_resistivity is not None:
         sigma = require_positive(flow_resistivity, "flow_resistivity")
         if model == "delany_bazley":
@@ -177,9 +178,8 @@ def _normalized_ground_impedance(
                 frequency, sigma, speed_of_sound=speed_of_sound, air_density=air_density
             )
         else:
-            raise ValueError(
-                f"unknown ground model {model!r}; options: 'delany_bazley', 'miki'."
-            )
+            msg = f"unknown ground model {model!r}; options: 'delany_bazley', 'miki'."
+            raise ValueError(msg)
         # Materials e^{+j omega t} -> Salomons e^{-i omega t}: conjugate.
         return np.asarray(np.conj(medium.normalized_impedance), dtype=np.complex128)
     if isinstance(impedance, PorousMediumResult):
@@ -201,14 +201,17 @@ def _resolve_impedance_array(impedance: ArrayLike | None, frequency: Real) -> Co
     if z.size == 1:
         z = np.full(frequency.shape, z[0], dtype=np.complex128)
     if z.shape != frequency.shape:
-        raise ValueError(
+        msg = (
             "'impedance' must be a scalar or match the frequency vector "
             f"(got {z.shape}, expected {frequency.shape})."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(z)):
-        raise ValueError("'impedance' must be finite.")
+        msg = "'impedance' must be finite."
+        raise ValueError(msg)
     if not np.all(np.abs(z) > 0.0):
-        raise ValueError("'impedance' must be non-zero.")
+        msg = "'impedance' must be non-zero."
+        raise ValueError(msg)
     return z
 
 
@@ -292,9 +295,11 @@ def spherical_reflection_coefficient(
         the impedance is zero, or its shape does not match the frequencies.
     """
     if source_height < 0.0 or receiver_height < 0.0:
-        raise ValueError("Source and receiver heights must be non-negative.")
+        msg = "Source and receiver heights must be non-negative."
+        raise ValueError(msg)
     if distance <= 0.0:
-        raise ValueError("'distance' must be positive.")
+        msg = "'distance' must be positive."
+        raise ValueError(msg)
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
     f = require_positive_array(frequencies, "frequencies")
     z = _resolve_impedance_array(normalized_impedance, f)
@@ -387,9 +392,11 @@ def ground_effect(
         are given, a height is negative, or the distance is not positive.
     """
     if source_height < 0.0 or receiver_height < 0.0:
-        raise ValueError("Source and receiver heights must be non-negative.")
+        msg = "Source and receiver heights must be non-negative."
+        raise ValueError(msg)
     if distance <= 0.0:
-        raise ValueError("'distance' must be positive.")
+        msg = "'distance' must be positive."
+        raise ValueError(msg)
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
     f = require_positive_array(frequencies, "frequencies")
     z = _normalized_ground_impedance(
@@ -448,7 +455,8 @@ def fresnel_number(
         ("direct_distance", direct_distance),
     ):
         if value <= 0.0:
-            raise ValueError(f"'{name}' must be positive.")
+            msg = f"'{name}' must be positive."
+            raise ValueError(msg)
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
     f = require_positive_array(frequencies, "frequencies")
     lam = speed_of_sound / f
@@ -696,9 +704,8 @@ class BarrierInsertionLoss:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso9613 import render_barrier_insertion_loss_report
 
         return render_barrier_insertion_loss_report(
@@ -722,23 +729,27 @@ def _validate_barrier_geometry(
         line of sight, or a thick barrier whose far edge reaches the receiver.
     """
     if barrier_distance <= 0.0 or receiver_distance <= 0.0:
-        raise ValueError("Barrier and receiver distances must be positive.")
+        msg = "Barrier and receiver distances must be positive."
+        raise ValueError(msg)
     if receiver_distance <= barrier_distance:
-        raise ValueError("'receiver_distance' must exceed 'barrier_distance'.")
+        msg = "'receiver_distance' must exceed 'barrier_distance'."
+        raise ValueError(msg)
     if barrier_height <= max(source_height, receiver_height):
-        raise ValueError(
+        msg = (
             "'barrier_height' must exceed the source and receiver heights "
             "(the receiver must be in the geometric shadow)."
         )
+        raise ValueError(msg)
     if thickness is None:
         return None
     # require_positive rejects NaN/inf as well as non-positive widths.
     thickness = require_positive(thickness, "thickness")
     if barrier_distance + thickness >= receiver_distance:
-        raise ValueError(
+        msg = (
             "'receiver_distance' must exceed 'barrier_distance + thickness' "
             "(the receiver must lie beyond the barrier's far edge)."
         )
+        raise ValueError(msg)
     return thickness
 
 
@@ -835,7 +846,8 @@ def barrier_insertion_loss(
 
     if method == "kurze_anderson":
         if has_ground:
-            raise ValueError("the coherent ground model requires method='exact'.")
+            msg = "the coherent ground model requires method='exact'."
+            raise ValueError(msg)
         il = kurze_anderson_attenuation(n)
     elif method == "exact":
         il = _exact_barrier_il(
@@ -856,9 +868,8 @@ def barrier_insertion_loss(
             )
         )
     else:
-        raise ValueError(
-            f"unknown method {method!r}; options: 'kurze_anderson', 'exact'."
-        )
+        msg = f"unknown method {method!r}; options: 'kurze_anderson', 'exact'."
+        raise ValueError(msg)
     return BarrierInsertionLoss(
         frequencies=f,
         insertion_loss=np.asarray(il, dtype=np.float64),

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -128,13 +128,14 @@ class Barrier:
     def __post_init__(self) -> None:
         """Reject negative ``dss``/``dsr``/``a`` and a non-positive spacing ``e``."""
         if self.source_to_edge < 0.0 or self.edge_to_receiver < 0.0:
-            raise ValueError("Barrier edge distances must be non-negative.")
+            msg = "Barrier edge distances must be non-negative."
+            raise ValueError(msg)
         if self.parallel_distance < 0.0:
-            raise ValueError("'parallel_distance' must be non-negative.")
+            msg = "'parallel_distance' must be non-negative."
+            raise ValueError(msg)
         if self.edge_separation is not None and self.edge_separation <= 0.0:
-            raise ValueError(
-                "'edge_separation' must be positive; use None for single diffraction."
-            )
+            msg = "'edge_separation' must be positive; use None for single diffraction."
+            raise ValueError(msg)
 
     @property
     def is_double(self) -> bool:
@@ -352,9 +353,8 @@ class OutdoorAttenuation:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso9613 import render_outdoor_attenuation_report
 
         return render_outdoor_attenuation_report(
@@ -527,14 +527,17 @@ def ground_attenuation(
         ("ground_receiver", ground_receiver),
     ):
         if not 0.0 <= g <= 1.0:
-            raise ValueError(f"'{name}' must be within [0, 1].")
+            msg = f"'{name}' must be within [0, 1]."
+            raise ValueError(msg)
     if distance <= 0.0:
         raise ValueError(_DISTANCE_NOT_POSITIVE)
     if source_height < 0.0 or receiver_height < 0.0:
-        raise ValueError("Source and receiver heights must be non-negative.")
+        msg = "Source and receiver heights must be non-negative."
+        raise ValueError(msg)
     freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if np.any(freqs <= 0.0):
-        raise ValueError("'frequencies' must be positive.")
+        msg = "'frequencies' must be positive."
+        raise ValueError(msg)
     dp = _projected_distance(
         distance, source_height, receiver_height, projected_distance
     )
@@ -652,7 +655,8 @@ def barrier_attenuation(
         raise ValueError(_DISTANCE_NOT_POSITIVE)
     freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if np.any(freqs <= 0.0):
-        raise ValueError("'frequencies' must be positive.")
+        msg = "'frequencies' must be positive."
+        raise ValueError(msg)
     dss = barrier.source_to_edge
     dsr = barrier.edge_to_receiver
     a = barrier.parallel_distance

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -132,13 +132,15 @@ def linear_sound_speed_profile(
     c0 = require_positive(ground_speed, "ground_speed")
     h = require_positive(max_height, "max_height")
     if not np.isfinite(gradient):
-        raise ValueError("'gradient' must be finite.")
+        msg = "'gradient' must be finite."
+        raise ValueError(msg)
     top = c0 + gradient * h
     if top <= 0.0:
-        raise ValueError(
+        msg = (
             "the linear profile reaches a non-positive sound speed within "
             "'max_height'; reduce 'max_height' or the gradient magnitude."
         )
+        raise ValueError(msg)
     sign = "+" if gradient >= 0 else "-"
     return EffectiveSoundSpeedProfile(
         heights=np.array([0.0, h], dtype=np.float64),
@@ -177,9 +179,11 @@ def log_linear_sound_speed_profile(
     z0 = require_positive(roughness_length, "roughness_length")
     h = require_positive(max_height, "max_height")
     if not np.isfinite(b):
-        raise ValueError("'b' must be finite.")
+        msg = "'b' must be finite."
+        raise ValueError(msg)
     if int(n_points) < 2:
-        raise ValueError("'n_points' must be at least 2.")
+        msg = "'n_points' must be at least 2."
+        raise ValueError(msg)
     # Logarithmic height grid from the ground to max_height (z = 0 included).
     z = np.concatenate(
         (
@@ -190,10 +194,11 @@ def log_linear_sound_speed_profile(
     z = np.unique(np.clip(z, 0.0, h))
     c = c0 + b * np.log1p(z / z0)
     if np.any(c <= 0.0):
-        raise ValueError(
+        msg = (
             "the logarithmic profile reaches a non-positive sound speed within "
             "'max_height'; reduce 'max_height' or |b|."
         )
+        raise ValueError(msg)
     sign = "+" if b >= 0 else "-"
     return EffectiveSoundSpeedProfile(
         heights=np.asarray(z, dtype=np.float64),
@@ -209,17 +214,23 @@ def _clean_profile(
     z = np.asarray(profile.heights, dtype=np.float64)
     c = np.asarray(profile.sound_speeds, dtype=np.float64)
     if z.ndim != 1 or z.size < 2:
-        raise ValueError("the profile must have at least two height samples.")
+        msg = "the profile must have at least two height samples."
+        raise ValueError(msg)
     if c.shape != z.shape:
-        raise ValueError("'sound_speeds' must match 'heights' in length.")
+        msg = "'sound_speeds' must match 'heights' in length."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(z)) and np.all(np.isfinite(c))):
-        raise ValueError("the profile heights and speeds must be finite.")
+        msg = "the profile heights and speeds must be finite."
+        raise ValueError(msg)
     if abs(float(z[0])) > 1e-9:
-        raise ValueError("the profile must start at the ground z = 0.")
+        msg = "the profile must start at the ground z = 0."
+        raise ValueError(msg)
     if np.any(np.diff(z) <= 0.0):
-        raise ValueError("the profile heights must be strictly increasing.")
+        msg = "the profile heights must be strictly increasing."
+        raise ValueError(msg)
     if np.any(c <= 0.0):
-        raise ValueError("the profile sound speeds must be strictly positive.")
+        msg = "the profile sound speeds must be strictly positive."
+        raise ValueError(msg)
     return z, c
 
 
@@ -250,9 +261,11 @@ def ray_curvature_radius(
     """
     c0 = require_positive(ground_speed, "ground_speed")
     if not (np.isfinite(gradient) and abs(gradient) > 0.0):
-        raise ValueError("'gradient' must be finite and non-zero (a curved ray).")
+        msg = "'gradient' must be finite and non-zero (a curved ray)."
+        raise ValueError(msg)
     if abs(launch_angle_deg) >= 90.0:
-        raise ValueError("'launch_angle_deg' must be within (-90, 90) degrees.")
+        msg = "'launch_angle_deg' must be within (-90, 90) degrees."
+        raise ValueError(msg)
     return float(c0 / (abs(gradient) * np.cos(np.radians(launch_angle_deg))))
 
 
@@ -288,12 +301,14 @@ def shadow_zone_distance(
     """
     c0 = require_positive(ground_speed, "ground_speed")
     if not np.isfinite(gradient) or gradient >= 0.0:
-        raise ValueError(
+        msg = (
             "'gradient' must be negative (an upward-refracting profile) for an "
             "acoustic shadow zone to exist."
         )
+        raise ValueError(msg)
     if source_height < 0.0 or receiver_height < 0.0:
-        raise ValueError("Source and receiver heights must be non-negative.")
+        msg = "Source and receiver heights must be non-negative."
+        raise ValueError(msg)
     rc = c0 / abs(gradient)
     return float(
         np.sqrt(2.0 * rc) * (np.sqrt(source_height) + np.sqrt(receiver_height))
@@ -377,15 +392,19 @@ def atmospheric_ray_paths(
     top = float(z_prof[-1])
     zs = float(source_height)
     if zs < 0.0:
-        raise ValueError("'source_height' must be non-negative.")
+        msg = "'source_height' must be non-negative."
+        raise ValueError(msg)
     rmax = require_positive(max_range, "max_range")
     if int(n_steps) < 2:
-        raise ValueError("'n_steps' must be at least 2.")
+        msg = "'n_steps' must be at least 2."
+        raise ValueError(msg)
     angles = np.asarray(launch_angles_deg, dtype=np.float64).ravel()
     if angles.size == 0 or not np.all(np.isfinite(angles)):
-        raise ValueError("'launch_angles_deg' must be finite and non-empty.")
+        msg = "'launch_angles_deg' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(np.abs(angles) >= 90.0):
-        raise ValueError("'launch_angles_deg' must be within (-90, 90) degrees.")
+        msg = "'launch_angles_deg' must be within (-90, 90) degrees."
+        raise ValueError(msg)
 
     # Piecewise-constant gradient per profile segment (sharp kinks preserved);
     # above the profile top the atmosphere is taken as homogeneous (gradient 0).
@@ -597,7 +616,8 @@ def atmospheric_parabolic_equation(
     z_prof, c_prof = _clean_profile(profile)
     zs = float(source_height)
     if zs <= 0.0:
-        raise ValueError("'source_height' must be positive.")
+        msg = "'source_height' must be positive."
+        raise ValueError(msg)
     rmax = require_positive(max_range, "max_range")
     zmax = require_positive(max_height, "max_height")
     c_ref = float(c_prof[0])  # reference speed at the ground (ka = k0)
@@ -609,7 +629,8 @@ def atmospheric_parabolic_equation(
     )
     dr = require_positive(range_step, "range_step") if range_step is not None else lam
     if dr > rmax:
-        raise ValueError("'range_step' must not exceed 'max_range'.")
+        msg = "'range_step' must not exceed 'max_range'."
+        raise ValueError(msg)
     z_imp = _resolve_pe_impedance(
         f, impedance, flow_resistivity, model, c_ref, air_density
     )

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -411,10 +411,11 @@ class VehicleDescriptor:
         """
         text = str(code).strip()
         if len(text) < 4 or not text[1:-2].isdigit():
-            raise ValueError(
+            msg = (
                 f"{code!r} is not a Table [2.3.a] vehicle descriptor: it must "
                 "read <type><axles><brake><measure>, for example 'a4cn'."
             )
+            raise ValueError(msg)
         try:
             return cls(
                 vehicle_type=VehicleType(text[0]),
@@ -423,9 +424,8 @@ class VehicleDescriptor:
                 measure=WheelMeasure(text[-1]),
             )
         except ValueError as exc:  # pragma: no cover - message pass-through
-            raise ValueError(
-                f"{code!r} is not a Table [2.3.a] vehicle descriptor: {exc}"
-            ) from exc
+            msg = f"{code!r} is not a Table [2.3.a] vehicle descriptor: {exc}"
+            raise ValueError(msg) from exc
 
     @property
     def code(self) -> str:
@@ -465,10 +465,11 @@ class TrackDescriptor:
         """
         text = str(code).strip()
         if len(text) != 6:
-            raise ValueError(
+            msg = (
                 f"{code!r} is not a Table [2.3.b] track descriptor: it must "
                 "have exactly six digits, for example 'BMSNNN'."
             )
+            raise ValueError(msg)
         try:
             return cls(
                 base=TrackBase(text[0]),
@@ -479,9 +480,8 @@ class TrackDescriptor:
                 curvature=TrackCurvature(text[5]),
             )
         except ValueError as exc:  # pragma: no cover - message pass-through
-            raise ValueError(
-                f"{code!r} is not a Table [2.3.b] track descriptor: {exc}"
-            ) from exc
+            msg = f"{code!r} is not a Table [2.3.b] track descriptor: {exc}"
+            raise ValueError(msg) from exc
 
     @property
     def code(self) -> str:
@@ -1698,24 +1698,27 @@ _SQUEAL_MINIMUM_TRACK_LENGTH = 50.0
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar):
-        raise ValueError(f"'{name}' must be a finite number.")
+        msg = f"'{name}' must be a finite number."
+        raise ValueError(msg)
     return scalar
 
 
 def _speed(value: float, name: str = "speed") -> float:
     v = _finite(value, name)
     if v <= 0.0:
-        raise ValueError(f"'{name}' must be a positive number of km/h.")
+        msg = f"'{name}' must be a positive number of km/h."
+        raise ValueError(msg)
     return v
 
 
 def _spectrum(values: Any, name: str, size: int = 24) -> NDArray[np.float64]:
     array = np.asarray(values, dtype=np.float64)
     if array.shape != (size,):
-        raise ValueError(
+        msg = (
             f"'{name}' must hold {size} values, one per band; got "
             f"{array.shape[0] if array.ndim == 1 else array.shape}."
         )
+        raise ValueError(msg)
     return array
 
 
@@ -2007,15 +2010,18 @@ def roughness_to_frequency(
     y = np.asarray(levels, dtype=np.float64)
     lam = np.asarray(wavelengths, dtype=np.float64) / 1000.0
     if y.ndim != 1 or y.shape != lam.shape:
-        raise ValueError(
+        msg = (
             "'levels' and 'wavelengths' must be one-dimensional and of the "
             f"same length; got {y.shape} and {lam.shape}."
         )
+        raise ValueError(msg)
     if np.any(lam <= 0.0):
-        raise ValueError("'wavelengths' must all be positive.")
+        msg = "'wavelengths' must all be positive."
+        raise ValueError(msg)
     freqs = np.asarray(frequencies, dtype=np.float64)
     if np.any(freqs <= 0.0):
-        raise ValueError("'frequencies' must all be positive.")
+        msg = "'frequencies' must all be positive."
+        raise ValueError(msg)
     order = np.argsort(lam)
     lam, y = lam[order], y[order]
     wanted = _speed(speed) / 3.6 / freqs
@@ -2062,7 +2068,8 @@ def impact_roughness(single: Any, joint_density: float) -> NDArray[np.float64]:
     """
     density = _finite(joint_density, "joint_density")
     if density < 0.0:
-        raise ValueError("'joint_density' must be a non-negative number of m^-1.")
+        msg = "'joint_density' must be a non-negative number of m^-1."
+        raise ValueError(msg)
     spectrum = _spectrum(single, "single")
     # The guard above already rejects a negative density, so this is the
     # zero case: no joint at all, and no impact roughness to add.
@@ -2092,7 +2099,8 @@ def rolling_sound_power(
     """
     n_a = _finite(axles, "axles")
     if n_a <= 0.0:
-        raise ValueError("'axles' must be a positive number of axles per vehicle.")
+        msg = "'axles' must be a positive number of axles per vehicle."
+        raise ValueError(msg)
     return np.asarray(
         _spectrum(roughness, "roughness")
         + _spectrum(transfer, "transfer")
@@ -2129,10 +2137,12 @@ def curve_squeal_excess(
     """
     r = _finite(radius, "radius")
     if r <= 0.0:
-        raise ValueError("'radius' must be a positive number of metres.")
+        msg = "'radius' must be a positive number of metres."
+        raise ValueError(msg)
     length = _finite(track_length, "track_length")
     if length < 0.0:
-        raise ValueError("'track_length' must be a non-negative number of metres.")
+        msg = "'track_length' must be a non-negative number of metres."
+        raise ValueError(msg)
     if tram:
         return _SQUEAL_TRAM if r <= _SQUEAL_TRAM_RADIUS else 0.0
     if turnout:
@@ -2201,7 +2211,8 @@ def vertical_directivity(
     angle = np.radians(_finite(psi, "psi"))
     freqs = np.asarray(frequencies, dtype=np.float64)
     if height not in (1, 2):
-        raise ValueError("'height' must be 1 (source A) or 2 (source B).")
+        msg = "'height' must be 1 (source A) or 2 (source B)."
+        raise ValueError(msg)
     if height == 2:
         if aerodynamic and angle < 0.0:
             return np.full(len(freqs), 10.0 * np.log10(np.cos(angle) ** 2))
@@ -2422,7 +2433,8 @@ def _flow_term(vehicle: RailwayVehicle, reference_time: float, length: float) ->
     if vehicle.condition is RunningCondition.IDLING:
         idle = _finite(vehicle.idling_time, "idling_time")
         if idle < 0.0:
-            raise ValueError("'idling_time' must be a non-negative period.")
+            msg = "'idling_time' must be a non-negative period."
+            raise ValueError(msg)
         # The guard above leaves only the zero case: a vehicle that never
         # idles contributes no energy at all.
         if idle <= 0.0:
@@ -2430,7 +2442,8 @@ def _flow_term(vehicle: RailwayVehicle, reference_time: float, length: float) ->
         return float(10.0 * np.log10(idle / (reference_time * length)))
     q = _finite(vehicle.flow_rate, "flow_rate")
     if q < 0.0:
-        raise ValueError("'flow_rate' must be a non-negative number per hour.")
+        msg = "'flow_rate' must be a non-negative number per hour."
+        raise ValueError(msg)
     # As above: an empty track is a legitimate input and carries -inf.
     if q <= 0.0:
         return -np.inf
@@ -2568,11 +2581,14 @@ def railway_source_power(
     """
     vehicles = [traffic] if isinstance(traffic, RailwayVehicle) else list(traffic)
     if not vehicles:
-        raise ValueError("'traffic' must carry at least one vehicle.")
+        msg = "'traffic' must carry at least one vehicle."
+        raise ValueError(msg)
     if _finite(reference_time, "reference_time") <= 0.0:
-        raise ValueError("'reference_time' must be a positive period.")
+        msg = "'reference_time' must be a positive period."
+        raise ValueError(msg)
     if _finite(track.length, "length") <= 0.0:
-        raise ValueError("'length' must be a positive number of metres.")
+        msg = "'length' must be a positive number of metres."
+        raise ValueError(msg)
 
     n_bands = len(RAILWAY_THIRD_OCTAVE_BANDS)
     per_height: list[list[NDArray[np.float64]]] = [[], []]

--- a/src/phonometry/environment/sources/cnossos_road.py
+++ b/src/phonometry/environment/sources/cnossos_road.py
@@ -496,7 +496,8 @@ class RoadTraffic:
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar):
-        raise ValueError(f"'{name}' must be a finite number.")
+        msg = f"'{name}' must be a finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -574,11 +575,12 @@ def _surface_of(
         else (road_surface_coefficients(surface))
     )
     if key not in row.alpha or key not in row.beta:
-        raise ValueError(
+        msg = (
             f"The road surface {row.name!r} has no coefficients for category "
             f"{key!r}; a substituted Table F-4 row must cover every category "
             "of the modelled traffic."
         )
+        raise ValueError(msg)
     return row
 
 
@@ -598,9 +600,11 @@ def _studded_correction(
 ) -> NDArray[np.float64]:
     """``dL_studdedtyres,i,m`` of (2.2.6) to (2.2.9), in dB per octave band."""
     if not 0.0 <= studded_fraction <= 1.0:
-        raise ValueError("'studded_fraction' must be a fraction in [0, 1].")
+        msg = "'studded_fraction' must be a fraction in [0, 1]."
+        raise ValueError(msg)
     if not 0.0 <= studded_months <= 12.0:
-        raise ValueError("'studded_months' must be a number of months in [0, 12].")
+        msg = "'studded_months' must be a number of months in [0, 12]."
+        raise ValueError(msg)
     if key != "1" or studded_months <= 0.0 or studded_fraction <= 0.0:
         return np.zeros(len(ROAD_OCTAVE_BANDS))
     # (2.2.6): the speed dependence saturates below 50 km/h and above 90 km/h.
@@ -767,7 +771,8 @@ def road_propulsion_noise(
 def _positive_speed(speed: float) -> float:
     v = _finite(speed, "speed")
     if v <= 0.0:
-        raise ValueError("'speed' must be a positive number of km/h.")
+        msg = "'speed' must be a positive number of km/h."
+        raise ValueError(msg)
     return v
 
 
@@ -923,16 +928,19 @@ def road_source_power(
     """
     flows = [traffic] if isinstance(traffic, RoadTraffic) else list(traffic)
     if not flows:
-        raise ValueError("'traffic' must carry at least one vehicle category.")
+        msg = "'traffic' must carry at least one vehicle category."
+        raise ValueError(msg)
     keys = [_category_key(flow.category) for flow in flows]
     if len(set(keys)) != len(keys):
-        raise ValueError("'traffic' must carry at most one flow per vehicle category.")
+        msg = "'traffic' must carry at most one flow per vehicle category."
+        raise ValueError(msg)
 
     rolling, propulsion, vehicle, line = [], [], [], []
     for flow, key in zip(flows, keys, strict=True):
         q = _finite(flow.flow_rate, "flow_rate")
         if q < 0.0:
-            raise ValueError("'flow_rate' must be a non-negative number of vehicles/h.")
+            msg = "'flow_rate' must be a non-negative number of vehicles/h."
+            raise ValueError(msg)
         v = _positive_speed(flow.speed)
         lwr = road_rolling_noise(
             key,
@@ -997,7 +1005,8 @@ def line_source_segment_power(
     """
     dl = _finite(length, "length")
     if dl <= 0.0:
-        raise ValueError("'length' must be a positive number of metres.")
+        msg = "'length' must be a positive number of metres."
+        raise ValueError(msg)
     return np.asarray(
         np.atleast_1d(np.asarray(line_power, dtype=np.float64)) + 10.0 * np.log10(dl),
         dtype=np.float64,

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -57,7 +57,8 @@ _LOW_FREQ_BANDWIDTH = 100.0
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -89,7 +90,8 @@ def slant_distance(
     elif rotor_axis == "vertical":
         r0 = h + d
     else:
-        raise ValueError("'rotor_axis' must be 'horizontal' or 'vertical'.")
+        msg = "'rotor_axis' must be 'horizontal' or 'vertical'."
+        raise ValueError(msg)
     return float(np.hypot(h, r0))
 
 
@@ -116,7 +118,8 @@ def apparent_sound_power_level(
     """
     levels = np.atleast_1d(np.asarray(band_levels, dtype=np.float64))
     if levels.size == 0 or not np.all(np.isfinite(levels)):
-        raise ValueError("'band_levels' must be finite and non-empty.")
+        msg = "'band_levels' must be finite and non-empty."
+        raise ValueError(msg)
     r = _positive(r1, "r1")
     geometry = 10.0 * np.log10(4.0 * np.pi * r**2 / _REFERENCE_AREA)
     lwa_bands = levels - _BOARD_TERM + geometry
@@ -268,9 +271,8 @@ class WindTurbineTonalityResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iec61400 import render_wind_turbine_tonality_report
 
         return render_wind_turbine_tonality_report(
@@ -286,19 +288,19 @@ def _validate_narrowband(
     lv = np.asarray(levels, dtype=np.float64)
     fr = np.asarray(frequencies, dtype=np.float64)
     if lv.ndim != 1 or lv.shape != fr.shape or lv.size < 3:
-        raise ValueError(
-            "'levels' and 'frequencies' must be 1-D and the same length (>= 3)."
-        )
+        msg = "'levels' and 'frequencies' must be 1-D and the same length (>= 3)."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(lv)) and np.all(np.isfinite(fr))):
-        raise ValueError("'levels' and 'frequencies' must be finite.")
+        msg = "'levels' and 'frequencies' must be finite."
+        raise ValueError(msg)
     diffs = np.diff(fr)
     if np.any(diffs <= 0.0):
-        raise ValueError("'frequencies' must be strictly increasing.")
+        msg = "'frequencies' must be strictly increasing."
+        raise ValueError(msg)
     df = float(np.median(diffs))
     if np.any(np.abs(diffs - df) > 1e-3 * df):
-        raise ValueError(
-            "'frequencies' must be uniformly spaced (a narrowband spectrum)."
-        )
+        msg = "'frequencies' must be uniformly spaced (a narrowband spectrum)."
+        raise ValueError(msg)
     return lv, fr, df
 
 
@@ -314,10 +316,11 @@ def _candidate_peak(
         return int(np.argmax(lv))
     tf = float(tone_frequency)
     if not np.isfinite(tf) or tf < float(fr[0]) or tf > float(fr[-1]):
-        raise ValueError(
+        msg = (
             "'tone_frequency' must be finite and inside the spectrum's "
             f"frequency range [{fr[0]:.1f}, {fr[-1]:.1f}] Hz."
         )
+        raise ValueError(msg)
     return int(np.argmin(np.abs(fr - tf)))
 
 
@@ -387,10 +390,11 @@ def wind_turbine_tonality(
     peak = _candidate_peak(lv, fr, tone_frequency)
     fc = float(fr[peak])
     if fc < _LOW_FREQ_MIN:
-        raise ValueError(
+        msg = (
             "The candidate tone lies below 20 Hz: outside the standard's "
             "analysis range (the critical band would extend below 0 Hz)."
         )
+        raise ValueError(msg)
     cbw = critical_bandwidth(fc)
     lo, hi = _critical_band_edges(fc)
     if fr[0] > lo + 1e-9 or fr[-1] < hi - 1e-9:

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -173,20 +173,22 @@ def class_limits(
     """
     spec = _FILTER_EDITIONS.get(edition)
     if spec is None:
-        raise ValueError("edition must be '2014' or '1995'.")
+        msg = "edition must be '2014' or '1995'."
+        raise ValueError(msg)
     if filter_class not in spec["classes"]:
-        raise ValueError(
-            f"filter_class must be one of {spec['classes']} for edition '{edition}'."
-        )
+        msg = f"filter_class must be one of {spec['classes']} for edition '{edition}'."
+        raise ValueError(msg)
     if fraction <= 0:
-        raise ValueError("'fraction' must be positive.")
+        msg = "'fraction' must be positive."
+        raise ValueError(msg)
     col = spec["col"][filter_class]
     passband_max = spec["passband_max"]
     stopband_min = spec["stopband_min"]
 
     omega_arr = np.asarray(omega, dtype=np.float64)
     if np.any(omega_arr <= 0):
-        raise ValueError("Normalized frequencies must be positive.")
+        msg = "Normalized frequencies must be positive."
+        raise ValueError(msg)
     # Formula (10): low side mirrors the high side.
     omega_h = np.where(omega_arr < 1.0, 1.0 / omega_arr, omega_arr)
 
@@ -312,10 +314,12 @@ def verify_filter_class(
         over ``f_m``).
     """
     if num_points < 16:
-        raise ValueError("'num_points' must be at least 16.")
+        msg = "'num_points' must be at least 16."
+        raise ValueError(msg)
     spec = _FILTER_EDITIONS.get(edition)
     if spec is None:
-        raise ValueError("edition must be '2014' or '1995'.")
+        msg = "edition must be '2014' or '1995'."
+        raise ValueError(msg)
     classes_ordered: tuple[int, ...] = spec["classes"]  # best -> worst
 
     bands: list[dict[str, Any]] = []
@@ -433,10 +437,11 @@ class FilterComplianceResult:
             return self.overall_class
         classes = self.available_classes()
         if not classes:
-            raise ValueError(
+            msg = (
                 "This filter-compliance result has no bands, so it has no "
                 "reference class; check the bank's frequency limits."
             )
+            raise ValueError(msg)
         return max(classes)
 
     def plot(
@@ -495,9 +500,8 @@ class FilterComplianceResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iec61260 import render_iec61260_report
 
         return render_iec61260_report(
@@ -560,4 +564,5 @@ def __getattr__(name: str) -> Any:
         from . import weighting_compliance
 
         return getattr(weighting_compliance, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/phonometry/filters/core.py
+++ b/src/phonometry/filters/core.py
@@ -127,26 +127,32 @@ def _validate_bank_design(
     none was given.
     """
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     if fraction <= 0:
-        raise ValueError("Bandwidth 'fraction' must be positive.")
+        msg = "Bandwidth 'fraction' must be positive."
+        raise ValueError(msg)
     if order <= 0:
-        raise ValueError("Filter 'order' must be positive.")
+        msg = "Filter 'order' must be positive."
+        raise ValueError(msg)
     if limits is None:
         limits = [12, 20000]
     if len(limits) != 2:
-        raise ValueError("Limits must be a list of two frequencies [f_min, f_max].")
+        msg = "Limits must be a list of two frequencies [f_min, f_max]."
+        raise ValueError(msg)
     if limits[0] <= 0 or limits[1] <= 0:
-        raise ValueError("Limit frequencies must be positive.")
+        msg = "Limit frequencies must be positive."
+        raise ValueError(msg)
     if limits[0] >= limits[1]:
-        raise ValueError("The lower limit must be less than the upper limit.")
+        msg = "The lower limit must be less than the upper limit."
+        raise ValueError(msg)
     if design.filter_type not in _VALID_FILTERS:
-        raise ValueError(f"Invalid filter_type. Must be one of {_VALID_FILTERS}")
+        msg = f"Invalid filter_type. Must be one of {_VALID_FILTERS}"
+        raise ValueError(msg)
     if design.resample and block_processing.stateful:
         # a stateful resampling algorithm would be required...
-        raise ValueError(
-            "Resampling and stateful behaviour (block processing) are not supported."
-        )
+        msg = "Resampling and stateful behaviour (block processing) are not supported."
+        raise ValueError(msg)
     return limits
 
 
@@ -404,7 +410,8 @@ class OctaveFilterBank:
         :return: A tuple containing (SPL_array, Frequencies_list) or (SPL_array, Frequencies_list, signals).
         """
         if zero_phase and self.stateful:
-            raise ValueError("zero_phase is not compatible with stateful processing.")
+            msg = "zero_phase is not compatible with stateful processing."
+            raise ValueError(msg)
 
         x_proc, is_multichannel = self._prepare_signal(x, detrend)
         num_channels = x_proc.shape[0]
@@ -512,9 +519,11 @@ class OctaveFilterBank:
             each window's center in seconds.
         """
         if self.stateful:
-            raise ValueError("spectrogram() is not supported on stateful banks.")
+            msg = "spectrogram() is not supported on stateful banks."
+            raise ValueError(msg)
         if not 0 <= overlap < 1:
-            raise ValueError("overlap must be in [0, 1).")
+            msg = "overlap must be in [0, 1)."
+            raise ValueError(msg)
 
         refuse_foreign_rate(x, self.fs, "filter bank")
         x_proc = resolve_samples(x, calibrate=self._default_calibration)
@@ -523,9 +532,8 @@ class OctaveFilterBank:
         win = round(window_time * self.fs)
         hop = max(1, round(win * (1 - overlap)))
         if win <= 0 or win > n_samples:
-            raise ValueError(
-                "window_time must be positive and shorter than the signal."
-            )
+            msg = "window_time must be positive and shorter than the signal."
+            raise ValueError(msg)
 
         # Filter once per band at full rate so windows stay time-aligned
         # across bands regardless of per-band decimation.
@@ -651,7 +659,8 @@ class OctaveFilterBank:
         elif mode.lower() == "peak":
             val_linear = np.max(np.abs(y), axis=-1)
         else:
-            raise ValueError("Invalid mode. Use 'rms' or 'peak'.")
+            msg = "Invalid mode. Use 'rms' or 'peak'."
+            raise ValueError(msg)
 
         eps = np.finfo(float).eps
 

--- a/src/phonometry/filters/design.py
+++ b/src/phonometry/filters/design.py
@@ -13,7 +13,8 @@ def _cheby2_transition_ratio(order: int, attenuation: float) -> float:
     """Ratio between stopband-edge and -3 dB frequencies for a Chebyshev II prototype."""
     # Below ~3.01 dB the -3 dB point does not exist (arccosh argument < 1).
     if attenuation <= 10 * np.log10(2):
-        raise ValueError("cheby2 'attenuation' must be greater than 3.01 dB.")
+        msg = "cheby2 'attenuation' must be greater than 3.01 dB."
+        raise ValueError(msg)
     eps_term = np.sqrt(10 ** (attenuation / 10) - 1)
     return float(np.cosh(np.arccosh(eps_term) / order))
 
@@ -169,9 +170,8 @@ def _showfilter(
     try:
         import matplotlib.pyplot as plt
     except ImportError as exc:
-        raise ImportError(
-            "Plotting requires matplotlib. Install it with: pip install phonometry[plot]"
-        ) from exc
+        msg = "Plotting requires matplotlib. Install it with: pip install phonometry[plot]"
+        raise ImportError(msg) from exc
 
     wn = 8192
     w = np.zeros([wn, len(freq)])

--- a/src/phonometry/filters/equalizer.py
+++ b/src/phonometry/filters/equalizer.py
@@ -146,10 +146,11 @@ class EQSection:
 def _validate_section(section: EQSection) -> None:
     """Validate one :class:`EQSection` against the cookbook's parameter rules."""
     if section.filter_type not in _DESIGNERS:
-        raise ValueError(
+        msg = (
             f"Unknown filter_type {section.filter_type!r}; expected one of "
             f"{sorted(_DESIGNERS)}."
         )
+        raise ValueError(msg)
     for name, value in (
         ("f0", section.f0),
         ("gain_db", section.gain_db),
@@ -158,9 +159,11 @@ def _validate_section(section: EQSection) -> None:
         ("slope", section.slope),
     ):
         if value is not None and not math.isfinite(value):
-            raise ValueError(f"'{name}' must be finite, got {value!r}.")
+            msg = f"'{name}' must be finite, got {value!r}."
+            raise ValueError(msg)
     if section.f0 <= 0:
-        raise ValueError("Centre frequency 'f0' must be positive.")
+        msg = "Centre frequency 'f0' must be positive."
+        raise ValueError(msg)
     _gain_amplitude(section.gain_db)
     _validate_section_parameterization(section)
 
@@ -178,10 +181,11 @@ def _gain_amplitude(gain_db: float) -> float:
     except OverflowError:
         big_a = math.inf
     if not (big_a > 0.0 and math.isfinite(big_a)):
-        raise ValueError(
+        msg = (
             f"'gain_db' = {gain_db:g} dB is outside the representable "
             "range: 10^(gain_db/40) must be a positive finite number."
         )
+        raise ValueError(msg)
     return big_a
 
 
@@ -201,11 +205,12 @@ def _validate_shelf_slope(section: EQSection) -> None:
         return
     bound = a_sum / (a_sum - 2.0)
     if section.slope >= bound:
-        raise ValueError(
+        msg = (
             f"Shelf slope 'slope' = {section.slope:g} is too steep for "
             f"gain_db = {section.gain_db:g}: the cookbook's alpha is real "
             f"only for slopes below (A + 1/A)/(A + 1/A - 2) = {bound:.6g}."
         )
+        raise ValueError(msg)
 
 
 def _validate_section_parameterization(section: EQSection) -> None:
@@ -220,23 +225,28 @@ def _validate_section_parameterization(section: EQSection) -> None:
         if value is not None
     ]
     if len(given) > 1:
-        raise ValueError(f"Give only one of 'q', 'bw' and 'slope', not {given}.")
+        msg = f"Give only one of 'q', 'bw' and 'slope', not {given}."
+        raise ValueError(msg)
     if section.q is not None and section.q <= 0:
-        raise ValueError("Quality factor 'q' must be positive.")
+        msg = "Quality factor 'q' must be positive."
+        raise ValueError(msg)
     if section.bw is not None and section.bw <= 0:
-        raise ValueError("Bandwidth 'bw' must be positive (octaves).")
+        msg = "Bandwidth 'bw' must be positive (octaves)."
+        raise ValueError(msg)
     if section.slope is not None and section.slope <= 0:
-        raise ValueError("Shelf slope 'slope' must be positive.")
+        msg = "Shelf slope 'slope' must be positive."
+        raise ValueError(msg)
     if section.slope is not None and section.filter_type not in _SHELF_TYPES:
-        raise ValueError("'slope' applies to the shelving types only.")
+        msg = "'slope' applies to the shelving types only."
+        raise ValueError(msg)
     if section.bw is not None and section.filter_type not in _BANDWIDTH_TYPES:
-        raise ValueError(
+        msg = (
             "'bw' applies to 'peaking', 'bandpass', 'bandpass_skirt' and 'notch' only."
         )
+        raise ValueError(msg)
     if abs(section.gain_db) > 0 and section.filter_type not in _GAIN_TYPES:
-        raise ValueError(
-            "'gain_db' applies to 'peaking', 'lowshelf' and 'highshelf' only."
-        )
+        msg = "'gain_db' applies to 'peaking', 'lowshelf' and 'highshelf' only."
+        raise ValueError(msg)
     _validate_shelf_slope(section)
 
 
@@ -340,13 +350,14 @@ def _section_alpha(section: EQSection, w0: float, big_a: float) -> float:
         try:
             return sin_w0 * math.sinh(math.log(2.0) / 2 * section.bw * w0 / sin_w0)
         except OverflowError:
-            raise ValueError(
+            msg = (
                 f"Bandwidth 'bw' = {section.bw:g} octaves is too wide for "
                 f"f0 = {section.f0:g} Hz this close to the Nyquist "
                 "frequency: the cookbook's bandwidth-to-alpha relation "
                 "overflows. Reduce 'bw', lower 'f0' or parameterize the "
                 "section with 'q' instead."
-            ) from None
+            )
+            raise ValueError(msg) from None
     if section.slope is not None:
         return (sin_w0 / 2) * math.sqrt(
             (big_a + 1 / big_a) * (1 / section.slope - 1) + 2
@@ -369,7 +380,7 @@ def _check_section_stability(
     """
     if abs(a2) < 1.0 and abs(a1) < 1.0 + a2:
         return
-    raise ValueError(
+    msg = (
         f"The designed {section.filter_type!r} section at f0 = "
         f"{section.f0:g} Hz (fs = {fs:g} Hz) is not strictly stable after "
         f"rounding (a1 = {a1:.17g}, a2 = {a2:.17g}): its poles do not lie "
@@ -378,15 +389,17 @@ def _check_section_stability(
         "Nyquist frequency; bring the section parameters back from the "
         "extreme."
     )
+    raise ValueError(msg)
 
 
 def _section_sos(fs: float, section: EQSection) -> NDArray[np.float64]:
     """One normalized SOS row ``[b0, b1, b2, 1, a1, a2]`` for the section."""
     if section.f0 >= fs / 2:
-        raise ValueError(
+        msg = (
             f"Centre frequency f0 = {section.f0} Hz must sit below the "
             f"Nyquist frequency {fs / 2} Hz."
         )
+        raise ValueError(msg)
     w0 = 2 * math.pi * section.f0 / fs
     big_a = _gain_amplitude(section.gain_db)
     alpha = _section_alpha(section, w0, big_a)
@@ -485,11 +498,13 @@ class ParametricEQ:
         :param steady_ic: If True, initialize the state at steady state.
         """
         if fs <= 0:
-            raise ValueError("Sample rate 'fs' must be positive.")
+            msg = "Sample rate 'fs' must be positive."
+            raise ValueError(msg)
         if isinstance(sections, EQSection):
             sections = (sections,)
         if len(sections) == 0:
-            raise ValueError("Give at least one EQSection.")
+            msg = "Give at least one EQSection."
+            raise ValueError(msg)
 
         self.fs = float(fs)
         self.sections: tuple[EQSection, ...] = tuple(sections)
@@ -539,15 +554,17 @@ class ParametricEQ:
             plots the magnitude/phase response).
         """
         if n_points < 2:
-            raise ValueError("'n_points' must be at least 2.")
+            msg = "'n_points' must be at least 2."
+            raise ValueError(msg)
         nyquist = self.fs / 2
         if f_max is None:
             f_max = nyquist
         if not 0 < f_min < f_max <= nyquist:
-            raise ValueError(
+            msg = (
                 "Need 0 < f_min < f_max <= fs/2; got "
                 f"f_min = {f_min}, f_max = {f_max}, fs/2 = {nyquist}."
             )
+            raise ValueError(msg)
 
         freqs = np.logspace(np.log10(f_min), np.log10(f_max), n_points)
         # Per-section responses; the cascade is their product.

--- a/src/phonometry/filters/frequencies.py
+++ b/src/phonometry/filters/frequencies.py
@@ -225,5 +225,6 @@ def normalized_frequencies(fraction: int) -> list[float]:
         ],
     }
     if fraction not in predefined:
-        raise ValueError("Normalized frequencies only available for fraction=1 or 3")
+        msg = "Normalized frequencies only available for fraction=1 or 3"
+        raise ValueError(msg)
     return predefined[fraction]

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -129,9 +129,8 @@ class WeightingFilter:
         if high_accuracy is None:
             high_accuracy = not stateful
         if high_accuracy and stateful:
-            raise ValueError(
-                "high_accuracy is not compatible with stateful processing."
-            )
+            msg = "high_accuracy is not compatible with stateful processing."
+            raise ValueError(msg)
 
         self.fs = fs
         self.curve = curve.upper()
@@ -152,9 +151,8 @@ class WeightingFilter:
             return
 
         if self.curve not in ["A", "B", "C", "D", "G", "AU"]:
-            raise ValueError(
-                "Weighting curve must be 'A', 'B', 'C', 'D', 'G', 'AU' or 'Z'"
-            )
+            msg = "Weighting curve must be 'A', 'B', 'C', 'D', 'G', 'AU' or 'Z'"
+            raise ValueError(msg)
 
         z, p, k = self._analog_design()
 
@@ -645,9 +643,8 @@ def _prepare_time_weighting_initial_state(
     try:
         return np.broadcast_to(state, state_shape).astype(x_sq.dtype, copy=True)
     except ValueError as exc:
-        raise ValueError(
-            "initial_state must be scalar or broadcastable to the input shape without the time axis"
-        ) from exc
+        msg = "initial_state must be scalar or broadcastable to the input shape without the time axis"
+        raise ValueError(msg) from exc
 
 
 def _impulse_kernel_py(
@@ -759,7 +756,8 @@ def time_weighting(
         # Move time axis back
         return _as_envelope(x, np.moveaxis(y_t, 0, -1), fs, mode_lower)
 
-    raise ValueError("Invalid time weighting mode. Use ['fast', 'slow', 'impulse']")
+    msg = "Invalid time weighting mode. Use ['fast', 'slow', 'impulse']"
+    raise ValueError(msg)
 
 
 class TimeWeighting:
@@ -776,9 +774,8 @@ class TimeWeighting:
         if fs <= 0:
             raise ValueError(_FS_POSITIVE)
         if mode.lower() not in ("fast", "slow", "impulse"):
-            raise ValueError(
-                "Invalid time weighting mode. Use ['fast', 'slow', 'impulse']"
-            )
+            msg = "Invalid time weighting mode. Use ['fast', 'slow', 'impulse']"
+            raise ValueError(msg)
         self.fs = fs
         self.mode = mode.lower()
         self._state: np.ndarray | None = None
@@ -855,7 +852,8 @@ def linkwitz_riley(
     fs = resolve_fs(x, fs)
     x_proc = resolve_samples(x)
     if order % 2 != 0:
-        raise ValueError("Linkwitz-Riley order must be even (typically 2 or 4).")
+        msg = "Linkwitz-Riley order must be even (typically 2 or 4)."
+        raise ValueError(msg)
 
     # A Linkwitz-Riley filter of order N is two Butterworth filters of order N/2 in series
     half_order = order // 2

--- a/src/phonometry/filters/weighting_compliance.py
+++ b/src/phonometry/filters/weighting_compliance.py
@@ -335,7 +335,8 @@ def weighting_class_limits(
         limit of ``-inf`` means only the upper limit applies.
     """
     if weighting_class not in (1, 2):
-        raise ValueError("weighting_class must be 1 or 2.")
+        msg = "weighting_class must be 1 or 2."
+        raise ValueError(msg)
     up_col, lo_col = (3, 4) if weighting_class == 1 else (5, 6)
     freqs = np.array([row[0] for row in _WEIGHTING_TABLE3], dtype=np.float64)
     upper = np.array([row[up_col] for row in _WEIGHTING_TABLE3], dtype=np.float64)
@@ -563,9 +564,11 @@ def verify_weighting_class(
         "margin_class1_db", "margin_class2_db"}`` for the sweep.
     """
     if wf.curve not in _WEIGHTING_COL and wf.curve not in ("B", "AU"):
-        raise ValueError("Weighting curve must be 'A', 'B', 'C', 'AU' or 'Z'.")
+        msg = "Weighting curve must be 'A', 'B', 'C', 'AU' or 'Z'."
+        raise ValueError(msg)
     if sweep_points < 64:
-        raise ValueError("'sweep_points' must be at least 64.")
+        msg = "'sweep_points' must be at least 64."
+        raise ValueError(msg)
 
     nyquist = wf.fs / 2.0
     nominal, design_all, limits1_all, limits2_all = _curve_design_and_limits(wf.curve)

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -219,9 +219,8 @@ class NiptsResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso1999 import render_nipts_report
 
         return render_nipts_report(
@@ -313,9 +312,8 @@ class HtlanResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso1999 import render_htlan_report
 
         return render_htlan_report(
@@ -332,10 +330,11 @@ def _select(values: np.ndarray, frequencies: ArrayLike | None) -> np.ndarray:
     for f in fr:
         matches = np.isclose(NIPTS_FREQUENCIES, f, rtol=1e-3)
         if not matches.any():
-            raise ValueError(
+            msg = (
                 f"frequency {f} Hz is not an ISO 1999 audiometric frequency "
                 f"(500 Hz - 6000 Hz)."
             )
+            raise ValueError(msg)
         idx.append(int(np.argmax(matches)))
     return values[idx]
 
@@ -407,9 +406,11 @@ def nipts(
     extrapolation, and the ``.report()`` fiche prints the matching caveat.
     """
     if years <= 0.0:
-        raise ValueError(f"years must be positive; got {years}.")
+        msg = f"years must be positive; got {years}."
+        raise ValueError(msg)
     if not 0.0 < fractile < 1.0:
-        raise ValueError(f"fractile must be in (0, 1); got {fractile}.")
+        msg = f"fractile must be in (0, 1); got {fractile}."
+        raise ValueError(msg)
     _warn_outside_domain(float(l_ex), float(years), float(fractile))
 
     from scipy.special import ndtri  # standard-normal quantile

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -169,9 +169,11 @@ def table_c4_contribution(n_samples: int, u1: float) -> float:
     :return: The contribution :math:`c_1 u_1` in dB.
     """
     if n_samples < 2:
-        raise ValueError("Table C.4 needs at least 2 samples.")
+        msg = "Table C.4 needs at least 2 samples."
+        raise ValueError(msg)
     if u1 < 0:
-        raise ValueError("'u1' must be non-negative.")
+        msg = "'u1' must be non-negative."
+        raise ValueError(msg)
 
     n_axis = np.asarray(_C4_N_AXIS, dtype=float)
     u_axis = np.asarray((0.0,) + _C4_U1_AXIS, dtype=float)
@@ -199,7 +201,8 @@ def minimum_cumulative_duration_hours(n_workers: int) -> float:
         is the tabulated fallback.
     """
     if n_workers < 1:
-        raise ValueError("'n_workers' must be a positive integer.")
+        msg = "'n_workers' must be a positive integer."
+        raise ValueError(msg)
     if n_workers <= 5:
         return 5.0
     if n_workers <= 15:
@@ -267,9 +270,11 @@ class Task:
     def __post_init__(self) -> None:
         """Reject an empty ``samples`` tuple and a non-positive ``duration_hours``."""
         if len(self.samples) == 0:
-            raise ValueError("A Task needs at least one Lp,A,eqT sample.")
+            msg = "A Task needs at least one Lp,A,eqT sample."
+            raise ValueError(msg)
         if self.duration_hours <= 0.0:
-            raise ValueError("'duration_hours' must be positive.")
+            msg = "'duration_hours' must be positive."
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -403,9 +408,8 @@ class ExposureResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso9612 import render_iso9612_report
 
         return render_iso9612_report(
@@ -455,9 +459,8 @@ def _duration_uncertainty(task: Task) -> float:
     if task.duration_range is not None:
         t_min, t_max = task.duration_range
         if t_max < t_min:
-            raise ValueError(
-                "duration_range must be (T_min, T_max) with T_max >= T_min."
-            )
+            msg = "duration_range must be (T_min, T_max) with T_max >= T_min."
+            raise ValueError(msg)
         return 0.5 * (t_max - t_min)
     return 0.0
 
@@ -538,9 +541,11 @@ def task_based_exposure(
     :return: An :class:`ExposureResult` with per-task contributions.
     """
     if not tasks:
-        raise ValueError("At least one task is required.")
+        msg = "At least one task is required."
+        raise ValueError(msg)
     if u3 < 0:
-        raise ValueError("'u3' must be non-negative.")
+        msg = "'u3' must be non-negative."
+        raise ValueError(msg)
 
     # First pass: task levels and durations (Eq 7, 8).
     levels, durations = _task_levels(tasks)
@@ -585,11 +590,14 @@ def _sampled_exposure(
     arr = np.asarray(samples, dtype=float)
     n = int(arr.size)
     if n < 2:
-        raise ValueError("At least two samples are required.")
+        msg = "At least two samples are required."
+        raise ValueError(msg)
     if effective_duration_hours <= 0:
-        raise ValueError("'effective_duration_hours' must be positive.")
+        msg = "'effective_duration_hours' must be positive."
+        raise ValueError(msg)
     if u3 < 0:
-        raise ValueError("'u3' must be non-negative.")
+        msg = "'u3' must be non-negative."
+        raise ValueError(msg)
 
     lp_aeqte = energy_mean(samples)  # Eq 11
     lex_8h = lp_aeqte + 10.0 * log10(effective_duration_hours / _T0)  # Eq 12/13
@@ -657,7 +665,8 @@ def job_based_exposure(
     :return: An :class:`ExposureResult`.
     """
     if sample_duration_hours is not None and sample_duration_hours <= 0.0:
-        raise ValueError("'sample_duration_hours' must be positive.")
+        msg = "'sample_duration_hours' must be positive."
+        raise ValueError(msg)
     result = _sampled_exposure(
         samples,
         effective_duration_hours,

--- a/src/phonometry/hearing/threshold.py
+++ b/src/phonometry/hearing/threshold.py
@@ -229,10 +229,11 @@ def _select(values: np.ndarray, frequencies: ArrayLike | None) -> np.ndarray:
     for f in fr:
         matches = np.isclose(AUDIOMETRIC_FREQUENCIES, f, rtol=1e-3)
         if not matches.any():
-            raise ValueError(
+            msg = (
                 f"frequency {f} Hz is not an ISO 7029 audiometric frequency "
                 f"(125 Hz - 8000 Hz)."
             )
+            raise ValueError(msg)
         idx.append(int(np.argmax(matches)))
     return values[idx]
 
@@ -271,14 +272,17 @@ def age_threshold(
         (0, 1), or an unknown frequency.
     """
     if age < _REFERENCE_AGE:
-        raise ValueError(
+        msg = (
             f"age must be at least {_REFERENCE_AGE:.0f} years (the ISO 7029 "
             f"lower limit); got {age}."
         )
+        raise ValueError(msg)
     if sex not in _MEDIAN:
-        raise ValueError(f"sex must be one of {SEXES}; got {sex!r}.")
+        msg = f"sex must be one of {SEXES}; got {sex!r}."
+        raise ValueError(msg)
     if not 0.0 < fractile < 1.0:
-        raise ValueError(f"fractile must be in (0, 1); got {fractile}.")
+        msg = f"fractile must be in (0, 1); got {fractile}."
+        raise ValueError(msg)
 
     from scipy.special import ndtri  # standard-normal quantile
 
@@ -319,5 +323,6 @@ def reference_threshold(
     :raises ValueError: for an unknown field or frequency.
     """
     if field not in _REFERENCE:
-        raise ValueError(f"field must be one of {FIELDS}; got {field!r}.")
+        msg = f"field must be one of {FIELDS}; got {field!r}."
+        raise ValueError(msg)
     return _select(_REFERENCE[field], frequencies)

--- a/src/phonometry/io/_backends.py
+++ b/src/phonometry/io/_backends.py
@@ -117,7 +117,8 @@ def _sniff(path: str | Path) -> str | None:
     # (11 set bits: 0xFF 0xE0).
     if len(head) >= 2 and head[0] == 0xFF and head[1] & 0xE0 == 0xE0:
         return "MPEG audio (MP3)"
-    raise ValueError(f"{path}: not a recognised audio file")
+    msg = f"{path}: not a recognised audio file"
+    raise ValueError(msg)
 
 
 def _import_soundfile(format_name: str) -> Any:
@@ -125,10 +126,11 @@ def _import_soundfile(format_name: str) -> Any:
     try:
         import soundfile
     except ImportError as exc:
-        raise ImportError(
+        msg = (
             f"Reading {format_name} requires python-soundfile, which "
             f"phonometry ships as the [audio] extra. {_AUDIO_EXTRA_HINT}"
-        ) from exc
+        )
+        raise ImportError(msg) from exc
     return soundfile
 
 

--- a/src/phonometry/io/_bext.py
+++ b/src/phonometry/io/_bext.py
@@ -128,20 +128,21 @@ def serialize_bext(meta: BroadcastMetadata) -> bytes:
     for attribute, name, size in _STRING_FIELDS:
         raw = str(getattr(meta, attribute)).encode("latin-1")
         if len(raw) > size:
-            raise ValueError(
-                f"bext {name} is {len(raw)} bytes; the Tech 3285 field holds {size}"
-            )
+            msg = f"bext {name} is {len(raw)} bytes; the Tech 3285 field holds {size}"
+            raise ValueError(msg)
         encoded.append(raw)
     if not 0 <= meta.time_reference < 2**64:
-        raise ValueError(
+        msg = (
             "bext TimeReference is an unsigned 64-bit sample count; got "
             f"{meta.time_reference}"
         )
+        raise ValueError(msg)
     if meta.umid is not None and meta.version < 1:
-        raise ValueError(
+        msg = (
             f"bext version {meta.version} has no UMID field (version >= 1); "
             "raise the version instead of losing the UMID"
         )
+        raise ValueError(msg)
     loudness = (
         meta.loudness_value,
         meta.loudness_range,
@@ -150,13 +151,15 @@ def serialize_bext(meta: BroadcastMetadata) -> bytes:
         meta.max_short_term_loudness,
     )
     if meta.version < 2 and any(value is not None for value in loudness):
-        raise ValueError(
+        msg = (
             f"bext version {meta.version} has no loudness fields "
             "(version >= 2); raise the version instead of losing them"
         )
+        raise ValueError(msg)
     umid = meta.umid or b""
     if len(umid) > 64:
-        raise ValueError(f"bext UMID is {len(umid)} bytes; the field holds 64")
+        msg = f"bext UMID is {len(umid)} bytes; the field holds 64"
+        raise ValueError(msg)
     history = meta.coding_history.encode("latin-1")
     return (
         _BEXT_FIXED.pack(

--- a/src/phonometry/io/_blocks.py
+++ b/src/phonometry/io/_blocks.py
@@ -105,10 +105,11 @@ def _iter_wav_blocks(
             fh.seek(chunks.data_offset + start * fmt.block_align)
             raw = fh.read(n * fmt.block_align)
             if len(raw) < n * fmt.block_align:
-                raise ValueError(
+                msg = (
                     f"{path}: data chunk ends {n * fmt.block_align - len(raw)} "
                     f"bytes short of frame {start + n}"
                 )
+                raise ValueError(msg)
             yield _squeeze(_decode_linear_frames(raw, fmt))
             start += step
 
@@ -161,12 +162,14 @@ def read_blocks(
     block_size = int(block_size)
     overlap = int(overlap)
     if block_size < 1:
-        raise ValueError(f"block_size must be at least 1; got {block_size}")
+        msg = f"block_size must be at least 1; got {block_size}"
+        raise ValueError(msg)
     if not 0 <= overlap < block_size:
-        raise ValueError(
+        msg = (
             f"overlap must satisfy 0 <= overlap < block_size; got "
             f"{overlap} against {block_size}"
         )
+        raise ValueError(msg)
     format_name = _sniff(path)
     if format_name is None:
         fmt = parse_wav_chunks(path).fmt

--- a/src/phonometry/io/_chunks.py
+++ b/src/phonometry/io/_chunks.py
@@ -394,10 +394,11 @@ def _loudness(raw: int) -> float | None:
 def _parse_bext(payload: bytes) -> BroadcastMetadata:
     """Decode a ``bext`` payload laid out per the class docstring's table."""
     if len(payload) < _BEXT_FIXED.size:
-        raise ValueError(
+        msg = (
             f"bext chunk is {len(payload)} bytes; the EBU Tech 3285 fixed "
             f"part is {_BEXT_FIXED.size}"
         )
+        raise ValueError(msg)
     (
         description,
         originator,
@@ -440,7 +441,8 @@ def _parse_bext(payload: bytes) -> BroadcastMetadata:
 def _parse_fmt(payload: bytes) -> FormatChunk:
     """Decode ``fmt``, including the EXTENSIBLE extension when present."""
     if len(payload) < 16:
-        raise ValueError(f"fmt chunk is {len(payload)} bytes; at least 16 required")
+        msg = f"fmt chunk is {len(payload)} bytes; at least 16 required"
+        raise ValueError(msg)
     tag, channels, fs, byte_rate, block_align, bits = struct.unpack_from(
         "<HHIIHH", payload
     )
@@ -449,10 +451,11 @@ def _parse_fmt(payload: bytes) -> FormatChunk:
     subformat: bytes | None = None
     if tag == WAVE_FORMAT_EXTENSIBLE:
         if len(payload) < 40:
-            raise ValueError(
+            msg = (
                 f"WAVE_FORMAT_EXTENSIBLE fmt chunk is {len(payload)} bytes; "
                 "the 22-byte extension requires 40"
             )
+            raise ValueError(msg)
         # cbSize (uint16 at offset 16) precedes the extension proper.
         valid_bits, channel_mask = struct.unpack_from("<HI", payload, 18)
         subformat = payload[24:40]
@@ -480,16 +483,16 @@ def _parse_cue(payload: bytes) -> tuple[CuePoint, ...]:
     type every other malformed-chunk path here raises, would not catch).
     """
     if len(payload) < 4:
-        raise ValueError(
-            f"cue chunk is {len(payload)} bytes; its uint32 record count requires 4"
-        )
+        msg = f"cue chunk is {len(payload)} bytes; its uint32 record count requires 4"
+        raise ValueError(msg)
     (count,) = struct.unpack_from("<I", payload)
     needed = 4 + 24 * count
     if len(payload) < needed:
-        raise ValueError(
+        msg = (
             f"cue chunk declares {count} points but is {len(payload)} "
             f"bytes; the 24-byte records require {needed}"
         )
+        raise ValueError(msg)
     points = []
     for i in range(count):
         cue_id, position, chunk_id, chunk_start, block_start, sample_offset = (
@@ -511,10 +514,11 @@ def _parse_cue(payload: bytes) -> tuple[CuePoint, ...]:
 def _parse_ds64(payload: bytes, path: str | Path) -> Ds64Chunk:
     """Decode the three mandatory 64-bit sizes of a ``ds64`` chunk."""
     if len(payload) < 24:
-        raise ValueError(
+        msg = (
             f"{path}: ds64 chunk is {len(payload)} bytes; the "
             "riffSize, dataSize and sampleCount fields require 24"
         )
+        raise ValueError(msg)
     riff_size, chunk_data_size, sample_count = struct.unpack_from("<QQQ", payload)
     return Ds64Chunk(
         riff_size=riff_size,
@@ -526,10 +530,11 @@ def _parse_ds64(payload: bytes, path: str | Path) -> Ds64Chunk:
 def _parse_fact(payload: bytes, path: str | Path) -> int:
     """Decode the ``fact`` chunk's single uint32 frame count."""
     if len(payload) < 4:
-        raise ValueError(
+        msg = (
             f"{path}: fact chunk is {len(payload)} bytes; its "
             "uint32 frame count requires 4"
         )
+        raise ValueError(msg)
     (fact_frames,) = struct.unpack_from("<I", payload)
     return int(fact_frames)
 
@@ -538,13 +543,15 @@ def _read_wave_header(fh: BinaryIO, path: str | Path) -> str:
     """Check the 12-byte RIFF prelude and name the container it declares."""
     header = fh.read(12)
     if len(header) < 12 or header[8:12] != b"WAVE":
-        raise ValueError(f"{path}: not a WAVE file")
+        msg = f"{path}: not a WAVE file"
+        raise ValueError(msg)
     fourcc = header[:4]
     containers = {b"RIFF": "WAV", b"RF64": "RF64", b"BW64": "BW64"}
     if fourcc not in containers:
-        raise ValueError(
+        msg = (
             f"{path}: unknown container fourcc {fourcc!r} (expected RIFF, RF64 or BW64)"
         )
+        raise ValueError(msg)
     return containers[fourcc]
 
 
@@ -561,10 +568,11 @@ def _check_chunk_extent(
     of an odd last chunk, and the payload itself is whole either way.
     """
     if offset + size > file_size:
-        raise ValueError(
+        msg = (
             f"{path}: chunk {chunk_id!r} claims {size} bytes but only "
             f"{file_size - offset} remain in the file"
         )
+        raise ValueError(msg)
 
 
 def _read_chunk_payload(
@@ -577,10 +585,11 @@ def _read_chunk_payload(
     """
     payload = fh.read(size)
     if len(payload) < size:
-        raise ValueError(
+        msg = (
             f"{path}: chunk {chunk_id!r} claims {size} bytes but the "
             f"file ends after {len(payload)}"
         )
+        raise ValueError(msg)
     if size % 2:
         fh.seek(1, 1)  # chunks are word-aligned; the pad byte is not counted
     return payload
@@ -593,10 +602,11 @@ def _true_data_size(
     if size != 0xFFFFFFFF or container == "WAV":
         return size
     if ds64 is None:
-        raise ValueError(
+        msg = (
             f"{path}: RF64 data chunk defers its size to a "
             "ds64 chunk that never appeared"
         )
+        raise ValueError(msg)
     return ds64.data_size
 
 
@@ -696,9 +706,11 @@ def parse_wav_chunks(path: str | Path) -> WavChunks:
             fh.seek(size + size % 2, 1)
 
     if seen.fmt is None:
-        raise ValueError(f"{path}: no fmt chunk found")
+        msg = f"{path}: no fmt chunk found"
+        raise ValueError(msg)
     if data_offset is None or data_size is None:
-        raise ValueError(f"{path}: no data chunk found")
+        msg = f"{path}: no data chunk found"
+        raise ValueError(msg)
     return WavChunks(
         container=container,
         fmt=seen.fmt,

--- a/src/phonometry/io/_convert.py
+++ b/src/phonometry/io/_convert.py
@@ -149,19 +149,21 @@ def _default_subtype(kind: str, bits: int, *, flac: bool) -> str:
         else:
             depth = 32
         if flac and depth > 24:
-            raise ValueError(
+            msg = (
                 "FLAC holds integer PCM up to 24 bits (libsndfile); a "
                 f"{bits}-bit integer source cannot pass through whole. "
                 "Pass subtype='PCM_24' to accept the truncation explicitly."
             )
+            raise ValueError(msg)
         return f"PCM_{depth}"
     if flac:
-        raise ValueError(
+        msg = (
             "FLAC holds integer PCM only; converting a "
             f"{'float' if kind == 'float' else 'lossy-decoded'} source "
             "quantises it, so choose subtype='PCM_16' or 'PCM_24' "
             "explicitly rather than have the library narrow it silently."
         )
+        raise ValueError(msg)
     if kind == "float":
         return "FLOAT" if bits == 32 else "DOUBLE"
     return "FLOAT"
@@ -202,33 +204,38 @@ def _check_conversion_paths(src: str | Path, dst: str | Path) -> None:
     source, target = Path(src), Path(dst)
     suffix = target.suffix.lower()
     if suffix in _LOSSY_TARGET_SUFFIXES:
-        raise ValueError(
+        msg = (
             f"{dst}: writing lossy formats is outside this API by policy; "
             "a metrology library does not export approximations of its "
             "own data. Convert to WAV or FLAC instead."
         )
+        raise ValueError(msg)
     if suffix not in _WAV_SUFFIXES and suffix != ".flac":
-        raise ValueError(
+        msg = (
             f"{dst}: unsupported target {target.suffix!r}; convert() "
             "produces the WAV family (.wav, .wave, .bwf) and, with the "
             "[audio] extra, FLAC."
         )
+        raise ValueError(msg)
     if source.resolve() == target.resolve():
-        raise ValueError(f"{src}: source and destination are the same file")
+        msg = f"{src}: source and destination are the same file"
+        raise ValueError(msg)
 
 
 def _check_resolved_subtype(resolved: str, *, flac: bool) -> None:
     """Refuse a subtype the chosen container cannot hold."""
     if flac and resolved not in ("PCM_16", "PCM_24"):
-        raise ValueError(
+        msg = (
             f"FLAC holds integer PCM up to 24 bits; subtype {resolved!r} "
             "is not available (choose PCM_16 or PCM_24)"
         )
+        raise ValueError(msg)
     if not flac and resolved not in _SUBTYPE_SPEC:
-        raise ValueError(
+        msg = (
             f"unknown subtype {resolved!r}; the WAV writer offers "
             f"{sorted(_SUBTYPE_SPEC)}"
         )
+        raise ValueError(msg)
 
 
 def _stream_to_flac(

--- a/src/phonometry/io/_flac.py
+++ b/src/phonometry/io/_flac.py
@@ -54,7 +54,8 @@ def read_flac_bext(path: str | Path) -> BroadcastMetadata | None:
     """
     with Path(path).open("rb") as fh:
         if fh.read(4) != b"fLaC":
-            raise ValueError(f"{path}: not a FLAC file")
+            msg = f"{path}: not a FLAC file"
+            raise ValueError(msg)
         while True:
             header = fh.read(4)
             if len(header) < 4:
@@ -100,21 +101,24 @@ def embed_flac_bext(path: str | Path, bext_payload: bytes) -> None:
         + (b"\x00" if len(bext_payload) % 2 else b"")
     )
     if len(chunk) >= 1 << 24:
-        raise ValueError(
+        msg = (
             f"{path}: bext chunk of {len(bext_payload)} bytes exceeds the "
             "24-bit FLAC metadata block length"
         )
+        raise ValueError(msg)
     source = Path(path)
     staging = source.with_name(source.name + ".phonometry-tmp")
     with source.open("rb") as src, staging.open("wb") as dst:
         magic = src.read(4)
         if magic != b"fLaC":
-            raise ValueError(f"{path}: not a FLAC file")
+            msg = f"{path}: not a FLAC file"
+            raise ValueError(msg)
         dst.write(magic)
         while True:
             header = src.read(4)
             if len(header) < 4:
-                raise ValueError(f"{path}: truncated FLAC metadata chain")
+                msg = f"{path}: truncated FLAC metadata chain"
+                raise ValueError(msg)
             body = src.read(int.from_bytes(header[1:4], "big"))
             last = bool(header[0] & 0x80)
             # Clear the last-block flag: our block goes beneath this one.

--- a/src/phonometry/io/_resolve.py
+++ b/src/phonometry/io/_resolve.py
@@ -93,10 +93,11 @@ def resolve_optional_fs[Rate: (int, float)](
     """
     if isinstance(x, Signal):
         if fs is not None and fs != x.fs:
-            raise ValueError(
+            msg = (
                 f"{rate}={fs} conflicts with the Signal's own fs={x.fs}; "
                 "pass one or the other, not a disagreement"
             )
+            raise ValueError(msg)
         return x.fs
     return fs
 
@@ -120,7 +121,8 @@ def resolve_fs[Rate: (int, float)](
     """
     resolved = resolve_optional_fs(x, fs, rate=rate)
     if resolved is None:
-        raise ValueError(f"{rate} is required when '{name}' is a bare array")
+        msg = f"{rate} is required when '{name}' is a bare array"
+        raise ValueError(msg)
     return resolved
 
 
@@ -139,11 +141,12 @@ def refuse_foreign_rate(x: SignalInput, fs: float, what: str) -> None:
     :raises ValueError: If *x* is a Signal at a different rate.
     """
     if isinstance(x, Signal) and x.fs != fs:
-        raise ValueError(
+        msg = (
             f"the Signal was recorded at {x.fs} Hz but this {what} was "
             f"designed for {fs:g} Hz; resample the Signal, or build a "
             f"{what} for its own rate"
         )
+        raise ValueError(msg)
 
 
 def resolve_calibration(x: SignalInput, calibration_factor: float | None) -> float:
@@ -270,11 +273,12 @@ def _agreed_pair(x: SignalInput, y: SignalInput, names: tuple[str, str]) -> Sign
     :raises ValueError: If both are Signals recorded at different rates.
     """
     if isinstance(x, Signal) and isinstance(y, Signal) and x.fs != y.fs:
-        raise ValueError(
+        msg = (
             f"'{names[0]}' and '{names[1]}' are Signals recorded at "
             f"different rates ({x.fs} Hz and {y.fs} Hz); resample one of "
             "them before comparing them"
         )
+        raise ValueError(msg)
     return x if isinstance(x, Signal) else y
 
 

--- a/src/phonometry/io/_sidecar.py
+++ b/src/phonometry/io/_sidecar.py
@@ -97,10 +97,11 @@ class CalibrationSidecar:
     def __post_init__(self) -> None:
         factor = float(self.calibration_factor)
         if not (math.isfinite(factor) and factor > 0):
-            raise ValueError(
+            msg = (
                 f"calibration_factor must be finite and positive; got "
                 f"{self.calibration_factor!r}"
             )
+            raise ValueError(msg)
 
 
 def sidecar_path(audio_path: str | Path) -> Path:
@@ -172,8 +173,9 @@ def _optional_number(payload: dict[str, object], key: str, path: Path) -> float 
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, int | float):
+        msg = f"{path}: {key} must be a number or null; got {value!r}"
         raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            f"{path}: {key} must be a number or null; got {value!r}"
+            msg
         )
     return float(value)
 
@@ -183,23 +185,27 @@ def _load_sidecar_payload(source: Path) -> dict[str, object]:
     try:
         payload = json.loads(source.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        raise ValueError(f"{source}: sidecar is not valid JSON") from exc
+        msg = f"{source}: sidecar is not valid JSON"
+        raise ValueError(msg) from exc
     if not isinstance(payload, dict) or payload.get("schema") != SIDECAR_SCHEMA:
-        raise ValueError(
+        msg = (
             f"{source}: not a {SIDECAR_SCHEMA!r} sidecar; refusing to "
             "guess at its meaning"
         )
+        raise ValueError(msg)
     version = payload.get("schema_version")
     if not isinstance(version, int) or isinstance(version, bool):
+        msg = f"{source}: schema_version must be an integer"
         raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            f"{source}: schema_version must be an integer"
+            msg
         )
     if version > SIDECAR_VERSION:
-        raise ValueError(
+        msg = (
             f"{source}: sidecar schema version {version} is newer than the "
             f"version {SIDECAR_VERSION} this phonometry understands; "
             "upgrade phonometry to read it"
         )
+        raise ValueError(msg)
     return payload
 
 
@@ -207,8 +213,9 @@ def _required_factor(payload: dict[str, object], source: Path) -> float:
     """The mandatory calibration factor, validated as a number."""
     factor = payload.get("calibration_factor")
     if isinstance(factor, bool) or not isinstance(factor, int | float):
+        msg = f"{source}: calibration_factor must be a number; got {factor!r}"
         raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            f"{source}: calibration_factor must be a number; got {factor!r}"
+            msg
         )
     return float(factor)
 
@@ -221,12 +228,14 @@ def _calibrator_fields(
     if calibrator is None:
         calibrator = {}
     if not isinstance(calibrator, dict):
+        msg = f"{source}: calibrator must be an object or null"
         raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            f"{source}: calibrator must be an object or null"
+            msg
         )
     model = calibrator.get("model")
     if model is not None and not isinstance(model, str):
-        raise ValueError(f"{source}: calibrator model must be a string or null")
+        msg = f"{source}: calibrator model must be a string or null"
+        raise ValueError(msg)
     return calibrator, model
 
 
@@ -238,9 +247,8 @@ def _channel_labels(payload: dict[str, object], source: Path) -> tuple[str, ...]
     if not isinstance(labels, list) or not all(
         isinstance(label, str) for label in labels
     ):
-        raise ValueError(
-            f"{source}: channel_labels must be an array of strings or null"
-        )
+        msg = f"{source}: channel_labels must be an array of strings or null"
+        raise ValueError(msg)
     return tuple(labels)
 
 
@@ -281,4 +289,5 @@ def read_sidecar(audio_path: str | Path) -> CalibrationSidecar | None:
             ),
         )
     except ValueError as exc:
-        raise ValueError(f"{source}: {exc}") from exc
+        msg = f"{source}: {exc}"
+        raise ValueError(msg) from exc

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -106,31 +106,33 @@ class Signal:
     def __post_init__(self) -> None:
         data = np.atleast_2d(np.asarray(self.data, dtype=np.float64))
         if data.ndim != 2:
-            raise ValueError(
-                f"data must be 1-D or (channels, samples); got {data.ndim}-D"
-            )
+            msg = f"data must be 1-D or (channels, samples); got {data.ndim}-D"
+            raise ValueError(msg)
         object.__setattr__(self, "data", np.ascontiguousarray(data))
         if (
             self.channel_labels is not None
             and len(self.channel_labels) != data.shape[0]
         ):
-            raise ValueError(
+            msg = (
                 f"{len(self.channel_labels)} channel labels for "
                 f"{data.shape[0]} channels"
             )
+            raise ValueError(msg)
         # Finiteness is checked alongside the sign: NaN and infinity pass
         # every comparison against zero, and an fs or calibration of NaN
         # would flow into durations and levels as a wrong number that
         # looks computed.
         if not np.isfinite(self.fs) or self.fs <= 0:
-            raise ValueError(f"fs must be a positive finite number; got {self.fs}")
+            msg = f"fs must be a positive finite number; got {self.fs}"
+            raise ValueError(msg)
         if self.calibration_factor is not None and (
             not np.isfinite(self.calibration_factor) or self.calibration_factor <= 0
         ):
-            raise ValueError(
+            msg = (
                 "calibration_factor must be a positive finite number; "
                 f"got {self.calibration_factor}"
             )
+            raise ValueError(msg)
 
     @property
     def _view(self) -> NDArray[np.float64]:
@@ -199,9 +201,8 @@ class Signal:
         picked = [int(c) for c in wanted]
         for c in picked:
             if not -self.data.shape[0] <= c < self.data.shape[0]:
-                raise IndexError(
-                    f"channel {c} out of range for a {self.data.shape[0]}-channel signal"
-                )
+                msg = f"channel {c} out of range for a {self.data.shape[0]}-channel signal"
+                raise IndexError(msg)
         labels = (
             tuple(self.channel_labels[c] for c in picked)
             if self.channel_labels is not None
@@ -234,11 +235,14 @@ class Signal:
         start = 0.0 if tmin is None else float(tmin)
         stop = self.duration if tmax is None else float(tmax)
         if not np.isfinite(start) or not np.isfinite(stop):
-            raise ValueError("'tmin' and 'tmax' must be finite times in seconds")
+            msg = "'tmin' and 'tmax' must be finite times in seconds"
+            raise ValueError(msg)
         if start < 0.0:
-            raise ValueError(f"'tmin' must not be negative; got {start}")
+            msg = f"'tmin' must not be negative; got {start}"
+            raise ValueError(msg)
         if stop <= start:
-            raise ValueError(f"'tmax' ({stop}) must be greater than 'tmin' ({start})")
+            msg = f"'tmax' ({stop}) must be greater than 'tmin' ({start})"
+            raise ValueError(msg)
         # Ceiling, not rounding: the span is half-open, so a sample belongs
         # to it when tmin <= i/fs < tmax, which is i >= tmin*fs. Rounding
         # would pull in the sample just before tmin whenever the edge falls
@@ -247,9 +251,8 @@ class Signal:
         first = math.ceil(round(start * self.fs, 9))
         last = min(math.ceil(round(stop * self.fs, 9)), self.data.shape[1])
         if first >= last:
-            raise ValueError(
-                f"the span [{start}, {stop}) s holds no samples at {self.fs} Hz"
-            )
+            msg = f"the span [{start}, {stop}) s holds no samples at {self.fs} Hz"
+            raise ValueError(msg)
         return Signal(
             data=self.data[:, first:last],
             fs=self.fs,

--- a/src/phonometry/io/_wav.py
+++ b/src/phonometry/io/_wav.py
@@ -206,19 +206,21 @@ def read_wav(
     parsed = parse_wav_chunks(path) if chunks is None else chunks
     fmt = parsed.fmt
     if fmt.resolved_tag not in (WAVE_FORMAT_PCM, WAVE_FORMAT_IEEE_FLOAT):
-        raise ValueError(
+        msg = (
             f"{path}: {fmt.format_name} is not linear PCM/float; "
             "read it through the [audio] backend"
         )
+        raise ValueError(msg)
     payload_end = parsed.data_offset + parsed.data_size
     actual = Path(path).stat().st_size
     if actual < payload_end:
-        raise ValueError(
+        msg = (
             f"{path}: data chunk claims {parsed.data_size} bytes "
             f"({parsed.frames} frames) but the file ends "
             f"{payload_end - actual} bytes short; refusing to read a "
             "truncated recording as if it were complete"
         )
+        raise ValueError(msg)
     if parsed.container == "BW64":
         # scipy honours ds64 for the RF64 fourcc but rejects BW64 (ITU-R
         # BS.2088), which differs from RF64 in that four-byte tag alone;

--- a/src/phonometry/io/_write.py
+++ b/src/phonometry/io/_write.py
@@ -135,21 +135,25 @@ def _resolve_input(
     """
     if isinstance(x, Signal):
         if fs is not None and int(fs) != x.fs:
-            raise ValueError(
+            msg = (
                 f"fs={fs} conflicts with the Signal's own fs={x.fs}; "
                 "pass one or the other, not a disagreement"
             )
+            raise ValueError(msg)
         return x.data, x.fs
     data = np.asarray(x)
     if fs is None:
-        raise ValueError("fs is required when writing a bare array")
+        msg = "fs is required when writing a bare array"
+        raise ValueError(msg)
     if int(fs) <= 0:
-        raise ValueError("fs must be positive")
+        msg = "fs must be positive"
+        raise ValueError(msg)
     if data.dtype not in _PASSTHROUGH_SUBTYPES:
         data = np.asarray(data, dtype=np.float64)
     data = np.atleast_2d(data)
     if data.ndim != 2:
-        raise ValueError(f"x must be 1-D or (channels, samples); got {data.ndim}-D")
+        msg = f"x must be 1-D or (channels, samples); got {data.ndim}-D"
+        raise ValueError(msg)
     return data, int(fs)
 
 
@@ -167,24 +171,27 @@ def _resolve_subtype(data: np.ndarray, subtype: str | None) -> str:
     implied = _PASSTHROUGH_SUBTYPES.get(data.dtype)
     if implied is not None:
         if subtype is not None and subtype != implied:
-            raise ValueError(
+            msg = (
                 f"integer {data.dtype} input is a bit-exact pass-through of "
                 f"{implied}; requesting subtype={subtype!r} would resample "
                 "the codes. Convert to float64 first to choose a depth."
             )
+            raise ValueError(msg)
         return implied
     if data.dtype.kind != "f":
-        raise ValueError(
+        msg = (
             f"unsupported input dtype {data.dtype}: pass float data, or "
             "int16/int32 codes for bit-exact pass-through"
         )
+        raise ValueError(msg)
     if subtype is None:
         return "FLOAT"
     if subtype not in _SUBTYPE_SPEC:
-        raise ValueError(
+        msg = (
             f"unknown subtype {subtype!r}; the WAV writer offers "
             f"{sorted(_SUBTYPE_SPEC)}"
         )
+        raise ValueError(msg)
     return subtype
 
 
@@ -354,7 +361,8 @@ def append_riff_chunk(path: str | Path, chunk_id: bytes, payload: bytes) -> None
     with Path(path).open("r+b") as fh:
         fourcc = fh.read(4)
         if fourcc not in (b"RIFF", b"RF64", b"BW64"):
-            raise ValueError(f"{path}: not a RIFF/RF64/BW64 file")
+            msg = f"{path}: not a RIFF/RF64/BW64 file"
+            raise ValueError(msg)
         fh.seek(0, 2)
         if fh.tell() % 2:
             fh.write(b"\x00")
@@ -362,10 +370,11 @@ def append_riff_chunk(path: str | Path, chunk_id: bytes, payload: bytes) -> None
         riff_size = fh.tell() - 8
         if fourcc == b"RIFF":
             if riff_size > 0xFFFFFFFF:
-                raise ValueError(
+                msg = (
                     f"{path}: appending {len(payload)} bytes overflows the "
                     "32-bit RIFF size; the file needed to be RF64"
                 )
+                raise ValueError(msg)
             fh.seek(4)
             fh.write(struct.pack("<I", riff_size))
         else:
@@ -388,14 +397,16 @@ def _check_dither(dither: str | None, subtype: str) -> None:
     if dither is None:
         return
     if dither != "tpdf":
-        raise ValueError(f"unknown dither {dither!r}; offered: 'tpdf'")
+        msg = f"unknown dither {dither!r}; offered: 'tpdf'"
+        raise ValueError(msg)
     if subtype != "PCM_16":
-        raise ValueError(
+        msg = (
             "dither='tpdf' applies only when quantising to PCM_16: at "
             "24 bits and above the quantisation error is already far "
             "below any microphone chain's noise floor, and dithering "
             "float data only adds noise to it"
         )
+        raise ValueError(msg)
 
 
 def _resolve_bext(
@@ -431,9 +442,8 @@ def _resolve_bext(
             full_scale = data / float(2 ** (8 * data.dtype.itemsize - 1))
         meta = with_measured_loudness(base, full_scale, fs)
     else:
-        raise ValueError(
-            f"unknown bext {bext!r}: pass None, 'loudness' or a BroadcastMetadata"
-        )
+        msg = f"unknown bext {bext!r}: pass None, 'loudness' or a BroadcastMetadata"
+        raise ValueError(msg)
     if meta is None:
         return None
     line = coding_history_line(
@@ -477,11 +487,12 @@ def _reconcile_streamed_header(
         metadata_chunks=metadata_chunks,
     )
     if len(patched) != header_len:
-        raise ValueError(
+        msg = (
             f"{path}: the {written} frames actually streamed move the "
             "header across the RF64 promotion boundary the estimated "
             "count chose; the estimate was too wrong to reconcile"
         )
+        raise ValueError(msg)
     fh.seek(0)
     fh.write(patched)
 
@@ -549,10 +560,11 @@ def write_wav_stream(
             )
             frames = written
     if written != frames:
-        raise ValueError(
+        msg = (
             f"{path}: the block stream carried {written} frames but the "
             f"header promised {frames}; the file is inconsistent"
         )
+        raise ValueError(msg)
 
 
 def write_wav(
@@ -579,13 +591,14 @@ def _check_target_suffix(path: str | Path, target: Path) -> None:
     """Refuse any destination outside the WAV family and FLAC."""
     suffix = target.suffix.lower()
     if suffix not in _WAV_SUFFIXES and suffix != ".flac":
-        raise ValueError(
+        msg = (
             f"{path}: unsupported target {target.suffix!r}; the writer "
             "produces the WAV family (.wav, .wave, .bwf) and, with the "
             "[audio] extra, FLAC. Lossy formats are deliberately not "
             "offered: a metrology library does not export approximations "
             "of its own data."
         )
+        raise ValueError(msg)
 
 
 def _check_sidecar_request(
@@ -593,20 +606,22 @@ def _check_sidecar_request(
 ) -> None:
     """Refuse a sidecar request without a calibrated Signal behind it."""
     if sidecar and (not isinstance(x, Signal) or x.calibration_factor is None):
-        raise ValueError(
+        msg = (
             "sidecar=True needs a Signal with a calibration_factor: the "
             "sidecar exists to carry a calibration, and inventing one "
             "is the single thing this library must never do"
         )
+        raise ValueError(msg)
 
 
 def _refuse_passthrough_dither(dither: str | None) -> None:
     """Integer input has nothing to dither; say so instead of ignoring."""
     if dither is not None:
-        raise ValueError(
+        msg = (
             "dither applies to quantisation, and integer input is a "
             "bit-exact pass-through: there is nothing to dither"
         )
+        raise ValueError(msg)
 
 
 def _write_pcm24(
@@ -763,10 +778,11 @@ def write(
     _check_target_suffix(path, target)
     _check_sidecar_request(x, sidecar)
     if rng is not None and dither is None:
-        raise ValueError(
+        msg = (
             "rng seeds the TPDF dither noise and does nothing without it; "
             "pass dither='tpdf' alongside it or drop it"
         )
+        raise ValueError(msg)
     data, rate = _resolve_input(x, fs)
     if target.suffix.lower() == ".flac":
         _write_flac(path, x, data, rate, subtype, bext, dither, rng)
@@ -830,10 +846,11 @@ def _flac_passthrough_codes(
 ) -> np.ndarray:
     """int16 codes pass through whole; a conflicting request is refused."""
     if subtype not in (None, "PCM_16"):
-        raise ValueError(
+        msg = (
             "integer int16 input is a bit-exact pass-through of PCM_16; "
             f"requesting subtype={subtype!r} would resample the codes"
         )
+        raise ValueError(msg)
     _refuse_passthrough_dither(dither)
     return data.astype(np.int16)
 
@@ -847,16 +864,18 @@ def _flac_quantised_codes(
 ) -> tuple[str, np.ndarray]:
     """Quantise float data to the integer codes a FLAC subtype stores."""
     if data.dtype.kind != "f":
-        raise ValueError(
+        msg = (
             f"unsupported input dtype {data.dtype}: pass float data, "
             "or int16 codes for bit-exact pass-through"
         )
+        raise ValueError(msg)
     resolved = "PCM_24" if subtype is None else subtype
     if resolved not in ("PCM_16", "PCM_24"):
-        raise ValueError(
+        msg = (
             f"FLAC holds integer PCM up to 24 bits; subtype "
             f"{resolved!r} is not available (choose PCM_16 or PCM_24)"
         )
+        raise ValueError(msg)
     _check_dither(dither, resolved)
     bits = _SUBTYPE_BITS[resolved]
     codes, clipped, peak_dbfs = _quantise(data, bits, dither, rng)
@@ -903,12 +922,13 @@ def _write_flac(
     implied = _PASSTHROUGH_SUBTYPES.get(data.dtype)
     out: np.ndarray
     if implied == "PCM_32":
-        raise ValueError(
+        msg = (
             f"{path}: FLAC stores integers up to 24 bits (libsndfile), so "
             "int32 codes cannot pass through bit-exact. Convert to float64 "
             "and choose subtype='PCM_24' to accept the 8-bit truncation "
             "explicitly."
         )
+        raise ValueError(msg)
     if implied == "PCM_16":
         resolved = "PCM_16"
         out = _flac_passthrough_codes(data, subtype, dither)

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -225,9 +225,8 @@ class StaticAirflowResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso9053 import render_static_airflow_report
 
         return render_static_airflow_report(
@@ -242,7 +241,8 @@ def linear_airflow_velocity(volume_flow_rate: float, area: float) -> float:
     ``u`` in m/s.
     """
     if volume_flow_rate < 0.0:
-        raise ValueError("'volume_flow_rate' must be non-negative.")
+        msg = "'volume_flow_rate' must be non-negative."
+        raise ValueError(msg)
     if area <= 0.0:
         raise ValueError(_AREA_POSITIVE_MSG)
     return volume_flow_rate / area
@@ -256,9 +256,11 @@ def airflow_resistance(pressure_drop: float, volume_flow_rate: float) -> float:
     ``q_v`` (m3/s). Returns ``R`` in Pa*s/m3.
     """
     if pressure_drop < 0.0:
-        raise ValueError("'pressure_drop' must be non-negative.")
+        msg = "'pressure_drop' must be non-negative."
+        raise ValueError(msg)
     if volume_flow_rate <= 0.0:
-        raise ValueError("'volume_flow_rate' must be positive.")
+        msg = "'volume_flow_rate' must be positive."
+        raise ValueError(msg)
     return pressure_drop / volume_flow_rate
 
 
@@ -284,25 +286,32 @@ def specific_airflow_resistance(
     from_resistance = resistance is not None and area is not None
     from_pressure = pressure_drop is not None and velocity is not None
     if from_resistance == from_pressure:
-        raise ValueError(
+        msg = (
             "Provide exactly one route: ('resistance' and 'area') or "
             "('pressure_drop' and 'velocity')."
         )
+        raise ValueError(msg)
     if resistance is not None and area is not None:
         if resistance < 0.0:
-            raise ValueError("'resistance' must be non-negative.")
+            msg = "'resistance' must be non-negative."
+            raise ValueError(msg)
         if area <= 0.0:
             raise ValueError(_AREA_POSITIVE_MSG)
         return resistance * area
     if pressure_drop is not None and velocity is not None:
         if pressure_drop < 0.0:
-            raise ValueError("'pressure_drop' must be non-negative.")
+            msg = "'pressure_drop' must be non-negative."
+            raise ValueError(msg)
         if velocity <= 0.0:
-            raise ValueError("'velocity' must be positive.")
+            msg = "'velocity' must be positive."
+            raise ValueError(msg)
         return pressure_drop / velocity
-    raise ValueError(  # pragma: no cover - unreachable, guarded above
+    msg = (
         "Provide exactly one route: ('resistance' and 'area') or "
         "('pressure_drop' and 'velocity')."
+    )
+    raise ValueError(  # pragma: no cover - unreachable, guarded above
+        msg
     )
 
 
@@ -313,9 +322,11 @@ def airflow_resistivity(specific_resistance: float, thickness: float) -> float:
     the specimen thickness in the flow direction. Returns ``sigma`` in Pa*s/m2.
     """
     if specific_resistance < 0.0:
-        raise ValueError("'specific_resistance' must be non-negative.")
+        msg = "'specific_resistance' must be non-negative."
+        raise ValueError(msg)
     if thickness <= 0.0:
-        raise ValueError("'thickness' must be positive.")
+        msg = "'thickness' must be positive."
+        raise ValueError(msg)
     return specific_resistance / thickness
 
 
@@ -363,21 +374,28 @@ def static_airflow_resistance(
     u = np.asarray(velocities, dtype=np.float64)
     dp = np.asarray(pressure_drops, dtype=np.float64)
     if u.ndim != 1 or dp.ndim != 1:
-        raise ValueError("'velocities' and 'pressure_drops' must be 1-D.")
+        msg = "'velocities' and 'pressure_drops' must be 1-D."
+        raise ValueError(msg)
     if u.shape != dp.shape:
-        raise ValueError("'velocities' and 'pressure_drops' must have equal length.")
+        msg = "'velocities' and 'pressure_drops' must have equal length."
+        raise ValueError(msg)
     if u.size < 2:
-        raise ValueError("At least two measurement steps are required.")
+        msg = "At least two measurement steps are required."
+        raise ValueError(msg)
     if bool(np.any(u <= 0.0)):
-        raise ValueError("All velocities must be positive.")
+        msg = "All velocities must be positive."
+        raise ValueError(msg)
     if bool(np.any(dp < 0.0)):
-        raise ValueError("All pressure drops must be non-negative.")
+        msg = "All pressure drops must be non-negative."
+        raise ValueError(msg)
     if area <= 0.0:
         raise ValueError(_AREA_POSITIVE_MSG)
     if thickness is not None and thickness <= 0.0:
-        raise ValueError("'thickness' must be positive.")
+        msg = "'thickness' must be positive."
+        raise ValueError(msg)
     if evaluation_velocity <= 0.0:
-        raise ValueError("'evaluation_velocity' must be positive.")
+        msg = "'evaluation_velocity' must be positive."
+        raise ValueError(msg)
 
     _warn_static_velocity_range(u, stacklevel=2)
 
@@ -417,9 +435,11 @@ def piston_volume_flow_rate(
     if frequency <= 0.0:
         raise ValueError(_FREQUENCY_POSITIVE_MSG)
     if stroke_amplitude < 0.0:
-        raise ValueError("'stroke_amplitude' must be non-negative.")
+        msg = "'stroke_amplitude' must be non-negative."
+        raise ValueError(msg)
     if piston_area <= 0.0:
-        raise ValueError("'piston_area' must be positive.")
+        msg = "'piston_area' must be positive."
+        raise ValueError(msg)
     # Normative clause 6.2 form q_v = 2*pi*f*h*A_P verbatim; Annex A.2 prints
     # the rms variant j*omega*A_P*h/sqrt(2) (internal tension in the standard,
     # the normative text wins).
@@ -451,13 +471,17 @@ def thermal_boundary_layer_thickness(
     if frequency <= 0.0:
         raise ValueError(_FREQUENCY_POSITIVE_MSG)
     if speed_of_sound <= 0.0:
-        raise ValueError("'speed_of_sound' must be positive.")
+        msg = "'speed_of_sound' must be positive."
+        raise ValueError(msg)
     if air_density <= 0.0:
-        raise ValueError("'air_density' must be positive.")
+        msg = "'air_density' must be positive."
+        raise ValueError(msg)
     if specific_heat_cp <= 0.0:
-        raise ValueError("'specific_heat_cp' must be positive.")
+        msg = "'specific_heat_cp' must be positive."
+        raise ValueError(msg)
     if thermal_conductivity <= 0.0:
-        raise ValueError("'thermal_conductivity' must be positive.")
+        msg = "'thermal_conductivity' must be positive."
+        raise ValueError(msg)
     omega = 2.0 * math.pi * frequency
     diffusion_length = thermal_conductivity / (
         air_density * speed_of_sound * specific_heat_cp
@@ -499,11 +523,14 @@ def effective_kappa(
     :math:`f = 2` Hz) yields :math:`\kappa' = 1.370`.
     """
     if cavity_surface <= 0.0:
-        raise ValueError("'cavity_surface' must be positive.")
+        msg = "'cavity_surface' must be positive."
+        raise ValueError(msg)
     if cavity_volume <= 0.0:
-        raise ValueError("'cavity_volume' must be positive.")
+        msg = "'cavity_volume' must be positive."
+        raise ValueError(msg)
     if specific_heat_ratio <= 0.0:
-        raise ValueError("'specific_heat_ratio' must be positive.")
+        msg = "'specific_heat_ratio' must be positive."
+        raise ValueError(msg)
     boundary_thickness = thermal_boundary_layer_thickness(
         frequency,
         speed_of_sound=speed_of_sound,
@@ -588,15 +615,20 @@ def alternating_airflow_resistance(
     if frequency <= 0.0:
         raise ValueError(_FREQUENCY_POSITIVE_MSG)
     if cavity_volume <= 0.0:
-        raise ValueError("'cavity_volume' must be positive.")
+        msg = "'cavity_volume' must be positive."
+        raise ValueError(msg)
     if piston_stroke_specimen <= 0.0:
-        raise ValueError("'piston_stroke_specimen' must be positive.")
+        msg = "'piston_stroke_specimen' must be positive."
+        raise ValueError(msg)
     if piston_stroke_termination <= 0.0:
-        raise ValueError("'piston_stroke_termination' must be positive.")
+        msg = "'piston_stroke_termination' must be positive."
+        raise ValueError(msg)
     if static_pressure <= 0.0:
-        raise ValueError("'static_pressure' must be positive.")
+        msg = "'static_pressure' must be positive."
+        raise ValueError(msg)
     if kappa_prime <= 0.0:
-        raise ValueError("'kappa_prime' must be positive.")
+        msg = "'kappa_prime' must be positive."
+        raise ValueError(msg)
 
     low, high = _ALT_FREQUENCY_RANGE
     if not low <= frequency <= high:

--- a/src/phonometry/materials/absorbers/biot.py
+++ b/src/phonometry/materials/absorbers/biot.py
@@ -109,14 +109,17 @@ def _require_shear_modulus(value: complex, name: str) -> complex:
     r"""Validate a complex shear modulus :math:`N = N'(1 + j \eta)`."""
     n = complex(value)
     if not np.isfinite(n):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     if n.real <= 0.0:
-        raise ValueError(f"'{name}' must have a positive real part.")
+        msg = f"'{name}' must have a positive real part."
+        raise ValueError(msg)
     if n.imag < 0.0:
-        raise ValueError(
+        msg = (
             f"'{name}' must have a non-negative imaginary part in the "
             "e^{+j w t} convention (a lossy frame has Im(N) >= 0)."
         )
+        raise ValueError(msg)
     return n
 
 
@@ -124,7 +127,8 @@ def _require_poisson_ratio(value: float) -> float:
     """Validate a Poisson coefficient of an isotropic frame."""
     nu = float(value)
     if not -1.0 < nu < 0.5:
-        raise ValueError("'poisson_ratio' must satisfy -1 < nu < 0,5.")
+        msg = "'poisson_ratio' must satisfy -1 < nu < 0,5."
+        raise ValueError(msg)
     return nu
 
 
@@ -423,7 +427,8 @@ def biot_waves(
         raise ValueError(_POROSITY_MESSAGE)
     alpha_inf = require_positive(tortuosity, "tortuosity")
     if alpha_inf < 1.0:
-        raise ValueError("'tortuosity' must be >= 1.")
+        msg = "'tortuosity' must be >= 1."
+        raise ValueError(msg)
     rho1 = require_positive(frame_density, "frame_density")
     n_mod = _require_shear_modulus(shear_modulus, "shear_modulus")
     nu = _require_poisson_ratio(poisson_ratio)
@@ -785,12 +790,13 @@ def _block_count(attenuation: float, owner: str) -> int:
     """Blocks needed to keep *attenuation* nepers under the budget."""
     pieces = max(1, int(np.ceil(attenuation / _BLOCK_NEPERS)))
     if pieces > _MAX_BLOCKS:
-        raise ValueError(
+        msg = (
             f"{owner} attenuates by {attenuation:.0f} nepers, which the "
             f"global-matrix assembly cannot resolve in {_MAX_BLOCKS} blocks. "
             "Reduce the thickness, or, for a frame with no stiffness, model "
             "the material with limp_frame() instead of a Biot layer."
         )
+        raise ValueError(msg)
     return pieces
 
 

--- a/src/phonometry/materials/absorbers/four_microphone.py
+++ b/src/phonometry/materials/absorbers/four_microphone.py
@@ -101,7 +101,8 @@ def speed_of_sound_astm(temperature: ArrayLike) -> Real:
     """
     t = np.asarray(temperature, dtype=np.float64)
     if np.any(t <= -_ASTM_T0):
-        raise ValueError("'temperature' must exceed -273,15 degC.")
+        msg = "'temperature' must exceed -273,15 degC."
+        raise ValueError(msg)
     return np.asarray(_ASTM_C_CONST * np.sqrt(_ASTM_T0 + t), dtype=np.float64)
 
 
@@ -120,9 +121,11 @@ def air_density_astm(
     t = np.asarray(temperature, dtype=np.float64)
     p = np.asarray(atmospheric_pressure, dtype=np.float64)
     if np.any(t <= -_ASTM_T0):
-        raise ValueError("'temperature' must exceed -273,15 degC.")
+        msg = "'temperature' must exceed -273,15 degC."
+        raise ValueError(msg)
     if np.any(p <= 0.0):
-        raise ValueError("'atmospheric_pressure' must be positive (kPa).")
+        msg = "'atmospheric_pressure' must be positive (kPa)."
+        raise ValueError(msg)
     return np.asarray(
         _ASTM_RHO_REF * (p / _ASTM_P_REF) * (_ASTM_T0 / (_ASTM_T0 + t)),
         dtype=np.float64,
@@ -193,7 +196,8 @@ def _warn_astm_plane_wave(
     every microphone pair (largest spacing), the lower one the smallest.
     """
     if s1 <= 0.0 or s2 <= 0.0:
-        raise ValueError("'s1' and 's2' must be positive.")
+        msg = "'s1' and 's2' must be positive."
+        raise ValueError(msg)
     if diameter <= 0.0:
         raise ValueError(_DIAMETER_POSITIVE)
     k = np.real(np.asarray(wavenumber, dtype=np.complex128))
@@ -275,7 +279,8 @@ def wave_decomposition(
     :return: Tuple ``(A, B, C, D)`` of complex amplitudes.
     """
     if s1 <= 0.0 or s2 <= 0.0:
-        raise ValueError("'s1' and 's2' must be positive.")
+        msg = "'s1' and 's2' must be positive."
+        raise ValueError(msg)
     canonical = _canonical_shape(shape)
     if diameter is not None:
         _warn_astm_plane_wave(
@@ -457,7 +462,8 @@ class TransferMatrix:
         :return: Complex material wavenumber ``k'``, in reciprocal metres.
         """
         if thickness <= 0.0:
-            raise ValueError("'thickness' must be positive.")
+            msg = "'thickness' must be positive."
+            raise ValueError(msg)
         t11 = np.asarray(self.t11, dtype=np.complex128)
         return np.asarray(np.arccos(t11) / thickness, dtype=np.complex128)
 
@@ -515,10 +521,11 @@ class TransferMatrix:
         if characteristic_impedance is None:
             characteristic_impedance = self.air_characteristic_impedance
         if frequency is None or characteristic_impedance is None:
-            raise ValueError(
+            msg = (
                 "'frequency' and 'characteristic_impedance' must be supplied "
                 "when the matrix does not retain them (hand-built matrices)."
             )
+            raise ValueError(msg)
         from ..._i18n import check_language
         from ..._plot.materials import plot_transfer_matrix
 
@@ -572,7 +579,8 @@ def air_layer_transfer_matrix(
     if characteristic_impedance <= 0.0:
         raise ValueError(_IMPEDANCE_POSITIVE)
     if thickness <= 0.0:
-        raise ValueError("'thickness' must be positive.")
+        msg = "'thickness' must be positive."
+        raise ValueError(msg)
     rc = characteristic_impedance
     k = np.asarray(wavenumber, dtype=np.complex128)
     kd = k * thickness

--- a/src/phonometry/materials/absorbers/impedance_tube.py
+++ b/src/phonometry/materials/absorbers/impedance_tube.py
@@ -122,7 +122,8 @@ def speed_of_sound_iso(temperature: ArrayLike) -> Real:
     """
     t = np.asarray(temperature, dtype=np.float64)
     if np.any(t <= 0.0):
-        raise ValueError("'temperature' must be positive (kelvin).")
+        msg = "'temperature' must be positive (kelvin)."
+        raise ValueError(msg)
     return np.asarray(_ISO_C_REF * np.sqrt(t / _ISO_T_REF), dtype=np.float64)
 
 
@@ -142,9 +143,11 @@ def air_density_iso(
     t = np.asarray(temperature, dtype=np.float64)
     pa = np.asarray(atmospheric_pressure, dtype=np.float64)
     if np.any(t <= 0.0):
-        raise ValueError("'temperature' must be positive (kelvin).")
+        msg = "'temperature' must be positive (kelvin)."
+        raise ValueError(msg)
     if np.any(pa <= 0.0):
-        raise ValueError("'atmospheric_pressure' must be positive (kPa).")
+        msg = "'atmospheric_pressure' must be positive (kPa)."
+        raise ValueError(msg)
     return np.asarray(
         _ISO_RHO_REF * (pa * _ISO_T_REF) / (_ISO_P_REF * t), dtype=np.float64
     )
@@ -158,9 +161,8 @@ def _canonical_shape(shape: str) -> str:
     try:
         return _SHAPE_ALIASES[shape]
     except KeyError:
-        raise ValueError(
-            "'shape' must be 'circular', 'rectangular' or 'square'."
-        ) from None
+        msg = "'shape' must be 'circular', 'rectangular' or 'square'."
+        raise ValueError(msg) from None
 
 
 def hydraulic_diameter(width: float, height: float) -> float:
@@ -177,7 +179,8 @@ def hydraulic_diameter(width: float, height: float) -> float:
     :return: Hydraulic diameter :math:`d_\mathrm{h} = 4A/P`, in metres.
     """
     if width <= 0.0 or height <= 0.0:
-        raise ValueError("'width' and 'height' must be positive.")
+        msg = "'width' and 'height' must be positive."
+        raise ValueError(msg)
     return float(2.0 * width * height / (width + height))
 
 
@@ -203,7 +206,8 @@ def tube_attenuation_constant(
         raise ValueError(_DIAMETER_POSITIVE)
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f < 0.0):
-        raise ValueError("'frequency' must be non-negative.")
+        msg = "'frequency' must be non-negative."
+        raise ValueError(msg)
     return np.asarray(
         _ISO_ATTEN_CONST * np.sqrt(f) / (speed_of_sound * diameter),
         dtype=np.float64,
@@ -274,9 +278,11 @@ def reflection_factor(
     :return: Complex reflection factor ``r`` at the reference plane.
     """
     if spacing <= 0.0:
-        raise ValueError("'spacing' must be positive.")
+        msg = "'spacing' must be positive."
+        raise ValueError(msg)
     if x1 <= 0.0:
-        raise ValueError("'x1' must be positive.")
+        msg = "'x1' must be positive."
+        raise ValueError(msg)
     h = np.asarray(h12, dtype=np.complex128)
     k0 = np.asarray(wavenumber, dtype=np.complex128)
     h_i = np.exp(-1j * k0 * spacing)
@@ -310,7 +316,8 @@ def surface_impedance(
     :return: Surface impedance ``Z``, in rayls (complex).
     """
     if characteristic_impedance <= 0.0:
-        raise ValueError("'characteristic_impedance' must be positive.")
+        msg = "'characteristic_impedance' must be positive."
+        raise ValueError(msg)
     return np.asarray(
         characteristic_impedance * normalized_surface_impedance(reflection),
         dtype=np.complex128,
@@ -426,7 +433,8 @@ def _frequency_range(
 ) -> tuple[float, float]:
     """Shared ISO/ASTM plane-wave frequency-range arithmetic."""
     if spacing <= 0.0:
-        raise ValueError("'spacing' must be positive.")
+        msg = "'spacing' must be positive."
+        raise ValueError(msg)
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_OF_SOUND_POSITIVE)
     canonical = _canonical_shape(shape)
@@ -570,9 +578,8 @@ class ImpedanceTubeResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso10534 import render_iso10534_report
 
         return render_iso10534_report(
@@ -650,5 +657,6 @@ def characteristic_impedance(density: float, speed_of_sound: float) -> float:
     :return: Characteristic impedance ``rho c``, in rayls.
     """
     if density <= 0.0 or speed_of_sound <= 0.0:
-        raise ValueError("'density' and 'speed_of_sound' must be positive.")
+        msg = "'density' and 'speed_of_sound' must be positive."
+        raise ValueError(msg)
     return float(density * speed_of_sound)

--- a/src/phonometry/materials/absorbers/layered.py
+++ b/src/phonometry/materials/absorbers/layered.py
@@ -326,7 +326,8 @@ def _sheet_impedance(
             surface_density=layer.surface_density,
             resistance=layer.resistance,
         )
-    raise TypeError(f"not a sheet layer: {layer!r}")  # pragma: no cover
+    msg = f"not a sheet layer: {layer!r}"
+    raise TypeError(msg)  # pragma: no cover
 
 
 def _fluid_layer_terms(
@@ -448,17 +449,18 @@ def _termination_impedance(
             return None
         if termination == "free":
             return np.full(f.shape, rc / cos_t, dtype=np.complex128)
-        raise ValueError(
-            "'termination' must be 'rigid', 'free' or a complex impedance."
-        )
+        msg = "'termination' must be 'rigid', 'free' or a complex impedance."
+        raise ValueError(msg)
     zl_arr = np.asarray(termination, dtype=np.complex128)
     if zl_arr.ndim > 0 and zl_arr.shape != f.shape:
-        raise ValueError(
+        msg = (
             "'termination' impedance array must be scalar or match the "
             f"frequency vector length ({f.size}), got {zl_arr.size}."
         )
+        raise ValueError(msg)
     if not np.all(np.abs(zl_arr) > 0.0):
-        raise ValueError("'termination' impedance must be non-zero.")
+        msg = "'termination' impedance must be non-zero."
+        raise ValueError(msg)
     return np.asarray(np.broadcast_to(zl_arr, f.shape), dtype=np.complex128)
 
 
@@ -509,10 +511,11 @@ def _chain_matrix(terms: list[tuple[str, Complex, Complex]], f: Real) -> Complex
 def _check_medium_grid(medium: PorousMediumResult, f: Real, owner: str) -> None:
     """Reject a medium evaluated on a different frequency vector."""
     if not np.array_equal(np.asarray(medium.frequency), f):
-        raise ValueError(
+        msg = (
             f"{owner}.medium was evaluated on a different frequency "
             "vector; rebuild the medium on the solver grid."
         )
+        raise ValueError(msg)
 
 
 def _split_fluid_run(
@@ -543,12 +546,13 @@ def _split_fluid_run(
     # Checked before the run is expanded, so an absurd input cannot build the
     # sub-layer list it would then be refused for.
     if attenuation > budget * limit:
-        raise ValueError(
+        msg = (
             f"the fluid layers of the stack attenuate by {attenuation:.0f} "
             f"nepers, which the global-matrix assembly cannot resolve in "
             f"{limit} blocks. Reduce their thickness: nothing behind such a "
             "run contributes to the surface impedance."
         )
+        raise ValueError(msg)
 
     parts: list[tuple[str, Complex, Complex, float]] = []
     for (kind, a, b), loss in zip(terms, losses):
@@ -575,12 +579,13 @@ def _split_fluid_run(
     # into more blocks than the assembly resolves. Refuse on what was actually
     # produced rather than on what was estimated.
     if len(groups) > limit:
-        raise ValueError(
+        msg = (
             f"the fluid layers of the stack pack into {len(groups)} chain "
             f"blocks of at most {budget:.0f} nepers, more than the {limit} "
             "the global-matrix assembly can resolve. Reduce their thickness: "
             "nothing behind such a run contributes to the surface impedance."
         )
+        raise ValueError(msg)
     return groups
 
 
@@ -703,13 +708,15 @@ def layered_absorber(
     """
     f = require_positive_array(frequency, "frequency")
     if not layers:
-        raise ValueError("'layers' must contain at least one layer.")
+        msg = "'layers' must contain at least one layer."
+        raise ValueError(msg)
     theta = float(angle)
     # The last ~3e-8 rad below pi/2 round sin(theta)**2 to 1.0, driving the
     # in-depth wavenumber of an air layer to exactly zero (inf * 0 = nan in
     # the recursion); reject effectively grazing input with a clear error.
     if not 0.0 <= theta < np.pi / 2.0 - 1e-6:
-        raise ValueError("'angle' must satisfy 0 <= angle < pi/2 - 1e-6.")
+        msg = "'angle' must satisfy 0 <= angle < pi/2 - 1e-6."
+        raise ValueError(msg)
     c0 = require_positive(speed_of_sound, "speed_of_sound")
     rho0 = require_positive(air_density, "air_density")
     require_positive(viscosity, "viscosity")
@@ -733,7 +740,8 @@ def layered_absorber(
             transverse_wavenumber=np.asarray(k0 * np.sin(theta)),
         )
         if not blocks:
-            raise ValueError("'layers' must contain at least one layer.")
+            msg = "'layers' must contain at least one layer."
+            raise ValueError(msg)
         zs = biot._stack_surface_impedance(
             blocks, _termination_impedance(termination, f, cos_t=cos_t, rc=rc)
         )
@@ -815,10 +823,12 @@ def diffuse_field_absorption(
     f = require_positive_array(frequency, "frequency")
     lim = float(angle_limit)
     if not 0.0 < lim <= np.pi / 2.0:
-        raise ValueError("'angle_limit' must satisfy 0 < angle_limit <= pi/2.")
+        msg = "'angle_limit' must satisfy 0 < angle_limit <= pi/2."
+        raise ValueError(msg)
     n = int(quadrature_points)
     if n < 2:
-        raise ValueError("'quadrature_points' must be at least 2.")
+        msg = "'quadrature_points' must be at least 2."
+        raise ValueError(msg)
     nodes, weights = np.polynomial.legendre.leggauss(n)
     theta = 0.5 * lim * (nodes + 1.0)
     w = 0.5 * lim * weights
@@ -875,10 +885,12 @@ def statistical_absorption(
     """
     z = np.asarray(normalized_impedance, dtype=np.complex128)
     if np.any(z.real <= 0.0):
-        raise ValueError("'normalized_impedance' must have a positive real part.")
+        msg = "'normalized_impedance' must have a positive real part."
+        raise ValueError(msg)
     lim = float(angle_limit)
     if not 0.0 < lim <= np.pi / 2.0:
-        raise ValueError("'angle_limit' must satisfy 0 < angle_limit <= pi/2.")
+        msg = "'angle_limit' must satisfy 0 < angle_limit <= pi/2."
+        raise ValueError(msg)
     g = 1.0 / z
     g1 = g.real
     g2 = g.imag

--- a/src/phonometry/materials/absorbers/porous.py
+++ b/src/phonometry/materials/absorbers/porous.py
@@ -347,15 +347,15 @@ def delany_bazley(
             coeffs = DELANY_BAZLEY_COEFFICIENTS[coefficients]
         except KeyError:
             options = ", ".join(sorted(DELANY_BAZLEY_COEFFICIENTS))
-            raise ValueError(
-                f"unknown coefficient preset {coefficients!r}; options: {options}."
-            ) from None
+            msg = f"unknown coefficient preset {coefficients!r}; options: {options}."
+            raise ValueError(msg) from None
         model = f"delany_bazley[{coefficients}]"
     else:
         coeffs = tuple(float(v) for v in coefficients)
         model = "delany_bazley[custom]"
     if len(coeffs) != 8:
-        raise ValueError("'coefficients' must provide exactly 8 values C1..C8.")
+        msg = "'coefficients' must provide exactly 8 values C1..C8."
+        raise ValueError(msg)
     c1, c2, c3, c4, c5, c6, c7, c8 = coeffs
     x = np.asarray(rho0 * f / sigma, dtype=np.float64)
     _warn_fit_range(x, DELANY_BAZLEY_VALIDITY, "X = rho f / sigma", "Delany-Bazley")
@@ -484,7 +484,8 @@ def johnson_champoux_allard(
         raise ValueError(_POROSITY_MESSAGE)
     t_inf = require_positive(tortuosity, "tortuosity")
     if t_inf < 1.0:
-        raise ValueError("'tortuosity' must be >= 1.")
+        msg = "'tortuosity' must be >= 1."
+        raise ValueError(msg)
     lam_v = require_positive(viscous_length, "viscous_length")
     lam_t = require_positive(thermal_length, "thermal_length")
     c0 = require_positive(speed_of_sound, "speed_of_sound")

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -178,21 +178,23 @@ def _coerce(
             elif float(c) in values:
                 out.append(float(values[float(c)]))
             else:
-                raise ValueError(
-                    f"{name} mapping is missing band {c} Hz; expected keys {centers}"
-                )
+                msg = f"{name} mapping is missing band {c} Hz; expected keys {centers}"
+                raise ValueError(msg)
     else:
         arr = np.asarray(values, dtype=np.float64)
         if arr.ndim != 1:
-            raise ValueError(f"{name} must be 1-D, got shape {arr.shape}.")
+            msg = f"{name} must be 1-D, got shape {arr.shape}."
+            raise ValueError(msg)
         out = arr.tolist()
         if len(out) != len(centers):
-            raise ValueError(
+            msg = (
                 f"{name} must have {len(centers)} values for bands {centers}, "
                 f"got {len(out)}"
             )
+            raise ValueError(msg)
     if not all(math.isfinite(v) for v in out):
-        raise ValueError(f"{name} values must all be finite (no NaN or inf).")
+        msg = f"{name} values must all be finite (no NaN or inf)."
+        raise ValueError(msg)
     return out
 
 
@@ -307,9 +309,8 @@ class AbsorptionRatingResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso11654 import render_iso11654_report
 
         return render_iso11654_report(
@@ -338,7 +339,8 @@ def practical_absorption_coefficient(
     """
     values = _coerce(third_octave_alpha_s, THIRD_OCTAVE_BANDS, "third_octave_alpha_s")
     if any(v < 0.0 for v in values):
-        raise ValueError("alpha_s values must be non-negative")
+        msg = "alpha_s values must be non-negative"
+        raise ValueError(msg)
     alpha_p = [
         _practical_round((values[3 * i] + values[3 * i + 1] + values[3 * i + 2]) / 3.0)
         for i in range(len(OCTAVE_BANDS))

--- a/src/phonometry/materials/absorbers/slow_sound.py
+++ b/src/phonometry/materials/absorbers/slow_sound.py
@@ -233,7 +233,8 @@ def rectangular_duct_properties(
     p0 = air.atmospheric_pressure
     n = int(sum_terms)
     if n < 1:
-        raise ValueError("'sum_terms' must be at least 1.")
+        msg = "'sum_terms' must be at least 1."
+        raise ValueError(msg)
 
     kappa0 = gamma * p0
     omega = 2.0 * np.pi * np.atleast_1d(f).astype(np.float64)
@@ -312,9 +313,8 @@ def _slit_resonator_ducts(
 ) -> tuple[Complex, Complex, Complex, Complex, Complex, Complex, float]:
     """Duct parameters of the 2-D resonator (Sci. Rep. Eqs. (8)-(12))."""
     if slit_height is None or lattice_step is None:
-        raise ValueError(
-            "The 'slit' resonator geometry requires 'slit_height' and 'lattice_step'."
-        )
+        msg = "The 'slit' resonator geometry requires 'slit_height' and 'lattice_step'."
+        raise ValueError(msg)
     h = require_positive(slit_height, "slit_height")
     a = require_positive(lattice_step, "lattice_step")
     rho_n, kap_n = slit_effective_properties(f, slit_height=wn, air=air)
@@ -426,7 +426,8 @@ def helmholtz_resonator_impedance(
     lc = require_positive(resonator.cavity_length, "cavity_length")
     wc = require_positive(resonator.cavity_side, "cavity_side")
     if geometry not in ("square", "slit"):
-        raise ValueError("'geometry' must be 'square' or 'slit'.")
+        msg = "'geometry' must be 'square' or 'slit'."
+        raise ValueError(msg)
     omega = 2.0 * np.pi * f
     if geometry == "slit":
         rho_n, kap_n, rho_c, kap_c, z_n, z_c, dl = _slit_resonator_ducts(
@@ -666,17 +667,20 @@ def slit_helmholtz_absorber(
         resonators = (resonators,)
     res = tuple(resonators)
     if not res:
-        raise ValueError("'resonators' must contain at least one resonator.")
+        msg = "'resonators' must contain at least one resonator."
+        raise ValueError(msg)
     h = require_positive(slit_height, "slit_height")
     a = require_positive(lattice_step, "lattice_step")
     d = require_positive(period, "period")
     if h > d:
-        raise ValueError("'slit_height' must not exceed 'period'.")
+        msg = "'slit_height' must not exceed 'period'."
+        raise ValueError(msg)
     c0 = air.speed_of_sound
     rho0 = air.density
     theta = float(angle)
     if not 0.0 <= theta < np.pi / 2.0 - 1e-6:
-        raise ValueError("'angle' must satisfy 0 <= angle < pi/2 - 1e-6.")
+        msg = "'angle' must satisfy 0 <= angle < pi/2 - 1e-6."
+        raise ValueError(msg)
 
     omega = 2.0 * np.pi * f
     tm = _panel_transfer_matrix(
@@ -819,7 +823,8 @@ def critical_coupling_design(
     rho0 = air.density
     theta = float(angle)
     if not 0.0 <= theta < np.pi / 2.0 - 1e-6:
-        raise ValueError("'angle' must satisfy 0 <= angle < pi/2 - 1e-6.")
+        msg = "'angle' must satisfy 0 <= angle < pi/2 - 1e-6."
+        raise ValueError(msg)
     h_lo, h_hi = slit_height_bounds
     lc_lo, lc_hi = cavity_length_bounds
     cos_t = float(np.cos(theta))

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -142,7 +142,8 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
     """
     if speed_of_sound is not None:
         if speed_of_sound <= 0.0:
-            raise ValueError("'speed_of_sound' must be positive.")
+            msg = "'speed_of_sound' must be positive."
+            raise ValueError(msg)
         return float(speed_of_sound)
     lo, hi = _EQ6_TEMPERATURE_RANGE
     if not lo <= temperature <= hi:
@@ -171,7 +172,8 @@ def attenuation_from_alpha(alpha: ArrayLike) -> NDArray[np.float64]:
     """
     a = np.asarray(alpha, dtype=np.float64)
     if np.any(a < 0.0):
-        raise ValueError("'alpha' must be non-negative.")
+        msg = "'alpha' must be non-negative."
+        raise ValueError(msg)
     return a / _TEN_LG_E
 
 
@@ -179,15 +181,17 @@ def _validate_area_inputs(
     t: NDArray[np.float64], volume: float, m: NDArray[np.float64]
 ) -> None:
     if volume <= 0.0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     if np.any(t <= 0.0):
-        raise ValueError("Reverberation times must be positive.")
+        msg = "Reverberation times must be positive."
+        raise ValueError(msg)
     if np.any(m < 0.0):
-        raise ValueError("Air attenuation coefficient 'm' must be non-negative.")
+        msg = "Air attenuation coefficient 'm' must be non-negative."
+        raise ValueError(msg)
     if m.ndim != 0 and m.shape != t.shape:
-        raise ValueError(
-            "'m' must be a scalar or an array matching the shape of 't60'."
-        )
+        msg = "'m' must be a scalar or an array matching the shape of 't60'."
+        raise ValueError(msg)
 
 
 def _absorption_area(
@@ -309,9 +313,11 @@ def absorption_coefficient(
         ``t1`` and ``t2``.
     """
     if sample_area <= 0.0:
-        raise ValueError("'sample_area' must be positive.")
+        msg = "'sample_area' must be positive."
+        raise ValueError(msg)
     if volume <= 0.0:
-        raise ValueError("'volume' must be positive.")
+        msg = "'volume' must be positive."
+        raise ValueError(msg)
     if temperature2 is None:
         temperature2 = temperature1
     if speed_of_sound2 is None:
@@ -475,9 +481,8 @@ class SoundAbsorptionMeasurement:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso354 import render_iso354_report
 
         return render_iso354_report(
@@ -548,10 +553,11 @@ def measure_sound_absorption(
     t1 = np.asarray(t_empty, dtype=np.float64)
     t2 = np.asarray(t_specimen, dtype=np.float64)
     if not (freqs.shape == t1.shape == t2.shape):
-        raise ValueError(
+        msg = (
             "'frequencies', 't_empty' and 't_specimen' must share one shape; "
             f"got {freqs.shape}, {t1.shape} and {t2.shape}."
         )
+        raise ValueError(msg)
     m_arr = np.broadcast_to(np.asarray(m, dtype=np.float64), freqs.shape).astype(
         np.float64, copy=True
     )

--- a/src/phonometry/materials/absorbers/standing_wave.py
+++ b/src/phonometry/materials/absorbers/standing_wave.py
@@ -52,13 +52,15 @@ def standing_wave_ratio_from_level(level_difference: ArrayLike) -> Real:
     """
     dl = np.asarray(level_difference, dtype=np.float64)
     if np.any(dl < 0.0):
-        raise ValueError("'level_difference' must be non-negative.")
+        msg = "'level_difference' must be non-negative."
+        raise ValueError(msg)
     return np.asarray(10.0 ** (dl / 20.0), dtype=np.float64)
 
 
 def _check_swr(swr: NDArray[np.float64]) -> None:
     if np.any(swr < 1.0):
-        raise ValueError("Standing-wave ratio 's' must be >= 1.")
+        msg = "Standing-wave ratio 's' must be >= 1."
+        raise ValueError(msg)
 
 
 def standing_wave_reflection_magnitude(swr: ArrayLike) -> Real:
@@ -94,9 +96,11 @@ def _standing_wave_phase(
 ) -> NDArray[np.float64]:
     """Reflection phase from the first minimum (ISO 10534-1, Eq. (20))."""
     if np.any(wavelength <= 0.0):
-        raise ValueError("'wavelength' must be positive.")
+        msg = "'wavelength' must be positive."
+        raise ValueError(msg)
     if np.any(first_min_distance < 0.0):
-        raise ValueError("'first_min_distance' must be non-negative.")
+        msg = "'first_min_distance' must be non-negative."
+        raise ValueError(msg)
     return np.asarray(
         np.pi * (4.0 * first_min_distance / wavelength - 1.0), dtype=np.float64
     )

--- a/src/phonometry/materials/absorbers/uncertainty.py
+++ b/src/phonometry/materials/absorbers/uncertainty.py
@@ -135,9 +135,8 @@ _COEFFICIENT_QUANTITIES = frozenset(
 
 def _condition(condition: str) -> str:
     if condition not in _CONDITIONS:
-        raise ValueError(
-            f"'condition' must be one of {_CONDITIONS}; got {condition!r}."
-        )
+        msg = f"'condition' must be one of {_CONDITIONS}; got {condition!r}."
+        raise ValueError(msg)
     return condition
 
 
@@ -146,7 +145,8 @@ def _finite_bands(
 ) -> np.ndarray:
     a = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if not np.all(np.isfinite(a)):
-        raise ValueError(f"'{name}' must contain only finite values.")
+        msg = f"'{name}' must contain only finite values."
+        raise ValueError(msg)
     return a
 
 
@@ -167,9 +167,10 @@ def absorption_coverage_factor(confidence: float = 0.95) -> float:
         if abs(level - confidence) < 1e-9:
             return k
     valid = ", ".join(f"{level:g}" for level in _COVERAGE_FACTORS)
-    raise ValueError(
+    msg = (
         f"Confidence level {confidence!r} is not tabulated in Table 3. Valid: {valid}."
     )
+    raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -240,10 +241,11 @@ def _table_constants(
         mn = np.array([table[float(f)] for f in frequencies], dtype=np.float64)
     except KeyError as exc:
         valid = ", ".join(f"{f:g}" for f in table)
-        raise ValueError(
+        msg = (
             f"Frequency {exc.args[0]:g} Hz is not a tabulated {band_kind} band. "
             f"Valid: {valid}."
-        ) from None
+        )
+        raise ValueError(msg) from None
     return mn[:, 0], mn[:, 1]
 
 
@@ -261,10 +263,11 @@ def _band_uncertainty(
     :math:`\sigma_\mathrm{R} = m \alpha + n` (values == α).
     """
     if values.shape != frequencies.shape:
-        raise ValueError(
+        msg = (
             f"'{quantity}' values and frequencies must have the same shape; "
             f"got {values.shape} and {frequencies.shape}."
         )
+        raise ValueError(msg)
     m, n = _table_constants(frequencies, table, band_kind)
     sigma_r = m * values + n
     u = sigma_r if condition == "reproducibility" else _REPEATABILITY_FACTOR * sigma_r
@@ -336,10 +339,11 @@ def equivalent_area_uncertainty(
     a = _finite_bands(area, "area")
     f = _finite_bands(frequencies, "frequencies")
     if a.shape != f.shape:
-        raise ValueError(
+        msg = (
             f"'area' values and frequencies must have the same shape; "
             f"got {a.shape} and {f.shape}."
         )
+        raise ValueError(msg)
     m, n = _table_constants(f, _TABLE1, "one-third-octave")
     cond = _condition(condition)
     sigma_r = m * a + n * _EQUIV_AREA_REFERENCE_S
@@ -458,7 +462,8 @@ def single_number_rating_uncertainty(
     """
     value = float(dl_alpha)
     if not np.isfinite(value) or value < 0.0:
-        raise ValueError("'dl_alpha' must be a non-negative, finite value.")
+        msg = "'dl_alpha' must be a non-negative, finite value."
+        raise ValueError(msg)
     cond = _condition(condition)
     return _single_number(
         value,

--- a/src/phonometry/materials/diffusers/design.py
+++ b/src/phonometry/materials/diffusers/design.py
@@ -106,7 +106,8 @@ def _positive_scalar(value: float, name: str) -> float:
     """Return ``value`` as a positive, finite float or raise ``ValueError``."""
     v = float(value)
     if not math.isfinite(v) or v <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return v
 
 
@@ -114,12 +115,15 @@ def _prime_generator(prime: int) -> int:
     """Return ``prime`` as an odd prime >= 3 or raise ``ValueError``."""
     n = int(prime)
     if n != prime:
-        raise ValueError("'prime' must be an integer.")
+        msg = "'prime' must be an integer."
+        raise ValueError(msg)
     if n < 3 or n % 2 == 0:
-        raise ValueError("'prime' must be an odd prime >= 3.")
+        msg = "'prime' must be an odd prime >= 3."
+        raise ValueError(msg)
     for factor in range(3, math.isqrt(n) + 1, 2):
         if n % factor == 0:
-            raise ValueError(f"'prime' must be prime; {n} is divisible by {factor}.")
+            msg = f"'prime' must be prime; {n} is divisible by {factor}."
+            raise ValueError(msg)
     return n
 
 
@@ -233,9 +237,8 @@ def _polar_levels(pressure: Complex) -> Real:
     magnitude = np.abs(np.asarray(pressure, dtype=np.complex128))
     peak = float(np.max(magnitude))
     if peak <= 0.0:
-        raise ValueError(
-            "The predicted polar response carries no energy; check the inputs."
-        )
+        msg = "The predicted polar response carries no energy; check the inputs."
+        raise ValueError(msg)
     ratio = magnitude / peak
     floor = 1e-10  # -200 dB relative to the peak.
     return np.asarray(20.0 * np.log10(np.maximum(ratio, floor)), dtype=np.float64)
@@ -317,21 +320,24 @@ def _resolve_reflection(
     sequence) must be given.
     """
     if (depths is None) == (reflection is None):
-        raise ValueError("Provide exactly one of 'depths' or 'reflection'.")
+        msg = "Provide exactly one of 'depths' or 'reflection'."
+        raise ValueError(msg)
     if reflection is not None:
         r = np.atleast_1d(np.asarray(reflection, dtype=np.complex128))
         if r.ndim != 1 or r.size < 2:
-            raise ValueError(
-                "'reflection' must be a 1-D sequence of at least two wells."
-            )
+            msg = "'reflection' must be a 1-D sequence of at least two wells."
+            raise ValueError(msg)
         if not np.all(np.isfinite(r)):
-            raise ValueError("'reflection' values must be finite.")
+            msg = "'reflection' values must be finite."
+            raise ValueError(msg)
         return r
     d = np.atleast_1d(np.asarray(depths, dtype=np.float64))
     if d.ndim != 1 or d.size < 2:
-        raise ValueError("'depths' must be a 1-D sequence of at least two wells.")
+        msg = "'depths' must be a 1-D sequence of at least two wells."
+        raise ValueError(msg)
     if not np.all(np.isfinite(d)) or np.any(d < 0.0):
-        raise ValueError("'depths' values must be finite and non-negative.")
+        msg = "'depths' values must be finite and non-negative."
+        raise ValueError(msg)
     k = 2.0 * np.pi * frequency / speed_of_sound
     return np.asarray(np.exp(-2j * k * d), dtype=np.complex128)
 
@@ -350,15 +356,19 @@ def _prepare_geometry(
     c = _positive_scalar(speed_of_sound, "speed_of_sound")
     ang = np.atleast_1d(np.asarray(angles, dtype=np.float64))
     if ang.ndim != 1 or ang.size < 2:
-        raise ValueError("'angles' must be a 1-D sequence of at least two angles.")
+        msg = "'angles' must be a 1-D sequence of at least two angles."
+        raise ValueError(msg)
     if not np.all(np.isfinite(ang)):
-        raise ValueError("'angles' values must be finite.")
+        msg = "'angles' values must be finite."
+        raise ValueError(msg)
     psi = float(source_angle)
     if not math.isfinite(psi):
-        raise ValueError("'source_angle' must be finite.")
+        msg = "'source_angle' must be finite."
+        raise ValueError(msg)
     n_periods = int(periods)
     if n_periods != periods or n_periods < 1:
-        raise ValueError("'periods' must be an integer of at least 1.")
+        msg = "'periods' must be an integer of at least 1."
+        raise ValueError(msg)
     return w, f, ang, psi, n_periods, c
 
 
@@ -520,14 +530,16 @@ def predicted_diffusion_spectrum(
         if ``reflection_of`` is not ``None``.
     """
     if reflection_of is not None:
-        raise ValueError(
+        msg = (
             "'reflection_of' is reserved for a future frequency-dependent "
             "reflection model and must be None; build the spectrum from "
             "predict_diffuser_polar_response for an explicit reflection model."
         )
+        raise ValueError(msg)
     freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if freqs.ndim != 1 or freqs.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D sequence.")
+        msg = "'frequencies' must be a non-empty 1-D sequence."
+        raise ValueError(msg)
     d_period = np.atleast_1d(np.asarray(depths, dtype=np.float64))
     flat = np.zeros_like(d_period)
 

--- a/src/phonometry/materials/diffusers/metadiffuser.py
+++ b/src/phonometry/materials/diffusers/metadiffuser.py
@@ -82,7 +82,8 @@ class MetadiffuserWell:
         """Reject a non-positive ``slit_height`` and a well with no resonators."""
         require_positive(self.slit_height, "slit_height")
         if not self.resonators:
-            raise ValueError("'resonators' must contain at least one resonator.")
+            msg = "'resonators' must contain at least one resonator."
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -147,17 +148,20 @@ def _check_panel(
     require_positive(period, "period")
     cells = tuple(wells)
     if len(cells) < 2:
-        raise ValueError("'wells' must contain at least two wells.")
+        msg = "'wells' must contain at least two wells."
+        raise ValueError(msg)
     for i, well in enumerate(cells):
         if well is None:
             continue
         if not isinstance(well, MetadiffuserWell):
-            raise TypeError(
+            msg = (
                 f"wells[{i}] must be a MetadiffuserWell or None, "
                 f"got {type(well).__name__}."
             )
+            raise TypeError(msg)
         if well.slit_height >= period:
-            raise ValueError(f"wells[{i}].slit_height must be smaller than the period.")
+            msg = f"wells[{i}].slit_height must be smaller than the period."
+            raise ValueError(msg)
     return cells
 
 
@@ -339,7 +343,8 @@ def metadiffuser_diffusion_spectrum(
     """
     freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if freqs.ndim != 1 or freqs.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D sequence.")
+        msg = "'frequencies' must be a non-empty 1-D sequence."
+        raise ValueError(msg)
     cells = _check_panel(wells, depth, period)
     flat = np.ones(len(cells), dtype=np.complex128)
     result = metadiffuser_reflection(

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -141,7 +141,8 @@ def _positive_scalar(value: float, name: str) -> float:
     """Return ``value`` as a positive float or raise ``ValueError``."""
     v = float(value)
     if not math.isfinite(v) or v <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return v
 
 
@@ -149,9 +150,11 @@ def _positive_array(value: ArrayLike, name: str) -> Real:
     """Return ``value`` as a positive float array or raise ``ValueError``."""
     arr = np.asarray(value, dtype=np.float64)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' values must be finite.")
+        msg = f"'{name}' values must be finite."
+        raise ValueError(msg)
     if np.any(arr <= 0.0):
-        raise ValueError(f"'{name}' values must be positive.")
+        msg = f"'{name}' values must be positive."
+        raise ValueError(msg)
     return arr
 
 
@@ -159,9 +162,11 @@ def _nonneg_array(value: ArrayLike, name: str) -> Real:
     """Return ``value`` as a non-negative float array or raise ``ValueError``."""
     arr = np.asarray(value, dtype=np.float64)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' values must be finite.")
+        msg = f"'{name}' values must be finite."
+        raise ValueError(msg)
     if np.any(arr < 0.0):
-        raise ValueError(f"'{name}' values must be non-negative.")
+        msg = f"'{name}' values must be non-negative."
+        raise ValueError(msg)
     return arr
 
 
@@ -181,7 +186,8 @@ def speed_of_sound(temperature: ArrayLike) -> Real:
     t = np.asarray(temperature, dtype=np.float64)
     kelvin = _T0 + t
     if np.any(kelvin <= 0.0):
-        raise ValueError("'temperature' must exceed -273,15 degC.")
+        msg = "'temperature' must exceed -273,15 degC."
+        raise ValueError(msg)
     return np.asarray(_C_REF * np.sqrt(kelvin / _T_REF_K), dtype=np.float64)
 
 
@@ -347,7 +353,8 @@ def scattering_coefficient(
     diff = np.asarray(alpha_s, dtype=np.float64)
     denom = 1.0 - diff
     if np.any(np.isclose(denom, 0.0)):
-        raise ValueError("'alpha_s' must not equal 1 (division by zero).")
+        msg = "'alpha_s' must not equal 1 (division by zero)."
+        raise ValueError(msg)
     s = (spec - diff) / denom
     if truncate_negative:
         s = np.maximum(s, 0.0)
@@ -428,9 +435,8 @@ class ScatteringResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso17497 import render_scattering_report
 
         return render_scattering_report(
@@ -469,10 +475,11 @@ def scattering_coefficient_spectrum(
         or freq.shape != spec.shape
         or freq.shape != rand.shape
     ):
-        raise ValueError(
+        msg = (
             "'frequencies', 'specular_absorption' and 'random_absorption' must "
             "be non-empty, 1-D and equal-length."
         )
+        raise ValueError(msg)
     s = scattering_coefficient(spec, rand, truncate_negative=truncate_negative)
     return ScatteringResult(
         frequencies=freq,
@@ -547,17 +554,19 @@ def check_base_plate_scattering(
             elif float(band) in scattering:
                 values[band] = float(scattering[float(band)])
             else:
-                raise ValueError(
+                msg = (
                     f"scattering mapping is missing band {band} Hz; "
                     f"expected keys {BASE_PLATE_BANDS}"
                 )
+                raise ValueError(msg)
     else:
         arr = np.asarray(scattering, dtype=np.float64)
         if arr.ndim != 1 or arr.size != len(BASE_PLATE_BANDS):
-            raise ValueError(
+            msg = (
                 f"scattering must have {len(BASE_PLATE_BANDS)} values for "
                 f"bands {BASE_PLATE_BANDS}, got shape {arr.shape}"
             )
+            raise ValueError(msg)
         values = dict(zip(BASE_PLATE_BANDS, arr.tolist()))
     exceeded = tuple(
         band
@@ -596,10 +605,12 @@ def reverberation_time_uncertainty(times: ArrayLike) -> Real:
     """
     arr = _positive_array(times, "times")
     if arr.ndim != 1:
-        raise ValueError("'times' must be a 1-D sequence of measurements.")
+        msg = "'times' must be a 1-D sequence of measurements."
+        raise ValueError(msg)
     n = arr.size
     if n < 2:
-        raise ValueError("'times' needs at least two measurements (N >= 2).")
+        msg = "'times' needs at least two measurements (N >= 2)."
+        raise ValueError(msg)
     mean = arr.mean()
     variance_of_mean = np.sum((arr - mean) ** 2) / (n * (n - 1))
     return np.asarray(np.sqrt(variance_of_mean), dtype=np.float64)
@@ -695,9 +706,11 @@ def scattering_coefficient_uncertainty(
     spec_term = spec - 1.0
     diff_term = 1.0 - diff
     if np.any(np.isclose(diff_term, 0.0)):
-        raise ValueError("'alpha_s' must not equal 1 (division by zero).")
+        msg = "'alpha_s' must not equal 1 (division by zero)."
+        raise ValueError(msg)
     if np.any(np.isclose(spec_term, 0.0)):
-        raise ValueError("'alpha_spec' must not equal 1 (division by zero).")
+        msg = "'alpha_spec' must not equal 1 (division by zero)."
+        raise ValueError(msg)
     u_s = np.abs(spec_term / diff_term) * np.sqrt(
         (u_spec / spec_term) ** 2 + (u_diff / diff_term) ** 2
     )

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -131,9 +131,8 @@ class DiffusionResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso17497 import render_diffusion_polar_report
 
         return render_diffusion_polar_report(
@@ -225,9 +224,8 @@ class DiffusionSpectrum:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso17497 import render_diffusion_spectrum_report
 
         return render_diffusion_spectrum_report(
@@ -262,14 +260,14 @@ def diffusion_spectrum(
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     d = np.atleast_1d(np.asarray(diffusion, dtype=np.float64))
     if freq.ndim != 1 or freq.size == 0 or freq.shape != d.shape:
-        raise ValueError(
-            "'frequencies' and 'diffusion' must be non-empty, 1-D and equal-length."
-        )
+        msg = "'frequencies' and 'diffusion' must be non-empty, 1-D and equal-length."
+        raise ValueError(msg)
     d_n: Real | None = None
     if normalized is not None:
         d_n = np.atleast_1d(np.asarray(normalized, dtype=np.float64))
         if d_n.shape != freq.shape:
-            raise ValueError("'normalized' must match 'frequencies' in length.")
+            msg = "'normalized' must match 'frequencies' in length."
+            raise ValueError(msg)
     return DiffusionSpectrum(
         frequencies=freq,
         diffusion=d,
@@ -300,7 +298,8 @@ def directional_diffusion(
     ang = np.atleast_1d(np.asarray(angles, dtype=np.float64))
     lev = np.atleast_1d(np.asarray(levels, dtype=np.float64))
     if ang.shape != lev.shape:
-        raise ValueError("'angles' and 'levels' must have the same length.")
+        msg = "'angles' and 'levels' must have the same length."
+        raise ValueError(msg)
     d = float(directional_diffusion_coefficient(lev, area_weights=weights))
     return DiffusionResult(angles=ang, levels=lev, coefficient=d)
 
@@ -349,32 +348,38 @@ def directional_diffusion_coefficient(
     """
     lvl = np.asarray(levels, dtype=np.float64)
     if lvl.ndim != 1:
-        raise ValueError("'levels' must be a 1-D sequence of receiver SPLs.")
+        msg = "'levels' must be a 1-D sequence of receiver SPLs."
+        raise ValueError(msg)
     n = lvl.size
     if n < 2:
-        raise ValueError("'levels' needs at least two receivers (n >= 2).")
+        msg = "'levels' needs at least two receivers (n >= 2)."
+        raise ValueError(msg)
     p = np.power(10.0, lvl / 10.0)
     if area_weights is None:
         weights = np.ones(n, dtype=np.float64)
     else:
         weights = np.asarray(area_weights, dtype=np.float64)
         if weights.ndim != 1 or weights.size != n:
-            raise ValueError(
+            msg = (
                 "'area_weights' must match the number of receivers "
                 f"({n}), got shape {weights.shape}."
             )
+            raise ValueError(msg)
         if np.any(weights <= 0.0):
-            raise ValueError("'area_weights' values must be positive.")
+            msg = "'area_weights' values must be positive."
+            raise ValueError(msg)
     weight_sum = float(np.sum(weights))
     if weight_sum <= 1.0:
-        raise ValueError("The total area weight must exceed 1.")
+        msg = "The total area weight must exceed 1."
+        raise ValueError(msg)
     weighted_energy = np.sum(p * weights)
     weighted_energy_sq = np.sum(weights * p**2)
     if weighted_energy_sq <= 0.0:
-        raise ValueError(
+        msg = (
             "The polar response carries no energy (all levels -inf); the "
             "diffusion coefficient is undefined."
         )
+        raise ValueError(msg)
     numerator = weighted_energy**2 - weighted_energy_sq
     denominator = (weight_sum - 1.0) * weighted_energy_sq
     return float(numerator / denominator)
@@ -403,7 +408,8 @@ def normalized_diffusion_coefficient(
     d_ref = np.asarray(d_theta_reference, dtype=np.float64)
     denom = 1.0 - d_ref
     if np.any(np.isclose(denom, 0.0)):
-        raise ValueError("'d_theta_reference' must not equal 1 (division by zero).")
+        msg = "'d_theta_reference' must not equal 1 (division by zero)."
+        raise ValueError(msg)
     return np.asarray((d - d_ref) / denom, dtype=np.float64)
 
 
@@ -453,7 +459,8 @@ def area_factors(
     """
     theta_deg = np.asarray(elevations, dtype=np.float64)
     if theta_deg.ndim != 1 or theta_deg.size == 0:
-        raise ValueError("'elevations' must be a non-empty 1-D sequence of angles.")
+        msg = "'elevations' must be a non-empty 1-D sequence of angles."
+        raise ValueError(msg)
     d_theta = _positive_scalar(delta_theta, "delta_theta")
     d_phi = d_theta if delta_phi is None else _positive_scalar(delta_phi, "delta_phi")
     theta = np.radians(theta_deg)
@@ -470,7 +477,8 @@ def area_factors(
     areas[general] = 2.0 * np.sin(theta[general]) * np.sin(d_theta_rad / 2.0)
     a_min = np.min(areas)
     if a_min <= 0.0:
-        raise ValueError("Area factors must be positive; check the angles.")
+        msg = "Area factors must be positive; check the angles."
+        raise ValueError(msg)
     return np.asarray(areas / a_min, dtype=np.float64)
 
 
@@ -498,21 +506,26 @@ def random_incidence_diffusion(
     """
     d = np.asarray(directional_coefficients, dtype=np.float64)
     if d.ndim != 1:
-        raise ValueError("'directional_coefficients' must be a 1-D sequence.")
+        msg = "'directional_coefficients' must be a 1-D sequence."
+        raise ValueError(msg)
     if d.size == 0:
-        raise ValueError("'directional_coefficients' must not be empty.")
+        msg = "'directional_coefficients' must not be empty."
+        raise ValueError(msg)
     if weights is None:
         w = np.ones(d.size, dtype=np.float64)
     else:
         w = np.asarray(weights, dtype=np.float64)
         if w.ndim != 1 or w.size != d.size:
-            raise ValueError(
+            msg = (
                 "'weights' must match the number of source positions "
                 f"({d.size}), got shape {w.shape}."
             )
+            raise ValueError(msg)
         if np.any(w < 0.0):
-            raise ValueError("'weights' values must be non-negative.")
+            msg = "'weights' values must be non-negative."
+            raise ValueError(msg)
     total = float(np.sum(w))
     if total <= 0.0:
-        raise ValueError("The total source weight must be positive.")
+        msg = "The total source weight must be positive."
+        raise ValueError(msg)
     return float(np.sum(w * d) / total)

--- a/src/phonometry/materials/resilient/dynamic_stiffness.py
+++ b/src/phonometry/materials/resilient/dynamic_stiffness.py
@@ -129,7 +129,8 @@ def apparent_dynamic_stiffness(
     total_mass_per_area = require_positive(total_mass_per_area, "total_mass_per_area")
     fr = np.asarray(resonant_frequency, dtype=np.float64)
     if np.any(fr <= 0.0):
-        raise ValueError("'resonant_frequency' must be positive.")
+        msg = "'resonant_frequency' must be positive."
+        raise ValueError(msg)
     return as_float_or_array(_FOUR_PI_SQ * total_mass_per_area * fr**2)
 
 
@@ -160,10 +161,12 @@ def enclosed_gas_stiffness(
         atmospheric_pressure, "atmospheric_pressure"
     )
     if not 0.0 < porosity <= 1.0:
-        raise ValueError("'porosity' must be in the range (0, 1].")
+        msg = "'porosity' must be in the range (0, 1]."
+        raise ValueError(msg)
     d = np.asarray(thickness, dtype=np.float64)
     if np.any(d <= 0.0):
-        raise ValueError("'thickness' must be positive.")
+        msg = "'thickness' must be positive."
+        raise ValueError(msg)
     return as_float_or_array(atmospheric_pressure / (d * porosity))
 
 
@@ -199,9 +202,11 @@ def installed_dynamic_stiffness(
     """
     apparent_stiffness = require_positive(apparent_stiffness, "apparent_stiffness")
     if airflow_resistivity <= 0.0:
-        raise ValueError("'airflow_resistivity' must be positive.")
+        msg = "'airflow_resistivity' must be positive."
+        raise ValueError(msg)
     if gas_stiffness < 0.0:
-        raise ValueError("'gas_stiffness' must be non-negative.")
+        msg = "'gas_stiffness' must be non-negative."
+        raise ValueError(msg)
 
     if airflow_resistivity >= _HIGH_RESISTIVITY:
         return apparent_stiffness
@@ -244,7 +249,8 @@ def natural_frequency(
     mass_per_area = require_positive(mass_per_area, "mass_per_area")
     s = np.asarray(dynamic_stiffness, dtype=np.float64)
     if np.any(s <= 0.0):
-        raise ValueError("'dynamic_stiffness' must be positive.")
+        msg = "'dynamic_stiffness' must be positive."
+        raise ValueError(msg)
     return as_float_or_array(np.sqrt(s / mass_per_area) / _TWO_PI)
 
 
@@ -343,9 +349,8 @@ class DynamicStiffnessResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso9052 import render_dynamic_stiffness_report
 
         return render_dynamic_stiffness_report(
@@ -391,10 +396,11 @@ def floating_floor_resonance(
     s_gas = 0.0
     if airflow_resistivity < _HIGH_RESISTIVITY:
         if thickness is None or porosity is None:
-            raise ValueError(
+            msg = (
                 "'thickness' and 'porosity' are required for the enclosed-gas "
                 "term when airflow_resistivity < 100 kPa.s/m2."
             )
+            raise ValueError(msg)
         s_gas = float(
             enclosed_gas_stiffness(
                 thickness, porosity, atmospheric_pressure=atmospheric_pressure

--- a/src/phonometry/materials/surfaces/road_absorption.py
+++ b/src/phonometry/materials/surfaces/road_absorption.py
@@ -234,7 +234,8 @@ def reflected_path_delay(
     :raises ValueError: If ``dm`` or ``c`` is not positive.
     """
     if mic_height <= 0.0:
-        raise ValueError("'mic_height' must be positive.")
+        msg = "'mic_height' must be positive."
+        raise ValueError(msg)
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_POSITIVE)
     return float(2.0 * mic_height / speed_of_sound)
@@ -321,16 +322,20 @@ def adrienne_window(
     if fs <= 0.0:
         raise ValueError(_FS_POSITIVE)
     if flat_duration <= 0.0:
-        raise ValueError("'flat_duration' must be positive.")
+        msg = "'flat_duration' must be positive."
+        raise ValueError(msg)
     if leading_duration < 0.0 or trailing_duration < 0.0:
-        raise ValueError("Edge durations must be non-negative.")
+        msg = "Edge durations must be non-negative."
+        raise ValueError(msg)
     if leading_edge not in _EDGE_SHAPES or trailing_edge not in _EDGE_SHAPES:
-        raise ValueError(f"Edge shapes must be one of {_EDGE_SHAPES}.")
+        msg = f"Edge shapes must be one of {_EDGE_SHAPES}."
+        raise ValueError(msg)
     n_lead = round(leading_duration * fs)
     n_flat = round(flat_duration * fs)
     n_trail = round(trailing_duration * fs)
     if n_flat <= 0:
-        raise ValueError("'flat_duration' is too short for 'fs'.")
+        msg = "'flat_duration' is too short for 'fs'."
+        raise ValueError(msg)
     rising = _edge(n_lead, leading_edge, rising=True)
     flat = np.ones(n_flat, dtype=np.float64)
     falling = _edge(n_trail, trailing_edge, rising=False)
@@ -358,10 +363,12 @@ def _transfer_functions(
         reflected_ir, np.atleast_1d(np.asarray(reflected_ir, dtype=np.float64))
     )
     if hi_t.size == 0 or hr_t.size == 0:
-        raise ValueError("Impulse responses must be non-empty.")
+        msg = "Impulse responses must be non-empty."
+        raise ValueError(msg)
     length = n if n is not None else max(hi_t.size, hr_t.size)
     if length <= 0:
-        raise ValueError("'n' must be positive.")
+        msg = "'n' must be positive."
+        raise ValueError(msg)
     hi = np.fft.rfft(hi_t, n=length)
     hr = np.fft.rfft(hr_t, n=length)
     return (
@@ -428,7 +435,8 @@ def insitu_reflection_factor(
     r = (hr / hi) / kr
     if delay is not None:
         if fs is None:
-            raise ValueError("'fs' is required to apply 'delay'.")
+            msg = "'fs' is required to apply 'delay'."
+            raise ValueError(msg)
         if fs <= 0.0:
             raise ValueError(_FS_POSITIVE)
         # ``length`` is the exact time-domain length used for the FFTs, so
@@ -605,9 +613,8 @@ def one_third_octave_absorption(
     freq = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     alpha = np.atleast_1d(np.asarray(absorption, dtype=np.float64))
     if freq.size == 0 or freq.shape != alpha.shape:
-        raise ValueError(
-            "'frequency' and 'absorption' must be non-empty and equal-length."
-        )
+        msg = "'frequency' and 'absorption' must be non-empty and equal-length."
+        raise ValueError(msg)
     centres = np.array(
         [c for c in _ONE_THIRD_OCTAVE_CENTERS if f_min <= c <= f_max],
         dtype=np.float64,
@@ -786,7 +793,8 @@ def max_sampled_area_radius(
     """
     _check_geometry(source_height, mic_height)
     if window_width <= 0.0:
-        raise ValueError("'window_width' must be positive.")
+        msg = "'window_width' must be positive."
+        raise ValueError(msg)
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_POSITIVE)
     ds, dm, ctw = source_height, mic_height, speed_of_sound * window_width
@@ -820,13 +828,16 @@ def msa_major_axis(
     :raises ValueError: On non-positive window width, speed, or negative ``dp``.
     """
     if window_width <= 0.0:
-        raise ValueError("'window_width' must be positive.")
+        msg = "'window_width' must be positive."
+        raise ValueError(msg)
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_POSITIVE)
     if projected_distance < 0.0:
-        raise ValueError("'projected_distance' must be non-negative.")
+        msg = "'projected_distance' must be non-negative."
+        raise ValueError(msg)
     if source_height <= 0.0 or mic_height <= 0.0:
-        raise ValueError("Heights must be positive.")
+        msg = "Heights must be positive."
+        raise ValueError(msg)
     return float(
         speed_of_sound * window_width
         + np.hypot(source_height + mic_height, projected_distance)
@@ -854,7 +865,8 @@ def spot_tube_upper_frequency(
     :raises ValueError: If ``d`` or ``c0`` is not positive.
     """
     if diameter <= 0.0:
-        raise ValueError("'diameter' must be positive.")
+        msg = "'diameter' must be positive."
+        raise ValueError(msg)
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_POSITIVE)
     return float(_SPOT_FU_FACTOR * speed_of_sound / diameter)
@@ -887,9 +899,11 @@ def spot_microphone_spacing_bounds(
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_POSITIVE)
     if f_min <= 0.0 or f_max <= 0.0:
-        raise ValueError("Frequencies must be positive.")
+        msg = "Frequencies must be positive."
+        raise ValueError(msg)
     if f_min >= f_max:
-        raise ValueError("'f_min' must be less than 'f_max'.")
+        msg = "'f_min' must be less than 'f_max'."
+        raise ValueError(msg)
     s_max = _SPOT_SMAX_FACTOR * speed_of_sound / f_max
     s_min = _SPOT_SMIN_FACTOR * speed_of_sound / f_min
     if s_min >= s_max:
@@ -915,7 +929,8 @@ def check_spot_frequency_range(frequency: ArrayLike) -> None:
     """
     freq = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     if np.any(freq < 0.0):
-        raise ValueError("'frequency' must be non-negative.")
+        msg = "'frequency' must be non-negative."
+        raise ValueError(msg)
     lo, hi = SPOT_FREQUENCY_RANGE
     if np.any(freq < lo) or np.any(freq > hi):
         warnings.warn(
@@ -959,9 +974,8 @@ def spot_internal_loss_correction(
     alpha_m = np.atleast_1d(np.asarray(measured_absorption, dtype=np.float64))
     alpha_s = np.atleast_1d(np.asarray(system_absorption, dtype=np.float64))
     if alpha_m.shape != alpha_s.shape:
-        raise ValueError(
-            "'measured_absorption' and 'system_absorption' must share a shape."
-        )
+        msg = "'measured_absorption' and 'system_absorption' must share a shape."
+        raise ValueError(msg)
     corrected = alpha_m - alpha_s
     if clip_negative:
         corrected = np.maximum(corrected, 0.0)
@@ -971,6 +985,8 @@ def spot_internal_loss_correction(
 def _check_geometry(source_height: float, mic_height: float) -> None:
     """Validate the source/microphone heights of the extended-surface geometry."""
     if source_height <= 0.0 or mic_height <= 0.0:
-        raise ValueError("'source_height' and 'mic_height' must be positive.")
+        msg = "'source_height' and 'mic_height' must be positive."
+        raise ValueError(msg)
     if source_height <= mic_height:
-        raise ValueError("'source_height' must exceed 'mic_height'.")
+        msg = "'source_height' must exceed 'mic_height'."
+        raise ValueError(msg)

--- a/src/phonometry/metrology/calibration.py
+++ b/src/phonometry/metrology/calibration.py
@@ -129,20 +129,24 @@ def sensitivity(
         resolve_samples(ref_signal, calibrate=False), dtype=np.float64
     )
     if signal_arr.size == 0:
-        raise ValueError("Reference signal is empty, cannot calibrate.")
+        msg = "Reference signal is empty, cannot calibrate."
+        raise ValueError(msg)
     if not np.all(np.isfinite(signal_arr)):
-        raise ValueError(
+        msg = (
             "Reference signal contains non-finite samples (NaN/inf); they "
             "would silently corrupt the calibration factor."
         )
+        raise ValueError(msg)
     if narrowband:
         if fs is None:
-            raise ValueError("narrowband tone estimation requires 'fs'.")
+            msg = "narrowband tone estimation requires 'fs'."
+            raise ValueError(msg)
         rms_ref = _narrowband_tone_rms(signal_arr, fs, frequency)
     else:
         rms_ref = float(np.sqrt(np.mean(signal_arr**2)))
     if rms_ref == 0:
-        raise ValueError("Reference signal is silent, cannot calibrate.")
+        msg = "Reference signal is silent, cannot calibrate."
+        raise ValueError(msg)
 
     if validate and fs is not None:
         limit = (

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -393,18 +393,18 @@ def _trend_test_runs(values: NDArray[np.float64], alpha: float) -> TrendTestResu
     keep = np.abs(values - median) > 0.0
     kept = values[keep]
     if kept.size < _MIN_OBSERVATIONS:
-        raise ValueError(
+        msg = (
             "The runs test needs at least "
             f"{_MIN_OBSERVATIONS} observations distinct from the median; "
             f"got {kept.size}."
         )
+        raise ValueError(msg)
     above = kept > median
     n1 = int(np.count_nonzero(above))
     n2 = int(above.size - n1)
     if n1 == 0 or n2 == 0:
-        raise ValueError(
-            "The runs test needs observations on both sides of the median."
-        )
+        msg = "The runs test needs observations on both sides of the median."
+        raise ValueError(msg)
     statistic = _count_runs(above)
     mean, std = _runs_moments(n1, n2)
     bounds = _runs_bounds(n1, n2, alpha)
@@ -428,18 +428,23 @@ def _validate_trend_inputs(
 ) -> NDArray[np.float64]:
     seq = np.asarray(values, dtype=np.float64)
     if seq.ndim != 1:
-        raise ValueError("'values' must be one-dimensional.")
+        msg = "'values' must be one-dimensional."
+        raise ValueError(msg)
     if seq.size < _MIN_OBSERVATIONS:
-        raise ValueError(
+        msg = (
             f"'values' must hold at least {_MIN_OBSERVATIONS} observations "
             f"(B&P Table A.6 starts at N = 10); got {seq.size}."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(seq)):
-        raise ValueError("'values' must be finite.")
+        msg = "'values' must be finite."
+        raise ValueError(msg)
     if method not in _METHODS:
-        raise ValueError(f"'method' must be one of {_METHODS}, got {method!r}.")
+        msg = f"'method' must be one of {_METHODS}, got {method!r}."
+        raise ValueError(msg)
     if not 0.0 < alpha < 1.0:
-        raise ValueError(f"'alpha' must be inside (0, 1), got {alpha!r}.")
+        msg = f"'alpha' must be inside (0, 1), got {alpha!r}."
+        raise ValueError(msg)
     return seq
 
 
@@ -603,15 +608,15 @@ def stationarity_test(
     xa = _validate_signal(x, "x", context="a stationarity test")
     fs_v = _positive(resolve_fs(x, fs), "fs")
     if statistic not in _STATISTICS:
-        raise ValueError(
-            f"'statistic' must be one of {_STATISTICS}, got {statistic!r}."
-        )
+        msg = f"'statistic' must be one of {_STATISTICS}, got {statistic!r}."
+        raise ValueError(msg)
     segments = int(n_segments)
     if not _MIN_OBSERVATIONS <= segments <= xa.size:
-        raise ValueError(
+        msg = (
             f"'n_segments' must be between {_MIN_OBSERVATIONS} and the "
             f"record length ({xa.size} samples), got {n_segments!r}."
         )
+        raise ValueError(msg)
 
     per_segment = xa.size // segments
     trimmed = xa[: per_segment * segments].reshape(segments, per_segment)
@@ -771,16 +776,19 @@ def level_crossing_rate(
     xa = xa - float(np.mean(xa))
     sigma = float(np.sqrt(np.mean(xa**2)))
     if sigma <= 0.0:  # RMS is non-negative: <= 0 means a constant record
-        raise ValueError("'x' must not be constant.")
+        msg = "'x' must not be constant."
+        raise ValueError(msg)
 
     if levels is None:
         level_arr = np.linspace(-3.0, 3.0, 13) * sigma
     else:
         level_arr = np.asarray(levels, dtype=np.float64)
         if level_arr.ndim != 1 or level_arr.size == 0:
-            raise ValueError("'levels' must be a non-empty 1-D array.")
+            msg = "'levels' must be a non-empty 1-D array."
+            raise ValueError(msg)
         if not np.all(np.isfinite(level_arr)):
-            raise ValueError("'levels' must be finite.")
+            msg = "'levels' must be finite."
+            raise ValueError(msg)
 
     duration = (xa.size - 1) / fs_v
     counts = _count_level_crossings(xa, level_arr)
@@ -967,7 +975,8 @@ def peak_statistics(
     xa = xa - float(np.mean(xa))
     sigma = float(np.sqrt(np.mean(xa**2)))
     if sigma <= 0.0:  # RMS is non-negative: <= 0 means a constant record
-        raise ValueError("'x' must not be constant.")
+        msg = "'x' must not be constant."
+        raise ValueError(msg)
 
     interior = xa[1:-1]
     maxima = (interior > xa[:-2]) & (interior > xa[2:])

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -77,14 +77,17 @@ class Quantity:
     def __post_init__(self) -> None:
         """Reject a negative uncertainty, an unrecognised PDF or non-positive dof."""
         if self.uncertainty < 0.0:
-            raise ValueError("uncertainty must be non-negative.")
+            msg = "uncertainty must be non-negative."
+            raise ValueError(msg)
         if self.distribution not in DISTRIBUTIONS:
-            raise ValueError(
+            msg = (
                 f"distribution must be one of {DISTRIBUTIONS}; "
                 f"got {self.distribution!r}."
             )
+            raise ValueError(msg)
         if self.dof <= 0.0:
-            raise ValueError("dof must be positive.")
+            msg = "dof must be positive."
+            raise ValueError(msg)
 
 
 def rectangular(value: float, half_width: float, name: str = "") -> Quantity:
@@ -155,12 +158,13 @@ class UncertaintyResult:
             k = float(coverage_factor_override)
             return k, k * self.combined_uncertainty
         if math.isnan(self.effective_dof):
-            raise ValueError(
+            msg = (
                 "The effective degrees of freedom are undefined for a "
                 "correlated budget with finite input dof (the GUM defines "
                 "no Welch-Satterthwaite form there): pass an explicit "
                 "coverage_factor_override."
             )
+            raise ValueError(msg)
         k = coverage_factor(coverage, self.effective_dof)
         return k, k * self.combined_uncertainty
 
@@ -283,16 +287,20 @@ def _validated_correlation(correlation: ArrayLike | None, n: int) -> np.ndarray 
         return None
     r = np.asarray(correlation, dtype=np.float64)
     if r.shape != (n, n):
-        raise ValueError(f"correlation must have shape ({n}, {n}); got {r.shape}.")
+        msg = f"correlation must have shape ({n}, {n}); got {r.shape}."
+        raise ValueError(msg)
     if not np.allclose(r, r.T):
-        raise ValueError("correlation matrix must be symmetric.")
+        msg = "correlation matrix must be symmetric."
+        raise ValueError(msg)
     if not np.allclose(np.diag(r), 1.0):
-        raise ValueError("correlation matrix diagonal must be 1.0.")
+        msg = "correlation matrix diagonal must be 1.0."
+        raise ValueError(msg)
     # A symmetric, unit-diagonal matrix can still be indefinite, which would
     # make the variance negative and be silently masked by the clamp that
     # follows the propagation; reject it.
     if float(np.min(np.linalg.eigvalsh(r))) < -1e-8:
-        raise ValueError("correlation matrix must be positive semi-definite.")
+        msg = "correlation matrix must be positive semi-definite."
+        raise ValueError(msg)
     return r
 
 
@@ -358,7 +366,8 @@ def combine_uncertainty(
     :raises ValueError: for no inputs or a malformed correlation matrix.
     """
     if len(quantities) == 0:
-        raise ValueError("at least one input quantity is required.")
+        msg = "at least one input quantity is required."
+        raise ValueError(msg)
     values = np.array([q.value for q in quantities], dtype=np.float64)
     uncert = np.array([q.uncertainty for q in quantities], dtype=np.float64)
     n = values.size
@@ -399,7 +408,8 @@ def coverage_factor(coverage: float = 0.95, dof: float = math.inf) -> float:
     :raises ValueError: for a coverage outside (0, 1).
     """
     if not 0.0 < coverage < 1.0:
-        raise ValueError(f"coverage must be in (0, 1); got {coverage}.")
+        msg = f"coverage must be in (0, 1); got {coverage}."
+        raise ValueError(msg)
     p = 0.5 * (1.0 + coverage)
     if math.isinf(dof):
         from scipy.special import ndtri
@@ -482,11 +492,14 @@ def monte_carlo(
     :raises ValueError: for no inputs, fewer than 2 trials or bad coverage.
     """
     if len(quantities) == 0:
-        raise ValueError("at least one input quantity is required.")
+        msg = "at least one input quantity is required."
+        raise ValueError(msg)
     if trials < 2:
-        raise ValueError("trials must be at least 2.")
+        msg = "trials must be at least 2."
+        raise ValueError(msg)
     if not 0.0 < coverage < 1.0:
-        raise ValueError(f"coverage must be in (0, 1); got {coverage}.")
+        msg = f"coverage must be in (0, 1); got {coverage}."
+        raise ValueError(msg)
 
     rng = np.random.default_rng(seed)
     samples = [_sample(q, trials, rng) for q in quantities]

--- a/src/phonometry/noise_control/_criterion.py
+++ b/src/phonometry/noise_control/_criterion.py
@@ -45,7 +45,8 @@ def validate_target(criterion: str, target: float | None) -> tuple[str, float | 
         return family, None
     value = float(target)
     if not np.isfinite(value):
-        raise ValueError("'target' must be a finite criterion value.")
+        msg = "'target' must be a finite criterion value."
+        raise ValueError(msg)
     return family, value
 
 
@@ -71,12 +72,14 @@ def as_band_spectrum(
     if arr.size == 1:
         arr = np.full(n, float(arr[0]), dtype=np.float64)
     if arr.shape != (n,):
-        raise ValueError(
+        msg = (
             f"'{name}' must be a scalar or have one value per band ({n}); "
             f"got shape {arr.shape}."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return arr
 
 

--- a/src/phonometry/noise_control/duct_modes.py
+++ b/src/phonometry/noise_control/duct_modes.py
@@ -141,10 +141,11 @@ def _mach(flow_velocity: float, speed_of_sound: float) -> tuple[float, float]:
     u = require_non_negative(flow_velocity, "flow_velocity")
     mach = u / c
     if mach >= 1.0:
-        raise ValueError(
+        msg = (
             "'flow_velocity' must be subsonic; the cut-on correction "
             "sqrt(1 - M^2) is undefined at and above M = 1."
         )
+        raise ValueError(msg)
     return mach, float(np.sqrt(1.0 - mach**2))
 
 
@@ -185,7 +186,8 @@ def circular_duct_cut_on(
     d = require_positive(diameter, "diameter")
     mach, beta = _mach(flow_velocity, speed_of_sound)
     if not 1 <= count <= len(CIRCULAR_EIGENVALUES):
-        raise ValueError(f"'count' must be between 1 and {len(CIRCULAR_EIGENVALUES)}.")
+        msg = f"'count' must be between 1 and {len(CIRCULAR_EIGENVALUES)}."
+        raise ValueError(msg)
     radius = 0.5 * d
     ordered = sorted(CIRCULAR_EIGENVALUES.items(), key=lambda item: item[1])[:count]
     modes = tuple(mode for mode, _ in ordered)
@@ -239,7 +241,8 @@ def rectangular_duct_cut_on(
     b = require_positive(height, "height")
     mach, beta = _mach(flow_velocity, speed_of_sound)
     if count < 1:
-        raise ValueError("'count' must be at least 1.")
+        msg = "'count' must be at least 1."
+        raise ValueError(msg)
     # A (count+1)-square grid of orders always contains the `count` lowest.
     orders = [
         (p, q) for p in range(count + 1) for q in range(count + 1) if (p, q) != (0, 0)
@@ -299,7 +302,8 @@ def plane_wave_limit(
     if diameter is None and area is not None:
         diameter = float(np.sqrt(4.0 * require_positive(area, "area") / np.pi))
     if diameter is None:
-        raise ValueError("give 'diameter', or both 'width' and 'height', or 'area'.")
+        msg = "give 'diameter', or both 'width' and 'height', or 'area'."
+        raise ValueError(msg)
     return circular_duct_cut_on(
         diameter,
         flow_velocity=flow_velocity,

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -373,9 +373,8 @@ class DuctPathResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.duct_path import render_duct_path_report
 
         return render_duct_path_report(
@@ -440,7 +439,8 @@ def duct_path(
     """
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     n = f.size
     level = as_band_spectrum(source_level, n, "source_level")
     family, goal = validate_target(criterion, target)
@@ -456,10 +456,11 @@ def duct_path(
     stages: list[DuctPathStage] = []
     for position, element in enumerate(elements, start=1):
         if not isinstance(element, DuctElement):
-            raise TypeError(
+            msg = (
                 "'elements' must hold DuctElement entries; got "
                 f"{type(element).__name__} at position {position}."
             )
+            raise TypeError(msg)
         attenuation = as_band_spectrum(
             element.attenuation, n, f"elements[{position - 1}].attenuation"
         )
@@ -528,11 +529,13 @@ def combine_duct_paths(
     """
     items = list(paths)
     if not items:
-        raise ValueError("'paths' must hold at least one DuctPathResult.")
+        msg = "'paths' must hold at least one DuctPathResult."
+        raise ValueError(msg)
     f = np.asarray(items[0].frequencies, dtype=np.float64)
     for other in items[1:]:
         if not np.array_equal(np.asarray(other.frequencies, dtype=np.float64), f):
-            raise ValueError("all paths must share the same analysis bands.")
+            msg = "all paths must share the same analysis bands."
+            raise ValueError(msg)
     family, goal = validate_target(
         items[0].criterion if criterion is None else criterion,
         next((p.target for p in items if p.target is not None), None)

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -171,9 +171,8 @@ class EnclosureResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.enclosure import render_enclosure_report
 
         return render_enclosure_report(
@@ -205,9 +204,11 @@ def _resolve_frequencies(
         return None
     freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if freqs.ndim != 1 or freqs.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(freqs <= 0.0) or not np.all(np.isfinite(freqs)):
-        raise ValueError("'frequencies' must be positive and finite.")
+        msg = "'frequencies' must be positive and finite."
+        raise ValueError(msg)
     return freqs
 
 
@@ -219,14 +220,17 @@ def _resolve_panel_r(
     """Resolve a per-band decibel spectrum into a validated 1-D array."""
     if callable(values):
         if freqs is None:
-            raise ValueError(f"'frequencies' is required when '{name}' is a callable.")
+            msg = f"'frequencies' is required when '{name}' is a callable."
+            raise ValueError(msg)
         r = np.atleast_1d(np.asarray(values(freqs), dtype=np.float64))
     else:
         r = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if r.ndim != 1 or r.size == 0:
-        raise ValueError(f"'{name}' must be a non-empty 1-D array.")
+        msg = f"'{name}' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if not np.all(np.isfinite(r)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return r
 
 
@@ -262,16 +266,17 @@ def _resolve_interior(
 
     alpha = np.asarray(internal_absorption, dtype=np.float64)
     if alpha.ndim > 1:
-        raise ValueError("'internal_absorption' must be a scalar or a 1-D array.")
+        msg = "'internal_absorption' must be a scalar or a 1-D array."
+        raise ValueError(msg)
     if np.any(alpha <= 0.0) or np.any(alpha >= 1.0) or not np.all(np.isfinite(alpha)):
-        raise ValueError("'internal_absorption' must lie strictly in (0, 1).")
+        msg = "'internal_absorption' must lie strictly in (0, 1)."
+        raise ValueError(msg)
 
     r_i = np.atleast_1d(np.asarray(room_constant(s_i, alpha), dtype=np.float64))
     r_i_b, v_b = np.broadcast_arrays(r_i, v)
     if freqs is not None and freqs.shape != v_b.shape:
-        raise ValueError(
-            f"'frequencies' must match the number of {name} / absorption bands."
-        )
+        msg = f"'frequencies' must match the number of {name} / absorption bands."
+        raise ValueError(msg)
     correction = 10.0 * np.log10(floor + s_e / r_i_b)
     return (
         freqs,

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -385,9 +385,11 @@ _DAMPER_CORRECTION: dict[str, NDArray[np.float64]] = {
 def _frequencies(frequencies: ArrayLike) -> NDArray[np.float64]:
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(f <= 0.0) or not np.all(np.isfinite(f)):
-        raise ValueError("'frequencies' must be positive and finite.")
+        msg = "'frequencies' must be positive and finite."
+        raise ValueError(msg)
     return f
 
 
@@ -411,10 +413,11 @@ def _octave_slots(
     ratio = np.abs(np.log2(f[:, None] / bands[None, :]))
     idx = np.asarray(np.argmin(ratio, axis=1), dtype=np.intp)
     if np.any(ratio[np.arange(f.size), idx] > np.log2(1.05)):
-        raise ValueError(
+        msg = (
             "'frequencies' must be octave-band centres of "
             f"{bands.tolist()} Hz for this tabulated method."
         )
+        raise ValueError(msg)
     return f, idx
 
 
@@ -495,9 +498,8 @@ class HvacSpectrumResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.hvac import render_hvac_report
 
         return render_hvac_report(
@@ -553,7 +555,8 @@ def end_reflection_loss(
     elif termination == "free":
         table = _END_REFLECTION_FREE
     else:
-        raise ValueError("'termination' must be 'flush' or 'free'.")
+        msg = "'termination' must be 'flush' or 'free'."
+        raise ValueError(msg)
     require_positive(speed_of_sound, "speed_of_sound")
 
     log_d = np.log(_END_REFLECTION_DIAMETERS_MM)
@@ -600,12 +603,14 @@ def elbow_insertion_loss(
     c = require_positive(speed_of_sound, "speed_of_sound")
     if bend_type == "round":
         if vanes or lined:
-            raise ValueError("round bends take neither vanes nor lining.")
+            msg = "round bends take neither vanes nor lining."
+            raise ValueError(msg)
         key = "round"
     elif bend_type == "square":
         key = "square" + ("_vanes" if vanes else "") + ("_lined" if lined else "")
     else:
-        raise ValueError("'bend_type' must be 'square' or 'round'.")
+        msg = "'bend_type' must be 'square' or 'round'."
+        raise ValueError(msg)
     col = _ELBOW_TABLE[key]
     wl = w * f / c
     # Table 8.11 bounds each row as "a <= W/lambda < b", so a ratio exactly on
@@ -659,7 +664,8 @@ def plenum_attenuation(
     s_w = require_positive(wall_area, "wall_area")
     alpha = np.asarray(mean_absorption, dtype=np.float64)
     if np.any(alpha <= 0.0) or np.any(alpha >= 1.0) or not np.all(np.isfinite(alpha)):
-        raise ValueError("'mean_absorption' must lie strictly in (0, 1).")
+        msg = "'mean_absorption' must lie strictly in (0, 1)."
+        raise ValueError(msg)
     r_const = np.asarray(room_constant(s_w, alpha), dtype=np.float64)
     direct = np.cos(angle) / (np.pi * r**2)
     reverberant = 1.0 / r_const
@@ -771,7 +777,8 @@ def blade_passing_frequency(rotational_speed: float, blades: int) -> float:
     """
     rpm = require_positive(rotational_speed, "rotational_speed")
     if blades <= 0:
-        raise ValueError("'blades' must be a positive integer.")
+        msg = "'blades' must be a positive integer."
+        raise ValueError(msg)
     return rpm * float(blades) / 60.0
 
 
@@ -792,7 +799,8 @@ def fan_efficiency_correction(relative_efficiency: float) -> float:
     """
     eta = require_positive(relative_efficiency, "relative_efficiency")
     if eta > 100.0:
-        raise ValueError("'relative_efficiency' must not exceed 100 per cent.")
+        msg = "'relative_efficiency' must not exceed 100 per cent."
+        raise ValueError(msg)
     for lower, correction in _EFFICIENCY_CORRECTION:
         if eta >= lower:
             return correction
@@ -1174,11 +1182,14 @@ def split_loss(
     s_m = require_positive(main_area, "main_area")
     areas = np.atleast_1d(np.asarray(branch_areas, dtype=np.float64))
     if areas.ndim != 1 or areas.size == 0:
-        raise ValueError("'branch_areas' must be a non-empty 1-D array.")
+        msg = "'branch_areas' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(areas <= 0.0) or not np.all(np.isfinite(areas)):
-        raise ValueError("'branch_areas' must be positive and finite.")
+        msg = "'branch_areas' must be positive and finite."
+        raise ValueError(msg)
     if not 0 <= branch < areas.size:
-        raise ValueError(f"'branch' must index 'branch_areas' (0..{areas.size - 1}).")
+        msg = f"'branch' must index 'branch_areas' (0..{areas.size - 1})."
+        raise ValueError(msg)
     total = float(np.sum(areas))
     reflection = 1.0 - ((total - s_m) / (total + s_m)) ** 2
     return float(-10.0 * np.log10(reflection) - 10.0 * np.log10(areas[branch] / total))
@@ -1290,9 +1301,11 @@ def splitter_silencer_insertion_loss(
     """
     widths = np.atleast_1d(np.asarray(airway_widths, dtype=np.float64))
     if widths.ndim != 1 or widths.size == 0:
-        raise ValueError("'airway_widths' must be a non-empty 1-D array.")
+        msg = "'airway_widths' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(widths <= 0.0) or not np.all(np.isfinite(widths)):
-        raise ValueError("'airway_widths' must be positive and finite.")
+        msg = "'airway_widths' must be positive and finite."
+        raise ValueError(msg)
     thickness = require_positive(splitter_thickness, "splitter_thickness")
     liner = 0.5 * thickness
     per_airway = np.array(
@@ -1358,7 +1371,8 @@ def silencer_self_noise(
     f, idx = _octave_slots(frequencies)
     v = require_positive(airway_velocity, "airway_velocity")
     if passages <= 0:
-        raise ValueError("'passages' must be a positive integer.")
+        msg = "'passages' must be a positive integer."
+        raise ValueError(msg)
     h_mm = require_positive(height, "height") * 1000.0
     overall = (
         55.0 * np.log10(v)
@@ -1449,7 +1463,8 @@ def diffuser_sound_power(
     drop_in_wg = require_positive(pressure_drop, "pressure_drop") / _PA_PER_IN_WG
     profile = require_choice(shape, "shape", ("rectangular", "round"))
     if count <= 0:
-        raise ValueError("'count' must be a positive integer.")
+        msg = "'count' must be a positive integer."
+        raise ValueError(msg)
     # Eq. 13.28: Long prints "ft/min" under U_\mathrm{G} but defines it in the same
     # breath as Q / (60 S_\mathrm{G}), which is ft/s, the unit Eq. 13.27 declares and
     # the only one for which the 334.9 constant is the velocity-pressure
@@ -1501,10 +1516,11 @@ def air_terminal_velocity_limit(
     table = _TERMINAL_VELOCITY_LIMIT[side]
     key = round(design_criterion)
     if key not in table:
-        raise ValueError(
+        msg = (
             f"'design_criterion' must be one of {sorted(table)}; "
             f"got {design_criterion!r}."
         )
+        raise ValueError(msg)
     return table[key]
 
 
@@ -1573,6 +1589,7 @@ def room_effect(
     q = require_positive(directivity, "directivity")
     r_const = np.asarray(room_constant, dtype=np.float64)
     if np.any(r_const <= 0.0) or not np.all(np.isfinite(r_const)):
-        raise ValueError("'room_constant' must be positive and finite.")
+        msg = "'room_constant' must be positive and finite."
+        raise ValueError(msg)
     values = -10.0 * np.log10(q / (4.0 * np.pi * r**2) + 4.0 / r_const)
     return float(values) if values.ndim == 0 else values

--- a/src/phonometry/noise_control/room_to_room.py
+++ b/src/phonometry/noise_control/room_to_room.py
@@ -133,15 +133,17 @@ class SourceRoom:
         at the line that built it.
         """
         if (self.level is None) == (self.power_level is None):
-            raise ValueError(
+            msg = (
                 "give exactly one of 'level' (the source-room level L_p1) or "
                 "'power_level' (the source sound power level L_W)."
             )
+            raise ValueError(msg)
         if self.power_level is not None and self.room_constant is None:
-            raise ValueError(
+            msg = (
                 "'room_constant' is required with 'power_level'; build it "
                 "with phonometry.room.room_constant."
             )
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -436,7 +438,8 @@ def room_to_room_transmission(
 
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     n = f.size
 
     require_choice(source.model, "source.model", tuple(SOURCE_POWER_MODELS))
@@ -456,7 +459,8 @@ def room_to_room_transmission(
             dtype=np.float64,
         )
     elif source.level is None:  # pragma: no cover - __post_init__ guards this
-        raise ValueError("'source.level' must be given.")
+        msg = "'source.level' must be given."
+        raise ValueError(msg)
     else:
         lp1 = as_band_spectrum(source.level, n, "source.level")
 
@@ -464,10 +468,11 @@ def room_to_room_transmission(
     s_w = require_positive(partition_area, "partition_area")
     absorption = as_band_spectrum(receiving_absorption, n, "receiving_absorption")
     if np.any(absorption <= 0.0):
-        raise ValueError(
+        msg = (
             "'receiving_absorption' must be positive: a receiving room with no "
             "absorption has no finite reverberant level."
         )
+        raise ValueError(msg)
     penalty = require_non_negative(
         criterion.flanking_penalty, "criterion.flanking_penalty"
     )

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -142,9 +142,11 @@ def _frequencies(frequencies: ArrayLike) -> NDArray[np.float64]:
     """Validate a strictly positive, finite 1-D frequency grid (Hz)."""
     f = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if f.ndim != 1 or f.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(f <= 0.0) or not np.all(np.isfinite(f)):
-        raise ValueError("'frequencies' must be positive and finite.")
+        msg = "'frequencies' must be positive and finite."
+        raise ValueError(msg)
     return f
 
 
@@ -191,7 +193,8 @@ def shunt_matrix(branch_impedance: ArrayLike) -> _Complex:
     """
     zb = np.atleast_1d(np.asarray(branch_impedance, dtype=np.complex128))
     if zb.ndim != 1 or zb.size == 0:
-        raise ValueError("'branch_impedance' must be a non-empty 1-D array.")
+        msg = "'branch_impedance' must be a non-empty 1-D array."
+        raise ValueError(msg)
     t = np.zeros((zb.size, 2, 2), dtype=np.complex128)
     t[:, 0, 0] = 1.0
     # A lossless branch at exact resonance has Z_b -> 0 (it shorts the duct);
@@ -236,12 +239,12 @@ def cascade(*matrices: _Complex) -> _Complex:
     :return: The compound ``(n_freq, 2, 2)`` array.
     """
     if not matrices:
-        raise ValueError("cascade() needs at least one matrix.")
+        msg = "cascade() needs at least one matrix."
+        raise ValueError(msg)
     n = matrices[0].shape[0]
     if any(m.shape[0] != n for m in matrices[1:]):
-        raise ValueError(
-            "cascade() matrices must share the same frequency grid (n_freq)."
-        )
+        msg = "cascade() matrices must share the same frequency grid (n_freq)."
+        raise ValueError(msg)
     total = matrices[0]
     for m in matrices[1:]:
         total = np.matmul(total, m)
@@ -534,9 +537,8 @@ class ReactiveSilencerResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.silencer import render_reactive_silencer_report
 
         return render_reactive_silencer_report(
@@ -832,7 +834,8 @@ def extended_tube_chamber(
     la = require_non_negative(inlet_extension, "inlet_extension")
     lb = require_non_negative(outlet_extension, "outlet_extension")
     if s_exp <= s_duct:
-        raise ValueError("'chamber_area' must exceed 'pipe_area'.")
+        msg = "'chamber_area' must exceed 'pipe_area'."
+        raise ValueError(msg)
     # The straight section between the two junction planes. Extensions that
     # meet exactly are the accepted limit, but binary arithmetic does not
     # respect that: 0.1 + 0.2 exceeds 0.3 by an ulp, so a chamber described in
@@ -842,11 +845,12 @@ def extended_tube_chamber(
     # negative length is not a thing either.
     straight = length - la - lb
     if straight < -_MEETING_SLACK * max(length, la + lb):
-        raise ValueError(
+        msg = (
             "the inlet and outlet extensions cannot together exceed the "
             "chamber length (they would overlap inside the chamber, leaving "
             "a straight chamber section of negative length)."
         )
+        raise ValueError(msg)
     straight = max(straight, 0.0)
     annulus = s_exp - s_duct
 
@@ -1051,11 +1055,12 @@ class SilencerChain:
         if zb.ndim == 0:
             zb = np.full(self._frequencies.size, zb, dtype=np.complex128)
         if zb.shape != self._frequencies.shape:
-            raise ValueError(
+            msg = (
                 "'branch_impedance' must be a scalar or hold one value per "
                 f"analysis frequency ({self._frequencies.size} values); got "
                 f"shape {zb.shape}."
             )
+            raise ValueError(msg)
         self._elements.append(
             SilencerChainElement(
                 matrix=shunt_matrix(zb),

--- a/src/phonometry/psychoacoustics/erb_scale.py
+++ b/src/phonometry/psychoacoustics/erb_scale.py
@@ -85,7 +85,8 @@ def erb_bandwidth(frequency: ArrayLike) -> np.ndarray | float:
     """
     f = np.asarray(frequency, dtype=np.float64)
     if not np.all(np.isfinite(f)) or np.any(f < 0.0):
-        raise ValueError("'frequency' must be non-negative and finite.")
+        msg = "'frequency' must be non-negative and finite."
+        raise ValueError(msg)
     return as_float_or_array(ERB_C1 * (ERB_C2 * f + 1.0))
 
 
@@ -102,7 +103,8 @@ def cam_from_frequency(frequency: ArrayLike) -> np.ndarray | float:
     """
     f = np.asarray(frequency, dtype=np.float64)
     if not np.all(np.isfinite(f)) or np.any(f < 0.0):
-        raise ValueError("'frequency' must be non-negative and finite.")
+        msg = "'frequency' must be non-negative and finite."
+        raise ValueError(msg)
     return as_float_or_array(CAM_C * np.log10(ERB_C2 * f + 1.0))
 
 
@@ -116,5 +118,6 @@ def frequency_from_cam(cam: ArrayLike) -> np.ndarray | float:
     """
     i = np.asarray(cam, dtype=np.float64)
     if not np.all(np.isfinite(i)) or np.any(i < 0.0):
-        raise ValueError("'cam' must be non-negative and finite.")
+        msg = "'cam' must be non-negative and finite."
+        raise ValueError(msg)
     return as_float_or_array((np.power(10.0, i / CAM_C) - 1.0) / ERB_C2)

--- a/src/phonometry/psychoacoustics/loudness/contours.py
+++ b/src/phonometry/psychoacoustics/loudness/contours.py
@@ -66,11 +66,12 @@ def _params(frequency: float) -> tuple[float, float, float]:
     for f, params in _TABLE1.items():
         if abs(frequency - f) <= 1e-6 * f:
             return params
-    raise ValueError(
+    msg = (
         f"ISO 226:2023 Table 1 defines parameters only at the 29 preferred "
         f"third-octave frequencies (20 Hz to 12.5 kHz); got frequency "
         f"{frequency!r} Hz. The standard specifies no interpolation."
     )
+    raise ValueError(msg)
 
 
 def _spl_from_phon(frequency: float, phon: float) -> float:
@@ -97,10 +98,11 @@ def equal_loudness_contour(phon: float) -> tuple[np.ndarray, np.ndarray]:
     :return: Tuple ``(frequencies, spl)`` in Hz and dB re 20 uPa.
     """
     if not 20.0 <= phon <= 90.0:
-        raise ValueError(
+        msg = (
             "ISO 226:2023 Formula (1) is specified for 20 phon to 90 phon "
             f"(80 phon above 4 kHz); got {phon!r}."
         )
+        raise ValueError(msg)
     freqs = _FREQUENCIES if phon <= 80.0 else _FREQUENCIES[_FREQUENCIES <= 4000.0]
     spl = np.array([_spl_from_phon(f, phon) for f in freqs])
     return freqs.copy(), spl

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -681,16 +681,19 @@ def loudness_ecma(
     residual's origin). Monaural only (no Clause 8.1.5 binaural combination).
     """
     if field not in ("free", "diffuse"):
-        raise ValueError("field must be 'free' or 'diffuse'")
+        msg = "field must be 'free' or 'diffuse'"
+        raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
         signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
     )
     if x.size == 0:
-        raise ValueError("signal must not be empty")
+        msg = "signal must not be empty"
+        raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:
-        raise ValueError("fs must be positive")
+        msg = "fs must be positive"
+        raise ValueError(msg)
     if fs != _FS:
         n_target = round(x.size * _FS / fs)
         x = signal.resample(x, n_target)

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -756,11 +756,11 @@ def _result_from_components(
 
 def _validate_conditions(field: str, presentation: str) -> None:
     if field not in _FIELDS:
-        raise ValueError(f"field must be one of {_FIELDS}, got {field!r}.")
+        msg = f"field must be one of {_FIELDS}, got {field!r}."
+        raise ValueError(msg)
     if presentation not in _PRESENTATIONS:
-        raise ValueError(
-            f"presentation must be one of {_PRESENTATIONS}, got {presentation!r}."
-        )
+        msg = f"presentation must be one of {_PRESENTATIONS}, got {presentation!r}."
+        raise ValueError(msg)
 
 
 def _as_components(
@@ -771,16 +771,19 @@ def _as_components(
     if array.size == 0:
         return np.empty(0, dtype=np.float64), np.empty(0, dtype=np.float64)
     if array.ndim != 2 or array.shape[1] != 2:
-        raise ValueError(
+        msg = (
             "components must be a sequence of (frequency_Hz, level_dB) pairs, "
             f"got array of shape {array.shape}."
         )
+        raise ValueError(msg)
     freqs = array[:, 0]
     levels = array[:, 1]
     if not np.all(np.isfinite(array)):
-        raise ValueError("components must contain only finite values.")
+        msg = "components must contain only finite values."
+        raise ValueError(msg)
     if np.any(freqs <= 0.0):
-        raise ValueError("component frequencies must be positive.")
+        msg = "component frequencies must be positive."
+        raise ValueError(msg)
     return freqs, levels
 
 
@@ -870,12 +873,14 @@ def loudness_moore_glasberg_from_third_octave(
     _validate_conditions(field, presentation)
     levels = np.asarray(band_levels, dtype=np.float64)
     if levels.ndim != 1 or levels.size != _N_THIRD_OCTAVE:
-        raise ValueError(
+        msg = (
             f"band_levels must contain exactly {_N_THIRD_OCTAVE} one-third-"
             f"octave band levels (25 Hz to 16 kHz), got shape {levels.shape}."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(levels)):
-        raise ValueError("band_levels must contain only finite values.")
+        msg = "band_levels must contain only finite values."
+        raise ValueError(msg)
     freqs, comp_levels = _third_octave_components(levels)
     return _result_from_components(freqs, comp_levels, field, presentation)
 
@@ -958,11 +963,14 @@ def loudness_moore_glasberg(
         x, require_1d_signal(_typesignal(np.asarray(x)), name="'x'")
     )
     if pressure.size == 0:
-        raise ValueError("Input signal 'x' cannot be empty.")
+        msg = "Input signal 'x' cannot be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(pressure)):
-        raise ValueError("Input signal 'x' must contain only finite values.")
+        msg = "Input signal 'x' must contain only finite values."
+        raise ValueError(msg)
     if fs <= 0.0:
-        raise ValueError(f"'fs' must be a positive sampling rate, got {fs!r}.")
+        msg = f"'fs' must be a positive sampling rate, got {fs!r}."
+        raise ValueError(msg)
     components = _signal_components(pressure, float(fs))
     return loudness_moore_glasberg_from_spectrum(
         components, field=field, presentation=presentation

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -617,22 +617,22 @@ def _as_two_channels(
         elif array.shape[0] == 2:
             left, right = array[0], array[1]
         else:
-            raise ValueError(
-                f"signal must be mono (1-D) or two-channel; got shape {array.shape}."
-            )
+            msg = f"signal must be mono (1-D) or two-channel; got shape {array.shape}."
+            raise ValueError(msg)
     elif array.ndim == 1:
         left = array
         right = None  # mono: diotic (both ears) or single ear (monaural)
     else:
-        raise ValueError(
-            f"signal must be mono (1-D) or two-channel; got shape {array.shape}."
-        )
+        msg = f"signal must be mono (1-D) or two-channel; got shape {array.shape}."
+        raise ValueError(msg)
     if left.size == 0:
-        raise ValueError("Input signal cannot be empty.")
+        msg = "Input signal cannot be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(left)) or (
         right is not None and not np.all(np.isfinite(right))
     ):
-        raise ValueError("Input signal must contain only finite values.")
+        msg = "Input signal must contain only finite values."
+        raise ValueError(msg)
     if presentation == "monaural":
         right = None
     return left, right
@@ -687,7 +687,8 @@ def loudness_moore_glasberg_time(
     _validate_conditions(field, presentation)
     fs = resolve_fs(signal, fs, name="signal")
     if fs <= 0.0:
-        raise ValueError(f"'fs' must be a positive sampling rate, got {fs!r}.")
+        msg = f"'fs' must be a positive sampling rate, got {fs!r}."
+        raise ValueError(msg)
     left, right = _as_two_channels(signal, presentation)
 
     comp_f, plans, perm = _spectral_plan(float(fs))

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -178,9 +178,8 @@ class ZwickerLoudness:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso532 import render_iso532_report
 
         return render_iso532_report(
@@ -244,10 +243,11 @@ def _third_octave_levels(
         # One 500 Hz output sample needs _SR_LEVEL/_SR_LOUDNESS level steps.
         min_steps = _SR_LEVEL // _SR_LOUDNESS
         if num_dec < min_steps:
-            raise ValueError(
+            msg = (
                 "Input signal is too short for the time-varying method: at "
                 f"least {dec_factor * min_steps} samples at 48 kHz are required."
             )
+            raise ValueError(msg)
 
     levels = np.empty((_N_BANDS, num_dec))
     for band in range(_N_BANDS):
@@ -700,7 +700,8 @@ def _percentile(values: np.ndarray, percentile: int) -> float:
 def _validate_field(field: str) -> bool:
     """Return True for the diffuse field; raise on invalid values."""
     if field not in ("free", "diffuse"):
-        raise ValueError(f"'field' must be 'free' or 'diffuse', got {field!r}.")
+        msg = f"'field' must be 'free' or 'diffuse', got {field!r}."
+        raise ValueError(msg)
     return field == "diffuse"
 
 
@@ -733,12 +734,14 @@ def loudness_zwicker_from_spectrum(
     diffuse = _validate_field(field)
     band_levels = np.asarray(levels, dtype=np.float64)
     if band_levels.ndim != 1 or band_levels.size != _N_BANDS:
-        raise ValueError(
+        msg = (
             f"'levels' must contain exactly {_N_BANDS} one-third-octave band "
             f"levels (25 Hz to 12.5 kHz), got shape {band_levels.shape}."
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(band_levels)):
-        raise ValueError("'levels' must contain only finite values.")
+        msg = "'levels' must contain only finite values."
+        raise ValueError(msg)
     core = _core_loudness_from_levels(band_levels[:, np.newaxis], diffuse)
     loudness, specific = _slopes_over_time(core)
     total = float(loudness[0])
@@ -827,44 +830,52 @@ def loudness_zwicker(
     diffuse = _validate_field(field)
     fs = resolve_fs(x, fs)
     if fs <= 0:
-        raise ValueError(f"'fs' must be a positive sampling rate, got {fs!r}.")
+        msg = f"'fs' must be a positive sampling rate, got {fs!r}."
+        raise ValueError(msg)
     factor = resolve_calibration(x, calibration_factor)
     require_positive(factor, "calibration_factor")
     pressure = _typesignal(np.asarray(x))
     if pressure.ndim != 1:
-        raise ValueError(
+        msg = (
             "loudness_zwicker() accepts single-channel signals only, got "
             f"shape {pressure.shape}."
         )
+        raise ValueError(msg)
     if pressure.size == 0:
-        raise ValueError("Input signal 'x' cannot be empty.")
+        msg = "Input signal 'x' cannot be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(pressure)):
-        raise ValueError("Input signal 'x' must contain only finite values.")
+        msg = "Input signal 'x' must contain only finite values."
+        raise ValueError(msg)
     pressure = pressure * factor
 
     if int(fs) != fs:
-        raise ValueError(f"'fs' must be an integer sampling rate, got {fs!r}.")
+        msg = f"'fs' must be an integer sampling rate, got {fs!r}."
+        raise ValueError(msg)
     fs_int = int(fs)
     if fs_int != _FS_REF:
         gcd = math.gcd(_FS_REF, fs_int)
         up, down = _FS_REF // gcd, fs_int // gcd
         if max(up, down) > 1000:
-            raise ValueError(
+            msg = (
                 f"Sampling rate {fs_int} Hz needs an impractical resampling "
                 f"ratio ({up}/{down}) to reach 48000 Hz; resample the signal "
                 "to a standard rate first."
             )
+            raise ValueError(msg)
         pressure = np.asarray(signal.resample_poly(pressure, up, down))
 
     time_skip = float(time_skip)
     if not math.isfinite(time_skip) or time_skip < 0.0:
-        raise ValueError("'time_skip' must be a non-negative, finite time.")
+        msg = "'time_skip' must be a non-negative, finite time."
+        raise ValueError(msg)
     skip_samples = round(time_skip * _FS_REF)
     if skip_samples >= pressure.size:
-        raise ValueError(
+        msg = (
             "'time_skip' must leave at least one sample of signal "
             f"({time_skip} s skips the whole {pressure.size / _FS_REF:.3f} s input)."
         )
+        raise ValueError(msg)
 
     levels = _third_octave_levels(pressure, stationary, skip_samples)
     core = _core_loudness_from_levels(levels, diffuse)

--- a/src/phonometry/psychoacoustics/quality/annoyance.py
+++ b/src/phonometry/psychoacoustics/quality/annoyance.py
@@ -72,7 +72,8 @@ _WFR_ROUGHNESS_WEIGHT = 0.6
 def _nonnegative(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar < 0.0:
-        raise ValueError(f"'{name}' must be a non-negative, finite number.")
+        msg = f"'{name}' must be a non-negative, finite number."
+        raise ValueError(msg)
     return scalar
 
 

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -103,11 +103,14 @@ def fluctuation_strength_am_noise(
     fmod = float(mod_frequency)
     lvl = float(level_db)
     if not np.isfinite(m) or not 0.0 <= m <= 1.0:
-        raise ValueError("'modulation_factor' must be in [0, 1].")
+        msg = "'modulation_factor' must be in [0, 1]."
+        raise ValueError(msg)
     if not np.isfinite(fmod) or fmod <= 0.0:
-        raise ValueError("'mod_frequency' must be positive and finite.")
+        msg = "'mod_frequency' must be positive and finite."
+        raise ValueError(msg)
     if not np.isfinite(lvl):
-        raise ValueError("'level_db' must be finite.")
+        msg = "'level_db' must be finite."
+        raise ValueError(msg)
     numerator = (
         _BBN_SCALE
         * (_BBN_M_SLOPE * m - _BBN_M_OFFSET)
@@ -254,11 +257,14 @@ def _cross_covariance(x: NDArray[np.float64], y: NDArray[np.float64]) -> float:
 def _validate_signal(x: Signal | NDArray[np.float64]) -> NDArray[np.float64]:
     sig = np.asarray(x, dtype=np.float64)
     if sig.ndim != 1:
-        raise ValueError("'signal' must be one-dimensional.")
+        msg = "'signal' must be one-dimensional."
+        raise ValueError(msg)
     if sig.size == 0:
-        raise ValueError("'signal' must not be empty.")
+        msg = "'signal' must not be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(sig)):
-        raise ValueError("'signal' must be finite.")
+        msg = "'signal' must be finite."
+        raise ValueError(msg)
     return sig
 
 
@@ -447,7 +453,8 @@ def _c_fs() -> float:
         raw = float(np.median(_analyze(_reference_signal())[0]))
         c = 1.0 / raw if raw > 0.0 else 0.0
         if not 0.15 <= c < 0.50:  # pragma: no cover - sanity guard
-            raise RuntimeError(f"C_FS={c} outside the expected range")
+            msg = f"C_FS={c} outside the expected range"
+            raise RuntimeError(msg)
         _C_FS = c
     return _C_FS
 
@@ -515,7 +522,8 @@ def fluctuation_strength(
     sig = apply_calibration(signal_in, _validate_signal(signal_in))
     fs_v = float(fs)
     if not np.isfinite(fs_v) or fs_v <= 0.0:
-        raise ValueError("'fs' must be positive and finite.")
+        msg = "'fs' must be positive and finite."
+        raise ValueError(msg)
 
     # Resample to the model design rate.
     if fs_v != _FS_SAMPLE_RATE:

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -883,15 +883,18 @@ def fluctuation_strength_ecma(
     percentile settles, by a 12 s signal).
     """
     if field not in ("free", "diffuse"):
-        raise ValueError("field must be 'free' or 'diffuse'")
+        msg = "field must be 'free' or 'diffuse'"
+        raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
         signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
     )
     if x.size == 0:
-        raise ValueError("signal must not be empty")
+        msg = "signal must not be empty"
+        raise ValueError(msg)
     if not np.all(np.isfinite(x)):
-        raise ValueError("'signal' must be finite.")
+        msg = "'signal' must be finite."
+        raise ValueError(msg)
     fs = require_positive(float(fs), "fs")
     if fs != _FS:
         x = signal.resample(x, max(1, round(x.size * _FS / fs)))

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -558,16 +558,19 @@ def roughness_ecma(
     asper with the tabulated c_R of Formula (104)).
     """
     if field not in ("free", "diffuse"):
-        raise ValueError("field must be 'free' or 'diffuse'")
+        msg = "field must be 'free' or 'diffuse'"
+        raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
         signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
     )
     if x.size == 0:
-        raise ValueError("signal must not be empty")
+        msg = "signal must not be empty"
+        raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:
-        raise ValueError("fs must be positive")
+        msg = "fs must be positive"
+        raise ValueError(msg)
     if fs != _FS:
         x = signal.resample(x, round(x.size * _FS / fs))
 

--- a/src/phonometry/psychoacoustics/quality/sharpness.py
+++ b/src/phonometry/psychoacoustics/quality/sharpness.py
@@ -71,7 +71,8 @@ def _moment(specific: np.ndarray, method: str) -> float:
     if method == "aures":
         num = float(np.sum(specific * _g_aures(_Z, n_total) * _Z) * _DZ)
         return num / n_total
-    raise ValueError("method must be 'din', 'aures' or 'bismarck'")
+    msg = "method must be 'din', 'aures' or 'bismarck'"
+    raise ValueError(msg)
 
 
 def reference_sound(
@@ -116,7 +117,8 @@ def _k_din() -> float:
     if _K_DIN is None:
         _K_DIN = 1.0 / _moment(_reference_specific(), "din")
         if not 0.105 <= _K_DIN < 0.115:  # pragma: no cover - sanity guard
-            raise RuntimeError(f"k={_K_DIN} outside the DIN 45692 range")
+            msg = f"k={_K_DIN} outside the DIN 45692 range"
+            raise RuntimeError(msg)
     return _K_DIN
 
 
@@ -133,14 +135,16 @@ def sharpness_din_from_specific(
     """
     specific = np.asarray(specific, dtype=np.float64)
     if specific.shape != (240,):
-        raise ValueError("specific must be the 240-bin ISO 532-1 pattern.")
+        msg = "specific must be the 240-bin ISO 532-1 pattern."
+        raise ValueError(msg)
     if method == "din":
         return _k_din() * _moment(specific, "din")
     if method in ("bismarck", "aures"):
         # Annex B (B.1)/(B.2): the published literal 0.11, NOT a derived
         # per-variant anchor -- see the _K_ANNEX_B note.
         return _K_ANNEX_B * _moment(specific, method)
-    raise ValueError("method must be 'din', 'aures' or 'bismarck'")
+    msg = "method must be 'din', 'aures' or 'bismarck'"
+    raise ValueError(msg)
 
 
 def sharpness_din(

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -179,15 +179,17 @@ def _averaged_spectrum(
     """
     nperseg = round(fs / resolution_hz)
     if nperseg < 16:
-        raise ValueError(
+        msg = (
             f"resolution_hz={resolution_hz!r} is too coarse for fs={fs}: it "
             "leaves fewer than 16 samples per FFT segment."
         )
+        raise ValueError(msg)
     if x.shape[-1] < nperseg:
-        raise ValueError(
+        msg = (
             f"Signal too short for the requested {resolution_hz} Hz "
             f"resolution: need at least {nperseg} samples, got {x.shape[-1]}."
         )
+        raise ValueError(msg)
     freqs, psd = _welch_autospectrum(x, float(fs), nperseg, nperseg // 2)
     df = float(freqs[1] - freqs[0])
     return freqs, psd * df, df
@@ -197,12 +199,14 @@ def _find_peak(freqs: np.ndarray, power: np.ndarray, tone_freq: float | None) ->
     if tone_freq is None:
         in_range = (freqs >= _F_MIN) & (freqs <= _F_MAX)
         if not np.any(in_range):
-            raise ValueError("Spectrum has no bins in the 89.1 Hz - 11.2 kHz range.")
+            msg = "Spectrum has no bins in the 89.1 Hz - 11.2 kHz range."
+            raise ValueError(msg)
         return int(np.flatnonzero(in_range)[np.argmax(power[in_range])])
     _, _, dfc = _critical_band(tone_freq)
     near = np.abs(freqs - tone_freq) <= dfc / 2.0
     if not np.any(near):
-        raise ValueError(f"No spectrum bins near tone_freq={tone_freq!r} Hz.")
+        msg = f"No spectrum bins near tone_freq={tone_freq!r} Hz."
+        raise ValueError(msg)
     return int(np.flatnonzero(near)[np.argmax(power[near])])
 
 
@@ -236,10 +240,11 @@ def _band_power(
     mask = (freqs > f1) & (freqs <= f2)
     n = int(np.count_nonzero(mask))
     if n == 0:
-        raise ValueError(
+        msg = (
             f"No spectrum bins fall in the {f1:.1f}-{f2:.1f} Hz band; use a "
             "finer resolution_hz."
         )
+        raise ValueError(msg)
     return float(np.sum(power[mask])), n
 
 
@@ -291,13 +296,17 @@ def tone_to_noise_ratio(
     fs = resolve_fs(x, fs)
     x_proc = apply_calibration(x, np.atleast_1d(_typesignal(np.asarray(x))))
     if x_proc.ndim != 1:
-        raise ValueError("tone_to_noise_ratio expects a 1D signal.")
+        msg = "tone_to_noise_ratio expects a 1D signal."
+        raise ValueError(msg)
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     if resolution_hz <= 0:
-        raise ValueError("'resolution_hz' must be positive.")
+        msg = "'resolution_hz' must be positive."
+        raise ValueError(msg)
     if tone_freq is not None and tone_freq <= 0:
-        raise ValueError("'tone_freq' must be positive.")
+        msg = "'tone_freq' must be positive."
+        raise ValueError(msg)
 
     freqs, power, df = _averaged_spectrum(x_proc, fs, resolution_hz)
     peak = _find_peak(freqs, power, tone_freq)
@@ -378,7 +387,8 @@ def _fitted_edge(
     for lo, hi, (c0, c1, c2) in table:
         if lo <= ft <= hi:
             return float(c0 + c1 * ft + c2 * ft**2)
-    raise AssertionError("unreachable: ft clipped to the table span")
+    msg = "unreachable: ft clipped to the table span"
+    raise AssertionError(msg)
 
 
 def prominence_ratio(
@@ -413,13 +423,17 @@ def prominence_ratio(
     fs = resolve_fs(x, fs)
     x_proc = apply_calibration(x, np.atleast_1d(_typesignal(np.asarray(x))))
     if x_proc.ndim != 1:
-        raise ValueError("prominence_ratio expects a 1D signal.")
+        msg = "prominence_ratio expects a 1D signal."
+        raise ValueError(msg)
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     if resolution_hz <= 0:
-        raise ValueError("'resolution_hz' must be positive.")
+        msg = "'resolution_hz' must be positive."
+        raise ValueError(msg)
     if tone_freq is not None and tone_freq <= 0:
-        raise ValueError("'tone_freq' must be positive.")
+        msg = "'tone_freq' must be positive."
+        raise ValueError(msg)
 
     freqs, power, df = _averaged_spectrum(x_proc, fs, resolution_hz)
     peak = _find_peak(freqs, power, tone_freq)

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -132,11 +132,14 @@ def _band_range(f_low: float | None, f_high: float | None) -> tuple[int, int]:
     f_L < f_H.
     """
     if f_low is not None and f_low <= 16.0:
-        raise ValueError("'f_low' must exceed 16 Hz (Formula 56).")
+        msg = "'f_low' must exceed 16 Hz (Formula 56)."
+        raise ValueError(msg)
     if f_high is not None and f_high >= 20000.0:
-        raise ValueError("'f_high' must be below 20 kHz (Formula 57).")
+        msg = "'f_high' must be below 20 kHz (Formula 57)."
+        raise ValueError(msg)
     if f_low is not None and f_high is not None and f_low >= f_high:
-        raise ValueError("'f_low' must be below 'f_high'.")
+        msg = "'f_low' must be below 'f_high'."
+        raise ValueError(msg)
     z_lo = 0
     z_hi = _CBF - 1
     mid = (_F_CENTRE[:-1] + _F_CENTRE[1:]) / 2.0  # inter-band boundaries
@@ -233,16 +236,19 @@ def tonality_ecma(
     calibration factor of Formula (51).
     """
     if field not in ("free", "diffuse"):
-        raise ValueError("field must be 'free' or 'diffuse'")
+        msg = "field must be 'free' or 'diffuse'"
+        raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
         signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
     )
     if x.size == 0:
-        raise ValueError("signal must not be empty")
+        msg = "signal must not be empty"
+        raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:
-        raise ValueError("fs must be positive")
+        msg = "fs must be positive"
+        raise ValueError(msg)
     if fs != _FS:
         x = signal.resample(x, round(x.size * _FS / fs))
 

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -132,14 +132,16 @@ NO_TONE_AUDIBILITY = -10.0
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return scalar
 
 
@@ -284,9 +286,11 @@ def energy_sum_level(
     """
     levels = np.asarray(line_levels, dtype=np.float64)
     if levels.size == 0:
-        raise ValueError("'line_levels' must contain at least one line.")
+        msg = "'line_levels' must contain at least one line."
+        raise ValueError(msg)
     if not np.all(np.isfinite(levels)):
-        raise ValueError("'line_levels' must be finite.")
+        msg = "'line_levels' must be finite."
+        raise ValueError(msg)
     factor = _positive(effective_bandwidth_factor, "effective_bandwidth_factor")
     if levels.size == 1:
         # Formula (7): a single-line tone takes its level unchanged; the
@@ -307,17 +311,23 @@ def _validate_spectrum(
     lev = np.asarray(levels, dtype=np.float64)
     freq = np.asarray(frequencies, dtype=np.float64)
     if lev.ndim != 1 or freq.ndim != 1:
-        raise ValueError("'levels' and 'frequencies' must be one-dimensional.")
+        msg = "'levels' and 'frequencies' must be one-dimensional."
+        raise ValueError(msg)
     if lev.size != freq.size:
-        raise ValueError("'levels' and 'frequencies' must share their length.")
+        msg = "'levels' and 'frequencies' must share their length."
+        raise ValueError(msg)
     if lev.size == 0:
-        raise ValueError("'levels' and 'frequencies' must not be empty.")
+        msg = "'levels' and 'frequencies' must not be empty."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(lev)) and np.all(np.isfinite(freq))):
-        raise ValueError("'levels' and 'frequencies' must be finite.")
+        msg = "'levels' and 'frequencies' must be finite."
+        raise ValueError(msg)
     if not np.all(np.diff(freq) > 0.0):
-        raise ValueError("'frequencies' must be strictly increasing.")
+        msg = "'frequencies' must be strictly increasing."
+        raise ValueError(msg)
     if freq[0] <= 0.0:
-        raise ValueError("'frequencies' must be positive.")
+        msg = "'frequencies' must be positive."
+        raise ValueError(msg)
     return lev, freq
 
 
@@ -395,7 +405,8 @@ def _mean_narrowband_level_lines(
     under = int(np.argmin(np.abs(freq - ft)))
     band = [i for i in range(lev.size) if f1 <= freq[i] <= f2 and i != under]
     if not band:
-        raise ValueError("No spectral lines fall in the critical band.")
+        msg = "No spectral lines fall in the critical band."
+        raise ValueError(msg)
 
     def _ls(indices: list[int]) -> float:
         return float(
@@ -698,7 +709,8 @@ def analyze_spectrum(
             )
             tones.append((float(freq[peak]), lt, ls, u, delta, kept))
     if not tones:
-        raise ValueError("No audible tone was detected in the spectrum.")
+        msg = "No audible tone was detected in the spectrum."
+        raise ValueError(msg)
 
     # Clause 5.3.8 Step 3: combine the tone levels of tones sharing a critical
     # band (Formula (17)), rated at the most audible member, except exactly
@@ -775,12 +787,14 @@ def combined_tone_level(
     fts = np.asarray(tone_frequencies, dtype=np.float64)
     lss = np.asarray(mean_narrowband_levels, dtype=np.float64)
     if fts.ndim != 1 or lss.ndim != 1 or fts.size != lss.size:
-        raise ValueError(
+        msg = (
             "'tone_frequencies' and 'mean_narrowband_levels' must be "
             "one-dimensional and share their length."
         )
+        raise ValueError(msg)
     if fts.size == 0:
-        raise ValueError("At least one tone is required.")
+        msg = "At least one tone is required."
+        raise ValueError(msg)
     marked: set[int] = set()
     for ft, ls in zip(fts, lss):
         peak = int(np.argmin(np.abs(freq - ft)))
@@ -901,9 +915,11 @@ def mean_audibility(decisive_audibilities: ArrayLike) -> float:
     """
     deltas = np.asarray(decisive_audibilities, dtype=np.float64)
     if deltas.size == 0:
-        raise ValueError("'decisive_audibilities' must not be empty.")
+        msg = "'decisive_audibilities' must not be empty."
+        raise ValueError(msg)
     if not np.all(np.isfinite(deltas)):
-        raise ValueError("'decisive_audibilities' must be finite.")
+        msg = "'decisive_audibilities' must be finite."
+        raise ValueError(msg)
     return float(10.0 * np.log10(np.mean(10.0 ** (deltas / 10.0))))
 
 
@@ -971,9 +987,11 @@ def audibility_uncertainty(
     lt = np.asarray(tone_line_levels, dtype=np.float64)
     ls = np.asarray(noise_line_levels, dtype=np.float64)
     if lt.size == 0 or ls.size == 0:
-        raise ValueError("Both line sets must contain at least one line.")
+        msg = "Both line sets must contain at least one line."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(lt)) and np.all(np.isfinite(ls))):
-        raise ValueError("Line levels must be finite.")
+        msg = "Line levels must be finite."
+        raise ValueError(msg)
     ft = _positive(tone_frequency, "tone_frequency")
     df = _positive(line_spacing, "line_spacing")
     sigma = _positive(sigma_level_db, "sigma_level_db")
@@ -1017,14 +1035,17 @@ def mean_audibility_uncertainty(
     deltas = np.asarray(decisive_audibilities, dtype=np.float64)
     uncertainties = np.asarray(extended_uncertainties, dtype=np.float64)
     if deltas.size == 0:
-        raise ValueError("'decisive_audibilities' must not be empty.")
+        msg = "'decisive_audibilities' must not be empty."
+        raise ValueError(msg)
     if deltas.shape != uncertainties.shape:
-        raise ValueError(
+        msg = (
             "'decisive_audibilities' and 'extended_uncertainties' must share "
             "their length."
         )
+        raise ValueError(msg)
     if not (np.all(np.isfinite(deltas)) and np.all(np.isfinite(uncertainties))):
-        raise ValueError("Inputs must be finite.")
+        msg = "Inputs must be finite."
+        raise ValueError(msg)
     weights = 10.0 ** (0.1 * deltas)
     return float(np.sqrt(np.sum((weights * uncertainties) ** 2)) / np.sum(weights))
 
@@ -1120,7 +1141,8 @@ class ToneAudibilityResult:
         )
 
         if view not in ("audibility", "levels"):
-            raise ValueError(f"Unknown view {view!r}; use 'audibility' or 'levels'.")
+            msg = f"Unknown view {view!r}; use 'audibility' or 'levels'."
+            raise ValueError(msg)
         render = (
             plot_tone_audibility
             if view == "audibility"
@@ -1173,9 +1195,8 @@ class ToneAudibilityResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso1996_tone import render_tone_audibility_report
 
         return render_tone_audibility_report(
@@ -1246,31 +1267,36 @@ def assess_tones(
     ls = np.asarray(mean_narrowband_levels, dtype=np.float64)
     df = _positive(line_spacing, "line_spacing")
     if freqs.ndim != 1 or lt.ndim != 1 or ls.ndim != 1:
-        raise ValueError(
+        msg = (
             "'tone_frequencies', 'tone_levels' and 'mean_narrowband_levels' "
             "must be one-dimensional."
         )
+        raise ValueError(msg)
     if not (freqs.size == lt.size == ls.size):
-        raise ValueError(
+        msg = (
             "'tone_frequencies', 'tone_levels' and 'mean_narrowband_levels' "
             "must share their length."
         )
+        raise ValueError(msg)
     if freqs.size == 0:
-        raise ValueError("At least one tone is required.")
+        msg = "At least one tone is required."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(freqs)) and np.all(freqs > 0.0)):
-        raise ValueError("'tone_frequencies' must be positive and finite.")
+        msg = "'tone_frequencies' must be positive and finite."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(lt)) and np.all(np.isfinite(ls))):
-        raise ValueError("'tone_levels' and 'mean_narrowband_levels' must be finite.")
+        msg = "'tone_levels' and 'mean_narrowband_levels' must be finite."
+        raise ValueError(msg)
 
     uncertainties: NDArray[np.float64] | None = None
     if extended_uncertainties is not None:
         uncertainties = np.asarray(extended_uncertainties, dtype=np.float64)
         if uncertainties.shape != freqs.shape:
-            raise ValueError(
-                "'extended_uncertainties' must match 'tone_frequencies' in length."
-            )
+            msg = "'extended_uncertainties' must match 'tone_frequencies' in length."
+            raise ValueError(msg)
         if not np.all(np.isfinite(uncertainties)):
-            raise ValueError("'extended_uncertainties' must be finite.")
+            msg = "'extended_uncertainties' must be finite."
+            raise ValueError(msg)
 
     dfc = np.array([critical_bandwidth_engineering(f) for f in freqs])
     # Corner frequencies (Formulae 4/5) from the already-computed Δfc, in the

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -211,9 +211,8 @@ class RoomAcousticsResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso3382 import render_iso3382_report
 
         return render_iso3382_report(
@@ -397,11 +396,14 @@ def _band_parameters(x: np.ndarray, fs: int) -> tuple[float, ...]:
 def _validate_ir(ir: Signal | list[float] | np.ndarray, fs: int) -> np.ndarray:
     x = _typesignal(np.asarray(ir))
     if x.ndim != 1:
-        raise ValueError("The impulse response must be one-dimensional.")
+        msg = "The impulse response must be one-dimensional."
+        raise ValueError(msg)
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     if not np.any(x):
-        raise ValueError("Impulse response 'ir' is silent.")
+        msg = "Impulse response 'ir' is silent."
+        raise ValueError(msg)
     return apply_calibration(ir, x)
 
 
@@ -491,7 +493,8 @@ def decay_curve(
     x = _validate_ir(ir, fs)
     if band is not None:
         if band <= 0.0:
-            raise ValueError("Band centre frequency 'band' must be positive.")
+            msg = "Band centre frequency 'band' must be positive."
+            raise ValueError(msg)
         half_width = 2.0 ** (1.0 / (4.0 * fraction))
         bank = OctaveFilterBank(
             fs=fs,
@@ -512,7 +515,8 @@ def decay_curve(
         x = np.asarray(signals[idx])
     p2 = x.astype(np.float64) ** 2
     if not np.any(p2 > 0.0):
-        raise ValueError("The selected band has no energy.")
+        msg = "The selected band has no energy."
+        raise ValueError(msg)
     p2 = p2[_onset_index(p2) :]
     time, level, _, _, _, _ = _schroeder(p2, fs)
     return DecayCurve(time=time, level=level, band=band)
@@ -579,7 +583,8 @@ def room_parameters(
         band_signals: list[np.ndarray] = [x]
     else:
         if len(limits) != 2:
-            raise ValueError("'limits' must be a (f_min, f_max) pair or None.")
+            msg = "'limits' must be a (f_min, f_max) pair or None."
+            raise ValueError(msg)
         bank = OctaveFilterBank(
             fs=fs, fraction=fraction, order=6, limits=[limits[0], limits[1]]
         )

--- a/src/phonometry/room/crowd_noise.py
+++ b/src/phonometry/room/crowd_noise.py
@@ -107,7 +107,8 @@ def _require_distance(value: ArrayLike, name: str) -> NDArray[np.float64]:
     """Validate a positive, finite distance (scalar or array)."""
     r = np.asarray(value, dtype=np.float64)
     if not np.all(np.isfinite(r)) or np.any(r <= 0.0):
-        raise ValueError(f"'{name}' must be positive and finite.")
+        msg = f"'{name}' must be positive and finite."
+        raise ValueError(msg)
     return r
 
 
@@ -158,10 +159,12 @@ def crowd_noise_level(
     """
     n = np.asarray(talkers, dtype=np.float64)
     if not np.all(np.isfinite(n)) or np.any(n < 1.0):
-        raise ValueError("'talkers' must be at least 1 and finite.")
+        msg = "'talkers' must be at least 1 and finite."
+        raise ValueError(msg)
     a = np.asarray(absorption_area, dtype=np.float64)
     if not np.all(np.isfinite(a)) or np.any(a <= 0.0):
-        raise ValueError("'absorption_area' must be positive and finite.")
+        msg = "'absorption_area' must be positive and finite."
+        raise ValueError(msg)
     lw = float(sound_power_level)
     return as_float_or_array(lw + 10.0 * np.log10(n) + 10.0 * np.log10(4.0 / a))
 
@@ -188,7 +191,8 @@ def speech_to_noise_ratio(
     r = _require_distance(distance, "distance")
     a_tab = np.asarray(absorption_per_table, dtype=np.float64)
     if not np.all(np.isfinite(a_tab)) or np.any(a_tab <= 0.0):
-        raise ValueError("'absorption_per_table' must be positive and finite.")
+        msg = "'absorption_per_table' must be positive and finite."
+        raise ValueError(msg)
     q = require_positive(directivity, "directivity")
     return as_float_or_array(
         10.0 * np.log10(q / (4.0 * np.pi * r**2)) + 10.0 * np.log10(a_tab / 4.0)
@@ -219,7 +223,8 @@ def absorption_per_table(
     q = require_positive(directivity, "directivity")
     snr = float(speech_to_noise)
     if not np.isfinite(snr):
-        raise ValueError("'speech_to_noise' must be finite.")
+        msg = "'speech_to_noise' must be finite."
+        raise ValueError(msg)
     return as_float_or_array(16.0 * np.pi * r**2 * 10.0 ** (snr / 10.0) / q)
 
 
@@ -300,18 +305,22 @@ def crowd_noise(
     """
     areas = np.atleast_1d(np.asarray(absorption_areas, dtype=np.float64))
     if areas.ndim != 1 or areas.size == 0:
-        raise ValueError("'absorption_areas' must be a non-empty 1-D array.")
+        msg = "'absorption_areas' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if not np.all(np.isfinite(areas)) or np.any(areas <= 0.0):
-        raise ValueError("'absorption_areas' must be positive and finite.")
+        msg = "'absorption_areas' must be positive and finite."
+        raise ValueError(msg)
     n = (
         np.arange(1.0, 21.0)
         if talkers is None
         else np.atleast_1d(np.asarray(talkers, dtype=np.float64))
     )
     if n.ndim != 1 or n.size == 0:
-        raise ValueError("'talkers' must be a non-empty 1-D array.")
+        msg = "'talkers' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if not np.all(np.isfinite(n)) or np.any(n < 1.0):
-        raise ValueError("'talkers' must be at least 1 and finite.")
+        msg = "'talkers' must be at least 1 and finite."
+        raise ValueError(msg)
 
     r = require_positive(distance, "distance")
     q = require_positive(directivity, "directivity")

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -95,10 +95,12 @@ def object_fraction(object_volumes: ArrayLike, volume: float) -> float:
     volume = require_positive(volume, "volume")
     vols = np.asarray(object_volumes, dtype=np.float64)
     if np.any(vols < 0.0):
-        raise ValueError("object volumes must be non-negative.")
+        msg = "object volumes must be non-negative."
+        raise ValueError(msg)
     psi = float(np.sum(vols)) / volume
     if psi >= 1.0:
-        raise ValueError("the object volumes cannot exceed the room volume.")
+        msg = "the object volumes cannot exceed the room volume."
+        raise ValueError(msg)
     return psi
 
 
@@ -114,7 +116,8 @@ def hard_object_absorption(object_volume: ArrayLike) -> np.ndarray:
     """
     vol = np.asarray(object_volume, dtype=np.float64)
     if np.any(vol < 0.0):
-        raise ValueError("object volumes must be non-negative.")
+        msg = "object volumes must be non-negative."
+        raise ValueError(msg)
     return vol**_OBJECT_EXPONENT
 
 
@@ -134,7 +137,8 @@ def air_absorption_area(
     object_fraction = require_fraction(object_fraction, "object_fraction")
     m_arr = np.asarray(m, dtype=np.float64)
     if np.any(m_arr < 0.0):
-        raise ValueError("the attenuation coefficient m must be non-negative.")
+        msg = "the attenuation coefficient m must be non-negative."
+        raise ValueError(msg)
     area = 4.0 * m_arr * volume * (1.0 - object_fraction)
     return as_float_or_array(area)
 
@@ -161,18 +165,22 @@ def equivalent_absorption_area(
     """
     total = np.asarray(air_area, dtype=np.float64)
     if np.any(total < 0.0):
-        raise ValueError("air_area must be non-negative.")
+        msg = "air_area must be non-negative."
+        raise ValueError(msg)
     for area, alpha in surfaces:
         if area < 0.0:
-            raise ValueError("surface areas must be non-negative.")
+            msg = "surface areas must be non-negative."
+            raise ValueError(msg)
         alpha_arr = np.asarray(alpha, dtype=np.float64)
         if np.any(alpha_arr < 0.0):
-            raise ValueError("absorption coefficients must be non-negative.")
+            msg = "absorption coefficients must be non-negative."
+            raise ValueError(msg)
         total = total + area * alpha_arr
     obj = np.atleast_1d(np.asarray(objects, dtype=np.float64))
     if obj.size:
         if np.any(obj < 0.0):
-            raise ValueError("object absorption areas must be non-negative.")
+            msg = "object absorption areas must be non-negative."
+            raise ValueError(msg)
         total = total + obj.sum(axis=0)
     return as_float_or_array(total)
 
@@ -204,7 +212,8 @@ def reverberation_time(
     object_fraction = require_fraction(object_fraction, "object_fraction")
     area = np.asarray(absorption_area, dtype=np.float64)
     if np.any(area <= 0.0):
-        raise ValueError("absorption_area must be positive.")
+        msg = "absorption_area must be positive."
+        raise ValueError(msg)
     t = _RT_CONSTANT / speed_of_sound * volume * (1.0 - object_fraction) / area
     return as_float_or_array(t)
 
@@ -284,9 +293,8 @@ class ReverberationResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.reverberation import render_enclosed_space_report
 
         return render_enclosed_space_report(
@@ -324,11 +332,12 @@ def enclosed_space_reverberation(
     """
     freq = np.asarray(frequencies, dtype=np.float64)
     if air_condition is not None and not np.array_equal(freq, OCTAVE_BANDS):
-        raise ValueError(
+        msg = (
             "the built-in air_condition profiles cover the standard "
             "OCTAVE_BANDS only; for custom frequencies compute the air term "
             "with air_absorption_area and pass it to equivalent_absorption_area."
         )
+        raise ValueError(msg)
     if air_condition is None:
         air_area: np.ndarray | float = 0.0
     elif air_condition in AIR_ATTENUATION:
@@ -336,10 +345,11 @@ def enclosed_space_reverberation(
             AIR_ATTENUATION[air_condition], volume, object_fraction
         )
     else:
-        raise ValueError(
+        msg = (
             f"air_condition must be one of {tuple(AIR_ATTENUATION)} or None; "
             f"got {air_condition!r}."
         )
+        raise ValueError(msg)
     area = np.broadcast_to(
         equivalent_absorption_area(surfaces, objects=objects, air_area=air_area),
         freq.shape,

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -113,14 +113,16 @@ def _resolve_walls(
     """
     alpha = np.asarray(absorption, dtype=np.float64)
     if not np.all(np.isfinite(alpha)):
-        raise ValueError("absorption coefficients must be finite.")
+        msg = "absorption coefficients must be finite."
+        raise ValueError(msg)
     if np.any(alpha < 0.0) or np.any(alpha > 1.0):
-        raise ValueError(
+        msg = (
             "absorption coefficients must lie in [0, 1]: the image-source "
             "reflection factor R = sqrt(1 - alpha) has no real value for "
             "alpha > 1, so the edge-effect coefficients above 1 that Sabine "
             "tolerates must be capped at 1 here."
         )
+        raise ValueError(msg)
     if alpha.ndim == 0:
         walls = np.full((6, 1), float(alpha), dtype=np.float64)
     elif alpha.ndim == 1 and alpha.shape[0] == 6 and n_freq != 6:
@@ -133,11 +135,12 @@ def _resolve_walls(
     elif alpha.ndim == 2 and alpha.shape[0] == 6:
         walls = alpha
     else:
-        raise ValueError(
+        msg = (
             "'absorption' must be a scalar, a length-6 per-wall vector, a "
             "per-band vector, or a (6, n_bands) per-wall per-band array; got "
             f"shape {alpha.shape}."
         )
+        raise ValueError(msg)
     return np.sqrt(1.0 - walls), walls.shape[1]
 
 
@@ -274,15 +277,18 @@ def _validate_point(
     """Validate a 3-vector strictly inside the room box."""
     p = np.asarray(point, dtype=np.float64)
     if p.shape != (3,):
-        raise ValueError(f"'{name}' must be a 3-vector (x, y, z).")
+        msg = f"'{name}' must be a 3-vector (x, y, z)."
+        raise ValueError(msg)
     if not np.all(np.isfinite(p)):
-        raise ValueError(f"'{name}' coordinates must be finite.")
+        msg = f"'{name}' coordinates must be finite."
+        raise ValueError(msg)
     for value, length, axis in zip(p, dimensions, "xyz"):
         if not 0.0 < value < length:
-            raise ValueError(
+            msg = (
                 f"'{name}' coordinate {axis} = {value} lies outside the room "
                 f"(0, {length}); source and receiver must be strictly inside."
             )
+            raise ValueError(msg)
     return p
 
 
@@ -304,7 +310,8 @@ def _resolve_band_maps(
     """
     m = np.asarray(air_attenuation, dtype=np.float64)
     if not np.all(np.isfinite(m)) or np.any(m < 0.0):
-        raise ValueError("'air_attenuation' must be finite and non-negative.")
+        msg = "'air_attenuation' must be finite and non-negative."
+        raise ValueError(msg)
     banded = freq is not None or n_alpha_bands > 1 or m.size > 1
     if freq is not None:
         n_bands = freq.size
@@ -315,16 +322,18 @@ def _resolve_band_maps(
     if reflection.shape[1] == 1 and n_bands > 1:
         reflection = np.broadcast_to(reflection, (6, n_bands)).copy()
     elif reflection.shape[1] not in (1, n_bands):
-        raise ValueError(
+        msg = (
             f"'absorption' has {reflection.shape[1]} bands but the result has "
             f"{n_bands}; a per-band 'absorption' must match the band count of "
             "'frequencies' (or the air attenuation)."
         )
+        raise ValueError(msg)
     if m.size not in (1, n_bands):
-        raise ValueError(
+        msg = (
             f"'air_attenuation' has {m.size} bands but the result has "
             f"{n_bands}; they must match."
         )
+        raise ValueError(msg)
     return reflection, np.broadcast_to(m, (n_bands,)), n_bands, banded
 
 
@@ -413,7 +422,8 @@ def _sample_ir(
         duration = require_positive(duration, "duration")
     n_samples = int(np.ceil(duration * fs))
     if n_samples < 1:
-        raise ValueError("'duration' must cover at least one sample.")
+        msg = "'duration' must cover at least one sample."
+        raise ValueError(msg)
     sample_idx = np.rint(times * fs).astype(np.int64)
     inside = sample_idx < n_samples
     ir = np.zeros((n_bands, n_samples), dtype=np.float64)
@@ -493,18 +503,21 @@ def image_source_rir(
     lz = require_positive(float(dimensions[2]), "Lz")
     dims = (lx, ly, lz)
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
     if max_order < 0:
-        raise ValueError("'max_order' must be non-negative.")
+        msg = "'max_order' must be non-negative."
+        raise ValueError(msg)
     src = _validate_point(source, dims, "source")
     rcv = _validate_point(receiver, dims, "receiver")
     if float(np.linalg.norm(src - rcv)) <= 0.0:
-        raise ValueError(
+        msg = (
             "source and receiver coincide; the direct path has zero length "
             "and infinite amplitude. Separate them so the direct distance is "
             "positive."
         )
+        raise ValueError(msg)
 
     freq: np.ndarray | None = None
     n_freq: int | None = None
@@ -559,7 +572,8 @@ def audible_image_count(max_order: int) -> int:
     :return: The audible image count.
     """
     if max_order < 0:
-        raise ValueError("'max_order' must be non-negative.")
+        msg = "'max_order' must be non-negative."
+        raise ValueError(msg)
     i0 = int(max_order)
     return (2 * (2 * i0**3 + 3 * i0**2 + 4 * i0)) // 3
 

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -235,17 +235,22 @@ def sweep_signal(
     :return: The sweep samples, length ``round(seconds*fs)``.
     """
     if f1 <= 0.0:
-        raise ValueError("f1 must be positive")
+        msg = "f1 must be positive"
+        raise ValueError(msg)
     if f2 <= f1:
-        raise ValueError("f2 must be greater than f1")
+        msg = "f2 must be greater than f1"
+        raise ValueError(msg)
     if f2 > fs / 2.0:
-        raise ValueError("f2 must not exceed the Nyquist frequency fs/2")
+        msg = "f2 must not exceed the Nyquist frequency fs/2"
+        raise ValueError(msg)
     if not 0.0 <= fade < 0.5:
-        raise ValueError("fade must be in [0, 0.5)")
+        msg = "fade must be in [0, 0.5)"
+        raise ValueError(msg)
 
     n = round(seconds * fs)
     if n < 2:
-        raise ValueError("seconds*fs must yield at least 2 samples")
+        msg = "seconds*fs must yield at least 2 samples"
+        raise ValueError(msg)
 
     t = np.arange(n) / fs
     ts = n / fs
@@ -324,11 +329,12 @@ def inverse_filter(
     freqs = np.fft.rfftfreq(comp.size, d=1.0 / fs)
     band = (freqs >= f1) & (freqs <= f2)
     if not np.any(band):
-        raise ValueError(
+        msg = (
             "no frequency bin falls within the sweep band [f1, f2]; the "
             "sweep is too short for this frequency resolution; increase "
             "'seconds' or widen the (f1, f2) range."
         )
+        raise ValueError(msg)
     gain = float(np.median(np.abs(np.fft.rfft(comp)[band])))
     if gain > 0.0:
         inv = inv / gain
@@ -350,7 +356,8 @@ def _farina_deconvolve(
     the spectral method, which would silently produce a wrong inverse filter).
     """
     if f_range is None:
-        raise ValueError("method='farina' requires f_range=(f1, f2)")
+        msg = "method='farina' requires f_range=(f1, f2)"
+        raise ValueError(msg)
     # A reference that was zero-padded to the recording length - the correct
     # input for method="spectral" - makes the rebuilt sweep longer than the
     # real excitation, silently producing a wrong inverse filter (the IR peak
@@ -361,13 +368,14 @@ def _farina_deconvolve(
     last_nonzero = int(nonzero[-1]) if nonzero.size else -1
     n_trailing = ref.size - 1 - last_nonzero
     if n_trailing > _FARINA_MAX_TRAILING_ZEROS:
-        raise ValueError(
+        msg = (
             f"method='farina' requires the unpadded excitation sweep as "
             f"'reference', but it ends in {n_trailing} zero samples "
             "(zero-padding to the recording length is only correct for "
             "method='spectral'). Pass the exact-length sweep from "
             "sweep_signal(), or use method='spectral'."
         )
+        raise ValueError(msg)
     inv = inverse_filter(fs, f_range[0], f_range[1], ref.size / fs)
     conv = signal.fftconvolve(rec, inv)
     # The linear IR peaks where the inverse aligns with the sweep, at index
@@ -476,9 +484,11 @@ def impulse_response(
     rec = apply_calibration(recorded, _typesignal(np.asarray(recorded)))
     ref = _typesignal(np.asarray(reference))
     if rec.ndim != 1 or ref.ndim != 1:
-        raise ValueError("'recorded' and 'reference' must be one-dimensional.")
+        msg = "'recorded' and 'reference' must be one-dimensional."
+        raise ValueError(msg)
     if rec.size == 0 or ref.size == 0:
-        raise ValueError("'recorded' and 'reference' must be non-empty.")
+        msg = "'recorded' and 'reference' must be non-empty."
+        raise ValueError(msg)
     out_len = length if length is not None else rec.size
     n = rec.size + ref.size - 1
 
@@ -491,14 +501,16 @@ def impulse_response(
         full = np.fft.irfft(h_spec, n=n)
     elif method == "farina":
         if fs is None:
-            raise ValueError(
+            msg = (
                 "method='farina' requires fs: unlike the spectral division, "
                 "it rebuilds the analytic inverse filter, which is defined "
                 "in hertz. Pass fs, or hand a Signal that carries it"
             )
+            raise ValueError(msg)
         full = _farina_deconvolve(rec, ref, fs, f_range)
     else:
-        raise ValueError(f"unknown method {method!r}")
+        msg = f"unknown method {method!r}"
+        raise ValueError(msg)
 
     ir = full if return_full else full[:out_len]
     return ImpulseResponseResult(ir=np.asarray(ir), fs=fs, method=method)
@@ -517,7 +529,8 @@ def mls_signal(order: int) -> np.ndarray:
     :return: The bipolar MLS samples (values in ``{-1.0, +1.0}``).
     """
     if order not in _MLS_TAPS:
-        raise ValueError(f"order must be one of {sorted(_MLS_TAPS)} (got {order})")
+        msg = f"order must be one of {sorted(_MLS_TAPS)} (got {order})"
+        raise ValueError(msg)
     taps = _MLS_TAPS[order]
     length = (1 << order) - 1
     # LFSR state as a boolean register, seeded with all ones (any non-zero
@@ -587,14 +600,15 @@ def mls_impulse_response(
     rec = apply_calibration(recorded, _typesignal(np.asarray(recorded)))
     seq = _typesignal(np.asarray(mls))
     if rec.ndim != 1 or seq.ndim != 1:
-        raise ValueError("'recorded' and 'mls' must be one-dimensional.")
+        msg = "'recorded' and 'mls' must be one-dimensional."
+        raise ValueError(msg)
     if rec.size == 0 or seq.size == 0:
-        raise ValueError("'recorded' and 'mls' must be non-empty.")
+        msg = "'recorded' and 'mls' must be non-empty."
+        raise ValueError(msg)
     period = seq.size
     if rec.size % period != 0:
-        raise ValueError(
-            "recorded length must be a positive multiple of the MLS length"
-        )
+        msg = "recorded length must be a positive multiple of the MLS length"
+        raise ValueError(msg)
     # Average the recorded periods (synchronous averaging, ISO 18233 6.3.6).
     averaged = rec.reshape(-1, period).mean(axis=0)
     # Circular cross-correlation: DFT{corr} = conj(SEQ) * REC.
@@ -677,9 +691,8 @@ def golay_pair(order: int) -> tuple[np.ndarray, np.ndarray]:
     :return: The pair ``(a, b)`` as bipolar float arrays (values ``+1/-1``).
     """
     if not 1 <= order <= _GOLAY_MAX_ORDER:
-        raise ValueError(
-            f"order must be between 1 and {_GOLAY_MAX_ORDER} (got {order})"
-        )
+        msg = f"order must be between 1 and {_GOLAY_MAX_ORDER} (got {order})"
+        raise ValueError(msg)
     a = np.array([1.0, 1.0])
     b = np.array([1.0, -1.0])
     for _ in range(order - 1):
@@ -752,13 +765,15 @@ def golay_impulse_response(
     )
     code_a, code_b = (_typesignal(c) for c in pair)
     if code_a.ndim != 1 or code_b.ndim != 1:
-        raise ValueError("both Golay codes must be one-dimensional.")
+        msg = "both Golay codes must be one-dimensional."
+        raise ValueError(msg)
     period = code_a.size
     if period < 2 or code_b.size != period:
-        raise ValueError(
+        msg = (
             "'pair' must hold two equal-length codes of at least 2 samples "
             "(use golay_pair())."
         )
+        raise ValueError(msg)
     responses = []
     for name, rec_in, code in (
         ("recorded_a", recorded_a, code_a),
@@ -766,12 +781,14 @@ def golay_impulse_response(
     ):
         rec = apply_calibration(rec_in, _typesignal(np.asarray(rec_in)))
         if rec.ndim != 1:
-            raise ValueError(f"'{name}' must be one-dimensional.")
+            msg = f"'{name}' must be one-dimensional."
+            raise ValueError(msg)
         if rec.size == 0 or rec.size % period != 0:
-            raise ValueError(
+            msg = (
                 f"'{name}' length must be a positive multiple of the "
                 f"{period}-sample code length"
             )
+            raise ValueError(msg)
         # Synchronous averaging of the recorded periods (as with the MLS).
         averaged = rec.reshape(-1, period).mean(axis=0)
         # Circular cross-correlation: DFT{corr} = conj(CODE) * REC.
@@ -879,21 +896,25 @@ def _shaped_target_db(
             return np.zeros_like(freqs)
         if target == "pink":
             return np.asarray(-10.0 * np.log10(safe / f_range[0]))
-        raise ValueError(
+        msg = (
             f"unknown named target {target!r}; use 'white', 'pink' or a "
             "(frequencies_hz, magnitude_db) pair"
         )
+        raise ValueError(msg)
     t_freq = np.asarray(target[0], dtype=np.float64)
     t_db = np.asarray(target[1], dtype=np.float64)
     if t_freq.ndim != 1 or t_freq.size < 2 or t_db.shape != t_freq.shape:
-        raise ValueError(
+        msg = (
             "an array target must be a (frequencies_hz, magnitude_db) pair "
             "of equal-length 1-D arrays with at least 2 points"
         )
+        raise ValueError(msg)
     if np.any(t_freq <= 0.0) or np.any(np.diff(t_freq) <= 0.0):
-        raise ValueError("target frequencies must be positive and increasing")
+        msg = "target frequencies must be positive and increasing"
+        raise ValueError(msg)
     if not np.all(np.isfinite(t_db)):
-        raise ValueError("target magnitudes must be finite")
+        msg = "target magnitudes must be finite"
+        raise ValueError(msg)
     return np.asarray(np.interp(np.log10(safe), np.log10(t_freq), t_db))
 
 
@@ -1002,22 +1023,30 @@ def shaped_sweep_signal(
     """
     fs_v = float(fs)
     if fs_v <= 0.0:
-        raise ValueError("fs must be positive")
+        msg = "fs must be positive"
+        raise ValueError(msg)
     if f1 <= 0.0:
-        raise ValueError("f1 must be positive")
+        msg = "f1 must be positive"
+        raise ValueError(msg)
     if f2 <= f1:
-        raise ValueError("f2 must be greater than f1")
+        msg = "f2 must be greater than f1"
+        raise ValueError(msg)
     if f2 > fs_v / 2.0:
-        raise ValueError("f2 must not exceed the Nyquist frequency fs/2")
+        msg = "f2 must not exceed the Nyquist frequency fs/2"
+        raise ValueError(msg)
     if seconds <= 0.0:
-        raise ValueError("seconds must be positive")
+        msg = "seconds must be positive"
+        raise ValueError(msg)
     if amplitude <= 0.0:
-        raise ValueError("amplitude must be positive")
+        msg = "amplitude must be positive"
+        raise ValueError(msg)
     if not 0.0 <= fade < 0.5:
-        raise ValueError("fade must be in [0, 0.5)")
+        msg = "fade must be in [0, 0.5)"
+        raise ValueError(msg)
     lead = 0.05 * seconds if start_delay is None else float(start_delay)
     if lead <= 0.0:
-        raise ValueError("start_delay must be positive")
+        msg = "start_delay must be positive"
+        raise ValueError(msg)
 
     # FFT block at least double the total signal so low-frequency
     # pre-ringing folding to "negative times" stays clear of the tail
@@ -1025,14 +1054,16 @@ def shaped_sweep_signal(
     total = seconds + 2.0 * lead
     n_keep = round(total * fs_v)
     if n_keep < 16:
-        raise ValueError("seconds*fs must yield at least 16 samples")
+        msg = "seconds*fs must yield at least 16 samples"
+        raise ValueError(msg)
     n_fft = int(2 ** np.ceil(np.log2(2 * n_keep)))
     freqs = np.asarray(np.fft.rfftfreq(n_fft, 1.0 / fs_v), dtype=np.float64)
     if not np.any((freqs >= f1) & (freqs <= f2)):
-        raise ValueError(
+        msg = (
             "no frequency bin falls within [f1, f2]; lengthen 'seconds' or "
             "widen the (f1, f2) range."
         )
+        raise ValueError(msg)
 
     # Band-limited target magnitude (linear, normalised to peak 1).
     target_db = _shaped_target_db(target, freqs, (float(f1), float(f2)))

--- a/src/phonometry/room/modes.py
+++ b/src/phonometry/room/modes.py
@@ -93,11 +93,11 @@ def _require_dimensions(dimensions: ArrayLike) -> NDArray[np.float64]:
     """Validate the three room dimensions and return them as an array."""
     dims = np.asarray(dimensions, dtype=np.float64).ravel()
     if dims.size != 3:
-        raise ValueError(
-            "'dimensions' must hold the three room dimensions (lx, ly, lz) in m."
-        )
+        msg = "'dimensions' must hold the three room dimensions (lx, ly, lz) in m."
+        raise ValueError(msg)
     if not np.all(np.isfinite(dims)) or np.any(dims <= 0.0):
-        raise ValueError("'dimensions' must be positive and finite.")
+        msg = "'dimensions' must be positive and finite."
+        raise ValueError(msg)
     return dims
 
 
@@ -142,9 +142,11 @@ def room_mode_frequency(
     else:
         single = False
     if n.ndim != 2 or n.shape[1] != 3:
-        raise ValueError("'orders' must be a triple (nx, ny, nz) or an (N, 3) array.")
+        msg = "'orders' must be a triple (nx, ny, nz) or an (N, 3) array."
+        raise ValueError(msg)
     if np.any(n < 0.0) or np.any(n != np.floor(n)):
-        raise ValueError("'orders' must be non-negative integers.")
+        msg = "'orders' must be non-negative integers."
+        raise ValueError(msg)
     freqs = 0.5 * c0 * np.sqrt(np.sum((n / dims) ** 2, axis=1))
     return float(freqs[0]) if single else freqs
 
@@ -177,7 +179,8 @@ def room_mode_count(
     c0 = require_positive(speed_of_sound, "speed_of_sound")
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f < 0.0) or not np.all(np.isfinite(f)):
-        raise ValueError("'frequency' must be non-negative and finite.")
+        msg = "'frequency' must be non-negative and finite."
+        raise ValueError(msg)
     volume, surface, edges = _room_geometry(dims)
     x = f / c0
     n = (
@@ -214,7 +217,8 @@ def room_modal_density(
     c0 = require_positive(speed_of_sound, "speed_of_sound")
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f < 0.0) or not np.all(np.isfinite(f)):
-        raise ValueError("'frequency' must be non-negative and finite.")
+        msg = "'frequency' must be non-negative and finite."
+        raise ValueError(msg)
     volume, surface, edges = _room_geometry(dims)
     density = (
         4.0 * np.pi * volume * f**2 / c0**3
@@ -327,7 +331,7 @@ def room_modes(
     n_max = np.floor(2.0 * f_max * dims / c0).astype(int)
     lattice = float(np.prod(n_max + 1, dtype=np.float64))
     if lattice > MAX_ENUMERATED_LATTICE:
-        raise ValueError(
+        msg = (
             f"Enumerating the modes of a "
             f"{dims[0]:g} x {dims[1]:g} x {dims[2]:g} m room up to "
             f"{f_max:g} Hz needs {lattice:.3g} order triples, above the "
@@ -335,6 +339,7 @@ def room_modes(
             f"room_mode_count / room_modal_density, which are accurate "
             f"wherever the count is this large."
         )
+        raise ValueError(msg)
     grids = np.meshgrid(*(np.arange(n + 1) for n in n_max), indexing="ij")
     orders = np.stack([g.ravel() for g in grids], axis=1)
     orders = orders[np.any(orders > 0, axis=1)]  # drop (0, 0, 0)

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -209,9 +209,8 @@ class NCResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.ansi_s12_2 import render_nc_report
 
         return render_nc_report(
@@ -320,9 +319,8 @@ class RCResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.ansi_s12_2 import render_rc_report
 
         return render_rc_report(
@@ -340,10 +338,11 @@ def nc_curve(index: float) -> np.ndarray:
     :raises ValueError: if ``index`` is outside the tabulated range.
     """
     if index < NC_INDICES[0] or index > NC_INDICES[-1]:
-        raise ValueError(
+        msg = (
             f"NC index {index} is outside the tabulated range "
             f"[{NC_INDICES[0]:.0f}, {NC_INDICES[-1]:.0f}]."
         )
+        raise ValueError(msg)
     return np.array(
         [np.interp(index, NC_INDICES, NC_CURVES[:, k]) for k in range(_N_BANDS)]
     )
@@ -392,25 +391,29 @@ def _align_levels(levels: ArrayLike, frequencies: ArrayLike | None) -> np.ndarra
     """Validate levels and align them to :data:`OCTAVE_BANDS`."""
     lv = np.atleast_1d(np.asarray(levels, dtype=np.float64))
     if lv.ndim != 1:
-        raise ValueError("levels must be a 1-D vector of octave-band levels.")
+        msg = "levels must be a 1-D vector of octave-band levels."
+        raise ValueError(msg)
     if frequencies is None:
         if lv.size != _N_BANDS:
-            raise ValueError(
+            msg = (
                 f"levels must have {_N_BANDS} octave-band values (16 Hz - "
                 f"8000 Hz) when frequencies are not given; got {lv.size}."
             )
+            raise ValueError(msg)
         return lv
     fr = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if fr.shape != lv.shape:
-        raise ValueError("levels and frequencies must have the same shape.")
+        msg = "levels and frequencies must have the same shape."
+        raise ValueError(msg)
     aligned = np.full(_N_BANDS, np.nan)
     for f, level in zip(fr, lv):
         matches = np.isclose(OCTAVE_BANDS, f, rtol=0.03)
         if not matches.any():
-            raise ValueError(
+            msg = (
                 f"frequency {f} Hz is not one of the ANSI S12.2 octave bands "
                 f"(16 Hz - 8000 Hz)."
             )
+            raise ValueError(msg)
         aligned[np.argmax(matches)] = level
     return aligned
 
@@ -448,7 +451,8 @@ def noise_criterion(
     aligned = _align_levels(levels, frequencies)
     valid = ~np.isnan(aligned)
     if not valid.any():
-        raise ValueError("no valid octave-band levels were supplied.")
+        msg = "no valid octave-band levels were supplied."
+        raise ValueError(msg)
 
     sil_levels = aligned[_SIL_BANDS]
     sil = float(np.mean(sil_levels)) if not np.isnan(sil_levels).any() else float("nan")
@@ -540,10 +544,11 @@ def room_criterion(levels: ArrayLike, frequencies: ArrayLike | None = None) -> R
     aligned = _align_levels(levels, frequencies)
     mid = aligned[5:8]  # 500, 1000, 2000 Hz.
     if np.isnan(mid).any():
-        raise ValueError(
+        msg = (
             "the 500, 1000 and 2000 Hz octave bands are required to compute "
             "the mid-frequency average (RC rating)."
         )
+        raise ValueError(msg)
     required = aligned[_RC_REQUIRED_BANDS]
     if np.isnan(required).any():
         missing = OCTAVE_BANDS[_RC_REQUIRED_BANDS][np.isnan(required)]

--- a/src/phonometry/room/open_plan.py
+++ b/src/phonometry/room/open_plan.py
@@ -180,9 +180,8 @@ class OpenPlanResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.iso3382_3 import render_iso3382_3_report
 
         return render_iso3382_3_report(
@@ -252,23 +251,22 @@ def open_plan_metrics(
     sti = np.asarray(sti_values, dtype=np.float64)
 
     if not (r.shape == lp.shape == sti.shape):
-        raise ValueError(
-            "positions_m, spl_a_speech and sti_values must have the same length."
-        )
+        msg = "positions_m, spl_a_speech and sti_values must have the same length."
+        raise ValueError(msg)
     if r.ndim != 1:
-        raise ValueError("Inputs must be one-dimensional.")
+        msg = "Inputs must be one-dimensional."
+        raise ValueError(msg)
     if r.size < _MIN_POSITIONS:
-        raise ValueError(
-            f"ISO 3382-3 requires at least 4 measurement positions (got {r.size})."
-        )
+        msg = f"ISO 3382-3 requires at least 4 measurement positions (got {r.size})."
+        raise ValueError(msg)
     if not (
         np.all(np.isfinite(r)) and np.all(np.isfinite(lp)) and np.all(np.isfinite(sti))
     ):
-        raise ValueError(
-            "positions_m, spl_a_speech and sti_values must be finite (no NaN or Inf)."
-        )
+        msg = "positions_m, spl_a_speech and sti_values must be finite (no NaN or Inf)."
+        raise ValueError(msg)
     if np.any(r <= 0.0):
-        raise ValueError("Distances 'positions_m' must be positive.")
+        msg = "Distances 'positions_m' must be positive."
+        raise ValueError(msg)
 
     d2s = float("nan")
     lp_as_4m = float("nan")

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -119,11 +119,12 @@ def _broadcast_or_raise(
     try:
         return np.broadcast_shapes(*shapes)
     except ValueError:
-        raise ValueError(
+        msg = (
             f"the per-band {name} have incompatible shapes "
             f"{[tuple(s) for s in shapes]}; each must be a scalar or share a "
             "common band count."
-        ) from None
+        )
+        raise ValueError(msg) from None
 
 
 def _accumulate_surfaces(
@@ -148,29 +149,34 @@ def _accumulate_surfaces(
         not broadcast together.
     """
     if not surfaces:
-        raise ValueError("at least one surface is required.")
+        msg = "at least one surface is required."
+        raise ValueError(msg)
     areas: list[float] = []
     alphas: list[NDArray[np.float64]] = []
     for area, alpha in surfaces:
         areas.append(require_non_negative(area, "surface area"))
         alpha_arr = np.asarray(alpha, dtype=np.float64)
         if not np.all(np.isfinite(alpha_arr)):
-            raise ValueError("absorption coefficients must be finite.")
+            msg = "absorption coefficients must be finite."
+            raise ValueError(msg)
         if np.any(alpha_arr < 0.0):
-            raise ValueError("absorption coefficients must be non-negative.")
+            msg = "absorption coefficients must be non-negative."
+            raise ValueError(msg)
         if np.any(alpha_arr > _MAX_ABSORPTION):
-            raise ValueError(
+            msg = (
                 f"absorption coefficients above {_MAX_ABSORPTION} look like a "
                 "unit error (a percentage passed instead of a fraction); "
                 "measured ISO 354 coefficients do not exceed about 1.2."
             )
+            raise ValueError(msg)
         alphas.append(alpha_arr)
     shape = _broadcast_or_raise(
         [a.shape for a in alphas], "surface absorption coefficients"
     )
     total_area = float(sum(areas))
     if total_area <= 0.0:
-        raise ValueError("the total surface area must be positive.")
+        msg = "the total surface area must be positive."
+        raise ValueError(msg)
     absorption_area = np.zeros(shape, dtype=np.float64)
     for area, alpha_arr in zip(areas, alphas):
         absorption_area = absorption_area + area * alpha_arr
@@ -181,7 +187,8 @@ def _air_term(air_attenuation: ArrayLike, volume: float) -> NDArray[np.float64]:
     """Air absorption area ``4 m V`` (m2), validated finite and non-negative."""
     m = np.asarray(air_attenuation, dtype=np.float64)
     if not np.all(np.isfinite(m)) or np.any(m < 0.0):
-        raise ValueError("'air_attenuation' must be finite and non-negative.")
+        msg = "'air_attenuation' must be finite and non-negative."
+        raise ValueError(msg)
     return np.asarray(4.0 * m * volume, dtype=np.float64)
 
 
@@ -210,12 +217,13 @@ def _millington_absorption(
     total = np.asarray(0.0, dtype=np.float64)
     for area, alpha_arr in pairs:
         if np.any(alpha_arr >= 1.0):
-            raise ValueError(
+            msg = (
                 "Millington-Sette requires every absorption coefficient below "
                 "1: its per-surface ln(1 - alpha) diverges at alpha = 1. For "
                 "measured ISO 354 coefficients at or above 1 use Sabine, or "
                 "Eyring if the mean absorption stays below 1."
             )
+            raise ValueError(msg)
         total = total - area * np.log1p(-alpha_arr)
     return np.asarray(total, dtype=np.float64)
 
@@ -227,13 +235,14 @@ def _eyring_absorption(
     # A mean of exactly 1 (fully absorbing on average) has no finite Eyring
     # time: ln(1 - mean) diverges, so fail with a clear message instead.
     if np.any(mean_absorption >= 1.0):
-        raise ValueError(
+        msg = (
             "the mean absorption coefficient must be below 1 for the "
             "Eyring-family models: ln(1 - mean) diverges at a mean of 1. "
             "Individual coefficients at or above 1 are accepted (up to the "
             "shared unit-error ceiling of 2) as long as the mean stays "
             "below 1; Sabine does not constrain the mean."
         )
+        raise ValueError(msg)
     return np.asarray(-total_area * np.log1p(-mean_absorption), dtype=np.float64)
 
 
@@ -244,10 +253,11 @@ def _reverberation_time(
     positive-absorption guard.
     """
     if np.any(absorption <= 0.0):
-        raise ValueError(
+        msg = (
             "the total absorption is non-positive; a perfectly reflecting room "
             "has no finite reverberation time."
         )
+        raise ValueError(msg)
     t = _SABINE_NUMERATOR / speed_of_sound * volume / absorption
     return as_float_or_array(t)
 
@@ -393,7 +403,8 @@ def _axial_geometry(
     :math:`S_z = 2 L_x L_y`.
     """
     if len(dimensions) != 3:
-        raise ValueError("'dimensions' must be the three room lengths (Lx, Ly, Lz).")
+        msg = "'dimensions' must be the three room lengths (Lx, Ly, Lz)."
+        raise ValueError(msg)
     lx, ly, lz = (require_positive(float(d), "dimension") for d in dimensions)
     volume = lx * ly * lz
     pair_areas = np.array(
@@ -416,10 +427,11 @@ def _axial_eyring_times(
     construction), plus the shared air term ``4 m V``.
     """
     if len(absorptions) != 3:
-        raise ValueError(
+        msg = (
             "'absorptions' must give the mean absorption of the three wall pairs "
             "(perpendicular to x, y and z)."
         )
+        raise ValueError(msg)
     volume, total_area, pair_areas = _axial_geometry(dimensions)
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
     air = _air_term(air_attenuation, volume)
@@ -427,16 +439,19 @@ def _axial_eyring_times(
     for alpha in absorptions:
         mean = np.asarray(alpha, dtype=np.float64)
         if not np.all(np.isfinite(mean)):
-            raise ValueError("absorption coefficients must be finite.")
+            msg = "absorption coefficients must be finite."
+            raise ValueError(msg)
         if np.any(mean < 0.0):
-            raise ValueError("absorption coefficients must be non-negative.")
+            msg = "absorption coefficients must be non-negative."
+            raise ValueError(msg)
         if np.any(mean >= 1.0):
-            raise ValueError(
+            msg = (
                 "each wall-pair mean absorption must be below 1: the axial "
                 "Eyring term ln(1 - alpha_i) diverges at alpha_i = 1. The "
                 "inputs of the Fitzroy and Arau-Puchades models are "
                 "themselves the means entering the logarithm."
             )
+            raise ValueError(msg)
         means.append(mean)
     # The three axial times are combined (arithmetic/geometric mean), so their
     # band counts -- and the shared air term -- must broadcast together.
@@ -617,9 +632,8 @@ class ReverberationModelResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.reverberation import render_reverberation_models_report
 
         return render_reverberation_models_report(
@@ -658,9 +672,8 @@ def reverberation_time_models(
     """
     volume, total_area, pair_areas = _axial_geometry(dimensions)
     if len(absorptions) != 3:
-        raise ValueError(
-            "'absorptions' must give the mean absorption of the three wall pairs."
-        )
+        msg = "'absorptions' must give the mean absorption of the three wall pairs."
+        raise ValueError(msg)
     # Two equal-area opposing walls per axis share the axis mean absorption.
     surfaces: list[Surface] = []
     for area, alpha in zip(pair_areas, absorptions):
@@ -715,10 +728,11 @@ def reverberation_time_models(
     else:
         freq = np.asarray(frequencies, dtype=np.float64)
         if curve_bands not in (1, freq.size):
-            raise ValueError(
+            msg = (
                 f"'frequencies' has {freq.size} bands but the per-band "
                 f"absorption has {curve_bands}; they must match."
             )
+            raise ValueError(msg)
         n_bands = freq.size
 
     def _fit(arr: np.ndarray) -> np.ndarray:

--- a/src/phonometry/room/steady_field.py
+++ b/src/phonometry/room/steady_field.py
@@ -92,13 +92,15 @@ def _require_fraction_below_one(value: ArrayLike, name: str) -> NDArray[np.float
     """Validate a mean absorption in ``(0, 1)`` (scalar or per-band)."""
     arr = np.asarray(value, dtype=np.float64)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     if np.any(arr <= 0.0) or np.any(arr >= 1.0):
-        raise ValueError(
+        msg = (
             f"'{name}' must lie strictly in (0, 1): the room constant "
             "R = S*alpha/(1 - alpha) diverges as the mean absorption tends "
             "to 1 (a perfectly absorbing room has no reverberant field)."
         )
+        raise ValueError(msg)
     return arr
 
 
@@ -141,7 +143,8 @@ def critical_distance(
     directivity = require_positive(directivity, "directivity")
     r = np.asarray(room_constant, dtype=np.float64)
     if np.any(r <= 0.0) or not np.all(np.isfinite(r)):
-        raise ValueError("'room_constant' must be positive and finite.")
+        msg = "'room_constant' must be positive and finite."
+        raise ValueError(msg)
     return as_float_or_array(np.sqrt(directivity * r / (16.0 * np.pi)))
 
 
@@ -163,7 +166,8 @@ def schroeder_frequency(
     volume = require_positive(volume, "volume")
     t = np.asarray(reverberation_time, dtype=np.float64)
     if np.any(t <= 0.0) or not np.all(np.isfinite(t)):
-        raise ValueError("'reverberation_time' must be positive and finite.")
+        msg = "'reverberation_time' must be positive and finite."
+        raise ValueError(msg)
     return as_float_or_array(2000.0 * np.sqrt(t / volume))
 
 
@@ -237,12 +241,14 @@ def steady_state_spl(
     directivity = require_positive(directivity, "directivity")
     model = require_choice(source_model, "source_model", tuple(SOURCE_POWER_MODELS))
     if np.any(r_const <= 0.0) or not np.all(np.isfinite(r_const)):
-        raise ValueError("'room_constant' must be positive and finite.")
+        msg = "'room_constant' must be positive and finite."
+        raise ValueError(msg)
     bracket = 4.0 / r_const
     if distance is not None:
         r = np.asarray(distance, dtype=np.float64)
         if np.any(r <= 0.0) or not np.all(np.isfinite(r)):
-            raise ValueError("'distance' must be positive and finite.")
+            msg = "'distance' must be positive and finite."
+            raise ValueError(msg)
         bracket = directivity / (4.0 * np.pi * r**2) + bracket
     lp = (
         lw
@@ -334,9 +340,11 @@ def steady_state_field(
     else:
         r = np.asarray(distances, dtype=np.float64)
         if r.ndim != 1 or r.size == 0:
-            raise ValueError("'distances' must be a non-empty 1D array.")
+            msg = "'distances' must be a non-empty 1D array."
+            raise ValueError(msg)
         if np.any(r <= 0.0) or not np.all(np.isfinite(r)):
-            raise ValueError("'distances' must be positive and finite.")
+            msg = "'distances' must be positive and finite."
+            raise ValueError(msg)
 
     offset = (
         10.0

--- a/src/phonometry/signals/cepstrum.py
+++ b/src/phonometry/signals/cepstrum.py
@@ -127,9 +127,11 @@ def _validate_nfft(n: int, nfft: int | None) -> int:
         return n if n % 2 == 0 else n + 1
     out = int(nfft)
     if out < n:
-        raise ValueError(f"'nfft' must be at least the record length ({n} samples).")
+        msg = f"'nfft' must be at least the record length ({n} samples)."
+        raise ValueError(msg)
     if out % 2 != 0:
-        raise ValueError("'nfft' must be even.")
+        msg = "'nfft' must be even."
+        raise ValueError(msg)
     return out
 
 
@@ -138,7 +140,8 @@ def _log_magnitude(x: NDArray[np.float64], nfft: int) -> NDArray[np.float64]:
     magnitude = np.abs(np.fft.rfft(x, nfft))
     peak = float(np.max(magnitude))
     if peak <= 0.0:  # max of |X| is non-negative: <= 0 means all-zero
-        raise ValueError("'x' must not be identically zero.")
+        msg = "'x' must not be identically zero."
+        raise ValueError(msg)
     return np.asarray(
         np.log(np.maximum(magnitude, peak * _MAGNITUDE_FLOOR)),
         dtype=np.float64,
@@ -160,7 +163,8 @@ def _complex_cepstrum(
     magnitude = np.abs(spectrum)
     peak = float(np.max(magnitude))
     if peak <= 0.0:  # max of |X| is non-negative: <= 0 means all-zero
-        raise ValueError("'x' must not be identically zero.")
+        msg = "'x' must not be identically zero."
+        raise ValueError(msg)
     log_mag = np.log(np.maximum(magnitude, peak * _MAGNITUDE_FLOOR))
     phase = np.unwrap(np.angle(spectrum))
     half = nfft // 2
@@ -213,10 +217,11 @@ class CepstrumResult:
         :raises ValueError: If :attr:`kind` is not ``"complex"``.
         """
         if self.kind != "complex":
-            raise ValueError(
+            msg = (
                 "Only the complex cepstrum is invertible; the power and "
                 "real cepstra discard the phase."
             )
+            raise ValueError(msg)
         log_spectrum = np.fft.fft(self.cepstrum)
         ramp = (
             np.pi * self.linear_phase_samples * np.arange(self.nfft) / (self.nfft // 2)
@@ -279,7 +284,8 @@ def cepstrum(
     xa = _validate_signal(x, "x", context="a cepstrum")
     fs_v = _positive(resolve_fs(x, fs), "fs")
     if kind not in _KINDS:
-        raise ValueError(f"'kind' must be one of {_KINDS}, got {kind!r}.")
+        msg = f"'kind' must be one of {_KINDS}, got {kind!r}."
+        raise ValueError(msg)
     n = _validate_nfft(xa.size, nfft)
 
     delay = 0
@@ -384,15 +390,17 @@ def lifter(
     xa = _validate_signal(x, "x", context="liftering")
     fs_v = _positive(resolve_fs(x, fs), "fs")
     if mode not in ("lowpass", "highpass"):
-        raise ValueError(f"'mode' must be 'lowpass' or 'highpass', got {mode!r}.")
+        msg = f"'mode' must be 'lowpass' or 'highpass', got {mode!r}."
+        raise ValueError(msg)
     n = _validate_nfft(xa.size, nfft)
     cut = round(_positive(cutoff, "cutoff") * fs_v)
     if not 1 <= cut <= n // 2:
-        raise ValueError(
+        msg = (
             "'cutoff' must resolve to between 1 sample and nfft/2 samples "
             f"({1.0 / fs_v:.3g} s to {n // 2 / fs_v:.3g} s), got "
             f"{cutoff:.3g} s."
         )
+        raise ValueError(msg)
 
     log_mag = _log_magnitude(xa, n)
     values = np.asarray(np.fft.irfft(log_mag, n), dtype=np.float64)
@@ -544,11 +552,12 @@ def echo_detection(
     lo = 16 if min_quefrency is None else round(min_quefrency * fs_v)
     hi = n // 2 if max_quefrency is None else round(max_quefrency * fs_v)
     if not 1 <= lo < hi <= n // 2:
-        raise ValueError(
+        msg = (
             "The quefrency search band must satisfy "
             f"1 sample <= min < max <= nfft/2 samples; got [{lo}, {hi}] "
             f"samples of nfft = {n}."
         )
+        raise ValueError(msg)
 
     # Peak-pick on the magnitude so a negative (inverting) reflection is
     # found at its true delay; the signed value at the peak is reported.

--- a/src/phonometry/signals/correlation.py
+++ b/src/phonometry/signals/correlation.py
@@ -265,7 +265,8 @@ def correlation(
     is_auto = y is None
     ya = xa if y is None else _validate_signal(y, "y", context="a correlation estimate")
     if xa.size != ya.size:
-        raise ValueError("'x' and 'y' must have the same length.")
+        msg = "'x' and 'y' must have the same length."
+        raise ValueError(msg)
     if isinstance(x, Signal) or isinstance(y, Signal):
         fs = resolve_pair_fs(x, x if y is None else y, fs)
     elif fs is None:
@@ -281,9 +282,8 @@ def correlation(
     if max_lag is not None:
         m = round(_positive(max_lag, "max_lag") * fs_v)
         if not 1 <= m <= n - 1:
-            raise ValueError(
-                "'max_lag' must be at least one sample and shorter than the record."
-            )
+            msg = "'max_lag' must be at least one sample and shorter than the record."
+            raise ValueError(msg)
 
     lag_samples = np.arange(-(n - 1), n, dtype=np.float64)
     coeff = _coefficient_correlation(xa, ya)
@@ -294,9 +294,8 @@ def correlation(
     elif normalization == "unbiased":
         values = _linear_correlation(xa, ya) / (n - np.abs(lag_samples))
     else:
-        raise ValueError(
-            "'normalization' must be 'biased', 'unbiased' or 'coefficient'."
-        )
+        msg = "'normalization' must be 'biased', 'unbiased' or 'coefficient'."
+        raise ValueError(msg)
 
     keep = np.abs(lag_samples) <= m
     return CorrelationResult(
@@ -348,7 +347,8 @@ def correlation_random_error(
     t = _positive(duration, "duration")
     rho = float(coefficient)
     if not np.isfinite(rho) or abs(rho) > 1.0:
-        raise ValueError("'coefficient' must be in [-1, 1].")
+        msg = "'coefficient' must be in [-1, 1]."
+        raise ValueError(msg)
     # IEEE division carries rho = 0 to the correct limit (an infinite
     # error) without a floating-point equality branch.
     with np.errstate(divide="ignore"):
@@ -444,10 +444,12 @@ def _refine_peak(
 
 def _validate_refinement(interpolation: str, upsample: int) -> int:
     if interpolation not in ("parabolic", "none"):
-        raise ValueError("'interpolation' must be 'parabolic' or 'none'.")
+        msg = "'interpolation' must be 'parabolic' or 'none'."
+        raise ValueError(msg)
     factor = int(upsample)
     if factor < 1:
-        raise ValueError("'upsample' must be a positive integer.")
+        msg = "'upsample' must be a positive integer."
+        raise ValueError(msg)
     return factor
 
 
@@ -541,7 +543,8 @@ def _gcc_weight(
         coherence = _coherence_from_spectra(gxy, gxx, gyy)
         denom = mag * (1.0 - coherence)
         return np.divide(coherence, denom, out=np.zeros_like(denom), where=denom > 0.0)
-    raise ValueError("'weighting' must be 'none', 'roth', 'scot', 'phat' or 'ml'.")
+    msg = "'weighting' must be 'none', 'roth', 'scot', 'phat' or 'ml'."
+    raise ValueError(msg)
 
 
 def _delay_error(
@@ -620,9 +623,8 @@ def _direct_tde_curve(
     if max_delay is not None:
         m = round(_positive(max_delay, "max_delay") * fs)
         if not 1 <= m <= n - 1:
-            raise ValueError(
-                "'max_delay' must be at least one sample and shorter than the record."
-            )
+            msg = "'max_delay' must be at least one sample and shorter than the record."
+            raise ValueError(msg)
     curve = _coefficient_correlation(xa, ya)
     lag_samples = np.arange(-(n - 1), n, dtype=np.float64)
     keep = np.abs(lag_samples) <= m
@@ -646,10 +648,11 @@ def _gcc_curve(
         # Knapp & Carter's Eq. 45b weight exists only for |γ|² < 1; a
         # single-segment coherence estimate is identically one, so the
         # weight would be floating-point rounding noise.
-        raise ValueError(
+        msg = (
             "the 'ml' weighting needs an averaged coherence estimate: "
             "use at least two Welch segments (reduce 'nperseg')."
         )
+        raise ValueError(msg)
     _freqs, gxy, gxx, gyy = _welch_pair(xa, ya, fs, seg, nov, window)
     psi = _gcc_weight(weighting, gxy, gxx, gyy)
     r = np.fft.irfft(psi * gxy, n=seg)
@@ -658,11 +661,12 @@ def _gcc_curve(
     if max_delay is not None:
         m = round(_positive(max_delay, "max_delay") * fs)
         if not 1 <= m <= (seg - 1) // 2:
-            raise ValueError(
+            msg = (
                 "'max_delay' must be at least one sample and shorter than "
                 "half the segment length (increase 'nperseg' for longer "
                 "delays)."
             )
+            raise ValueError(msg)
         keep = np.abs(lag_samples) <= m
         lag_samples = lag_samples[keep]
         curve = curve[keep]
@@ -759,11 +763,13 @@ def time_delay(
     ya = _validate_signal(y, "y", context="a time-delay estimate")
     fs = resolve_pair_fs(x, y, fs)
     if xa.size != ya.size:
-        raise ValueError("'x' and 'y' must have the same length.")
+        msg = "'x' and 'y' must have the same length."
+        raise ValueError(msg)
     if float(np.std(xa)) <= 0.0 or float(np.std(ya)) <= 0.0:
-        raise ValueError(
+        msg = (
             "'x' and 'y' must not be constant: there is no correlation peak to locate."
         )
+        raise ValueError(msg)
     fs_v = _positive(fs, "fs")
     factor = _validate_refinement(interpolation, upsample)
 
@@ -798,7 +804,8 @@ def time_delay(
         if peak_mag > 0.0:
             curve = curve / peak_mag
     else:
-        raise ValueError("'method' must be 'gcc', 'direct' or 'phase'.")
+        msg = "'method' must be 'gcc', 'direct' or 'phase'."
+        raise ValueError(msg)
 
     rho, std, interval = _delay_error(
         xa, ya, float(delay_samples), signal_bandwidth, fs_v
@@ -953,7 +960,8 @@ def align_impulse_responses(
     ira = _validate_signal(ir, "ir", context=_DELAY_CONTEXT)
     refa = _validate_signal(reference, "reference", context=_DELAY_CONTEXT)
     if ira.size != refa.size:
-        raise ValueError("'ir' and 'reference' must have the same length.")
+        msg = "'ir' and 'reference' must have the same length."
+        raise ValueError(msg)
     fs_v = _positive(
         resolve_pair_fs(ir, reference, fs, names=("ir", "reference")), "fs"
     )

--- a/src/phonometry/signals/envelope.py
+++ b/src/phonometry/signals/envelope.py
@@ -178,9 +178,11 @@ def envelope(
     fs_v = _positive(resolve_fs(x, fs), "fs")
     factor = int(decimation_factor)
     if factor < 1:
-        raise ValueError("'decimation_factor' must be a positive integer.")
+        msg = "'decimation_factor' must be a positive integer."
+        raise ValueError(msg)
     if factor >= xa.size:
-        raise ValueError("'decimation_factor' must be smaller than the record length.")
+        msg = "'decimation_factor' must be smaller than the record length."
+        raise ValueError(msg)
 
     analytic = sp_signal.hilbert(xa)
     env = np.asarray(np.abs(analytic), dtype=np.float64)
@@ -275,24 +277,25 @@ def _bandpass_pre_filter(
     try:
         low, high = (float(edge) for edge in band)
     except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"'band' must be a pair of numeric (low, high) edges in Hz, got {band!r}."
-        ) from exc
+        msg = f"'band' must be a pair of numeric (low, high) edges in Hz, got {band!r}."
+        raise ValueError(msg) from exc
     if not 0.0 < low < high < fs / 2.0:
-        raise ValueError(
+        msg = (
             "'band' must satisfy 0 < low < high < fs/2; got "
             f"({low:g}, {high:g}) at fs = {fs:g} Hz."
         )
+        raise ValueError(msg)
     sos = sp_signal.butter(4, (low, high), btype="bandpass", fs=fs, output="sos")
     # sosfiltfilt's default edge padding needs 3*(2*n_sections + 1)
     # samples; fail with a clear message instead of scipy's padlen error.
     min_length = 3 * (2 * sos.shape[0] + 1) + 1
     if xa.size < min_length:
-        raise ValueError(
+        msg = (
             f"'x' is too short ({xa.size} samples) for the zero-phase "
             f"band-pass pre-filter, which needs at least {min_length} "
             "samples of padding; lengthen the record or omit 'band'."
         )
+        raise ValueError(msg)
     filtered = np.asarray(sp_signal.sosfiltfilt(sos, xa), dtype=np.float64)
     return filtered, (low, high)
 
@@ -374,11 +377,13 @@ def envelope_spectrum(
     xa = _validate_signal(x, "x", context="an envelope spectrum")
     fs_v = _positive(resolve_fs(x, fs), "fs")
     if kind not in ("magnitude", "squared"):
-        raise ValueError(f"'kind' must be 'magnitude' or 'squared', got {kind!r}.")
+        msg = f"'kind' must be 'magnitude' or 'squared', got {kind!r}."
+        raise ValueError(msg)
     n = xa.size
     nfft_v = n if nfft is None else int(nfft)
     if nfft_v < n:
-        raise ValueError(f"'nfft' must be at least the record length ({n} samples).")
+        msg = f"'nfft' must be at least the record length ({n} samples)."
+        raise ValueError(msg)
 
     band_v: tuple[float, float] | None = None
     if band is not None:

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -136,7 +136,8 @@ class InverseFilterResult:
 
         arr = _typesignal(x)
         if arr.ndim != 1:
-            raise ValueError("'x' must be one-dimensional.")
+            msg = "'x' must be one-dimensional."
+            raise ValueError(msg)
         full = sp_signal.fftconvolve(arr, self.inverse)
         return np.asarray(full[self.delay : self.delay + arr.size])
 
@@ -197,11 +198,14 @@ def _validated_response(response: Any) -> np.ndarray:
     """Validate the measured impulse response array."""
     h = _typesignal(np.asarray(response, dtype=np.float64))
     if h.ndim != 1:
-        raise ValueError("'response' must be one-dimensional.")
+        msg = "'response' must be one-dimensional."
+        raise ValueError(msg)
     if h.size < 2:
-        raise ValueError("'response' must have at least 2 samples.")
+        msg = "'response' must have at least 2 samples."
+        raise ValueError(msg)
     if not np.all(np.isfinite(h)):
-        raise ValueError("'response' must be finite.")
+        msg = "'response' must be finite."
+        raise ValueError(msg)
     return apply_calibration(response, h)
 
 
@@ -209,11 +213,14 @@ def _validated_band(f_range: tuple[float, float], fs: float) -> tuple[float, flo
     """Validate the equalization band against the sample rate."""
     f1, f2 = float(f_range[0]), float(f_range[1])
     if f1 <= 0.0:
-        raise ValueError("f_range[0] must be positive")
+        msg = "f_range[0] must be positive"
+        raise ValueError(msg)
     if f2 <= f1:
-        raise ValueError("f_range[1] must be greater than f_range[0]")
+        msg = "f_range[1] must be greater than f_range[0]"
+        raise ValueError(msg)
     if f2 > fs / 2.0:
-        raise ValueError("f_range[1] must not exceed the Nyquist frequency")
+        msg = "f_range[1] must not exceed the Nyquist frequency"
+        raise ValueError(msg)
     return f1, f2
 
 
@@ -230,13 +237,15 @@ def _resolve_fs(response: Any, fs: float | None) -> float:
     if fs is None:
         fs = getattr(response, "fs", None)
     if fs is None:
-        raise ValueError(
+        msg = (
             "'fs' is required (pass it explicitly, or pass a result object "
             "that carries a sample rate)"
         )
+        raise ValueError(msg)
     fs_v = float(fs)
     if fs_v <= 0.0:
-        raise ValueError("fs must be positive")
+        msg = "fs must be positive"
+        raise ValueError(msg)
     return fs_v
 
 
@@ -313,27 +322,31 @@ def regularized_inverse_filter(
     fs_v = _resolve_fs(response, fs)
     f1, f2 = _validated_band(f_range, fs_v)
     if regularization_inside <= 0.0 or regularization_outside <= 0.0:
-        raise ValueError("both regularization levels must be positive")
+        msg = "both regularization levels must be positive"
+        raise ValueError(msg)
     if transition_octaves <= 0.0:
-        raise ValueError("transition_octaves must be positive")
+        msg = "transition_octaves must be positive"
+        raise ValueError(msg)
 
     size = n_fft if n_fft is not None else 2 ** int(np.ceil(np.log2(2 * h.size)))
     if size < h.size:
-        raise ValueError("n_fft must be at least the response length")
+        msg = "n_fft must be at least the response length"
+        raise ValueError(msg)
     lag = size // 2 if delay is None else int(delay)
     if not 0 <= lag < size:
-        raise ValueError("delay must be in [0, n_fft)")
+        msg = "delay must be in [0, n_fft)"
+        raise ValueError(msg)
 
     freqs = np.asarray(np.fft.rfftfreq(size, 1.0 / fs_v), dtype=np.float64)
     if not np.any((freqs >= f1) & (freqs <= f2)):
-        raise ValueError(
-            "no frequency bin falls within f_range; increase n_fft or widen the band."
-        )
+        msg = "no frequency bin falls within f_range; increase n_fft or widen the band."
+        raise ValueError(msg)
     spectrum_h = np.fft.rfft(h, n=size)
     power = np.abs(spectrum_h) ** 2
     scale = float(np.max(power))
     if scale <= 0.0:
-        raise ValueError("'response' must not be identically zero.")
+        msg = "'response' must not be identically zero."
+        raise ValueError(msg)
     eps = _regularization_profile(
         freqs,
         (f1, f2),

--- a/src/phonometry/signals/levels.py
+++ b/src/phonometry/signals/levels.py
@@ -57,9 +57,11 @@ def _level_db(
 def _validate_level_input(x_proc: np.ndarray, calibration_factor: float) -> None:
     """Shared validation for the public level functions."""
     if x_proc.shape[-1] == 0:
-        raise ValueError("Input signal 'x' cannot be empty.")
+        msg = "Input signal 'x' cannot be empty."
+        raise ValueError(msg)
     if calibration_factor <= 0:
-        raise ValueError("'calibration_factor' must be positive.")
+        msg = "'calibration_factor' must be positive."
+        raise ValueError(msg)
 
 
 def leq(
@@ -154,7 +156,8 @@ def ln_levels(
     _validate_level_input(x_proc, calibration_factor)
     for value in n:
         if not 0 < value < 100:
-            raise ValueError("Percentile values in 'n' must be between 0 and 100.")
+            msg = "Percentile values in 'n' must be between 0 and 100."
+            raise ValueError(msg)
     if weighting is not None and weighting.upper() != "Z":
         x_proc = weighting_filter(x_proc, fs, weighting)
 
@@ -214,7 +217,8 @@ def lc_peak(
     :return: Scalar for 1D input, array of shape (channels,) for 2D input.
     """
     if not isinstance(oversample, (int, np.integer)) or oversample < 1:
-        raise ValueError("oversample must be an integer >= 1.")
+        msg = "oversample must be an integer >= 1."
+        raise ValueError(msg)
     fs = _resolve_fs(x, fs)
     calibration_factor = _resolve_calibration(x, calibration_factor)
     x_proc = _resolve_samples_raw(x, calibrate=False)
@@ -260,7 +264,8 @@ def sel(
     x_proc = _resolve_samples_raw(x, calibrate=False)
     _validate_level_input(x_proc, calibration_factor)
     if fs <= 0:
-        raise ValueError("Sample rate 'fs' must be positive.")
+        msg = "Sample rate 'fs' must be positive."
+        raise ValueError(msg)
     if weighting is not None and weighting.upper() != "Z":
         x_proc = weighting_filter(x_proc, fs, weighting)
     duration_s = x_proc.shape[-1] / fs
@@ -300,7 +305,8 @@ def sound_exposure(
     x_proc = _resolve_samples_raw(x, calibrate=False)
     _validate_level_input(x_proc, calibration)
     if duration_hours is not None and duration_hours <= 0:
-        raise ValueError("'duration_hours' must be positive.")
+        msg = "'duration_hours' must be positive."
+        raise ValueError(msg)
     p_a = weighting_filter(x_proc, fs, "A") * calibration
     mean_square = np.mean(p_a**2, axis=-1)
     hours = (

--- a/src/phonometry/signals/miso.py
+++ b/src/phonometry/signals/miso.py
@@ -124,11 +124,12 @@ def _resolve_miso_fs(
         # for at most one of them.
         rates = sorted({row.fs for row in signals})
         if len(rates) > 1:
-            raise ValueError(
+            msg = (
                 f"'inputs' holds Signals recorded at different rates ({rates} "
                 "Hz); a MISO estimate cross-spectra them against each other, "
                 "so resample them to a common rate first"
             )
+            raise ValueError(msg)
         carrier = signals[0] if signals else np.asarray(output)
     if isinstance(carrier, Signal) or isinstance(output, Signal):
         return float(resolve_pair_fs(carrier, output, fs, names=("inputs", "output")))
@@ -162,12 +163,14 @@ def _validate_inputs(
         # calibration, applied by _validate_signal below.
         rows = list(inputs)
     if len(rows) < 2:
-        raise ValueError("'inputs' must hold at least two input records.")
+        msg = "'inputs' must hold at least two input records."
+        raise ValueError(msg)
     xs = [_validate_signal(x, f"inputs[{i}]") for i, x in enumerate(rows)]
     ya = _validate_signal(output, "output")
     for i, x in enumerate(xs):
         if x.size != ya.size:
-            raise ValueError(f"'inputs[{i}]' and 'output' must have the same length.")
+            msg = f"'inputs[{i}]' and 'output' must have the same length."
+            raise ValueError(msg)
     return xs, ya
 
 
@@ -177,7 +180,8 @@ def _validate_order(order: Sequence[int] | None, q: int) -> tuple[int, ...]:
         return tuple(range(q))
     perm = tuple(int(i) for i in order)
     if sorted(perm) != list(range(q)):
-        raise ValueError(f"'order' must be a permutation of range({q}).")
+        msg = f"'order' must be a permutation of range({q})."
+        raise ValueError(msg)
     return perm
 
 

--- a/src/phonometry/signals/multitaper.py
+++ b/src/phonometry/signals/multitaper.py
@@ -160,16 +160,16 @@ def _validate_multitaper_params(
     """
     nw = _positive(time_half_bandwidth, "time_half_bandwidth")
     if nw < 1.0 or nw >= n / 2.0:
-        raise ValueError(
-            f"'time_half_bandwidth' must be in [1, n/2) (got {nw:g} for {n} samples)."
-        )
+        msg = f"'time_half_bandwidth' must be in [1, n/2) (got {nw:g} for {n} samples)."
+        raise ValueError(msg)
     shannon = int(2.0 * nw)
     k = shannon - 1 if n_tapers is None else int(n_tapers)
     if not 1 <= k <= shannon:
-        raise ValueError(
+        msg = (
             "'n_tapers' must be between 1 and the Shannon number "
             f"2·NW = {shannon} (got {k})."
         )
+        raise ValueError(msg)
     return nw, k
 
 
@@ -383,7 +383,8 @@ def multitaper_psd(
     # calibration (a DC offset counts as signal power here too).
     power = float(np.mean(xa * xa))
     if power <= 0.0:
-        raise ValueError("'x' must not be identically zero.")
+        msg = "'x' must not be identically zero."
+        raise ValueError(msg)
 
     sk, eigenvalues, dc_gains_sq = _dpss_eigenspectra(xa, fs_v, nw, k)
     if adaptive:

--- a/src/phonometry/signals/phase.py
+++ b/src/phonometry/signals/phase.py
@@ -78,21 +78,26 @@ def _validate_response(
 ) -> NDArray[np.complex128]:
     arr = np.asarray(response)
     if arr.ndim != 1:
-        raise ValueError(f"'{name}' must be one-dimensional.")
+        msg = f"'{name}' must be one-dimensional."
+        raise ValueError(msg)
     if arr.size < _MIN_BINS:
-        raise ValueError(f"'{name}' must have at least {_MIN_BINS} frequency bins.")
+        msg = f"'{name}' must have at least {_MIN_BINS} frequency bins."
+        raise ValueError(msg)
     if not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     out = arr.astype(np.complex128, copy=False)
     if not np.any(np.abs(out) > 0.0):
-        raise ValueError(f"'{name}' must not be identically zero.")
+        msg = f"'{name}' must not be identically zero."
+        raise ValueError(msg)
     return out
 
 
 def _validate_oversample(oversample: int) -> int:
     factor = int(oversample)
     if factor < 1:
-        raise ValueError("'oversample' must be a positive integer.")
+        msg = "'oversample' must be a positive integer."
+        raise ValueError(msg)
     return factor
 
 
@@ -193,7 +198,8 @@ def group_delay(
     resp = _validate_response(response)
     fs_v = float(fs)
     if not np.isfinite(fs_v) or fs_v <= 0.0:
-        raise ValueError("'fs' must be a positive, finite number.")
+        msg = "'fs' must be a positive, finite number."
+        raise ValueError(msg)
     phase = np.unwrap(np.angle(resp))
     domega = 2.0 * np.pi * (fs_v / 2.0) / (resp.size - 1)
     return np.asarray(-np.gradient(phase, domega), dtype=np.float64)
@@ -304,7 +310,8 @@ def phase_decomposition(
     resp = _validate_response(response)
     fs_v = float(fs)
     if not np.isfinite(fs_v) or fs_v <= 0.0:
-        raise ValueError("'fs' must be a positive, finite number.")
+        msg = "'fs' must be a positive, finite number."
+        raise ValueError(msg)
     reconstructed = minimum_phase(resp, oversample=oversample)
     measured = np.unwrap(np.angle(resp))
     measured = measured - measured[0]

--- a/src/phonometry/signals/spectra.py
+++ b/src/phonometry/signals/spectra.py
@@ -103,7 +103,8 @@ _MIN_SAMPLES = 32
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -126,11 +127,14 @@ def _validate_signal(
     """
     xa = np.asarray(x, dtype=np.float64)
     if xa.ndim != 1:
-        raise ValueError(f"'{name}' must be one-dimensional.")
+        msg = f"'{name}' must be one-dimensional."
+        raise ValueError(msg)
     if xa.size < _MIN_SAMPLES:
-        raise ValueError(f"Signal too short for {context}: {xa.size} samples.")
+        msg = f"Signal too short for {context}: {xa.size} samples."
+        raise ValueError(msg)
     if not np.all(np.isfinite(xa)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return apply_calibration(x, xa)
 
 
@@ -138,12 +142,12 @@ def _validate_welch_params(
     n: int, fs: float, nperseg: int | None, overlap: float
 ) -> tuple[int, float]:
     if not 0.0 <= float(overlap) < 1.0:
-        raise ValueError("'overlap' must be in [0, 1).")
+        msg = "'overlap' must be in [0, 1)."
+        raise ValueError(msg)
     seg = _default_nperseg(n, fs) if nperseg is None else int(nperseg)
     if seg < _MIN_SAMPLES or seg > n:
-        raise ValueError(
-            f"'nperseg' must be between {_MIN_SAMPLES} and the signal length."
-        )
+        msg = f"'nperseg' must be between {_MIN_SAMPLES} and the signal length."
+        raise ValueError(msg)
     return seg, float(overlap)
 
 
@@ -341,13 +345,15 @@ def _coherence_from_spectra(
 def _validate_confidence(confidence: float) -> float:
     conf = float(confidence)
     if not 0.0 < conf < 1.0:
-        raise ValueError("'confidence' must be in (0, 1).")
+        msg = "'confidence' must be in (0, 1)."
+        raise ValueError(msg)
     return conf
 
 
 def _validate_scaling(scaling: str) -> str:
     if scaling not in ("density", "spectrum"):
-        raise ValueError("'scaling' must be 'density' or 'spectrum'.")
+        msg = "'scaling' must be 'density' or 'spectrum'."
+        raise ValueError(msg)
     return scaling
 
 
@@ -629,7 +635,8 @@ def cross_spectral_density(
     xa = _validate_signal(x, "x")
     ya = _validate_signal(y, "y")
     if xa.size != ya.size:
-        raise ValueError("'x' and 'y' must have the same length.")
+        msg = "'x' and 'y' must have the same length."
+        raise ValueError(msg)
     fs_v = _positive(resolve_pair_fs(x, y, fs), "fs")
     scaling_v = _validate_scaling(scaling)
     seg, ovl = _validate_welch_params(xa.size, fs_v, nperseg, overlap)
@@ -803,7 +810,8 @@ def coherent_output_spectrum(
     xa = _validate_signal(x, "x")
     ya = _validate_signal(y, "y")
     if xa.size != ya.size:
-        raise ValueError("'x' and 'y' must have the same length.")
+        msg = "'x' and 'y' must have the same length."
+        raise ValueError(msg)
     fs_v = _positive(resolve_pair_fs(x, y, fs), "fs")
     scaling_v = _validate_scaling(scaling)
     seg, ovl = _validate_welch_params(xa.size, fs_v, nperseg, overlap)
@@ -863,25 +871,32 @@ def coherent_output_spectrum(
 def _smoothing_validate(f: NDArray[np.float64], v: NDArray[np.float64]) -> None:
     """Validate the frequency axis / spectrum pair of the smoother."""
     if f.ndim != 1 or v.ndim != 1:
-        raise ValueError("'frequencies' and 'values' must be one-dimensional.")
+        msg = "'frequencies' and 'values' must be one-dimensional."
+        raise ValueError(msg)
     if f.size != v.size:
-        raise ValueError("'frequencies' and 'values' must have the same length.")
+        msg = "'frequencies' and 'values' must have the same length."
+        raise ValueError(msg)
     if f.size < 2:
-        raise ValueError("At least two frequency points are required.")
+        msg = "At least two frequency points are required."
+        raise ValueError(msg)
     if not np.all(np.isfinite(f)) or not np.all(np.isfinite(v)):
-        raise ValueError("'frequencies' and 'values' must be finite.")
+        msg = "'frequencies' and 'values' must be finite."
+        raise ValueError(msg)
     if np.any(np.diff(f) <= 0.0):
-        raise ValueError("'frequencies' must be strictly increasing.")
+        msg = "'frequencies' must be strictly increasing."
+        raise ValueError(msg)
 
 
 def _smoothing_to_power(v: NDArray[np.float64], domain: str) -> NDArray[np.float64]:
     """Map the input spectrum onto power-like values per ``domain``."""
     if domain not in ("power", "amplitude", "db"):
-        raise ValueError("'domain' must be 'power', 'amplitude' or 'db'.")
+        msg = "'domain' must be 'power', 'amplitude' or 'db'."
+        raise ValueError(msg)
     if domain == "db":
         return np.asarray(10.0 ** (v / 10.0), dtype=np.float64)
     if np.any(v < 0.0):
-        raise ValueError(f"'values' must be non-negative in the {domain} domain.")
+        msg = f"'values' must be non-negative in the {domain} domain."
+        raise ValueError(msg)
     return v.copy() if domain == "power" else v * v
 
 

--- a/src/phonometry/signals/synchronous_average.py
+++ b/src/phonometry/signals/synchronous_average.py
@@ -129,19 +129,22 @@ def comb_filter_response(
     period_v = _positive(period, "period")
     n = int(n_averages)
     if n < 1:
-        raise ValueError("'n_averages' must be a positive integer.")
+        msg = "'n_averages' must be a positive integer."
+        raise ValueError(msg)
     freqs = np.asarray(frequencies, dtype=np.float64)
     if not np.all(np.isfinite(freqs)):
-        raise ValueError("'frequencies' must be finite.")
+        msg = "'frequencies' must be finite."
+        raise ValueError(msg)
     order = freqs * period_v
     # Finite inputs can still overflow the phase products f*T and N*pi*f*T
     # (sin(inf) is NaN); reject them so the bounded-response contract holds.
     if not np.all(np.isfinite(n * np.pi * order)):
-        raise ValueError(
+        msg = (
             "'frequencies' * 'period' (times n_averages*pi) overflows the "
             "floating-point range; the comb filter cannot be evaluated at "
             "such orders."
         )
+        raise ValueError(msg)
     lower = np.sin(np.pi * order)
     upper = np.sin(n * np.pi * order)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -222,10 +225,11 @@ def _samples_per_period(fs: float, period: float) -> tuple[float, int]:
     samples = fs * period
     rounded = round(samples)
     if rounded < 2:
-        raise ValueError(
+        msg = (
             "'period' is too short for the sample rate: it must span at "
             "least 2 samples."
         )
+        raise ValueError(msg)
     return samples, rounded
 
 
@@ -235,17 +239,20 @@ def _resolve_n_averages(
     """Number of whole periods to average, validated against the record."""
     available = int(np.floor((length - m_int) / samples)) + 1
     if available < 1:
-        raise ValueError("The record is shorter than one period; nothing to average.")
+        msg = "The record is shorter than one period; nothing to average."
+        raise ValueError(msg)
     if n_averages is None:
         return available
     requested = int(n_averages)
     if requested < 1:
-        raise ValueError("'n_averages' must be a positive integer.")
+        msg = "'n_averages' must be a positive integer."
+        raise ValueError(msg)
     if requested > available:
-        raise ValueError(
+        msg = (
             f"'n_averages' = {requested} exceeds the {available} whole "
             f"periods available in the record."
         )
+        raise ValueError(msg)
     return requested
 
 
@@ -322,7 +329,8 @@ def time_synchronous_average(
     period_v = _positive(period, "period")
     n_harmonics_v = int(n_harmonics)
     if n_harmonics_v < 1:
-        raise ValueError("'n_harmonics' must be a positive integer.")
+        msg = "'n_harmonics' must be a positive integer."
+        raise ValueError(msg)
 
     samples, m_int = _samples_per_period(fs_v, period_v)
     n_avg = _resolve_n_averages(n_averages, xa.size, samples, m_int)

--- a/src/phonometry/signals/test_signals.py
+++ b/src/phonometry/signals/test_signals.py
@@ -114,20 +114,23 @@ def noise_signal(
     """
     fs_v = float(fs)
     if not np.isfinite(fs_v) or fs_v <= 0.0:
-        raise ValueError("'fs' must be a positive, finite number.")
+        msg = "'fs' must be a positive, finite number."
+        raise ValueError(msg)
     seconds_v = float(seconds)
     if not np.isfinite(seconds_v) or seconds_v <= 0.0:
-        raise ValueError("'seconds' must be a positive, finite number.")
+        msg = "'seconds' must be a positive, finite number."
+        raise ValueError(msg)
     n = round(fs_v * seconds_v)
     if n < 16:
-        raise ValueError(f"'fs'*'seconds' must give at least 16 samples, got {n}.")
+        msg = f"'fs'*'seconds' must give at least 16 samples, got {n}."
+        raise ValueError(msg)
     if color not in _COLOR_EXPONENTS:
-        raise ValueError(
-            "'color' must be one of 'white', 'pink', 'red', 'blue', 'violet'."
-        )
+        msg = "'color' must be one of 'white', 'pink', 'red', 'blue', 'violet'."
+        raise ValueError(msg)
     rms_v = float(rms)
     if not np.isfinite(rms_v) or rms_v <= 0.0:
-        raise ValueError("'rms' must be a positive, finite number.")
+        msg = "'rms' must be a positive, finite number."
+        raise ValueError(msg)
 
     rng = np.random.default_rng(seed)
     x = rng.standard_normal(n)
@@ -144,7 +147,8 @@ def noise_signal(
     x = x - float(np.mean(x))
     scale = float(np.sqrt(np.mean(x * x)))
     if scale <= 0.0:  # pragma: no cover - white Gaussian is never all-zero
-        raise ValueError("Degenerate all-zero record; use another seed.")
+        msg = "Degenerate all-zero record; use another seed."
+        raise ValueError(msg)
     return np.asarray(x * (rms_v / scale), dtype=np.float64)
 
 
@@ -165,11 +169,14 @@ def _validate_1d_finite(
     """
     xa = np.asarray(x, dtype=np.float64)
     if xa.ndim != 1:
-        raise ValueError(f"'{name}' must be one-dimensional.")
+        msg = f"'{name}' must be one-dimensional."
+        raise ValueError(msg)
     if xa.size < 2:
-        raise ValueError(f"'{name}' must have at least 2 samples.")
+        msg = f"'{name}' must have at least 2 samples."
+        raise ValueError(msg)
     if not np.all(np.isfinite(xa)):
-        raise ValueError(f"'{name}' must be finite.")
+        msg = f"'{name}' must be finite."
+        raise ValueError(msg)
     return apply_calibration(x, xa)
 
 
@@ -247,17 +254,21 @@ def _tone_burst_scalars(
     fs_v = _positive(fs, "fs")
     f_v = _positive(frequency, "frequency")
     if f_v >= fs_v / 2.0:
-        raise ValueError("'frequency' must be below the Nyquist rate fs/2.")
+        msg = "'frequency' must be below the Nyquist rate fs/2."
+        raise ValueError(msg)
     cycles_v = int(cycles)
     if cycles_v != cycles or cycles_v < 1:
-        raise ValueError("'cycles' must be a positive integer.")
+        msg = "'cycles' must be a positive integer."
+        raise ValueError(msg)
     amplitude_v = _positive(amplitude, "amplitude")
     repetitions_v = int(repetitions)
     if repetitions_v != repetitions or repetitions_v < 1:
-        raise ValueError("'repetitions' must be a positive integer.")
+        msg = "'repetitions' must be a positive integer."
+        raise ValueError(msg)
     for name, value in (("pre_silence", pre_silence), ("post_silence", post_silence)):
         if not np.isfinite(float(value)) or float(value) < 0.0:
-            raise ValueError(f"'{name}' must be a non-negative, finite number.")
+            msg = f"'{name}' must be a non-negative, finite number."
+            raise ValueError(msg)
     return fs_v, f_v, cycles_v, amplitude_v, repetitions_v
 
 
@@ -273,15 +284,17 @@ def _tone_burst_period(
     """
     if repetition_rate is None:
         if repetitions_v > 1:
-            raise ValueError("'repetition_rate' is required when 'repetitions' > 1.")
+            msg = "'repetition_rate' is required when 'repetitions' > 1."
+            raise ValueError(msg)
         return None, None, None
     rate_v = _positive(repetition_rate, "repetition_rate")
     period = round(fs_v / rate_v)
     if period < n_on:
-        raise ValueError(
+        msg = (
             "The burst does not fit in one repetition period: "
             f"{n_on} samples per burst, {period} per period."
         )
+        raise ValueError(msg)
     return rate_v, period, n_on / period
 
 
@@ -347,9 +360,8 @@ def tone_burst(
     exact_samples = fs_v * burst_seconds
     n_on = round(exact_samples)
     if n_on < 2:
-        raise ValueError(
-            "The burst is shorter than 2 samples; increase 'cycles' or 'fs'."
-        )
+        msg = "The burst is shorter than 2 samples; increase 'cycles' or 'fs'."
+        raise ValueError(msg)
     rate_v, period, duty = _tone_burst_period(
         fs_v, n_on, repetitions_v, repetition_rate
     )
@@ -526,21 +538,25 @@ def resample_signal(
     fs_new_v = _positive(fs_new, "fs_new")
     atten = float(stopband_attenuation_db)
     if not np.isfinite(atten) or atten < 30.0:
-        raise ValueError("'stopband_attenuation_db' must be at least 30 dB.")
+        msg = "'stopband_attenuation_db' must be at least 30 dB."
+        raise ValueError(msg)
     tw = float(transition_width)
     if not np.isfinite(tw) or not 0.0 < tw <= 0.5:
-        raise ValueError("'transition_width' must be in (0, 0.5].")
+        msg = "'transition_width' must be in (0, 0.5]."
+        raise ValueError(msg)
     max_den = int(max_denominator)
     if max_den < 1:
-        raise ValueError("'max_denominator' must be a positive integer.")
+        msg = "'max_denominator' must be a positive integer."
+        raise ValueError(msg)
 
     ratio = Fraction(fs_new_v / fs_v).limit_denominator(max_den)
     up, down = ratio.numerator, ratio.denominator
     if up == 0 or abs(up / down - fs_new_v / fs_v) > 1e-9 * (fs_new_v / fs_v):
-        raise ValueError(
+        msg = (
             f"'fs_new'/'fs' = {fs_new_v / fs_v!r} is not a rational ratio "
             f"with denominator <= {max_den}."
         )
+        raise ValueError(msg)
 
     if up == down:  # Same rate: nothing to do, and nothing to filter.
         return ResampledSignalResult(
@@ -678,14 +694,17 @@ def fractional_delay(
     xa = _validate_1d_finite(x, "x")
     delay_v = float(delay)
     if not np.isfinite(delay_v):
-        raise ValueError("'delay' must be a finite number.")
+        msg = "'delay' must be a finite number."
+        raise ValueError(msg)
     if abs(delay_v) >= xa.size:
-        raise ValueError(
+        msg = (
             "'delay' magnitude must be smaller than the record length "
             f"({xa.size} samples)."
         )
+        raise ValueError(msg)
     if mode not in ("linear", "circular"):
-        raise ValueError("'mode' must be 'linear' or 'circular'.")
+        msg = "'mode' must be 'linear' or 'circular'."
+        raise ValueError(msg)
     if mode == "linear":
         # A delay is a negative advance; float negation is exact, so the
         # phase ramp is bit-identical to the alignment kernel's.

--- a/src/phonometry/signals/time_frequency.py
+++ b/src/phonometry/signals/time_frequency.py
@@ -360,13 +360,15 @@ def zoom_fft(
     lo = float(f_min)
     hi = float(f_max)
     if not 0.0 <= lo < hi <= fs_v / 2.0:
-        raise ValueError("The zoom band must satisfy 0 <= f_min < f_max <= fs/2.")
+        msg = "The zoom band must satisfy 0 <= f_min < f_max <= fs/2."
+        raise ValueError(msg)
     if n_points is None:
         m = int(np.ceil((hi - lo) * xa.size / fs_v)) + 1
     else:
         m = int(n_points)
     if m < 2:
-        raise ValueError("'n_points' must be at least 2.")
+        msg = "'n_points' must be at least 2."
+        raise ValueError(msg)
 
     w = _taper(window, xa.size)
     coeffs = np.asarray(

--- a/src/phonometry/signals/windows.py
+++ b/src/phonometry/signals/windows.py
@@ -125,7 +125,8 @@ def _mainlobe_edge(level_db: NDArray[np.float64]) -> int:
     falling = np.diff(level_db) < 0.0
     edges = np.flatnonzero(~falling[1:] & falling[:-1]) + 1
     if edges.size == 0:  # pragma: no cover - every proper taper has a null
-        raise ValueError("The window spectrum has no sidelobe structure.")
+        msg = "The window spectrum has no sidelobe structure."
+        raise ValueError(msg)
     return int(edges[0])
 
 
@@ -165,15 +166,18 @@ def window_metrics(
 
     n_v = int(n)
     if n_v < 16:
-        raise ValueError("'n' must be at least 16 samples.")
+        msg = "'n' must be at least 16 samples."
+        raise ValueError(msg)
     try:
         w = np.asarray(
             sp_signal.get_window(window, n_v, fftbins=True), dtype=np.float64
         )
     except (ValueError, TypeError) as exc:
-        raise ValueError(f"Unknown window specification: {window!r}") from exc
+        msg = f"Unknown window specification: {window!r}"
+        raise ValueError(msg) from exc
     if np.any(~np.isfinite(w)) or float(np.sum(w)) <= 0.0:
-        raise ValueError(f"Degenerate window: {window!r}")
+        msg = f"Degenerate window: {window!r}"
+        raise ValueError(msg)
 
     wsum = float(np.sum(w))
     coherent_gain = wsum / n_v

--- a/src/phonometry/simulation/elastic_fdtd.py
+++ b/src/phonometry/simulation/elastic_fdtd.py
@@ -174,7 +174,8 @@ class ForceSource:
         """Reject a non-finite gain and a ``direction`` other than ``"x"``/``"y"``."""
         _finite("amplitude", self.amplitude)
         if self.direction not in _DIRECTIONS:
-            raise ValueError("direction must be 'x' or 'y'")
+            msg = "direction must be 'x' or 'y'"
+            raise ValueError(msg)
 
 
 ElasticSource = ExplosionSource | ForceSource
@@ -214,10 +215,12 @@ class Material:
         c_p = _positive_finite("c_p", self.c_p)
         c_s = _finite("c_s", self.c_s)
         if c_s < 0.0:
-            raise ValueError("c_s must be non-negative (0 marks a fluid)")
+            msg = "c_s must be non-negative (0 marks a fluid)"
+            raise ValueError(msg)
         rho = _positive_finite("rho", self.rho)
         if c_p**2 < 2.0 * c_s**2 * (1.0 - 1e-9):
-            raise ValueError("c_p**2 must be at least 2 * c_s**2 (non-negative lambda)")
+            msg = "c_p**2 must be at least 2 * c_s**2 (non-negative lambda)"
+            raise ValueError(msg)
         object.__setattr__(self, "c_p", c_p)
         object.__setattr__(self, "c_s", c_s)
         object.__setattr__(self, "rho", rho)
@@ -251,7 +254,8 @@ def _as_material(name: str, value: object) -> Material:
     if isinstance(value, Sequence) and not isinstance(value, str) and len(value) == 3:
         c_p, c_s, rho = (float(np.real(v)) for v in value)
         return Material(c_p=c_p, c_s=c_s, rho=rho)
-    raise ValueError(f"{name} must be a Material or a (c_p, c_s, rho) triple")
+    msg = f"{name} must be a Material or a (c_p, c_s, rho) triple"
+    raise ValueError(msg)
 
 
 def scholte_speed(
@@ -293,9 +297,11 @@ def scholte_speed(
     flu = _as_material("fluid", fluid)
     sol = _as_material("solid", solid)
     if not flu.is_fluid:
-        raise ValueError("fluid must have c_s = 0")
+        msg = "fluid must have c_s = 0"
+        raise ValueError(msg)
     if sol.is_fluid:
-        raise ValueError("solid must have c_s > 0")
+        msg = "solid must have c_s > 0"
+        raise ValueError(msg)
     q = sol.c_s**2 / sol.c_p**2
     r = sol.c_s**2 / flu.c_p**2
     m = sol.rho / flu.rho
@@ -318,7 +324,8 @@ def scholte_speed(
     signs = np.sign(values)
     crossings = np.nonzero(np.diff(signs) != 0)[0]
     if crossings.size == 0:  # pragma: no cover - a root always exists
-        raise ValueError("no Scholte root found; check the material pair")
+        msg = "no Scholte root found; check the material pair"
+        raise ValueError(msg)
     k = int(crossings[-1])
     root = float(brentq(characteristic, grid[k], grid[k + 1], xtol=1e-15, rtol=8.9e-16))
     return sol.c_s * float(np.sqrt(root))
@@ -330,12 +337,14 @@ def _resolve_speed_map(
     """Broadcast/validate a wave-speed spec into a finite 2D map."""
     if np.isscalar(value):
         if shape is None:
-            raise ValueError(f"shape is required when {name} is a scalar")
+            msg = f"shape is required when {name} is a scalar"
+            raise ValueError(msg)
         out = np.full(shape, float(np.real(value)), dtype=np.float64)
     else:
         out = np.asarray(value, dtype=np.float64)
     if out.ndim != 2:
-        raise ValueError(f"{name} must be a 2D (ny, nx) map")
+        msg = f"{name} must be a 2D (ny, nx) map"
+        raise ValueError(msg)
     return out
 
 
@@ -352,7 +361,8 @@ def _resolve_free_sides(
         sides = tuple(free_sides)
     unknown = set(sides) - set(_SIDES)
     if unknown:
-        raise ValueError(f"unknown free sides: {sorted(unknown)}")
+        msg = f"unknown free sides: {sorted(unknown)}"
+        raise ValueError(msg)
     return sides
 
 
@@ -436,32 +446,38 @@ class ElasticFDTD2D:
         _positive_map("c_p", cp_map)
         ny, nx = cp_map.shape
         if ny < 2 or nx < 2:
-            raise ValueError("the grid must be at least 2 x 2 cells")
+            msg = "the grid must be at least 2 x 2 cells"
+            raise ValueError(msg)
         cs_map = _resolve_speed_map("c_s", c_s, (ny, nx))
         if cs_map.shape != (ny, nx):
-            raise ValueError("c_s map must match the shape of c_p")
+            msg = "c_s map must match the shape of c_p"
+            raise ValueError(msg)
         if not np.all(np.isfinite(cs_map)) or bool(np.any(cs_map < 0.0)):
-            raise ValueError("c_s must be non-negative and finite everywhere")
+            msg = "c_s must be non-negative and finite everywhere"
+            raise ValueError(msg)
         # lambda >= 0 <=> c_p**2 >= 2 c_s**2 (a small relative tolerance
         # admits c_s = c_p / sqrt(2) given in rounded floats).
         if bool(np.any(cp_map**2 < 2.0 * cs_map**2 * (1.0 - 1e-9))):
-            raise ValueError(
+            msg = (
                 "c_p**2 must be at least 2 * c_s**2 in every "
                 "cell (non-negative lambda); c_s = 0 marks a "
                 "fluid cell"
             )
+            raise ValueError(msg)
         if not np.isfinite(cfl) or not 0.0 < cfl < 1.0:
-            raise ValueError(
+            msg = (
                 "cfl must lie in (0, 1): the leapfrog scheme "
                 "is unstable beyond the Courant bound CN = 1"
             )
+            raise ValueError(msg)
         rho_map = (
             np.full((ny, nx), float(np.real(rho)), dtype=np.float64)
             if np.isscalar(rho)
             else np.asarray(rho, dtype=np.float64)
         )
         if rho_map.shape != (ny, nx):
-            raise ValueError("rho map must match the shape of c_p")
+            msg = "rho map must match the shape of c_p"
+            raise ValueError(msg)
         _positive_map("rho", rho_map)
         sponge_width, damping_map = _validate_sponge_damping(
             sponge_width, sponge_reflection, damping, ny, nx
@@ -516,9 +532,8 @@ class ElasticFDTD2D:
         self.free_sides: tuple[str, ...] = _resolve_free_sides(free_sides)
         overlap = set(self.free_sides) & set(self.sponge_sides)
         if overlap:
-            raise ValueError(
-                f"sides {sorted(overlap)} cannot be both free and absorbing"
-            )
+            msg = f"sides {sorted(overlap)} cannot be both free and absorbing"
+            raise ValueError(msg)
         self._init_decay(sides, sponge_width, sponge_reflection, damping_map, c_max)
         self._init_obstacle(obstacle_mask, ny, nx)
 
@@ -566,7 +581,8 @@ class ElasticFDTD2D:
         ny = _integer("shape[0]", shape[0])
         nx = _integer("shape[1]", shape[1])
         if ny < 2 or nx < 2:
-            raise ValueError("the grid must be at least 2 x 2 cells")
+            msg = "the grid must be at least 2 x 2 cells"
+            raise ValueError(msg)
         bg = _as_material("background", background)
         c_p = np.full((ny, nx), bg.c_p, dtype=np.float64)
         c_s = np.full((ny, nx), bg.c_s, dtype=np.float64)
@@ -577,9 +593,8 @@ class ElasticFDTD2D:
             if isinstance(index, np.ndarray) and (
                 index.dtype != np.bool_ or index.shape != (ny, nx)
             ):
-                raise ValueError(
-                    f"regions[{k}] mask must be a boolean array of shape {(ny, nx)}"
-                )
+                msg = f"regions[{k}] mask must be a boolean array of shape {(ny, nx)}"
+                raise ValueError(msg)
             c_p[index] = mat.c_p
             c_s[index] = mat.c_s
             rho[index] = mat.rho
@@ -691,9 +706,11 @@ class ElasticFDTD2D:
         """Check an explosion cell against the grid and the obstacle mask."""
         ny, nx = self.txx.shape
         if not (0 <= ix < nx and 0 <= iy < ny):
-            raise ValueError("source position lies outside the grid")
+            msg = "source position lies outside the grid"
+            raise ValueError(msg)
         if self._obstacle is not None and self._obstacle[iy, ix]:
-            raise ValueError("source position lies inside an obstacle")
+            msg = "source position lies inside an obstacle"
+            raise ValueError(msg)
 
     def _validate_force_position(self, source: ForceSource, ix: int, iy: int) -> None:
         """Check a force velocity node against the grid and the obstacle."""
@@ -701,12 +718,14 @@ class ElasticFDTD2D:
         open_map = self._vx_open if source.direction == "x" else self._vy_open
         limit = (ny, nx - 1) if source.direction == "x" else (ny - 1, nx)
         if not (0 <= ix < limit[1] and 0 <= iy < limit[0]):
-            raise ValueError("source position lies outside the grid")
+            msg = "source position lies outside the grid"
+            raise ValueError(msg)
         # The open map holds exact 0.0/1.0 factors cast from booleans:
         # exact zero marks a face closed by the obstacle mask (<= avoids
         # the float-equality lint without changing the semantics).
         if open_map is not None and open_map[iy, ix] <= 0.0:
-            raise ValueError("source position lies inside an obstacle")
+            msg = "source position lies inside an obstacle"
+            raise ValueError(msg)
 
     def step(self) -> None:
         """Advance the leapfrog scheme by one time step (Virieux Eq. 5)."""
@@ -929,7 +948,8 @@ class ElasticFDTD2D:
         if field == "p":
             return self.p
         if field not in _FIELD_NAMES:
-            raise ValueError(f"field must be one of {_FIELD_NAMES}")
+            msg = f"field must be one of {_FIELD_NAMES}"
+            raise ValueError(msg)
         ny, nx = self.txx.shape
         out = np.zeros((ny, nx), dtype=np.float64)
         if field == "vx":
@@ -1042,7 +1062,8 @@ class ElasticFDTDResult:
             return plot_elastic_snapshot(
                 self, ax=ax, frame=frame, language=language, **kwargs
             )
-        raise ValueError("kind must be 'probes' or 'snapshot'")
+        msg = "kind must be 'probes' or 'snapshot'"
+        raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -1098,17 +1119,19 @@ def _parse_elastic_boundaries(
     else:
         unknown = set(boundaries) - set(_SIDES)
         if unknown:
-            raise ValueError(f"unknown boundary sides: {sorted(unknown)}")
+            msg = f"unknown boundary sides: {sorted(unknown)}"
+            raise ValueError(msg)
         spec = {side: boundaries.get(side, "rigid") for side in _SIDES}
     absorbing: list[str] = []
     free: list[str] = []
     for side in _SIDES:
         value = spec[side]
         if value not in _BOUNDARY_NAMES:
-            raise ValueError(
+            msg = (
                 f"boundary for side {side!r} must be one of "
                 f"{_BOUNDARY_NAMES}, got {value!r}"
             )
+            raise ValueError(msg)
         if value == "absorbing":
             absorbing.append(side)
         elif value == "free":
@@ -1120,12 +1143,15 @@ def _resolve_probe_fields(probe_fields: Sequence[str]) -> tuple[str, ...]:
     """Validate the probe-field spec into a non-empty unique tuple."""
     fields = tuple(probe_fields)
     if not fields:
-        raise ValueError("probe_fields must not be empty")
+        msg = "probe_fields must not be empty"
+        raise ValueError(msg)
     unknown = set(fields) - set(_FIELD_NAMES)
     if unknown:
-        raise ValueError(f"unknown probe fields: {sorted(unknown)}")
+        msg = f"unknown probe fields: {sorted(unknown)}"
+        raise ValueError(msg)
     if len(set(fields)) != len(fields):
-        raise ValueError("probe_fields must not repeat a field")
+        msg = "probe_fields must not repeat a field"
+        raise ValueError(msg)
     return fields
 
 
@@ -1183,11 +1209,13 @@ def _validated_snapshot_options(
     snapshot_every = recording.snapshot_every
     snapshot_field = recording.snapshot_field
     if snapshot_field not in _FIELD_NAMES:
-        raise ValueError(f"snapshot_field must be one of {_FIELD_NAMES}")
+        msg = f"snapshot_field must be one of {_FIELD_NAMES}"
+        raise ValueError(msg)
     if snapshot_every is not None:
         snapshot_every = _integer("snapshot_every", snapshot_every)
         if snapshot_every < 1:
-            raise ValueError("snapshot_every must be >= 1")
+            msg = "snapshot_every must be >= 1"
+            raise ValueError(msg)
     return snapshot_every, snapshot_field
 
 
@@ -1200,7 +1228,8 @@ def _validated_absorbing_layer(
         return 0
     cells = _integer("absorbing_layer_cells", boundaries.absorbing_layer_cells)
     if cells < 1:
-        raise ValueError("absorbing_layer_cells must be >= 1")
+        msg = "absorbing_layer_cells must be >= 1"
+        raise ValueError(msg)
     return cells
 
 
@@ -1266,7 +1295,8 @@ def elastic_fdtd_simulation(
     recording = ElasticRecording() if recording is None else recording
     boundaries = ElasticBoundaries() if boundaries is None else boundaries
     if len(sources) == 0:
-        raise ValueError("at least one source is required")
+        msg = "at least one source is required"
+        raise ValueError(msg)
     duration = _positive_finite("duration", duration)
     fields = _resolve_probe_fields(recording.probe_fields)
     snapshot_every, snapshot_field = _validated_snapshot_options(recording)
@@ -1294,9 +1324,8 @@ def elastic_fdtd_simulation(
 
     steps = round(duration / sim.dt)
     if steps < 1:
-        raise ValueError(
-            f"duration must cover at least one time step (dt = {sim.dt:.3e} s)"
-        )
+        msg = f"duration must cover at least one time step (dt = {sim.dt:.3e} s)"
+        raise ValueError(msg)
     times = np.arange(steps + 1, dtype=np.float64) * sim.dt
     signals, frames, frame_steps = _record_elastic_run(
         sim, steps, probe_ix, fields, snapshot_every, snapshot_field

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -67,7 +67,8 @@ def _positive_finite(name: str, value: float) -> float:
     """Validate that *value* is a strictly positive finite scalar."""
     out = float(value)
     if not np.isfinite(out) or out <= 0.0:
-        raise ValueError(f"{name} must be positive and finite")
+        msg = f"{name} must be positive and finite"
+        raise ValueError(msg)
     return out
 
 
@@ -75,21 +76,24 @@ def _finite(name: str, value: float) -> float:
     """Validate that *value* is a finite scalar."""
     out = float(value)
     if not np.isfinite(out):
-        raise ValueError(f"{name} must be finite")
+        msg = f"{name} must be finite"
+        raise ValueError(msg)
     return out
 
 
 def _integer(name: str, value: int) -> int:
     """Validate that *value* is an integral scalar (bool is rejected)."""
     if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
-        raise ValueError(f"{name} must be an integer")  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        msg = f"{name} must be an integer"
+        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
     return int(value)
 
 
 def _positive_map(name: str, field: Field2D) -> None:
     """Validate that every cell of *field* is strictly positive and finite."""
     if not np.all(np.isfinite(field)) or bool(np.any(field <= 0.0)):
-        raise ValueError(f"{name} must be strictly positive and finite everywhere")
+        msg = f"{name} must be strictly positive and finite everywhere"
+        raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -152,7 +156,8 @@ class CWSource:
         _positive_finite("frequency", self.frequency)
         _finite("amplitude", self.amplitude)
         if not np.isfinite(self.ramp_cycles) or self.ramp_cycles < 0.0:
-            raise ValueError("ramp_cycles must be non-negative and finite")
+            msg = "ramp_cycles must be non-negative and finite"
+            raise ValueError(msg)
 
     def value(self, t: float) -> float:
         """Source waveform at time ``t`` (seconds)."""
@@ -196,11 +201,14 @@ class SignalSource:
         _finite("amplitude", self.amplitude)
         arr = np.array(self.samples, dtype=np.float64)
         if arr.ndim != 1:
-            raise ValueError("samples must be a 1D array")
+            msg = "samples must be a 1D array"
+            raise ValueError(msg)
         if arr.size == 0:
-            raise ValueError("samples must not be empty")
+            msg = "samples must not be empty"
+            raise ValueError(msg)
         if not np.all(np.isfinite(arr)):
-            raise ValueError("samples must be finite")
+            msg = "samples must be finite"
+            raise ValueError(msg)
         arr.flags.writeable = False
         object.__setattr__(self, "samples", arr)
 
@@ -310,20 +318,26 @@ def _validate_sponge_damping(
     """Validate the sponge/damping spec into ``(width, damping map)``."""
     sponge_width = _integer("sponge_width", sponge_width)
     if sponge_width < 0:
-        raise ValueError("sponge_width must be non-negative")
+        msg = "sponge_width must be non-negative"
+        raise ValueError(msg)
     if sponge_width >= min(nx, ny):
-        raise ValueError("sponge_width must be narrower than the smallest grid side")
+        msg = "sponge_width must be narrower than the smallest grid side"
+        raise ValueError(msg)
     if not 0.0 < sponge_reflection < 1.0:
-        raise ValueError("sponge_reflection must lie strictly between 0 and 1")
+        msg = "sponge_reflection must lie strictly between 0 and 1"
+        raise ValueError(msg)
     damping_map = np.asarray(damping, dtype=np.float64)
     if damping_map.ndim not in (0, 2):
-        raise ValueError("damping must be a scalar or an (ny, nx) map")
+        msg = "damping must be a scalar or an (ny, nx) map"
+        raise ValueError(msg)
     if not np.all(np.isfinite(damping_map)) or np.any(damping_map < 0.0):
-        raise ValueError("damping must be non-negative and finite")
+        msg = "damping must be non-negative and finite"
+        raise ValueError(msg)
     if damping_map.ndim == 2 and damping_map.shape != (ny, nx):
-        raise ValueError(
+        msg = (
             f"damping map shape {damping_map.shape} does not match the grid {(ny, nx)}"
         )
+        raise ValueError(msg)
     return sponge_width, damping_map
 
 
@@ -347,14 +361,17 @@ def _run_recording(
     """Validate the ``run()`` arguments and march, stacking pressure frames."""
     steps = _integer("steps", steps)
     if steps < 0:
-        raise ValueError("steps must be non-negative")
+        msg = "steps must be non-negative"
+        raise ValueError(msg)
     if record_every is not None:
         record_every = _integer("record_every", record_every)
         if record_every < 1:
-            raise ValueError("record_every must be >= 1")
+            msg = "record_every must be >= 1"
+            raise ValueError(msg)
     decimate = _integer("decimate", decimate)
     if decimate < 1:
-        raise ValueError("decimate must be >= 1")
+        msg = "decimate must be >= 1"
+        raise ValueError(msg)
     frames: list[Field2D] = []
     if record_every is not None:
         frames.append(engine.p[::decimate, ::decimate].copy())
@@ -375,11 +392,14 @@ def _validated_obstacle(
         return None
     mask = np.asarray(obstacle_mask)
     if mask.shape != (ny, nx):
-        raise ValueError("obstacle_mask must match the grid shape")
+        msg = "obstacle_mask must match the grid shape"
+        raise ValueError(msg)
     if mask.dtype != np.bool_:
-        raise ValueError("obstacle_mask must be a boolean array")
+        msg = "obstacle_mask must be a boolean array"
+        raise ValueError(msg)
     if bool(mask.all()):
-        raise ValueError("obstacle_mask must leave open cells")
+        msg = "obstacle_mask must leave open cells"
+        raise ValueError(msg)
     return mask.copy() if bool(mask.any()) else None
 
 
@@ -387,12 +407,14 @@ def _resolve_c_map(c: float | Field2D, shape: tuple[int, int] | None) -> Field2D
     """Broadcast/validate the sound-speed spec into a positive 2D map."""
     if np.isscalar(c):
         if shape is None:
-            raise ValueError("shape is required when c is a scalar")
+            msg = "shape is required when c is a scalar"
+            raise ValueError(msg)
         c_map = np.full(shape, float(np.real(c)), dtype=np.float64)
     else:
         c_map = np.asarray(c, dtype=np.float64)
     if c_map.ndim != 2:
-        raise ValueError("c must be a 2D (ny, nx) map")
+        msg = "c must be a 2D (ny, nx) map"
+        raise ValueError(msg)
     _positive_map("c", c_map)
     return c_map
 
@@ -405,7 +427,8 @@ def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
         else np.asarray(rho, dtype=np.float64)
     )
     if rho_map.shape != (ny, nx):
-        raise ValueError("rho map must match the shape of c")
+        msg = "rho map must match the shape of c"
+        raise ValueError(msg)
     _positive_map("rho", rho_map)
     return rho_map
 
@@ -423,7 +446,8 @@ def _resolve_sponge_sides(
         sides = tuple(sponge_sides)
     unknown = set(sides) - set(_SIDES)
     if unknown:
-        raise ValueError(f"unknown sponge sides: {sorted(unknown)}")
+        msg = f"unknown sponge sides: {sorted(unknown)}"
+        raise ValueError(msg)
     return sides
 
 
@@ -435,14 +459,14 @@ def _edge_impedance_profile(
     if z.ndim == 0:
         z = np.full(n_edge, float(z), dtype=np.float64)
     if z.shape != (n_edge,):
-        raise ValueError(
+        msg = (
             f"impedance for side {side!r} must be a scalar or a 1D "
             f"array of length {n_edge}"
         )
+        raise ValueError(msg)
     if not np.all(np.isfinite(z)) or bool(np.any(z <= 0.0)):
-        raise ValueError(
-            f"impedance for side {side!r} must be strictly positive and finite"
-        )
+        msg = f"impedance for side {side!r} must be strictly positive and finite"
+        raise ValueError(msg)
     return z
 
 
@@ -537,11 +561,12 @@ class ContourProbe:
         iy0 = _integer("iy0", iy0)
         iy1 = _integer("iy1", iy1)
         if not (1 <= ix0 <= ix1 <= nx - 2 and 1 <= iy0 <= iy1 <= ny - 2):
-            raise ValueError(
+            msg = (
                 "the contour block needs 1 <= ix0 <= ix1 <= nx - 2 and "
                 "1 <= iy0 <= iy1 <= ny - 2, so every sampled face has an "
                 "open cell on both sides"
             )
+            raise ValueError(msg)
         freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
         if (
             freqs.ndim != 1
@@ -549,9 +574,10 @@ class ContourProbe:
             or not np.all(np.isfinite(freqs))
             or bool(np.any(freqs <= 0.0))
         ):
-            raise ValueError(
+            msg = (
                 "frequencies must be a non-empty 1D sequence of positive finite values"
             )
+            raise ValueError(msg)
         if sim._obstacle is not None:
             # Every sampled face needs open cells on both of its sides:
             # the two cell columns flanking the vertical faces and the two
@@ -561,11 +587,12 @@ class ContourProbe:
                 or sim._obstacle[[iy0 - 1, iy0, iy1, iy1 + 1], ix0 : ix1 + 1].any()
             )
             if blocked:
-                raise ValueError(
+                msg = (
                     "the contour faces touch obstacle cells; the closed "
                     "rectangle must run through open air with the whole "
                     "scatterer strictly inside"
                 )
+                raise ValueError(msg)
         self._ix0, self._ix1 = ix0, ix1
         self._iy0, self._iy1 = iy0, iy1
         self._ys = slice(iy0, iy1 + 1)
@@ -648,12 +675,14 @@ class ContourProbe:
             i for i, f in enumerate(self.frequencies) if np.isclose(f, float(frequency))
         ]
         if not matches:
-            raise ValueError(
+            msg = (
                 f"frequency {frequency!r} Hz is not tracked by this probe "
                 f"(tracked: {self.frequencies})"
             )
+            raise ValueError(msg)
         if self.samples == 0:
-            raise ValueError("no samples accumulated yet; step the simulation first")
+            msg = "no samples accumulated yet; step the simulation first"
+            raise ValueError(msg)
         scale = 2.0 / self.samples
         i = matches[0]
         return ContourPhasors(
@@ -736,10 +765,11 @@ class FDTD2D:
     ) -> None:
         c_map = _resolve_c_map(c, shape)
         if not np.isfinite(cfl) or not 0.0 < cfl < 1.0:
-            raise ValueError(
+            msg = (
                 "cfl must lie in (0, 1): the leapfrog scheme "
                 "is unstable beyond the Courant bound CN = 1"
             )
+            raise ValueError(msg)
         ny, nx = c_map.shape
         rho_map = _resolve_rho_map(rho, ny, nx)
         sponge_width, damping_map = _validate_sponge_damping(
@@ -836,7 +866,8 @@ class FDTD2D:
             return edges
         unknown = set(edge_impedance) - set(_SIDES)
         if unknown:
-            raise ValueError(f"unknown impedance sides: {sorted(unknown)}")
+            msg = f"unknown impedance sides: {sorted(unknown)}"
+            raise ValueError(msg)
         absorbing = set(sponge_sides) if sponge_width > 0 else set()
         rho_edges = {
             "left": self.rho[:, 0],
@@ -848,9 +879,10 @@ class FDTD2D:
             if side not in edge_impedance:
                 continue
             if side in absorbing:
-                raise ValueError(
+                msg = (
                     f"side {side!r} cannot be both absorbing and an impedance boundary"
                 )
+                raise ValueError(msg)
             n_edge = ny if side in ("left", "right") else nx
             z = _edge_impedance_profile(side, edge_impedance[side], n_edge)
             edges.append(_ImpedanceEdge(side, z, rho_edges[side], self.dt, self.dx))
@@ -896,11 +928,14 @@ class FDTD2D:
             ``width``/``wavelength``.
         """
         if direction not in _SIDE_TRAVEL:
-            raise ValueError("'direction' must be 'down', 'up', 'left' or 'right'.")
+            msg = "'direction' must be 'down', 'up', 'left' or 'right'."
+            raise ValueError(msg)
         if width <= 0.0:
-            raise ValueError("'width' must be positive.")
+            msg = "'width' must be positive."
+            raise ValueError(msg)
         if wavelength is not None and wavelength <= 0.0:
-            raise ValueError("'wavelength' must be positive.")
+            msg = "'wavelength' must be positive."
+            raise ValueError(msg)
 
         def profile(coord: NDArray[np.floating]) -> NDArray[np.float64]:
             envelope = amplitude * np.exp(-(((coord - center) / width) ** 2))
@@ -974,9 +1009,11 @@ class FDTD2D:
         ix = _integer("source ix", source.ix)
         iy = _integer("source iy", source.iy)
         if not (0 <= ix < nx and 0 <= iy < ny):
-            raise ValueError("source position lies outside the grid")
+            msg = "source position lies outside the grid"
+            raise ValueError(msg)
         if self._obstacle is not None and self._obstacle[iy, ix]:
-            raise ValueError("source position lies inside an obstacle")
+            msg = "source position lies inside an obstacle"
+            raise ValueError(msg)
         self._sources.append(source)
 
     def add_contour_probe(
@@ -1018,12 +1055,14 @@ class FDTD2D:
     def _add_plane_source(self, source: PlaneWaveSource) -> None:
         """Validate and register a plane-wave injection line."""
         if source.direction not in _SIDE_TRAVEL:
-            raise ValueError("'direction' must be 'down', 'up', 'left' or 'right'.")
+            msg = "'direction' must be 'down', 'up', 'left' or 'right'."
+            raise ValueError(msg)
         offset = _integer("plane-wave offset", source.offset)
         ny, nx = self.p.shape
         limit = ny if source.direction in ("down", "up") else nx
         if not 0 <= offset < limit - 1:
-            raise ValueError("plane-wave offset lies outside the grid")
+            msg = "plane-wave offset lies outside the grid"
+            raise ValueError(msg)
         if self._obstacle is not None:
             if source.direction == "down":
                 line = self._obstacle[offset, :]
@@ -1034,7 +1073,8 @@ class FDTD2D:
             else:
                 line = self._obstacle[:, nx - 1 - offset]
             if bool(np.any(line)):
-                raise ValueError("plane-wave injection line crosses an obstacle")
+                msg = "plane-wave injection line crosses an obstacle"
+                raise ValueError(msg)
         self._plane_sources.append(source)
 
     def step(self) -> None:
@@ -1200,7 +1240,8 @@ class FDTDResult:
             return plot_fdtd_snapshot(
                 self, ax=ax, frame=frame, language=language, **kwargs
             )
-        raise ValueError("kind must be 'probes' or 'snapshot'")
+        msg = "kind must be 'probes' or 'snapshot'"
+        raise ValueError(msg)
 
 
 def _parse_boundaries(
@@ -1213,7 +1254,8 @@ def _parse_boundaries(
     else:
         unknown = set(boundaries) - set(_SIDES)
         if unknown:
-            raise ValueError(f"unknown boundary sides: {sorted(unknown)}")
+            msg = f"unknown boundary sides: {sorted(unknown)}"
+            raise ValueError(msg)
         spec = {side: boundaries.get(side, "rigid") for side in _SIDES}
     absorbing: list[str] = []
     impedance: dict[str, float | NDArray[np.float64]] = {}
@@ -1221,10 +1263,11 @@ def _parse_boundaries(
         value = spec[side]
         if isinstance(value, str):
             if value not in _BOUNDARY_NAMES:
-                raise ValueError(
+                msg = (
                     f"boundary for side {side!r} must be one of "
                     f"{_BOUNDARY_NAMES} or a real impedance, got {value!r}"
                 )
+                raise ValueError(msg)
             if value == "absorbing":
                 absorbing.append(side)
         else:
@@ -1244,9 +1287,11 @@ def _probe_indices(
         ix = _integer("probe ix", ix)
         iy = _integer("probe iy", iy)
         if not (0 <= ix < nx and 0 <= iy < ny):
-            raise ValueError(f"probe ({ix}, {iy}) lies outside the grid")
+            msg = f"probe ({ix}, {iy}) lies outside the grid"
+            raise ValueError(msg)
         if obstacle is not None and obstacle[iy, ix]:
-            raise ValueError(f"probe ({ix}, {iy}) lies inside an obstacle")
+            msg = f"probe ({ix}, {iy}) lies inside an obstacle"
+            raise ValueError(msg)
         probe_ix[k] = (ix, iy)
     return probe_ix
 
@@ -1343,17 +1388,20 @@ def fdtd_simulation(
     :raises ValueError: If the inputs are invalid.
     """
     if len(sources) == 0:
-        raise ValueError("at least one source is required")
+        msg = "at least one source is required"
+        raise ValueError(msg)
     duration = _positive_finite("duration", duration)
     if snapshot_every is not None:
         snapshot_every = _integer("snapshot_every", snapshot_every)
         if snapshot_every < 1:
-            raise ValueError("snapshot_every must be >= 1")
+            msg = "snapshot_every must be >= 1"
+            raise ValueError(msg)
     absorbing_sides, edge_impedance = _parse_boundaries(boundaries)
     if absorbing_sides:
         absorbing_layer_cells = _integer("absorbing_layer_cells", absorbing_layer_cells)
         if absorbing_layer_cells < 1:
-            raise ValueError("absorbing_layer_cells must be >= 1")
+            msg = "absorbing_layer_cells must be >= 1"
+            raise ValueError(msg)
 
     sim = FDTD2D(
         c,
@@ -1375,9 +1423,8 @@ def fdtd_simulation(
 
     steps = round(duration / sim.dt)
     if steps < 1:
-        raise ValueError(
-            f"duration must cover at least one time step (dt = {sim.dt:.3e} s)"
-        )
+        msg = f"duration must cover at least one time step (dt = {sim.dt:.3e} s)"
+        raise ValueError(msg)
     times = np.arange(steps + 1, dtype=np.float64) * sim.dt
     pressures, frames, frame_steps = _record_run(sim, steps, probe_ix, snapshot_every)
 

--- a/src/phonometry/simulation/ntff.py
+++ b/src/phonometry/simulation/ntff.py
@@ -107,26 +107,30 @@ class ContourPhasors:
     def __post_init__(self) -> None:
         """Check positive scalars, matched shapes and finite samples; coerce dtypes."""
         if not np.isfinite(self.frequency) or self.frequency <= 0.0:
-            raise ValueError("frequency must be positive and finite")
+            msg = "frequency must be positive and finite"
+            raise ValueError(msg)
         if not np.isfinite(self.segment) or self.segment <= 0.0:
-            raise ValueError("segment must be positive and finite")
+            msg = "segment must be positive and finite"
+            raise ValueError(msg)
         pos = np.asarray(self.positions, dtype=np.float64)
         nrm = np.asarray(self.normals, dtype=np.float64)
         p = np.asarray(self.pressure, dtype=np.complex128)
         v = np.asarray(self.normal_velocity, dtype=np.complex128)
         n = p.shape[0] if p.ndim == 1 else -1
         if n < 1 or pos.shape != (n, 2) or nrm.shape != (n, 2) or v.shape != (n,):
-            raise ValueError(
+            msg = (
                 "positions and normals must have shape (n, 2) and pressure "
                 "and normal_velocity shape (n,) for the same n >= 1"
             )
+            raise ValueError(msg)
         if not (
             np.all(np.isfinite(pos))
             and np.all(np.isfinite(nrm))
             and np.all(np.isfinite(p))
             and np.all(np.isfinite(v))
         ):
-            raise ValueError("contour phasor arrays must be finite")
+            msg = "contour phasor arrays must be finite"
+            raise ValueError(msg)
         # Store the converted arrays so hand-built instances (lists, mixed
         # dtypes) behave exactly like probe-built ones downstream.
         object.__setattr__(self, "positions", pos)
@@ -143,12 +147,14 @@ class ContourPhasors:
         (incident-only) phasors. Geometry and frequency must match.
         """
         if not np.isclose(self.frequency, reference.frequency):
-            raise ValueError("cannot subtract phasors at different frequencies")
+            msg = "cannot subtract phasors at different frequencies"
+            raise ValueError(msg)
         if self.positions.shape != reference.positions.shape or not (
             np.allclose(self.positions, reference.positions)
             and np.allclose(self.normals, reference.normals)
         ):
-            raise ValueError("cannot subtract phasors sampled on different contours")
+            msg = "cannot subtract phasors sampled on different contours"
+            raise ValueError(msg)
         return ContourPhasors(
             frequency=self.frequency,
             positions=self.positions,
@@ -231,23 +237,26 @@ def far_field_from_contour(
         an observation circle that does not clear the contour.
     """
     if not isinstance(contour, ContourPhasors):
-        raise TypeError("contour must be a ContourPhasors")
+        msg = "contour must be a ContourPhasors"
+        raise TypeError(msg)
     ang = np.atleast_1d(np.asarray(angles, dtype=np.float64))
     if ang.ndim != 1 or ang.size == 0 or not np.all(np.isfinite(ang)):
-        raise ValueError(
-            "angles must be a non-empty 1D sequence of finite values in degrees"
-        )
+        msg = "angles must be a non-empty 1D sequence of finite values in degrees"
+        raise ValueError(msg)
     c = float(speed_of_sound)
     rho = float(air_density)
     if not np.isfinite(c) or c <= 0.0:
-        raise ValueError("speed_of_sound must be positive and finite")
+        msg = "speed_of_sound must be positive and finite"
+        raise ValueError(msg)
     if not np.isfinite(rho) or rho <= 0.0:
-        raise ValueError("air_density must be positive and finite")
+        msg = "air_density must be positive and finite"
+        raise ValueError(msg)
     omega = 2.0 * np.pi * contour.frequency
     k = omega / c
     ox, oy = float(origin[0]), float(origin[1])
     if not (np.isfinite(ox) and np.isfinite(oy)):
-        raise ValueError("origin must be finite")
+        msg = "origin must be finite"
+        raise ValueError(msg)
     pos = contour.positions - np.asarray([ox, oy])
     rad = np.radians(ang)
     u = np.stack((np.cos(rad), np.sin(rad)), axis=1)  # (A, 2)
@@ -264,13 +273,15 @@ def far_field_from_contour(
         )
     d = float(distance)
     if not np.isfinite(d) or d <= 0.0:
-        raise ValueError("distance must be positive and finite")
+        msg = "distance must be positive and finite"
+        raise ValueError(msg)
     reach = float(np.max(np.hypot(pos[:, 0], pos[:, 1])))
     if d <= reach:
-        raise ValueError(
+        msg = (
             f"distance {d:g} m does not clear the contour (farthest sample "
             f"{reach:g} m from origin); the representation is exterior only"
         )
+        raise ValueError(msg)
     obs = d * u  # (A, 2)
     sep = obs[:, np.newaxis, :] - pos[np.newaxis, :, :]  # (A, n, 2)
     dist = np.hypot(sep[..., 0], sep[..., 1])  # (A, n)

--- a/src/phonometry/speech/objective_intelligibility.py
+++ b/src/phonometry/speech/objective_intelligibility.py
@@ -249,15 +249,19 @@ def _validate_pair(
     x = np.asarray(clean, dtype=np.float64)
     y = np.asarray(degraded, dtype=np.float64)
     if x.ndim != 1 or y.ndim != 1:
-        raise ValueError("'clean' and 'degraded' must be 1-D signals.")
+        msg = "'clean' and 'degraded' must be 1-D signals."
+        raise ValueError(msg)
     if x.shape != y.shape:
-        raise ValueError(
+        msg = (
             f"'clean' and 'degraded' must have equal length; got {x.size} and {y.size}."
         )
+        raise ValueError(msg)
     if x.size == 0:
-        raise ValueError("'clean' and 'degraded' must be non-empty.")
+        msg = "'clean' and 'degraded' must be non-empty."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(x)) and np.all(np.isfinite(y))):
-        raise ValueError("'clean' and 'degraded' must be finite.")
+        msg = "'clean' and 'degraded' must be finite."
+        raise ValueError(msg)
     return apply_calibration(clean, x), apply_calibration(degraded, y)
 
 
@@ -326,7 +330,8 @@ def stoi(
     fs = resolve_pair_fs(clean, degraded, fs, names=("clean", "degraded"))
     x, y = _validate_pair(clean, degraded)
     if int(fs) <= 0:
-        raise ValueError("'fs' must be a positive sample rate.")
+        msg = "'fs' must be a positive sample rate."
+        raise ValueError(msg)
 
     x = _resample_to_internal(x, int(fs))
     y = _resample_to_internal(y, int(fs))
@@ -337,11 +342,12 @@ def stoi(
     # friendly message (a bare matmul on an empty spectrogram would raise a
     # cryptic shape error instead).
     if _n_frames(x.size, _FRAME // 2) < _N_SEGMENT:
-        raise ValueError(
+        msg = (
             "Too few short-time frames to score (need at least 30 after "
             "silent-frame removal, i.e. about 0.4 s of active speech); check "
             "the inputs are speech and long enough."
         )
+        raise ValueError(msg)
 
     matrix, centers = _third_octave_matrix()
     window = _analysis_window()

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -637,9 +637,8 @@ def _procedure(method: str) -> _BandProcedure:
     try:
         return _PROCEDURES[method]
     except KeyError:
-        raise ValueError(
-            f"Unknown SII method {method!r}; choose from {', '.join(SII_METHODS)}."
-        ) from None
+        msg = f"Unknown SII method {method!r}; choose from {', '.join(SII_METHODS)}."
+        raise ValueError(msg) from None
 
 
 @dataclass(frozen=True)
@@ -724,9 +723,8 @@ class SIIResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.sii import render_sii_report
 
         return render_sii_report(
@@ -745,10 +743,11 @@ def standard_speech_spectrum(vocal_effort: str = "normal") -> np.ndarray:
     try:
         return _SPEECH_SPECTRA[vocal_effort].copy()
     except KeyError:
-        raise ValueError(
+        msg = (
             f"Unknown vocal_effort {vocal_effort!r}; choose from "
             f"{', '.join(VOCAL_EFFORTS)}."
-        ) from None
+        )
+        raise ValueError(msg) from None
 
 
 @dataclass(frozen=True)
@@ -822,10 +821,11 @@ def standard_speech_spectra(
         (vocal_efforts,) if isinstance(vocal_efforts, str) else tuple(vocal_efforts)
     )
     if not efforts:
-        raise ValueError(
+        msg = (
             "'vocal_efforts' cannot be empty; choose at least one of "
             f"{', '.join(VOCAL_EFFORTS)}."
         )
+        raise ValueError(msg)
     levels = np.array(
         [standard_speech_spectrum(effort) for effort in efforts],
         dtype=np.float64,
@@ -849,11 +849,12 @@ def _as_band_vector(
         # one-third-octave procedure the limits are the computed 2**(-+1/6) fi,
         # and "142.544 Hz - 8979.7 Hz" is a worse hint than "160 Hz - 8000 Hz".
         centres = proc.frequencies
-        raise ValueError(
+        msg = (
             f"{name!r} must be a 1-D vector of {expected} "
             f"{proc.method} band values "
             f"({centres[0]:g} Hz - {centres[-1]:g} Hz); got shape {arr.shape}."
         )
+        raise ValueError(msg)
     return arr
 
 
@@ -910,16 +911,18 @@ def _procedure_speech_spectrum(
     if vocal_effort == "normal":
         return procedure.speech_spectrum.copy()
     if vocal_effort in VOCAL_EFFORTS:
-        raise ValueError(
+        msg = (
             f"The {procedure.method!r} procedure carries the standard speech "
             f"spectrum for normal vocal effort only; {vocal_effort!r} is "
             "carried for the one-third-octave procedure. Pass an explicit "
             "equivalent speech spectrum level instead."
         )
-    raise ValueError(
+        raise ValueError(msg)
+    msg = (
         f"Unknown vocal_effort {vocal_effort!r}; choose from "
         f"{', '.join(VOCAL_EFFORTS)}."
     )
+    raise ValueError(msg)
 
 
 def speech_intelligibility_index(

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -169,9 +169,8 @@ class STIResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from .._report.sti import render_sti_report
 
         return render_sti_report(
@@ -216,10 +215,11 @@ def _octave_bank(fs: int) -> OctaveFilterBank:
     """Octave filter bank for the 7 STI bands (IEC 61260-1 class 0/1)."""
     bank = OctaveFilterBank(fs=fs, fraction=1, order=6, limits=list(_BAND_LIMITS))
     if bank.num_bands != _NUM_BANDS:
-        raise ValueError(
+        msg = (
             f"Expected {_NUM_BANDS} octave bands between 125 Hz and 8 kHz, "
             f"got {bank.num_bands} at fs={fs}."
         )
+        raise ValueError(msg)
     return bank
 
 
@@ -228,10 +228,11 @@ def _validate_band_vector(
 ) -> np.ndarray:
     arr = np.asarray(values, dtype=np.float64)
     if arr.shape != (_NUM_BANDS,):
-        raise ValueError(
+        msg = (
             f"'{name}' must contain exactly {_NUM_BANDS} octave-band values "
             f"(125 Hz - 8 kHz), got shape {arr.shape}."
         )
+        raise ValueError(msg)
     return arr
 
 
@@ -243,12 +244,14 @@ def _truncated_mtf(mtf: np.ndarray) -> np.ndarray:
     """
     m = np.array(mtf, dtype=np.float64)
     if m.ndim != 2 or m.shape[0] != _NUM_BANDS:
-        raise ValueError(
+        msg = (
             f"'mtf' must have shape ({_NUM_BANDS}, n_modulation_frequencies), "
             f"got {m.shape}."
         )
+        raise ValueError(msg)
     if np.any(m < 0.0) or not np.all(np.isfinite(m)):
-        raise ValueError("Modulation transfer values must be finite and >= 0.")
+        msg = "Modulation transfer values must be finite and >= 0."
+        raise ValueError(msg)
     if np.any(m > 1.3):
         warnings.warn(
             "Modulation transfer values above 1.3 detected: the measurement "
@@ -269,10 +272,11 @@ def _snr_vector(
     if snr_arr.ndim == 0:
         return np.full(_NUM_BANDS, float(snr_arr))
     if snr_arr.shape != (_NUM_BANDS,):
-        raise ValueError(
+        msg = (
             f"'snr' must be a scalar or a vector of {_NUM_BANDS} "
             f"octave-band values, got shape {snr_arr.shape}."
         )
+        raise ValueError(msg)
     return snr_arr
 
 
@@ -291,10 +295,11 @@ def _corrected_mtf(
     """
     if level is None:
         if ambient is not None:
-            raise ValueError(
+            msg = (
                 "'ambient' requires the speech octave-band levels 'level' to "
                 "form the intensity-domain correction; pass 'snr' instead."
             )
+            raise ValueError(msg)
         if snr_arr is not None:
             # I_k / (I_k + I_n,k) with I_n,k = I_k * 10^(-SNR/10).
             m = m / (1.0 + 10.0 ** (-snr_arr[:, np.newaxis] / 10.0))
@@ -351,7 +356,8 @@ def _sti_from_mtf(
     m = _truncated_mtf(mtf)
 
     if snr is not None and ambient is not None:
-        raise ValueError("Provide either 'snr' or 'ambient' noise levels, not both.")
+        msg = "Provide either 'snr' or 'ambient' noise levels, not both."
+        raise ValueError(msg)
 
     snr_arr = _snr_vector(snr)
     m, band_levels = _corrected_mtf(m, snr_arr, level, ambient)
@@ -471,16 +477,19 @@ def sti_from_impulse_response(
     fs = resolve_fs(ir, fs, name="ir")
     ir_proc = apply_calibration(ir, _typesignal(np.asarray(ir)))
     if ir_proc.ndim != 1:
-        raise ValueError("sti_from_impulse_response expects a 1D impulse response.")
+        msg = "sti_from_impulse_response expects a 1D impulse response."
+        raise ValueError(msg)
     if fs <= 0:
         raise ValueError(_FS_NOT_POSITIVE_MSG)
     if fs < _MIN_FS:
-        raise ValueError(
+        msg = (
             f"Sample rate 'fs' must be >= {_MIN_FS} Hz: the 8 kHz octave band "
             "extends to 11,2 kHz (IEC 61260-1)."
         )
+        raise ValueError(msg)
     if not np.any(ir_proc):
-        raise ValueError("Impulse response 'ir' is silent.")
+        msg = "Impulse response 'ir' is silent."
+        raise ValueError(msg)
 
     bank = _octave_bank(fs)
     _, _, bands = bank.filter(
@@ -489,7 +498,8 @@ def sti_from_impulse_response(
     p_bands = np.asarray(bands) ** 2  # h_k^2(t), shape (7, n)
     denom = p_bands.sum(axis=1)
     if np.any(denom <= 0.0):
-        raise ValueError("An octave band of the impulse response has no energy.")
+        msg = "An octave band of the impulse response has no energy."
+        raise ValueError(msg)
 
     t = np.arange(ir_proc.shape[-1]) / fs
     mtf = np.empty((_NUM_BANDS, _MOD_FREQS.size))
@@ -539,11 +549,12 @@ def _stipa_modulation_depths(env: np.ndarray, fs: int) -> np.ndarray:
         for j, fm in enumerate((float(_STIPA_F1[k]), float(_STIPA_F2[k]))):
             periods = int(np.floor(duration * fm))
             if periods < 1:
-                raise ValueError(
+                msg = (
                     f"Signal too short for STIPA: it must contain at least one "
                     f"full period of the {fm} Hz modulation (>= {1.0 / fm:.2f} s; "
                     "the standard recommends 15 s to 25 s)."
                 )
+                raise ValueError(msg)
             n_use = round(periods / fm * fs)
             seg = env[k, :n_use]
             total = float(np.sum(seg))
@@ -667,14 +678,16 @@ def stipa(
     )
     x_proc = apply_calibration(x, _typesignal(np.asarray(x)))
     if x_proc.ndim != 1:
-        raise ValueError("stipa expects a 1D signal.")
+        msg = "stipa expects a 1D signal."
+        raise ValueError(msg)
     if fs <= 0:
         raise ValueError(_FS_NOT_POSITIVE_MSG)
     if fs < _MIN_FS:
-        raise ValueError(
+        msg = (
             f"Sample rate 'fs' must be >= {_MIN_FS} Hz: the 8 kHz octave band "
             "extends to 11,2 kHz (IEC 61260-1)."
         )
+        raise ValueError(msg)
 
     if x_proc.size / fs < _STIPA_MIN_SECONDS:
         warnings.warn(
@@ -690,10 +703,12 @@ def stipa(
     if reference is not None:
         ref_proc = apply_calibration(reference, _typesignal(np.asarray(reference)))
         if ref_proc.ndim != 1:
-            raise ValueError("'reference' must be a 1D signal.")
+            msg = "'reference' must be a 1D signal."
+            raise ValueError(msg)
         mdt = _stipa_modulation_depths(_intensity_envelopes(ref_proc, fs), fs)
         if np.any(mdt <= 0.0):
-            raise ValueError("'reference' has zero modulation depth in a band.")
+            msg = "'reference' has zero modulation depth in a band."
+            raise ValueError(msg)
         mtf = mdr / mdt
     else:
         mtf = mdr / _STIPA_MOD_INDEX
@@ -739,12 +754,14 @@ def stipa_signal(
     if fs <= 0:
         raise ValueError(_FS_NOT_POSITIVE_MSG)
     if fs < _MIN_FS:
-        raise ValueError(
+        msg = (
             f"Sample rate 'fs' must be >= {_MIN_FS} Hz: the 8 kHz half-octave "
             "carrier extends beyond 9,4 kHz."
         )
+        raise ValueError(msg)
     if seconds <= 0:
-        raise ValueError("'seconds' must be positive.")
+        msg = "'seconds' must be positive."
+        raise ValueError(msg)
 
     n = round(seconds * fs)
     rng = np.random.default_rng(seed)

--- a/src/phonometry/underwater/acoustics.py
+++ b/src/phonometry/underwater/acoustics.py
@@ -50,7 +50,8 @@ _NO_ENERGY_MSG = "'pressure' has no energy."
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -59,12 +60,15 @@ def _validate_pressure(
 ) -> NDArray[np.float64]:
     sig = np.asarray(pressure, dtype=np.float64)
     if sig.ndim != 1:
-        raise ValueError("'pressure' must be one-dimensional.")
+        msg = "'pressure' must be one-dimensional."
+        raise ValueError(msg)
     if sig.size < min_samples:
         plural = "sample" if min_samples == 1 else "samples"
-        raise ValueError(f"'pressure' must contain at least {min_samples} {plural}.")
+        msg = f"'pressure' must contain at least {min_samples} {plural}."
+        raise ValueError(msg)
     if not np.all(np.isfinite(sig)):
-        raise ValueError("'pressure' must be finite.")
+        msg = "'pressure' must be finite."
+        raise ValueError(msg)
     return apply_calibration(pressure, sig)
 
 

--- a/src/phonometry/underwater/bioacoustics/audiograms.py
+++ b/src/phonometry/underwater/bioacoustics/audiograms.py
@@ -138,9 +138,8 @@ def audiogram_parameters(
             if key == "LF"
             else ""
         )
-        raise ValueError(
-            f"'group' must be one of {AUDIOGRAM_GROUPS}, got {group!r}.{extra}"
-        )
+        msg = f"'group' must be one of {AUDIOGRAM_GROUPS}, got {group!r}.{extra}"
+        raise ValueError(msg)
     return table[key]
 
 
@@ -184,9 +183,11 @@ def _frequency_khz(
 ) -> NDArray[np.float64]:
     f = np.atleast_1d(np.asarray(frequency_hz, dtype=np.float64))
     if f.size == 0 or not np.all(np.isfinite(f)):
-        raise ValueError("'frequency_hz' must be finite and non-empty.")
+        msg = "'frequency_hz' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency_hz' must be strictly positive.")
+        msg = "'frequency_hz' must be strictly positive."
+        raise ValueError(msg)
     return f / 1000.0
 
 
@@ -271,10 +272,11 @@ def orca_audiogram(
     # A relative slack of 1e-9 keeps a grid built on the exact end points (e.g.
     # np.logspace) from tripping on floating-point representation error.
     if np.any(f_khz < lo * (1.0 - 1e-9)) or np.any(f_khz > hi * (1.0 + 1e-9)):
-        raise ValueError(
+        msg = (
             f"'frequency_hz' must lie within {lo * 1e3:g}-{hi * 1e3:g} Hz,"
             " the range over which Equation (11.159) is fitted."
         )
+        raise ValueError(msg)
     b1, b2 = _ORCA_BREAKS
     threshold = np.where(
         f_khz < b1,

--- a/src/phonometry/underwater/bioacoustics/weighting.py
+++ b/src/phonometry/underwater/bioacoustics/weighting.py
@@ -506,9 +506,8 @@ def check_guidance(guidance: str) -> str:
     """
     key = str(guidance).strip().lower().replace("_", "-")
     if key not in _PARAMETERS:
-        raise ValueError(
-            f"'guidance' must be one of {WEIGHTING_GUIDANCE}, got {guidance!r}."
-        )
+        msg = f"'guidance' must be one of {WEIGHTING_GUIDANCE}, got {guidance!r}."
+        raise ValueError(msg)
     return key
 
 
@@ -536,10 +535,11 @@ def weighting_parameters(
     table = _PARAMETERS[key]
     name = str(group).strip().upper()
     if name not in table:
-        raise ValueError(
+        msg = (
             f"'group' must be one of {tuple(table)} for guidance {key!r}, got {group!r}."
             " Group codes are not portable between guidance versions."
         )
+        raise ValueError(msg)
     return table[name]
 
 
@@ -597,9 +597,11 @@ def _positive_frequencies(
 ) -> NDArray[np.float64]:
     f = np.array(frequency_hz, dtype=np.float64, copy=True, ndmin=1)
     if f.size == 0 or not np.all(np.isfinite(f)):
-        raise ValueError("'frequency_hz' must be finite and non-empty.")
+        msg = "'frequency_hz' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency_hz' must be strictly positive.")
+        msg = "'frequency_hz' must be strictly positive."
+        raise ValueError(msg)
     return f
 
 
@@ -785,16 +787,17 @@ def weighted_exposure(
     f = _positive_frequencies(frequency_hz)
     sel = np.array(band_sel, dtype=np.float64, copy=True, ndmin=1)
     if sel.shape != f.shape:
-        raise ValueError("'band_sel' must have the same length as 'frequency_hz'.")
+        msg = "'band_sel' must have the same length as 'frequency_hz'."
+        raise ValueError(msg)
     # -inf is admitted as the level of a band that carries no energy (see
     # StrikeSelSpectrum.band_sel); it is the neutral element of the energy sum.
     if np.any(np.isnan(sel)) or np.any(sel == np.inf):
-        raise ValueError(
-            "'band_sel' must be finite, or -inf for a band with no energy."
-        )
+        msg = "'band_sel' must be finite, or -inf for a band with no energy."
+        raise ValueError(msg)
     n_float = float(n_events)
     if not n_float.is_integer() or int(n_float) < 1:
-        raise ValueError("'n_events' must be a whole number of events, at least 1.")
+        msg = "'n_events' must be a whole number of events, at least 1."
+        raise ValueError(msg)
     n = int(n_float)
 
     weights = auditory_weighting(f, group, guidance=guidance)
@@ -807,7 +810,8 @@ def weighted_exposure(
     if peak_spl is not None:
         peak = float(peak_spl)
         if not np.isfinite(peak):
-            raise ValueError("'peak_spl' must be finite.")
+            msg = "'peak_spl' must be finite."
+            raise ValueError(msg)
 
     sel_margin = _margin(cumulative, criteria.injury_sel)
     tts_margin = _margin(cumulative, criteria.tts_sel)

--- a/src/phonometry/underwater/propagation/closed_form.py
+++ b/src/phonometry/underwater/propagation/closed_form.py
@@ -51,7 +51,8 @@ _M_PER_KM = 1000.0
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -60,9 +61,11 @@ def _positive_array(
 ) -> NDArray[np.float64]:
     arr = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if arr.size == 0 or not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite and non-empty.")
+        msg = f"'{name}' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(arr <= 0.0):
-        raise ValueError(f"'{name}' must be strictly positive.")
+        msg = f"'{name}' must be strictly positive."
+        raise ValueError(msg)
     return arr
 
 
@@ -95,12 +98,14 @@ def spreading_loss(
         return 10.0 * np.log10(r)
     if key == "practical":
         if transition_range is None:
-            raise ValueError("'transition_range' is required for the 'practical' law.")
+            msg = "'transition_range' is required for the 'practical' law."
+            raise ValueError(msg)
         r0 = _positive(transition_range, "transition_range")
         return np.where(
             r <= r0, 20.0 * np.log10(r), 20.0 * np.log10(r0) + 10.0 * np.log10(r / r0)
         )
-    raise ValueError(f"'law' must be one of {_SPREADING_LAWS}, got {law!r}.")
+    msg = f"'law' must be one of {_SPREADING_LAWS}, got {law!r}."
+    raise ValueError(msg)
 
 
 def _thorp(f_khz: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -186,9 +191,11 @@ def seawater_absorption(
     s = float(salinity)
     z = float(depth)
     if not (np.isfinite(t) and np.isfinite(s) and np.isfinite(z) and np.isfinite(ph)):
-        raise ValueError("'temperature', 'salinity', 'depth' and 'ph' must be finite.")
+        msg = "'temperature', 'salinity', 'depth' and 'ph' must be finite."
+        raise ValueError(msg)
     if s < 0.0 or z < 0.0:
-        raise ValueError("'salinity' and 'depth' must be non-negative.")
+        msg = "'salinity' and 'depth' must be non-negative."
+        raise ValueError(msg)
     key = model.strip().lower()
     if key == "thorp":
         return _thorp(f_khz)
@@ -196,7 +203,8 @@ def seawater_absorption(
         return _francois_garrison(f_khz, t, s, z, float(ph))
     if key == "ainslie-mccolm":
         return _ainslie_mccolm(f_khz, t, s, z / _M_PER_KM, float(ph))
-    raise ValueError(f"'model' must be one of {_ABSORPTION_MODELS}, got {model!r}.")
+    msg = f"'model' must be one of {_ABSORPTION_MODELS}, got {model!r}."
+    raise ValueError(msg)
 
 
 @dataclass(frozen=True)

--- a/src/phonometry/underwater/propagation/numerical.py
+++ b/src/phonometry/underwater/propagation/numerical.py
@@ -87,17 +87,23 @@ def _clean_profile(
     z = np.asarray(depths, dtype=np.float64)
     c = np.asarray(sound_speeds, dtype=np.float64)
     if z.ndim != 1 or z.size < 2:
-        raise ValueError("'depths' must be a 1-D array of at least two points.")
+        msg = "'depths' must be a 1-D array of at least two points."
+        raise ValueError(msg)
     if c.shape != z.shape:
-        raise ValueError("'sound_speeds' must match 'depths' in length.")
+        msg = "'sound_speeds' must match 'depths' in length."
+        raise ValueError(msg)
     if not (np.all(np.isfinite(z)) and np.all(np.isfinite(c))):
-        raise ValueError("'depths' and 'sound_speeds' must be finite.")
+        msg = "'depths' and 'sound_speeds' must be finite."
+        raise ValueError(msg)
     if np.any(np.diff(z) <= 0.0):
-        raise ValueError("'depths' must be strictly increasing.")
+        msg = "'depths' must be strictly increasing."
+        raise ValueError(msg)
     if abs(float(z[0])) > 1e-9:
-        raise ValueError("'depths' must start at the surface z = 0.")
+        msg = "'depths' must start at the surface z = 0."
+        raise ValueError(msg)
     if np.any(c <= 0.0):
-        raise ValueError("'sound_speeds' must be strictly positive.")
+        msg = "'sound_speeds' must be strictly positive."
+        raise ValueError(msg)
     return z, c
 
 
@@ -121,31 +127,38 @@ def _clean_bathymetry(
         return None
     pair = tuple(bathymetry)
     if len(pair) != 2 or pair[0] is None or pair[1] is None:
-        raise ValueError("'bathymetry' must be a (ranges_m, depths_m) pair of arrays.")
+        msg = "'bathymetry' must be a (ranges_m, depths_m) pair of arrays."
+        raise ValueError(msg)
     br = np.asarray(pair[0], dtype=np.float64).ravel()
     bd = np.asarray(pair[1], dtype=np.float64).ravel()
     if br.size < 2 or bd.shape != br.shape:
-        raise ValueError(
+        msg = (
             "the two halves of 'bathymetry' must be 1-D"
             " arrays of equal length, at least two points."
         )
+        raise ValueError(msg)
     if not (np.all(np.isfinite(br)) and np.all(np.isfinite(bd))):
-        raise ValueError("the bathymetry must be finite.")
+        msg = "the bathymetry must be finite."
+        raise ValueError(msg)
     if np.any(np.diff(br) <= 0.0):
-        raise ValueError("the bathymetry ranges must be strictly increasing.")
+        msg = "the bathymetry ranges must be strictly increasing."
+        raise ValueError(msg)
     if abs(float(br[0])) > 1e-9:
-        raise ValueError("the bathymetry must start at the source, r = 0.")
+        msg = "the bathymetry must start at the source, r = 0."
+        raise ValueError(msg)
     if np.any(bd <= 0.0):
-        raise ValueError(
+        msg = (
             "the bathymetry depths must be strictly positive: the wedge apex"
             " itself, where the water ends, cannot carry a water column."
         )
+        raise ValueError(msg)
     if float(bd.max()) > float(z_prof[-1]) + 1e-9:
-        raise ValueError(
+        msg = (
             "the bathymetry depths must not run below the sound-speed"
             " profile: the profile is the medium, so it must reach the"
             " deepest point of the bottom."
         )
+        raise ValueError(msg)
     return br, bd
 
 
@@ -199,7 +212,8 @@ def _resolve_boundary(
         )
     key = bottom.strip().lower()
     if key not in _BOTTOM_TYPES:
-        raise ValueError(f"'bottom' must be one of {_BOTTOM_TYPES}, got {bottom!r}.")
+        msg = f"'bottom' must be one of {_BOTTOM_TYPES}, got {bottom!r}."
+        raise ValueError(msg)
     return key, None
 
 
@@ -420,19 +434,20 @@ def normal_modes(
     zs = float(source_depth)
     zr = float(receiver_depth)
     if not (0.0 < zs < water_depth) or not (0.0 < zr < water_depth):
-        raise ValueError(
-            "'source_depth'/'receiver_depth' must lie within the water column."
-        )
+        msg = "'source_depth'/'receiver_depth' must lie within the water column."
+        raise ValueError(msg)
     key = bottom.strip().lower()
     if key not in _BOTTOM_TYPES:
-        raise ValueError(f"'bottom' must be one of {_BOTTOM_TYPES}, got {bottom!r}.")
+        msg = f"'bottom' must be one of {_BOTTOM_TYPES}, got {bottom!r}."
+        raise ValueError(msg)
     if n_depth_points is None:
         n_depth_points = min(
             20_000,
             max(400, int(np.ceil(60.0 * water_depth * f / float(np.min(c_prof))))),
         )
     if int(n_depth_points) < 8:
-        raise ValueError("'n_depth_points' must be at least 8.")
+        msg = "'n_depth_points' must be at least 8."
+        raise ValueError(msg)
 
     ranges = (
         np.linspace(100.0, 10_000.0, 400)
@@ -440,7 +455,8 @@ def normal_modes(
         else np.asarray(ranges_m, dtype=np.float64).ravel()
     )
     if np.any(ranges <= 0.0) or not np.all(np.isfinite(ranges)):
-        raise ValueError("'ranges_m' must be finite and positive.")
+        msg = "'ranges_m' must be finite and positive."
+        raise ValueError(msg)
 
     omega = 2.0 * np.pi * f
     n = int(n_depth_points)
@@ -718,14 +734,15 @@ def ray_trace(
         raise ValueError(_SOURCE_OUTSIDE)
     rmax = require_positive(max_range, "max_range")
     if int(n_steps) < 2:
-        raise ValueError("'n_steps' must be at least 2.")
+        msg = "'n_steps' must be at least 2."
+        raise ValueError(msg)
     angles = np.asarray(launch_angles_deg, dtype=np.float64).ravel()
     if angles.size == 0 or not np.all(np.isfinite(angles)):
-        raise ValueError("'launch_angles_deg' must be finite and non-empty.")
+        msg = "'launch_angles_deg' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(np.abs(angles) >= 90.0):
-        raise ValueError(
-            "'launch_angles_deg' must be within (-90, 90) degrees (forward rays)."
-        )
+        msg = "'launch_angles_deg' must be within (-90, 90) degrees (forward rays)."
+        raise ValueError(msg)
 
     ns = int(n_steps)
     ranges = np.linspace(0.0, rmax, ns)
@@ -1245,7 +1262,7 @@ def eigenrays(
     """
     key, seabed = _resolve_boundary(bottom)
     if trace.bathymetry_ranges is not None:
-        raise ValueError(
+        msg = (
             "'trace' was made over a sloping bottom, which this search does"
             " not price: each slope bounce rotates Snell's invariant, so an"
             " arrival's bottom touches no longer share one grazing angle and"
@@ -1253,6 +1270,7 @@ def eigenrays(
             " to the touch count) stops holding. Trace over a level bottom to"
             " list eigenrays."
         )
+        raise ValueError(msg)
     z_prof = np.asarray(trace.profile_depths, dtype=np.float64)
     c_prof = np.asarray(trace.profile_speeds, dtype=np.float64)
     water_depth = float(trace.water_depth)
@@ -1260,24 +1278,29 @@ def eigenrays(
     r_rec = require_positive(receiver_range, "receiver_range")
     r_grid = np.asarray(trace.ranges[0], dtype=np.float64)
     if r_rec > float(r_grid[-1]):
-        raise ValueError("'receiver_range' must not run past the traced fan.")
+        msg = "'receiver_range' must not run past the traced fan."
+        raise ValueError(msg)
     z_rec = float(receiver_depth)
     if not (0.0 < z_rec < water_depth):
-        raise ValueError(
+        msg = (
             "'receiver_depth' must lie strictly inside the water column: a"
             " folded ray only ever grazes the boundaries, so a receiver on"
             " one is touched tangentially and never crossed."
         )
+        raise ValueError(msg)
     if int(max_arrivals) < 1:
-        raise ValueError("'max_arrivals' must be at least 1.")
+        msg = "'max_arrivals' must be at least 1."
+        raise ValueError(msg)
     if trace.launch_angles.size < 2:
-        raise ValueError("'trace' must carry at least two rays to bracket between.")
+        msg = "'trace' must carry at least two rays to bracket between."
+        raise ValueError(msg)
     if n_steps is None:
         ns = max(2, int(np.ceil(r_rec / float(r_grid[1] - r_grid[0]))) + 1)
     else:
         ns = int(n_steps)
         if ns < 2:
-            raise ValueError("'n_steps' must be at least 2.")
+            msg = "'n_steps' must be at least 2."
+            raise ValueError(msg)
 
     launch, crossing = _bracket_launches(trace, r_grid, r_rec, z_rec)
     refined = _refine_brackets(
@@ -1309,7 +1332,8 @@ def eigenrays(
         n_steps=ns,
     )
     if final.spreadings is None:  # pragma: no cover
-        raise ValueError("the march must carry the dynamic ray states.")
+        msg = "the march must carry the dynamic ray states."
+        raise ValueError(msg)
     c0 = float(np.interp(zs, z_prof, c_prof))
     z_end = final.positions[:, -1]
     c_end = np.asarray(np.interp(z_end, z_prof, c_prof))
@@ -2504,9 +2528,11 @@ def _beam_range_grid(
         np.arange(n_steps) * dr if ranges_m is None else ranges_m, dtype=np.float64
     ).ravel()
     if ranges.size == 0 or not np.all(np.isfinite(ranges)) or np.any(ranges < 0.0):
-        raise ValueError("'ranges_m' must be finite, non-negative and non-empty.")
+        msg = "'ranges_m' must be finite, non-negative and non-empty."
+        raise ValueError(msg)
     if np.any(ranges > rmax + 0.5 * dr):
-        raise ValueError("'ranges_m' must not run past 'max_range'.")
+        msg = "'ranges_m' must not run past 'max_range'."
+        raise ValueError(msg)
     return ranges
 
 
@@ -2526,14 +2552,17 @@ def _beam_receiver_grid(
     if receiver_depths_m is None:
         n_z = int(n_depth_points)
         if n_z < 2:
-            raise ValueError("'n_depth_points' must be at least 2.")
+            msg = "'n_depth_points' must be at least 2."
+            raise ValueError(msg)
         dz = water_depth / (n_z + 1)
         return np.asarray(dz * np.arange(1, n_z + 1), dtype=np.float64)
     receivers = np.asarray(receiver_depths_m, dtype=np.float64).ravel()
     if receivers.size == 0 or not np.all(np.isfinite(receivers)):
-        raise ValueError("'receiver_depths_m' must be finite and non-empty.")
+        msg = "'receiver_depths_m' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(receivers < 0.0) or np.any(receivers > water_depth):
-        raise ValueError("'receiver_depths_m' must lie within the water column.")
+        msg = "'receiver_depths_m' must lie within the water column."
+        raise ValueError(msg)
     return receivers
 
 
@@ -2625,10 +2654,11 @@ def _resolve_absorption(
     spec = VolumeAbsorption(absorption) if isinstance(absorption, str) else absorption
     key = spec.model.strip().lower()
     if key not in _ABSORPTION_MODELS:
-        raise ValueError(
+        msg = (
             f"'absorption' must name one of {_ABSORPTION_MODELS} or be None,"
             f" got {spec.model!r}."
         )
+        raise ValueError(msg)
     return key, float(
         seawater_absorption(
             frequency_hz,
@@ -2651,7 +2681,8 @@ def _resolve_fan(
     """The concrete fan a :class:`BeamFan` asks for, widths resolved."""
     theta_max = float(fan.max_angle_deg)
     if not (0.0 < theta_max < 90.0):
-        raise ValueError("'max_angle_deg' must lie in (0, 90) degrees.")
+        msg = "'max_angle_deg' must lie in (0, 90) degrees."
+        raise ValueError(msg)
     # The width the fan's density is sized for has to exist before the fan
     # does, and the overlap condition below must hold for every beam, so it
     # is the *widest* width of the run: an explicit one applies everywhere,
@@ -2670,7 +2701,8 @@ def _resolve_fan(
         else int(fan.n_beams)
     )
     if n_fan < 2:
-        raise ValueError("'n_beams' must be at least 2.")
+        msg = "'n_beams' must be at least 2."
+        raise ValueError(msg)
     launch = np.linspace(-np.radians(theta_max), np.radians(theta_max), n_fan)
     w0 = (
         np.full(n_fan, float(w_fan))
@@ -3002,10 +3034,11 @@ def gaussian_beams(
     rmax = require_positive(max_range, "max_range")
     dr_step = require_positive(range_step, "range_step")
     if dr_step > rmax:
-        raise ValueError("'range_step' must not exceed 'max_range'.")
+        msg = "'range_step' must not exceed 'max_range'."
+        raise ValueError(msg)
     key, seabed = _resolve_boundary(bottom)
     if seabed is not None and bathy is not None:
-        raise ValueError(
+        msg = (
             "a lossy fluid seabed and a sloping bottom cannot be combined:"
             " the one-coefficient-per-beam collapse (and the image ladder's"
             " powers of R) rests on Snell's invariant fixing a single grazing"
@@ -3013,6 +3046,7 @@ def gaussian_beams(
             " invariant at every touch. Sloping runs take the perfect"
             " reflectors of 'bottom'."
         )
+        raise ValueError(msg)
     absorption_key, alpha = _resolve_absorption(absorption, f, zs)
     # dB/km to nepers/m: N dB is e^(N ln 10 / 20) in amplitude.
     attenuation = alpha * np.log(10.0) / (20.0 * _M_PER_KM)
@@ -3196,7 +3230,8 @@ def _assemble_beam_field(
         or march.horizontals is None
         or march.stopped_columns is None
     ):  # pragma: no cover
-        raise ValueError("the march must carry the dynamic ray states.")
+        msg = "the march must carry the dynamic ray states."
+        raise ValueError(msg)
     q = np.asarray(march.spreadings, dtype=np.complex128)
     p = np.asarray(march.spreading_slopes, dtype=np.complex128)
     speed = np.interp(march.positions, z_prof, c_prof)
@@ -3342,10 +3377,12 @@ def parabolic_equation(
     rmax = require_positive(max_range, "max_range")
     dr = require_positive(range_step, "range_step")
     if dr > rmax:
-        raise ValueError("'range_step' must not exceed 'max_range'.")
+        msg = "'range_step' must not exceed 'max_range'."
+        raise ValueError(msg)
     n = int(n_depth_points)
     if n < 16:
-        raise ValueError("'n_depth_points' must be at least 16.")
+        msg = "'n_depth_points' must be at least 16."
+        raise ValueError(msg)
 
     # Interior depth grid z_j = j·Δz, j = 1..n (pressure-release at 0 and D).
     dz = water_depth / (n + 1)

--- a/src/phonometry/underwater/propagation/seabed_reflection.py
+++ b/src/phonometry/underwater/propagation/seabed_reflection.py
@@ -59,7 +59,8 @@ def critical_angle(c1: float, c2: float) -> float:
     cw = require_positive(c1, "c1")
     cs = require_positive(c2, "c2")
     if cs <= cw:
-        raise ValueError("A critical angle exists only when c2 > c1 (faster sediment).")
+        msg = "A critical angle exists only when c2 > c1 (faster sediment)."
+        raise ValueError(msg)
     return float(np.degrees(np.arccos(cw / cs)))
 
 
@@ -85,9 +86,11 @@ def reflection_coefficient(
     """
     phi = np.atleast_1d(np.asarray(grazing_angle, dtype=np.float64))
     if phi.size == 0 or not np.all(np.isfinite(phi)):
-        raise ValueError("'grazing_angle' must be finite and non-empty.")
+        msg = "'grazing_angle' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(phi < 0.0) or np.any(phi > 90.0):
-        raise ValueError("'grazing_angle' must be within [0, 90] degrees.")
+        msg = "'grazing_angle' must be within [0, 90] degrees."
+        raise ValueError(msg)
     r1 = require_positive(rho1, "rho1")
     cw = require_positive(c1, "c1")
     r2 = require_positive(rho2, "rho2")

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -52,14 +52,16 @@ _DEPTH_MODELS = ("mackenzie", "medwin")
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar) or scalar <= 0.0:
-        raise ValueError(f"'{name}' must be a positive, finite number.")
+        msg = f"'{name}' must be a positive, finite number."
+        raise ValueError(msg)
     return scalar
 
 
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar):
-        raise ValueError(f"'{name}' must be a finite number.")
+        msg = f"'{name}' must be a finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -77,7 +79,8 @@ def depth_to_pressure(depth: float, latitude: float = 45.0) -> float:
     """
     z = _finite(depth, "depth")
     if z < 0.0:
-        raise ValueError("'depth' must be non-negative.")
+        msg = "'depth' must be non-negative."
+        raise ValueError(msg)
     return float(_pressure_mpa(z, _finite(latitude, "latitude")))
 
 
@@ -258,10 +261,12 @@ def sea_water_sound_speed(
     t = _finite(temperature, "temperature")
     s = _finite(salinity, "salinity")
     if s < 0.0:
-        raise ValueError("'salinity' must be non-negative.")
+        msg = "'salinity' must be non-negative."
+        raise ValueError(msg)
     z = _finite(depth, "depth")
     if z < 0.0:
-        raise ValueError("'depth' must be non-negative.")
+        msg = "'depth' must be non-negative."
+        raise ValueError(msg)
     key = model.strip().lower()
     if key == "mackenzie":
         return float(_mackenzie(t, s, z))
@@ -272,7 +277,8 @@ def sea_water_sound_speed(
         return float(_unesco(t, s, pressure_bar))
     if key == "del_grosso":
         return float(_del_grosso(t, s, pressure_bar * _KGCM2_PER_BAR))
-    raise ValueError(f"'model' must be one of {_MODELS}, got {model!r}.")
+    msg = f"'model' must be one of {_MODELS}, got {model!r}."
+    raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -323,17 +329,22 @@ def sound_speed_profile(
     """
     z = np.asarray(depths, dtype=np.float64)
     if z.ndim != 1 or z.size < 2:
-        raise ValueError("'depths' must be a 1-D array of at least two depths.")
+        msg = "'depths' must be a 1-D array of at least two depths."
+        raise ValueError(msg)
     if np.any(z < 0.0) or not np.all(np.isfinite(z)):
-        raise ValueError("'depths' must be finite and non-negative.")
+        msg = "'depths' must be finite and non-negative."
+        raise ValueError(msg)
     if np.any(np.diff(z) <= 0.0):
-        raise ValueError("'depths' must be strictly increasing.")
+        msg = "'depths' must be strictly increasing."
+        raise ValueError(msg)
     temp = np.broadcast_to(np.asarray(temperatures, dtype=np.float64), z.shape)
     sal = np.broadcast_to(np.asarray(salinities, dtype=np.float64), z.shape)
     if not (np.all(np.isfinite(temp)) and np.all(np.isfinite(sal))):
-        raise ValueError("'temperatures' and 'salinities' must be finite.")
+        msg = "'temperatures' and 'salinities' must be finite."
+        raise ValueError(msg)
     if np.any(sal < 0.0):
-        raise ValueError("'salinities' must be non-negative.")
+        msg = "'salinities' must be non-negative."
+        raise ValueError(msg)
     key = model.strip().lower()
     lat = _finite(latitude, "latitude")
     if key in _DEPTH_MODELS:
@@ -348,7 +359,8 @@ def sound_speed_profile(
             else _del_grosso(temp, sal, pressure_bar * _KGCM2_PER_BAR)
         )
     else:
-        raise ValueError(f"'model' must be one of {_MODELS}, got {model!r}.")
+        msg = f"'model' must be one of {_MODELS}, got {model!r}."
+        raise ValueError(msg)
     c = np.asarray(c_any, dtype=np.float64)
     gradient = np.gradient(c, z)
     return SoundSpeedProfile(

--- a/src/phonometry/underwater/propagation/weston_regimes.py
+++ b/src/phonometry/underwater/propagation/weston_regimes.py
@@ -122,9 +122,8 @@ def _seabed(seabed: str | WestonSeabed) -> WestonSeabed:
         return seabed
     key = str(seabed).strip().lower()
     if key not in WESTON_SEABEDS:
-        raise ValueError(
-            f"'seabed' must be one of {tuple(WESTON_SEABEDS)} or a WestonSeabed, got {seabed!r}."
-        )
+        msg = f"'seabed' must be one of {tuple(WESTON_SEABEDS)} or a WestonSeabed, got {seabed!r}."
+        raise ValueError(msg)
     return WESTON_SEABEDS[key]
 
 
@@ -160,9 +159,8 @@ def loss_parameter(attenuation_db_per_wavelength: float) -> float:
     """
     beta = float(attenuation_db_per_wavelength)
     if not np.isfinite(beta) or beta < 0.0:
-        raise ValueError(
-            "'attenuation_db_per_wavelength' must be non-negative and finite."
-        )
+        msg = "'attenuation_db_per_wavelength' must be non-negative and finite."
+        raise ValueError(msg)
     return float(beta / (40.0 * np.pi * np.log10(np.e)))
 
 
@@ -200,14 +198,14 @@ def reflection_loss_gradient(
             / np.sin(psi_c) ** 3
         )
     if bed.sound_speed_gradient <= 0.0:
-        raise ValueError(
+        msg = (
             "a seabed without a critical angle needs a positive 'sound_speed_gradient'"
             " to use the refracting branch of Equation (9.53)."
         )
+        raise ValueError(msg)
     if frequency_hz is None:
-        raise ValueError(
-            "'frequency_hz' is required for a refracting seabed (Equation 9.53)."
-        )
+        msg = "'frequency_hz' is required for a refracting seabed (Equation 9.53)."
+        raise ValueError(msg)
     f = require_positive(frequency_hz, "frequency_hz")
     return float(
         2.0 * (2.0 * np.pi * f) * bed.loss_parameter / bed.sound_speed_gradient
@@ -242,10 +240,11 @@ def effective_depth(
     bed = _seabed(seabed)
     psi_c = critical_grazing_angle(bed.sound_speed_ratio)
     if psi_c <= 0.0:
-        raise ValueError(
+        msg = (
             "'effective_depth' needs a seabed with a critical angle (c_sed > c_w);"
             f" {bed.name!r} has none."
         )
+        raise ValueError(msg)
     k = 2.0 * np.pi * f / c
     return float(h + bed.density_ratio / (k * np.sin(psi_c)))
 
@@ -275,10 +274,11 @@ def waveguide_cutoff_frequency(
     bed = _seabed(seabed)
     psi_c = critical_grazing_angle(bed.sound_speed_ratio)
     if psi_c <= 0.0:
-        raise ValueError(
+        msg = (
             "'waveguide_cutoff_frequency' needs a seabed with a critical angle"
             f" (c_sed > c_w); {bed.name!r} has none."
         )
+        raise ValueError(msg)
     return float((np.pi - bed.density_ratio) / (2.0 * np.pi * np.sin(psi_c)) * c / h)
 
 
@@ -397,23 +397,24 @@ def _angle_and_gradient(
     if critical_angle is None:
         psi_c = critical_grazing_angle(bed.sound_speed_ratio)
         if psi_c <= 0.0:
-            raise ValueError(
+            msg = (
                 f"seabed {bed.name!r} has no critical angle; pass 'critical_angle'"
                 " explicitly (in degrees) to fix the trapped-ray cone."
             )
+            raise ValueError(msg)
     else:
         deg = float(critical_angle)
         if not np.isfinite(deg) or not (0.0 < deg <= 90.0):
-            raise ValueError("'critical_angle' must lie in (0, 90] degrees.")
+            msg = "'critical_angle' must lie in (0, 90] degrees."
+            raise ValueError(msg)
         psi_c = np.radians(deg)
     if gradient is None:
         eta = reflection_loss_gradient(bed, frequency_hz=frequency_hz)
     else:
         eta = float(gradient)
         if not np.isfinite(eta) or eta < 0.0:
-            raise ValueError(
-                "'reflection_loss_gradient_value' must be non-negative and finite."
-            )
+            msg = "'reflection_loss_gradient_value' must be non-negative and finite."
+            raise ValueError(msg)
     return float(psi_c), float(eta)
 
 
@@ -523,14 +524,17 @@ def weston_propagation_loss(
     c = require_positive(sound_speed, "sound_speed")
     r = np.atleast_1d(np.asarray(range_m, dtype=np.float64))
     if r.size == 0 or not np.all(np.isfinite(r)):
-        raise ValueError("'range_m' must be finite and non-empty.")
+        msg = "'range_m' must be finite and non-empty."
+        raise ValueError(msg)
     if np.any(r <= 0.0):
-        raise ValueError("'range_m' must be strictly positive.")
+        msg = "'range_m' must be strictly positive."
+        raise ValueError(msg)
     z0 = h / 2.0 if source_depth is None else float(source_depth)
     zr = h / 2.0 if receiver_depth is None else float(receiver_depth)
     for name, value in (("source_depth", z0), ("receiver_depth", zr)):
         if not np.isfinite(value) or not (0.0 <= value <= h):
-            raise ValueError(f"'{name}' must lie within the water column [0, H].")
+            msg = f"'{name}' must lie within the water column [0, H]."
+            raise ValueError(msg)
 
     bed = _seabed(seabed)
     bounds = weston_regime_boundaries(

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -54,7 +54,8 @@ if TYPE_CHECKING:
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
     if not np.isfinite(scalar):
-        raise ValueError(f"'{name}' must be a finite number.")
+        msg = f"'{name}' must be a finite number."
+        raise ValueError(msg)
     return scalar
 
 
@@ -63,7 +64,8 @@ def _finite_array(
 ) -> NDArray[np.float64]:
     arr = np.atleast_1d(np.asarray(values, dtype=np.float64))
     if arr.size == 0 or not np.all(np.isfinite(arr)):
-        raise ValueError(f"'{name}' must be finite and non-empty.")
+        msg = f"'{name}' must be finite and non-empty."
+        raise ValueError(msg)
     return arr
 
 
@@ -303,9 +305,11 @@ def detection_range(
     fom = _finite(figure_of_merit, "figure_of_merit")
     rmax = _finite(max_range, "max_range")
     if rmax <= 1.0:
-        raise ValueError("'max_range' must exceed 1 m.")
+        msg = "'max_range' must exceed 1 m."
+        raise ValueError(msg)
     if int(n_points) < 2:
-        raise ValueError("'n_points' must be at least 2.")
+        msg = "'n_points' must be at least 2."
+        raise ValueError(msg)
     options = {
         "law": law,
         "temperature": temperature,
@@ -372,14 +376,15 @@ def detection_range_from_curve(
     r = _finite_array(range_m, "range_m")
     pl = _finite_array(propagation_loss, "propagation_loss")
     if r.shape != pl.shape:
-        raise ValueError("'propagation_loss' must have the same length as 'range_m'.")
+        msg = "'propagation_loss' must have the same length as 'range_m'."
+        raise ValueError(msg)
     if r.size < 2 or np.any(np.diff(r) <= 0.0):
-        raise ValueError(
-            "'range_m' must be strictly increasing with at least two samples."
-        )
+        msg = "'range_m' must be strictly increasing with at least two samples."
+        raise ValueError(msg)
     key = crossing.strip().lower()
     if key not in ("first", "last"):
-        raise ValueError(f"'crossing' must be 'first' or 'last', got {crossing!r}.")
+        msg = f"'crossing' must be 'first' or 'last', got {crossing!r}."
+        raise ValueError(msg)
     below = pl <= fom
     up = np.flatnonzero(below[:-1] & ~below[1:])
     if up.size == 0:

--- a/src/phonometry/underwater/sources/ambient_noise.py
+++ b/src/phonometry/underwater/sources/ambient_noise.py
@@ -111,7 +111,8 @@ def thermal_noise_spectrum(
     f = require_positive_array(frequency_hz, "frequency_hz")
     t_kelvin = float(temperature) + 273.15
     if not np.isfinite(t_kelvin) or t_kelvin <= 0.0:
-        raise ValueError("'temperature' must be above absolute zero.")
+        msg = "'temperature' must be above absolute zero."
+        raise ValueError(msg)
     rho = require_positive(density, "density")
     c = require_positive(sound_speed, "sound_speed")
     p2 = 4.0 * np.pi * _BOLTZMANN * t_kelvin * rho * f**2 / c
@@ -184,9 +185,8 @@ def ocean_ambient_noise(
     if shipping is not None:
         ship_arr = np.asarray(shipping, dtype=np.float64)
         if ship_arr.shape != f.shape or not np.all(np.isfinite(ship_arr)):
-            raise ValueError(
-                "'shipping' must be finite and match 'frequency_hz' in length."
-            )
+            msg = "'shipping' must be finite and match 'frequency_hz' in length."
+            raise ValueError(msg)
         energies = energies + 10.0 ** (ship_arr / 10.0)
     spectrum = 10.0 * np.log10(energies)
     return AmbientNoiseResult(

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -81,9 +81,11 @@ def cumulative_sel(single_sels: NDArray[np.float64] | list[float]) -> float:
     """
     sels = np.asarray(single_sels, dtype=np.float64)
     if sels.ndim != 1 or sels.size < 1:
-        raise ValueError("'single_sels' must be a non-empty 1-D sequence.")
+        msg = "'single_sels' must be a non-empty 1-D sequence."
+        raise ValueError(msg)
     if not np.all(np.isfinite(sels)):
-        raise ValueError("'single_sels' must be finite.")
+        msg = "'single_sels' must be finite."
+        raise ValueError(msg)
     return float(10.0 * np.log10(np.sum(10.0 ** (sels / 10.0))))
 
 
@@ -99,12 +101,15 @@ def cumulative_sel_identical(sel_ss: float, n_strikes: int) -> float:
     """
     n_float = float(n_strikes)
     if not n_float.is_integer():
-        raise ValueError("'n_strikes' must be a whole number of strikes.")
+        msg = "'n_strikes' must be a whole number of strikes."
+        raise ValueError(msg)
     n = int(n_float)
     if n < 1:
-        raise ValueError("'n_strikes' must be at least 1.")
+        msg = "'n_strikes' must be at least 1."
+        raise ValueError(msg)
     if not np.isfinite(sel_ss):
-        raise ValueError("'sel_ss' must be finite.")
+        msg = "'sel_ss' must be finite."
+        raise ValueError(msg)
     return float(float(sel_ss) + 10.0 * np.log10(n))
 
 
@@ -233,10 +238,12 @@ def strike_sel_spectrum(
     sig = _validate_pressure(pressure, min_samples=2)
     fs_v = _positive(fs, "fs")
     if int(fraction) not in (1, 3):
-        raise ValueError("'fraction' must be 1 (octave) or 3 (one-third octave).")
+        msg = "'fraction' must be 1 (octave) or 3 (one-third octave)."
+        raise ValueError(msg)
     lo, hi = (float(limits[0]), float(limits[1]))
     if not (np.isfinite(lo) and np.isfinite(hi)) or not (0.0 < lo < hi):
-        raise ValueError("'limits' must be a finite, increasing, positive pair.")
+        msg = "'limits' must be a finite, increasing, positive pair."
+        raise ValueError(msg)
 
     centres, lower, upper, _ = nominal_frequencies(int(fraction), [lo, hi])
     n = sig.size
@@ -264,7 +271,8 @@ def strike_sel_spectrum(
         band_sel = 10.0 * np.log10(band_energy / e0)
     total = float(band_energy.sum())
     if total <= 0.0:
-        raise ValueError("'pressure' has no energy inside the requested bands.")
+        msg = "'pressure' has no energy inside the requested bands."
+        raise ValueError(msg)
     return StrikeSelSpectrum(
         frequencies=fc,
         band_sel=np.asarray(band_sel, dtype=np.float64),

--- a/src/phonometry/underwater/sources/ship_radiated_noise.py
+++ b/src/phonometry/underwater/sources/ship_radiated_noise.py
@@ -89,9 +89,8 @@ def hydrophone_depths(
         or np.any(ang <= 0.0)
         or np.any(ang >= 90.0)
     ):
-        raise ValueError(
-            "'angles' must be finite and lie in the open interval (0, 90) degrees."
-        )
+        msg = "'angles' must be finite and lie in the open interval (0, 90) degrees."
+        raise ValueError(msg)
     return np.asarray(cpa * np.tan(np.radians(ang)), dtype=np.float64)
 
 
@@ -198,13 +197,16 @@ def monopole_source_level(
     freqs = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     rnl_arr = np.atleast_1d(np.asarray(rnl, dtype=np.float64))
     if np.any(freqs <= 0.0) or not np.all(np.isfinite(freqs)):
-        raise ValueError("'frequency' must be positive and finite.")
+        msg = "'frequency' must be positive and finite."
+        raise ValueError(msg)
     if not np.all(np.isfinite(rnl_arr)):
-        raise ValueError("'rnl' must be finite.")
+        msg = "'rnl' must be finite."
+        raise ValueError(msg)
     if rnl_arr.size == 1 and freqs.size > 1:
         rnl_arr = np.full(freqs.shape, rnl_arr[0])
     if rnl_arr.shape != freqs.shape:
-        raise ValueError("'rnl' and 'frequency' must have the same length.")
+        msg = "'rnl' and 'frequency' must have the same length."
+        raise ValueError(msg)
     source_depth = _SOURCE_DEPTH_FRACTION * d
     delta_l = _surface_correction(freqs, source_depth, speed)
     return ShipSourceLevelResult(

--- a/src/phonometry/underwater/sources/ship_traffic_noise.py
+++ b/src/phonometry/underwater/sources/ship_traffic_noise.py
@@ -88,9 +88,8 @@ def _jomopans_echo(
 ) -> NDArray[np.float64]:
     key = vessel_class.strip().lower()
     if key not in _VESSEL_CLASSES:
-        raise ValueError(
-            f"'vessel_class' must be one of {VESSEL_CLASSES}, got {vessel_class!r}."
-        )
+        msg = f"'vessel_class' must be one of {VESSEL_CLASSES}, got {vessel_class!r}."
+        raise ValueError(msg)
     v_c, cargo, d_lo, d_hi = _VESSEL_CLASSES[key]
     v = require_positive(speed_knots, "speed_knots")
     length = require_positive(length_m, "length_m")
@@ -220,7 +219,8 @@ def ship_source_spectrum(
     elif key == "wales-heitmeyer":
         psd = _wales_heitmeyer(f)
     else:
-        raise ValueError(f"'model' must be one of {_MODELS}, got {model!r}.")
+        msg = f"'model' must be one of {_MODELS}, got {model!r}."
+        raise ValueError(msg)
     band = psd + 10.0 * np.log10(0.231 * f)
     return ShipTrafficSpectrum(
         frequency=f,

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -320,9 +320,8 @@ def _params(name: str) -> _WParams:
     try:
         return _WEIGHTINGS[name]
     except KeyError:
-        raise ValueError(
-            f"Unknown weighting {name!r}; choose from {', '.join(WEIGHTING_NAMES)}."
-        ) from None
+        msg = f"Unknown weighting {name!r}; choose from {', '.join(WEIGHTING_NAMES)}."
+        raise ValueError(msg) from None
 
 
 def _weighting_response(name: str, freq: Real) -> Complex:
@@ -420,7 +419,8 @@ def frequency_weighting(name: str, frequencies: ArrayLike) -> WeightingResponse:
     """
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if freq.ndim != 1 or freq.size == 0:
-        raise ValueError("'frequencies' must be a non-empty 1-D array.")
+        msg = "'frequencies' must be a non-empty 1-D array."
+        raise ValueError(msg)
     resp = _weighting_response(name, freq)
     mag = np.abs(resp)
     with np.errstate(divide="ignore"):
@@ -551,10 +551,11 @@ def weighted_acceleration(
     accel = np.atleast_1d(np.asarray(band_accelerations, dtype=np.float64))
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if accel.ndim != 1 or accel.size == 0 or accel.shape != freq.shape:
-        raise ValueError(
+        msg = (
             "'band_accelerations' and 'frequencies' must be non-empty, 1-D and "
             "equal-length."
         )
+        raise ValueError(msg)
     factors = weighting_factors(weighting, freq)
     weighted = factors * accel
     overall = float(np.sqrt(np.sum(weighted**2)))
@@ -581,7 +582,8 @@ def _weighted_signal(signal: SignalInput) -> Real:
     """
     x = np.asarray(resolve_samples(signal, calibrate=False), dtype=np.float64)
     if x.ndim != 1 or x.size == 0:
-        raise ValueError("'signal' must be a non-empty 1-D array.")
+        msg = "'signal' must be a non-empty 1-D array."
+        raise ValueError(msg)
     return x
 
 
@@ -589,7 +591,8 @@ def _positive_fs(fs: float) -> float:
     """Return ``fs`` as a positive, finite float or raise ``ValueError``."""
     fs = float(fs)
     if not math.isfinite(fs) or fs <= 0.0:
-        raise ValueError("'fs' must be a positive, finite sampling frequency.")
+        msg = "'fs' must be a positive, finite sampling frequency."
+        raise ValueError(msg)
     return fs
 
 
@@ -622,7 +625,8 @@ def running_rms(
     fs = _positive_fs(fs)
     tau = float(integration_time)
     if not math.isfinite(tau) or tau <= 0.0:
-        raise ValueError("'integration_time' must be positive and finite.")
+        msg = "'integration_time' must be positive and finite."
+        raise ValueError(msg)
     power = x**2
     if method == "linear":
         window = max(1, round(tau * fs))
@@ -639,7 +643,8 @@ def running_rms(
         alpha = 1.0 - math.exp(-1.0 / (tau * fs))
         mean_power = sig.lfilter([alpha], [1.0, -(1.0 - alpha)], power)
     else:
-        raise ValueError("'method' must be 'linear' or 'exponential'.")
+        msg = "'method' must be 'linear' or 'exponential'."
+        raise ValueError(msg)
     return np.sqrt(mean_power)
 
 
@@ -770,13 +775,15 @@ def vibration_total_value(
     """
     comp = np.atleast_1d(np.asarray(components, dtype=np.float64))
     if comp.ndim != 1 or comp.size == 0:
-        raise ValueError("'components' must be a non-empty 1-D array.")
+        msg = "'components' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if k is None:
         factors = np.ones_like(comp)
     else:
         factors = np.atleast_1d(np.asarray(k, dtype=np.float64))
         if factors.shape != comp.shape:
-            raise ValueError("'k' must have the same length as 'components'.")
+            msg = "'k' must have the same length as 'components'."
+            raise ValueError(msg)
     return float(np.sqrt(np.sum((factors * comp) ** 2)))
 
 
@@ -803,7 +810,8 @@ def wbv_exposure_basis(a_wx: float, a_wy: float, a_wz: float) -> float:
     """
     values = (float(a_wx), float(a_wy), float(a_wz))
     if any(not math.isfinite(v) or v < 0.0 for v in values):
-        raise ValueError("The axis r.m.s. accelerations must be non-negative.")
+        msg = "The axis r.m.s. accelerations must be non-negative."
+        raise ValueError(msg)
     return max(1.4 * values[0], 1.4 * values[1], values[2])
 
 
@@ -823,7 +831,8 @@ def daily_exposure(total_value: float, duration_s: float) -> float:
     a = float(total_value)
     t = float(duration_s)
     if a < 0.0 or t < 0.0:
-        raise ValueError("'total_value' and 'duration_s' must be non-negative.")
+        msg = "'total_value' and 'duration_s' must be non-negative."
+        raise ValueError(msg)
     return a * math.sqrt(t / REFERENCE_DURATION_S)
 
 
@@ -842,7 +851,8 @@ def combine_partial_exposures(partials: ArrayLike) -> float:
     """
     parts = np.atleast_1d(np.asarray(partials, dtype=np.float64))
     if parts.ndim != 1 or parts.size == 0:
-        raise ValueError("'partials' must be a non-empty 1-D array.")
+        msg = "'partials' must be a non-empty 1-D array."
+        raise ValueError(msg)
     return float(np.sqrt(np.sum(parts**2)))
 
 
@@ -863,11 +873,13 @@ def hav_daily_exposure(
     ahv = np.atleast_1d(np.asarray(total_values, dtype=np.float64))
     t = np.atleast_1d(np.asarray(durations_s, dtype=np.float64))
     if ahv.ndim != 1 or ahv.size == 0 or ahv.shape != t.shape:
-        raise ValueError(
+        msg = (
             "'total_values' and 'durations_s' must be non-empty, 1-D and equal-length."
         )
+        raise ValueError(msg)
     if np.any(ahv < 0.0) or np.any(t < 0.0):
-        raise ValueError("'total_values' and 'durations_s' must be non-negative.")
+        msg = "'total_values' and 'durations_s' must be non-negative."
+        raise ValueError(msg)
     return float(np.sqrt(np.sum(ahv**2 * t) / REFERENCE_DURATION_S))
 
 
@@ -888,14 +900,15 @@ def energy_equivalent_acceleration(
     a = np.atleast_1d(np.asarray(magnitudes, dtype=np.float64))
     t = np.atleast_1d(np.asarray(durations_s, dtype=np.float64))
     if a.ndim != 1 or a.size == 0 or a.shape != t.shape:
-        raise ValueError(
-            "'magnitudes' and 'durations_s' must be non-empty, 1-D and equal-length."
-        )
+        msg = "'magnitudes' and 'durations_s' must be non-empty, 1-D and equal-length."
+        raise ValueError(msg)
     if np.any(t < 0.0):
-        raise ValueError("'durations_s' must be non-negative.")
+        msg = "'durations_s' must be non-negative."
+        raise ValueError(msg)
     total = float(np.sum(t))
     if total <= 0.0:
-        raise ValueError("The total duration must be positive.")
+        msg = "The total duration must be positive."
+        raise ValueError(msg)
     return float(np.sqrt(np.sum(a**2 * t) / total))
 
 
@@ -913,7 +926,8 @@ def hav_vwf_lifetime_years(a8: float) -> float:
     """
     a = float(a8)
     if not math.isfinite(a) or a <= 0.0:
-        raise ValueError("'a8' must be a positive daily exposure.")
+        msg = "'a8' must be a positive daily exposure."
+        raise ValueError(msg)
     return float(31.8 * a**-1.06)
 
 
@@ -963,7 +977,8 @@ def exposure_assessment(
     """
     v = float(value)
     if v < 0.0:
-        raise ValueError("'value' must be non-negative.")
+        msg = "'value' must be non-negative."
+        raise ValueError(msg)
     if kind == "hav" and metric == "a8":
         eav, elv = HAV_EAV_A8, HAV_ELV_A8
     elif kind == "wbv" and metric == "a8":
@@ -971,9 +986,8 @@ def exposure_assessment(
     elif kind == "wbv" and metric == "vdv":
         eav, elv = WBV_EAV_VDV, WBV_ELV_VDV
     else:
-        raise ValueError(
-            "kind must be 'hav' or 'wbv'; metric 'a8' (both) or 'vdv' (wbv only)."
-        )
+        msg = "kind must be 'hav' or 'wbv'; metric 'a8' (both) or 'vdv' (wbv only)."
+        raise ValueError(msg)
     exceeds_action = v >= eav
     exceeds_limit = v >= elv
     if exceeds_limit:
@@ -1078,9 +1092,8 @@ class DailyVibrationExposure:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.human_vibration import render_human_vibration_report
 
         return render_human_vibration_report(
@@ -1121,15 +1134,17 @@ def daily_vibration_exposure(
     ahv = np.atleast_1d(np.asarray(total_values, dtype=np.float64))
     t = np.atleast_1d(np.asarray(durations_s, dtype=np.float64))
     if ahv.ndim != 1 or ahv.size == 0 or ahv.shape != t.shape:
-        raise ValueError(
+        msg = (
             "'total_values' and 'durations_s' must be non-empty, 1-D and equal-length."
         )
+        raise ValueError(msg)
     if labels is None:
         labels = tuple(f"op {i + 1}" for i in range(ahv.size))
     else:
         labels = tuple(labels)
         if len(labels) != ahv.size:
-            raise ValueError("'labels' must match the number of operations.")
+            msg = "'labels' must match the number of operations."
+            raise ValueError(msg)
     partials = np.array(
         [daily_exposure(float(a), float(dt)) for a, dt in zip(ahv, t)],
         dtype=np.float64,

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -187,9 +187,11 @@ def spinal_response(acceleration: SignalInput, fs: float | None = None) -> np.nd
     # this is an acceleration in m/s2. See phonometry.io._resolve.
     az = np.asarray(resolve_samples(acceleration, calibrate=False), dtype=np.float64)
     if az.ndim != 1:
-        raise ValueError("acceleration must be a 1-D time series.")
+        msg = "acceleration must be a 1-D time series."
+        raise ValueError(msg)
     if az.size == 0:
-        raise ValueError("acceleration must not be empty.")
+        msg = "acceleration must not be empty."
+        raise ValueError(msg)
     spectrum = np.fft.rfft(az)
     freq = np.fft.rfftfreq(az.size, d=1.0 / fs)
     response = np.fft.irfft(spectrum * seat_to_spine_transfer(freq), n=az.size)
@@ -290,11 +292,14 @@ def daily_dose_multi(
     td = np.asarray(exposure_times, dtype=np.float64).ravel()
     tm = np.asarray(measurement_times, dtype=np.float64).ravel()
     if not dz.shape == td.shape == tm.shape:
-        raise ValueError("doses, exposure_times and measurement_times must match.")
+        msg = "doses, exposure_times and measurement_times must match."
+        raise ValueError(msg)
     if dz.size == 0:
-        raise ValueError("at least one condition is required.")
+        msg = "at least one condition is required."
+        raise ValueError(msg)
     if not np.all(tm > 0.0) or not np.all(td > 0.0):
-        raise ValueError("exposure_times and measurement_times must be positive.")
+        msg = "exposure_times and measurement_times must be positive."
+        raise ValueError(msg)
     total = float(np.sum(dz**DOSE_EXPONENT * (td / tm)))
     return float(total ** (1.0 / DOSE_EXPONENT))
 
@@ -372,17 +377,19 @@ def injury_risk(
     """
     require_choice(sex, "sex", _SEXES)
     if years <= 0:
-        raise ValueError("years must be a positive integer.")
+        msg = "years must be a positive integer."
+        raise ValueError(msg)
     days_per_year = require_positive(days_per_year, "days_per_year")
     mz = _mz_for_sex(sex) if mz is None else mz
     s_stat = static_stress(mz)
     ages = start_age + np.arange(years, dtype=np.float64)
     strength = ultimate_strength(ages, sex=sex) - s_stat
     if np.any(strength <= 0.0):
-        raise ValueError(
+        msg = (
             "ultimate strength minus static stress is non-positive within the "
             "exposure period; the age range exceeds the model's validity."
         )
+        raise ValueError(msg)
     numerator = daily_compression * days_per_year ** (1.0 / DOSE_EXPONENT)
     total = float(np.sum((numerator / strength) ** DOSE_EXPONENT))
     return float(total ** (1.0 / DOSE_EXPONENT))
@@ -516,9 +523,8 @@ class MultipleShockResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso2631_5 import render_iso2631_5_report
 
         return render_iso2631_5_report(
@@ -605,10 +611,11 @@ def multiple_shock_assessment(
     """
     require_choice(sex, "sex", _SEXES)
     if (exposure_time is None) != (measurement_time is None):
-        raise ValueError(
+        msg = (
             "provide both exposure_time and measurement_time to scale to a "
             "daily dose, or neither."
         )
+        raise ValueError(msg)
     mz = _mz_for_sex(sex) if mz is None else mz
     peaks = response_peaks(spinal_response(acceleration, fs))
     dz = dose_from_peaks(peaks)

--- a/src/phonometry/vibration/machinery/diagnostics.py
+++ b/src/phonometry/vibration/machinery/diagnostics.py
@@ -200,10 +200,11 @@ class FaultFrequencyResult:
         for line in self.lines:
             if line.name == name:
                 return line.frequency
-        raise KeyError(
+        msg = (
             f"no fault line named {name!r}; available: "
             f"{', '.join(line.name for line in self.lines)}."
         )
+        raise KeyError(msg)
 
     def __contains__(self, name: object) -> bool:
         """Whether a line called *name* is present."""
@@ -255,7 +256,8 @@ class FaultFrequencyResult:
         lo = require_non_negative(low, "low")
         hi = require_positive(high, "high")
         if hi <= lo:
-            raise ValueError("'high' must be greater than 'low'.")
+            msg = "'high' must be greater than 'low'."
+            raise ValueError(msg)
         kept = tuple(ln for ln in self.lines if lo <= ln.frequency <= hi)
         return FaultFrequencyResult(
             lines=kept, shaft_rate=self.shaft_rate, source=self.source
@@ -304,13 +306,15 @@ def combine_fault_lines(
     :raises ValueError: If no result is given, or the shaft rates disagree.
     """
     if not results:
-        raise ValueError("'combine_fault_lines' needs at least one result.")
+        msg = "'combine_fault_lines' needs at least one result."
+        raise ValueError(msg)
     rates = {round(res.shaft_rate, 9) for res in results}
     if len(rates) > 1:
-        raise ValueError(
+        msg = (
             "all results must share the same shaft rate; got "
             f"{sorted(res.shaft_rate for res in results)} Hz."
         )
+        raise ValueError(msg)
     seen: set[str] = set()
     merged: list[FaultLine] = []
     for res in results:
@@ -379,10 +383,12 @@ def bearing_fault_frequencies(
     d = require_positive(element_diameter, "element_diameter")
     dm = require_positive(pitch_diameter, "pitch_diameter")
     if d >= dm:
-        raise ValueError("'element_diameter' must be smaller than 'pitch_diameter'.")
+        msg = "'element_diameter' must be smaller than 'pitch_diameter'."
+        raise ValueError(msg)
     phi = require_non_negative(contact_angle_deg, "contact_angle_deg")
     if phi >= 90.0:
-        raise ValueError("'contact_angle_deg' must be below 90 degrees.")
+        msg = "'contact_angle_deg' must be below 90 degrees."
+        raise ValueError(msg)
     race = require_choice(rotating_race, "rotating_race", ("inner", "outer"))
 
     # g = (d/D) cos(phi). The cage rate carries (1 - g) with a stationary
@@ -610,7 +616,8 @@ def induction_motor_frequencies(
     fs = shaft_rate(speed_rpm)
     p = int(poles)
     if p < 2 or p % 2:
-        raise ValueError("'poles' must be an even integer of at least 2.")
+        msg = "'poles' must be an even integer of at least 2."
+        raise ValueError(msg)
     bars = _require_count(rotor_bars, "rotor_bars")
     n_slot = _require_count(slot_harmonics, "slot_harmonics")
     n_side = _require_count(sidebands, "sidebands", minimum=0)
@@ -619,16 +626,18 @@ def induction_motor_frequencies(
         fe = require_positive(supply_frequency, "supply_frequency")
         synchronous = 2.0 * fe / p
         if fs >= synchronous:
-            raise ValueError(
+            msg = (
                 "the shaft rate must stay below the synchronous speed "
                 f"{synchronous:g} Hz implied by 'supply_frequency' and "
                 "'poles'; check the pole count."
             )
+            raise ValueError(msg)
         s = 1.0 - fs / synchronous
     else:
         s = require_non_negative(slip, "slip")
         if s >= 1.0:
-            raise ValueError("'slip' must be below 1.")
+            msg = "'slip' must be below 1."
+            raise ValueError(msg)
         # Eq. (8.19), fe = fs p / 2, made slip-consistent: the field turns at
         # fs/(1 - s), so fe = fs p / (2 (1 - s)). Identical at s = 0.
         fe = fs * p / (2.0 * (1.0 - s))

--- a/src/phonometry/vibration/structural/experimental_sea.py
+++ b/src/phonometry/vibration/structural/experimental_sea.py
@@ -397,10 +397,11 @@ def _broadcast_bands(
     for name, value in values.items():
         arr = np.atleast_1d(require_positive_array(value, name))
         if arr.size not in (1, f.size):
-            raise ValueError(
+            msg = (
                 f"'{name}' must be a scalar or match the {f.size} frequency "
                 f"bands, got {arr.size} values."
             )
+            raise ValueError(msg)
         out[name] = np.broadcast_to(arr, f.shape).astype(np.float64)
     return f, out
 
@@ -466,11 +467,12 @@ def power_injection_clf(
     denominator = e_1 - e_2 * ratio
     if np.any(denominator <= 0.0):
         bad = f[denominator <= 0.0]
-        raise ValueError(
+        msg = (
             "the driven subsystem must hold more modal energy than the "
             "receiver (E1/n1 > E2/n2) for a two-subsystem SEA inversion; "
             f"violated at {np.array2string(bad, precision=4)} Hz."
         )
+        raise ValueError(msg)
     eta_12 = eta_2 * e_2 / denominator
     eta_21 = eta_12 * ratio
     power_in = 2.0 * np.pi * f * (eta_1 * e_1 + eta_2 * e_2)
@@ -521,15 +523,17 @@ def power_injection_matrix(
     e = np.asarray(energies, dtype=np.float64)
     p = np.asarray(input_powers, dtype=np.float64)
     if e.shape != (2, 2, f.size):
-        raise ValueError(f"'energies' must have shape (2, 2, {f.size}), got {e.shape}.")
+        msg = f"'energies' must have shape (2, 2, {f.size}), got {e.shape}."
+        raise ValueError(msg)
     if p.shape != (2, f.size):
-        raise ValueError(
-            f"'input_powers' must have shape (2, {f.size}), got {p.shape}."
-        )
+        msg = f"'input_powers' must have shape (2, {f.size}), got {p.shape}."
+        raise ValueError(msg)
     if not np.all(np.isfinite(e)) or np.any(e <= 0.0):
-        raise ValueError("'energies' must be finite and positive.")
+        msg = "'energies' must be finite and positive."
+        raise ValueError(msg)
     if not np.all(np.isfinite(p)) or np.any(p <= 0.0):
-        raise ValueError("'input_powers' must be finite and positive.")
+        msg = "'input_powers' must be finite and positive."
+        raise ValueError(msg)
 
     omega = 2.0 * np.pi * f
     # Test j gives  (eta1 + eta12) E1j - eta21 E2j = P1j/omega  and
@@ -554,10 +558,11 @@ def power_injection_matrix(
         axis=-2,
     )
     if np.any(np.abs(np.linalg.det(m_a)) < np.finfo(np.float64).tiny):
-        raise ValueError(
+        msg = (
             "the measured energy matrix is singular in at least one band; the "
             "two drive tests must produce independent energy distributions."
         )
+        raise ValueError(msg)
     # numpy>=2 only treats the right-hand side as a stack of vectors when it is
     # 1-D, so give it the explicit trailing axis and drop it again.
     ab = np.linalg.solve(m_a, (p_1.T / omega[:, None])[..., None])[..., 0]

--- a/src/phonometry/vibration/structural/junction_transmission.py
+++ b/src/phonometry/vibration/structural/junction_transmission.py
@@ -287,9 +287,11 @@ def _check_angle(angle: ArrayLike) -> NDArray[np.float64]:
     """Incidence angle(s) in radians, restricted to ``[0, pi/2]``."""
     theta = np.asarray(angle, dtype=np.float64)
     if not np.all(np.isfinite(theta)):
-        raise ValueError("'angle' must be finite.")
+        msg = "'angle' must be finite."
+        raise ValueError(msg)
     if np.any(theta < 0.0) or np.any(theta > math.pi / 2.0 + 1e-9):
-        raise ValueError("'angle' must lie in [0, pi/2] radians.")
+        msg = "'angle' must lie in [0, pi/2] radians."
+        raise ValueError(msg)
     return theta
 
 
@@ -347,9 +349,8 @@ def straight_transmission_coefficient(
     p = require_positive(psi, "psi")
     _, _, j3 = _junction(junction)
     if j3 is None:
-        raise ValueError(
-            f"junction {junction!r} has no straight section (use 'X' or 'T1')."
-        )
+        msg = f"junction {junction!r} has no straight section (use 'X' or 'T1')."
+        raise ValueError(msg)
     sin = np.sin(theta)
     sin2 = sin * sin
     cos2 = np.cos(theta) ** 2
@@ -456,12 +457,14 @@ def coupling_loss_factor(
     """
     tau = np.asarray(transmission_coefficient, dtype=np.float64)
     if np.any(tau < 0.0):
-        raise ValueError("'transmission_coefficient' must be non-negative.")
+        msg = "'transmission_coefficient' must be non-negative."
+        raise ValueError(msg)
     cg = require_positive(group_velocity, "group_velocity")
     lij = require_positive(junction_length, "junction_length")
     freq = np.asarray(frequency, dtype=np.float64)
     if np.any(freq <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     area = require_positive(plate_area, "plate_area")
     eta = cg * lij * tau / (2.0 * math.pi**2 * freq * area)
     return np.asarray(eta, dtype=np.float64)
@@ -584,10 +587,12 @@ def point_connection_coupling_loss_factor(
     """
     freq = np.asarray(frequency, dtype=np.float64)
     if np.any(freq <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     n = int(n_connections)
     if n < 1:
-        raise ValueError("'n_connections' must be a positive integer.")
+        msg = "'n_connections' must be a positive integer."
+        raise ValueError(msg)
     h_1 = require_positive(thickness1, "thickness1")
     h_2 = require_positive(thickness2, "thickness2")
     rs_1 = require_positive(surface_density1, "surface_density1")
@@ -634,7 +639,8 @@ def wave_vibration_reduction_index(
     """
     tau = np.asarray(transmission_coefficient, dtype=np.float64)
     if np.any(tau <= 0.0):
-        raise ValueError("'transmission_coefficient' must be positive.")
+        msg = "'transmission_coefficient' must be positive."
+        raise ValueError(msg)
     fcj = require_positive(critical_frequency_receiver, "critical_frequency_receiver")
     kij = 10.0 * np.log10(1.0 / tau) + 5.0 * math.log10(fcj / _REFERENCE_FREQUENCY)
     return np.asarray(kij, dtype=np.float64)
@@ -775,7 +781,8 @@ def junction_transmission(
     else:
         grid = np.atleast_1d(np.asarray(angles_deg, dtype=np.float64))
         if grid.ndim != 1 or grid.size == 0:
-            raise ValueError("'angles_deg' must be a non-empty 1-D array.")
+            msg = "'angles_deg' must be a non-empty 1-D array."
+            raise ValueError(msg)
     theta = np.radians(grid)
     corner = corner_transmission_coefficient(theta, chi, psi, name)
     corner_avg = angular_average_transmission_coefficient(

--- a/src/phonometry/vibration/structural/mechanical_mobility.py
+++ b/src/phonometry/vibration/structural/mechanical_mobility.py
@@ -115,9 +115,8 @@ def _omega(frequency: ArrayLike) -> NDArray[np.float64]:
     r"""Angular frequency :math:`\omega = 2 \pi f` (rad/s); rejects f <= 0."""
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f <= 0.0):
-        raise ValueError(
-            "'frequency' must be positive (mobility conversions divide by omega)."
-        )
+        msg = "'frequency' must be positive (mobility conversions divide by omega)."
+        raise ValueError(msg)
     return 2.0 * np.pi * f
 
 
@@ -177,19 +176,19 @@ def convert_frf(
     """
     for name, role in ((source, "source"), (target, "target")):
         if name not in _FRF_TYPES:
-            raise ValueError(
-                f"unknown {role} FRF {name!r}; choose from {tuple(_FRF_TYPES)}."
-            )
+            msg = f"unknown {role} FRF {name!r}; choose from {tuple(_FRF_TYPES)}."
+            raise ValueError(msg)
     omega = _omega(frequency)
     val = np.asarray(value, dtype=np.complex128)
     if (_FRF_TYPES[source][1] or _FRF_TYPES[target][1]) and not np.all(
         np.abs(val) > 0.0
     ):
-        raise ValueError(
+        msg = (
             "'value' contains zeros (dead channel); converting "
             f"{source!r} to {target!r} takes a reciprocal, which is "
             "undefined there."
         )
+        raise ValueError(msg)
     receptance = _to_receptance(val, omega, source)
     return np.asarray(_from_receptance(receptance, omega, target), dtype=np.complex128)
 
@@ -351,13 +350,15 @@ def rigid_mass_calibration_check(
         or frequency, or mismatched shapes.
     """
     if quantity not in ("accelerance", "mobility"):
-        raise ValueError("'quantity' must be 'accelerance' or 'mobility'.")
+        msg = "'quantity' must be 'accelerance' or 'mobility'."
+        raise ValueError(msg)
     mass = require_positive(mass, "mass")
     tolerance = require_positive(tolerance, "tolerance")
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     measured = np.abs(np.atleast_1d(np.asarray(frf, dtype=np.complex128)))
     if measured.shape != freq.shape:
-        raise ValueError("'frf' and 'frequencies' must have the same shape.")
+        msg = "'frf' and 'frequencies' must have the same shape."
+        raise ValueError(msg)
     omega = _omega(freq)
     if quantity == "accelerance":
         expected = np.full_like(freq, 1.0 / mass)
@@ -399,10 +400,12 @@ def random_error_percent(coherence: ArrayLike, n_averages: int) -> np.ndarray:
     """
     n = int(n_averages)
     if n < 1:
-        raise ValueError("'n_averages' must be at least 1.")
+        msg = "'n_averages' must be at least 1."
+        raise ValueError(msg)
     gamma2 = np.asarray(coherence, dtype=np.float64)
     if np.any(gamma2 <= 0.0) or np.any(gamma2 > 1.0):
-        raise ValueError("'coherence' must lie in (0, 1].")
+        msg = "'coherence' must lie in (0, 1]."
+        raise ValueError(msg)
     eps = np.sqrt((1.0 - gamma2) / (2.0 * n * gamma2))
     return np.asarray(100.0 * eps, dtype=np.float64)
 
@@ -504,9 +507,8 @@ class MobilityResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso7626 import render_mobility_report
 
         return render_mobility_report(

--- a/src/phonometry/vibration/structural/point_mobility.py
+++ b/src/phonometry/vibration/structural/point_mobility.py
@@ -110,7 +110,8 @@ def plate_bending_stiffness(
     e = require_positive(youngs_modulus, "youngs_modulus")
     h = require_positive(thickness, "thickness")
     if not -1.0 < poisson_ratio < 1.0:
-        raise ValueError("'poisson_ratio' must lie in (-1, 1).")
+        msg = "'poisson_ratio' must lie in (-1, 1)."
+        raise ValueError(msg)
     return float(e * h**3 / (12.0 * (1.0 - poisson_ratio**2)))
 
 
@@ -155,7 +156,8 @@ def _omega(frequency: ArrayLike) -> NDArray[np.float64]:
     r"""Angular frequency :math:`\omega = 2\pi f` (rad/s); rejects f <= 0."""
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     return np.asarray(2.0 * np.pi * f, dtype=np.float64)
 
 
@@ -186,7 +188,8 @@ def infinite_plate_impedance(
     b = require_positive(bending_stiffness, "bending_stiffness")
     m2 = require_positive(mass_per_area, "mass_per_area")
     if location not in _PLATE_CONSTANT:
-        raise ValueError("'location' must be 'centre' or 'edge'.")
+        msg = "'location' must be 'centre' or 'edge'."
+        raise ValueError(msg)
     return float(_PLATE_CONSTANT[location] * np.sqrt(b * m2))
 
 
@@ -239,7 +242,8 @@ def infinite_beam_impedance(
     :raises ValueError: for a non-positive input or unknown location.
     """
     if location not in _BEAM_CONSTANT:
-        raise ValueError("'location' must be 'centre' or 'end'.")
+        msg = "'location' must be 'centre' or 'end'."
+        raise ValueError(msg)
     m1 = require_positive(mass_per_length, "mass_per_length")
     c_b = beam_bending_wave_speed(frequency, bending_stiffness, m1)
     z = _BEAM_CONSTANT[location] * m1 * c_b * (1.0 + 1j)
@@ -382,7 +386,8 @@ def infinite_plate_point_mobility(
     """
     freq = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     if np.any(freq <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     y = infinite_plate_mobility(bending_stiffness, mass_per_area, location=location)
     mob = np.full(freq.shape, y, dtype=np.complex128)
     return MobilityResult(frequencies=freq, mobility=mob, driving_point=True)

--- a/src/phonometry/vibration/structural/radiation_efficiency.py
+++ b/src/phonometry/vibration/structural/radiation_efficiency.py
@@ -216,9 +216,11 @@ def radiation_efficiency(
     """
     freq = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     if freq.ndim != 1 or freq.size == 0:
-        raise ValueError("'frequency' must be a non-empty 1-D array.")
+        msg = "'frequency' must be a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(freq <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     lx = require_positive(length_x, "length_x")
     ly = require_positive(length_y, "length_y")
     fc = require_positive(critical_frequency, "critical_frequency")

--- a/src/phonometry/vibration/structural/transfer_stiffness.py
+++ b/src/phonometry/vibration/structural/transfer_stiffness.py
@@ -85,7 +85,8 @@ def _omega(frequency: ArrayLike) -> NDArray[np.float64]:
     r"""Angular frequency :math:`\omega = 2\pi f` (rad/s); rejects f <= 0."""
     f = np.asarray(frequency, dtype=np.float64)
     if np.any(f <= 0.0):
-        raise ValueError("'frequency' must be positive.")
+        msg = "'frequency' must be positive."
+        raise ValueError(msg)
     return 2.0 * np.pi * f
 
 
@@ -107,10 +108,11 @@ def transfer_stiffness_level(
     reference = require_positive(reference, "reference")
     magnitude = np.abs(np.asarray(stiffness, dtype=np.complex128))
     if not np.all(magnitude > 0.0):
-        raise ValueError(
+        msg = (
             "'stiffness' contains zero magnitudes; a zero (dead-channel) "
             "stiffness has no level."
         )
+        raise ValueError(msg)
     return np.asarray(20.0 * np.log10(magnitude / reference), dtype=np.float64)
 
 
@@ -131,10 +133,11 @@ def loss_factor(stiffness: ArrayLike) -> np.ndarray:
     """
     k = np.asarray(stiffness, dtype=np.complex128)
     if not np.all(np.abs(k.real) > 0.0):
-        raise ValueError(
+        msg = (
             "'stiffness' contains purely imaginary values (Re = 0); the loss "
             "factor eta = Im/Re is undefined there."
         )
+        raise ValueError(msg)
     return np.asarray(k.imag / k.real, dtype=np.float64)
 
 
@@ -155,10 +158,11 @@ def transfer_stiffness_direct(
     f2b = np.asarray(blocking_force, dtype=np.complex128)
     u1 = np.asarray(input_displacement, dtype=np.complex128)
     if not np.all(np.abs(u1) > 0.0):
-        raise ValueError(
+        msg = (
             "'input_displacement' contains zeros (dead input channel); the "
             "ratio k2,1 = F2,b/u1 is undefined there."
         )
+        raise ValueError(msg)
     return np.asarray(f2b / u1, dtype=np.complex128)
 
 
@@ -259,7 +263,8 @@ def blocking_force_ratio(
     k22 = np.asarray(driving_point_stiffness, dtype=np.complex128)
     kt = np.asarray(termination_stiffness, dtype=np.complex128)
     if not np.all(np.abs(kt) > 0.0):
-        raise ValueError("'termination_stiffness' must be non-zero.")
+        msg = "'termination_stiffness' must be non-zero."
+        raise ValueError(msg)
     return np.asarray(1.0 / (1.0 + k22 / kt), dtype=np.complex128)
 
 
@@ -405,9 +410,8 @@ class TransferStiffnessResult:
 
         check_language(language)
         if engine != "reportlab":
-            raise ValueError(
-                f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            )
+            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+            raise ValueError(msg)
         from ..._report.iso10846 import render_transfer_stiffness_report
 
         return render_transfer_stiffness_report(

--- a/tests/building/test_building_plots.py
+++ b/tests/building/test_building_plots.py
@@ -54,9 +54,8 @@ def _line_by_label(ax, needle: str):
     for line in ax.lines:
         if needle in line.get_label():
             return line
-    raise AssertionError(
-        f"no line labelled with {needle!r}; got {[ln.get_label() for ln in ax.lines]}"
-    )
+    msg = f"no line labelled with {needle!r}; got {[ln.get_label() for ln in ax.lines]}"
+    raise AssertionError(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/data/stipa/make_extract.py
+++ b/tests/data/stipa/make_extract.py
@@ -135,9 +135,11 @@ def _write(source: pathlib.Path, destination: pathlib.Path) -> None:
             path = source / relative
             fs, samples = wavfile.read(path)
             if fs != _FS:
-                raise SystemExit(f"{relative}: expected {_FS} Hz, got {fs}")
+                msg = f"{relative}: expected {_FS} Hz, got {fs}"
+                raise SystemExit(msg)
             if samples.dtype != np.int16 or samples.ndim != 1:
-                raise SystemExit(f"{relative}: expected 16-bit mono PCM")
+                msg = f"{relative}: expected 16-bit mono PCM"
+                raise SystemExit(msg)
             order = best_order(samples)
             member = f"{relative}.i4"
             archive.writestr(_member(member), encode(samples, order))
@@ -175,7 +177,8 @@ def _write(source: pathlib.Path, destination: pathlib.Path) -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        raise SystemExit(f"usage: {sys.argv[0]} <stipa-verification-directory>")
+        msg = f"usage: {sys.argv[0]} <stipa-verification-directory>"
+        raise SystemExit(msg)
     build(
         pathlib.Path(sys.argv[1]),
         pathlib.Path(__file__).with_name("stipa_certified_extract.zip"),

--- a/tests/io/test_io_flac.py
+++ b/tests/io/test_io_flac.py
@@ -198,7 +198,8 @@ def test_flac_target_without_the_extra_names_it(
 
     def blocked(name: str, *args: object, **kwargs: object) -> object:
         if name.split(".")[0] == "soundfile":
-            raise ImportError("blocked for the test")
+            msg = "blocked for the test"
+            raise ImportError(msg)
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(builtins, "__import__", blocked)

--- a/tests/io/test_io_read.py
+++ b/tests/io/test_io_read.py
@@ -421,7 +421,8 @@ def test_missing_audio_extra_is_named_in_the_error(
 
     def blocked(name: str, *args: object, **kwargs: object) -> object:
         if name == "soundfile" or name.startswith("soundfile."):
-            raise ImportError("No module named 'soundfile'")
+            msg = "No module named 'soundfile'"
+            raise ImportError(msg)
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(builtins, "__import__", blocked)

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -164,7 +164,8 @@ def _scalar(result: object) -> float:
     ):
         if hasattr(result, name):
             return float(np.asarray(getattr(result, name)).ravel()[0])
-    raise AssertionError(f"no scalar on {type(result).__name__}")
+    msg = f"no scalar on {type(result).__name__}"
+    raise AssertionError(msg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/speech/test_stipa_certified.py
+++ b/tests/speech/test_stipa_certified.py
@@ -125,12 +125,13 @@ def _load(relative: str) -> np.ndarray:
         # the full bench, but a signal inside one of them is missing. Say so
         # rather than dying on a bare FileNotFoundError - and do not quietly
         # substitute the committed extract, which would hide the gap.
-        raise AssertionError(
+        msg = (
             f"{relative} is missing from the local bench at {FULL_BENCH}. "
             "The download is incomplete: remove or complete it, or point "
             "STIPA_VERIFICATION_DATA elsewhere, to fall back to the "
             "committed extract."
         )
+        raise AssertionError(msg)
     return _read_wav(path)
 
 

--- a/tests/test_animation_fingerprint.py
+++ b/tests/test_animation_fingerprint.py
@@ -280,7 +280,8 @@ def _fake_batch(monkeypatch: pytest.MonkeyPatch, fails: str | None) -> list[list
 
     def render(clip: str, output_dir: str) -> None:
         if clip == fails:
-            raise RuntimeError("the encoder died")
+            msg = "the encoder died"
+            raise RuntimeError(msg)
 
     monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
     monkeypatch.setattr(

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -427,7 +427,8 @@ def test_submit_falls_back_to_local_numpy_run(
     monkeypatch.setattr(fdtd_gpu_remote, "remote_available", lambda config: True)
 
     def _boom(job: dict[str, Any], config: Any, timeout: float = 0.0) -> dict[str, Any]:
-        raise fdtd_gpu_remote.RemoteRunError("docker run failed")
+        msg = "docker run failed"
+        raise fdtd_gpu_remote.RemoteRunError(msg)
 
     monkeypatch.setattr(fdtd_gpu_remote, "run_remote", _boom)
     monkeypatch.setattr(job_runner, "_pick_backend", lambda: (np, "numpy"))

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -322,7 +322,8 @@ def test_showfilter_raises_helpful_error_without_matplotlib(monkeypatch) -> None
 
     def blocked_import(name, *args, **kwargs):
         if name.startswith("matplotlib"):
-            raise ImportError("No module named 'matplotlib'")
+            msg = "No module named 'matplotlib'"
+            raise ImportError(msg)
         return real_import(name, *args, **kwargs)
 
     spectrum = np.array([1])

--- a/tests/test_repository_config.py
+++ b/tests/test_repository_config.py
@@ -61,7 +61,8 @@ def _glob_to_regex(pattern: str) -> re.Pattern[str]:
         elif re.fullmatch(r"[\w.*-]+", segment):
             out += re.escape(segment).replace(r"\*", "[^/]*")
         else:
-            raise AssertionError(f"unsupported glob segment {segment!r} in {pattern!r}")
+            msg = f"unsupported glob segment {segment!r} in {pattern!r}"
+            raise AssertionError(msg)
         if not last:
             out += "/"
     return re.compile(out)

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -112,7 +112,8 @@ def test_plot_raises_helpful_error_without_matplotlib(monkeypatch) -> None:
 
     def blocked(name, *args, **kwargs):
         if name.startswith("matplotlib"):
-            raise ImportError("No module named 'matplotlib'")
+            msg = "No module named 'matplotlib'"
+            raise ImportError(msg)
         return real_import(name, *args, **kwargs)
 
     res = _zwicker_stationary()

--- a/tests/test_transition_stub.py
+++ b/tests/test_transition_stub.py
@@ -88,7 +88,8 @@ def _gate(tool: str) -> tuple[str, str]:
             elif not text.startswith("- name:"):
                 break
         return command, " ".join(reversed(comment))
-    raise AssertionError(f"no step in {_WORKFLOW.name} runs {tool}")
+    msg = f"no step in {_WORKFLOW.name} runs {tool}"
+    raise AssertionError(msg)
 
 
 def _stub_project() -> dict[str, object]:

--- a/tests/underwater/propagation/test_bathymetry.py
+++ b/tests/underwater/propagation/test_bathymetry.py
@@ -108,7 +108,8 @@ def _fold_wedge_ray(
     i = n_surf = n_bot = 0
     for _ in range(10_000):
         if abs(th) >= np.pi / 2:
-            raise AssertionError("the sampled grid must end before a reversal")
+            msg = "the sampled grid must end before a reversal"
+            raise AssertionError(msg)
         if th > 0:
             r_hit = (depth0 - z_seg + np.tan(th) * r0) / (np.tan(th) + tanb)
         elif th < 0:
@@ -130,7 +131,8 @@ def _fold_wedge_ray(
         else:
             th = -th
             n_surf += 1
-    raise AssertionError("the fold did not close")
+    msg = "the fold did not close"
+    raise AssertionError(msg)
 
 
 def test_the_wedge_trace_is_the_exact_folded_geometry() -> None:

--- a/tests/underwater/propagation/test_numerical.py
+++ b/tests/underwater/propagation/test_numerical.py
@@ -366,7 +366,8 @@ def _arc_walk(rmax: float) -> tuple[float, float]:
         r += leg
         t += abs(arc(phi) - arc(phi_b)) / _BOUNCE_G
         phi = -phi_b  # the reflection itself
-    raise AssertionError("the arc walk did not reach the range")
+    msg = "the arc walk did not reach the range"
+    raise AssertionError(msg)
 
 
 def test_bouncing_ray_matches_the_exact_arc_through_every_reflection() -> None:

--- a/tests/wav_forge.py
+++ b/tests/wav_forge.py
@@ -100,7 +100,8 @@ def pcm_data(samples: np.ndarray, bits: int) -> bytes:
         return b"".join(int(v).to_bytes(4, "little", signed=True)[:3] for v in flat)
     if bits == 32:
         return flat.astype("<i4").tobytes()
-    raise ValueError(f"unsupported PCM depth {bits}")
+    msg = f"unsupported PCM depth {bits}"
+    raise ValueError(msg)
 
 
 def pcm_wav(


### PR DESCRIPTION
## What and why

Every exception message is assigned to a variable and raised by name: 2148 sites, `msg = ...` then `raise SomethingError(msg)` (ruff EM, now selected). What it buys is the traceback: the line the interpreter prints for the raise is `raise ClauseError(msg)`, not the first of several wrapped lines of a long clause citation, so the message appears once, in the exception itself, and the frame stays one line.

The fix is ruff's, applied tree-wide, and the diff is mechanical throughout: every added line is the `msg` assignment, the raise it feeds, a string continuation, or a closing bracket. The variable name was free everywhere: no file in the tree bound `msg` before this change. The one site left alone is a guard that cannot fire in the code that draws `anim_fdtd_side_branch`, where the rewrite would move the clip's recorded fingerprint and demand a re-render that draws the same frames; the `noqa` says so in place.

## Validation

No new computation. Message texts are unchanged, so every `pytest.raises(match=...)` in the suite still binds. The regenerated artifacts (API reference, llms, conformance) came out byte-identical and all 42 animation fingerprints stayed put.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files you touched
- [x] `mypy src scripts`
- [x] `bandit -r src` (any finding fails, including Low)
- [x] `pytest -q` (8958 passed, 16 skipped)

Regenerated where this change touches them:

- [x] `make conformance`: byte-identical, nothing to commit
- [x] `make api-docs`: byte-identical, nothing to commit
- [x] `make llms`: byte-identical, nothing to commit

Always:

- [x] CHANGELOG entry under `[Unreleased]`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Improve exception tracebacks by ensuring messages are assigned once and passed by name when exceptions are raised.

Enhancements:
- Standardize exception construction across the codebase by assigning messages before raising them, improving traceback readability while preserving all exception text and behavior.

Build:
- Enable Ruff EM exception-message rules in the project lint configuration.

Chores:
- Document the tree-wide exception-message style update and retain an inline exemption for the animation fingerprint guard.