### PR TITLE
Give the numbers in comparisons the names they were carrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- A number in a comparison carries a name. `PLR2004` is selected for `src`,
+  and the 487 magic values it found there were read one at a time before it
+  went on: 380 became named constants, 29 reach an existing symbol that
+  already said it, and 85 lines keep their literal under a `noqa` that says
+  why. The names state the concept rather than the number, so `if
+  len(header) < 4` is `< _BLOCK_HEADER_BYTES` (a FLAC metadata block header
+  is one type byte and three length bytes) and `if nominal >= 1000.0` is
+  `>= _HZ_PER_KHZ`. Where a name would say less than the expression already
+  does, the literal stays: `order == 2` sits under a docstring that says
+  "Product order (2 or 3)", and the transcribed CIEDE2000 formula keeps the
+  180 and 360 degrees its published equations are written with.
+
+  Reading every site found things a rule never would. Absolute zero is in
+  the tree twice, as the exact -273.15 and as the -273.0 that ISO 3741
+  writes into its own `273 + theta` arithmetic; they are now
+  `_ABS_ZERO_C` and `_ROUNDED_ABS_ZERO_C`, deliberately unmergeable. Four
+  modules already spelled the 1 kHz reference `_REFERENCE_FREQUENCY`, so
+  the new ones join them instead of inventing a fifth spelling. The RIFF
+  wire magics now live once in `io/_chunks.py` and are read from there,
+  which closed a duplicate spelling of the bext chunk identifier and a
+  sniffer table that had drifted from the name it was meant to match. A
+  fiche's private frequency-label helper turned out to be byte-identical to
+  `filters.frequencies._format_nominal_freq` and now calls it.
+
+  The strings are not part of this: `PLR2004` exempts `str` and `bytes` by
+  default and stays that way, because a comparison against `"cremer"` or
+  `"es"` is the API's own vocabulary and the literal is the name. Only the
+  format magics among them were named. `tests` and `scripts` are exempt
+  too: the tests compare against printed oracle values, and the figure
+  scripts lay out halves and angles, where a name for every number is noise.
+
 - Every exception message is assigned to a variable and raised by name:
   2148 sites, `msg = ...` then `raise SomethingError(msg)`. What it buys is
   the traceback: the line the interpreter prints for the raise is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ extend-exclude = ["*.md"]
 # The default set (E4, E7, E9, F) plus the families this tree already satisfies
 # or very nearly does, so the gate stays honest instead of drowning in noise.
 # Deliberately absent, with the count each would raise today:
-#   PL   (5753) mostly magic-value comparisons, and the magic values here are
-#               transcribed normative constants: that is the content.
+#   PL   (5265) minus PLR2004, which is selected below. The rest is mostly
+#               complexity counts and design opinions this tree does not share.
 #   RUF  (1705) ambiguous-unicode in prose that legitimately carries the
 #               degree sign, the multiplication sign and ISO symbols.
 #   TID  (2218) bans the relative imports this package uses by design.
@@ -153,6 +153,10 @@ select = [
     "ICN",                  # the conventional alias for a well-known package
     "N812",                 # an alias must not disguise a function as a class
     "INP", "T20",           # both already clean in `src`, and kept that way
+    "PLR2004",              # a number in a comparison carries a name or a
+                            # reasoned noqa; every site was censused one by
+                            # one before this went on (str/bytes stay exempt:
+                            # that vocabulary is its own name)
     "EM",                   # the message lives in a variable, so a traceback
                             # shows `raise ClauseError(msg)` and the text once,
                             # not a two-line message split across the frame
@@ -217,13 +221,16 @@ ignore = [
 # A print is what a command line tool is for, and neither the scripts nor the
 # tests are packages anyone imports by name. Both rules are here to hold `src`,
 # where they already find nothing.
-"scripts/**" = ["E402", "T201", "INP001"]
+# Scripts lay out figures with bare halves and angles, and the tests compare
+# against printed oracle values; a name for every such number would be noise.
+# The census that named the `src` sites covered neither, deliberately.
+"scripts/**" = ["E402", "T201", "INP001", "PLR2004"]
 # A test may open its docstring with the clause it checks, quoted verbatim:
 # `""" "Up till about 1000 Hz..." `. The space after the triple quote is what
 # keeps that from being four quotation marks in a row; D210 wants it gone and
 # has no way to fix it. The quotation stays, so the rule stands down in tests
 # and holds `src`, where it finds nothing.
-"tests/**" = ["E402", "T201", "INP001", "D210"]
+"tests/**" = ["E402", "T201", "INP001", "D210", "PLR2004"]
 ".github/**" = ["T201", "INP001"]
 # The PyOctaveBand transition shim exists to re-export the whole package under
 # the old name; the star import is the point of the file.

--- a/src/phonometry/_internal/utils.py
+++ b/src/phonometry/_internal/utils.py
@@ -11,6 +11,11 @@ from scipy import signal
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+# Rank of the cached SOS filter state ``zi`` as ``_sos_initial_state`` lays
+# it out: (n_sections, 2) for 1-D input, (n_sections, n_channels, 2) for 2-D.
+_ZI_NDIM_MONO = 2
+_ZI_NDIM_MULTICHANNEL = 3
+
 
 def _typesignal(x: Sequence[float] | np.ndarray) -> np.ndarray:
     """Ensure signal is a float64 numpy array.
@@ -97,5 +102,5 @@ def _sos_state_mismatch(zi: np.ndarray, x_proc: np.ndarray) -> bool:
     if zi.size == 0:
         return True
     if x_proc.ndim == 1:
-        return zi.ndim != 2
-    return zi.ndim != 3 or zi.shape[1] != x_proc.shape[0]
+        return zi.ndim != _ZI_NDIM_MONO
+    return zi.ndim != _ZI_NDIM_MULTICHANNEL or zi.shape[1] != x_proc.shape[0]

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -80,6 +80,19 @@ _C_EDGE: Final = "#555555"
 #: Standard-normal quantile of 0.9 (the 10 % / 90 % fractile offset).
 _Z90: Final = 1.2816
 
+#: One kilohertz in hertz: a band centre at or above it is labelled with the
+#: short "k" suffix (1k, 2k) after being scaled down by the same value.
+_HZ_PER_KHZ: Final = 1000.0
+
+#: Half the 1 dB quantum of an integer ISO 717 rating: a gap of at least this
+#: between the rating and the 500 Hz read value means the octave-band -5 dB
+#: reduction (ISO 717-2 Clause 4.3.2) applied, not mere integer rounding.
+_RATING_ROUNDING_HALF_DB: Final = 0.5
+
+#: Minimum in-corridor samples before ``np.polyfit`` degree 1 can define the
+#: least-squares straight line of a Schroeder decay (two points make a line).
+_MIN_LINE_FIT_POINTS: Final = 2
+
 # ---------------------------------------------------------------------------
 # Signed wave-field colormaps: the zero of a diverging field should blend
 # into the page, so the default is picked from the axes background at draw
@@ -91,6 +104,10 @@ _Z90: Final = 1.2816
 _FIELD_CMAP_LIGHT: Final = "RdBu_r"
 #: Diverging wave-field colormap of a dark axes background (black centre).
 _FIELD_CMAP_DARK: Final = "phonometry_field_dark"
+
+#: Midpoint of the 0-1 luminance scale: an axes facecolor whose luminance
+#: falls below it counts as a dark background and gets the dark-centre map.
+_DARK_BACKGROUND_LUMINANCE_MAX: Final = 0.5
 
 
 def _register_field_dark_cmap() -> None:
@@ -135,7 +152,11 @@ def _field_cmap(ax: Axes) -> str:
     _register_field_dark_cmap()
     r, g, b = to_rgb(ax.get_facecolor())
     luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-    return _FIELD_CMAP_DARK if luminance < 0.5 else _FIELD_CMAP_LIGHT
+    return (
+        _FIELD_CMAP_DARK
+        if luminance < _DARK_BACKGROUND_LUMINANCE_MAX
+        else _FIELD_CMAP_LIGHT
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +176,10 @@ _SRGB_TO_XYZ: Final = np.array(
         [0.0193339, 0.1191920, 0.9503041],
     ]
 )
+
+#: sRGB transfer-function threshold (IEC 61966-2-1): encoded channel values at
+#: or below it decode through the linear segment (/ 12.92), not the power law.
+_SRGB_LINEAR_THRESHOLD: Final = 0.04045
 
 #: CIE D65 reference white in XYZ, the sRGB adopted white point.
 _D65_WHITE: Final = np.array([0.95047, 1.00000, 1.08883])
@@ -191,7 +216,9 @@ def _srgb_to_lab(rgb: tuple[float, float, float]) -> tuple[float, float, float]:
     """CIE L*a*b* (D65, 2 degree observer) of a 0-1 sRGB triple."""
     channels = np.asarray(rgb, dtype=np.float64)
     linear = np.where(
-        channels <= 0.04045, channels / 12.92, ((channels + 0.055) / 1.055) ** 2.4
+        channels <= _SRGB_LINEAR_THRESHOLD,
+        channels / 12.92,
+        ((channels + 0.055) / 1.055) ** 2.4,
     )
     ratio = (_SRGB_TO_XYZ @ linear) / _D65_WHITE
     f = np.where(
@@ -242,7 +269,7 @@ def delta_e_2000(
     d_c = cp_2 - cp_1
     if neutral_pair:
         d_h = 0.0
-    elif abs(hp_2 - hp_1) <= 180.0:
+    elif abs(hp_2 - hp_1) <= 180.0:  # noqa: PLR2004
         d_h = hp_2 - hp_1
     else:
         d_h = hp_2 - hp_1 - 360.0 * float(np.sign(hp_2 - hp_1))
@@ -252,9 +279,9 @@ def delta_e_2000(
     c_bar = 0.5 * (cp_1 + cp_2)
     if neutral_pair:
         h_bar = hp_1 + hp_2
-    elif abs(hp_1 - hp_2) <= 180.0:
+    elif abs(hp_1 - hp_2) <= 180.0:  # noqa: PLR2004
         h_bar = 0.5 * (hp_1 + hp_2)
-    elif hp_1 + hp_2 < 360.0:
+    elif hp_1 + hp_2 < 360.0:  # noqa: PLR2004
         h_bar = 0.5 * (hp_1 + hp_2 + 360.0)
     else:
         h_bar = 0.5 * (hp_1 + hp_2 - 360.0)
@@ -402,7 +429,8 @@ def _fill_weight(
 def relative_luminance(color: tuple[float, float, float]) -> float:
     """WCAG 2.2 relative luminance of a 0-1 sRGB triple."""
     linear = [
-        c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in color
+        c / 12.92 if c <= _SRGB_LINEAR_THRESHOLD else ((c + 0.055) / 1.055) ** 2.4
+        for c in color
     ]
     return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
 
@@ -580,7 +608,7 @@ def _format_freq(f: float, language: str = "en") -> str:
     """
     from .._i18n import decimal_comma
 
-    text = f"{f / 1000.0:g}k" if f >= 1000.0 else f"{f:g}"
+    text = f"{f / _HZ_PER_KHZ:g}k" if f >= _HZ_PER_KHZ else f"{f:g}"
     return decimal_comma(text, language)
 
 
@@ -931,7 +959,7 @@ def _annotate_impact_500(
         label=read_label,
     )
     offset = rating - read_value
-    if abs(offset) >= 0.5:  # octave-band -5 dB rule (Clause 4.3.2)
+    if abs(offset) >= _RATING_ROUNDING_HALF_DB:  # octave-band -5 dB rule (Clause 4.3.2)
         rating_str = format_number(rating, language, decimals=0)
         # The sign between the read value and "5 dB" is a subtraction operator,
         # so it is set with the typographic minus, not the ASCII hyphen.
@@ -1068,7 +1096,7 @@ def _fit_segment(
 ) -> np.ndarray | None:
     """Least-squares straight line over ``hi <= level <= lo``, over full time."""
     mask = (level <= lo) & (level >= hi) & np.isfinite(level)
-    if int(np.count_nonzero(mask)) < 2:
+    if int(np.count_nonzero(mask)) < _MIN_LINE_FIT_POINTS:
         return None
     slope, intercept = np.polyfit(time[mask], level[mask], 1)
     return np.asarray(slope * time + intercept, dtype=np.float64)

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -177,13 +177,14 @@ def plot_harmonic_distortion(
     ref = amps[0] if amps.size and amps[0] > 0.0 else 1.0
     levels_db = 20.0 * np.log10(np.maximum(amps, tiny) / ref)
     orders = np.arange(1, amps.size + 1)
+    floor_db = -160.0  # display floor of the panel, in dB re the fundamental
 
-    ax.vlines(orders, -160.0, levels_db, color=_C_PRIMARY, lw=1.5)
+    ax.vlines(orders, floor_db, levels_db, color=_C_PRIMARY, lw=1.5)
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("label", _t("Harmonics", language))
     ax.plot(orders, levels_db, "o", **kwargs)
     for order, level in zip(orders, levels_db):
-        if level > -160.0:
+        if level > floor_db:
             ax.annotate(
                 f"{order}",
                 (order, level),
@@ -195,7 +196,7 @@ def plot_harmonic_distortion(
     ax.set_xlabel(_t(r"Harmonic order $n$  ($f = n \cdot f_1$)", language))
     ax.set_ylabel(_t("Level re fundamental [dB]", language))
     ax.set_xticks(orders)
-    ax.set_ylim(bottom=-160.0, top=10.0)
+    ax.set_ylim(bottom=floor_db, top=10.0)
     thd_f = decimal_comma(f"{result.thd_f * 100.0:.3g}", language)
     thd_r = decimal_comma(f"{result.thd_r * 100.0:.3g}", language)
     sinad = format_number(result.sinad_db, language, decimals=1)

--- a/src/phonometry/_plot/emission.py
+++ b/src/phonometry/_plot/emission.py
@@ -41,6 +41,11 @@ _FREQ_LABEL = "Frequency [Hz]"
 #: Y-axis label of the residual-index plots (identical in both languages,
 #: the symbol carries the meaning).
 _LABEL_RESIDUAL_INDEX = r"$\delta_{pI0}$ [dB]"
+#: Fewest frequency bands that make a per-band ISO 9614-1 indicators result
+#: drawable as a curve: a size-1 array after ``atleast_1d`` is the
+#: scalar/overall form of ``field_indicators`` (1D per-position input), which
+#: ``plot()`` rejects as carrying no per-band data.
+_MIN_BANDS = 2
 
 #: Spanish translations of the fixed labels/titles/legends rendered by the
 #: emission-domain ``.plot()`` renderers, keyed by their verbatim English
@@ -281,7 +286,7 @@ def plot_field_indicators(
     from .._i18n import localize_axes
 
     f2 = np.atleast_1d(np.asarray(result.f2, dtype=np.float64))
-    if result.frequency is None or f2.size < 2:
+    if result.frequency is None or f2.size < _MIN_BANDS:
         msg = (
             "plot() needs per-band indicators; call field_indicators(...) with "
             "2D (positions, bands) arrays and 'frequencies'."
@@ -483,7 +488,7 @@ def plot_intensity_class(
 
     # Ring the bands that block the next class up: class 1 for a class 2 chain,
     # class 2 for a chain that meets neither. A class 1 chain has none.
-    marked_cls = 1 if result.overall_class == 2 else 2
+    marked_cls = 1 if result.overall_class == 2 else 2  # noqa: PLR2004
     marked_mask = class1 if marked_cls == 1 else class2
     failing = (
         np.zeros(freqs.shape, dtype=bool)

--- a/src/phonometry/_plot/filters.py
+++ b/src/phonometry/_plot/filters.py
@@ -27,6 +27,11 @@ from .common import (
     theme_line,
 )
 
+#: Cap on how many per-section light magnitude lines of the parametric-EQ
+#: cascade get their own legend entry; sections past the eighth still draw
+#: but unlabeled, keeping the legend from swallowing the axes.
+_MAX_LABELED_SECTIONS = 8
+
 #: Spanish translations of the fixed strings rendered by the filters
 #: ``.plot()`` renderers, keyed by their verbatim English text. ``_t``
 #: returns the English key unchanged for any language other than ``"es"``,
@@ -287,7 +292,7 @@ def plot_parametric_eq(
                     color=_C_MUTED,
                     lw=0.9,
                     alpha=0.7,
-                    label=label if idx < 8 else None,
+                    label=label if idx < _MAX_LABELED_SECTIONS else None,
                 )
         kwargs.setdefault("lw", 1.8)
         kwargs.setdefault("label", _t("Cascade", language))

--- a/src/phonometry/_plot/geometry/_draft.py
+++ b/src/phonometry/_plot/geometry/_draft.py
@@ -40,6 +40,14 @@ _AXIS_Y = "y [m]"
 _AXIS_Z = "z [m]"
 #: Shared legend placement of the geometry drawings.
 _LEGEND_LOC: Final = "upper right"
+#: Tolerance below which a span, offset or label shift counts as zero: a
+#: degenerate dimension is skipped before its unit normal would divide by
+#: zero, and only an offset that actually moves a line or label changes it.
+_EPS: Final = 1e-12
+#: Upper edge (degrees, inclusive) of the half-open band (-90, 90] of label
+#: rotations that read left-to-right; past it a label would render
+#: upside-down, so its rotation is folded back by a half turn.
+_MAX_READABLE_ROTATION: Final = 90.0
 
 
 #: Spanish translations of the fixed strings rendered here, keyed by their
@@ -121,12 +129,12 @@ def _dim(
     b = np.asarray(p2, dtype=np.float64)
     direction = b - a
     length = float(np.hypot(*direction))
-    if length < 1e-12:
+    if length < _EPS:
         return
     normal = np.array([-direction[1], direction[0]]) / length
     ao = a + normal * offset
     bo = b + normal * offset
-    if abs(offset) > 1e-12:
+    if abs(offset) > _EPS:
         _dim_extension_lines(ax, ((a, ao), (b, bo)))
     style = "|-|, widthA=0.4, widthB=0.4" if tight else "<->"
     ax.annotate(
@@ -138,7 +146,7 @@ def _dim(
     )
     mid = (ao + bo) / 2.0
     angle = float(np.degrees(np.arctan2(direction[1], direction[0])))
-    if angle > 90.0 or angle <= -90.0:
+    if angle > _MAX_READABLE_ROTATION or angle <= -_MAX_READABLE_ROTATION:
         angle += 180.0
     shift = normal * (9.0 * label_side)
     ha, va, rotation = _dim_label_anchor(shift, angle, label_upright)
@@ -182,9 +190,9 @@ def _dim_label_anchor(
     if not upright:
         return "center", "center", angle
     ha, va = "center", "center"
-    if abs(shift[0]) > 1e-12:
+    if abs(shift[0]) > _EPS:
         ha = "left" if shift[0] > 0.0 else "right"
-    if abs(shift[1]) > 1e-12:
+    if abs(shift[1]) > _EPS:
         va = "bottom" if shift[1] > 0.0 else "top"
     return ha, va, 0.0
 

--- a/src/phonometry/_plot/geometry/emission.py
+++ b/src/phonometry/_plot/geometry/emission.py
@@ -48,6 +48,17 @@ if TYPE_CHECKING:
 
     from ...emission.intensity import IntensityResult
 
+#: Luma threshold above which a point-index chip is light enough to carry
+#: black ink; compared against the chip's BT.601 luma
+#: (0.299 R + 0.587 G + 0.114 B).
+_BLACK_INK_LUMA_MIN = 0.6
+
+#: A position counts as dipping below the reflecting plane at z = 0 (drawing
+#: the full sphere instead of the hemisphere) only when its z is more negative
+#: than this, so floating-point noise on the z = 0 ring of a hemispherical
+#: array does not flip the surface.
+_BELOW_PLANE_Z_EPS = -1e-9
+
 #: Spanish translations of the fixed strings rendered here, keyed by their
 #: verbatim English text. ``_t`` returns the English key unchanged for any
 #: language other than ``"es"``.
@@ -110,7 +121,11 @@ def _number_points(ax: Any, pts: np.ndarray, colours: Any) -> None:
         colours = [colours] * len(pts)
     for index, ((x, y, z), chip) in enumerate(zip(pts, colours, strict=True), start=1):
         red, green, blue = to_rgb(chip)
-        ink = "black" if 0.299 * red + 0.587 * green + 0.114 * blue > 0.6 else "white"
+        ink = (
+            "black"
+            if 0.299 * red + 0.587 * green + 0.114 * blue > _BLACK_INK_LUMA_MIN
+            else "white"
+        )
         # Explicit and above the markers: matplotlib orders 3-D artists by
         # depth, so without this a point in front of its own label clips the
         # digits, which is what the numbers looked like before.
@@ -157,7 +172,7 @@ def plot_microphone_positions(
     """
     _check_language(language)
     pts = np.asarray(positions, dtype=np.float64)
-    if pts.ndim != 2 or pts.shape[1] != 3 or pts.shape[0] == 0:
+    if pts.ndim != 2 or pts.shape[1] != 3 or pts.shape[0] == 0:  # noqa: PLR2004
         msg = "'positions' must have shape (N, 3) with N >= 1."
         raise ValueError(msg)
     if radius is not None and radius <= 0.0:
@@ -171,7 +186,7 @@ def plot_microphone_positions(
     if ax is None:
         plt = _import_pyplot()
         _fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
-    full_sphere = bool(np.any(pts[:, 2] < -1e-9))
+    full_sphere = bool(np.any(pts[:, 2] < _BELOW_PLANE_Z_EPS))
     # The page's own ink, so the mesh is the brightest line on either theme.
     # Read off the axes rather than the rcParams: pyplot is only imported
     # here when this function creates the axes, and callers pass their own.

--- a/src/phonometry/_plot/geometry/materials.py
+++ b/src/phonometry/_plot/geometry/materials.py
@@ -1052,7 +1052,7 @@ def plot_metadiffuser_panel_geometry(
         msg = "'depth' and 'period' must be positive."
         raise ValueError(msg)
     cells = list(wells)
-    if len(cells) < 2:
+    if len(cells) < 2:  # noqa: PLR2004
         msg = "'wells' must contain at least two wells."
         raise ValueError(msg)
     for well in cells:
@@ -1468,6 +1468,13 @@ def plot_dynamic_stiffness_rig(
 # ---------------------------------------------------------------------------
 # Free-field diffusion goniometer (plan view).
 # ---------------------------------------------------------------------------
+#: Half-span of the semicircular receiver arc, in degrees, and so the upper
+#: bound on the receiver angular spacing: the microphones run from -90 to
+#: +90 degrees off the sample normal, and a step within the half-span always
+#: places a receiver on each side of the normal.
+_RECEIVER_ARC_HALF_SPAN_DEG = 90.0
+
+
 def plot_goniometer_geometry(
     ax: Axes | None = None,
     *,
@@ -1498,7 +1505,7 @@ def plot_goniometer_geometry(
     if source_distance <= 0.0 or receiver_radius <= 0.0:
         msg = "'source_distance' and 'receiver_radius' must be positive."
         raise ValueError(msg)
-    if not 0.0 < angular_step <= 90.0:
+    if not 0.0 < angular_step <= _RECEIVER_ARC_HALF_SPAN_DEG:
         msg = "'angular_step' must be in (0, 90] degrees."
         raise ValueError(msg)
     if sample_width <= 0.0:

--- a/src/phonometry/_plot/geometry/room.py
+++ b/src/phonometry/_plot/geometry/room.py
@@ -212,7 +212,7 @@ def plot_open_plan_geometry(
     """
     _check_language(language)
     pos = np.sort(np.asarray(positions, dtype=np.float64).ravel())
-    if pos.size < 2 or np.any(pos <= 0.0):
+    if pos.size < 2 or np.any(pos <= 0.0):  # noqa: PLR2004
         msg = "'positions' needs at least two positive distances."
         raise ValueError(msg)
     if ax is None:

--- a/src/phonometry/_plot/geometry/simulation.py
+++ b/src/phonometry/_plot/geometry/simulation.py
@@ -142,7 +142,7 @@ def plot_fdtd_domain(
     pts: NDArray[np.float64] | None = None
     if probes is not None:
         pts = np.asarray(probes, dtype=np.float64)
-        if pts.ndim != 2 or pts.shape[1] != 2:
+        if pts.ndim != 2 or pts.shape[1] != 2:  # noqa: PLR2004
             msg = "'probes' must have shape (N, 2)."
             raise ValueError(msg)
     if ax is None:

--- a/src/phonometry/_plot/hearing.py
+++ b/src/phonometry/_plot/hearing.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
     from ..hearing.occupational_exposure import ExposureResult
     from ..hearing.threshold import AgeThresholdResult
 
+# Tolerance under which the requested population fractile counts as the
+# median (0.5), so the separate fractile curve, which would duplicate the
+# median line, is skipped.
+_MEDIAN_FRACTILE_EPS = 1e-9
+
 #: Spanish translations of the fixed strings rendered by the hearing
 #: ``.plot()`` renderers, keyed by their verbatim English text. ``_t``
 #: returns the English key unchanged for any language other than ``"es"``,
@@ -90,7 +95,7 @@ def plot_age_threshold(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("label", _t("Median", language))
     ax.plot(freqs, median, "o-", **kwargs)
-    if abs(result.fractile - 0.5) > 1e-9:
+    if abs(result.fractile - 0.5) > _MEDIAN_FRACTILE_EPS:
         ax.plot(
             freqs,
             np.asarray(result.threshold, dtype=np.float64),
@@ -151,7 +156,7 @@ def plot_nipts(
     kwargs.setdefault("color", _C_SECONDARY)
     kwargs.setdefault("label", _t("Median $N_{50}$", language))
     ax.plot(freqs, median, "o-", **kwargs)
-    if abs(result.fractile - 0.5) > 1e-9:
+    if abs(result.fractile - 0.5) > _MEDIAN_FRACTILE_EPS:
         ax.plot(
             freqs,
             np.asarray(result.value, dtype=np.float64),

--- a/src/phonometry/_plot/materials.py
+++ b/src/phonometry/_plot/materials.py
@@ -54,6 +54,11 @@ _DIFFUSION_TITLE = "Directional diffusion coefficient (ISO 17497-2)"
 _HARD_BACKED_ALPHA_LABEL = r"Hard-backed absorption $\alpha$"
 _SIGMA_UNFAV_LABEL = r"$\Sigma$ unfav. = "
 
+#: Half-span of the single-plane receiver semicircle about the surface
+#: normal that the ISO 17497-2 diffusion polar covers (Clause 6.3,
+#: Figure 4); negated for the lower edge of the span.
+_POLAR_SEMICIRCLE_DEG = 90.0
+
 #: Spanish translations of the fixed strings rendered by the materials
 #: ``.plot()`` renderers, keyed by their verbatim English text.  ``_t`` returns
 #: the English key unchanged for any language other than ``"es"``, so the
@@ -427,8 +432,8 @@ def plot_diffusion_polar_report(
     polar_ax.set_theta_direction(-1)
     if (
         angles_deg.size
-        and float(np.nanmin(angles_deg)) >= -90.0
-        and float(np.nanmax(angles_deg)) <= 90.0
+        and float(np.nanmin(angles_deg)) >= -_POLAR_SEMICIRCLE_DEG
+        and float(np.nanmax(angles_deg)) <= _POLAR_SEMICIRCLE_DEG
     ):
         polar_ax.set_thetamin(-90)
         polar_ax.set_thetamax(90)
@@ -1021,8 +1026,8 @@ def plot_diffuser_polar_response(
     polar_ax.set_theta_direction(-1)
     if (
         angles_deg.size
-        and float(np.nanmin(angles_deg)) >= -90.0
-        and float(np.nanmax(angles_deg)) <= 90.0
+        and float(np.nanmin(angles_deg)) >= -_POLAR_SEMICIRCLE_DEG
+        and float(np.nanmax(angles_deg)) <= _POLAR_SEMICIRCLE_DEG
     ):
         polar_ax.set_thetamin(-90)
         polar_ax.set_thetamax(90)

--- a/src/phonometry/_plot/noise_control.py
+++ b/src/phonometry/_plot/noise_control.py
@@ -191,6 +191,15 @@ _CASCADE_STYLES: tuple[str, ...] = ("-", "--", ":")
 #: full description belongs in the table, not in a corner of the chart.
 _LEGEND_CHARS = 30
 
+#: The largest number of cascade series (duct-path elements plus the source)
+#: that still get individual legend entries; past it the per-element labels are
+#: suppressed so the legend does not drown the chart.
+_LEGEND_MAX_SERIES = 10
+
+#: The largest series count whose legend still fits in a single column; above
+#: it the cascade legend wraps to two columns.
+_LEGEND_SINGLE_COLUMN_MAX = 4
+
 
 def _cascade_series(result: DuctPathResult) -> list[tuple[str, np.ndarray]]:
     """The labelled spectra of a duct path, from the source to the receiver."""
@@ -240,7 +249,7 @@ def plot_duct_path(
             color=colour,
             lw=1.1,
             alpha=0.85,
-            label=label if len(series) <= 10 else None,
+            label=label if len(series) <= _LEGEND_MAX_SERIES else None,
         )
     curve = result.criterion_curve
     if curve is not None and result.target is not None:
@@ -267,7 +276,7 @@ def plot_duct_path(
     ax.legend(
         loc="upper right",
         fontsize="xx-small",
-        ncol=2 if len(series) > 4 else 1,
+        ncol=2 if len(series) > _LEGEND_SINGLE_COLUMN_MAX else 1,
         framealpha=0.85,
     )
     localize_axes(ax, language)

--- a/src/phonometry/_plot/psychoacoustics.py
+++ b/src/phonometry/_plot/psychoacoustics.py
@@ -50,6 +50,17 @@ _AXIS_BARK_HMS = r"Critical-band rate $z$ [$\mathrm{Bark}_{\mathrm{HMS}}$]"
 _AXIS_TIME = "Time [s]"
 #: Frequency axis label shared by the spectral psychoacoustic renderers.
 _AXIS_FREQUENCY = "Frequency [Hz]"
+#: Fewest time samples the HMS specific-value heatmap needs: with fewer than
+#: two time coordinates ``pcolormesh`` cannot span a mesh cell, so the
+#: heatmap panel of the two-panel figure is left empty.
+_MIN_HEATMAP_TIME_SAMPLES = 2
+#: The 1 kHz corner frequency of the ECMA-418-1 prominence criteria (TNR,
+#: clause 11; PR, clause 12): below it the limits rise with their
+#: low-frequency slopes, from 1 kHz up they are flat (8 dB TNR, 9 dB PR).
+_CRITERION_PLATEAU_HZ = 1000.0
+#: The 1 kHz reference frequency of the phon scale, where each ISO 226:2023
+#: equal-loudness contour crosses SPL = phon by definition.
+_REFERENCE_FREQUENCY = 1000.0
 
 #: Spanish translations of the fixed strings rendered by the
 #: psychoacoustics ``.plot()`` renderers, keyed by their verbatim English
@@ -524,7 +535,7 @@ def _plot_hms_time_and_heatmap(
         return ax_time
 
     ax_heat = cast("Axes", axes[1])
-    if time.size >= 2 and spec_vs_time.size:
+    if time.size >= _MIN_HEATMAP_TIME_SAMPLES and spec_vs_time.size:
         mesh = ax_heat.pcolormesh(
             time, bark, spec_vs_time.T, cmap="magma", shading="auto"
         )
@@ -753,10 +764,18 @@ def plot_tone_assessment(
     criterion = float(result.criterion_db)
 
     def _tnr(f: np.ndarray) -> np.ndarray:
-        return np.where(f < 1000.0, 8.0 + 8.33 * np.log10(1000.0 / f), 8.0)
+        return np.where(
+            f < _CRITERION_PLATEAU_HZ,
+            8.0 + 8.33 * np.log10(_CRITERION_PLATEAU_HZ / f),
+            8.0,
+        )
 
     def _pr(f: np.ndarray) -> np.ndarray:
-        return np.where(f < 1000.0, 9.0 + 10.0 * np.log10(1000.0 / f), 9.0)
+        return np.where(
+            f < _CRITERION_PLATEAU_HZ,
+            9.0 + 10.0 * np.log10(_CRITERION_PLATEAU_HZ / f),
+            9.0,
+        )
 
     ft_arr = np.array([max(ft, _TONE_RANGE_HZ[0])])
     is_tnr = abs(criterion - float(_tnr(ft_arr)[0])) <= abs(
@@ -1015,7 +1034,7 @@ def plot_equal_loudness_contours(
     # The per-contour labels sit at the 1 kHz crossing (SPL = phon by
     # definition); when a frequency subset excludes 1 kHz they would land
     # outside the axes, so they are skipped.
-    annotate_phons = fmin <= 1000.0 <= fmax
+    annotate_phons = fmin <= _REFERENCE_FREQUENCY <= fmax
     for phon, spl in zip(result.phons, contours, strict=True):
         ax.plot(freqs, spl, **kwargs)
         if annotate_phons:

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -61,6 +61,14 @@ _REVERBERATION_TIME_LABEL = "Reverberation time $T$ [s]"
 #: Shared legend entry naming the equivalent absorption area of a curve.
 _ABSORPTION_AREA_LABEL = "$A$ = {value} m²"
 
+#: Highest octave band shaded with the +5 dB rumble tolerance in the RC Mark II
+#: plot (ANSI/ASA S12.2 Annex D, clause D.3: at and below 500 Hz).
+_RC_RUMBLE_MAX_HZ = 500.0
+
+#: Lowest octave band shaded with the +3 dB hiss tolerance in the RC Mark II
+#: plot (ANSI/ASA S12.2 Annex D, clause D.3: at and above 1000 Hz).
+_RC_HISS_MIN_HZ = 1000.0
+
 #: Spanish translations of the fixed strings rendered by the room ``.plot()``
 #: renderers, keyed by their verbatim English text.  ``_t`` returns the English
 #: key unchanged for any language other than ``"es"``, so the English output is
@@ -467,8 +475,8 @@ def plot_room_criterion(
         color=_C_MUTED,
         label=f"{_t('Reference RC-', language)}{result.rating}",
     )
-    low = freqs <= 500.0
-    high = freqs >= 1000.0
+    low = freqs <= _RC_RUMBLE_MAX_HZ
+    high = freqs >= _RC_HISS_MIN_HZ
     ax.fill_between(
         freqs[low],
         reference[low],
@@ -787,7 +795,7 @@ def plot_image_source_reflectogram(
     ax = ax if ax is not None else _new_axes()
     times = np.asarray(result.times, dtype=np.float64)
     amp = np.asarray(result.amplitudes, dtype=np.float64)
-    if amp.ndim == 2:
+    if amp.ndim == 2:  # noqa: PLR2004
         amp = amp[0]
     orders = np.asarray(result.orders, dtype=np.int_)
     tiny = np.finfo(np.float64).tiny

--- a/src/phonometry/_plot/signals.py
+++ b/src/phonometry/_plot/signals.py
@@ -48,6 +48,11 @@ from .common import (
     format_frequency_axis,
 )
 
+#: The two edge bins (DC and Nyquist) trimmed from a per-frequency array
+#: before averaging; with no more bins than these, the ``[1:-1]`` interior
+#: slice would be empty, so callers fall back to the full array.
+_DC_NYQUIST_BINS = 2
+
 #: Spanish translations of the fixed strings rendered by the signal
 #: ``.plot()`` renderers, keyed by their verbatim English text. ``_t``
 #: returns the English key unchanged for any language other than ``"es"``,
@@ -311,7 +316,7 @@ def plot_multitaper_spectral_density(
     # the array can have <=2 bins, where trimming the DC/Nyquist edges would
     # leave an empty slice, so fall back to the full array there.
     dof = result.degrees_of_freedom
-    interior = dof[1:-1] if dof.size > 2 else dof
+    interior = dof[1:-1] if dof.size > _DC_NYQUIST_BINS else dof
     nu_mean = float(np.mean(interior))
     nu = format_number(nu_mean, language, decimals=1)
     nw = decimal_comma(f"{result.time_half_bandwidth:g}", language)

--- a/src/phonometry/_report/_layout.py
+++ b/src/phonometry/_report/_layout.py
@@ -71,6 +71,11 @@ _SCRIPT_RISE = "25%"
 #: attributes, so only the attribute-less tags need rewriting.
 _SCRIPT_TAG_RE = re.compile(r"<(sub|sup|super)>")
 
+#: Row count of the octave-band variant of the sound-insulation band table
+#: (one row per octave, the five octave centres 125-2000 Hz); a table this
+#: size carries no one-third-octave triplets to rule.
+_OCTAVE_TABLE_ROWS = 5
+
 
 def fiche_paragraph(text: str, style: Any, **kwargs: Any) -> Any:
     """Build a reportlab ``Paragraph`` whose sub/superscripts cannot collide.
@@ -393,7 +398,7 @@ def band_table(
         ("BOX", (0, 0), (-1, -1), 0.5, accent),
     ]
     # Octave-band tables (5 rows, one per octave) have no triplets to group.
-    if n_data != 5:
+    if n_data != _OCTAVE_TABLE_ROWS:
         for triplet_end in range(3, n_data, 3):
             style_cmds.append(
                 ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)

--- a/src/phonometry/_report/_sound_power_fiche.py
+++ b/src/phonometry/_report/_sound_power_fiche.py
@@ -52,6 +52,14 @@ if TYPE_CHECKING:
 #: Reference sound power for the sound power level, 1 pW = 10^-12 W.
 POWER_REFERENCE = "1 pW"
 
+#: The fewest band centres from which an adjacent-centre ratio exists so the
+#: band fraction can be inferred; below it the conventional octave default 1
+#: is used, the same guard ``_infer_band_fraction`` documents and applies.
+_MIN_BANDS_TO_INFER_FRACTION = 2
+
+#: The IEC 61260 band-fraction designator for a one-third-octave set.
+_THIRD_OCTAVE_FRACTION = 3
+
 
 def _num(value: float | None, language: str = "en") -> str | None:
     """Round-trip a client-supplied metadata number, or ``None`` when unset."""
@@ -107,7 +115,9 @@ def band_labels(frequencies: np.ndarray | None, n: int) -> tuple[list[str], int]
     from ..filters.frequencies import _infer_band_fraction, _nominal_freq_for_band
 
     freqs = np.asarray(frequencies, dtype=np.float64)
-    fraction = _infer_band_fraction(freqs) if freqs.size >= 2 else 1
+    fraction = (
+        _infer_band_fraction(freqs) if freqs.size >= _MIN_BANDS_TO_INFER_FRACTION else 1
+    )
     labels = [f"{_nominal_freq_for_band(f, float(fraction)):g}" for f in freqs]
     return labels, fraction
 
@@ -351,7 +361,7 @@ def power_value_table(
     ]
     # A one-third-octave set groups by octave (a thin rule after every triplet),
     # as accredited sound-power tables print it; an octave set has no triplets.
-    if fraction == 3:
+    if fraction == _THIRD_OCTAVE_FRACTION:
         for triplet_end in range(3, n, 3):
             style_cmds.append(
                 ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)

--- a/src/phonometry/_report/annex16_epnl.py
+++ b/src/phonometry/_report/annex16_epnl.py
@@ -59,6 +59,12 @@ if TYPE_CHECKING:
     from ..aircraft.certification import EPNLResult
     from .metadata import ReportMetadata
 
+#: Floating-point slack in dB for quantities Annex 16 reads "to one decimal
+#: place": eight orders of magnitude below the 0.1 display step. Below it a
+#: bandsharing adjustment is display-zero (its row is omitted), and an EPNL
+#: exactly at the certification limit still passes despite binary round-off.
+_DB_EPS = 1e-9
+
 
 def _metadata_pairs(
     metadata: ReportMetadata, language: str = "en"
@@ -101,7 +107,7 @@ def _metric_rows(result: EPNLResult, language: str = "en") -> list[tuple[str, st
             f"{k_first + 1}&#8211;{k_last + 1}",
         ),
     ]
-    if abs(result.bandsharing_adjustment) > 1e-9:
+    if abs(result.bandsharing_adjustment) > _DB_EPS:
         rows.append(
             (
                 t("Bandsharing adjustment [dB]", language),
@@ -136,7 +142,7 @@ def _verdict_rows(
     """
     epnl = display_round(result.epnl)
     margin = limit - epnl
-    status = "pass" if epnl <= limit + 1e-9 else "fail"
+    status = "pass" if epnl <= limit + _DB_EPS else "fail"
     return [
         (
             t("EPNL [EPNdB]", language),

--- a/src/phonometry/_report/duct_path.py
+++ b/src/phonometry/_report/duct_path.py
@@ -74,11 +74,20 @@ _LEVEL_KINDS = (
 #: The longest element description printed in full before it is elided.
 _LABEL_CHARS = 46
 
+#: The irreducible row count of the elided path table: the source row at the
+#: head plus the three foot rows (room effect, received, criterion) that
+#: :func:`_elide` always keeps -- 1 + the length of its ``tail_kinds``, so a
+#: new tail kind moves this value. At this count the one-page fit loop stops
+#: because nothing more can be trimmed.
+_MIN_SHEET_ROWS = 4
+
 
 def _band_header(frequencies: np.ndarray, language: str) -> list[str]:
     """Column headings: the row-code and element columns, then the band centres."""
+    from ..filters.frequencies import _format_nominal_freq
+
     return [t("Ref.", language), t("Element", language)] + [
-        f"{f:g}" if f < 1000 else f"{f / 1000:g}k" for f in frequencies
+        _format_nominal_freq(f) for f in frequencies
     ]
 
 
@@ -494,7 +503,7 @@ def _fit_to_one_page(
     the table; the complete sheet always stays available through
     :meth:`~phonometry.noise_control.duct_path.DuctPathResult.table`.
     """
-    while len(rows) > 4:
+    while len(rows) > _MIN_SHEET_ROWS:
         used = _flow_height(flow)
         if used <= _FRAME_HEIGHT:
             return

--- a/src/phonometry/_report/hvac.py
+++ b/src/phonometry/_report/hvac.py
@@ -54,6 +54,10 @@ if TYPE_CHECKING:
 #: Reference sound power for a regenerated-noise sound power level, 1 pW.
 _POWER_REFERENCE = "1 pW"
 
+#: Band fraction returned by ``band_labels`` for a one-third-octave band set
+#: (1 = octave, 3 = one-third-octave, 0 = no octave grouping).
+_THIRD_OCTAVE_FRACTION = 3
+
 
 def _is_power(result: Any) -> bool:
     """Return ``True`` for a regenerated sound power spectrum, else attenuation."""
@@ -170,7 +174,7 @@ def _caption(result: Any, language: str = "en") -> str:
             if power
             else t("Octave-band attenuation", language)
         )
-    if fraction == 3:
+    if fraction == _THIRD_OCTAVE_FRACTION:
         return (
             t("One-third-octave-band regenerated sound power levels", language)
             if power

--- a/src/phonometry/_report/iec60268_5.py
+++ b/src/phonometry/_report/iec60268_5.py
@@ -63,6 +63,11 @@ _DB_PER_DECADE = 25.0
 
 _OHM = "&#937;"  # reportlab entity for the ohm sign
 
+#: The largest number of labelled frequency ticks that stays legible on the
+#: compressed multi-panel row of the PDF fiche without thinning; above it
+#: :func:`_thin_freq_ticklabels` blanks alternate labels.
+_MAX_UNTHINNED_TICKLABELS = 6
+
 
 def _basis(metadata: ReportMetadata | None, language: str = "en") -> str:
     """The standard-basis line: IEC 60268-5 with the IEC 60263 graph convention."""
@@ -317,7 +322,7 @@ def _thin_freq_ticklabels(ax: Any, keep_every: int = 2) -> None:
 
     formatter = ax.xaxis.get_major_formatter()
     labels = list(getattr(formatter, "seq", []))
-    if len(labels) <= 6:
+    if len(labels) <= _MAX_UNTHINNED_TICKLABELS:
         return
     ax.xaxis.set_major_formatter(
         FixedFormatter(

--- a/src/phonometry/_report/iec61043.py
+++ b/src/phonometry/_report/iec61043.py
@@ -125,13 +125,6 @@ def _metadata_pairs(
     ]
 
 
-def _band_label(frequency: float) -> str:
-    """The nominal Table 2 band label of a centre frequency (``6.3k``)."""
-    if frequency >= 1000.0:
-        return f"{frequency / 1000.0:g}k"
-    return f"{frequency:g}"
-
-
 def _class_cell(band_class: int | None) -> str:
     """The achieved-class cell of a band row (the class number, or an en dash)."""
     if band_class is None:
@@ -154,6 +147,8 @@ def _band_rows(
     classification. The margin is taken against the achieved class, the one the
     boxed result states.
     """
+    from ..filters.frequencies import _format_nominal_freq
+
     header_style = band_table_header_style()
     cls = result.reference_class()
     key = f"limit_class{cls}_db"
@@ -170,7 +165,7 @@ def _band_rows(
         margin = float(band["residual_index_db"]) - float(band[key])
         rows.append(
             [
-                decimal_comma(_band_label(float(band["freq"])), language),
+                decimal_comma(_format_nominal_freq(float(band["freq"])), language),
                 format_number(float(band["limit_class1_db"]), language, decimals=1),
                 format_number(float(band["limit_class2_db"]), language, decimals=1),
                 format_number(float(band["residual_index_db"]), language, decimals=1),

--- a/src/phonometry/_report/iec61260.py
+++ b/src/phonometry/_report/iec61260.py
@@ -51,6 +51,10 @@ if TYPE_CHECKING:
     from ..filters.compliance import FilterComplianceResult
     from .metadata import ReportMetadata
 
+# Scale at which the nominal mid-band label switches from the "125 Hz" form to
+# the "1 kHz" form (IEC 61260-1:2014 5.5; IEC 61260:1995 4.2).
+_HZ_PER_KHZ = 1000.0
+
 
 def _binding_margin(result: FilterComplianceResult, cls: int) -> float:
     """Smallest per-band margin to class ``cls`` (the binding margin)."""
@@ -114,8 +118,8 @@ def _band_label(exact_freq: float, fraction: int) -> str:
     from ..filters.frequencies import _nominal_freq_for_band
 
     nominal = _nominal_freq_for_band(exact_freq, float(fraction))
-    if nominal >= 1000.0:
-        return f"{nominal / 1000.0:g} kHz"
+    if nominal >= _HZ_PER_KHZ:
+        return f"{nominal / _HZ_PER_KHZ:g} kHz"
     return f"{nominal:g} Hz"
 
 

--- a/src/phonometry/_report/iso10052.py
+++ b/src/phonometry/_report/iso10052.py
@@ -50,6 +50,12 @@ if TYPE_CHECKING:
     )
     from .metadata import ReportMetadata
 
+#: Band count of the octave-band survey set (5 values, 125 Hz to 2000 Hz, vs
+#: 16 one-third-octave values, 100 Hz to 3150 Hz); it picks the caption and the
+#: standard-basis wording ISO 717-1:2020 Clause 5.3 / ISO 717-2:2020 Clause 4.4
+#: require stating.
+_N_OCTAVE_BANDS = 5
+
 #: The survey-method field statement each report prints verbatim; it names the
 #: control (survey) method so it is never conflated with the ISO 16283
 #: engineering method.
@@ -142,7 +148,7 @@ def _render_survey(
     from ._i18n import t
 
     curve = np.atleast_1d(np.asarray(getattr(result, curve_attr), dtype=np.float64))
-    is_octave = curve.size <= 5
+    is_octave = curve.size <= _N_OCTAVE_BANDS
     band_set = "Octave-band" if is_octave else "One-third-octave"
     bands_wording = t(
         "octave bands" if is_octave else "one-third-octave bands", language

--- a/src/phonometry/_report/iso10140.py
+++ b/src/phonometry/_report/iso10140.py
@@ -43,6 +43,11 @@ if TYPE_CHECKING:
     )
     from .metadata import ReportMetadata
 
+#: Band-centre count that identifies an ISO 717 rating computed from octave
+#: bands (5 centres, 125 Hz to 2000 Hz); it selects the "Octave-band" caption
+#: ISO 717-1:2020 Clause 5.3 / ISO 717-2:2020 Clause 4.4 require.
+_N_OCTAVE_BANDS = 5
+
 #: Per-quantity fixed labels: title, basis line, the quantity symbol used in
 #: the table header, the rating symbol of the boxed result, the plot y-axis
 #: label (mathtext) and the laboratory-method statement.
@@ -134,7 +139,7 @@ def render_iso10140_report(
         # bands; the caption declares the set.
         caption_key = (
             "Octave-band {vh} [dB]"
-            if np.asarray(rating.band_centers).size == 5
+            if np.asarray(rating.band_centers).size == _N_OCTAVE_BANDS
             else "One-third-octave {vh} [dB]"
         )
         caption = t(caption_key, language).format(vh=spec["symbol"])

--- a/src/phonometry/_report/iso10848.py
+++ b/src/phonometry/_report/iso10848.py
@@ -87,6 +87,16 @@ _PART_DESIGNATIONS: dict[int, str] = {
     4: "ISO 10848-4:2010",
 }
 
+#: The fewest band centres from which a consecutive-pair step ratio exists;
+#: with fewer, the ``Kij`` band-type detector cannot measure a step and
+#: defaults to third-octave.
+_MIN_BANDS_TO_INFER_FRACTION = 2
+
+#: Discriminant on the median ratio of consecutive band centres: octave
+#: centres step by ~2, one-third-octave centres by ~1.26 (2^(1/3)), and 1.6
+#: sits between the two.
+_OCTAVE_STEP_THRESHOLD = 1.6
+
 
 def _part_designation(part: int) -> str:
     """The designation of ISO 10848 part ``part``, or raise."""
@@ -273,10 +283,10 @@ _KIJ_STATEMENT = (
 
 def _kij_band_type(frequencies: np.ndarray) -> str:
     """``"octave"`` when consecutive centres step by ~2, else third-octave."""
-    if frequencies.size < 2:
+    if frequencies.size < _MIN_BANDS_TO_INFER_FRACTION:
         return "third-octave"
     ratio = float(np.median(frequencies[1:] / frequencies[:-1]))
-    return "octave" if ratio > 1.6 else "third-octave"
+    return "octave" if ratio > _OCTAVE_STEP_THRESHOLD else "third-octave"
 
 
 def _kij_mean_membership(

--- a/src/phonometry/_report/iso15186.py
+++ b/src/phonometry/_report/iso15186.py
@@ -83,6 +83,11 @@ _SPEC: dict[str, str] = {
 #: the shared two-panel insulation skeleton).
 _LEFT_CELL_MM = 56.0
 
+#: The band count identifying an octave-band ISO 717-1 rating:
+#: ``band_centers`` carries 5 centres for octave bands versus 16 for
+#: one-third octaves (ISO 717-1:2020 Clause 5.3).
+_N_OCTAVE_BANDS = 5
+
 
 def _qualification_columns(
     fpi: Sequence[float] | np.ndarray | None,
@@ -203,7 +208,7 @@ def render_iso15186_report(
         # from one-third-octave or octave bands; both the plain and the
         # verbose caption declare the set (the verbose one also names the
         # RI,M column).
-        is_octave = np.asarray(rating.band_centers).size == 5
+        is_octave = np.asarray(rating.band_centers).size == _N_OCTAVE_BANDS
         if verbose and modified is not None:
             columns: list[Column] = [
                 (value_header, curve, 1),
@@ -336,7 +341,7 @@ def render_iso15186_element_report(
     # octaves.
     band_set = (
         "Octave-band"
-        if np.asarray(rating.band_centers).size == 5
+        if np.asarray(rating.band_centers).size == _N_OCTAVE_BANDS
         else "One-third-octave"
     )
     extra = _qualification_columns(

--- a/src/phonometry/_report/iso16283.py
+++ b/src/phonometry/_report/iso16283.py
@@ -66,6 +66,11 @@ if TYPE_CHECKING:
     )
     from .metadata import ReportMetadata
 
+#: Decimal places of the ``T [s]`` reverberation-time column in the verbose
+#: measurement chain (the chain tuple's third field); the width rule narrows
+#: two-decimal columns to the compact 10 mm width.
+_T_DECIMALS = 2
+
 #: The field engineering-method statement the airborne (ISO 16283-1) and facade
 #: (ISO 16283-3) reports print verbatim.
 _FIELD_STATEMENT = (
@@ -216,7 +221,7 @@ def render_iso16283_report(
         # Compact widths for the chain; the reported quantity (last column)
         # carries the longest header, so give it room to render on one line.
         col_widths = [10 * mm] + [
-            (10 if decimals == 2 else 12) * mm for _, _, decimals in columns
+            (10 if decimals == _T_DECIMALS else 12) * mm for _, _, decimals in columns
         ]
         col_widths[-1] = 15 * mm
         caption = t("Per-band measurement chain", language)

--- a/src/phonometry/_report/iso1999.py
+++ b/src/phonometry/_report/iso1999.py
@@ -66,6 +66,15 @@ if TYPE_CHECKING:
 #: schemes use as a single hearing-damage index.
 _HANDICAP_SET: tuple[float, float, float] = (2000.0, 3000.0, 4000.0)
 
+#: Tolerance in hertz within which a result frequency counts as one of the
+#: :data:`_HANDICAP_SET` audiometric frequencies; absorbs float
+#: representation noise around the exact values.
+_FREQ_MATCH_TOL_HZ = 1e-6
+
+#: Float-equality tolerance within which the requested population fractile
+#: counts as exactly the median 0.5.
+_MEDIAN_FRACTILE_EPS = 1e-9
+
 #: The compression-term denominator of the HTLAN Formula (1).
 _HTLAN_DENOM = 120.0
 
@@ -98,7 +107,7 @@ def _handicap_indices(frequencies: np.ndarray) -> list[int]:
     return [
         i
         for i, f in enumerate(frequencies)
-        if any(abs(float(f) - h) < 1e-6 for h in _HANDICAP_SET)
+        if any(abs(float(f) - h) < _FREQ_MATCH_TOL_HZ for h in _HANDICAP_SET)
     ]
 
 
@@ -114,7 +123,7 @@ def _representative(
     """
     vals = np.asarray(values, dtype=np.float64)
     idx = _handicap_indices(frequencies)
-    if len(idx) == 3:
+    if len(idx) == len(_HANDICAP_SET):
         return True, float(vals[idx].mean()), 0.0
     peak = int(np.argmax(vals))
     return False, float(vals[peak]), float(frequencies[peak])
@@ -141,7 +150,7 @@ def _fractile_phrase(fractile: float, language: str = "en") -> str:
     fractile 0.9 prints ``Q = 10 %``.
     """
     q = decimal_comma(f"{_iso_q_percent(fractile):g}", language)
-    if abs(fractile - 0.5) < 1e-9:
+    if abs(fractile - 0.5) < _MEDIAN_FRACTILE_EPS:
         return t("Population fractile Q = {q} % (median)", language).format(q=q)
     return t(
         "Population fractile Q = {q} % (fraction with worse hearing)", language

--- a/src/phonometry/_report/iso3382.py
+++ b/src/phonometry/_report/iso3382.py
@@ -74,6 +74,23 @@ _TMID_BANDS = (500.0, 1000.0)
 #: Tolerance (Hz, relative) for matching a band centre to a nominal frequency.
 _BAND_MATCH_REL = 0.06
 
+#: Fewest band centres from which adjacent-centre ratios can classify the band
+#: set as octave vs one-third octave (the same pair guard
+#: ``filters.frequencies._infer_band_fraction`` applies); below it the caption
+#: falls back to "Single-band parameters".
+_MIN_BANDS_TO_INFER_FRACTION = 2
+
+#: Largest per-band row count still laid out with the roomier octave spacing
+#: (an octave range has at most 6 rows, a one-third-octave range up to 18);
+#: above it the table and plot switch to the compact layout so table plus
+#: plot fit one A4 page.
+_MAX_ROOMY_ROWS = 8
+
+#: The one-third-octave bandwidth fraction as returned by
+#: ``filters.frequencies._infer_band_fraction`` (3 bands per octave, vs 1 for
+#: octaves).
+_THIRD_OCTAVE_FRACTION = 3
+
 
 def _cell(value: float, decimals: int, language: str, *, scale: float = 1.0) -> str:
     """Format one table value, or an em dash when it is not finite.
@@ -99,7 +116,7 @@ def _fraction_label(frequency: np.ndarray | None, language: str) -> str:
     """
     if frequency is None:
         return t("Broadband analysis", language)
-    if frequency.size < 2:
+    if frequency.size < _MIN_BANDS_TO_INFER_FRACTION:
         return t("Single-band parameters", language)
     from ..filters.frequencies import _infer_band_fraction
 
@@ -206,7 +223,7 @@ def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
     # A one-third-octave range carries up to 18 rows; tighten the padding and
     # cell font so the stacked table plus the landscape plot still fit one A4
     # page (an octave range has at most 6 rows and uses the roomier spacing).
-    compact = n > 8
+    compact = n > _MAX_ROOMY_ROWS
     pad = 1.0 if compact else 2.6
     body_font = 6.8 if compact else 8.0
 
@@ -261,7 +278,7 @@ def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
     # broadband single row has no one-third-octave triplets to group, so the
     # grouping rule is gated on the band structure actually being one-third
     # octave rather than merely on the row count.
-    if freq is not None and fraction == 3:
+    if freq is not None and fraction == _THIRD_OCTAVE_FRACTION:
         for triplet_end in range(3, n, 3):
             style_cmds.append(
                 ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
@@ -382,7 +399,7 @@ def _statement(
             value=_cell(t_value, 2, language)
         )
     extended: list[str] = []
-    if (t_is_mid or edt_is_mid) and fraction == 3:
+    if (t_is_mid or edt_is_mid) and fraction == _THIRD_OCTAVE_FRACTION:
         extended.append(
             t(
                 "Mid-frequency mean over the 500 Hz and 1 kHz one-third-octave bands.",
@@ -508,7 +525,7 @@ def render_iso3382_report(
     # inter-element gaps and the landscape plot so the table + plot still fit
     # one A4 page (an octave range keeps the roomier spacing and a taller plot).
     n_bands = np.asarray(result.t30, dtype=np.float64).size
-    compact = n_bands > 8
+    compact = n_bands > _MAX_ROOMY_ROWS
     gap = 3 if compact else 8
     fig_height = 2.0 if compact else 3.9
 

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -64,6 +64,12 @@ if TYPE_CHECKING:
     )
     from .metadata import ReportMetadata
 
+#: Band-centre count that identifies an ISO 717 rating computed from octave
+#: bands (5 centres versus 16 one-third-octave centres); it selects the caption
+#: ISO 717-1:2020 Clause 5.3 / ISO 717-2:2020 Clause 4.4 require, stating which
+#: band set produced the rating.
+_N_OCTAVE_BANDS = 5
+
 #: Threshold below which an unfavourable deviation is shown as an em dash.
 _DEVIATION_EPS = 0.05
 
@@ -511,7 +517,9 @@ def render_iso717_report(
     # whether the rating came from one-third-octave or octave bands; the
     # caption declares the actual set.
     caption_key = (
-        "Octave-band {vh} [dB]" if centers.size == 5 else "One-third-octave {vh} [dB]"
+        "Octave-band {vh} [dB]"
+        if centers.size == _N_OCTAVE_BANDS
+        else "One-third-octave {vh} [dB]"
     )
     left_cell = [
         fiche_paragraph(

--- a/src/phonometry/_report/iso7849.py
+++ b/src/phonometry/_report/iso7849.py
@@ -63,11 +63,16 @@ if TYPE_CHECKING:
     from ..emission.vibration_sound_power import VibrationSoundPowerResult
     from .metadata import ReportMetadata
 
+# Absolute tolerance under which every per-band radiation factor is taken to
+# equal the survey method's fixed epsilon = 1 (ISO/TS 7849-1), deciding whether
+# the basis line names Part 1 (survey) or Part 2 (engineering).
+_UNITY_TOLERANCE = 1e-9
+
 
 def _is_survey(result: Any) -> bool:
     """Return ``True`` for the survey method (every band uses ``epsilon = 1``)."""
     eps = np.asarray(result.radiation_factor, dtype=np.float64)
-    return bool(np.all(np.abs(eps - 1.0) < 1e-9))
+    return bool(np.all(np.abs(eps - 1.0) < _UNITY_TOLERANCE))
 
 
 def _basis(result: Any, language: str = "en") -> str:

--- a/src/phonometry/_report/iso9614.py
+++ b/src/phonometry/_report/iso9614.py
@@ -113,6 +113,15 @@ _COVERAGE_FACTOR = 2.0
 #: The Table 1 standard deviation of reproducibility of the A-weighted sound
 #: power level, in dB (footnote b: a relatively flat 50 Hz to 6,3 kHz spectrum).
 _SIGMA_A_WEIGHTED = 1.0
+#: Band fraction returned by ``band_labels`` for a one-third-octave band set
+#: (1 = octave, 3 = one-third octave, 0 = unlabelled); ISO 9614-3:2002 Table 1
+#: tabulates sigma_R0 for one-third-octave bands only, so any other fraction
+#: reports NaN uncertainty.
+_THIRD_OCTAVE_FRACTION = 3
+#: Minimum band count for the caption to state the determined frequency range
+#: as "lo Hz to hi Hz" (ISO 9614-3:2002 clause 4.3 requires a restricted
+#: determination to state its range); a single band has no first-and-last pair.
+_MIN_BANDS_FOR_RANGE = 2
 #: The two column headings every band table on these sheets opens with: the
 #: band centre, which is translated, and the sound power level, which is a
 #: quantity symbol and therefore is not.
@@ -365,7 +374,7 @@ def _band_uncertainty(result: Any) -> np.ndarray:
     if frequencies is None:
         return uncertainty
     labels, fraction = band_labels(frequencies, n)
-    if fraction != 3:
+    if fraction != _THIRD_OCTAVE_FRACTION:
         return uncertainty
     from ..emission.sound_power_intensity import _sigma_r0_9614_3
 
@@ -521,7 +530,7 @@ def _precision_caption(result: Any, language: str = "en") -> str:
     caption = fraction_caption(result, language)
     frequencies = getattr(result, "frequencies", None)
     n = np.asarray(result.sound_power_level, dtype=np.float64).size
-    if frequencies is None or n < 2:
+    if frequencies is None or n < _MIN_BANDS_FOR_RANGE:
         return caption
     labels, _fraction = band_labels(frequencies, n)
     return t("{caption}, {lo} Hz to {hi} Hz", language).format(

--- a/src/phonometry/_report/metadata.py
+++ b/src/phonometry/_report/metadata.py
@@ -198,6 +198,8 @@ class ReportMetadata:
         "source_relative_humidity",
         "receiving_relative_humidity",
     )
+    #: Upper bound of the relative-humidity percentage scale (saturation).
+    _MAX_RELATIVE_HUMIDITY_PERCENT = 100.0
 
     def _require(
         self, name: str, ok: Callable[[float], bool], description: str
@@ -226,7 +228,9 @@ class ReportMetadata:
         for name in self._HUMIDITY_FIELDS:
             self._require(
                 name,
-                lambda x: math.isfinite(x) and 0.0 <= x <= 100.0,
+                lambda x: (
+                    math.isfinite(x) and 0.0 <= x <= self._MAX_RELATIVE_HUMIDITY_PERCENT
+                ),
                 "a relative humidity in 0..100 %",
             )
         for name in self._POSITIVE_INT_FIELDS:

--- a/src/phonometry/_report/rd1367.py
+++ b/src/phonometry/_report/rd1367.py
@@ -85,6 +85,11 @@ if TYPE_CHECKING:
 #: Localised names of the three evaluation periods.
 _PERIOD_LABELS = {"day": "Day", "evening": "Evening", "night": "Night"}
 
+# Noise-phase-table row count up to which the assessment figure keeps its
+# full height; above it the figure is the elastic element, shrinking per
+# extra row so the fiche stays on one page.
+_FULL_HEIGHT_MAX_ROWS = 5
+
 
 def _fmt(value: float, language: str, decimals: int = 1) -> str:
     """A quantity rounded to ``decimals`` decimals, localised separator."""
@@ -422,7 +427,11 @@ def render_activity_report(
     # split into several phases each). The figure is the elastic element, so
     # its height shrinks as the table grows.
     rows = sum(len(period.phases) for period in result.periods)
-    figure_height = 2.7 if rows <= 5 else max(1.7, 2.7 - 0.22 * (rows - 5))
+    figure_height = (
+        2.7
+        if rows <= _FULL_HEIGHT_MAX_ROWS
+        else max(1.7, 2.7 - 0.22 * (rows - _FULL_HEIGHT_MAX_ROWS))
+    )
     flow.append(
         render_figure_drawing(
             _assessment_plot,

--- a/src/phonometry/_report/sti.py
+++ b/src/phonometry/_report/sti.py
@@ -65,7 +65,7 @@ def _is_stipa(result: STIResult) -> bool:
     frequencies of A.2.2.
     """
     mtf = np.asarray(result.mtf)
-    return mtf.ndim == 2 and mtf.shape[1] == 2
+    return mtf.ndim == 2 and mtf.shape[1] == 2  # noqa: PLR2004
 
 
 def _method_phrase(result: STIResult, language: str = "en") -> str:

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -50,6 +50,17 @@ _INSTALLATION = {
     "wing": (0.0039, 0.062, 0.8786),
     "fuselage": (0.1225, 0.329, 1.0),
 }
+#: Lateral displacement ℓ beyond which the ground-effect distance factor Γ(ℓ)
+#: saturates at 1 (Eq. 4-18/4-19).
+_ELL_SAT_M = 914.0
+#: Elevation angle β above which the air-to-ground attenuation Λ(β) is zero
+#: (Eq. 4-18/4-19).
+_BETA_CUTOFF_DEG = 50.0
+#: Absolute zero in °C, the lower validity bound of the aerodrome air temperature.
+_ABS_ZERO_C = -273.15
+#: Azimuth ψ from which the rearward start-of-roll directivity ΔSOR applies
+#: (90° ≤ ψ ≤ 180°, §4.5.7); ahead of the aircraft it is zero.
+_SOR_PSI_MIN_DEG = 90.0
 
 
 def lateral_attenuation(elevation_deg: float, lateral_m: float) -> float:
@@ -66,10 +77,10 @@ def lateral_attenuation(elevation_deg: float, lateral_m: float) -> float:
     if not np.isfinite(ell) or ell < 0.0 or not np.isfinite(beta):
         msg = "'lateral_m' must be non-negative and inputs finite."
         raise ValueError(msg)
-    gamma = 1.089 * (1.0 - np.exp(-0.00274 * ell)) if ell <= 914.0 else 1.0
+    gamma = 1.089 * (1.0 - np.exp(-0.00274 * ell)) if ell <= _ELL_SAT_M else 1.0
     if beta < 0.0:
         lam = 10.857
-    elif beta <= 50.0:
+    elif beta <= _BETA_CUTOFF_DEG:
         lam = 1.137 - 0.0229 * beta + 9.72 * np.exp(-0.142 * beta)
     else:
         lam = 0.0
@@ -184,7 +195,7 @@ def impedance_adjustment(
     if not (np.isfinite(t) and np.isfinite(p) and p > 0.0):
         msg = "'pressure' must be positive and inputs finite."
         raise ValueError(msg)
-    if t <= -273.15:
+    if t <= _ABS_ZERO_C:
         msg = "'temperature' must be above absolute zero (−273.15 °C)."
         raise ValueError(msg)
     delta = p / _P0_KPA
@@ -258,7 +269,7 @@ def start_of_roll_directivity(
     if key not in ("jet", "turbofan", "turboprop", "prop", "propeller"):
         msg = f"'engine' must be 'jet' or 'turboprop', got {engine!r}."
         raise ValueError(msg)
-    if psi < 90.0:  # ahead of / abeam the aircraft: no rearward directivity
+    if psi < _SOR_PSI_MIN_DEG:  # ahead of / abeam the aircraft: no rearward directivity
         return 0.0
     psi = min(psi, 180.0)
     if key in ("jet", "turbofan"):
@@ -294,7 +305,7 @@ def _clean_table(
     p = np.asarray(powers, dtype=np.float64).ravel()
     d = np.asarray(distances, dtype=np.float64).ravel()
     lv = np.asarray(levels, dtype=np.float64)
-    if p.size < 2 or d.size < 2:
+    if p.size < 2 or d.size < 2:  # noqa: PLR2004
         msg = "'powers' and 'distances' must each have at least two values."
         raise ValueError(msg)
     if lv.shape != (p.size, d.size):
@@ -615,7 +626,7 @@ def _validate_path(
 ) -> NDArray[np.float64]:
     """Coerce and validate a flight path to a finite ``(N, 5)`` array."""
     pts = np.asarray(path, dtype=np.float64)
-    if pts.ndim != 2 or pts.shape[1] != 5 or pts.shape[0] < 2:
+    if pts.ndim != 2 or pts.shape[1] != 5 or pts.shape[0] < 2:  # noqa: PLR2004
         msg = "'path' must have shape (N, 5) with N >= 2 (x,y,z,power,speed)."
         raise ValueError(msg)
     if not np.all(np.isfinite(pts)):
@@ -963,12 +974,14 @@ def _grid_lateral_attenuation(
     ell_att: NDArray[np.float64],
 ) -> NDArray[np.float64]:
     """``Λ(β, ℓ)`` (Eq. 4-18/4-19), the array form of :func:`lateral_attenuation`."""
-    gamma = np.where(ell_att <= 914.0, 1.089 * (1.0 - np.exp(-0.00274 * ell_att)), 1.0)
+    gamma = np.where(
+        ell_att <= _ELL_SAT_M, 1.089 * (1.0 - np.exp(-0.00274 * ell_att)), 1.0
+    )
     lam = np.where(
         beta_att < 0.0,
         10.857,
         np.where(
-            beta_att <= 50.0,
+            beta_att <= _BETA_CUTOFF_DEG,
             1.137 - 0.0229 * beta_att + 9.72 * np.exp(-0.142 * beta_att),
             0.0,
         ),
@@ -1024,7 +1037,9 @@ def _grid_sor(
         )
     dsor = np.maximum(ds, 1e-9)
     d0 = np.where(dsor > _DSOR0_M, d0 * (_DSOR0_M / dsor), d0)
-    return np.asarray(np.where(roll_behind & (psi >= 90.0), d0, 0.0), dtype=np.float64)
+    return np.asarray(
+        np.where(roll_behind & (psi >= _SOR_PSI_MIN_DEG), d0, 0.0), dtype=np.float64
+    )
 
 
 def _grid_noise_fraction(
@@ -1326,7 +1341,7 @@ def noise_contour(
     """
     gx = np.asarray(x, dtype=np.float64).ravel()
     gy = np.asarray(y, dtype=np.float64).ravel()
-    if gx.size < 2 or gy.size < 2:
+    if gx.size < 2 or gy.size < 2:  # noqa: PLR2004
         msg = "'x' and 'y' must each have at least two grid points."
         raise ValueError(msg)
     # Validate and clean the shared inputs once, not per grid point.

--- a/src/phonometry/aircraft/anp_fleet.py
+++ b/src/phonometry/aircraft/anp_fleet.py
@@ -63,23 +63,34 @@ _FT_M = 0.3048
 _KT_MS = 0.514444
 #: Altitude below which a profile point counts as on the ground, in metres.
 _GROUND_ALTITUDE_M = 1.0
+#: Minimum number of ``L_<ft>ft`` slant-distance columns an NPD table must
+#: provide: the NPD level lookup (Doc 29 Eq. 4-3/4-4) interpolates over the
+#: distance grid, which needs at least two tabulated distances.
+_MIN_NPD_DISTANCES = 2
 #: Lateral-directivity identifier -> Doc 29 engine mounting.
 _MOUNTING = {"wing": "wing", "fuselage": "fuselage", "prop": "propeller"}
+#: ANP operation code for departure (on-ground segments are a ground roll).
+_DEPARTURE = "D"
+#: ANP operation code for arrival (on-ground segments are a landing roll).
+_ARRIVAL = "A"
 #: Operation aliases -> ANP operation code (``"A"`` arrival, ``"D"`` departure).
 _OPERATION = {
-    "a": "A",
-    "arrival": "A",
-    "arrivals": "A",
-    "approach": "A",
-    "landing": "A",
-    "d": "D",
-    "departure": "D",
-    "departures": "D",
-    "takeoff": "D",
-    "take-off": "D",
+    "a": _ARRIVAL,
+    "arrival": _ARRIVAL,
+    "arrivals": _ARRIVAL,
+    "approach": _ARRIVAL,
+    "landing": _ARRIVAL,
+    "d": _DEPARTURE,
+    "departure": _DEPARTURE,
+    "departures": _DEPARTURE,
+    "takeoff": _DEPARTURE,
+    "take-off": _DEPARTURE,
 }
 #: Supported NPD noise metrics for the Doc 29 chain.
 _METRICS = ("SEL", "LAmax")
+#: The ANP database's identifier for an aircraft's default fixed-point profile,
+#: selected when the caller passes ``profile_id=None``.
+_DEFAULT_PROFILE_ID = "DEFAULT"
 
 
 def _operation_code(operation: str) -> str:
@@ -127,7 +138,7 @@ def _distances_m(header: Iterable[str]) -> NDArray[np.float64]:
         c = col.strip()
         if c.startswith("L_") and c.endswith("ft"):
             dist_ft.append(float(c[2:-2]))
-    if len(dist_ft) < 2:
+    if len(dist_ft) < _MIN_NPD_DISTANCES:
         msg = "NPD table has fewer than two 'L_<ft>ft' distance columns."
         raise ValueError(msg)
     distances = np.asarray(dist_ft, dtype=np.float64) * _FT_M
@@ -461,15 +472,15 @@ class AnpDatabase:
                     f"{stage_length} (available profiles: {ids})."
                 )
                 raise KeyError(msg)
-        elif "DEFAULT" in ids:
-            pid = "DEFAULT"
+        elif _DEFAULT_PROFILE_ID in ids:
+            pid = _DEFAULT_PROFILE_ID
         elif len(ids) == 1:
             pid = ids[0]
         else:
             msg = (
                 f"aircraft {aircraft_id!r}, operation {op!r}, stage length "
                 f"{stage_length} has several fixed-point profiles and none is "
-                f"'DEFAULT': {ids}. Pass profile_id= to choose one."
+                f"{_DEFAULT_PROFILE_ID!r}: {ids}. Pass profile_id= to choose one."
             )
             raise ValueError(msg)
         path = self._profiles[(aircraft_id, op, pid, stage)]
@@ -478,8 +489,8 @@ class AnpDatabase:
         # airborne point is above 150 m, so a 1 m threshold separates them.
         on_ground = np.abs(path[:, 2]) <= _GROUND_ALTITUDE_M
         seg_zero = on_ground[:-1] & on_ground[1:]
-        ground_roll = seg_zero & (op == "D")
-        landing_roll = seg_zero & (op == "A")
+        ground_roll = seg_zero & (op == _DEPARTURE)
+        landing_roll = seg_zero & (op == _ARRIVAL)
         return AnpProfile(
             aircraft_id=aircraft_id,
             operation=op,

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -187,6 +187,30 @@ _TONE_START = 2
 #: Bands the tone-correction routine works over (Appendix 2 §4.3).
 _TONE_BANDS = 24
 
+#: Step 2 of the slope ("encircling") method: a slope is encircled where it
+#: changes from the previous one by more than 5 dB (Appendix 2 §4.3).
+_ENCIRCLE_SLOPE_CHANGE_DB = 5.0
+
+#: Table A2-2: minimum tone excess ``F`` (dB); below it the correction is zero.
+_MIN_TONE_EXCESS_DB = 1.5
+
+#: Table A2-2: edges (Hz) of the middle frequency class, where the tone
+#: penalty is doubled.
+_TONE_MID_BAND_LOW_HZ = 500.0
+_TONE_MID_BAND_HIGH_HZ = 5000.0
+
+#: Table A2-2: the ``F`` breakpoint where the ramp-in segment of the
+#: tone-correction law ends and the proportional segment begins.
+_TONE_EXCESS_KNEE_DB = 3.0
+
+#: Table A2-2: the ``F`` excess beyond which the tone correction saturates
+#: at its cap.
+_TONE_EXCESS_SATURATION_DB = 20.0
+
+#: Highest 0-based band index accepted as the slope-analysis start band
+#: (band index 3 = 100 Hz).
+_MAX_TONE_START_BAND = 3
+
 
 def _tone_background(
     spl: NDArray[np.float64] | list[float],
@@ -229,7 +253,11 @@ def _tone_marked_slopes(
     # Step 2: encircle a slope where |s(i) - s(i-1)| > 5.
     s_enc = np.zeros(n, dtype=bool)
     for i in range(start + 1, n):
-        if not np.isnan(s[i]) and not np.isnan(s[i - 1]) and abs(s[i] - s[i - 1]) > 5.0:
+        if (
+            not np.isnan(s[i])
+            and not np.isnan(s[i - 1])
+            and abs(s[i] - s[i - 1]) > _ENCIRCLE_SLOPE_CHANGE_DB
+        ):
             s_enc[i] = True
 
     # Step 3: mark which SPL value to adjust.
@@ -315,17 +343,17 @@ def _tone_background_levels(
 
 def _tone_factor(excess: float, frequency: float) -> float:
     """Tone-correction factor ``C`` from the excess ``F`` (App. 2 Table A2-2)."""
-    if not np.isfinite(excess) or excess < 1.5:
+    if not np.isfinite(excess) or excess < _MIN_TONE_EXCESS_DB:
         return 0.0
-    if 500.0 <= frequency <= 5000.0:
-        if excess < 3.0:
+    if _TONE_MID_BAND_LOW_HZ <= frequency <= _TONE_MID_BAND_HIGH_HZ:
+        if excess < _TONE_EXCESS_KNEE_DB:
             return 2.0 * excess / 3.0 - 1.0
-        if excess < 20.0:
+        if excess < _TONE_EXCESS_SATURATION_DB:
             return excess / 3.0
         return 20.0 / 3.0
-    if excess < 3.0:
+    if excess < _TONE_EXCESS_KNEE_DB:
         return excess / 3.0 - 0.5
-    if excess < 20.0:
+    if excess < _TONE_EXCESS_SATURATION_DB:
         return excess / 6.0
     return 10.0 / 3.0
 
@@ -346,7 +374,7 @@ def tone_correction(
     :return: The tone-correction factor ``C``, in dB (0 if no tones qualify).
     :raises ValueError: If the spectrum is not 24 finite levels.
     """
-    if not 0 <= int(start_band) <= 3:
+    if not 0 <= int(start_band) <= _MAX_TONE_START_BAND:
         msg = "'start_band' must be between 0 (50 Hz) and 3 (100 Hz)."
         raise ValueError(msg)
     _, excess = _tone_background(spl, start=int(start_band))
@@ -589,7 +617,7 @@ def effective_perceived_noise_level(
         ``procedure`` is not ``"aeroplane"`` or ``"helicopter"``.
     """
     arr = np.asarray(spectra, dtype=np.float64)
-    if arr.ndim != 2 or arr.shape[1] != 24 or arr.shape[0] < 1:
+    if arr.ndim != 2 or arr.shape[1] != NOY_BANDS.size or arr.shape[0] < 1:  # noqa: PLR2004
         msg = "'spectra' must have shape (K, 24)."
         raise ValueError(msg)
     if not np.all(np.isfinite(arr)):

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -78,6 +78,25 @@ if TYPE_CHECKING:
 #: Standard acceleration of gravity, in m/s² (Eq. 20).
 _G0 = 9.80665
 
+#: Slack, in fractions of one grid cell, by which ``(stop - start) / step`` may
+#: miss a whole number and the step still count as dividing the hemisphere span
+#: evenly in ``_grid_axis``.
+_GRID_DIVISIBILITY_TOL = 1e-9
+
+#: Distance in the normalised (V̄, γ̄) plane below which the query lies on a
+#: database flight condition and adopts that hemisphere alone, keeping the
+#: 1/δ inverse-distance weights of Eq. 7/8 away from a zero divisor.
+_CONDITION_MATCH_TOL = 1e-12
+
+#: Slack on the barycentric coordinates so a query lying on a lookup-table
+#: triangle's edge or vertex still counts as enveloped by that triangle.
+_BARYCENTRIC_TOL = -1e-9
+
+#: Horizontal source-receiver span, in metres, at or below which the vertical
+#: terrain section degenerates (receiver under the source) and the plain
+#: flat-ground effect replaces the sampled section and screening chain.
+_MIN_SECTION_SPAN = 1e-6
+
 
 @dataclass(frozen=True)
 class RotorcraftHemisphere:
@@ -312,7 +331,7 @@ def _grid_axis(
     """A regular node axis from ``start`` to ``stop``; ``step`` must divide it."""
     s = require_positive(step, name)
     n = round((stop - start) / s)
-    if n < 1 or abs((stop - start) / s - n) > 1e-9:
+    if n < 1 or abs((stop - start) / s - n) > _GRID_DIVISIBILITY_TOL:
         msg = f"'{name}' must divide the {stop - start:g} degree span evenly."
         raise ValueError(msg)
     return np.linspace(start, stop, n + 1)
@@ -401,13 +420,13 @@ def hover_ring_hemisphere(
     freqs = require_positive_array(frequencies, "frequencies")
     brg = np.atleast_1d(np.asarray(bearings, dtype=np.float64))
     lv = np.asarray(levels, dtype=np.float64)
-    if brg.ndim != 1 or brg.size < 2:
+    if brg.ndim != 1 or brg.size < 2:  # noqa: PLR2004
         msg = "'bearings' must be 1-D with at least two ring directions."
         raise ValueError(msg)
     if not np.all(np.isfinite(brg)) or np.any(np.diff(brg) <= 0.0):
         msg = "'bearings' must be finite and strictly increasing."
         raise ValueError(msg)
-    if brg[0] < -180.0 or brg[-1] > 180.0:
+    if brg[0] < -180.0 or brg[-1] > 180.0:  # noqa: PLR2004
         msg = "'bearings' must lie within [-180, 180] degrees."
         raise ValueError(msg)
     if lv.shape != (brg.size, freqs.size):
@@ -585,7 +604,7 @@ def flight_condition_weights(
     delta = np.hypot(vn - qv, gn - qg)
 
     exact = int(np.argmin(delta))
-    if delta[exact] < 1e-12:  # on a database condition
+    if delta[exact] < _CONDITION_MATCH_TOL:  # on a database condition
         return [(exact, 1.0)]
 
     simplex = _enveloping_simplex(pts, q, v.size, triangles)
@@ -626,7 +645,7 @@ def _simplex_from_table(
 ) -> NDArray[np.intp] | None:
     """The first triangle of a lookup table enveloping ``q``, or ``None``."""
     tri = np.asarray(triangles, dtype=np.intp)
-    if tri.ndim != 2 or tri.shape[1] != 3 or tri.size == 0:
+    if tri.ndim != 2 or tri.shape[1] != 3 or tri.size == 0:  # noqa: PLR2004
         msg = "'triangles' must have shape (T, 3)."
         raise ValueError(msg)
     if tri.min() < 0 or tri.max() >= n:
@@ -639,7 +658,11 @@ def _simplex_from_table(
             lam = np.linalg.solve(m, q - p0)
         except np.linalg.LinAlgError:  # degenerate triangle
             continue
-        if lam[0] >= -1e-9 and lam[1] >= -1e-9 and lam.sum() <= 1.0 + 1e-9:
+        if (
+            lam[0] >= _BARYCENTRIC_TOL
+            and lam[1] >= _BARYCENTRIC_TOL
+            and lam.sum() <= 1.0 + 1e-9
+        ):
             return np.asarray(row, dtype=np.intp)
     return None
 
@@ -1001,7 +1024,7 @@ def _validated_track(
     """The validated ``(times, positions)`` track arrays."""
     t = np.asarray(times, dtype=np.float64)
     p = np.asarray(positions, dtype=np.float64)
-    if t.ndim != 1 or t.size < 2:
+    if t.ndim != 1 or t.size < 2:  # noqa: PLR2004
         msg = "'times' must be 1-D with at least two points."
         raise ValueError(msg)
     if p.shape != (t.size, 3):
@@ -1350,15 +1373,15 @@ def _validated_terrain(
     """The validated ``(x, y, z)`` digital elevation model, or ``None``."""
     if terrain is None:
         return None
-    if len(terrain) != 3:
+    if len(terrain) != 3:  # noqa: PLR2004
         msg = "'terrain' must be an (x, y, z) elevation model."
         raise ValueError(msg)
     tx = np.asarray(terrain[0], dtype=np.float64).ravel()
     ty = np.asarray(terrain[1], dtype=np.float64).ravel()
     tz = np.asarray(terrain[2], dtype=np.float64)
     if (
-        tx.size < 2
-        or ty.size < 2
+        tx.size < 2  # noqa: PLR2004
+        or ty.size < 2  # noqa: PLR2004
         or np.any(np.diff(tx) <= 0)
         or np.any(np.diff(ty) <= 0)
     ):
@@ -1505,7 +1528,7 @@ def _terrain_adjustments(
         py = sy + (receivers[i, 1] - sy) * t
         pz = _dem_height(dem, px, py)
         d = span * t
-        if span <= 1e-6:  # receiver under the source
+        if span <= _MIN_SECTION_SPAN:  # receiver under the source
             hs = sz - float(pz[0])
             out[i] = _ground_effect(
                 freqs, hs, setup.receiver_height, np.asarray([0.0]), sigma
@@ -1695,7 +1718,7 @@ def rotorcraft_event_level(
         interpolation=interpolation,
     )
     rx = np.asarray(receiver, dtype=np.float64).ravel()
-    if rx.size != 2 or not np.all(np.isfinite(rx)):
+    if rx.size != 2 or not np.all(np.isfinite(rx)):  # noqa: PLR2004
         msg = "'receiver' must be a finite (x, y) ground position."
         raise ValueError(msg)
     if not (np.isscalar(setup.sigma) and np.isscalar(setup.ground_elevation)):
@@ -1816,8 +1839,8 @@ def rotorcraft_noise_contour(
     gx = np.asarray(x, dtype=np.float64).ravel()
     gy = np.asarray(y, dtype=np.float64).ravel()
     if (
-        gx.size < 2
-        or gy.size < 2
+        gx.size < 2  # noqa: PLR2004
+        or gy.size < 2  # noqa: PLR2004
         or not (np.all(np.isfinite(gx)) and np.all(np.isfinite(gy)))
     ):
         msg = "'x' and 'y' must each be finite with at least two grid points."

--- a/src/phonometry/aircraft/rotorcraft_propagation.py
+++ b/src/phonometry/aircraft/rotorcraft_propagation.py
@@ -82,6 +82,12 @@ _FLOW_RESISTIVITY = {
     "G": 20.0e6,  # hard surfaces (asphalt, concrete)
     "H": 200.0e6,  # very hard and dense (dense asphalt, water)
 }
+#: Minimum vertex count of a terrain section: two vertices form the single
+#: straight segment the continuous least-squares mean-plane fit (Eq. 36-40) needs.
+_MIN_SECTION_VERTICES = 2
+#: Edge span ``e`` at or below which the multiple-diffraction factor C'' is 1,
+#: in metres (guidance Eq. 44).
+_SINGLE_DIFFRACTION_MAX_SPAN = 0.3
 
 
 # --------------------------------------------------------------------------- #
@@ -188,12 +194,13 @@ def _absorption_coefficient(
     import warnings
 
     from ..environment.propagation.air_absorption import (
+        _FREQ_RANGE,
         AtmosphericAbsorptionWarning,
         air_attenuation,
     )
 
     with warnings.catch_warnings():
-        if frequencies.max() <= 10000.0:
+        if frequencies.max() <= _FREQ_RANGE[1]:
             warnings.filterwarnings(
                 "ignore",
                 message="One or more frequencies are outside",
@@ -420,7 +427,7 @@ def _validated_section(
     """The validated ``(d, z)`` arrays of a terrain section."""
     d = np.atleast_1d(np.asarray(distances, dtype=np.float64))
     z = np.atleast_1d(np.asarray(heights, dtype=np.float64))
-    if d.ndim != 1 or d.shape != z.shape or d.size < 2:
+    if d.ndim != 1 or d.shape != z.shape or d.size < _MIN_SECTION_VERTICES:
         msg = "'distances' and 'heights' must be 1-D of equal size >= 2."
         raise ValueError(msg)
     if not (np.all(np.isfinite(d)) and np.all(np.isfinite(z))):
@@ -530,7 +537,7 @@ def diffraction_attenuation(
     e = require_non_negative(edge_span, "edge_span")
     lam = _C / f
     c2 = np.ones_like(f)
-    if e > 0.3:
+    if e > _SINGLE_DIFFRACTION_MAX_SPAN:
         c2 = (1.0 + (5.0 * lam / e) ** 2) / (1.0 / 3.0 + (5.0 * lam / e) ** 2)
     arg = 3.0 + 40.0 / lam * c2 * path_difference
     ch = np.minimum(f * h0 / 250.0, 1.0)
@@ -707,7 +714,7 @@ def _upper_hull(points: NDArray[np.float64]) -> NDArray[np.float64]:
     """The upper convex hull of ``(d, z)`` points sorted by ``d``."""
     hull: list[np.ndarray] = []
     for pt in points:
-        while len(hull) >= 2:
+        while len(hull) >= 2:  # noqa: PLR2004
             u, v = hull[-2], hull[-1]
             if (v[0] - u[0]) * (pt[1] - u[1]) - (v[1] - u[1]) * (pt[0] - u[0]) >= 0.0:
                 hull.pop()
@@ -765,7 +772,7 @@ def _screening_core(
     sigma_seg: NDArray[np.float64],
 ) -> tuple[NDArray[np.float64], bool, float, NDArray[np.float64]]:
     """The combined ground-and-screening adjustment of a section (Eq. 45-47)."""
-    interior = slice(1, -1) if d.size > 2 else slice(0, 0)
+    interior = slice(1, -1) if d.size > _MIN_SECTION_VERTICES else slice(0, 0)
     los = src[1] + (rcv[1] - src[1]) * (d - src[0]) / (rcv[0] - src[0])
     above = np.zeros(d.size, dtype=bool)
     above[interior] = z[interior] > los[interior]

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -83,6 +83,10 @@ BLOCK_OVERLAP = 0.75
 #: Short-term window length (EBU Tech 3341 section 2.2), in seconds.
 SHORT_TERM_DURATION = 3.0
 
+#: Largest allowed hop of the momentary and short-term loudness series, in
+#: seconds: the 10 Hz minimum meter update rate that EBU Tech 3341 requires.
+MAX_METER_STEP = 0.1
+
 #: Relative gating offset of the loudness range (EBU Tech 3342), in LU.
 LRA_RELATIVE_GATE = -20.0
 
@@ -94,6 +98,11 @@ _TRUE_PEAK_RATE = 192_000.0
 
 #: Sample rate the Annex 1 coefficient tables are given for, in Hz.
 _TABLE_RATE = 48_000.0
+
+#: The lowest sample rate the K-weighting redesign accepts, in Hz: below it
+#: the bilinear warping no longer preserves the specified 48 kHz response
+#: within the +/-0.1 LU metering tolerance.
+_MIN_REDESIGN_RATE = 16000.0
 
 #: Stage 1 of the K-weighting pre-filter (spherical-head shelf): the
 #: (b, a) coefficients of Table 1, valid at 48 kHz.
@@ -114,6 +123,19 @@ DEFAULT_CHANNEL_WEIGHTS: dict[int, tuple[float, ...]] = {
     5: (1.0, 1.0, 1.0, 1.41, 1.41),
     6: (1.0, 1.0, 1.0, 0.0, 1.41, 1.41),
 }
+
+#: Validation bounds of channel_weight, in degrees: input azimuths may span
+#: a full signed turn (+/-360 deg) before being folded, and a loudspeaker
+#: elevation is physically limited to +/-90 deg (straight up/down).
+_MAX_AZIMUTH_DEG = 360.0
+_MAX_ELEVATION_DEG = 90.0
+
+#: The "to the side of the listener" region of Annex 3 Table 4, in degrees:
+#: a mid-layer loudspeaker (|elevation| < 30) placed at 60 <= |azimuth| <= 120
+#: weighs 1.41 (+1.5 dB).
+_SIDE_AZIMUTH_MIN_DEG = 60.0
+_SIDE_AZIMUTH_MAX_DEG = 120.0
+_MID_LAYER_ELEVATION_DEG = 30.0
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +202,7 @@ def k_weighting_coefficients(
         spherical-head shelving filter and the RLB high-pass filter.
     """
     fs = require_positive(float(fs), "fs")
-    if fs < 16000.0:
+    if fs < _MIN_REDESIGN_RATE:
         msg = (
             "the K-weighting redesign requires fs >= 16000 Hz; below that "
             "the bilinear warping no longer preserves the specified response "
@@ -368,11 +390,15 @@ def channel_weight(
     if not (np.all(np.isfinite(theta)) and np.all(np.isfinite(phi))):
         msg = "azimuth and elevation must be finite."
         raise ValueError(msg)
-    if np.any(theta > 360.0) or np.any(phi > 90.0):
+    if np.any(theta > _MAX_AZIMUTH_DEG) or np.any(phi > _MAX_ELEVATION_DEG):
         msg = "azimuth must be within +/-360 deg and elevation within +/-90 deg."
         raise ValueError(msg)
-    theta = np.where(theta > 180.0, 360.0 - theta, theta)
-    side = (theta >= 60.0) & (theta <= 120.0) & (phi < 30.0)
+    theta = np.where(theta > 180.0, 360.0 - theta, theta)  # noqa: PLR2004
+    side = (
+        (theta >= _SIDE_AZIMUTH_MIN_DEG)
+        & (theta <= _SIDE_AZIMUTH_MAX_DEG)
+        & (phi < _MID_LAYER_ELEVATION_DEG)
+    )
     return as_float_or_array(np.where(side, 1.41, 1.0))
 
 
@@ -817,7 +843,7 @@ def program_loudness(
     fs = require_positive(float(fs), "fs")
     momentary_step = require_positive(float(momentary_step), "momentary_step")
     short_term_step = require_positive(float(short_term_step), "short_term_step")
-    if momentary_step > 0.1 or short_term_step > 0.1:
+    if momentary_step > MAX_METER_STEP or short_term_step > MAX_METER_STEP:
         msg = (
             "momentary_step and short_term_step must be <= 0.1 s: EBU Tech "
             "3341 requires a meter update rate of at least 10 Hz, and Tech "

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -146,6 +146,11 @@ _MODAL_OVERLAP_EXCLUSION = 0.25
 #: Nominal octave-band centre frequencies used to validate octave grouping.
 _OCTAVE_CENTRES = (31.5, 63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0)
 
+#: Median consecutive-centre-frequency ratio above which a band set is classed
+#: as octave-spaced (nominal step 2) rather than one-third-octave-spaced
+#: (step 2^(1/3) ≈ 1.26); the threshold sits between the two nominal steps.
+_OCTAVE_STEP_THRESHOLD = 1.6
+
 
 def _as_1d(values: float | Sequence[float] | np.ndarray, name: str) -> np.ndarray:
     """Coerce to a finite 1-D float array."""
@@ -450,10 +455,10 @@ def _validate_octave_triples(freq_groups: np.ndarray) -> None:
 
 def _detect_band_type(frequencies: np.ndarray | None) -> str:
     """``"octave"`` when consecutive centres step by ~2, else third-octave."""
-    if frequencies is None or frequencies.size < 2:
+    if frequencies is None or frequencies.size < 2:  # noqa: PLR2004
         return "third-octave"
     ratio = float(np.median(frequencies[1:] / frequencies[:-1]))
-    return "octave" if ratio > 1.6 else "third-octave"
+    return "octave" if ratio > _OCTAVE_STEP_THRESHOLD else "third-octave"
 
 
 def _single_number_kij(
@@ -551,7 +556,7 @@ def vibration_reduction_index(
         msg = "Supply both structural reverberation times (i and j) or neither."
         raise ValueError(msg)
 
-    if ts_given == 2:
+    if ts_given == 2:  # noqa: PLR2004
         if freq is None:
             msg = (
                 "'frequency' is required when structural reverberation times are "

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -372,7 +372,7 @@ def impact_improvement(
         limited_pos = lim0 | lim1
 
     delta_per_position = l0 - l1  # Formula (3)
-    if delta_per_position.ndim == 2:
+    if delta_per_position.ndim == 2:  # noqa: PLR2004
         improvement = delta_per_position.mean(axis=0)  # Formula (4)
         limited = np.any(limited_pos, axis=0)
     else:

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -188,6 +188,10 @@ HEAVY_IMPACT_A_WEIGHTING: dict[str, dict[float, float]] = {
 _FORCE_REFERENCE = 1.0
 #: Reference time interval ``Tref`` of Formula (A.1), in seconds.
 _TIME_REFERENCE = 1.0
+#: Minimum force-record length, in samples, for the trapezoidal rule that
+#: evaluates the Formula (A.1) integral: two samples define the first time
+#: interval.
+_MIN_TRAPEZOID_SAMPLES = 2
 #: Reference reverberation time ``T0`` of Formula (5), in seconds.
 _T0 = 0.5
 #: Reference receiving-room volume ``V0`` of Formula (4), in m3 (dwellings).
@@ -369,7 +373,7 @@ def impact_force_exposure_level(
     # calibrate=False: a Signal may carry a digital-to-pascal factor and
     # this record is a force in newtons. See phonometry.io._resolve.
     f = require_finite_array(resolve_samples(force, calibrate=False), "force")
-    if f.size < 2:
+    if f.size < _MIN_TRAPEZOID_SAMPLES:
         msg = "'force' must be a 1-D record of at least two samples."
         raise ValueError(msg)
     fs = require_positive(sample_rate, "sample_rate")

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -652,7 +652,7 @@ def _as_band_levels(levels: Sequence[float] | np.ndarray, name: str) -> np.ndarr
     data = np.asarray(levels, dtype=np.float64)
     if data.ndim == 1:
         out = data
-    elif data.ndim == 2:
+    elif data.ndim == 2:  # noqa: PLR2004
         out = np.asarray(energy_average_level(data, axis=0), dtype=np.float64)
     else:
         msg = f"'{name}' must be 1-D or 2-D (positions x bands)."

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -562,7 +562,7 @@ def combine_subareas(
         or exceed the forward flow, so no level exists).
     """
     levels = np.asarray(l_in, dtype=np.float64)
-    if levels.ndim != 2:
+    if levels.ndim != 2:  # noqa: PLR2004
         msg = "'l_in' must be a two-dimensional (subareas, bands) array."
         raise ValueError(msg)
     areas = np.asarray(measurement_area, dtype=np.float64)

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -120,6 +120,12 @@ _FREQ_THIRD_OCTAVE: tuple[float, ...] = (
 #: Octave band centre frequencies, 125 Hz to 2000 Hz (5 bands).
 _FREQ_OCTAVE: tuple[float, ...] = (125.0, 250.0, 500.0, 1000.0, 2000.0)
 
+#: Number of bands in each ISO 717 band set, used to infer the band set
+#: from the input length: 16 one-third-octave bands (100 Hz to 3150 Hz)
+#: and 5 octave bands (125 Hz to 2000 Hz).
+_N_THIRD_OCTAVE_BANDS = 16
+_N_OCTAVE_BANDS = 5
+
 #: Index of the 500 Hz band in each band set (the rating is read there).
 _INDEX_500_THIRD = 7
 _INDEX_500_OCTAVE = 2
@@ -134,6 +140,13 @@ _MAX_UNFAVOURABLE_OCTAVE = 10.0
 #: Tolerance absorbing floating-point noise when comparing the
 #: unfavourable-deviation sum (a true multiple of 0,1 dB) to the bound.
 _SHIFT_TOLERANCE = 1e-6
+
+#: Tolerance for checking that ``scale * step`` reconstructs exactly 1,
+#: i.e. that the reference-curve shift step divides 1 dB exactly (1.0 or
+#: 0.1 dB per ISO 717 / ISO 12999-1:2020 Annex B.2), absorbing the
+#: representation error of step values like 0.1. Distinct from
+#: _SHIFT_TOLERANCE, which guards the deviation-sum comparison.
+_STEP_DIVISOR_TOLERANCE = 1e-12
 
 # --- ISO 717-2 Table 3 impact reference values ---------------------------
 
@@ -600,8 +613,8 @@ def _resolve_band_set(
     :return: ``(reference, max_unfavourable, index_500, spectrum1,
         spectrum2)``.
     """
-    if bands == "third-octave" or (bands is None and n == 16):
-        if n != 16:
+    if bands == "third-octave" or (bands is None and n == _N_THIRD_OCTAVE_BANDS):
+        if n != _N_THIRD_OCTAVE_BANDS:
             msg = f"One-third-octave rating needs 16 bands (100-3150 Hz), got {n}."
             raise ValueError(msg)
         return (
@@ -611,8 +624,8 @@ def _resolve_band_set(
             _SPECTRUM1_THIRD,
             _SPECTRUM2_THIRD,
         )
-    if bands == "octave" or (bands is None and n == 5):
-        if n != 5:
+    if bands == "octave" or (bands is None and n == _N_OCTAVE_BANDS):
+        if n != _N_OCTAVE_BANDS:
             msg = f"Octave rating needs 5 bands (125-2000 Hz), got {n}."
             raise ValueError(msg)
         return (
@@ -658,7 +671,7 @@ def _best_shift(
     0,1 dB steps exact.
     """
     scale = round(1.0 / step)
-    if scale < 1 or abs(scale * step - 1.0) > 1e-12:
+    if scale < 1 or abs(scale * step - 1.0) > _STEP_DIVISOR_TOLERANCE:
         msg = "'step' must divide 1 dB exactly (e.g. 1.0 or 0.1)."
         raise ValueError(msg)
     # Start below any feasible shift, then climb while the bound holds.
@@ -724,7 +737,7 @@ def weighted_rating(
     rating = int(reference[index_500]) + round(shift)
     c = _adaptation_term(measured, spectrum1, rating)
     ctr = _adaptation_term(measured, spectrum2, rating)
-    centers = _FREQ_THIRD_OCTAVE if data.size == 16 else _FREQ_OCTAVE
+    centers = _FREQ_THIRD_OCTAVE if data.size == _N_THIRD_OCTAVE_BANDS else _FREQ_OCTAVE
     return WeightedRatingResult(
         rating=rating,
         c=c,
@@ -744,8 +757,8 @@ def _resolve_impact_band_set(
     :return: ``(reference, max_unfavourable, index_500, octave_offset,
         ci_band_count)``.
     """
-    if bands == "third-octave" or (bands is None and n == 16):
-        if n != 16:
+    if bands == "third-octave" or (bands is None and n == _N_THIRD_OCTAVE_BANDS):
+        if n != _N_THIRD_OCTAVE_BANDS:
             msg = (
                 f"One-third-octave impact rating needs 16 bands (100-3150 Hz), got {n}."
             )
@@ -757,8 +770,8 @@ def _resolve_impact_band_set(
             0,
             _CI_THIRD_OCTAVE_BANDS,
         )
-    if bands == "octave" or (bands is None and n == 5):
-        if n != 5:
+    if bands == "octave" or (bands is None and n == _N_OCTAVE_BANDS):
+        if n != _N_OCTAVE_BANDS:
             msg = f"Octave impact rating needs 5 bands (125-2000 Hz), got {n}."
             raise ValueError(msg)
         return (
@@ -845,7 +858,7 @@ def weighted_impact_rating(
     shift, unfavourable = _best_shift(-measured, -ref, limit)
     rating = int(reference[index_500]) - round(shift) + octave_offset
     ci = _impact_ci(measured, rating, ci_bands)
-    centers = _FREQ_THIRD_OCTAVE if data.size == 16 else _FREQ_OCTAVE
+    centers = _FREQ_THIRD_OCTAVE if data.size == _N_THIRD_OCTAVE_BANDS else _FREQ_OCTAVE
     return ImpactRatingResult(
         rating=rating,
         ci=ci,

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -122,6 +122,11 @@ _SABINE = 0.16
 #: Minimum-area factor of Clause 3.6: where V/7,5 > S, use V/7,5 for S.
 _MIN_AREA_FACTOR = 7.5
 
+#: Prescribed count of measurement positions for the service-equipment method
+#: (one near a corner, two in the reverberant field, Clause 6.3.3); also the
+#: 1/3 of the Clause 3.16 energy average.
+_SERVICE_EQUIPMENT_POSITIONS = 3
+
 #: Upper volume limits of the four Table 4 ranges (Clause 6.5); the table is
 #: valid for rooms up to 150 m³.
 _TABLE3_VOLUME_LIMITS = (15.0, 35.0, 60.0, 150.0)
@@ -820,7 +825,7 @@ def survey_service_equipment_level(
         are inconsistent, or if ``volume`` is not positive.
     """
     m = _finite_bands(measurements, "measurements")
-    if m.ndim not in (1, 2) or m.shape[0] != 3:
+    if m.ndim not in (1, 2) or m.shape[0] != _SERVICE_EQUIPMENT_POSITIONS:
         msg = (
             "'measurements' must give exactly three measurement positions "
             "(three scalars, or a (3, bands) array)."

--- a/src/phonometry/building/measurement/uncertainty.py
+++ b/src/phonometry/building/measurement/uncertainty.py
@@ -390,6 +390,11 @@ _COVERAGE_ONE_SIDED: dict[float, float] = {
     0.9995: 3.29,
 }
 
+#: Tolerance for float-matching a confidence fraction against the tabulated
+#: Table 8 levels (Clause 8): absorbs decimal-representation noise in
+#: fractions like 0.95 while staying far below the gap between adjacent levels.
+_CONFIDENCE_MATCH_TOL = 1e-9
+
 
 # --------------------------------------------------------------------------- #
 # Result containers.
@@ -595,7 +600,7 @@ def insulation_coverage_factor(
     """
     table = _COVERAGE_ONE_SIDED if one_sided else _COVERAGE_TWO_SIDED
     for level, k in table.items():
-        if abs(level - confidence) < 1e-9:
+        if abs(level - confidence) < _CONFIDENCE_MATCH_TOL:
             return k
     kind = "one-sided" if one_sided else "two-sided"
     valid = ", ".join(f"{level:g}" for level in table)

--- a/src/phonometry/building/prediction/aperture_transmission.py
+++ b/src/phonometry/building/prediction/aperture_transmission.py
@@ -375,7 +375,7 @@ def composite_transmission_loss(
         tau = 10.0 ** (-r / 10.0)
         total_1d = float(np.sum(s * tau) / np.sum(s))
         return np.asarray(-10.0 * np.log10(total_1d), dtype=np.float64)
-    if r.ndim == 2:
+    if r.ndim == 2:  # noqa: PLR2004
         if r.shape[0] != s.shape[0]:
             msg = "'reduction_indices' first axis must match 'areas'."
             raise ValueError(msg)

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -277,12 +277,9 @@ class FacadePredictionResult:
             (``pip install phonometry[report]``), or matplotlib is missing for
             the embedded figure (``pip install phonometry[plot]``).
         """
-        from ..._i18n import check_language
+        from .detailed_model import _check_report_request
 
-        check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        _check_report_request(engine, language)
         from ..._report.iso12354 import render_iso12354_facade_report
 
         return render_iso12354_facade_report(
@@ -543,6 +540,10 @@ _DELTA_LFS: dict[str, tuple[tuple[float, float, float] | None, ...]] = {
 #: αw grid of the Figure C.2 columns (≤ 0,3; 0,6; ≥ 0,9).
 _DLFS_ALPHAS = (0.3, 0.6, 0.9)
 
+#: Line-of-sight height bin edges of the Figure C.2 rows, in m
+#: (below 1,5 m; 1,5 m to 2,5 m; above 2,5 m).
+_DLFS_HEIGHT_EDGES = (1.5, 2.5)
+
 
 def facade_shape_level_difference(
     shape: str,
@@ -590,9 +591,10 @@ def facade_shape_level_difference(
     if not (np.isfinite(aw) and 0.0 <= aw <= 1.0):
         msg = "'absorption' must be an αw between 0 and 1."
         raise ValueError(msg)
-    if h < 1.5:
+    low, high = _DLFS_HEIGHT_EDGES
+    if h < low:
         row_index = 0
-    elif h <= 2.5:
+    elif h <= high:
         row_index = 1
     else:
         row_index = 2

--- a/src/phonometry/building/prediction/linings.py
+++ b/src/phonometry/building/prediction/linings.py
@@ -58,6 +58,11 @@ _CAVITY_STIFFNESS: float = 0.111e6
 #: ``ΔRw = 74,4 − 20 lg(fo) − Rw/2``, floored at 0 dB by NOTE 1.
 _TABLE_D1_LOW = (74.4, 20.0, 2.0)
 
+#: Highest nominal one-third-octave centre served by the ``_TABLE_D1_LOW``
+#: branch of Table D.1, in Hz; above it the fixed ``_TABLE_D1_HIGH`` rows
+#: apply.
+_TABLE_D1_LOW_MAX = 160.0
+
 #: ISO 12354-1:2017 Table D.1, the fixed rows above 160 Hz, as
 #: ``(upper bound of fo in Hz, ΔRw in dB)`` evaluated in order. The 1 600 Hz
 #: row is printed twice with different values; see ``docs/ERRATA.md``.
@@ -302,7 +307,7 @@ def weighted_lining_improvement(
             stacklevel=2,
         )
     nominal = _round_to_third_octave(f0)
-    if nominal <= 160.0:
+    if nominal <= _TABLE_D1_LOW_MAX:
         a, b, c = _TABLE_D1_LOW
         return float(max(0.0, a - b * np.log10(nominal) - rw / c))
     for upper, value in _TABLE_D1_HIGH:
@@ -442,7 +447,7 @@ def lining_improvement(
             )
             raise ValueError(msg)
         area = require_positive(glued_area, "glued_area")
-        if area > 100.0:
+        if area > 100.0:  # noqa: PLR2004
             msg = "'glued_area' is a percentage and cannot exceed 100."
             raise ValueError(msg)
         slope, offset = _ANNEX_D_GLUE

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -136,6 +136,11 @@ PLATEAU_MATERIALS: dict[str, tuple[float, float, float]] = {
 #: Field-incidence correction of Norton Eq. (3.106): a flat 5 dB below the
 #: normal-incidence mass law (a diffuse field limited to 78 degrees).
 _NORTON_FIELD_CORRECTION: float = 5.0
+#: Grazing incidence, degrees: the open upper bound of the fixed limiting
+#: angle ``theta_L`` of the field-incidence diffuse integral (at 90 degrees
+#: the upper limit :math:`\sin^{2}\theta_\mathrm{L}` of Bies Eq. (7.38)
+#: reaches 1).
+_GRAZING_INCIDENCE_DEG: float = 90.0
 
 
 def _band_axis(frequency: ArrayLike) -> np.ndarray:
@@ -1124,7 +1129,7 @@ def orthotropic_transmission_loss(
     # whichever method it was passed with, even where the method ignores it.
     if area is not None:
         require_positive(area, "area")
-    elif not 0.0 < limiting_angle < 90.0:
+    elif not 0.0 < limiting_angle < _GRAZING_INCIDENCE_DEG:
         msg = "'limiting_angle' must lie in (0, 90) degrees."
         raise ValueError(msg)
     f = _band_axis(frequency)

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -112,6 +112,14 @@ __all__ = [
     "window_size_correction",
 ]
 
+# Floating-point slack on the compliance margin (the signed distance from the
+# DB-HR limit, in the requirement's unit: ``reported - limit`` for a minimum,
+# ``limit - reported`` for a maximum): a margin that is mathematically zero,
+# i.e. the value exactly at the limit after DB-HR's prescribed rounding,
+# counts as compliant and must not be turned into a failure by binary
+# representation error in that subtraction.
+_COMPLIANCE_SLACK = -1e-9
+
 #: The eighteen one-third-octave band centre frequencies of DB-HR Annex A.
 DB_HR_FREQUENCIES: tuple[float, ...] = (
     100.0,
@@ -1153,7 +1161,7 @@ def check_db_hr_requirement(value: float, requirement: DbHrRequirement) -> DbHrC
         value=achieved,
         reported=reported,
         margin=margin,
-        complies=bool(margin >= -1e-9),
+        complies=bool(margin >= _COMPLIANCE_SLACK),
     )
 
 

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -45,8 +45,15 @@ if TYPE_CHECKING:
 
 #: Default number of harmonics summed for the THD (IEC 60268-3).
 _DEFAULT_N_HARMONICS = 10
+#: Lowest harmonic order (the fundamental is order 1, not a harmonic): the
+#: IEC 60268-3 THD sum runs over n >= 2, and 14.12.5 defines d_n for n >= 2.
+_MIN_HARMONIC_ORDER = 2
 #: Default standard-notch quality factor for THD+N (AES17 5.2.8: 1.2 <= Q <= 3).
 _DEFAULT_NOTCH_Q = 2.0
+#: AES17-2015 5.2.8 window for the effective quality factor of the standard
+#: notch filter used for THD+N.
+_AES17_NOTCH_Q_MIN = 1.2
+_AES17_NOTCH_Q_MAX = 3.0
 #: AES17 5.2.8 defines Q on the *applied* (combined) response. ``filtfilt``
 #: applies the notch twice, so the single-pass design must be sharper for the
 #: squared magnitude to have the requested -3 dB width. For the biquad notch
@@ -85,7 +92,7 @@ def _positive(value: float, name: str) -> float:
 def _validate_notch_q(notch_q: float) -> float:
     """Validate the effective notch quality factor (AES17 5.2.8: 1.2 <= Q <= 3)."""
     q = float(notch_q)
-    if not 1.2 <= q <= 3.0:
+    if not _AES17_NOTCH_Q_MIN <= q <= _AES17_NOTCH_Q_MAX:
         msg = "'notch_q' must be within the AES17 range [1.2, 3]."
         raise ValueError(msg)
     return q
@@ -247,7 +254,7 @@ def thd(
     if amps.size == 0 or amps[0] <= 0.0:
         msg = "No fundamental component found in the signal."
         raise ValueError(msg)
-    if amps.size < 2:
+    if amps.size < _MIN_HARMONIC_ORDER:
         msg = (
             "No harmonic of the fundamental lies below the Nyquist frequency; "
             "the THD is undefined (raise fs or lower the fundamental)."
@@ -293,7 +300,7 @@ def harmonic_distortion(
     sig = _validate_signal(signal)
     fs_v = _positive(fs, "fs")
     f0 = _positive(fundamental, "fundamental")
-    if order < 2:
+    if order < _MIN_HARMONIC_ORDER:
         msg = "'order' must be at least 2."
         raise ValueError(msg)
     n = max(n_harmonics, order)

--- a/src/phonometry/electroacoustics/intermodulation.py
+++ b/src/phonometry/electroacoustics/intermodulation.py
@@ -288,7 +288,7 @@ def difference_frequency_distortion(
     if ref <= 0.0:
         msg = "No primary tones found at 'f1'/'f2'."
         raise ValueError(msg)
-    if order == 2:
+    if order == 2:  # noqa: PLR2004
         value = _imd_component(freqs, amp, fb - fa, half, exclude=(fa, fb))
     else:
         value = _imd_component(

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -72,6 +72,9 @@ _OCTAVE_HALF = float(np.sqrt(2.0))
 _MIN_TROUGH_OCTAVES = 1.0 / 9.0
 #: Level drop, in decibels, defining the effective frequency range (21.2).
 _EFFECTIVE_DROP_DB = 10.0
+#: Minimum number of frequency points a paired (frequencies, values) response
+#: curve must have to constitute a curve at all.
+_MIN_CURVE_POINTS = 2
 
 
 def _as_curve(
@@ -83,7 +86,7 @@ def _as_curve(
     if f.ndim != 1 or v.ndim != 1 or f.shape != v.shape:
         msg = f"'{name}' frequencies and values must be 1-D and equal length."
         raise ValueError(msg)
-    if f.size < 2:
+    if f.size < _MIN_CURVE_POINTS:
         msg = f"'{name}' needs at least two frequency points."
         raise ValueError(msg)
     if np.any(f <= 0.0) or not np.all(np.isfinite(f)):

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -85,6 +85,16 @@ _REFERENCE_FREQUENCY = 1000.0
 #: Smallest polar-pattern angular span, in degrees, accepted for the 11.2.2 a)
 #: diffuse-field integral (the pattern must essentially reach the rear).
 _MIN_POLAR_SPAN_DEG = 150.0
+#: Degrees in the full circle: the upper bound of the accepted 0..360-degree
+#: polar-angle domain, and the angle :func:`_fold_angles_deg` subtracts from.
+_FULL_CIRCLE_DEG = 360.0
+#: The 180-degree edge of the 0..180 half plane: a full-circle angle beyond it
+#: re-measures the polar angle ``360 - angle``, folding the rear half onto the
+#: front for the 11.2.2 a) diffuse-field integral.
+_HALF_CIRCLE_DEG = 180.0
+#: Fewest angle points a polar pattern may supply: two, the least that forms a
+#: curve segment.
+_MIN_CURVE_POINTS = 2
 
 
 def _sensitivity_level_db(sensitivity_v_per_pa: float) -> float:
@@ -172,7 +182,9 @@ def _fold_angles_deg(angles_deg: NDArray[np.float64]) -> NDArray[np.float64]:
     folds onto the front half.
     """
     return np.asarray(
-        np.where(angles_deg > 180.0, 360.0 - angles_deg, angles_deg),
+        np.where(
+            angles_deg > _HALF_CIRCLE_DEG, _FULL_CIRCLE_DEG - angles_deg, angles_deg
+        ),
         dtype=np.float64,
     )
 
@@ -594,13 +606,13 @@ def _resolve_polar(
     if p_ang.ndim != 1 or p_ang.shape != p_db.shape:
         msg = "'polar' angles and levels must be 1-D and equal length."
         raise ValueError(msg)
-    if p_ang.size < 2:
+    if p_ang.size < _MIN_CURVE_POINTS:
         msg = "'polar' needs at least two angle points."
         raise ValueError(msg)
     if not (np.all(np.isfinite(p_ang)) and np.all(np.isfinite(p_db))):
         msg = "'polar' angles and levels must be finite."
         raise ValueError(msg)
-    if np.any(p_ang < 0.0) or np.any(p_ang > 360.0):
+    if np.any(p_ang < 0.0) or np.any(p_ang > _FULL_CIRCLE_DEG):
         msg = "'polar' angles must lie within 0..360 degrees."
         raise ValueError(msg)
     order = np.argsort(p_ang)

--- a/src/phonometry/electroacoustics/swept_sine.py
+++ b/src/phonometry/electroacoustics/swept_sine.py
@@ -82,6 +82,16 @@ _MIN_IR_LENGTH = 16
 #: 170 ms at 48 kHz; plenty for the anechoic tail of driver measurements).
 _DEFAULT_MAX_IR_LENGTH = 8192
 
+#: Exclusive upper bound on the half-Hann ``fade`` fraction: fade-in and
+#: fade-out each consume ``fade`` of the sweep duration, so at 0.5 the two
+#: fades would cover the whole signal with no unfaded portion left.
+_MAX_FADE_FRACTION = 0.5
+
+#: Minimum highest harmonic order that makes a distortion separation
+#: meaningful: order 1 is only the linear response H1, so the separation
+#: must reach at least the 2nd harmonic.
+_MIN_HARMONIC_ORDER = 2
+
 
 def _positive(value: float, name: str) -> float:
     scalar = float(value)
@@ -165,7 +175,7 @@ def synchronized_sweep_signal(
     _validate_sweep_band(fs_v, f1_v, float(f2))
     seconds_v = _positive(seconds, "seconds")
     amplitude_v = _positive(amplitude, "amplitude")
-    if not 0.0 <= fade < 0.5:
+    if not 0.0 <= fade < _MAX_FADE_FRACTION:
         msg = "fade must be in [0, 0.5)"
         raise ValueError(msg)
     rate = _sweep_rate(f1_v, float(f2), seconds_v)
@@ -626,7 +636,7 @@ def swept_sine_distortion(
         msg = "'method' must be 'synchronized' or 'farina'."
         raise ValueError(msg)
     n_orders = int(n_harmonics)
-    if n_orders < 2:
+    if n_orders < _MIN_HARMONIC_ORDER:
         msg = "'n_harmonics' must be at least 2."
         raise ValueError(msg)
 

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -70,6 +70,7 @@ from .._internal.levels_math import energy_mean
 from .._internal.utils import _typesignal
 from ..filters.frequencies import _genfreqs
 from ..signals.spectra import (
+    _MIN_SAMPLES,
     _default_nperseg,
     _welch_autospectrum,
     _welch_cross_spectrum,
@@ -92,6 +93,12 @@ _P0 = 2.0e-5
 #: the totals bounded while leaving the low-frequency region (where the bias
 #: matters and is trustworthy) exact.
 _BIAS_CORRECTION_MAX_KDR = np.pi / 2.0
+
+#: Fewest observations the ISO 9614-1:1993 coefficient of variation is
+#: defined from (M short-time samples for F1, N surface positions for F4):
+#: the sample standard deviation divides by (n - 1), equations (A.1) and
+#: (A.8).
+_MIN_VARIATION_OBSERVATIONS = 2
 
 
 def _finite_difference_correction(k_dr: np.ndarray) -> np.ndarray:
@@ -364,7 +371,7 @@ def _validate_band_options(fraction: int | None, limits: list[float] | None) -> 
         msg = "'fraction' must be None, 1 (octave) or 3 (one-third octave)."
         raise ValueError(msg)
     if limits is not None and (
-        len(limits) != 2 or limits[0] <= 0 or limits[1] <= limits[0]
+        len(limits) != 2 or limits[0] <= 0 or limits[1] <= limits[0]  # noqa: PLR2004
     ):
         msg = "'limits' must be [f_min, f_max] with 0 < f_min < f_max."
         raise ValueError(msg)
@@ -458,7 +465,7 @@ def sound_intensity(
     _validate_probe_signals(x1, x2)
     _validate_probe_medium(fs, spacing, rho, c)
     _validate_band_options(fraction, limits)
-    if x1.size < 32:
+    if x1.size < _MIN_SAMPLES:
         msg = f"Signals too short for a spectral estimate: {x1.size} samples."
         raise ValueError(msg)
 
@@ -627,7 +634,7 @@ def temporal_variability_indicator(
             "(samples, bands) arrays."
         )
         raise ValueError(msg)
-    if samples.shape[0] < 2:
+    if samples.shape[0] < _MIN_VARIATION_OBSERVATIONS:
         msg = (
             "At least two short-time samples are required for F1 "
             "(ISO 9614-1 Annex A Note 9 recommends M = 10)."
@@ -763,11 +770,11 @@ def field_indicators(
             f"shape, got {lp.shape} and {i_n.shape}."
         )
         raise ValueError(msg)
-    if lp.shape[0] < 2:
+    if lp.shape[0] < _MIN_VARIATION_OBSERVATIONS:
         msg = "At least two measurement positions are required."
         raise ValueError(msg)
 
-    n_bands = lp.shape[1] if lp.ndim == 2 else 1
+    n_bands = lp.shape[1] if lp.ndim == 2 else 1  # noqa: PLR2004
     freqs: np.ndarray | None = None
     if frequencies is not None:
         freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -373,7 +373,7 @@ def verify_intensity_class(
     # own and clause 12.4 tests it in one-third octaves, so the alternative is
     # not open to it at all.
     full_range = covered.issuperset(_THIRD_OCTAVE_BANDS) or (
-        device != "probe" and overall == 2 and covered.issuperset(_OCTAVE_BANDS)
+        device != "probe" and overall == 2 and covered.issuperset(_OCTAVE_BANDS)  # noqa: PLR2004
     )
     range_limited = not full_range
 

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -556,13 +556,13 @@ def _hemisphere_position_table(
     if grade == "engineering":  # ISO 3744 clause 8.1.1
         if reflecting_planes == 1:  # positions 1-10, Table B.1 (or B.2 broadband)
             return (_TABLE_B1 if tones else _TABLE_B2), tuple(range(10))
-        if reflecting_planes == 2:  # positions 2,3,6,7,9 of Table B.2
+        if reflecting_planes == 2:  # positions 2,3,6,7,9 of Table B.2  # noqa: PLR2004
             return _TABLE_B2, (1, 2, 5, 6, 8)
         return _TABLE_B3, (0, 1, 2)  # positions 1,2,3 of Table B.3
     # survey, ISO 3746 clause 8.2.1
     if reflecting_planes == 1:  # positions 4,5,6,10 of Table B.1
         return _TABLE_B1, (3, 4, 5, 9)
-    if reflecting_planes == 2:  # positions 14,15,18 of Table B.2
+    if reflecting_planes == 2:  # positions 14,15,18 of Table B.2  # noqa: PLR2004
         return _TABLE_B2, (13, 14, 17)
     # positions 14,21,22 of Table B.2 (extended array not transcribed)
     msg = (
@@ -631,7 +631,7 @@ def _box_area(
     if reflecting_planes == 1:  # Eq. 9
         a, b, c = 0.5 * l1 + d, 0.5 * l2 + d, l3 + d
         return 4.0 * (a * b + b * c + c * a)
-    if reflecting_planes == 2:  # Eq. 10 (against a wall)
+    if reflecting_planes == 2:  # Eq. 10 (against a wall)  # noqa: PLR2004
         a, b, c = 0.5 * l2 + 0.5 * d, 0.5 * l1 + d, l3 + d
         return 2.0 * (2.0 * a * b + b * c + 2.0 * c * a)
     # Eq. 11 (in a corner)
@@ -670,7 +670,7 @@ def _measurement_surface(
         if dimensions is None or distance is None:
             msg = "'dimensions' and 'distance' are required for a box."
             raise ValueError(msg)
-        if len(dimensions) != 3 or any(v <= 0 for v in dimensions) or distance <= 0:
+        if len(dimensions) != 3 or any(v <= 0 for v in dimensions) or distance <= 0:  # noqa: PLR2004
             msg = "'dimensions' must be 3 positive values and 'distance' > 0."
             raise ValueError(msg)
         return (
@@ -833,7 +833,7 @@ def sound_power_pressure(
     """
     grade = _check_grade(grade)
     levels = np.atleast_2d(np.asarray(levels_positions, dtype=np.float64))
-    if levels.ndim != 2:
+    if levels.ndim != 2:  # noqa: PLR2004
         msg = "'levels_positions' must be a 2D (positions, bands) array."
         raise ValueError(msg)
     n_positions = levels.shape[0]

--- a/src/phonometry/emission/sound_power_anechoic.py
+++ b/src/phonometry/emission/sound_power_anechoic.py
@@ -214,12 +214,19 @@ _PS0_KPA = 101.325  #: Reference static pressure, in kilopascals.
 _THETA0_K = 314.0  #: C1 reference temperature theta0, in kelvin.
 _THETA1_K = 296.0  #: C2 reference temperature theta1, in kelvin.
 
+#: Validity floor for the Celsius air temperature: absolute zero as implied by
+#: the standard's own rounded kelvin conversion (the Eq. 14 block writes
+#: 273 + theta), hence -273.0 rather than -273.15.
+_ROUNDED_ABS_ZERO_C = -273.0
+
 #: Background-noise correction floor criteria, in dB (clause 9.4.2). The lower
 #: criterion is 10 dB for one-third-octave mid-bands 250 Hz to 5000 Hz and
 #: 6 dB for bands <= 200 Hz and >= 6300 Hz; the upper criterion is 15 dB.
 _K1_UPPER_3745 = 15.0
 _K1_LOW_MID = 10.0  #: 250-5000 Hz
 _K1_LOW_EDGE = 6.0  #: <= 200 Hz and >= 6300 Hz
+_K1_MID_BAND_MIN_HZ = 250.0  #: Lowest mid-band of the 10 dB criterion range (9.4.2).
+_K1_MID_BAND_MAX_HZ = 5000.0  #: Highest mid-band of the 10 dB criterion range (9.4.2).
 
 #: A-weighted reproducibility standard deviation sigma_R0, in dB (Tables 2/3).
 _SIGMA_R0_3745_A = 0.5
@@ -403,7 +410,9 @@ def _k1_lower_criterion(frequencies: np.ndarray) -> np.ndarray:
     """Frequency-dependent lower K1 criterion, in dB (clause 9.4.2)."""
     freqs = np.asarray(frequencies, dtype=np.float64)
     return np.where(
-        (freqs >= 250.0) & (freqs <= 5000.0), _K1_LOW_MID, _K1_LOW_EDGE
+        (freqs >= _K1_MID_BAND_MIN_HZ) & (freqs <= _K1_MID_BAND_MAX_HZ),
+        _K1_LOW_MID,
+        _K1_LOW_EDGE,
     ).astype(np.float64)
 
 
@@ -504,7 +513,7 @@ def meteorological_corrections(
     if static_pressure <= 0.0:
         msg = "'static_pressure' must be positive (kPa)."
         raise ValueError(msg)
-    if temperature <= -273.0:
+    if temperature <= _ROUNDED_ABS_ZERO_C:
         msg = "'temperature' must be above -273 degrees Celsius."
         raise ValueError(msg)
     if radius <= 0.0:
@@ -528,15 +537,15 @@ def meteorological_corrections(
 
 def _sigma_r0_3745(nominal: int, room: PrecisionRoom) -> float:
     """Per-band sigma_R0 (ISO 3745:2012 Table 2 hemi / Table 3 anechoic), dB."""
-    if 50 <= nominal <= 80:
+    if 50 <= nominal <= 80:  # noqa: PLR2004
         return 2.0
-    if 100 <= nominal <= 630:
+    if 100 <= nominal <= 630:  # noqa: PLR2004
         return 1.5 if room == "hemi-anechoic" else 1.0
-    if 800 <= nominal <= 5000:
+    if 800 <= nominal <= 5000:  # noqa: PLR2004
         return 1.0 if room == "hemi-anechoic" else 0.5
-    if 6300 <= nominal <= 10000:
+    if 6300 <= nominal <= 10000:  # noqa: PLR2004
         return 1.5 if room == "hemi-anechoic" else 1.0
-    if 12500 <= nominal <= 20000:
+    if 12500 <= nominal <= 20000:  # noqa: PLR2004
         return 2.0
     msg = (
         f"No ISO 3745:2012 sigma_R0 for {nominal} Hz; expected a nominal "
@@ -752,7 +761,7 @@ def sound_power_anechoic(
         msg = "A positive 'radius' is required."
         raise ValueError(msg)
     levels = np.atleast_2d(np.asarray(levels_positions, dtype=np.float64))
-    if levels.ndim != 2:
+    if levels.ndim != 2:  # noqa: PLR2004
         msg = "'levels_positions' must be a 2D (positions, bands) array."
         raise ValueError(msg)
     n_positions, n_bands = levels.shape

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -120,6 +120,9 @@ _F_PLUS_MINUS_LIMIT = 3.0
 #: (4 dB), reused here as a per-band survey limit (extrapolated -- the
 #: per-band grade-3 use of the A-weighted 4 dB is non-normative).
 _S_SURVEY = 4.0
+#: Minimum measurement segments of a scan (ISO 9614-2:1996 clause 8.2); fewer
+#: segments only warns, it does not reject.
+_MIN_SEGMENTS = 4
 
 
 def _table2_s(nominal: int, band_type: BandType) -> float:
@@ -350,7 +353,7 @@ def _validate_scan(
     if np.any(seg <= 0.0):
         msg = "All segment 'areas' must be positive."
         raise ValueError(msg)
-    if n_seg < 4:
+    if n_seg < _MIN_SEGMENTS:
         warnings.warn(
             f"Only {n_seg} segment(s); ISO 9614-2:1996 clause 8.2 requires at "
             "least 4 measurement segments.",
@@ -680,6 +683,10 @@ _FS_LIMIT = 2.0  #: Criterion 4 field-non-uniformity limit (Eq. C.4).
 _F_PI_DIFF_LIMIT = 3.0  #: Criterion 3 signed-minus-unsigned limit, dB (Eq. C.3).
 _FS_RATIO_LOW = 0.83  #: Criterion 5 lower bound on FS(1)/FS(2) (Eq. C.5).
 _FS_RATIO_HIGH = 1.2  #: Criterion 5 upper bound on FS(1)/FS(2) (Eq. C.5).
+#: Fewest samples a Bessel-corrected (N-1) sample standard deviation needs:
+#: segments for FS (Eq. B.8) and time windows for FT (Eq. B.1).
+_MIN_STDDEV_SAMPLES = 2
+_ABS_ZERO_C = -273.15  #: Absolute zero, deg C: validity floor for theta (Eq. 10).
 
 
 @dataclass(frozen=True)
@@ -968,7 +975,7 @@ def precision_field_indicators(
         )
         raise ValueError(msg)
     n_seg = i_n.shape[0]
-    if n_seg < 2:
+    if n_seg < _MIN_STDDEV_SAMPLES:
         msg = "At least two segments are required for the indicators."
         raise ValueError(msg)
 
@@ -997,7 +1004,7 @@ def precision_field_indicators(
             msg = "'time_window_intensity' last axis must match the number of bands."
             raise ValueError(msg)
         m = win.shape[0]
-        if m < 2:
+        if m < _MIN_STDDEV_SAMPLES:
             msg = "At least two time windows are required for FT."
             raise ValueError(msg)
         mean_t = np.mean(win, axis=0)
@@ -1015,13 +1022,13 @@ def precision_field_indicators(
 
 def _sigma_r0_9614_3(nominal: int) -> float:
     """Per-band sigma_R0 (ISO 9614-3:2002 Table 1), in dB; also criterion-1 s."""
-    if 50 <= nominal <= 160:
+    if 50 <= nominal <= 160:  # noqa: PLR2004
         return 2.0
-    if 200 <= nominal <= 315:
+    if 200 <= nominal <= 315:  # noqa: PLR2004
         return 1.5
-    if 400 <= nominal <= 5000:
+    if 400 <= nominal <= 5000:  # noqa: PLR2004
         return 1.0
-    if nominal == 6300:
+    if nominal == 6300:  # noqa: PLR2004
         return 2.0
     msg = (
         f"No ISO 9614-3:2002 Table 1 sigma_R0 for {nominal} Hz; expected a "
@@ -1203,7 +1210,7 @@ def sound_power_intensity_precision(
     if np.any(seg <= 0.0):
         msg = "All 'areas' must be positive."
         raise ValueError(msg)
-    if temperature <= -273.15:
+    if temperature <= _ABS_ZERO_C:
         msg = "'temperature' must be above -273,15 degrees Celsius."
         raise ValueError(msg)
     if barometric_pressure <= 0.0:

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -72,6 +72,25 @@ _A0 = 1.0  #: Reference absorption area, in square metres (ISO 3741, Eq. 20).
 _PS0 = 101.325  #: Reference static pressure, in kPa (ISO 3741 clause 4).
 _THETA0 = 314.0  #: Reference temperature for C1, in K (ISO 3741 clause 9.1.4).
 _THETA1 = 296.0  #: Reference temperature for C2, in K (ISO 3741 clause 9.1.4).
+#: Temperature floor in degC: sqrt(273 + theta) of the speed-of-sound formula
+#: c = 20.05*sqrt(273 + theta) is zero or complex at or below it (ISO 3741, 9.1.4).
+_ROUNDED_ABS_ZERO_C = -273.0
+#: K1 qualification edges: bands at or below the low edge or at or above the
+#: high edge carry the relaxed 6 dB lower criterion (ISO 3741:2010, 9.1.2).
+_K1_EDGE_LOW_HZ = 200.0
+_K1_EDGE_HIGH_HZ = 6300.0
+#: Background margin at or above which the background is negligible and K1 = 0
+#: (ISO 3741:2010, 9.1.2).
+_K1_UPPER_DB = 15.0
+#: The T60 > V/S room-absorptivity criterion covers bands below 6,3 kHz
+#: (ISO 3741:2010, 5.3, Eq. 7); distinct from the K1 edge above.
+_ABSORPTION_CRITERION_MAX_HZ = 6300.0
+#: Minimum microphone positions in an unqualified room (ISO 3741:2010, 8.3, 8.4.1).
+_MIN_MIC_POSITIONS = 6
+#: The inter-position sample deviation sM (ddof=1) needs at least two positions.
+_MIN_POSITIONS_FOR_SM = 2
+#: Maximum admissible inter-position deviation sM (ISO 3741:2010, 8.4.2.2, Eq. 10).
+_SM_CRITERION_DB = 1.5
 
 
 @dataclass(frozen=True)
@@ -189,7 +208,7 @@ def _validate_meteorology(temperature: float, static_pressure: float) -> None:
     static pressure makes :math:`\log_{10}(p_\mathrm{s}/p_{\mathrm{s}0})` undefined; both are rejected
     with a clean ``ValueError``.
     """
-    if not np.isfinite(temperature) or temperature <= -273.0:
+    if not np.isfinite(temperature) or temperature <= _ROUNDED_ABS_ZERO_C:
         msg = "'temperature' must be finite and greater than -273 degC."
         raise ValueError(msg)
     if not np.isfinite(static_pressure) or static_pressure <= 0.0:
@@ -228,7 +247,7 @@ def _mean_level(levels: np.ndarray) -> np.ndarray:
     arr = np.asarray(levels, dtype=np.float64)
     if arr.ndim == 1:
         return arr
-    if arr.ndim == 2:
+    if arr.ndim == 2:  # noqa: PLR2004
         return energy_mean(arr, axis=0)
     msg = "'levels' must be a 1D spectrum or a 2D (positions, bands) array."
     raise ValueError(msg)
@@ -246,10 +265,14 @@ def _k1_eq14(delta: np.ndarray, frequencies: np.ndarray) -> tuple[np.ndarray, bo
     ``(NB,)`` or per position and band ``(NM, NB)``; the second returned value
     flags whether any element fell below the lower criterion.
     """
-    low = np.where((frequencies <= 200.0) | (frequencies >= 6300.0), 6.0, 10.0)
+    low = np.where(
+        (frequencies <= _K1_EDGE_LOW_HZ) | (frequencies >= _K1_EDGE_HIGH_HZ),
+        6.0,
+        10.0,
+    )
     clamped = np.maximum(delta, low)
     k1 = -10.0 * np.log10(1.0 - 10.0 ** (-0.1 * clamped))
-    k1 = np.where(delta >= 15.0, 0.0, k1)
+    k1 = np.where(delta >= _K1_UPPER_DB, 0.0, k1)
     return np.asarray(k1, dtype=np.float64), bool(np.any(delta < low))
 
 
@@ -277,7 +300,7 @@ def _background_corrected_mean(
     """
     arr = np.asarray(levels, dtype=np.float64)
     raw_mean = _mean_level(levels)
-    if arr.ndim == 2:
+    if arr.ndim == 2:  # noqa: PLR2004
         bg = np.asarray(background_levels, dtype=np.float64)
         if bg.ndim == 1:
             bg = np.broadcast_to(bg, arr.shape)
@@ -351,7 +374,7 @@ def _room_qualification_warnings(
             stacklevel=3,
         )
     floor = volume / surface_area
-    below_6k3 = frequencies < 6300.0
+    below_6k3 = frequencies < _ABSORPTION_CRITERION_MAX_HZ
     if np.any(below_6k3 & (t60 <= floor)):
         warnings.warn(
             f"Reverberation time falls to or below the V/S floor ({floor:g} s) "
@@ -373,20 +396,20 @@ def _position_sampling_warnings(levels: np.ndarray, stacklevel: int) -> None:
     spectrum carries no per-position information and is skipped.
     """
     arr = np.asarray(levels, dtype=np.float64)
-    if arr.ndim != 2:
+    if arr.ndim != 2:  # noqa: PLR2004
         return
     n_positions = arr.shape[0]
-    if n_positions < 6:
+    if n_positions < _MIN_MIC_POSITIONS:
         warnings.warn(
             f"Only {n_positions} microphone position(s) were supplied; an "
-            "unqualified reverberation room requires at least 6 "
+            f"unqualified reverberation room requires at least {_MIN_MIC_POSITIONS} "
             "(ISO 3741:2010, 8.3, 8.4.1).",
             SoundPowerWarning,
             stacklevel=stacklevel,
         )
-    if n_positions >= 2:
+    if n_positions >= _MIN_POSITIONS_FOR_SM:
         s_m = np.std(arr, axis=0, ddof=1)
-        if np.any(s_m > 1.5):
+        if np.any(s_m > _SM_CRITERION_DB):
             warnings.warn(
                 "Inter-position standard deviation exceeds the ISO 3741 sM "
                 "criterion (1,5 dB) in one or more bands; the source may radiate "

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -84,6 +84,11 @@ _K1A_TABLE: dict[int, float] = {
     9: 1.0,
     10: 0.0,
 }
+#: Table 2 top edge: Delta L_v (dB) at or above which the correction K1A is 0 dB.
+_K1A_ZERO_ABOVE_DB: float = 10.0
+#: Table 2 bottom edge: below this Delta L_v (dB) the table bottoms out, K1A is
+#: clamped to the 3 dB floor value and the result becomes an upper boundary.
+_K1A_CLAMPED_BELOW_DB: float = 3.0
 
 
 def velocity_level(
@@ -245,9 +250,9 @@ def extraneous_velocity_correction(level_difference: float) -> float:
     :param level_difference: Level difference :math:`\Delta L_v`, in dB.
     :return: The correction ``K1A`` to subtract, in dB.
     """
-    if level_difference >= 10.0:
+    if level_difference >= _K1A_ZERO_ABOVE_DB:
         return 0.0
-    if level_difference < 3.0:
+    if level_difference < _K1A_CLAMPED_BELOW_DB:
         return 3.0
     return _K1A_TABLE[round(level_difference)]
 

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -405,6 +405,11 @@ _CATEGORY_NOT_IMPULSIVE = "not impulsive"
 _CATEGORY_REGULAR_IMPULSIVE = "regular impulsive"
 _CATEGORY_HIGHLY_IMPULSIVE = "highly impulsive"
 
+#: Fewest level samples that determine a slope: two points are the minimum for
+#: the least-squares onset-rate fit (Clause 3.5) and for the gradient of the
+#: level history (Clause 4).
+_MIN_SLOPE_SAMPLES: int = 2
+
 _OnsetRateMethod = Literal["least_squares", "upper_half"]
 
 
@@ -693,10 +698,10 @@ def _onset_rate(
         # levels from Le - (Le - Ls)/2 to Le.
         threshold = lev[-1] - (lev[-1] - lev[0]) / 2.0
         mask = lev >= threshold
-        if np.count_nonzero(mask) >= 2:
+        if np.count_nonzero(mask) >= _MIN_SLOPE_SAMPLES:
             t = t[mask]
             lev = lev[mask]
-    if t.size < 2:
+    if t.size < _MIN_SLOPE_SAMPLES:
         return float((levels[-1] - levels[0]) / (times[-1] - times[0]))
     slope = np.polyfit(t - t[0], lev, 1)[0]
     return float(slope)
@@ -730,7 +735,7 @@ def detect_onsets(
     if not math.isfinite(dt) or dt <= 0.0:
         msg = "dt must be positive."
         raise ValueError(msg)
-    if lev.size < 2:
+    if lev.size < _MIN_SLOPE_SAMPLES:
         msg = "at least two level samples are required."
         raise ValueError(msg)
     times = np.arange(lev.size) * dt

--- a/src/phonometry/environment/assessment/measurement.py
+++ b/src/phonometry/environment/assessment/measurement.py
@@ -72,10 +72,23 @@ _KT_HIGH = 10.0
 #: Maximum tonal adjustment ``Kt`` (dB).
 _KT_MAX = 6.0
 
+#: Upper mean-audibility limits (dB) of the coarse 3-dB-step alternative
+#: to Table J.1: ΔL ≤ 2 → Kt = 0, ΔL ≤ 9 → Kt = 3, above → Kt = 6.
+_COARSE_KT_LOW = 2.0
+_COARSE_KT_HIGH = 9.0
+
 #: Critical-band centre-frequency split (Table C.1): 100 Hz up to 500 Hz.
 _CRITICAL_BAND_SPLIT = 500.0
 _CRITICAL_BAND_LOW_WIDTH = 100.0
 _CRITICAL_BAND_HIGH_FRACTION = 0.20
+
+#: Survey method (Annex K): fewest one-third-octave bands with an interior
+#: band to test (a band needs both neighbours), and the highest band-centre
+#: frequencies (Hz) of the low (25–125 Hz, 15 dB threshold) and mid
+#: (160–400 Hz, 8 dB threshold) ranges.
+_MIN_SURVEY_BANDS = 3
+_SURVEY_LOW_RANGE_TOP = 125.0
+_SURVEY_MID_RANGE_TOP = 400.0
 
 #: Coverage factors k (Clause 4): 95 % (k = 2) and 80 % (k = 1.3).
 _COVERAGE_FACTORS = {0.95: 2.0, 0.80: 1.3}
@@ -84,6 +97,16 @@ _COVERAGE_FACTORS = {0.95: 2.0, 0.80: 1.3}
 _GAUSS_CONSTANT = 0.115
 _GAUSS_DIVISOR_L90 = 1.28
 _GAUSS_DIVISOR_L95 = 1.65
+
+#: Margin L' − Lres (dB) that must be exceeded for the Formula (16)
+#: correction; within it, Clause 10.4 allows no correction and only the
+#: uncorrected L' is reportable, as an upper bound. A rule independent of
+#: the 3 dB Formula (20) Note 2 spread limit (_LEVEL_SPREAD_WARNING_DB).
+_MIN_CORRECTION_MARGIN_DB = 3.0
+
+#: Fewest repeated measured levels from which the Formula (17) sample
+#: standard deviation, with its (N − 1) denominator, exists.
+_MIN_REPEATED_LEVELS = 2
 
 
 class EnvironmentalMeasurementWarning(PhonometryWarning):
@@ -248,9 +271,9 @@ def tonal_adjustment_from_mean_audibility(
     """
     delta = _finite(mean_audibility, "mean_audibility")
     if coarse:
-        if delta <= 2.0:
+        if delta <= _COARSE_KT_LOW:
             return 0
-        if delta <= 9.0:
+        if delta <= _COARSE_KT_HIGH:
             return 3
         return 6
     for upper, adjustment in _TABLE_J1:
@@ -292,7 +315,7 @@ def tonal_seeking_survey(
     if lev.size != freq.size:
         msg = "'levels' and 'frequencies' must share their length."
         raise ValueError(msg)
-    if lev.size < 3:
+    if lev.size < _MIN_SURVEY_BANDS:
         msg = "Need at least three bands to test the neighbours."
         raise ValueError(msg)
     if not (np.all(np.isfinite(lev)) and np.all(np.isfinite(freq))):
@@ -308,9 +331,9 @@ def tonal_seeking_survey(
 
 def _survey_threshold(frequency: float) -> float:
     """The survey level-difference threshold for a band centre (Annex K)."""
-    if frequency <= 125.0:
+    if frequency <= _SURVEY_LOW_RANGE_TOP:
         return 15.0
-    if frequency <= 400.0:
+    if frequency <= _SURVEY_MID_RANGE_TOP:
         return 8.0
     return 5.0
 
@@ -371,7 +394,7 @@ def residual_sound_correction(
         msg = "'residual_level' must be below 'measured_level' to correct."
         raise ValueError(msg)
     corrected = 10.0 * np.log10(10.0 ** (lp / 10.0) - 10.0 ** (lres / 10.0))
-    reliable = margin > 3.0
+    reliable = margin > _MIN_CORRECTION_MARGIN_DB
     if not reliable:
         warnings.warn(
             "Residual is within 3 dB of the measured level; no correction is "
@@ -605,7 +628,7 @@ def uncertainty_from_repeated_measurements(
     import warnings
 
     lev = np.asarray(levels, dtype=np.float64)
-    if lev.ndim != 1 or lev.size < 2:
+    if lev.ndim != 1 or lev.size < _MIN_REPEATED_LEVELS:
         msg = "'levels' must be a 1-D array of at least two values."
         raise ValueError(msg)
     if not np.all(np.isfinite(lev)):

--- a/src/phonometry/environment/assessment/rating.py
+++ b/src/phonometry/environment/assessment/rating.py
@@ -14,6 +14,11 @@ import numpy as np
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+# Absolute tolerance, in hours, on the periods-sum-to-24-h check
+# (ISO 1996-1:2016, 6.5): pure FP-accumulation slack, not a quantity
+# from the standard.
+_HOURS_SUM_TOL = 1e-9
+
 
 def composite_rating_level(periods: Iterable[tuple[float, float, float]]) -> float:
     r"""Composite whole-day rating level (ISO 1996-1:2016, 6.5).
@@ -42,7 +47,7 @@ def composite_rating_level(periods: Iterable[tuple[float, float, float]]) -> flo
         msg = "Every period duration must be a positive, finite number."
         raise ValueError(msg)
     total = float(np.sum(hours))
-    if abs(total - 24.0) > 1e-9:
+    if abs(total - 24.0) > _HOURS_SUM_TOL:
         msg = f"Period durations must sum to 24 h; got {total!r}."
         raise ValueError(msg)
     acc = sum(h / 24.0 * 10 ** (0.1 * (level + k)) for level, h, k in periods)

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -286,6 +286,16 @@ _LEVEL_DIFFERENCE_HIGH = 15.0
 #: Band-centre matching tolerance (fractional) for the ``Kt`` band ranges.
 _BAND_TOLERANCE = 0.06
 
+#: Fewest one-third-octave bands the ``Kt`` procedure (Annex IV A.3.3) can
+#: read: each candidate band is compared against the arithmetic mean of its
+#: two neighbours, so the minimum spectrum is a centre band plus both.
+_MIN_KT_BANDS = 3
+
+#: Absolute floating-point tolerance, in hours, on the Annex IV A.3.4.2 b
+#: requirement that the noise-phase durations sum to the evaluation-period
+#: duration (sum Ti = T).
+_HOURS_SUM_TOL = 1e-9
+
 
 def _finite(value: float, name: str) -> float:
     """Return ``value`` as a float, rejecting non-finite input."""
@@ -405,7 +415,7 @@ def _validate_kt_spectrum(band_levels: np.ndarray, freqs: np.ndarray) -> None:
             f"{band_levels.size} and {freqs.size}."
         )
         raise ValueError(msg)
-    if band_levels.size < 3:
+    if band_levels.size < _MIN_KT_BANDS:
         msg = (
             "At least three one-third-octave bands are needed: the procedure "
             "compares a band against its two neighbours."
@@ -703,7 +713,7 @@ def evaluation_period_level(
         period = total
     else:
         period = _positive(hours, "hours")
-        if abs(total - period) > 1e-9:
+        if abs(total - period) > _HOURS_SUM_TOL:
             msg = (
                 "The phase durations must sum to the period duration "
                 f"(sum Ti = T); got {total!r} h for T = {period!r} h."

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -89,6 +89,10 @@ _T01 = 273.16
 _KELVIN = 273.15
 #: Np -> dB factor (20*lg e) ``20 lg e`` printed as 8,686 in Eq. (5).
 _EIGHT_686 = 8.686
+#: Full-scale relative humidity (saturation), in percent: hard upper validity
+#: bound of the input (raises on violation), unlike the advisory tabulated
+#: ``_HUMIDITY_RANGE`` checked alongside it.
+_MAX_RELATIVE_HUMIDITY_PERCENT = 100.0
 
 #: Tabulated ranges of ISO 9613-1:1993 (Scope / clause 1), used for advisories.
 _FREQ_RANGE = (50.0, 10_000.0)
@@ -140,7 +144,7 @@ def _validate(
     if temperature <= -_KELVIN:
         msg = "'temperature' must be above absolute zero (-273,15 degC)."
         raise ValueError(msg)
-    if not 0.0 <= relative_humidity <= 100.0:
+    if not 0.0 <= relative_humidity <= _MAX_RELATIVE_HUMIDITY_PERCENT:
         msg = "'relative_humidity' must be within [0, 100] %."
         raise ValueError(msg)
     if pressure <= 0.0:

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -129,6 +129,12 @@ DEFAULT_FREQUENCIES: tuple[float, ...] = (
     4000.0,
     8000.0,
 )
+#: Tolerance on |x|, x = sqrt(2*pi*N), below which x/tanh(x) is replaced by its
+#: x -> 0 limit of 1+0j (guards the 0/0 indeterminate form at N = 0).
+_X_OVER_TANH_EPS = 1e-9
+#: Illuminated-zone limit of Maekawa's curve: the Fresnel number below which
+#: barrier diffraction is taken as negligible (0 dB).
+_MAEKAWA_ILLUMINATED_LIMIT = -0.2
 
 Complex = NDArray[np.complex128]
 Real = NDArray[np.float64]
@@ -491,13 +497,13 @@ def kurze_anderson_attenuation(fresnel_number: ArrayLike) -> Real:
     # intermediate argument is clipped at -0.2 to keep it clear of the tangent
     # poles of the imaginary-argument branch (this cannot change the result,
     # which is forced to 0 there below) instead of oscillating through them.
-    n_clipped = np.maximum(n, -0.2)
+    n_clipped = np.maximum(n, _MAEKAWA_ILLUMINATED_LIMIT)
     x = np.sqrt(2.0 * np.pi * n_clipped.astype(np.complex128))
     # x / tanh(x) is real for both real and imaginary x; take the real part.
     with np.errstate(divide="ignore", invalid="ignore"):
-        ratio = np.where(np.abs(x) < 1e-9, 1.0 + 0.0j, x / np.tanh(x))
+        ratio = np.where(np.abs(x) < _X_OVER_TANH_EPS, 1.0 + 0.0j, x / np.tanh(x))
     delta = 5.0 + 20.0 * np.log10(np.abs(ratio))
-    delta = np.where(n <= -0.2, 0.0, delta)
+    delta = np.where(n <= _MAEKAWA_ILLUMINATED_LIMIT, 0.0, delta)
     return np.asarray(np.maximum(delta, 0.0), dtype=np.float64)
 
 

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -79,6 +79,10 @@ DEFAULT_FREQUENCIES: tuple[float, ...] = (
 _DZ_LIMIT_SINGLE = 20.0
 #: Barrier attenuation limit for double diffraction (clause 7.4), in dB.
 _DZ_LIMIT_DOUBLE = 25.0
+#: The nominal 63 Hz octave band, lowest row of ISO 9613-2:1996 Table 3: at (or
+#: below, after nominal snapping) it As/Ar is the constant -1.5 dB (Table 3,
+#: col. 2) and the middle-region term is Am = -3q (Table 3, note 2), in hertz.
+_LOWEST_NOMINAL_BAND = 63.0
 
 _NOMINAL_BANDS = np.array(DEFAULT_FREQUENCIES, dtype=np.float64)
 
@@ -469,7 +473,7 @@ def _nearest_nominal(freq: float) -> float:
 
 def _region_attenuation(nominal: float, g: float, h: float, dp: float) -> float:
     """As or Ar contribution for one band (ISO 9613-2:1996, Table 3, col. 2)."""
-    if nominal <= 63.0:
+    if nominal <= _LOWEST_NOMINAL_BAND:
         return -1.5
     if nominal in _PRIME_BY_BAND:
         return -1.5 + g * _PRIME_BY_BAND[nominal](h, dp)
@@ -550,7 +554,11 @@ def ground_attenuation(
         nominal = _nearest_nominal(float(f))
         a_s = _region_attenuation(nominal, ground_source, source_height, dp)
         a_r = _region_attenuation(nominal, ground_receiver, receiver_height, dp)
-        a_m = -3.0 * q if nominal <= 63.0 else -3.0 * q * (1.0 - ground_middle)
+        a_m = (
+            -3.0 * q
+            if nominal <= _LOWEST_NOMINAL_BAND
+            else -3.0 * q * (1.0 - ground_middle)
+        )
         out[i] = a_s + a_r + a_m
     return out
 

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -67,6 +67,16 @@ if TYPE_CHECKING:
 _C_SOUND = 343.0
 #: Default air density ``rho``, in kg/m3 (matches the environmental domain).
 _AIR_DENSITY = 1.205
+#: Fewest samples of a piecewise-linear profile: two nodes define its segment.
+_MIN_POLYLINE_NODES = 2
+#: Slack, in metres, within which the first profile height counts as the ground
+#: z = 0 (float round-off in user-built grids, not a physical height).
+_ORIGIN_SLACK_M = 1e-9
+#: The vertical, in degrees from the horizontal: exclusive launch-angle bound
+#: (at 90 the ray is vertical and the Snell invariant cos(theta0)/c degenerates).
+_VERTICAL_DEG = 90.0
+#: Fewest range steps per marched ray: the launch sample plus one step.
+_MIN_RAY_STEPS = 2
 
 
 # ===========================================================================
@@ -181,7 +191,7 @@ def log_linear_sound_speed_profile(
     if not np.isfinite(b):
         msg = "'b' must be finite."
         raise ValueError(msg)
-    if int(n_points) < 2:
+    if int(n_points) < _MIN_POLYLINE_NODES:
         msg = "'n_points' must be at least 2."
         raise ValueError(msg)
     # Logarithmic height grid from the ground to max_height (z = 0 included).
@@ -213,7 +223,7 @@ def _clean_profile(
     """Validate and return the height/speed arrays of a profile."""
     z = np.asarray(profile.heights, dtype=np.float64)
     c = np.asarray(profile.sound_speeds, dtype=np.float64)
-    if z.ndim != 1 or z.size < 2:
+    if z.ndim != 1 or z.size < _MIN_POLYLINE_NODES:
         msg = "the profile must have at least two height samples."
         raise ValueError(msg)
     if c.shape != z.shape:
@@ -222,7 +232,7 @@ def _clean_profile(
     if not (np.all(np.isfinite(z)) and np.all(np.isfinite(c))):
         msg = "the profile heights and speeds must be finite."
         raise ValueError(msg)
-    if abs(float(z[0])) > 1e-9:
+    if abs(float(z[0])) > _ORIGIN_SLACK_M:
         msg = "the profile must start at the ground z = 0."
         raise ValueError(msg)
     if np.any(np.diff(z) <= 0.0):
@@ -263,7 +273,7 @@ def ray_curvature_radius(
     if not (np.isfinite(gradient) and abs(gradient) > 0.0):
         msg = "'gradient' must be finite and non-zero (a curved ray)."
         raise ValueError(msg)
-    if abs(launch_angle_deg) >= 90.0:
+    if abs(launch_angle_deg) >= _VERTICAL_DEG:
         msg = "'launch_angle_deg' must be within (-90, 90) degrees."
         raise ValueError(msg)
     return float(c0 / (abs(gradient) * np.cos(np.radians(launch_angle_deg))))
@@ -395,14 +405,14 @@ def atmospheric_ray_paths(
         msg = "'source_height' must be non-negative."
         raise ValueError(msg)
     rmax = require_positive(max_range, "max_range")
-    if int(n_steps) < 2:
+    if int(n_steps) < _MIN_RAY_STEPS:
         msg = "'n_steps' must be at least 2."
         raise ValueError(msg)
     angles = np.asarray(launch_angles_deg, dtype=np.float64).ravel()
     if angles.size == 0 or not np.all(np.isfinite(angles)):
         msg = "'launch_angles_deg' must be finite and non-empty."
         raise ValueError(msg)
-    if np.any(np.abs(angles) >= 90.0):
+    if np.any(np.abs(angles) >= _VERTICAL_DEG):
         msg = "'launch_angles_deg' must be within (-90, 90) degrees."
         raise ValueError(msg)
 

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -285,6 +285,17 @@ _OCTAVE_SLICES: tuple[tuple[int, int], ...] = (
     (21, 24),
 )
 
+#: Minimum character length of the four-digit vehicle descriptor of
+#: Table [2.3.a]: at least one character per digit, since the axle-count
+#: digit may run to more than one character.
+_VEHICLE_DESCRIPTOR_MIN_LENGTH = 4
+#: Exact character length of the six-digit track descriptor of Table [2.3.b],
+#: each digit being exactly one character.
+_TRACK_DESCRIPTOR_LENGTH = 6
+#: The ``height`` selector value meaning source B at 4.0 m, whose vertical
+#: directivity follows (2.3.17); 1 selects source A at 0.5 m per (2.3.16).
+_SOURCE_B = 2
+
 
 # ---------------------------------------------------------------------------
 # Vehicle and track descriptors, Tables [2.3.a] and [2.3.b]
@@ -410,7 +421,7 @@ class VehicleDescriptor:
         :raises ValueError: If the code is not a valid four-digit descriptor.
         """
         text = str(code).strip()
-        if len(text) < 4 or not text[1:-2].isdigit():
+        if len(text) < _VEHICLE_DESCRIPTOR_MIN_LENGTH or not text[1:-2].isdigit():
             msg = (
                 f"{code!r} is not a Table [2.3.a] vehicle descriptor: it must "
                 "read <type><axles><brake><measure>, for example 'a4cn'."
@@ -464,7 +475,7 @@ class TrackDescriptor:
         :raises ValueError: If the code is not a valid six-digit descriptor.
         """
         text = str(code).strip()
-        if len(text) != 6:
+        if len(text) != _TRACK_DESCRIPTOR_LENGTH:
             msg = (
                 f"{code!r} is not a Table [2.3.b] track descriptor: it must "
                 "have exactly six digits, for example 'BMSNNN'."
@@ -2213,7 +2224,7 @@ def vertical_directivity(
     if height not in (1, 2):
         msg = "'height' must be 1 (source A) or 2 (source B)."
         raise ValueError(msg)
-    if height == 2:
+    if height == _SOURCE_B:
         if aerodynamic and angle < 0.0:
             return np.full(len(freqs), 10.0 * np.log10(np.cos(angle) ** 2))
         return np.zeros(len(freqs))

--- a/src/phonometry/environment/sources/cnossos_road.py
+++ b/src/phonometry/environment/sources/cnossos_road.py
@@ -104,6 +104,25 @@ _ROAD_MINIMUM_SPEED = 20.0
 _JUNCTION_RANGE = 100.0
 #: Largest gradient magnitude the gradient correction accounts for (2.2.13), %.
 _MAX_GRADIENT = 12.0
+#: Calendar months in a year: bounds ``T_s`` of (2.2.7), the months per year
+#: over which studded tyres are in use, and annualizes it in (2.2.7).
+_MONTHS_PER_YEAR = 12.0
+#: Road slope, in %, below which the downhill branch of the gradient
+#: correction (2.2.13)-(2.2.16) engages for light vehicles (category 1). That
+#: branch subtracts this threshold's magnitude, 6.0, from the capped downhill
+#: gradient, so the formula keeps that literal rather than this signed value.
+_LIGHT_DOWNHILL_SLOPE = -6.0
+#: Road slope, in %, above which the uphill branch of the gradient correction
+#: (2.2.13)-(2.2.16) engages for light vehicles (category 1). Being positive,
+#: this value is also, unchanged, the offset that branch subtracts from the
+#: capped uphill gradient.
+_LIGHT_UPHILL_SLOPE = 2.0
+#: Road slope, in %, below which the downhill branch of the gradient
+#: correction (2.2.13)-(2.2.16) engages for medium heavy and heavy vehicles
+#: (categories 2 and 3 share the one threshold). Both branch formulae
+#: subtract its magnitude, 4.0, from the capped downhill gradient, not this
+#: signed value.
+_HEAVY_DOWNHILL_SLOPE = -4.0
 
 #: Octave-band A-weighting ``AWC_f,i`` prescribed by 2.5.5 as amended by
 #: Commission Delegated Directive (EU) 2021/1226 Annex point (8)(b), in dB.
@@ -602,17 +621,21 @@ def _studded_correction(
     if not 0.0 <= studded_fraction <= 1.0:
         msg = "'studded_fraction' must be a fraction in [0, 1]."
         raise ValueError(msg)
-    if not 0.0 <= studded_months <= 12.0:
+    if not 0.0 <= studded_months <= _MONTHS_PER_YEAR:
         msg = "'studded_months' must be a number of months in [0, 12]."
         raise ValueError(msg)
-    if key != "1" or studded_months <= 0.0 or studded_fraction <= 0.0:
+    if (
+        key != RoadVehicleCategory.LIGHT.value
+        or studded_months <= 0.0
+        or studded_fraction <= 0.0
+    ):
         return np.zeros(len(ROAD_OCTAVE_BANDS))
     # (2.2.6): the speed dependence saturates below 50 km/h and above 90 km/h.
     clipped = min(max(speed, 50.0), 90.0)
     d_stud = _bands(coefficients.studded_a) + _bands(coefficients.studded_b) * np.log10(
         clipped / ROAD_REFERENCE_SPEED
     )
-    p_s = studded_fraction * studded_months / 12.0  # (2.2.7)
+    p_s = studded_fraction * studded_months / _MONTHS_PER_YEAR  # (2.2.7)
     return np.asarray(
         10.0 * np.log10((1.0 - p_s) + p_s * 10.0 ** (d_stud / 10.0)), dtype=np.float64
     )  # (2.2.8)
@@ -627,19 +650,19 @@ def _gradient_correction(key: str, slope: float, speed: float) -> float:
     """
     if key in ("4a", "4b"):
         return 0.0
-    if key == "1":
-        if slope < -6.0:
+    if key == RoadVehicleCategory.LIGHT.value:
+        if slope < _LIGHT_DOWNHILL_SLOPE:
             return (min(_MAX_GRADIENT, -slope) - 6.0) / 1.0
-        if slope > 2.0:
+        if slope > _LIGHT_UPHILL_SLOPE:
             return (min(_MAX_GRADIENT, slope) - 2.0) / 1.5 * speed / 100.0
         return 0.0
-    if key == "2":
-        if slope < -4.0:
+    if key == RoadVehicleCategory.MEDIUM_HEAVY.value:
+        if slope < _HEAVY_DOWNHILL_SLOPE:
             return (min(_MAX_GRADIENT, -slope) - 4.0) / 0.7 * (speed - 20.0) / 100.0
         if slope > 0.0:
             return min(_MAX_GRADIENT, slope) / 1.0 * speed / 100.0
         return 0.0
-    if slope < -4.0:
+    if slope < _HEAVY_DOWNHILL_SLOPE:
         return (min(_MAX_GRADIENT, -slope) - 4.0) / 0.5 * (speed - 10.0) / 100.0
     if slope > 0.0:
         return min(_MAX_GRADIENT, slope) / 0.8 * speed / 100.0

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -52,6 +52,10 @@ _HANNING_ENBW_FACTOR = 1.5
 #: Low-frequency band where the critical band is fixed to 20-120 Hz.
 _LOW_FREQ_MIN, _LOW_FREQ_MAX = 20.0, 70.0
 _LOW_FREQ_BANDWIDTH = 100.0
+#: Minimum lines of a valid narrowband spectrum (the error message's ">= 3"):
+#: the smallest size with more than one np.diff spacing to compare and
+#: adjacent lines about the candidate peak for the 9.5.2 screen.
+_MIN_SPECTRUM_LINES = 3
 
 
 def _positive(value: float, name: str) -> float:
@@ -287,7 +291,7 @@ def _validate_narrowband(
     """Coerce and validate a uniformly-spaced narrowband spectrum."""
     lv = np.asarray(levels, dtype=np.float64)
     fr = np.asarray(frequencies, dtype=np.float64)
-    if lv.ndim != 1 or lv.shape != fr.shape or lv.size < 3:
+    if lv.ndim != 1 or lv.shape != fr.shape or lv.size < _MIN_SPECTRUM_LINES:
         msg = "'levels' and 'frequencies' must be 1-D and the same length (>= 3)."
         raise ValueError(msg)
     if not (np.all(np.isfinite(lv)) and np.all(np.isfinite(fr))):
@@ -444,7 +448,7 @@ def wind_turbine_tonality(
     tone_energy = 0.0
     for run in runs:
         run_energy = float(np.sum(10.0 ** (lv[run] / 10.0)))
-        if run.size >= 2:
+        if run.size >= 2:  # noqa: PLR2004
             run_energy /= _HANNING_ENBW_FACTOR
         tone_energy += run_energy
     l_pt = 10.0 * np.log10(tone_energy)

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -55,6 +55,9 @@ __all__ = [
 
 _G = 10 ** (3 / 10)
 
+# Fewest per-band frequency-grid points the class verification accepts.
+_MIN_GRID_POINTS = 16
+
 # BS EN 61260-1:2014 Table 1, high side (Omega >= 1), as exponents x of the
 # octave-band normalized frequency G**x with (min, max) limits per class.
 # The low side mirrors these at 1/Omega (Formula 10). The band-edge rows
@@ -313,7 +316,7 @@ def verify_filter_class(
         frequency the band's verification could reach (its processing Nyquist
         over ``f_m``).
     """
-    if num_points < 16:
+    if num_points < _MIN_GRID_POINTS:
         msg = "'num_points' must be at least 16."
         raise ValueError(msg)
     spec = _FILTER_EDITIONS.get(edition)

--- a/src/phonometry/filters/core.py
+++ b/src/phonometry/filters/core.py
@@ -11,7 +11,11 @@ from typing import Literal, cast, overload
 import numpy as np
 from scipy import signal
 
-from .._internal.utils import _downsamplingfactor, _resample_to_length
+from .._internal.utils import (
+    _ZI_NDIM_MULTICHANNEL,
+    _downsamplingfactor,
+    _resample_to_length,
+)
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import (
     like_input,
@@ -137,7 +141,7 @@ def _validate_bank_design(
         raise ValueError(msg)
     if limits is None:
         limits = [12, 20000]
-    if len(limits) != 2:
+    if len(limits) != 2:  # noqa: PLR2004
         msg = "Limits must be a list of two frequencies [f_min, f_max]."
         raise ValueError(msg)
     if limits[0] <= 0 or limits[1] <= 0:
@@ -632,7 +636,10 @@ class OctaveFilterBank:
         elif self.stateful:
             n_channels = sd.shape[0]
             # Lazy init: allocate zi with correct channel count on first use
-            if self.zi[idx].ndim < 3 or self.zi[idx].shape[1] != n_channels:
+            if (
+                self.zi[idx].ndim < _ZI_NDIM_MULTICHANNEL
+                or self.zi[idx].shape[1] != n_channels
+            ):
                 n_sections = self.sos[idx].shape[0]
                 if not self._steady_ic:
                     self.zi[idx] = np.zeros((n_sections, n_channels, 2))

--- a/src/phonometry/filters/design.py
+++ b/src/phonometry/filters/design.py
@@ -8,6 +8,12 @@ from __future__ import annotations
 import numpy as np
 from scipy import signal
 
+from .frequencies import _format_nominal_freq
+
+# Fewest standard-frequency ticks that must land inside the plotted range
+# before _showfilter falls back to plain powers-of-10 decade ticks.
+_MIN_STANDARD_TICKS = 3
+
 
 def _cheby2_transition_ratio(order: int, attenuation: float) -> float:
     """Ratio between stopband-edge and -3 dB frequencies for a Chebyshev II prototype."""
@@ -241,18 +247,13 @@ def _showfilter(
     xticks = [f for f in all_ticks if f_min <= f <= f_max]
 
     # If too few ticks, use simpler logic
-    if len(xticks) < 3:
+    if len(xticks) < _MIN_STANDARD_TICKS:
         # Fallback to powers of 10
         p_min = int(np.floor(np.log10(f_min)))
         p_max = int(np.ceil(np.log10(f_max)))
         xticks = [10**p for p in range(p_min, p_max + 1)]
 
-    xticklabels = []
-    for f in xticks:
-        if f >= 1000:
-            xticklabels.append(f"{f / 1000:g}k")
-        else:
-            xticklabels.append(f"{f:g}")
+    xticklabels = [_format_nominal_freq(f) for f in xticks]
 
     ax.set_xticks(xticks)
     ax.set_xticklabels(xticklabels)

--- a/src/phonometry/filters/equalizer.py
+++ b/src/phonometry/filters/equalizer.py
@@ -107,6 +107,10 @@ _BANDWIDTH_TYPES = ("peaking", "bandpass", "bandpass_skirt", "notch")
 #: the Butterworth alignment of the second-order prototypes.
 _DEFAULT_Q = 1.0 / math.sqrt(2.0)
 
+#: Smallest usable ``n_points`` for :meth:`ParametricEQ.response`: a
+#: log-spaced evaluation grid needs at least its two endpoints.
+_MIN_RESPONSE_POINTS = 2
+
 
 @dataclass(frozen=True)
 class EQSection:
@@ -201,7 +205,7 @@ def _validate_shelf_slope(section: EQSection) -> None:
         return
     big_a = _gain_amplitude(section.gain_db)
     a_sum = big_a + 1.0 / big_a
-    if a_sum <= 2.0:  # A = 1 (gain 0 dB): every positive slope is fine
+    if a_sum <= 2.0:  # A = 1 (gain 0 dB): every positive slope is fine  # noqa: PLR2004
         return
     bound = a_sum / (a_sum - 2.0)
     if section.slope >= bound:
@@ -553,7 +557,7 @@ class ParametricEQ:
         :return: An :class:`EQResponseResult` (carries the SOS cascade and
             plots the magnitude/phase response).
         """
-        if n_points < 2:
+        if n_points < _MIN_RESPONSE_POINTS:
             msg = "'n_points' must be at least 2."
             raise ValueError(msg)
         nyquist = self.fs / 2

--- a/src/phonometry/filters/frequencies.py
+++ b/src/phonometry/filters/frequencies.py
@@ -10,6 +10,18 @@ import numpy as np
 
 from .._internal.warnings import PhonometryWarning
 
+# IEC 61260-1 Annex E.3: a most-significant digit of 1-4 keeps three
+# significant figures, one of 5-9 keeps two.
+_ANNEX_E3_MSD_THRESHOLD = 5.0
+
+# Adjacent mid-band centre ratio separating the two IEC 61260 band structures:
+# octave spacing (2) above it, one-third-octave spacing (2**(1/3) ~ 1.26) below.
+_OCTAVE_SPACING_MIN_RATIO = 1.5
+
+# One kilohertz in hertz: the boundary at which a nominal-frequency label
+# switches to the abbreviated "k" form, and the Hz-to-kHz divisor.
+_HZ_PER_KHZ = 1000
+
 
 def nominal_frequencies(
     fraction: float,
@@ -133,7 +145,11 @@ def _iec_e3_round(f: float) -> float:
         return f
     exponent = int(np.floor(np.log10(f)))
     msd = f / (10.0**exponent)
-    step = 10.0 ** (exponent - 2) if msd < 5.0 else 10.0 ** (exponent - 1)
+    step = (
+        10.0 ** (exponent - 2)
+        if msd < _ANNEX_E3_MSD_THRESHOLD
+        else 10.0 ** (exponent - 1)
+    )
     return round(f / step) * step
 
 
@@ -168,15 +184,15 @@ def _infer_band_fraction(frequency: np.ndarray) -> int:
     report fiche so they classify a band set identically.
     """
     freq = np.asarray(frequency, dtype=np.float64)
-    if freq.size < 2:
+    if freq.size < 2:  # noqa: PLR2004
         return 1
-    return 1 if float(freq[1] / freq[0]) > 1.5 else 3
+    return 1 if float(freq[1] / freq[0]) > _OCTAVE_SPACING_MIN_RATIO else 3
 
 
 def _format_nominal_freq(f: float) -> str:
     """Format a nominal frequency as a human-readable label string."""
-    if f >= 1000:
-        return f"{f / 1000:g}k"
+    if f >= _HZ_PER_KHZ:
+        return f"{f / _HZ_PER_KHZ:g}k"
     return f"{f:g}"
 
 

--- a/src/phonometry/filters/weighting_compliance.py
+++ b/src/phonometry/filters/weighting_compliance.py
@@ -41,6 +41,12 @@ __all__ = [
 
 _INF = float("inf")
 
+# Floor on the `sweep_points` parameter of `verify_weighting_class` (default
+# 4096): fewer grid frequencies would make the geometric grid of the
+# between-nominals sweep too coarse for its verdict to mean anything. The
+# floor is the function's own guard, not a value from the standard.
+_MIN_SWEEP_POINTS = 64
+
 # BS EN 61672-1:2013 Table 3 (standard page 22): design-goal frequency
 # weightings and class 1 / class 2 acceptance limits at the 34 nominal
 # frequencies. Columns: (nominal Hz, A dB, C dB, class1 upper, class1 lower,
@@ -566,7 +572,7 @@ def verify_weighting_class(
     if wf.curve not in _WEIGHTING_COL and wf.curve not in ("B", "AU"):
         msg = "Weighting curve must be 'A', 'B', 'C', 'AU' or 'Z'."
         raise ValueError(msg)
-    if sweep_points < 64:
+    if sweep_points < _MIN_SWEEP_POINTS:
         msg = "'sweep_points' must be at least 64."
         raise ValueError(msg)
 

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -76,6 +76,10 @@ _XY: np.ndarray = np.array(
 
 _HTLAN_DENOM = 120.0  # the compression term denominator of Formula (1).
 
+# Formula (2) covers 10 to 40 years directly; below 10 years Formula (3)
+# extrapolates the median NIPTS from the 10-year value (clause 6.3.1).
+_FORMULA_2_MIN_YEARS = 10.0
+
 #: Exposure durations, in years, the standard validates: Formula (2) covers
 #: 10 to 40 years and Formula (3) is "valid for exposure durations between
 #: 1 year and 10 years"; below 1 year its results "represent an extrapolation"
@@ -348,8 +352,8 @@ def _nipts_components(
     excess2 = np.maximum(l_ex - l0, 0.0) ** 2
     lg_t = math.log10(years)  # lg(t / t0), t0 = 1 year
 
-    n50_10 = (u + v * math.log10(10.0)) * excess2
-    if years >= 10.0:
+    n50_10 = (u + v * math.log10(_FORMULA_2_MIN_YEARS)) * excess2
+    if years >= _FORMULA_2_MIN_YEARS:
         n50 = (u + v * lg_t) * excess2
     else:
         # Formula (3): extrapolate below 10 years from the 10-year value.

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -73,6 +73,31 @@ _U3_DEFAULT: float = 1.0
 #: 10/ln(10), which converts a natural-log derivative to dB (the 4.34 of Eq C.5).
 _C5_FACTOR: float = 10.0 / np.log(10.0)  # = 4.3429...
 
+#: Fewest observations for a sample spread to exist (the ddof=1 standard
+#: deviations of Eq C.6/C.7/C.12 and the max-minus-min range); below it the
+#: dispersion is taken as 0 and Table C.4 rejects the sample count.
+_MIN_SAMPLES_FOR_SPREAD: int = 2
+
+#: 3 dB spread-rule threshold (Clauses 9.3 and 11.3): samples spanning this
+#: much or more trigger the advisory recommending further measurements.
+_SPREAD_ADVISORY_THRESHOLD: float = 3.0
+
+#: Clause 11.3 minimum of three whole-day measurements; the spread rule
+#: fires only when exactly this many are supplied.
+_MIN_FULL_DAY_SAMPLES: int = 3
+
+#: Largest group size n_G in the first band of Table 1 (flat 5 h minimum
+#: cumulative measurement duration).
+_TABLE1_SMALL_GROUP_MAX: int = 5
+
+#: Upper group-size edge of Table 1's second band (6 to 15 workers,
+#: +0.5 h per additional worker).
+_TABLE1_MEDIUM_GROUP_MAX: int = 15
+
+#: Largest group size Table 1 tabulates (16 to 40 workers, +0.25 h per
+#: worker); above it the standard advises splitting the group (17 h fallback).
+_TABLE1_LARGE_GROUP_MAX: int = 40
+
 InstrumentClass = Literal["class1", "class2", "personal_exposimeter"]
 
 #: Instrument standard uncertainty u2 by class (Table C.5), dB.
@@ -168,7 +193,7 @@ def table_c4_contribution(n_samples: int, u1: float) -> float:
     :param u1: Standard uncertainty of the samples, dB (>= 0).
     :return: The contribution :math:`c_1 u_1` in dB.
     """
-    if n_samples < 2:
+    if n_samples < _MIN_SAMPLES_FOR_SPREAD:
         msg = "Table C.4 needs at least 2 samples."
         raise ValueError(msg)
     if u1 < 0:
@@ -203,11 +228,11 @@ def minimum_cumulative_duration_hours(n_workers: int) -> float:
     if n_workers < 1:
         msg = "'n_workers' must be a positive integer."
         raise ValueError(msg)
-    if n_workers <= 5:
+    if n_workers <= _TABLE1_SMALL_GROUP_MAX:
         return 5.0
-    if n_workers <= 15:
+    if n_workers <= _TABLE1_MEDIUM_GROUP_MAX:
         return 5.0 + (n_workers - 5) * 0.5
-    if n_workers <= 40:
+    if n_workers <= _TABLE1_LARGE_GROUP_MAX:
         return 10.0 + (n_workers - 15) * 0.25
     return 17.0
 
@@ -221,7 +246,7 @@ def _sampling_std(levels: Sequence[float]) -> float:
     Used for the job/full-day sampling uncertainty ``u1`` (denominator ``N-1``).
     """
     arr = np.asarray(levels, dtype=float)
-    if arr.size < 2:
+    if arr.size < _MIN_SAMPLES_FOR_SPREAD:
         return 0.0
     return float(np.std(arr, ddof=1))
 
@@ -234,7 +259,7 @@ def _task_sampling_uncertainty(levels: Sequence[float]) -> float:
     smaller than the Eq C.12 sample standard deviation used for the job method.
     """
     arr = np.asarray(levels, dtype=float)
-    if arr.size < 2:
+    if arr.size < _MIN_SAMPLES_FOR_SPREAD:
         return 0.0
     return float(np.std(arr, ddof=1) / sqrt(arr.size))
 
@@ -452,7 +477,7 @@ def _duration_uncertainty(task: Task) -> float:
     """
     if task.duration_samples is not None:
         j = np.asarray(task.duration_samples, dtype=float)
-        if j.size < 2:
+        if j.size < _MIN_SAMPLES_FOR_SPREAD:
             return 0.0
         # Eq C.7 divides by J(J-1), like Eq C.6: standard error of the mean.
         return float(np.std(j, ddof=1) / sqrt(j.size))
@@ -476,8 +501,10 @@ def _task_contribution(
     """One task's Eq C.3 terms (Eq C.4 to C.7) and its Clause 9.3 spread advisory."""
     samples = np.asarray(task.samples, dtype=float)
     n = int(samples.size)
-    sample_range = float(samples.max() - samples.min()) if n >= 2 else 0.0
-    spread = n >= 2 and sample_range >= 3.0
+    sample_range = (
+        float(samples.max() - samples.min()) if n >= _MIN_SAMPLES_FOR_SPREAD else 0.0
+    )
+    spread = n >= _MIN_SAMPLES_FOR_SPREAD and sample_range >= _SPREAD_ADVISORY_THRESHOLD
 
     u1a = _task_sampling_uncertainty(task.samples)
     # c1a (Eq C.4): (T_m/T0) * 10^(0.1 (Lp - LEX,8h)); L* ~ Lp since Q2,Q3 ~ 0.
@@ -589,7 +616,7 @@ def _sampled_exposure(
     """Shared engine for job-based and full-day strategies (Eq 11-13, Eq C.9)."""
     arr = np.asarray(samples, dtype=float)
     n = int(arr.size)
-    if n < 2:
+    if n < _MIN_SAMPLES_FOR_SPREAD:
         msg = "At least two samples are required."
         raise ValueError(msg)
     if effective_duration_hours <= 0:
@@ -715,7 +742,10 @@ def full_day_exposure(
     :return: An :class:`ExposureResult`.
     """
     arr = np.asarray(samples, dtype=float)
-    spread = arr.size == 3 and float(arr.max() - arr.min()) >= 3.0
+    spread = (
+        arr.size == _MIN_FULL_DAY_SAMPLES
+        and float(arr.max() - arr.min()) >= _SPREAD_ADVISORY_THRESHOLD
+    )
     if spread and warn:
         warnings.warn(
             f"Only three full-day measurements spanning {float(arr.max() - arr.min()):.1f} dB "

--- a/src/phonometry/io/_backends.py
+++ b/src/phonometry/io/_backends.py
@@ -40,7 +40,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.warnings import PhonometryWarning
-from ._chunks import WAVE_FORMAT_IEEE_FLOAT, WAVE_FORMAT_PCM, parse_wav_chunks
+from ._chunks import (
+    _WAVE_FORM_TYPE,
+    WAVE_FORMAT_IEEE_FLOAT,
+    WAVE_FORMAT_PCM,
+    parse_wav_chunks,
+)
 from ._flac import read_flac_bext
 from ._sidecar import read_sidecar
 from ._signal import Signal, SignalOrigin
@@ -54,11 +59,16 @@ class LossyCompressionWarning(PhonometryWarning):
     """Warns that samples came through a lossy codec: levels are not defensible."""
 
 
+#: The sniffer's name for FLAC: the display name interpolated into errors
+#: and warnings, and the dispatch key that gates ``bext`` recovery. One
+#: spelling for the _MAGIC row and every comparison, so they cannot drift.
+_FLAC_NAME = "FLAC"
+
 #: Leading magic bytes -> format name, for dispatch and for error messages
 #: that name what the file actually is. The WAV family is recognised
 #: separately (fourcc + ``WAVE`` form type).
 _MAGIC: tuple[tuple[bytes, str], ...] = (
-    (b"fLaC", "FLAC"),
+    (b"fLaC", _FLAC_NAME),
     (b"OggS", "Ogg (Vorbis/Opus)"),
     (b"ID3", "MPEG audio (MP3)"),
     (b"FORM", "AIFF"),
@@ -67,6 +77,12 @@ _MAGIC: tuple[tuple[bytes, str], ...] = (
 )
 
 _WAV_FOURCC = (b"RIFF", b"RF64", b"BW64")
+
+#: MPEG audio frame sync: the 11 set bits that open every MP3 frame,
+#: recognised as a full first byte plus the top three bits of the second.
+_MPEG_SYNC_BYTES = 2  # least header length the sync test needs
+_MPEG_SYNC_BYTE_1 = 0xFF  # first 8 of the 11 set sync bits
+_MPEG_SYNC_BYTE_2_MASK = 0xE0  # remaining 3 sync bits: mask and expected value
 
 #: soundfile subtype substrings that mark a lossy or companded codec.
 #: libsndfile subtypes are stable identifiers ('VORBIS', 'OPUS',
@@ -108,14 +124,18 @@ def _sniff(path: str | Path) -> str | None:
     """
     with Path(path).open("rb") as fh:
         head = fh.read(12)
-    if head[:4] in _WAV_FOURCC and head[8:12] == b"WAVE":
+    if head[:4] in _WAV_FOURCC and head[8:12] == _WAVE_FORM_TYPE:
         return None
     for magic, name in _MAGIC:
         if head.startswith(magic):
             return name
     # An MP3 without an ID3 tag starts straight at a frame sync
     # (11 set bits: 0xFF 0xE0).
-    if len(head) >= 2 and head[0] == 0xFF and head[1] & 0xE0 == 0xE0:
+    if (
+        len(head) >= _MPEG_SYNC_BYTES
+        and head[0] == _MPEG_SYNC_BYTE_1
+        and head[1] & _MPEG_SYNC_BYTE_2_MASK == _MPEG_SYNC_BYTE_2_MASK
+    ):
         return "MPEG audio (MP3)"
     msg = f"{path}: not a recognised audio file"
     raise ValueError(msg)
@@ -172,7 +192,7 @@ def _read_soundfile(
     data, fs = sf.read(str(path), dtype="float64", always_2d=True)
     if chunks is not None:
         provenance = chunks.bext
-    elif format_name == "FLAC":
+    elif format_name == _FLAC_NAME:
         # A FLAC written by phonometry (or by flac --keep-foreign-metadata)
         # carries the bext chunk in an APPLICATION 'riff' block.
         provenance = read_flac_bext(path)
@@ -296,5 +316,5 @@ def info(path: str | Path) -> AudioFileInfo:
         duration=frames / float(fs) if fs else 0.0,
         bit_depth=_SUBTYPE_BITS.get(str(file_info.subtype)),
         lossy=_soundfile_lossy(str(file_info.subtype)),
-        bext=read_flac_bext(path) if format_name == "FLAC" else None,
+        bext=read_flac_bext(path) if format_name == _FLAC_NAME else None,
     )

--- a/src/phonometry/io/_bext.py
+++ b/src/phonometry/io/_bext.py
@@ -70,7 +70,12 @@ import math
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from ._chunks import _BEXT_FIXED, _LOUDNESS_UNSET, BroadcastMetadata
+from ._chunks import (
+    _BEXT_FIXED,
+    _BEXT_LOUDNESS_MIN_VERSION,
+    _LOUDNESS_UNSET,
+    BroadcastMetadata,
+)
 
 if TYPE_CHECKING:
     import numpy as np
@@ -84,6 +89,9 @@ _STRING_FIELDS: tuple[tuple[str, str, int], ...] = (
     ("origination_date", "OriginationDate", 10),
     ("origination_time", "OriginationTime", 8),
 )
+
+#: Byte size of the fixed UMID (SMPTE ST 330) field -- the "64s" of _BEXT_FIXED.
+_UMID_BYTES = 64
 
 
 def _encode_loudness(value: float | None) -> int:
@@ -150,14 +158,16 @@ def serialize_bext(meta: BroadcastMetadata) -> bytes:
         meta.max_momentary_loudness,
         meta.max_short_term_loudness,
     )
-    if meta.version < 2 and any(value is not None for value in loudness):
+    if meta.version < _BEXT_LOUDNESS_MIN_VERSION and any(
+        value is not None for value in loudness
+    ):
         msg = (
             f"bext version {meta.version} has no loudness fields "
             "(version >= 2); raise the version instead of losing them"
         )
         raise ValueError(msg)
     umid = meta.umid or b""
-    if len(umid) > 64:
+    if len(umid) > _UMID_BYTES:
         msg = f"bext UMID is {len(umid)} bytes; the field holds 64"
         raise ValueError(msg)
     history = meta.coding_history.encode("latin-1")
@@ -170,7 +180,7 @@ def serialize_bext(meta: BroadcastMetadata) -> bytes:
             umid,
             *(
                 (_encode_loudness(value) for value in loudness)
-                if meta.version >= 2
+                if meta.version >= _BEXT_LOUDNESS_MIN_VERSION
                 else (0, 0, 0, 0, 0)
             ),
             b"",  # the 180 reserved bytes: zeros in every version

--- a/src/phonometry/io/_blocks.py
+++ b/src/phonometry/io/_blocks.py
@@ -54,6 +54,13 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
+# Bit depths that pick the linear decoder's branch, per the scaling
+# convention of :mod:`phonometry.io._wav`.
+_SINGLE_PRECISION_BITS = 32  # IEEE float stored as "<f4"; the other width is "<f8"
+_UNSIGNED_PCM_BITS = 8  # the one unsigned PCM depth, re-centred on 128
+_THREE_BYTE_PCM_BITS = 24  # packed byte triplets; the depth no numpy dtype can map
+_TWO_BYTE_PCM_BITS = 16  # signed PCM through "<i2"; the other mappable depth is "<i4"
+
 
 def _decode_linear_frames(raw: bytes, fmt: FormatChunk) -> NDArray[np.float64]:
     """Decode interleaved linear PCM/float bytes to ``(channels, frames)``.
@@ -66,11 +73,13 @@ def _decode_linear_frames(raw: bytes, fmt: FormatChunk) -> NDArray[np.float64]:
     """
     bits = fmt.bits_per_sample
     if fmt.resolved_tag == WAVE_FORMAT_IEEE_FLOAT:
-        data = np.frombuffer(raw, dtype="<f4" if bits == 32 else "<f8")
+        data = np.frombuffer(
+            raw, dtype="<f4" if bits == _SINGLE_PRECISION_BITS else "<f8"
+        )
         scaled = data.astype(np.float64)
-    elif bits == 8:
+    elif bits == _UNSIGNED_PCM_BITS:
         scaled = (np.frombuffer(raw, dtype=np.uint8).astype(np.float64) - 128.0) / 128.0
-    elif bits == 24:
+    elif bits == _THREE_BYTE_PCM_BITS:
         triplets = np.frombuffer(raw, dtype=np.uint8).reshape(-1, 3)
         values = (
             triplets[:, 0].astype(np.int32)
@@ -79,7 +88,7 @@ def _decode_linear_frames(raw: bytes, fmt: FormatChunk) -> NDArray[np.float64]:
         )
         scaled = ((values ^ 0x800000) - 0x800000) / float(2**23)
     else:
-        data = np.frombuffer(raw, dtype="<i2" if bits == 16 else "<i4")
+        data = np.frombuffer(raw, dtype="<i2" if bits == _TWO_BYTE_PCM_BITS else "<i4")
         scaled = data.astype(np.float64) / float(2 ** (bits - 1))
     frames = scaled.reshape(-1, fmt.channels)
     return np.ascontiguousarray(frames.T)

--- a/src/phonometry/io/_chunks.py
+++ b/src/phonometry/io/_chunks.py
@@ -157,6 +157,57 @@ _BEXT_FIXED = struct.Struct("<256s32s32s10s8sIIH64shhhhh180s")
 #: rather than reporting an absurd 327.67 LUFS.
 _LOUDNESS_UNSET = 0x7FFF
 
+#: The ``bext`` version (EBU Tech 3285 v2, 2011) from which the five
+#: loudness fields carry values; below it those bytes are still reserved
+#: space and the reader returns the fields as ``None``.
+_BEXT_LOUDNESS_MIN_VERSION = 2
+
+#: Chunk IDs (fourccs) of the wire vocabulary the walker speaks. ``fmt``
+#: and ``cue`` carry the pad space RIFF requires to make 4 bytes (a
+#: re-typed ``b"fmt"`` would silently never match) and ``iXML``'s mixed
+#: case is likewise the spec's own.
+_FMT_CHUNK = b"fmt "  # wFormatTag/channels/rate/bits (1991 RIFF spec)
+_DS64_CHUNK = b"ds64"  # RF64/BW64 64-bit sizes (EBU Tech 3306)
+_BEXT_CHUNK = b"bext"  # EBU Tech 3285 broadcast extension
+_FACT_CHUNK = b"fact"  # uint32 frame count, mandatory for compressed formats
+_CUE_CHUNK = b"cue "  # event markers a recorder writes (1991 RIFF spec)
+_DATA_CHUNK = b"data"  # sample payload: located, deliberately never read
+_IXML_CHUNK = b"iXML"  # production metadata, recorded only as a presence flag
+
+#: RIFF form-type fourcc at bytes 8-12 of the prelude: declares that this
+#: RIFF/RF64/BW64 container holds a WAVE form (1991 Multimedia Programming
+#: Interface spec).
+_WAVE_FORM_TYPE = b"WAVE"
+
+#: Byte size of the RIFF prelude: 4-byte container fourcc, uint32 outer
+#: size, 4-byte ``WAVE`` form type.
+_RIFF_PRELUDE_BYTES = 12
+
+#: Byte size of one RIFF chunk header, the ``(fourcc, uint32 size)`` pair.
+_CHUNK_HEADER_BYTES = 8
+
+#: Byte width of one little-endian ``uint32`` field, e.g. the cue chunk's
+#: leading record count or the ``fact`` chunk's frame count.
+_UINT32_BYTES = 4
+
+#: Byte size of the six mandatory ``fmt`` fields (``<HHIIHH``), the
+#: minimum legal ``fmt`` chunk payload (1991 RIFF spec).
+_FMT_BASE_BYTES = 16
+
+#: Minimum ``fmt`` payload for WAVE_FORMAT_EXTENSIBLE: the 16-byte base
+#: plus the 2-byte ``cbSize`` plus the 22-byte extension (valid bits,
+#: channel mask, 16-byte SubFormat GUID).
+_FMT_EXTENSIBLE_BYTES = 40
+
+#: Byte size of the three mandatory 64-bit fields of a ``ds64`` chunk
+#: (``riffSize, dataSize, sampleCount`` as ``<QQQ``, EBU Tech 3306);
+#: distinct from the 24-byte cue-point record, which must not share it.
+_DS64_FIXED_BYTES = 24
+
+#: The RF64 size sentinel of EBU Tech 3306: a 32-bit chunk-size field set
+#: to 0xFFFFFFFF defers the true 64-bit size to the ``ds64`` chunk.
+_RF64_SIZE_SENTINEL = 0xFFFFFFFF
+
 
 @dataclass(frozen=True)
 class FormatChunk:
@@ -419,7 +470,7 @@ def _parse_bext(payload: bytes) -> BroadcastMetadata:
     coding_history = (
         payload[_BEXT_FIXED.size :].split(b"\x00", 1)[0].decode("latin-1").rstrip()
     )
-    v2 = version >= 2
+    v2 = version >= _BEXT_LOUDNESS_MIN_VERSION
     return BroadcastMetadata(
         description=_ascii_field(description),
         originator=_ascii_field(originator),
@@ -440,7 +491,7 @@ def _parse_bext(payload: bytes) -> BroadcastMetadata:
 
 def _parse_fmt(payload: bytes) -> FormatChunk:
     """Decode ``fmt``, including the EXTENSIBLE extension when present."""
-    if len(payload) < 16:
+    if len(payload) < _FMT_BASE_BYTES:
         msg = f"fmt chunk is {len(payload)} bytes; at least 16 required"
         raise ValueError(msg)
     tag, channels, fs, byte_rate, block_align, bits = struct.unpack_from(
@@ -450,7 +501,7 @@ def _parse_fmt(payload: bytes) -> FormatChunk:
     channel_mask: int | None = None
     subformat: bytes | None = None
     if tag == WAVE_FORMAT_EXTENSIBLE:
-        if len(payload) < 40:
+        if len(payload) < _FMT_EXTENSIBLE_BYTES:
             msg = (
                 f"WAVE_FORMAT_EXTENSIBLE fmt chunk is {len(payload)} bytes; "
                 "the 22-byte extension requires 40"
@@ -458,7 +509,7 @@ def _parse_fmt(payload: bytes) -> FormatChunk:
             raise ValueError(msg)
         # cbSize (uint16 at offset 16) precedes the extension proper.
         valid_bits, channel_mask = struct.unpack_from("<HI", payload, 18)
-        subformat = payload[24:40]
+        subformat = payload[24:_FMT_EXTENSIBLE_BYTES]
     return FormatChunk(
         format_tag=tag,
         channels=channels,
@@ -482,11 +533,11 @@ def _parse_cue(payload: bytes) -> tuple[CuePoint, ...]:
     :exc:`struct.error` (which a caller filtering on ``ValueError``, the
     type every other malformed-chunk path here raises, would not catch).
     """
-    if len(payload) < 4:
+    if len(payload) < _UINT32_BYTES:
         msg = f"cue chunk is {len(payload)} bytes; its uint32 record count requires 4"
         raise ValueError(msg)
     (count,) = struct.unpack_from("<I", payload)
-    needed = 4 + 24 * count
+    needed = _UINT32_BYTES + 24 * count
     if len(payload) < needed:
         msg = (
             f"cue chunk declares {count} points but is {len(payload)} "
@@ -496,7 +547,7 @@ def _parse_cue(payload: bytes) -> tuple[CuePoint, ...]:
     points = []
     for i in range(count):
         cue_id, position, chunk_id, chunk_start, block_start, sample_offset = (
-            struct.unpack_from("<II4sIII", payload, 4 + 24 * i)
+            struct.unpack_from("<II4sIII", payload, _UINT32_BYTES + 24 * i)
         )
         points.append(
             CuePoint(
@@ -513,7 +564,7 @@ def _parse_cue(payload: bytes) -> tuple[CuePoint, ...]:
 
 def _parse_ds64(payload: bytes, path: str | Path) -> Ds64Chunk:
     """Decode the three mandatory 64-bit sizes of a ``ds64`` chunk."""
-    if len(payload) < 24:
+    if len(payload) < _DS64_FIXED_BYTES:
         msg = (
             f"{path}: ds64 chunk is {len(payload)} bytes; the "
             "riffSize, dataSize and sampleCount fields require 24"
@@ -529,7 +580,7 @@ def _parse_ds64(payload: bytes, path: str | Path) -> Ds64Chunk:
 
 def _parse_fact(payload: bytes, path: str | Path) -> int:
     """Decode the ``fact`` chunk's single uint32 frame count."""
-    if len(payload) < 4:
+    if len(payload) < _UINT32_BYTES:
         msg = (
             f"{path}: fact chunk is {len(payload)} bytes; its "
             "uint32 frame count requires 4"
@@ -541,8 +592,8 @@ def _parse_fact(payload: bytes, path: str | Path) -> int:
 
 def _read_wave_header(fh: BinaryIO, path: str | Path) -> str:
     """Check the 12-byte RIFF prelude and name the container it declares."""
-    header = fh.read(12)
-    if len(header) < 12 or header[8:12] != b"WAVE":
+    header = fh.read(_RIFF_PRELUDE_BYTES)
+    if len(header) < _RIFF_PRELUDE_BYTES or header[8:12] != _WAVE_FORM_TYPE:
         msg = f"{path}: not a WAVE file"
         raise ValueError(msg)
     fourcc = header[:4]
@@ -599,7 +650,7 @@ def _true_data_size(
     size: int, container: str, ds64: Ds64Chunk | None, path: str | Path
 ) -> int:
     """Resolve the ``data`` size, through ``ds64`` for the RF64 sentinel."""
-    if size != 0xFFFFFFFF or container == "WAV":
+    if size != _RF64_SIZE_SENTINEL or container == "WAV":
         return size
     if ds64 is None:
         msg = (
@@ -614,7 +665,9 @@ def _true_data_size(
 #: skipped by seeking, never read: a ``JUNK`` (or any unknown) chunk can
 #: legitimately be huge, and loading it would break the walker's promise
 #: that header inspection costs kilobytes whatever the file size.
-_DECODED_CHUNKS = frozenset({b"fmt ", b"ds64", b"bext", b"fact", b"cue "})
+_DECODED_CHUNKS = frozenset(
+    {_FMT_CHUNK, _DS64_CHUNK, _BEXT_CHUNK, _FACT_CHUNK, _CUE_CHUNK}
+)
 
 
 @dataclass
@@ -630,15 +683,15 @@ class _WalkedChunks:
 
     def absorb(self, chunk_id: bytes, payload: bytes, path: str | Path) -> None:
         """Decode one chunk of :data:`_DECODED_CHUNKS` into its slot."""
-        if chunk_id == b"fmt ":
+        if chunk_id == _FMT_CHUNK:
             self.fmt = _parse_fmt(payload)
-        elif chunk_id == b"ds64":
+        elif chunk_id == _DS64_CHUNK:
             self.ds64 = _parse_ds64(payload, path)
-        elif chunk_id == b"bext":
+        elif chunk_id == _BEXT_CHUNK:
             self.bext = _parse_bext(payload)
-        elif chunk_id == b"fact":
+        elif chunk_id == _FACT_CHUNK:
             self.fact_frames = _parse_fact(payload, path)
-        elif chunk_id == b"cue ":
+        elif chunk_id == _CUE_CHUNK:
             self.cue_points = _parse_cue(payload)
 
 
@@ -675,12 +728,12 @@ def parse_wav_chunks(path: str | Path) -> WavChunks:
         file_size = os.fstat(fh.fileno()).st_size
         container = _read_wave_header(fh, path)
         while True:
-            chunk_header = fh.read(8)
-            if len(chunk_header) < 8:
+            chunk_header = fh.read(_CHUNK_HEADER_BYTES)
+            if len(chunk_header) < _CHUNK_HEADER_BYTES:
                 break
             chunk_id = chunk_header[:4]
             (size,) = struct.unpack("<I", chunk_header[4:])
-            if chunk_id == b"data":
+            if chunk_id == _DATA_CHUNK:
                 size = _true_data_size(size, container, seen.ds64, path)
                 data_offset = fh.tell()
                 data_size = size
@@ -699,7 +752,7 @@ def parse_wav_chunks(path: str | Path) -> WavChunks:
                     path,
                 )
                 continue
-            if chunk_id == b"iXML":
+            if chunk_id == _IXML_CHUNK:
                 seen.has_ixml = True
             # Skipped, not read: unknown chunks (and iXML, kept only as a
             # presence flag) can be arbitrarily large.

--- a/src/phonometry/io/_convert.py
+++ b/src/phonometry/io/_convert.py
@@ -57,7 +57,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ._backends import _import_soundfile, _sniff, info
+from ._backends import _FLAC_NAME, _import_soundfile, _sniff, info
 from ._blocks import read_blocks
 from ._chunks import (
     WAVE_FORMAT_IEEE_FLOAT,
@@ -102,6 +102,10 @@ _SF_SUBTYPE_TRAITS: dict[str, tuple[str, int]] = {
     "DOUBLE": ("float", 64),
 }
 
+#: libsndfile's FLAC integer ceiling: FLAC holds integer PCM up to 24 bits,
+#: above which an integer source cannot pass through a FLAC target whole.
+_FLAC_MAX_PCM_BITS = 24
+
 
 def _source_traits(
     path: str | Path,
@@ -128,7 +132,7 @@ def _source_traits(
     sf = _import_soundfile(format_name)
     file_info = sf.info(str(path))
     kind, bits = _SF_SUBTYPE_TRAITS.get(str(file_info.subtype), ("decoded", 0))
-    bext = read_flac_bext(path) if format_name == "FLAC" else None
+    bext = read_flac_bext(path) if format_name == _FLAC_NAME else None
     return (
         kind,
         bits,
@@ -142,13 +146,13 @@ def _source_traits(
 def _default_subtype(kind: str, bits: int, *, flac: bool) -> str:
     """The subtype that preserves the source, or a demand to choose one."""
     if kind == "int":
-        if bits <= 16:
+        if bits <= _SUBTYPE_BITS["PCM_16"]:
             depth = 16
-        elif bits <= 24:
+        elif bits <= _SUBTYPE_BITS["PCM_24"]:
             depth = 24
         else:
             depth = 32
-        if flac and depth > 24:
+        if flac and depth > _FLAC_MAX_PCM_BITS:
             msg = (
                 "FLAC holds integer PCM up to 24 bits (libsndfile); a "
                 f"{bits}-bit integer source cannot pass through whole. "
@@ -165,7 +169,7 @@ def _default_subtype(kind: str, bits: int, *, flac: bool) -> str:
         )
         raise ValueError(msg)
     if kind == "float":
-        return "FLOAT" if bits == 32 else "DOUBLE"
+        return "FLOAT" if bits == _SUBTYPE_BITS["FLOAT"] else "DOUBLE"
     return "FLOAT"
 
 

--- a/src/phonometry/io/_flac.py
+++ b/src/phonometry/io/_flac.py
@@ -34,7 +34,15 @@ import shutil
 import struct
 from pathlib import Path
 
-from ._chunks import BroadcastMetadata, _parse_bext
+from ._chunks import _BEXT_CHUNK, BroadcastMetadata, _parse_bext
+
+#: The FLAC stream marker (RFC 9639 section 8): the four bytes every
+#: FLAC file must open with, in the mixed case the spec mandates.
+_FLAC_MAGIC = b"fLaC"
+
+#: Byte size of a FLAC metadata block header -- the last-block-flag and
+#: block-type byte plus a 24-bit big-endian length (RFC 9639 section 8).
+_METADATA_BLOCK_HEADER_BYTES = 4
 
 #: FLAC metadata block types (RFC 9639 section 8.1).
 _APPLICATION = 2
@@ -42,6 +50,12 @@ _APPLICATION = 2
 #: The registered application ID the FLAC reference tools use for foreign
 #: RIFF chunks (flac --keep-foreign-metadata).
 _RIFF_APP_ID = b"riff"
+
+#: Preamble bytes inside an APPLICATION payload before the foreign
+#: chunk's data begins: the 4-byte ``riff`` application ID plus the
+#: verbatim RIFF chunk header (4-byte fourcc + 4-byte 32-bit
+#: little-endian size).
+_FOREIGN_CHUNK_HEADER_BYTES = 12
 
 
 def read_flac_bext(path: str | Path) -> BroadcastMetadata | None:
@@ -53,12 +67,12 @@ def read_flac_bext(path: str | Path) -> BroadcastMetadata | None:
     foreign metadata is some other chunk.
     """
     with Path(path).open("rb") as fh:
-        if fh.read(4) != b"fLaC":
+        if fh.read(4) != _FLAC_MAGIC:
             msg = f"{path}: not a FLAC file"
             raise ValueError(msg)
         while True:
             header = fh.read(4)
-            if len(header) < 4:
+            if len(header) < _METADATA_BLOCK_HEADER_BYTES:
                 return None
             block_type = header[0] & 0x7F
             length = int.from_bytes(header[1:4], "big")
@@ -66,11 +80,16 @@ def read_flac_bext(path: str | Path) -> BroadcastMetadata | None:
                 payload = fh.read(length)
                 if (
                     payload[:4] == _RIFF_APP_ID
-                    and payload[4:8] == b"bext"
-                    and len(payload) >= 12
+                    and payload[4:8] == _BEXT_CHUNK
+                    and len(payload) >= _FOREIGN_CHUNK_HEADER_BYTES
                 ):
                     (size,) = struct.unpack_from("<I", payload, 8)
-                    return _parse_bext(payload[12 : 12 + size])
+                    return _parse_bext(
+                        payload[
+                            _FOREIGN_CHUNK_HEADER_BYTES : _FOREIGN_CHUNK_HEADER_BYTES
+                            + size
+                        ]
+                    )
             else:
                 fh.seek(length, 1)
             if header[0] & 0x80:  # that was the last metadata block
@@ -95,7 +114,7 @@ def embed_flac_bext(path: str | Path, bext_payload: bytes) -> None:
     """
     chunk = (
         _RIFF_APP_ID
-        + b"bext"
+        + _BEXT_CHUNK
         + struct.pack("<I", len(bext_payload))
         + bext_payload
         + (b"\x00" if len(bext_payload) % 2 else b"")
@@ -110,13 +129,13 @@ def embed_flac_bext(path: str | Path, bext_payload: bytes) -> None:
     staging = source.with_name(source.name + ".phonometry-tmp")
     with source.open("rb") as src, staging.open("wb") as dst:
         magic = src.read(4)
-        if magic != b"fLaC":
+        if magic != _FLAC_MAGIC:
             msg = f"{path}: not a FLAC file"
             raise ValueError(msg)
         dst.write(magic)
         while True:
             header = src.read(4)
-            if len(header) < 4:
+            if len(header) < _METADATA_BLOCK_HEADER_BYTES:
                 msg = f"{path}: truncated FLAC metadata chain"
                 raise ValueError(msg)
             body = src.read(int.from_bytes(header[1:4], "big"))

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -105,7 +105,7 @@ class Signal:
 
     def __post_init__(self) -> None:
         data = np.atleast_2d(np.asarray(self.data, dtype=np.float64))
-        if data.ndim != 2:
+        if data.ndim != 2:  # noqa: PLR2004
             msg = f"data must be 1-D or (channels, samples); got {data.ndim}-D"
             raise ValueError(msg)
         object.__setattr__(self, "data", np.ascontiguousarray(data))

--- a/src/phonometry/io/_wav.py
+++ b/src/phonometry/io/_wav.py
@@ -66,6 +66,10 @@ if TYPE_CHECKING:
 
     from ._chunks import BroadcastMetadata, CuePoint
 
+# The one linear PCM bit depth scipy cannot memory-map: no numpy dtype can
+# map its 3-byte stride, so read_wav takes scipy's non-mmap path for it.
+_THREE_BYTE_PCM_BITS = 24
+
 
 @dataclass(frozen=True)
 class AudioFileInfo:
@@ -239,7 +243,9 @@ def read_wav(
             # about the skip would tell the user their metadata was lost
             # when it was not.
             warnings.simplefilter("ignore", wavfile.WavFileWarning)
-            fs, raw = wavfile.read(str(path), mmap=fmt.bits_per_sample != 24)
+            fs, raw = wavfile.read(
+                str(path), mmap=fmt.bits_per_sample != _THREE_BYTE_PCM_BITS
+            )
         # scipy returns (frames,) or (frames, channels); the transpose to
         # the library's (channels, samples) is taken before the float
         # conversion so the conversion itself materialises the C-contiguous

--- a/src/phonometry/io/_write.py
+++ b/src/phonometry/io/_write.py
@@ -85,7 +85,7 @@ from ._bext import (
     serialize_bext,
     with_measured_loudness,
 )
-from ._chunks import BroadcastMetadata
+from ._chunks import _RF64_SIZE_SENTINEL, BroadcastMetadata
 from ._signal import Signal
 
 if TYPE_CHECKING:
@@ -111,6 +111,12 @@ _SUBTYPE_SPEC: dict[str, tuple[int, int]] = {
     "DOUBLE": (0x0003, 8),
 }
 
+#: Bytes per sample of PCM_16, read from ``_SUBTYPE_SPEC`` so the value keeps
+#: living in one place: the per-sample width that separates the two
+#: scipy-served integer depths (PCM_16 vs PCM_32) and selects the ``<i2``
+#: dtype.
+_PCM16_SAMPLE_BYTES = _SUBTYPE_SPEC["PCM_16"][1]
+
 #: File suffixes the base writer owns (the WAV family; dispatch on write is
 #: by declared target, unlike the read side's magic bytes -- a file being
 #: created has no bytes to sniff).
@@ -119,6 +125,11 @@ _WAV_SUFFIXES = frozenset({".wav", ".wave", ".bwf"})
 #: numpy integer dtypes accepted for bit-exact pass-through, and the
 #: subtype their codes are.
 _PASSTHROUGH_SUBTYPES = {np.dtype(np.int16): "PCM_16", np.dtype(np.int32): "PCM_32"}
+
+#: Fourcc of the classic 32-bit WAV container: this file's declared size is
+#: the uint32 at offset 4, unlike RF64/BW64 whose real size is the uint64
+#: inside ``ds64`` at offset 20.
+_RIFF_FOURCC = b"RIFF"
 
 
 def _resolve_input(
@@ -151,7 +162,7 @@ def _resolve_input(
     if data.dtype not in _PASSTHROUGH_SUBTYPES:
         data = np.asarray(data, dtype=np.float64)
     data = np.atleast_2d(data)
-    if data.ndim != 2:
+    if data.ndim != 2:  # noqa: PLR2004
         msg = f"x must be 1-D or (channels, samples); got {data.ndim}-D"
         raise ValueError(msg)
     return data, int(fs)
@@ -296,7 +307,7 @@ def build_wav_header(
     # RIFF payload: the WAVE form type, every chunk, the data payload and
     # its pad byte; the outer 8-byte (fourcc + size) header is not counted.
     riff_payload = 4 + len(body) + 8 + data_size + data_size % 2
-    if riff_payload <= 0xFFFFFFFF:
+    if riff_payload <= _RF64_SIZE_SENTINEL:
         return (
             b"RIFF"
             + struct.pack("<I", riff_payload)
@@ -308,12 +319,12 @@ def build_wav_header(
     ds64 = b"ds64" + struct.pack("<IQQQI", 28, riff_payload + 36, data_size, frames, 0)
     return (
         b"RF64"
-        + struct.pack("<I", 0xFFFFFFFF)
+        + struct.pack("<I", _RF64_SIZE_SENTINEL)
         + b"WAVE"
         + ds64
         + body
         + b"data"
-        + struct.pack("<I", 0xFFFFFFFF)
+        + struct.pack("<I", _RF64_SIZE_SENTINEL)
     )
 
 
@@ -368,8 +379,8 @@ def append_riff_chunk(path: str | Path, chunk_id: bytes, payload: bytes) -> None
             fh.write(b"\x00")
         fh.write(frame_riff_chunk(chunk_id, payload))
         riff_size = fh.tell() - 8
-        if fourcc == b"RIFF":
-            if riff_size > 0xFFFFFFFF:
+        if fourcc == _RIFF_FOURCC:
+            if riff_size > _RF64_SIZE_SENTINEL:
                 msg = (
                     f"{path}: appending {len(payload)} bytes overflows the "
                     "32-bit RIFF size; the file needed to be RF64"
@@ -662,7 +673,11 @@ def _write_through_scipy(
         codes, clipped, peak_dbfs = _quantise(data, 8 * sample_bytes, dither, rng)
         if clipped:
             _warn_clipped(path, resolved, clipped, data.size, peak_dbfs)
-        _scipy_write(path, rate, codes.astype("<i2" if sample_bytes == 2 else "<i4"))
+        _scipy_write(
+            path,
+            rate,
+            codes.astype("<i2" if sample_bytes == _PCM16_SAMPLE_BYTES else "<i4"),
+        )
     else:
         _scipy_write(
             path, rate, data if resolved == "DOUBLE" else data.astype(np.float32)

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -113,6 +113,10 @@ _ANNEX_A_SPECIFIC_HEAT_CP = 938.7  # C_P (J/(kg*K))
 _STATIC_REFERENCE_VELOCITY = 0.5e-3
 #: Upper linear-velocity limit of the static method, ISO 9053-1:2018 clause 7.5 (m/s).
 _STATIC_MAX_VELOCITY = 15.0e-3
+#: Minimum stepwise (velocity, pressure-drop) measurement steps of the static method,
+#: ISO 9053-1:2018 clause 7.5: the through-origin fit dp = a*u + b*u**2 has two free
+#: coefficients, so two steps are the least that determine it.
+_MIN_MEASUREMENT_STEPS = 2
 #: Recommended specimen flow-velocity range, ISO 9053-2:2020 clause 6.2 (m/s).
 _ALT_VELOCITY_RANGE = (0.5e-3, 4.0e-3)
 #: Piston frequency range, ISO 9053-2:2020 clause 6.2 (Hz).
@@ -379,7 +383,7 @@ def static_airflow_resistance(
     if u.shape != dp.shape:
         msg = "'velocities' and 'pressure_drops' must have equal length."
         raise ValueError(msg)
-    if u.size < 2:
+    if u.size < _MIN_MEASUREMENT_STEPS:
         msg = "At least two measurement steps are required."
         raise ValueError(msg)
     if bool(np.any(u <= 0.0)):

--- a/src/phonometry/materials/absorbers/biot.py
+++ b/src/phonometry/materials/absorbers/biot.py
@@ -104,6 +104,18 @@ __all__ = [
 #: Shared validation message for open porosities.
 _POROSITY_MESSAGE = "'porosity' must not exceed 1."
 
+#: Upper bound of the Poisson ratio of an isotropic elastic frame:
+#: nu -> 0.5 is the incompressible-solid limit, where the frame bulk modulus
+#: Kb = 2N(nu + 1)/(3(1 - 2 nu)) (Allard & Atalla 2e Eq. (6.29), computed in
+#: ``frame_bulk_modulus`` below) diverges; -1 < nu < 0.5 is the isotropic
+#: stability range.
+_POISSON_INCOMPRESSIBLE_LIMIT = 0.5
+
+#: Discriminator of a two-variable fluid block in the global assembly (the
+#: six-variable alternative is ``"poroelastic"``): the kind decides which
+#: coupling matrices of A&A Sect. 11.4 join two adjacent blocks.
+_FLUID = "fluid"
+
 
 def _require_shear_modulus(value: complex, name: str) -> complex:
     r"""Validate a complex shear modulus :math:`N = N'(1 + j \eta)`."""
@@ -126,7 +138,7 @@ def _require_shear_modulus(value: complex, name: str) -> complex:
 def _require_poisson_ratio(value: float) -> float:
     """Validate a Poisson coefficient of an isotropic frame."""
     nu = float(value)
-    if not -1.0 < nu < 0.5:
+    if not -1.0 < nu < _POISSON_INCOMPRESSIBLE_LIMIT:
         msg = "'poisson_ratio' must satisfy -1 < nu < 0,5."
         raise ValueError(msg)
     return nu
@@ -748,7 +760,7 @@ class _Block:
 def _fluid_block(transfer_matrix: Complex) -> _Block:
     """A two-variable block from its ``(nf, 2, 2)`` chain matrix."""
     identity = np.broadcast_to(np.eye(2, dtype=np.complex128), transfer_matrix.shape)
-    return _Block("fluid", transfer_matrix, np.asarray(identity), 1.0)
+    return _Block(_FLUID, transfer_matrix, np.asarray(identity), 1.0)
 
 
 def _poroelastic_block(
@@ -841,10 +853,10 @@ def _interface(left: _Block | None, right: _Block) -> tuple[Complex, Complex]:
     :math:`[J_{pf}]` (Eq. (11.73)), with the two
     matrices interchanged for a fluid-porous boundary.
     """
-    left_kind = "fluid" if left is None else left.kind
+    left_kind = _FLUID if left is None else left.kind
     left_porosity = 1.0 if left is None else left.porosity
     if left_kind == right.kind:
-        if left_kind == "fluid":
+        if left_kind == _FLUID:
             return (
                 np.eye(2, dtype=np.complex128),
                 -np.eye(2, dtype=np.complex128),
@@ -861,7 +873,7 @@ def _interface(left: _Block | None, right: _Block) -> tuple[Complex, Complex]:
 
 def _wall_matrix(block: _Block) -> Complex:
     r""":math:`[Y]` of A&A Eq. (11.81): zero velocity against a hard wall."""
-    if block.kind == "fluid":
+    if block.kind == _FLUID:
         return np.array([[0.0, 1.0]], dtype=np.complex128)
     return np.eye(6, dtype=np.complex128)[:3]
 
@@ -899,7 +911,7 @@ def _stack_surface_impedance(
     # A semi-infinite fluid behind a poroelastic layer needs its own two
     # variables (A&A Eq. (11.85)); behind a fluid layer the impedance closes
     # the system directly.
-    trailing_fluid = termination is not None and last.kind != "fluid"
+    trailing_fluid = termination is not None and last.kind != _FLUID
     sizes = [2, *(block.unknowns for block in blocks)]
     if trailing_fluid:
         sizes.append(2)

--- a/src/phonometry/materials/absorbers/layered.py
+++ b/src/phonometry/materials/absorbers/layered.py
@@ -69,6 +69,23 @@ if TYPE_CHECKING:
 
     from ..._internal.types import Real
 
+#: Discriminator tag of the term tuples built by :func:`_layer_terms`: a
+#: fluid term carries ``(Zx, kx d)`` and takes the fluid-layer branch of the
+#: admittance recursion and of the chain matrix; any other tag is a series
+#: sheet transfer impedance.
+_FLUID = "fluid"
+
+#: Minimum accepted Gauss-Legendre quadrature order for the Paris-integral
+#: evaluation of :func:`diffuse_field_absorption`.
+_MIN_QUADRATURE_POINTS = 2
+
+#: ``|Im(1/z)| = |g2|`` below which :func:`statistical_absorption` replaces
+#: Mechel's arctan term, which cancels catastrophically as ``g2 -> 0``, with
+#: its exact ``g2 -> 0`` series limit: the limit's ``O(g2^2)`` truncation
+#: error is far below double precision at this threshold, while the direct
+#: form is stable for every larger ``|g2|`` (see the comment at the use site).
+_NEAR_REAL_EPS = 1e-30
+
 __all__ = [
     "AirLayer",
     "DiffuseFieldAbsorptionResult",
@@ -390,11 +407,11 @@ def _layer_terms(
             if d > 0.0:
                 zc = np.full(f.shape, rc, dtype=np.complex128)
                 k = np.asarray(k0, dtype=np.complex128)
-                terms.append(("fluid", *_fluid_layer_terms(zc, k, d, k0_sin2)))
+                terms.append((_FLUID, *_fluid_layer_terms(zc, k, d, k0_sin2)))
         elif isinstance(layer, PorousLayer):
             term = _porous_layer_term(layer, f, k0_sin2)
             if term is not None:
-                terms.append(("fluid", *term))
+                terms.append((_FLUID, *term))
         else:
             z = _sheet_impedance(
                 layer,
@@ -472,7 +489,7 @@ def _surface_admittance(
     Stable: ``tan`` saturates where the chain-matrix entries would overflow.
     """
     for kind, a, b in reversed(terms):
-        if kind == "fluid":
+        if kind == _FLUID:
             zx, kxd = a, b
             t = np.tan(kxd)
             g = (g + 1j * t / zx) / (1.0 + 1j * zx * t * g)
@@ -492,7 +509,7 @@ def _chain_matrix(terms: list[tuple[str, Complex, Complex]], f: Real) -> Complex
     t11, t12, t21, t22 = ones, zeros, zeros, ones
     with np.errstate(over="ignore", invalid="ignore"):
         for kind, a, b in terms:
-            if kind == "fluid":
+            if kind == _FLUID:
                 zx, kxd = a, b
                 cos_l, sin_l = np.cos(kxd), np.sin(kxd)
                 m = (cos_l, 1j * zx * sin_l, 1j * sin_l / zx, cos_l)
@@ -539,7 +556,7 @@ def _split_fluid_run(
     :raises ValueError: when the run would need more than *limit* blocks.
     """
     losses = [
-        float(np.max(np.abs(np.imag(b)))) if kind == "fluid" else 0.0
+        float(np.max(np.abs(np.imag(b)))) if kind == _FLUID else 0.0
         for kind, _, b in terms
     ]
     attenuation = sum(losses)
@@ -826,7 +843,7 @@ def diffuse_field_absorption(
         msg = "'angle_limit' must satisfy 0 < angle_limit <= pi/2."
         raise ValueError(msg)
     n = int(quadrature_points)
-    if n < 2:
+    if n < _MIN_QUADRATURE_POINTS:
         msg = "'quadrature_points' must be at least 2."
         raise ValueError(msg)
     nodes, weights = np.polynomial.legendre.leggauss(n)
@@ -913,7 +930,7 @@ def statistical_absorption(
     # threshold, while the direct form is stable for every larger |g2|.
     a = 1.0 + g1
     b = g1 + cos_t
-    near_real = np.abs(g2) < 1e-30
+    near_real = np.abs(g2) < _NEAR_REAL_EPS
     g2_safe = np.where(near_real, 1.0, g2)
     atan_term = np.where(
         near_real,

--- a/src/phonometry/materials/absorbers/porous.py
+++ b/src/phonometry/materials/absorbers/porous.py
@@ -122,6 +122,11 @@ DELANY_BAZLEY_COEFFICIENTS: Mapping[str, tuple[float, ...]] = {
     "wu": (0.212, 0.455, 0.105, 0.607, 0.163, 0.592, 0.188, 0.544),
 }
 
+#: Count of Delany-Bazley power-law coefficients ``C1..C8`` an explicit
+#: ``coefficients`` tuple must supply: four for ``Zc`` and four for ``k``
+#: (Mechel 2e Sect. G.11 Eqs. (1)-(2)), the length of the preset tuples above.
+_DELANY_BAZLEY_COEFFICIENT_COUNT = 8
+
 #: Stated validity range of the Delany-Bazley regression in ``X = rho f/sigma``
 #: (Hopkins Eq. (1.174); Cox & D'Antonio Sect. 6.5.1).
 DELANY_BAZLEY_VALIDITY = (0.01, 1.0)
@@ -353,7 +358,7 @@ def delany_bazley(
     else:
         coeffs = tuple(float(v) for v in coefficients)
         model = "delany_bazley[custom]"
-    if len(coeffs) != 8:
+    if len(coeffs) != _DELANY_BAZLEY_COEFFICIENT_COUNT:
         msg = "'coefficients' must provide exactly 8 values C1..C8."
         raise ValueError(msg)
     c1, c2, c3, c4, c5, c6, c7, c8 = coeffs

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -112,6 +112,11 @@ _INDEX_500 = 1
 #: float-safe grid arithmetic: 0.80, 1.00, 1.00, 1.00, 0.90.
 _REFERENCE_UNITS: tuple[int, ...] = (16, 20, 20, 20, 18)
 
+#: Full scale of the absorption coefficient (alpha = 1,00) in the twentieths
+#: (units of 0,05) of Clause 4.1; the Clause 4.2 shift loop never needs to
+#: lower the reference curve by more than one whole unit of alpha.
+_FULL_SCALE_UNITS = 20
+
 #: Unfavourable-deviation budget of Clause 4.2, in twentieths (0,10).
 _UNFAVOURABLE_BUDGET_UNITS = 2
 
@@ -405,7 +410,7 @@ def _rate(
     # The unfavourable sum is non-increasing in the shift, so the first
     # (smallest) qualifying shift is the answer.
     shift_units = 0
-    while shift_units <= 20:
+    while shift_units <= _FULL_SCALE_UNITS:
         shifted_units = [r - shift_units for r in _REFERENCE_UNITS]
         unfav_units = sum(max(0, s - m) for s, m in zip(shifted_units, measured_units))
         if unfav_units <= _UNFAVOURABLE_BUDGET_UNITS:

--- a/src/phonometry/materials/absorbers/slow_sound.py
+++ b/src/phonometry/materials/absorbers/slow_sound.py
@@ -86,6 +86,10 @@ if TYPE_CHECKING:
 #: Default number of transverse modes kept per axis in the duct series.
 _DUCT_TERMS = 40
 
+#: Minimum modelled absorption coefficient accepted as perfect absorption
+#: at the design point in :func:`critical_coupling_design`.
+_PERFECT_ABSORPTION_THRESHOLD = 0.999
+
 __all__ = [
     "CriticalCouplingResult",
     "HelmholtzResonator",
@@ -874,7 +878,7 @@ def critical_coupling_design(
         sol.success
         and lc_lo <= lc_opt <= lc_hi
         and h_lo <= h_opt <= h_hi
-        and alpha > 0.999
+        and alpha > _PERFECT_ABSORPTION_THRESHOLD
     )
     if not converged:
         warnings.warn(

--- a/src/phonometry/materials/absorbers/uncertainty.py
+++ b/src/phonometry/materials/absorbers/uncertainty.py
@@ -68,6 +68,10 @@ _EQUIV_AREA_REFERENCE_S = 10.0
 #: Repeatability factor ``σr = 0,6·σR`` (Formulae (3)/(5)).
 _REPEATABILITY_FACTOR = 0.6
 
+#: Condition selecting the between-laboratory σR as-is (u = σR); the other
+#: condition, "repeatability", takes σr = 0,6·σR (``_REPEATABILITY_FACTOR``).
+_REPRODUCIBILITY = "reproducibility"
+
 #: Measurement conditions selecting σR (reproducibility) or σr (repeatability).
 _CONDITIONS = ("reproducibility", "repeatability")
 
@@ -112,6 +116,10 @@ _ALPHA_W_SIGMA: dict[str, float] = {"reproducibility": 0.035, "repeatability": 0
 
 #: Single-number rating ``DLα,NRD`` scale factors (Clause 7, Formulae (8)/(9)).
 _DLALPHA_FACTOR: dict[str, float] = {"reproducibility": 0.10, "repeatability": 0.02}
+
+#: Float-key match tolerance for the Table 3 confidence-level lookup; far below
+#: the 0.009 minimum gap between tabulated levels.
+_CONFIDENCE_MATCH_TOL = 1e-9
 
 #: Table 3 (Clause 8): coverage factors ``k`` for a Gaussian measurand, keyed by
 #: confidence level as a fraction. Values are the standard's rounded factors
@@ -164,7 +172,7 @@ def absorption_coverage_factor(confidence: float = 0.95) -> float:
     :raises ValueError: Confidence level not tabulated in Table 3.
     """
     for level, k in _COVERAGE_FACTORS.items():
-        if abs(level - confidence) < 1e-9:
+        if abs(level - confidence) < _CONFIDENCE_MATCH_TOL:
             return k
     valid = ", ".join(f"{level:g}" for level in _COVERAGE_FACTORS)
     msg = (
@@ -270,7 +278,7 @@ def _band_uncertainty(
         raise ValueError(msg)
     m, n = _table_constants(frequencies, table, band_kind)
     sigma_r = m * values + n
-    u = sigma_r if condition == "reproducibility" else _REPEATABILITY_FACTOR * sigma_r
+    u = sigma_r if condition == _REPRODUCIBILITY else _REPEATABILITY_FACTOR * sigma_r
     k = absorption_coverage_factor(confidence)
     return AbsorptionUncertaintyResult(
         quantity=quantity,
@@ -347,7 +355,7 @@ def equivalent_area_uncertainty(
     m, n = _table_constants(f, _TABLE1, "one-third-octave")
     cond = _condition(condition)
     sigma_r = m * a + n * _EQUIV_AREA_REFERENCE_S
-    u = sigma_r if cond == "reproducibility" else _REPEATABILITY_FACTOR * sigma_r
+    u = sigma_r if cond == _REPRODUCIBILITY else _REPEATABILITY_FACTOR * sigma_r
     k = absorption_coverage_factor(confidence)
     return AbsorptionUncertaintyResult(
         quantity="equivalent_area",

--- a/src/phonometry/materials/diffusers/design.py
+++ b/src/phonometry/materials/diffusers/design.py
@@ -98,6 +98,14 @@ _C_DEFAULT = 343.0
 #: -90 deg to +90 deg in 5 deg steps (Clause 6.3, Figure 4), in degrees.
 DEFAULT_POLAR_ANGLES: tuple[int, ...] = tuple(range(-90, 91, 5))
 
+#: Fewest wells a per-period sequence must describe: a single well cannot
+#: form the phase-grating variation the Fraunhofer model sums over.
+_MIN_WELLS = 2
+
+#: Fewest receiver angles of a polar response reducible to the ISO 17497-2
+#: directional diffusion coefficient.
+_MIN_RECEIVERS = 2
+
 
 # ---------------------------------------------------------------------------
 # Validation helpers.
@@ -117,7 +125,7 @@ def _prime_generator(prime: int) -> int:
     if n != prime:
         msg = "'prime' must be an integer."
         raise ValueError(msg)
-    if n < 3 or n % 2 == 0:
+    if n < 3 or n % 2 == 0:  # noqa: PLR2004
         msg = "'prime' must be an odd prime >= 3."
         raise ValueError(msg)
     for factor in range(3, math.isqrt(n) + 1, 2):
@@ -324,7 +332,7 @@ def _resolve_reflection(
         raise ValueError(msg)
     if reflection is not None:
         r = np.atleast_1d(np.asarray(reflection, dtype=np.complex128))
-        if r.ndim != 1 or r.size < 2:
+        if r.ndim != 1 or r.size < _MIN_WELLS:
             msg = "'reflection' must be a 1-D sequence of at least two wells."
             raise ValueError(msg)
         if not np.all(np.isfinite(r)):
@@ -332,7 +340,7 @@ def _resolve_reflection(
             raise ValueError(msg)
         return r
     d = np.atleast_1d(np.asarray(depths, dtype=np.float64))
-    if d.ndim != 1 or d.size < 2:
+    if d.ndim != 1 or d.size < _MIN_WELLS:
         msg = "'depths' must be a 1-D sequence of at least two wells."
         raise ValueError(msg)
     if not np.all(np.isfinite(d)) or np.any(d < 0.0):
@@ -355,7 +363,7 @@ def _prepare_geometry(
     f = _positive_scalar(frequency, "frequency")
     c = _positive_scalar(speed_of_sound, "speed_of_sound")
     ang = np.atleast_1d(np.asarray(angles, dtype=np.float64))
-    if ang.ndim != 1 or ang.size < 2:
+    if ang.ndim != 1 or ang.size < _MIN_RECEIVERS:
         msg = "'angles' must be a 1-D sequence of at least two angles."
         raise ValueError(msg)
     if not np.all(np.isfinite(ang)):

--- a/src/phonometry/materials/diffusers/metadiffuser.py
+++ b/src/phonometry/materials/diffusers/metadiffuser.py
@@ -61,6 +61,10 @@ __all__ = [
     "metadiffuser_reflection",
 ]
 
+# A diffuser needs at least two wells per period to present a spatially
+# varying reflection profile along the panel face; one well cannot diffuse.
+_MIN_WELLS = 2
+
 
 @dataclass(frozen=True)
 class MetadiffuserWell:
@@ -147,7 +151,7 @@ def _check_panel(
     require_positive(depth, "depth")
     require_positive(period, "period")
     cells = tuple(wells)
-    if len(cells) < 2:
+    if len(cells) < _MIN_WELLS:
         msg = "'wells' must contain at least two wells."
         raise ValueError(msg)
     for i, well in enumerate(cells):

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -82,6 +82,11 @@ _T0 = 273.15
 #: attenuation coefficient ``m`` (1/m) of ISO 17497-1 Eq. (3).
 _DB_PER_NEPER = 10.0 * math.log10(math.e)
 
+#: Minimum number ``N`` of spatially-averaged reverberation-time measurements
+#: for the standard error of the mean of ISO 17497-1 Eq. (A.1); the
+#: ``N (N - 1)`` denominator vanishes for a single measurement.
+_MIN_MEASUREMENTS = 2
+
 #: One-third-octave centre frequencies of ISO 17497-1 Table 1, in Hz
 #: (equivalent full-scale ``f / N``), 100 Hz to 5000 Hz.
 BASE_PLATE_BANDS: tuple[int, ...] = (
@@ -608,7 +613,7 @@ def reverberation_time_uncertainty(times: ArrayLike) -> Real:
         msg = "'times' must be a 1-D sequence of measurements."
         raise ValueError(msg)
     n = arr.size
-    if n < 2:
+    if n < _MIN_MEASUREMENTS:
         msg = "'times' needs at least two measurements (N >= 2)."
         raise ValueError(msg)
     mean = arr.mean()

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -60,6 +60,11 @@ __all__ = [
 #: and each of the four +/-30 deg, +/-60 deg sources is weighted 3.
 TWO_DIMENSIONAL_SOURCE_WEIGHTS: tuple[int, ...] = (1, 3, 3, 3, 3)
 
+# Minimum number n of receivers in a polar response (ISO 17497-2,
+# Formulas (5)/(6)): Formula (5)'s (n - 1) denominator vanishes for a
+# single receiver, so the diffusion coefficient is undefined below two.
+_MIN_RECEIVERS = 2
+
 
 @dataclass(frozen=True)
 class DiffusionResult:
@@ -351,7 +356,7 @@ def directional_diffusion_coefficient(
         msg = "'levels' must be a 1-D sequence of receiver SPLs."
         raise ValueError(msg)
     n = lvl.size
-    if n < 2:
+    if n < _MIN_RECEIVERS:
         msg = "'levels' needs at least two receivers (n >= 2)."
         raise ValueError(msg)
     p = np.power(10.0, lvl / 10.0)

--- a/src/phonometry/metrology/calibration.py
+++ b/src/phonometry/metrology/calibration.py
@@ -11,6 +11,16 @@ import numpy as np
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import SignalInput, resolve_optional_fs, resolve_samples
 
+# IEC 60942:2017 Table 2 (p. 16) row edges in Hz for the class 1 short-term
+# level fluctuation limits; outside the specified span the strictest limit
+# is the fallback (see _class1_fluctuation_limit).
+_TABLE2_SPAN_LOW_HZ = 31.5  # bottom of the specified 31.5 Hz to 16 kHz span
+_TABLE2_LOW_ROW_TOP_HZ = 63.0  # top of the 0.20 dB row, floor of the 0.10 dB row
+_TABLE2_STRICT_ROW_MIN_HZ = 160.0  # at and above, the strictest 0.07 dB applies
+# Minimum sample count for the Hann-windowed coherent (Goertzel) tone
+# estimate; a shorter take falls back to broadband RMS.
+_MIN_COHERENT_SAMPLES = 4
+
 
 class CalibrationWarning(PhonometryWarning):
     """The calibration reference recording looks unreliable."""
@@ -27,9 +37,9 @@ def _class1_fluctuation_limit(frequency: float) -> float:
     0.10 dB; 160 Hz and above -> 0.07 dB. Frequencies outside the specified
     31.5 Hz to 16 kHz span fall back to the strictest limit (0.07 dB).
     """
-    if 31.5 <= frequency <= 63.0:
+    if _TABLE2_SPAN_LOW_HZ <= frequency <= _TABLE2_LOW_ROW_TOP_HZ:
         return 0.20
-    if 63.0 < frequency < 160.0:
+    if _TABLE2_LOW_ROW_TOP_HZ < frequency < _TABLE2_STRICT_ROW_MIN_HZ:
         return 0.10
     return 0.07
 
@@ -215,7 +225,7 @@ def _narrowband_tone_rms(signal_arr: np.ndarray, fs: int, frequency: float) -> f
         per_channel = [_narrowband_tone_rms(row, fs, frequency) for row in x]
         return float(np.sqrt(np.mean(np.square(per_channel))))
     n = x.size
-    if n < 4:
+    if n < _MIN_COHERENT_SAMPLES:
         # Too short for a coherent estimate; fall back to broadband RMS.
         return float(np.sqrt(np.mean(x**2)))
     window = np.hanning(n)

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -110,6 +110,14 @@ _EXACT_LIMIT = 100
 #: Fewest observations a trend test accepts (Table A.6 starts at N = 10).
 _MIN_OBSERVATIONS = 10
 
+#: Threshold on the squared Rice bandwidth parameter
+#: :math:`\epsilon^2 = 1 - r^2` below which (:math:`\epsilon \le` ~1e-15,
+#: ``r`` equal to 1 to machine precision) the standardized peak-height
+#: distribution of B&P Eqs. (5.217)/(5.223) is treated as exactly Rayleigh
+#: (the narrow-bandwidth limit, Eqs. (5.206)/(5.222)), avoiding division
+#: by :math:`\epsilon`.
+_EPS_SQ_RAYLEIGH_LIMIT = 1e-30
+
 
 # ---------------------------------------------------------------------------
 # Reverse arrangement test (B&P Sec. 4.5.2, Table A.6)
@@ -826,7 +834,7 @@ def _rice_peak_exceedance(
     r = irregularity
     eps_sq = max(0.0, 1.0 - r * r)
     tail = np.exp(-(z**2) / 2.0)
-    if eps_sq < 1e-30:  # narrow bandwidth limit: exactly Rayleigh
+    if eps_sq < _EPS_SQ_RAYLEIGH_LIMIT:  # narrow bandwidth limit: exactly Rayleigh
         return np.asarray(np.where(z > 0.0, tail, 1.0), dtype=np.float64)
     eps = float(np.sqrt(eps_sq))
     q_first = special.ndtr(-z / eps)
@@ -848,7 +856,7 @@ def _rice_peak_density(
     r = irregularity
     eps_sq = max(0.0, 1.0 - r * r)
     tail = np.exp(-(z**2) / 2.0)
-    if eps_sq < 1e-30:  # narrow bandwidth limit: exactly Rayleigh
+    if eps_sq < _EPS_SQ_RAYLEIGH_LIMIT:  # narrow bandwidth limit: exactly Rayleigh
         return np.asarray(np.where(z > 0.0, z * tail, 0.0), dtype=np.float64)
     eps = float(np.sqrt(eps_sq))
     gaussian = eps / np.sqrt(2.0 * np.pi) * np.exp(-(z**2) / (2.0 * eps_sq))

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -47,6 +47,15 @@ from .._internal.warnings import PhonometryWarning
 
 Model = Callable[..., float]
 
+# Eigenvalues of a caller-supplied correlation matrix down to minus this
+# tolerance are accepted as zero within floating point; anything more
+# negative marks the matrix indefinite (see _validated_correlation).
+_PSD_EIGENVALUE_TOLERANCE = 1e-8
+
+# Minimum number of Monte Carlo trials: the reported standard uncertainty
+# is np.std(output, ddof=1), undefined for fewer than two samples.
+_MIN_TRIALS = 2
+
 
 class UncertaintyWarning(PhonometryWarning):
     """A GUM propagation fell back outside its nominal assumptions."""
@@ -298,7 +307,7 @@ def _validated_correlation(correlation: ArrayLike | None, n: int) -> np.ndarray 
     # A symmetric, unit-diagonal matrix can still be indefinite, which would
     # make the variance negative and be silently masked by the clamp that
     # follows the propagation; reject it.
-    if float(np.min(np.linalg.eigvalsh(r))) < -1e-8:
+    if float(np.min(np.linalg.eigvalsh(r))) < -_PSD_EIGENVALUE_TOLERANCE:
         msg = "correlation matrix must be positive semi-definite."
         raise ValueError(msg)
     return r
@@ -494,8 +503,8 @@ def monte_carlo(
     if len(quantities) == 0:
         msg = "at least one input quantity is required."
         raise ValueError(msg)
-    if trials < 2:
-        msg = "trials must be at least 2."
+    if trials < _MIN_TRIALS:
+        msg = f"trials must be at least {_MIN_TRIALS}."
         raise ValueError(msg)
     if not 0.0 < coverage < 1.0:
         msg = f"coverage must be in (0, 1); got {coverage}."

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -94,6 +94,12 @@ OCTAVE_BANDS: NDArray[np.float64] = np.array(
     [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
 )
 
+# Half an octave, in log2 (octave) units: the half-spacing of adjacent
+# octave-band centres, used as the "same band" criterion so the blade frequency
+# increment C_BFI (Long Table 13.7) lands in exactly the one band of
+# OCTAVE_BANDS that matches the target band.
+_HALF_OCTAVE = 0.5
+
 # Imperial-to-SI conversions. The Reynolds regressions and the ASHRAE fan
 # equation are unit-sensitive empirical fits stated in foot-pound units, so the
 # SI arguments of this module are converted before the published constants are
@@ -102,6 +108,11 @@ _M_PER_FT = 0.3048
 _M_PER_IN = 0.0254
 _M3S_PER_CFM = 0.0004719474432  # 1 ft3/min in m3/s
 _PA_PER_IN_WG = 249.0  # Long Eq. 13.1 reference pressure P_REF
+
+# The perimeter-to-area ratio P/S, in ft^-1, at which the Reynolds (1990)
+# low-frequency (63-250 Hz) regression for unlined rectangular ducts switches
+# between its two fitted branches (Long Eqs. 14.9-14.11).
+_REYNOLDS_PS_SPLIT_PER_FT = 3.0
 
 # ---------------------------------------------------------------------------
 # Bies Table 8.14 -- duct end reflection loss (dB), ASHRAE.
@@ -798,7 +809,7 @@ def fan_efficiency_correction(relative_efficiency: float) -> float:
     :raises ValueError: If the efficiency is not in ``(0, 100]``.
     """
     eta = require_positive(relative_efficiency, "relative_efficiency")
-    if eta > 100.0:
+    if eta > 100.0:  # noqa: PLR2004
         msg = "'relative_efficiency' must not exceed 100 per cent."
         raise ValueError(msg)
     for lower, correction in _EFFICIENCY_CORRECTION:
@@ -877,7 +888,9 @@ def fan_sound_power(
         f_bp = require_positive(blade_frequency, "blade_frequency")
         nearest = int(np.argmin(np.abs(np.log2(f_bp / OCTAVE_BANDS))))
         band = float(OCTAVE_BANDS[nearest])
-    increment = np.where(np.abs(np.log2(OCTAVE_BANDS / band)) < 0.5, c_bfi, 0.0)
+    increment = np.where(
+        np.abs(np.log2(OCTAVE_BANDS / band)) < _HALF_OCTAVE, c_bfi, 0.0
+    )
 
     lw = _FAN_LEVEL_CORRECTION[kind][idx] + duty + c_eff + increment[idx]
     return HvacSpectrumResult(
@@ -958,7 +971,7 @@ def unlined_rectangular_duct_attenuation(
     ell = require_positive(length, "length") / _M_PER_FT
     low = (
         17.0 * ps**0.25 * f**-0.85 * ell
-        if ps >= 3.0
+        if ps >= _REYNOLDS_PS_SPLIT_PER_FT
         else 1.64 * ps**0.73 * f**-0.58 * ell
     )
     if wrapped:

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -134,6 +134,10 @@ _RHO_AIR = 1.206
 #: last bits of a sum like 0.1 + 0.2. Nine orders of magnitude below the length
 #: is far above the arithmetic and far below any dimension anyone draws.
 _MEETING_SLACK = 1e-9
+#: Smallest frequency grid on which an interior minimum of |Z_b| can exist:
+#: two endpoints plus at least one interior candidate, since a least value
+#: sitting on either end is a property of the grid rather than of the branch.
+_MIN_GRID_FOR_INTERIOR_MINIMUM = 3
 
 _Complex = NDArray[np.complex128]
 
@@ -216,7 +220,7 @@ def _shorting_frequency(
     end of the grid is a property of the grid rather than of the branch, and
     is not reported.
     """
-    if f.size < 3:
+    if f.size < _MIN_GRID_FOR_INTERIOR_MINIMUM:
         return None
     magnitude = np.abs(branch_impedance)
     magnitude = np.where(np.isfinite(magnitude), magnitude, np.inf)

--- a/src/phonometry/psychoacoustics/loudness/contours.py
+++ b/src/phonometry/psychoacoustics/loudness/contours.py
@@ -55,6 +55,15 @@ _TABLE1: dict[float, tuple[float, float, float]] = {
 
 _FREQUENCIES = np.array(sorted(_TABLE1))
 
+# Validity range of ISO 226:2023 Formula (1), clause 4.1: contours are
+# specified from 20 phon to 90 phon between 20 Hz and 4 kHz, and only up to
+# 80 phon between 5 kHz and 12.5 kHz - above that level a returned contour
+# is truncated to the grid rows at or below 4 kHz.
+_PHON_MIN = 20.0
+_PHON_MAX = 90.0
+_PHON_MAX_ABOVE_4KHZ = 80.0
+_F_MAX_ABOVE_80_PHON = 4000.0  # Hz
+
 
 def _params(frequency: float) -> tuple[float, float, float]:
     """Table 1 parameters for a preferred third-octave frequency.
@@ -97,13 +106,17 @@ def equal_loudness_contour(phon: float) -> tuple[np.ndarray, np.ndarray]:
     :param phon: Loudness level in phons (20 to 90).
     :return: Tuple ``(frequencies, spl)`` in Hz and dB re 20 uPa.
     """
-    if not 20.0 <= phon <= 90.0:
+    if not _PHON_MIN <= phon <= _PHON_MAX:
         msg = (
             "ISO 226:2023 Formula (1) is specified for 20 phon to 90 phon "
             f"(80 phon above 4 kHz); got {phon!r}."
         )
         raise ValueError(msg)
-    freqs = _FREQUENCIES if phon <= 80.0 else _FREQUENCIES[_FREQUENCIES <= 4000.0]
+    freqs = (
+        _FREQUENCIES
+        if phon <= _PHON_MAX_ABOVE_4KHZ
+        else _FREQUENCIES[_FREQUENCIES <= _F_MAX_ABOVE_80_PHON]
+    )
     spl = np.array([_spl_from_phon(f, phon) for f in freqs])
     return freqs.copy(), spl
 

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -84,6 +84,14 @@ _E_K5 = np.array([0.0, 1.0, 11.0, 11.0, 1.0])  # e_i for k = 5 (below Formula 15
 _Z = np.arange(0.5, 26.5 + 0.25, 0.5)  # critical-band-rate scale, 0.5..26.5
 _CBF = _Z.size  # number of critical band filters = 53
 
+# Band-dependent segmentation (Clause 5.1.5, Table 4): breakpoints on the
+# auditory-filter bandwidth df(z) selecting the block size s_b -- below each
+# limit the named block size applies; at or above the last one the smallest
+# 1024-sample block does.
+_DF_LIMIT_SB_8192 = 85.0
+_DF_LIMIT_SB_4096 = 170.0
+_DF_LIMIT_SB_2048 = 340.0
+
 # Outer and middle/inner ear filter, free field (Table 1): [b0,b1,b2,a1,a2].
 _EAR_FREE = np.array(
     [
@@ -171,6 +179,10 @@ _E_B = 0.5459  # exponent-function parameter b (Table 12)
 _TRANSIENT_BLOCKS = 56  # discard l in [0, 56] (~300 ms) (Clause 8.1.2)
 _R_SD = _FS / 256.0  # common-grid rate 187.5 Hz (Clause 6.2.6)
 
+# Width in time blocks of the Clause 6.2.3 neighbouring-block ACF average
+# (previous + current + next).
+_TIME_AVG_BLOCKS = 3
+
 # Noise-reduction sigmoid (Table 7) and g(z) parameters (Table 8).
 _NR_ALPHA = 20.0
 _NR_BETA = 0.07
@@ -190,11 +202,11 @@ def _block_sizes() -> tuple[np.ndarray, np.ndarray]:
     """Band-dependent block size s_b(z) and hop size s_h(z) (Table 4)."""
     s_b = np.empty(_CBF, dtype=np.int64)
     for i, df in enumerate(_DF):
-        if df < 85.0:
+        if df < _DF_LIMIT_SB_8192:
             s_b[i] = 8192
-        elif df < 170.0:
+        elif df < _DF_LIMIT_SB_4096:
             s_b[i] = 4096
-        elif df < 340.0:
+        elif df < _DF_LIMIT_SB_2048:
             s_b[i] = 2048
         else:
             s_b[i] = 1024
@@ -204,6 +216,7 @@ def _block_sizes() -> tuple[np.ndarray, np.ndarray]:
 
 _S_B, _S_H = _block_sizes()
 _S_B_MAX = int(_S_B.max())  # 8192
+_S_B_MIN = int(_S_B.min())  # 1024
 _S_H_MAX = int(_S_H.max())  # 2048
 # Interpolation factor to the common time grid (Table 6): s_h / 256.
 _INTERP = (_S_H // 256).astype(np.int64)
@@ -497,9 +510,9 @@ def _average_blocks(averaged: list[np.ndarray]) -> list[np.ndarray]:
     out: list[np.ndarray] = []
     for band in range(_CBF):
         acf = averaged[band]
-        if int(_S_B[band]) in (8192, 4096) and acf.shape[0] >= 3:
+        if int(_S_B[band]) in (8192, 4096) and acf.shape[0] >= _TIME_AVG_BLOCKS:
             smoothed = acf.copy()
-            smoothed[1:-1] = (acf[:-2] + acf[1:-1] + acf[2:]) / 3.0
+            smoothed[1:-1] = (acf[:-2] + acf[1:-1] + acf[2:]) / _TIME_AVG_BLOCKS
             out.append(smoothed)
         else:
             out.append(acf)
@@ -587,7 +600,7 @@ def _tonal_noise_split(
     # smallest (1024-sample) stage. The larger stages segment up to 7 blocks
     # past it (their i_start reaches further back into the start padding);
     # sizing from their count would only append edge-held interpolations.
-    n_common = int(averaged[int(np.argmax(_S_B == 1024))].shape[0])
+    n_common = int(averaged[int(np.argmax(_S_B == _S_B_MIN))].shape[0])
     n_tonal = np.zeros((n_common, _CBF))
     n_signal = np.zeros((n_common, _CBF))
     f_ton = np.zeros((n_common, _CBF))

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -248,6 +248,7 @@ _ERB_C1 = ERB_C1
 _ERB_C2 = ERB_C2
 _CAM_C = CAM_C  # Formula (6): i = 21.366 * log10(C2 * fc + 1)
 _ROEX_D = 0.35  # constant D of Formula (5)
+_ROEX_G_MAX = 4.0  # Formula (4): drop upper-side components g > 4 (clause 7.4)
 _I_MIN, _I_MAX, _I_STEP = 1.8, 38.9, 0.1  # ERB-number grid (clause 7.4)
 
 
@@ -382,6 +383,8 @@ _T4_A = np.array(
 )
 
 _C_SONE = 0.0617  # calibration constant C of Formula (7) [sone/Cam]
+_E_HIGH_LEVEL = 1e10  # E/E0 bound of the high-level Formula (9) (clause 7.5)
+_HF_MIN_FC_HZ = 500.0  # _HF parameters apply for fc >= this (clauses 7.5.2/7.5.4)
 _ALPHA_HF = 0.2  # exponent alpha for fc >= 500 Hz (clause 7.5.4)
 _A_HF = 4.13  # parameter A for fc >= 500 Hz = 2 * E_THRQ/E0 (clause 7.5.4)
 _E_THRQ_HF = 2.065  # E_THRQ/E0 for fc >= 500 Hz (clause 7.5.2)
@@ -509,6 +512,7 @@ _THIRD_OCTAVE_FREQ = np.array(
 )
 _N_THIRD_OCTAVE = _THIRD_OCTAVE_FREQ.size
 _THIRD_OCTAVE_RATIO = 2.0 ** (1.0 / 6.0)  # band edge factor (half a third-octave)
+_FINE_SPACING_MAX_CENTRE_HZ = 125.0  # 1 Hz spacing at/below, 10 Hz above (clause 5.5)
 
 
 @dataclass(frozen=True)
@@ -623,7 +627,7 @@ def _excitation_pattern(freqs: np.ndarray, levels_cochlea: np.ndarray) -> np.nda
         p = np.where(upper, p_ref, p_lower)
         weight = (1.0 + p * g) * np.exp(-p * g)
         # Integration ranges of Formula (4): drop upper-side components g > 4.
-        weight = np.where(upper & (g > 4.0), 0.0, weight)
+        weight = np.where(upper & (g > _ROEX_G_MAX), 0.0, weight)
         excitation[k] = float(np.dot(powers, weight))
     return excitation
 
@@ -636,7 +640,7 @@ def _specific_loudness(excitation: np.ndarray) -> np.ndarray:
     Tables 2-4; below the reference threshold the near-threshold expression of
     Formula (8) is used and above E/E0 = 1e10 the high-level Formula (9).
     """
-    high = _FC_GRID >= 500.0
+    high = _FC_GRID >= _HF_MIN_FC_HZ
     g_lin = np.ones(_FC_GRID.size)
     alpha = np.full(_FC_GRID.size, _ALPHA_HF)
     a_par = np.full(_FC_GRID.size, _A_HF)
@@ -661,7 +665,7 @@ def _specific_loudness(excitation: np.ndarray) -> np.ndarray:
     factor = np.power(2.0 * e / (e + e_thr[active]), 1.5)
     values = np.where(below, _C_SONE * factor * core, values)
     # High level (Formula 9): E/E0 > 1e10.
-    very_high = e > 1e10
+    very_high = e > _E_HIGH_LEVEL
     values = np.where(very_high, _C_SONE * np.power(e / 1.0707, 0.2), values)
     n_spec[active] = values
     return n_spec
@@ -770,7 +774,7 @@ def _as_components(
     array = np.asarray(components, dtype=np.float64)
     if array.size == 0:
         return np.empty(0, dtype=np.float64), np.empty(0, dtype=np.float64)
-    if array.ndim != 2 or array.shape[1] != 2:
+    if array.ndim != 2 or array.shape[1] != 2:  # noqa: PLR2004
         msg = (
             "components must be a sequence of (frequency_Hz, level_dB) pairs, "
             f"got array of shape {array.shape}."
@@ -838,7 +842,7 @@ def _third_octave_components(
     for centre, level in zip(_THIRD_OCTAVE_FREQ, band_levels):
         width = centre * (_THIRD_OCTAVE_RATIO - 1.0 / _THIRD_OCTAVE_RATIO)
         spectrum_level = float(level) - 10.0 * math.log10(width)
-        spacing = 1.0 if centre <= 125.0 else 10.0
+        spacing = 1.0 if centre <= _FINE_SPACING_MAX_CENTRE_HZ else 10.0
         component_level = spectrum_level + 10.0 * math.log10(spacing)
         f_lo = centre / _THIRD_OCTAVE_RATIO
         f_hi = centre * _THIRD_OCTAVE_RATIO

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -97,6 +97,7 @@ _FC_GRID = _fc_from_cam(_I_GRID)
 _ERB_GRID = _erb_bandwidth(_FC_GRID)
 _P_REF = 4.0 * _FC_GRID / _ERB_GRID  # p_u and p_l(51 dB, fc) per filter
 _PL51_1K = 4.0 * 1000.0 / _erb_bandwidth(np.array([1000.0]))[0]  # p_l(51 dB, 1 kHz)
+_ROEX_G_MAX = 4.0  # Formula (4): drop upper-side components g > 4 (clause 7.4)
 
 # ---------------------------------------------------------------------------
 # Reference threshold, cochlear gain and specific-loudness parameters
@@ -210,9 +211,11 @@ _C_SONE = 0.063  # calibration constant C of Formula (7) [sone/Cam]
 _ALPHA_HF = 0.2  # exponent alpha for fc >= 500 Hz (clause 7.5.4)
 _E_THRQ_HF = 2.307  # E_THRQ/E0 for fc >= 500 Hz (L_E = 3.63 dB, clause 7.5.2)
 _A_HF = 2.0 * _E_THRQ_HF  # A = 2 * E_THRQ/E0 for fc >= 500 Hz (clause 7.5.4)
+_E_HIGH_LEVEL = 1e10  # E/E0 bound of the high-level Formula (9) (clause 7.5)
+_HF_MIN_FC_HZ = 500.0  # _HF parameters apply for fc >= this (clauses 7.5.2/7.5.4)
 
 # Precomputed per-filter specific-loudness parameters (fixed by the grid).
-_HIGH = _FC_GRID >= 500.0
+_HIGH = _FC_GRID >= _HF_MIN_FC_HZ
 _G_LIN = np.ones(_FC_GRID.size)
 _ALPHA = np.full(_FC_GRID.size, _ALPHA_HF)
 _A_PAR = np.full(_FC_GRID.size, _A_HF)
@@ -271,6 +274,7 @@ _WINDOWS: tuple[tuple[float, float, float], ...] = (
 _SPECTRAL_CAL_DB = -0.9252
 _P0 = 2e-5  # reference sound pressure [Pa]
 _PRUNE_DB = 80.0  # drop components > 80 dB below the frame's loudest component
+_N_EARS = 2  # ear channels of a two-channel (left, right) input
 
 # ---------------------------------------------------------------------------
 # Loudness-level relationship (clause 7.10, Table 5) - DIFFERS from ISO 532-2.
@@ -419,7 +423,7 @@ def _excitation(comp_f: np.ndarray, comp_pow: np.ndarray) -> np.ndarray:
     np.clip(p_lower, 0.1, 1e4, out=p_lower)
     p = np.where(upper, p_ref, p_lower)
     weight = (1.0 + p * g) * np.exp(-p * g)
-    weight[upper & (g > 4.0)] = 0.0
+    weight[upper & (g > _ROEX_G_MAX)] = 0.0
     return np.asarray(weight @ comp_pow, dtype=np.float64)
 
 
@@ -443,7 +447,7 @@ def _specific_loudness(excitation: np.ndarray) -> np.ndarray:
     below = e < _E_THR[active]
     factor = np.power(2.0 * e / (e + _E_THR[active]), 1.5)
     values = np.where(below, _C_SONE * factor * core, values)
-    very_high = e > 1e10
+    very_high = e > _E_HIGH_LEVEL
     values = np.where(very_high, _C_SONE * np.power(e / 1.0707, 0.2), values)
     n_spec[active] = values
     return n_spec
@@ -611,10 +615,10 @@ def _as_two_channels(
 ) -> tuple[np.ndarray, np.ndarray | None]:
     """Split the input into left and (optional) right calibrated pressure signals."""
     array = apply_calibration(signal, np.asarray(signal, dtype=np.float64))
-    if array.ndim == 2:
-        if array.shape[1] == 2 and array.shape[0] != 2:
+    if array.ndim == 2:  # noqa: PLR2004
+        if array.shape[1] == _N_EARS and array.shape[0] != _N_EARS:
             left, right = array[:, 0], array[:, 1]
-        elif array.shape[0] == 2:
+        elif array.shape[0] == _N_EARS:
             left, right = array[0], array[1]
         else:
             msg = f"signal must be mono (1-D) or two-channel; got shape {array.shape}."

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -66,6 +66,11 @@ _FS_REF = 48000
 _SR_LEVEL = 2000
 # Output sampling rate of the total loudness vs. time (clause 6.5).
 _SR_LOUDNESS = 500
+# Cap on the reduced polyphase resampling factors (up and down) accepted
+# when converting the caller's sampling rate to _FS_REF; above it the
+# ratio is declared impractical and the caller is told to resample to a
+# standard rate first (a guard of this implementation, not of the standard).
+_MAX_RESAMPLE_FACTOR = 1000
 
 _N_BANDS = 28  # one-third-octave bands, 25 Hz .. 12.5 kHz
 _N_LCB_BANDS = 11  # bands 25 Hz .. 250 Hz grouped into critical bands
@@ -81,6 +86,11 @@ _LP_ITER = 24
 _T_SHORT = 0.005
 _T_LONG = 0.015
 _T_VAR = 0.075
+# Equality tolerance of the nonlinear decay state machine (clause 6.3):
+# once a decaying input has been ruled out, an input exceeding the
+# previous output by less than this is treated as equal, selecting the
+# "steady input" branch, as in the Annex A.4 reference implementation.
+_STEADY_INPUT_TOLERANCE = 1e-5
 
 # Python-list copies of the Table A.8/A.9 data for the sequential slope
 # state machine (scalar float access is much faster than numpy indexing).
@@ -410,7 +420,7 @@ def _nl_lp_step(
             uo = uo_last * b[4]
             uo = max(uo, ui)
             u2 = uo
-    elif abs(ui - uo_last) < 1e-5:  # steady input
+    elif abs(ui - uo_last) < _STEADY_INPUT_TOLERANCE:  # steady input
         uo = ui
         u2 = (u2_last - ui) * b[5] + ui if uo > u2_last else ui
     else:  # rising input: output follows immediately
@@ -685,7 +695,7 @@ def _percentile(values: np.ndarray, percentile: int) -> float:
     n = ordered.size
     if percentile == 0:
         return float(ordered[-1])
-    if percentile == 100:
+    if percentile == 100:  # noqa: PLR2004
         return float(ordered[0])
     k = int((1.0 - percentile / 100.0) * n)
     k = min(max(k, 1), n - 1)
@@ -856,7 +866,7 @@ def loudness_zwicker(
     if fs_int != _FS_REF:
         gcd = math.gcd(_FS_REF, fs_int)
         up, down = _FS_REF // gcd, fs_int // gcd
-        if max(up, down) > 1000:
+        if max(up, down) > _MAX_RESAMPLE_FACTOR:
             msg = (
                 f"Sampling rate {fs_int} Hz needs an impractical resampling "
                 f"ratio ({up}/{down}) to reach 48000 Hz; resample the signal "

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -131,6 +131,11 @@ _P_M = 1.7  # modulation-depth exponent p_m (Osses 2016 §3.1)
 _P_K = 1.7  # cross-covariance exponent p_k (Osses 2016 §3.1)
 _COMPRESSION_THRESHOLD = 0.7  # m* compression knee (Osses 2016 §2.1.3)
 _COMPRESSION_RATIO = 3.0  # 3:1 compression above the knee
+_G_TAPER_START_BARK = 15.0  # g(z) taper start, Bark (Osses 2016 §3.1)
+# Shortest analysis frame, in samples. Every frame is full length, so a frame
+# below this is only reachable when the whole signal is shorter; it is
+# degenerate for the FFT-based excitation front-end and is skipped.
+_MIN_FRAME_SAMPLES = 16
 # Envelope band-pass H(fmod). The paper's 3.1-12 Hz cascade was fitted to its
 # own 4096-tap FIR front-end and is too narrow for this FFT-based excitation
 # front-end -- it collapses the 1-2 Hz and 16-32 Hz tails of the modulation
@@ -149,6 +154,11 @@ _LP_ORDER = 3  # H(fmod) low-pass order (steep upper roll-off)
 #: reference stimulus through this implementation's own front-end and cached (see
 #: :func:`_c_fs`), replacing the paper's front-end-specific literal 0.2490.
 _C_FS: float | None = None
+#: Expected range (half-open, min <= C_FS < max) of the sanity guard on the
+#: derived C_FS, bracketing the paper's front-end literal 0.2490 and this
+#: implementation's ~0.28.
+_C_FS_EXPECTED_MIN = 0.15
+_C_FS_EXPECTED_MAX = 0.50
 
 
 def _hz_to_bark(f: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -188,8 +198,8 @@ def _g_weight(z: NDArray[np.float64]) -> NDArray[np.float64]:
     linear taper down to 0.5 at 23.5 Bark.
     """
     g = np.ones_like(z)
-    high = z > 15.0
-    g[high] = 1.0 - 0.5 * (z[high] - 15.0) / (23.5 - 15.0)
+    high = z > _G_TAPER_START_BARK
+    g[high] = 1.0 - 0.5 * (z[high] - _G_TAPER_START_BARK) / (23.5 - _G_TAPER_START_BARK)
     return np.clip(g, 0.5, 1.0)
 
 
@@ -410,7 +420,7 @@ def _analyze(
 
     for start in starts:
         frame = sig[start : start + frame_len]
-        if frame.size < 16:
+        if frame.size < _MIN_FRAME_SAMPLES:
             continue
         band_env = _band_envelopes(frame, z_axis, band_center_hz)
         m_star, h_bp = _modulation_depth(band_env, env_sos)
@@ -452,7 +462,9 @@ def _c_fs() -> float:
     if _C_FS is None:
         raw = float(np.median(_analyze(_reference_signal())[0]))
         c = 1.0 / raw if raw > 0.0 else 0.0
-        if not 0.15 <= c < 0.50:  # pragma: no cover - sanity guard
+        if (
+            not _C_FS_EXPECTED_MIN <= c < _C_FS_EXPECTED_MAX
+        ):  # pragma: no cover - sanity guard
             msg = f"C_FS={c} outside the expected range"
             raise RuntimeError(msg)
         _C_FS = c

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -135,6 +135,7 @@ _N_K = 49  # DFT bins k = 0..48 used for the HSA (Clause 9.1.4)
 _R_S50 = 50.0  # interpolated rate r_s50 (Clause 9.1.11)
 _DZ = 0.5  # critical-band overlap dz (Clause 9.1.13)
 _TRANSIENT = 36  # discard l50 in [0, 35] (Clause 9.1.12/9.1.14)
+_MIN_INTERP_BLOCKS = 2  # fewest block-time knots pchip can interpolate (9.1.11)
 _TAU = 0.75  # smoothing time constant tau (Formula 168) [s]
 
 # Calibration constant c_F (Formula 163, tabulated; adjustable +/- 0.25 %).
@@ -357,7 +358,7 @@ def _analysis_window(env: np.ndarray) -> tuple[int, int] | None:
     if n2 - n_zb + 1 < _MIN_RUN or n2 < _MIN_N2:
         return None
     seg = smoothed[n_zb + _REG_MARGIN : n2 - _REG_MARGIN + 1]
-    if seg.size < 2:  # pragma: no cover - implied by the length checks
+    if seg.size < 2:  # pragma: no cover - implied by the length checks  # noqa: PLR2004
         return None
     # Closed-form least-squares line fit over the uniform grid 0..n-1
     # (equivalent to a first-order polyfit, without the general-purpose
@@ -815,7 +816,7 @@ def _time_dependent(
     t_end = float(block_times[-1])
     n50 = int(np.floor(t_end * _R_S50)) + 1
     grid = np.arange(n50) / _R_S50
-    if block_times.size >= 2:
+    if block_times.size >= _MIN_INTERP_BLOCKS:
         f_est = PchipInterpolator(block_times, a_lz, axis=0)(grid)
     else:  # pragma: no cover - two blocks minimum for nonzero signals
         f_est = np.zeros((n50, _CBF))

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -89,6 +89,10 @@ _K_ONE = _SB_TILDE // 2 + 1  # 257 one-sided modulation-rate bins
 _R_S50 = 50.0  # interpolated rate r_s50 (Clause 7.1.7)
 _DZ = 0.5  # critical-band overlap dz (Clause 7.1.9)
 _TRANSIENT = 16  # discard l50 in [0, 15] (Clause 7.1.8)
+_REFERENCE_FREQUENCY = 1000.0  # 1 kHz reference of the Clause 7.1.5 weightings
+_MAX_PEAKS = 10  # keep only the 10 most prominent spectral peaks (Clause 7.1.5.1)
+_HARMONIC_TOL = 0.04  # 4 % harmonic-deviation gate (Formula 90)
+_MIN_INTERP_BLOCKS = 2  # fewest block-time knots pchip can interpolate (7.1.7)
 
 # Calibration constant c_R (Formula 104, tabulated; adjustable +/- 0.25 %).
 _C_R = 0.0180685
@@ -152,8 +156,8 @@ def _f_max() -> np.ndarray:
 def _r_max() -> np.ndarray:
     """Scaling factor r_max(z) (Formula 84, Table 11)."""
     lg = np.abs(np.log2(_F_CENTRE / 1000.0))
-    r1 = np.where(_F_CENTRE < 1000.0, 0.3560, 0.8024)
-    r2 = np.where(_F_CENTRE < 1000.0, 0.8049, 0.9333)
+    r1 = np.where(_F_CENTRE < _REFERENCE_FREQUENCY, 0.3560, 0.8024)
+    r2 = np.where(_F_CENTRE < _REFERENCE_FREQUENCY, 0.8049, 0.9333)
     return np.asarray(1.0 / (1.0 + r1 * lg**r2), dtype=np.float64)
 
 
@@ -358,8 +362,8 @@ def _pick_peaks(spec: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         return np.empty(0), np.empty(0)
     kloc = peaks + 2  # absolute modulation-rate index
     proms = np.asarray(props["prominences"], dtype=np.float64)
-    if kloc.size > 10:  # keep the 10 highest-prominence peaks
-        top = np.argsort(proms)[::-1][:10]
+    if kloc.size > _MAX_PEAKS:  # keep the 10 highest-prominence peaks
+        top = np.argsort(proms)[::-1][:_MAX_PEAKS]
         kloc = np.sort(kloc[top])
     amps = spec[kloc]
     keep = amps > 0.05 * np.max(amps)  # Formula 72
@@ -406,7 +410,7 @@ def _harmonic_members(f_p: np.ndarray, i0: int) -> list[int]:
         err = abs(f_p[i] / (r * f_p[i0]) - 1.0)  # Formula 89
         if r not in cand or err < cand[r][1]:
             cand[r] = (i, err)
-    return [i for i, err in cand.values() if err < 0.04]  # Formula 90
+    return [i for i, err in cand.values() if err < _HARMONIC_TOL]  # Formula 90
 
 
 def _fundamental_set(f_p: np.ndarray, a_tilde: np.ndarray) -> tuple[list[int], int]:
@@ -491,7 +495,7 @@ def _time_dependent(
     t_end = float(block_times[-1])
     n50 = int(np.floor(t_end * _R_S50)) + 1
     grid = np.arange(n50) / _R_S50
-    if block_times.size >= 2:
+    if block_times.size >= _MIN_INTERP_BLOCKS:
         # Piecewise cubic Hermite (Clause 7.1.7), all 53 bands in one
         # interpolator; pchip treats every column independently, so the
         # result is bit-identical to a per-band loop.

--- a/src/phonometry/psychoacoustics/quality/sharpness.py
+++ b/src/phonometry/psychoacoustics/quality/sharpness.py
@@ -25,21 +25,27 @@ if TYPE_CHECKING:
 
 _DZ = 0.1  # Bark step of the ISO 532-1 specific-loudness pattern
 _Z = np.arange(1, 241) * _DZ  # Bark bin centers (0.1 .. 24.0), reference convention
+_G_DIN_KNEE_BARK = 15.8  # DIN 45692 Eq. (1) g(z) knee: unity below it
+_G_BISMARCK_KNEE_BARK = 15.0  # Annex B von Bismarck g(z) knee: unity below it
+# DIN 45692 clause 5.2 range for the derived normalization constant k:
+# _K_DIN_MIN inclusive, _K_DIN_MAX exclusive.
+_K_DIN_MIN = 0.105
+_K_DIN_MAX = 0.115
 
 
 def _g_din(z: np.ndarray) -> np.ndarray:
     """DIN 45692 Eq. (1) weighting: 1 up to 15.8 Bark, rising beyond."""
     g = np.ones_like(z)
-    high = z > 15.8
-    g[high] = 0.15 * np.exp(0.42 * (z[high] - 15.8)) + 0.85
+    high = z > _G_DIN_KNEE_BARK
+    g[high] = 0.15 * np.exp(0.42 * (z[high] - _G_DIN_KNEE_BARK)) + 0.85
     return g
 
 
 def _g_bismarck(z: np.ndarray) -> np.ndarray:
     """DIN 45692 Annex B (informative), von Bismarck weighting."""
     g = np.ones_like(z)
-    high = z > 15.0
-    g[high] = 0.2 * np.exp(0.308 * (z[high] - 15.0)) + 0.8
+    high = z > _G_BISMARCK_KNEE_BARK
+    g[high] = 0.2 * np.exp(0.308 * (z[high] - _G_BISMARCK_KNEE_BARK)) + 0.8
     return g
 
 
@@ -116,7 +122,7 @@ def _k_din() -> float:
     global _K_DIN
     if _K_DIN is None:
         _K_DIN = 1.0 / _moment(_reference_specific(), "din")
-        if not 0.105 <= _K_DIN < 0.115:  # pragma: no cover - sanity guard
+        if not _K_DIN_MIN <= _K_DIN < _K_DIN_MAX:  # pragma: no cover - sanity guard
             msg = f"k={_K_DIN} outside the DIN 45692 range"
             raise RuntimeError(msg)
     return _K_DIN

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -45,7 +45,7 @@ def _warn_coarse_resolution(dfc: float, df: float, ft: float) -> None:
     bandwidth). At 250 Hz a 4 Hz bin already costs ~0.3 dB of TNR.
     """
     bins = 0.075 * dfc / df
-    if bins < 3.0:
+    if bins < _MIN_TONE_HALF_WIDTH_BINS:
         warnings.warn(
             f"Frequency resolution {df:.3g} Hz is coarse for the tone at "
             f"{ft:.0f} Hz: the tone band spans only {bins:.1f} bins (< 3), "
@@ -68,6 +68,40 @@ _F_MAX = 11200.0
 #: silence or DC input yields formally finite TNR/PR values that carry no
 #: meaning, so a warning is raised (about -100 dB SPL over a critical band).
 _NOISE_FLOOR_POWER = 4e-20
+
+# Minimum FFT bins across the tone-band half-width (0.075*dfc, the 15 %
+# critical-bandwidth window of clause 11.2) for an unbiased tone/noise
+# split; below it a TonalityWarning is raised (the "~3 bins" adequacy rule).
+_MIN_TONE_HALF_WIDTH_BINS = 3.0
+
+# Clause 10 crossover tone frequency: at or below it the critical-band edges
+# are arithmetic (Formulae (4)-(5)), above it geometric (Formulae (7)-(8)).
+_ARITHMETIC_EDGES_MAX_HZ = 500.0
+
+# Implementation floor on samples per FFT segment for the Hann-windowed,
+# RMS-averaged spectrum (clauses 11.1 / 12.1).
+_MIN_FFT_SEGMENT_SAMPLES = 16
+
+# At and above this frequency the prominence limit is constant: 8 dB for TNR
+# (clause 11.5 Formulae (12)-(13)) and 9 dB for PR (clause 12.6 Formulae
+# (25)-(26)); below it both limits rise with log10(1000/ft).
+_CRITERION_PLATEAU_HZ = 1000.0
+
+# Minimum critical-band bins outside the tone band for the clause 11.6
+# secondary-tone search to be attempted (an implementation guard so a
+# candidate local peak can have neighbours).
+_MIN_SECONDARY_SEARCH_BINS = 3
+
+# Clause 11.6 applicability bound of the Formula (14) proximity spacing: at
+# and above 1 kHz the spacing always exceeds half the critical band, so a
+# secondary tone in the band is unconditionally proximate.
+_ALWAYS_PROXIMATE_MIN_HZ = 1000.0
+
+# Clause 12.5: at or below this tone frequency the lower contiguous critical
+# band is truncated at 20 Hz and rescaled to a 100 Hz bandwidth by Formula
+# (24) instead of Formula (23); also the first row boundary of the Table 2
+# fit in _LOWER_EDGE_COEFFS, where the fitted lower edge equals 20 Hz.
+_TRUNCATED_LOWER_BAND_MAX_HZ = 171.4
 
 
 def _warn_degenerate(ft: float, band_power: float, df: float) -> None:
@@ -152,7 +186,7 @@ def _critical_band(f0: float) -> tuple[float, float, float]:
     (geometric) above.
     """
     dfc = 25.0 + 75.0 * (1.0 + 1.4 * (f0 / 1000.0) ** 2) ** 0.69
-    if f0 <= 500.0:
+    if f0 <= _ARITHMETIC_EDGES_MAX_HZ:
         f1 = f0 - dfc / 2.0
         f2 = f0 + dfc / 2.0
     else:
@@ -178,10 +212,11 @@ def _averaged_spectrum(
     Returns (frequencies, bin powers in Pa^2-like units, bin spacing).
     """
     nperseg = round(fs / resolution_hz)
-    if nperseg < 16:
+    if nperseg < _MIN_FFT_SEGMENT_SAMPLES:
         msg = (
             f"resolution_hz={resolution_hz!r} is too coarse for fs={fs}: it "
-            "leaves fewer than 16 samples per FFT segment."
+            f"leaves fewer than {_MIN_FFT_SEGMENT_SAMPLES} samples per FFT "
+            "segment."
         )
         raise ValueError(msg)
     if x.shape[-1] < nperseg:
@@ -250,14 +285,14 @@ def _band_power(
 
 def _tnr_criterion(ft: float) -> float:
     """Clause 11.5 Formulae (12)-(13): TNR prominence limit in dB."""
-    if ft < 1000.0:
+    if ft < _CRITERION_PLATEAU_HZ:
         return float(8.0 + 8.33 * np.log10(1000.0 / ft))
     return 8.0
 
 
 def _pr_criterion(ft: float) -> float:
     """Clause 12.6 Formulae (25)-(26): PR prominence limit in dB."""
-    if ft < 1000.0:
+    if ft < _CRITERION_PLATEAU_HZ:
         return float(9.0 + 10.0 * np.log10(1000.0 / ft))
     return 9.0
 
@@ -327,7 +362,7 @@ def tone_to_noise_ratio(
     in_band = (freqs > f1) & (freqs <= f2)
     band_idx = np.flatnonzero(in_band)
     outside_tone = band_idx[(band_idx < lo) | (band_idx > hi)]
-    if outside_tone.size >= 3:
+    if outside_tone.size >= _MIN_SECONDARY_SEARCH_BINS:
         rel = power[outside_tone]
         sec_local = outside_tone[np.argmax(rel)]
         # A secondary "tone" must be a local spectral peak, not noise floor:
@@ -335,7 +370,9 @@ def tone_to_noise_ratio(
         neigh = power[max(0, sec_local - 3)] + power[min(power.size - 1, sec_local + 3)]
         if power[sec_local] > 2.0 * neigh:
             fsec = float(freqs[sec_local])
-            proximate = ft >= 1000.0 or abs(fsec - ft) < _proximity_spacing(ft)
+            proximate = ft >= _ALWAYS_PROXIMATE_MIN_HZ or abs(
+                fsec - ft
+            ) < _proximity_spacing(ft)
             s_lo, s_hi = _tone_band(power, int(sec_local), half_width_bins)
             n_sec = s_hi - s_lo + 1
             p_sec = (
@@ -445,7 +482,7 @@ def prominence_ratio(
     # Lower band (12.3): truncated at 20 Hz below 171.4 Hz.
     f1_l = (
         max(_fitted_edge(ft, _LOWER_EDGE_COEFFS), 20.0)
-        if ft <= 171.4
+        if ft <= _TRUNCATED_LOWER_BAND_MAX_HZ
         else _fitted_edge(ft, _LOWER_EDGE_COEFFS)
     )
     # Upper band (12.4).
@@ -459,7 +496,7 @@ def prominence_ratio(
     p_l = max(p_l, np.finfo(float).tiny)
     p_u = max(p_u, np.finfo(float).tiny)
 
-    if ft <= 171.4:
+    if ft <= _TRUNCATED_LOWER_BAND_MAX_HZ:
         # Formula (24): rescale the truncated lower band to 100 Hz.
         df_l = n_l * df
         pr = 10 * np.log10(p_m) - 10 * np.log10((100.0 / df_l * p_l + p_u) * 0.5)

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -61,6 +61,10 @@ _Q_B = 0.003
 # Tonality calibration factor c_T (Formula 51); 1 kHz/40 dB -> 1 tu_HMS.
 _C_T = 2.8758615
 
+# Preconditions on the user band range [f_L, f_H] (Clause 6.2.10).
+_F_LOW_MIN_HZ = 16.0  # Formula 56 precondition: f_L > 16 Hz
+_F_HIGH_MAX_HZ = 20000.0  # Formula 57 precondition: f_H < 20 kHz
+
 #: Prominence criterion (Clause 6.3): a signal has a prominent tonality when
 #: the single value T (Formula 63) exceeds this value, in tu_HMS.
 PROMINENT_TONALITY_TU_HMS = 0.4
@@ -131,10 +135,10 @@ def _band_range(f_low: float | None, f_high: float | None) -> tuple[int, int]:
     Enforces the Formulae 56/57 preconditions: 16 Hz < f_L, f_H < 20 kHz and
     f_L < f_H.
     """
-    if f_low is not None and f_low <= 16.0:
+    if f_low is not None and f_low <= _F_LOW_MIN_HZ:
         msg = "'f_low' must exceed 16 Hz (Formula 56)."
         raise ValueError(msg)
-    if f_high is not None and f_high >= 20000.0:
+    if f_high is not None and f_high >= _F_HIGH_MAX_HZ:
         msg = "'f_high' must be below 20 kHz (Formula 57)."
         raise ValueError(msg)
     if f_low is not None and f_high is not None and f_low >= f_high:

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -632,7 +632,7 @@ def _step3_groups(
     for band_tone in tones:
         f1, f2 = critical_band_corners(band_tone[0])
         members = {i for i, t in enumerate(tones) if f1 <= t[0] <= f2}
-        if len(members) < 2:
+        if len(members) < 2:  # noqa: PLR2004
             continue
         for c in [c for c in clusters if c & members]:
             members |= c
@@ -641,7 +641,7 @@ def _step3_groups(
     groups: list[tuple[int, ...]] = []
     for cluster in clusters:
         members_t = tuple(sorted(cluster))
-        if len(members_t) == 2:
+        if len(members_t) == 2:  # noqa: PLR2004
             (ta, tb) = (tones[members_t[0]], tones[members_t[1]])
             if resolve_tones_separately(ta[0], tb[0], ta[4], tb[4]):
                 continue  # rated separately, no FG entry

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -97,6 +97,19 @@ _TRUST_MARGIN_DB = 10.0
 #: fitting the sloping line of ISO 3382-1:2009, 5.3.3, Equation (3).
 _SMOOTH_SECONDS = 0.010
 
+#: Minimum number of decay-level samples for the degree-1 least-squares
+#: line fits (a line fit needs at least two points): the sloping line of
+#: ISO 3382-1:2009, 5.3.3, Equation (3) in :func:`_truncation` and the
+#: evaluation-range fit of ISO 3382-2:2008, Equations (C.1)-(C.6) in
+#: :func:`_fit_decay_time`.
+_MIN_LINE_FIT_POINTS = 2
+
+#: Threshold on the fitted decay slope in dB/s: a slope at or shallower
+#: than this (implying a T60 of ~6e8 s, physically meaningless) is treated
+#: as no decay, protecting the decay constant alpha from underflowing and
+#: the tail terms p2_t1/alpha and 1/alpha**2 from overflowing to inf.
+_NO_DECAY_SLOPE_DB_PER_S = -1e-7
+
 #: Evaluation ranges in dB below the steady-state level:
 #: EDT 0 -> -10 (ISO 3382-1, A.2.2); T20 -5 -> -25 and T30 -5 -> -35
 #: (ISO 3382-2:2008, Clause 6).
@@ -281,7 +294,7 @@ def _truncation(
     level = 10.0 * np.log10(np.maximum(smoothed, tiny))
     noise_db = 10.0 * np.log10(noise_power)
     mask = (level <= level.max() - 5.0) & (level >= noise_db + _TRUST_MARGIN_DB)
-    if int(mask.sum()) < 2:
+    if int(mask.sum()) < _MIN_LINE_FIT_POINTS:
         return no_truncation
     slope, intercept = np.polyfit(t_smooth[mask], level[mask], 1)
     # A non-negative slope means no decay; a barely-negative slope (e.g.
@@ -290,7 +303,7 @@ def _truncation(
     # 1/alpha**2 overflow to inf. A slope of -1e-7 dB/s implies a T60 of
     # ~6e8 s, which is physically meaningless, so treat anything shallower
     # as no decay.
-    if slope >= -1e-7:
+    if slope >= _NO_DECAY_SLOPE_DB_PER_S:
         return no_truncation
     t1 = (noise_db - intercept) / slope
     i1 = min(max(round(t1 * fs), 2), n)
@@ -346,7 +359,7 @@ def _fit_decay_time(
     if lower < trust_floor_db:
         return float("nan")
     mask = (level <= upper) & (level >= lower)
-    if int(mask.sum()) < 2 or float(level.min()) > lower:
+    if int(mask.sum()) < _MIN_LINE_FIT_POINTS or float(level.min()) > lower:
         return float("nan")
     slope = float(np.polyfit(time[mask], level[mask], 1)[0])
     if slope >= 0.0:
@@ -582,7 +595,7 @@ def room_parameters(
         frequency = None
         band_signals: list[np.ndarray] = [x]
     else:
-        if len(limits) != 2:
+        if len(limits) != 2:  # noqa: PLR2004
             msg = "'limits' must be a (f_min, f_max) pair or None."
             raise ValueError(msg)
         bank = OctaveFilterBank(

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -125,14 +125,18 @@ def _resolve_walls(
         raise ValueError(msg)
     if alpha.ndim == 0:
         walls = np.full((6, 1), float(alpha), dtype=np.float64)
-    elif alpha.ndim == 1 and alpha.shape[0] == 6 and n_freq != 6:
+    elif (
+        alpha.ndim == 1
+        and alpha.shape[0] == len(WALL_ORDER)
+        and n_freq != len(WALL_ORDER)
+    ):
         # Length 6 with no matching frequencies -> the six per-wall values.
         walls = alpha[:, np.newaxis]
     elif alpha.ndim == 1:
         # A per-band curve, uniform across walls (this branch also handles a
         # length-6 curve when frequencies declares six bands).
         walls = np.broadcast_to(alpha, (6, alpha.shape[0])).copy()
-    elif alpha.ndim == 2 and alpha.shape[0] == 6:
+    elif alpha.ndim == 2 and alpha.shape[0] == len(WALL_ORDER):  # noqa: PLR2004
         walls = alpha
     else:
         msg = (

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -97,6 +97,18 @@ _MLS_ALIAS_TAIL_DB = -35.0
 #: reference was zero-padded (see the Farina guard in ``impulse_response``).
 _FARINA_MAX_TRAILING_ZEROS = 8
 
+#: Exclusive upper bound on the half-Hann ``fade`` fraction applied at each
+#: end of a generated sweep (transient suppression, ISO 18233:2006 B.3.3;
+#: end-pinning, Mueller & Massarani 2001, Sec. 4.2): at 0.5 the two fades
+#: together would cover the whole signal and leave no un-faded sweep.
+_MAX_FADE_FRACTION = 0.5
+
+#: Minimum retained sample count for the frequency-domain shaped-sweep
+#: synthesis -- the smallest signal its doubled FFT block (n_fft = next
+#: power of two of 2*n_keep, Mueller & Massarani 2001, Sec. 4.2) is
+#: prepared to synthesize.
+_MIN_SHAPED_SWEEP_SAMPLES = 16
+
 # Primitive-polynomial feedback taps (1-indexed register positions, highest
 # tap == order) yielding maximum-length sequences. Values from the standard
 # LFSR tables (Xilinx XAPP052, "Efficient Shift Registers, LFSR Counters,
@@ -243,12 +255,12 @@ def sweep_signal(
     if f2 > fs / 2.0:
         msg = "f2 must not exceed the Nyquist frequency fs/2"
         raise ValueError(msg)
-    if not 0.0 <= fade < 0.5:
+    if not 0.0 <= fade < _MAX_FADE_FRACTION:
         msg = "fade must be in [0, 0.5)"
         raise ValueError(msg)
 
     n = round(seconds * fs)
-    if n < 2:
+    if n < 2:  # noqa: PLR2004
         msg = "seconds*fs must yield at least 2 samples"
         raise ValueError(msg)
 
@@ -768,7 +780,7 @@ def golay_impulse_response(
         msg = "both Golay codes must be one-dimensional."
         raise ValueError(msg)
     period = code_a.size
-    if period < 2 or code_b.size != period:
+    if period < 2 or code_b.size != period:  # noqa: PLR2004
         msg = (
             "'pair' must hold two equal-length codes of at least 2 samples "
             "(use golay_pair())."
@@ -903,7 +915,7 @@ def _shaped_target_db(
         raise ValueError(msg)
     t_freq = np.asarray(target[0], dtype=np.float64)
     t_db = np.asarray(target[1], dtype=np.float64)
-    if t_freq.ndim != 1 or t_freq.size < 2 or t_db.shape != t_freq.shape:
+    if t_freq.ndim != 1 or t_freq.size < 2 or t_db.shape != t_freq.shape:  # noqa: PLR2004
         msg = (
             "an array target must be a (frequencies_hz, magnitude_db) pair "
             "of equal-length 1-D arrays with at least 2 points"
@@ -1040,7 +1052,7 @@ def shaped_sweep_signal(
     if amplitude <= 0.0:
         msg = "amplitude must be positive"
         raise ValueError(msg)
-    if not 0.0 <= fade < 0.5:
+    if not 0.0 <= fade < _MAX_FADE_FRACTION:
         msg = "fade must be in [0, 0.5)"
         raise ValueError(msg)
     lead = 0.05 * seconds if start_delay is None else float(start_delay)
@@ -1053,7 +1065,7 @@ def shaped_sweep_signal(
     # (Mueller & Massarani 2001, Sec. 4.2).
     total = seconds + 2.0 * lead
     n_keep = round(total * fs_v)
-    if n_keep < 16:
+    if n_keep < _MIN_SHAPED_SWEEP_SAMPLES:
         msg = "seconds*fs must yield at least 16 samples"
         raise ValueError(msg)
     n_fft = int(2 ** np.ceil(np.log2(2 * n_keep)))
@@ -1097,7 +1109,7 @@ def shaped_sweep_signal(
     # that would make the statistic blow up; fall back to the whole
     # retained sweep in that degenerate case.
     core = sweep[round(lead * fs_v) : round((lead + seconds) * fs_v)]
-    if core.size < 2:
+    if core.size < 2:  # noqa: PLR2004
         core = sweep
     rms = float(np.sqrt(np.mean(core**2)))
     crest_db = 20.0 * np.log10(float(np.max(np.abs(core))) / rms)

--- a/src/phonometry/room/modes.py
+++ b/src/phonometry/room/modes.py
@@ -88,11 +88,15 @@ MODE_KINDS: tuple[str, str, str] = ("axial", "tangential", "oblique")
 #: :func:`room_modal_density`.
 MAX_ENUMERATED_LATTICE = 20_000_000
 
+# One room dimension (lx, ly, lz) and one mode order (nx, ny, nz) per
+# coordinate axis of the rectangular box.
+_N_ROOM_AXES = 3
+
 
 def _require_dimensions(dimensions: ArrayLike) -> NDArray[np.float64]:
     """Validate the three room dimensions and return them as an array."""
     dims = np.asarray(dimensions, dtype=np.float64).ravel()
-    if dims.size != 3:
+    if dims.size != _N_ROOM_AXES:
         msg = "'dimensions' must hold the three room dimensions (lx, ly, lz) in m."
         raise ValueError(msg)
     if not np.all(np.isfinite(dims)) or np.any(dims <= 0.0):
@@ -141,7 +145,7 @@ def room_mode_frequency(
         single = True
     else:
         single = False
-    if n.ndim != 2 or n.shape[1] != 3:
+    if n.ndim != 2 or n.shape[1] != _N_ROOM_AXES:  # noqa: PLR2004
         msg = "'orders' must be a triple (nx, ny, nz) or an (N, 3) array."
         raise ValueError(msg)
     if np.any(n < 0.0) or np.any(n != np.floor(n)):

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -97,6 +97,19 @@ _SIL_BANDS = slice(5, 9)
 #: (at least the bands from 31.5 Hz through 4000 Hz).
 _RC_REQUIRED_BANDS = slice(1, 9)
 
+#: Bounds of the tabulated RC Mark II family: Table D.1 tabulates RC-25
+#: through RC-50 and clause D.3.5 defines the RC-NN(A) label only for
+#: integer ratings in that range; outside it the reference curve extrapolates.
+_RC_FAMILY_MIN = 25
+_RC_FAMILY_MAX = 50
+
+#: Clause D.3 deviation limits, in dB, over the reference RC Mark II curve:
+#: rumble ("R") when a band at or below 500 Hz exceeds it by more than
+#: _RC_RUMBLE_LIMIT_DB, hiss ("H") when a band at or above 1000 Hz exceeds
+#: it by more than _RC_HISS_LIMIT_DB.
+_RC_RUMBLE_LIMIT_DB = 5.0
+_RC_HISS_LIMIT_DB = 3.0
+
 
 @dataclass(frozen=True)
 class NCResult:
@@ -263,7 +276,7 @@ class RCResult:
         -5 dB/octave rule of Annex D, but the designation extrapolates beyond
         the standard's tabulated family.
         """
-        return not 25 <= self.rating <= 50
+        return not _RC_FAMILY_MIN <= self.rating <= _RC_FAMILY_MAX
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -568,8 +581,8 @@ def room_criterion(levels: ArrayLike, frequencies: ArrayLike | None = None) -> R
     high = slice(6, _N_BANDS)  # 1000 - 8000 Hz (at and above 1000 Hz).
     low_dev = deviation[low][~np.isnan(deviation[low])]
     high_dev = deviation[high][~np.isnan(deviation[high])]
-    rumble = low_dev.size > 0 and np.max(low_dev) > 5.0
-    hiss = high_dev.size > 0 and np.max(high_dev) > 3.0
+    rumble = low_dev.size > 0 and np.max(low_dev) > _RC_RUMBLE_LIMIT_DB
+    hiss = high_dev.size > 0 and np.max(high_dev) > _RC_HISS_LIMIT_DB
     tag = ("R" if rumble else "") + ("H" if hiss else "")
     classification = tag or "N"
 

--- a/src/phonometry/room/open_plan.py
+++ b/src/phonometry/room/open_plan.py
@@ -61,6 +61,11 @@ _STI_PRIVACY = 0.20
 #: Minimum number of measurement positions (ISO 3382-3:2012, 5.2.2).
 _MIN_POSITIONS = 4
 
+#: Minimum number of positions inside the 2 m to 16 m decay range to fit
+#: the D2,S regression line (ISO 3382-3:2012, 6.2): a degree-1 fit needs
+#: two points; below it, d2s and lp_as_4m are reported as nan.
+_MIN_DECAY_FIT_POSITIONS = 2
+
 
 @dataclass(frozen=True)
 class OpenPlanResult:
@@ -271,7 +276,7 @@ def open_plan_metrics(
     d2s = float("nan")
     lp_as_4m = float("nan")
     in_range = (r >= _DECAY_RANGE_M[0]) & (r <= _DECAY_RANGE_M[1])
-    if int(in_range.sum()) >= 2:
+    if int(in_range.sum()) >= _MIN_DECAY_FIT_POSITIONS:
         x = np.log10(r[in_range] / _R0)
         slope, intercept = _linear_fit(x, lp[in_range])
         # D2,S is the decay per distance doubling: slope is dB per unit of

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -99,6 +99,10 @@ DEFAULT_SPEED_OF_SOUND = 343.0
 #: reach it: their stricter below-1 wall-pair-mean check fires first.
 _MAX_ABSORPTION = 2.0
 
+#: Number of orthogonal axes -- equivalently wall pairs -- of the rectangular
+#: room the axial models describe: the three room lengths ``(Lx, Ly, Lz)``.
+_N_ROOM_AXES = 3
+
 
 Surface = tuple[float, ArrayLike]
 
@@ -402,7 +406,7 @@ def _axial_geometry(
     :math:`S_x = 2 L_y L_z`, :math:`S_y = 2 L_x L_z`,
     :math:`S_z = 2 L_x L_y`.
     """
-    if len(dimensions) != 3:
+    if len(dimensions) != _N_ROOM_AXES:
         msg = "'dimensions' must be the three room lengths (Lx, Ly, Lz)."
         raise ValueError(msg)
     lx, ly, lz = (require_positive(float(d), "dimension") for d in dimensions)
@@ -426,7 +430,7 @@ def _axial_eyring_times(
     ``alpha_bar_i`` of the wall pair perpendicular to that axis (Arau-Puchades'
     construction), plus the shared air term ``4 m V``.
     """
-    if len(absorptions) != 3:
+    if len(absorptions) != _N_ROOM_AXES:
         msg = (
             "'absorptions' must give the mean absorption of the three wall pairs "
             "(perpendicular to x, y and z)."
@@ -671,7 +675,7 @@ def reverberation_time_models(
     :return: The :class:`ReverberationModelResult`.
     """
     volume, total_area, pair_areas = _axial_geometry(dimensions)
-    if len(absorptions) != 3:
+    if len(absorptions) != _N_ROOM_AXES:
         msg = "'absorptions' must give the mean absorption of the three wall pairs."
         raise ValueError(msg)
     # Two equal-area opposing walls per axis share the axis mean absorption.

--- a/src/phonometry/signals/correlation.py
+++ b/src/phonometry/signals/correlation.py
@@ -87,6 +87,11 @@ __all__ = [
 #: upsampling extracts around the coarse correlation peak.
 _UPSAMPLE_HALF_WINDOW = 32
 
+#: Minimum number of averaged Welch segments the 'ml' GCC weighting
+#: requires: a single-segment coherence estimate is identically one, and
+#: Knapp & Carter's Eq. 45b weight exists only for |γ|² < 1.
+_MIN_COHERENCE_SEGMENTS = 2
+
 #: Validation context of the impulse-response delay utilities.
 _DELAY_CONTEXT = "a delay estimate"
 
@@ -644,7 +649,7 @@ def _gcc_curve(
     """Weighted GCC over the shared Welch core, fftshifted to ±seg/2."""
     seg, ovl = _validate_welch_params(xa.size, fs, nperseg, overlap)
     nov = _noverlap_samples(seg, ovl)
-    if weighting == "ml" and (xa.size - nov) // (seg - nov) < 2:
+    if weighting == "ml" and (xa.size - nov) // (seg - nov) < _MIN_COHERENCE_SEGMENTS:
         # Knapp & Carter's Eq. 45b weight exists only for |γ|² < 1; a
         # single-segment coherence estimate is identically one, so the
         # weight would be floating-point rounding noise.

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -58,6 +58,9 @@ __all__ = [
     "regularized_inverse_filter",
 ]
 
+#: Fewest samples a measured impulse response must have to be inverted.
+_MIN_RESPONSE_SAMPLES = 2
+
 
 @dataclass(frozen=True)
 class InverseFilterResult:
@@ -200,8 +203,8 @@ def _validated_response(response: Any) -> np.ndarray:
     if h.ndim != 1:
         msg = "'response' must be one-dimensional."
         raise ValueError(msg)
-    if h.size < 2:
-        msg = "'response' must have at least 2 samples."
+    if h.size < _MIN_RESPONSE_SAMPLES:
+        msg = f"'response' must have at least {_MIN_RESPONSE_SAMPLES} samples."
         raise ValueError(msg)
     if not np.all(np.isfinite(h)):
         msg = "'response' must be finite."

--- a/src/phonometry/signals/levels.py
+++ b/src/phonometry/signals/levels.py
@@ -155,7 +155,7 @@ def ln_levels(
     x_proc = _resolve_samples_raw(x, calibrate=False)
     _validate_level_input(x_proc, calibration_factor)
     for value in n:
-        if not 0 < value < 100:
+        if not 0 < value < 100:  # noqa: PLR2004
             msg = "Percentile values in 'n' must be between 0 and 100."
             raise ValueError(msg)
     if weighting is not None and weighting.upper() != "Z":

--- a/src/phonometry/signals/miso.py
+++ b/src/phonometry/signals/miso.py
@@ -88,6 +88,10 @@ _DEFAULT_OVERLAP = 0.5
 #: zero power (an empty or perfectly collinear input): its conditioning step
 #: is skipped and its coherence contribution is zero.
 _PIVOT_FLOOR_REL = 1e-12
+#: Minimum number of input records for a multiple-input (MISO) estimate
+#: (``q >= 2``): with one input the model is not multiple-input and the
+#: conditioning has nothing to order.
+_MIN_INPUT_RECORDS = 2
 
 
 # ---------------------------------------------------------------------------
@@ -156,13 +160,13 @@ def _validate_inputs(
         # are bare arrays and would otherwise reach the estimate in digital
         # units.
         rows = list(np.atleast_2d(resolve_samples(inputs)))
-    elif isinstance(inputs, np.ndarray) and inputs.ndim == 2:
+    elif isinstance(inputs, np.ndarray) and inputs.ndim == 2:  # noqa: PLR2004
         rows = [np.ascontiguousarray(row, dtype=np.float64) for row in inputs]
     else:
         # A sequence may hold Signals of its own; each element keeps its own
         # calibration, applied by _validate_signal below.
         rows = list(inputs)
-    if len(rows) < 2:
+    if len(rows) < _MIN_INPUT_RECORDS:
         msg = "'inputs' must hold at least two input records."
         raise ValueError(msg)
     xs = [_validate_signal(x, f"inputs[{i}]") for i, x in enumerate(rows)]

--- a/src/phonometry/signals/spectra.py
+++ b/src/phonometry/signals/spectra.py
@@ -91,6 +91,9 @@ __all__ = [
 _DEFAULT_OVERLAP = 0.5
 #: Minimum samples for a spectral estimate.
 _MIN_SAMPLES = 32
+#: Minimum frequency points for fractional-octave smoothing: the
+#: arithmetic-midpoint bin edges need at least two points.
+_MIN_SMOOTHING_POINTS = 2
 
 
 # ---------------------------------------------------------------------------
@@ -876,7 +879,7 @@ def _smoothing_validate(f: NDArray[np.float64], v: NDArray[np.float64]) -> None:
     if f.size != v.size:
         msg = "'frequencies' and 'values' must have the same length."
         raise ValueError(msg)
-    if f.size < 2:
+    if f.size < _MIN_SMOOTHING_POINTS:
         msg = "At least two frequency points are required."
         raise ValueError(msg)
     if not np.all(np.isfinite(f)) or not np.all(np.isfinite(v)):
@@ -984,6 +987,6 @@ def fractional_octave_smoothing(
     pos = f > 0.0
     fp = f[pos]
     out_power = power.copy()
-    if fp.size >= 2:
+    if fp.size >= _MIN_SMOOTHING_POINTS:
         out_power[pos] = _smoothing_window_average(fp, power[pos], frac)
     return _smoothing_from_power(out_power, domain)

--- a/src/phonometry/signals/synchronous_average.py
+++ b/src/phonometry/signals/synchronous_average.py
@@ -103,6 +103,10 @@ __all__ = [
 #: interpolation is applied and an integer-period record is exact.
 _ALIGN_TOL = 1e-9
 
+#: Validation floor for a period at the sample rate: the fewest samples a
+#: period may span for the block average to represent a waveform at all.
+_MIN_SAMPLES_PER_PERIOD = 2
+
 
 def comb_filter_response(
     frequencies: NDArray[np.float64] | list[float],
@@ -224,10 +228,10 @@ def _samples_per_period(fs: float, period: float) -> tuple[float, int]:
     """Exact and integer samples per period, with an integer-fit check."""
     samples = fs * period
     rounded = round(samples)
-    if rounded < 2:
+    if rounded < _MIN_SAMPLES_PER_PERIOD:
         msg = (
             "'period' is too short for the sample rate: it must span at "
-            "least 2 samples."
+            f"least {_MIN_SAMPLES_PER_PERIOD} samples."
         )
         raise ValueError(msg)
     return samples, rounded

--- a/src/phonometry/signals/test_signals.py
+++ b/src/phonometry/signals/test_signals.py
@@ -85,6 +85,29 @@ _COLOR_EXPONENTS: dict[str, float] = {
     "violet": 2.0,
 }
 
+#: Fewest samples ``round(fs * seconds)`` may give: the frequency-domain
+#: color shaping needs bins to work with.
+_MIN_NOISE_SAMPLES = 16
+
+#: Fewest samples of a processable one-dimensional record. Deliberately
+#: weaker than ``spectra._MIN_SAMPLES`` (the spectral-estimate floor these
+#: consumers do not need), so that constant is not reused here.
+_MIN_RECORD_SAMPLES = 2
+
+#: Gate-close offset (in samples) below which ``fs`` and ``frequency``
+#: count as commensurate (the gate closes sample-exactly on the tone's
+#: final zero crossing) and the incommensurate-frequency warning is
+#: suppressed. Same value as ``synchronous_average._ALIGN_TOL``, which
+#: cannot be imported here (that module imports this one).
+_GATE_ALIGN_TOL = 1e-9
+
+#: Smallest accepted anti-alias stopband attenuation, in dB.
+_MIN_STOPBAND_ATTENUATION_DB = 30.0
+
+#: Widest accepted transition band, as a fraction of the smaller Nyquist
+#: frequency.
+_MAX_TRANSITION_WIDTH = 0.5
+
 
 def noise_signal(
     fs: float,
@@ -121,7 +144,7 @@ def noise_signal(
         msg = "'seconds' must be a positive, finite number."
         raise ValueError(msg)
     n = round(fs_v * seconds_v)
-    if n < 16:
+    if n < _MIN_NOISE_SAMPLES:
         msg = f"'fs'*'seconds' must give at least 16 samples, got {n}."
         raise ValueError(msg)
     if color not in _COLOR_EXPONENTS:
@@ -171,7 +194,7 @@ def _validate_1d_finite(
     if xa.ndim != 1:
         msg = f"'{name}' must be one-dimensional."
         raise ValueError(msg)
-    if xa.size < 2:
+    if xa.size < _MIN_RECORD_SAMPLES:
         msg = f"'{name}' must have at least 2 samples."
         raise ValueError(msg)
     if not np.all(np.isfinite(xa)):
@@ -359,7 +382,7 @@ def tone_burst(
     burst_seconds = cycles_v / f_v
     exact_samples = fs_v * burst_seconds
     n_on = round(exact_samples)
-    if n_on < 2:
+    if n_on < _MIN_RECORD_SAMPLES:
         msg = "The burst is shorter than 2 samples; increase 'cycles' or 'fs'."
         raise ValueError(msg)
     rate_v, period, duty = _tone_burst_period(
@@ -370,7 +393,7 @@ def tone_burst(
     # repetition setup raises instead of warning first (which would mask
     # the error under a warnings-as-errors filter).
     delta = n_on - exact_samples  # gate-close offset from the zero crossing
-    if abs(delta) > 1e-9:
+    if abs(delta) > _GATE_ALIGN_TOL:
         residual = amplitude_v * math.sin(2.0 * math.pi * f_v * delta / fs_v)
         warnings.warn(
             f"'frequency' = {f_v:g} Hz is incommensurate with fs = "
@@ -537,11 +560,11 @@ def resample_signal(
     fs_v = _positive(resolve_fs(x, fs), "fs")
     fs_new_v = _positive(fs_new, "fs_new")
     atten = float(stopband_attenuation_db)
-    if not np.isfinite(atten) or atten < 30.0:
+    if not np.isfinite(atten) or atten < _MIN_STOPBAND_ATTENUATION_DB:
         msg = "'stopband_attenuation_db' must be at least 30 dB."
         raise ValueError(msg)
     tw = float(transition_width)
-    if not np.isfinite(tw) or not 0.0 < tw <= 0.5:
+    if not np.isfinite(tw) or not 0.0 < tw <= _MAX_TRANSITION_WIDTH:
         msg = "'transition_width' must be in (0, 0.5]."
         raise ValueError(msg)
     max_den = int(max_denominator)

--- a/src/phonometry/signals/time_frequency.py
+++ b/src/phonometry/signals/time_frequency.py
@@ -77,6 +77,10 @@ __all__ = [
     "zoom_fft",
 ]
 
+#: Minimum zoom-FFT grid points: the inclusive linspace over
+#: [f_min, f_max] needs at least its two band edges.
+_MIN_ZOOM_GRID_POINTS = 2
+
 
 def _taper(window: str, nperseg: int) -> NDArray[np.float64]:
     """The (periodic) analysis taper, as the Welch core uses it."""
@@ -366,7 +370,7 @@ def zoom_fft(
         m = int(np.ceil((hi - lo) * xa.size / fs_v)) + 1
     else:
         m = int(n_points)
-    if m < 2:
+    if m < _MIN_ZOOM_GRID_POINTS:
         msg = "'n_points' must be at least 2."
         raise ValueError(msg)
 

--- a/src/phonometry/signals/windows.py
+++ b/src/phonometry/signals/windows.py
@@ -39,6 +39,13 @@ __all__ = [
 #: Oversampling factor of the window spectrum (samples per DFT bin).
 _WINDOW_OVERSAMPLE = 256
 
+#: Half-power level in decibels, 10·log10(1/2) ≈ -3.0103: the threshold
+#: the two-sided -3 dB main-lobe width is measured at.
+_HALF_POWER_DB = -3.0103
+
+#: Minimum window length accepted by :func:`window_metrics`, in samples.
+_MIN_WINDOW_LENGTH = 16
+
 
 @dataclass(frozen=True)
 class WindowMetricsResult:
@@ -132,10 +139,10 @@ def _mainlobe_edge(level_db: NDArray[np.float64]) -> int:
 
 def _width_3db_bins(level_db: NDArray[np.float64], oversample: int) -> float:
     """Two-sided -3 dB main-lobe width in bins (linear dB interpolation)."""
-    below = np.flatnonzero(level_db <= -3.0103)
+    below = np.flatnonzero(level_db <= _HALF_POWER_DB)
     i = int(below[0])
     d0, d1 = float(level_db[i - 1]), float(level_db[i])
-    frac = ((-3.0103) - d0) / (d1 - d0)
+    frac = (_HALF_POWER_DB - d0) / (d1 - d0)
     return 2.0 * (i - 1 + frac) / oversample
 
 
@@ -165,8 +172,8 @@ def window_metrics(
     from scipy import signal as sp_signal
 
     n_v = int(n)
-    if n_v < 16:
-        msg = "'n' must be at least 16 samples."
+    if n_v < _MIN_WINDOW_LENGTH:
+        msg = f"'n' must be at least {_MIN_WINDOW_LENGTH} samples."
         raise ValueError(msg)
     try:
         w = np.asarray(

--- a/src/phonometry/simulation/elastic_fdtd.py
+++ b/src/phonometry/simulation/elastic_fdtd.py
@@ -101,6 +101,11 @@ _DIRECTIONS = ("x", "y")
 #: Fields a probe or a snapshot can record.
 _FIELD_NAMES = ("p", "vx", "vy")
 
+#: Smallest grid extent per axis (in cells) the staggered scheme supports:
+#: an axis shorter than this has no interior faces or corners, so the velocity
+#: field staggered across it and the shear stress txy would be empty arrays.
+_MIN_GRID_CELLS = 2
+
 
 @dataclass(frozen=True)
 class ExplosionSource:
@@ -251,7 +256,7 @@ def _as_material(name: str, value: object) -> Material:
     """Coerce a :class:`Material` or a ``(c_p, c_s, rho)`` triple."""
     if isinstance(value, Material):
         return value
-    if isinstance(value, Sequence) and not isinstance(value, str) and len(value) == 3:
+    if isinstance(value, Sequence) and not isinstance(value, str) and len(value) == 3:  # noqa: PLR2004
         c_p, c_s, rho = (float(np.real(v)) for v in value)
         return Material(c_p=c_p, c_s=c_s, rho=rho)
     msg = f"{name} must be a Material or a (c_p, c_s, rho) triple"
@@ -342,7 +347,7 @@ def _resolve_speed_map(
         out = np.full(shape, float(np.real(value)), dtype=np.float64)
     else:
         out = np.asarray(value, dtype=np.float64)
-    if out.ndim != 2:
+    if out.ndim != 2:  # noqa: PLR2004
         msg = f"{name} must be a 2D (ny, nx) map"
         raise ValueError(msg)
     return out
@@ -445,7 +450,7 @@ class ElasticFDTD2D:
         cp_map = _resolve_speed_map("c_p", c_p, shape)
         _positive_map("c_p", cp_map)
         ny, nx = cp_map.shape
-        if ny < 2 or nx < 2:
+        if ny < _MIN_GRID_CELLS or nx < _MIN_GRID_CELLS:
             msg = "the grid must be at least 2 x 2 cells"
             raise ValueError(msg)
         cs_map = _resolve_speed_map("c_s", c_s, (ny, nx))
@@ -580,7 +585,7 @@ class ElasticFDTD2D:
         """
         ny = _integer("shape[0]", shape[0])
         nx = _integer("shape[1]", shape[1])
-        if ny < 2 or nx < 2:
+        if ny < _MIN_GRID_CELLS or nx < _MIN_GRID_CELLS:
             msg = "the grid must be at least 2 x 2 cells"
             raise ValueError(msg)
         bg = _as_material("background", background)

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -333,7 +333,7 @@ def _validate_sponge_damping(
     if not np.all(np.isfinite(damping_map)) or np.any(damping_map < 0.0):
         msg = "damping must be non-negative and finite"
         raise ValueError(msg)
-    if damping_map.ndim == 2 and damping_map.shape != (ny, nx):
+    if damping_map.ndim == 2 and damping_map.shape != (ny, nx):  # noqa: PLR2004
         msg = (
             f"damping map shape {damping_map.shape} does not match the grid {(ny, nx)}"
         )
@@ -412,7 +412,7 @@ def _resolve_c_map(c: float | Field2D, shape: tuple[int, int] | None) -> Field2D
         c_map = np.full(shape, float(np.real(c)), dtype=np.float64)
     else:
         c_map = np.asarray(c, dtype=np.float64)
-    if c_map.ndim != 2:
+    if c_map.ndim != 2:  # noqa: PLR2004
         msg = "c must be a 2D (ny, nx) map"
         raise ValueError(msg)
     _positive_map("c", c_map)

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -68,6 +68,20 @@ _BETA_MALE = np.array([0.085, 0.078, 0.065, 0.011, 0.047, 0.095])
 # (Ed.5 Table A.3; identical to Ed.4 Table A.2).
 _ART_DB = np.array([46.0, 27.0, 12.0, 6.5, 7.5, 8.0, 12.0])
 
+# Segment breakpoints, in dB of total level L of the next lower octave
+# band, of the four-segment auditory masking function amdB (Ed.5 Table
+# A.2 = Ed.4 Table A.1): the steep 1.8 dB/dB middle segment runs from
+# 63 dB to 67 dB (0.5 dB/dB on either side), and amdB saturates at its
+# constant -10 dB from 100 dB up. All three are levels; 100.0 here is
+# unrelated to _ENVELOPE_LPF_HZ = 100.0 below, which is a frequency.
+_AMDB_STEEP_SEGMENT_START_DB = 63.0
+_AMDB_STEEP_SEGMENT_END_DB = 67.0
+_AMDB_SATURATION_DB = 100.0
+
+# Modulation-transfer validity ceiling: a value above 1.3 means the
+# measurement is likely invalid (IEC 60268-16 A.5.3 NOTE 1, Ed.4 = Ed.5).
+_MTF_INVALID_ABOVE = 1.3
+
 # STIPA modulation frequency pairs per octave band (Table B.1, unchanged
 # between Ed.4 and Ed.5) and the source modulation index per component.
 _STIPA_F1 = np.array([1.60, 1.00, 0.63, 2.00, 1.25, 0.80, 2.50])
@@ -204,7 +218,11 @@ def _masking_amdb(level: np.ndarray | float) -> np.ndarray:
     lvl = np.asarray(level, dtype=np.float64)
     return np.asarray(
         np.select(
-            [lvl < 63.0, lvl < 67.0, lvl < 100.0],
+            [
+                lvl < _AMDB_STEEP_SEGMENT_START_DB,
+                lvl < _AMDB_STEEP_SEGMENT_END_DB,
+                lvl < _AMDB_SATURATION_DB,
+            ],
             [0.5 * lvl - 65.0, 1.8 * lvl - 146.9, 0.5 * lvl - 59.8],
             default=-10.0,
         )
@@ -243,7 +261,7 @@ def _truncated_mtf(mtf: np.ndarray) -> np.ndarray:
     invalid, and every value is truncated to 1,0 before the chain runs.
     """
     m = np.array(mtf, dtype=np.float64)
-    if m.ndim != 2 or m.shape[0] != _NUM_BANDS:
+    if m.ndim != 2 or m.shape[0] != _NUM_BANDS:  # noqa: PLR2004
         msg = (
             f"'mtf' must have shape ({_NUM_BANDS}, n_modulation_frequencies), "
             f"got {m.shape}."
@@ -252,7 +270,7 @@ def _truncated_mtf(mtf: np.ndarray) -> np.ndarray:
     if np.any(m < 0.0) or not np.all(np.isfinite(m)):
         msg = "Modulation transfer values must be finite and >= 0."
         raise ValueError(msg)
-    if np.any(m > 1.3):
+    if np.any(m > _MTF_INVALID_ABOVE):
         warnings.warn(
             "Modulation transfer values above 1.3 detected: the measurement "
             "is likely invalid (IEC 60268-16 A.5.3). Values truncated to 1.0.",

--- a/src/phonometry/underwater/propagation/closed_form.py
+++ b/src/phonometry/underwater/propagation/closed_form.py
@@ -46,6 +46,10 @@ _SPREADING_LAWS = ("spherical", "cylindrical", "practical")
 _ABSORPTION_MODELS = ("francois-garrison", "ainslie-mccolm", "thorp")
 #: Metres per kilometre.
 _M_PER_KM = 1000.0
+#: Francois-Garrison pure-water (A3) coefficient boundary, in degrees Celsius:
+#: the "20 C switch" between the two published A3 cubics (see the note in
+#: _francois_garrison -- they do not meet exactly there).
+_FG_A3_SWITCH_T_C = 20.0
 
 
 def _positive(value: float, name: str) -> float:
@@ -134,7 +138,7 @@ def _francois_garrison(
     # The two published A3 cubics do not meet exactly at the 20 C switch
     # (step of 1e-7*f^2 dB/km, i.e. 0.1 dB/km at 1 MHz, 0.03 % of alpha there);
     # inherent in the Francois-Garrison coefficients -- do not "fix" it.
-    if t <= 20.0:
+    if t <= _FG_A3_SWITCH_T_C:
         a3 = 4.937e-4 - 2.59e-5 * t + 9.11e-7 * t**2 - 1.50e-8 * t**3
     else:
         a3 = 3.964e-4 - 1.146e-5 * t + 1.45e-7 * t**2 - 6.50e-10 * t**3

--- a/src/phonometry/underwater/propagation/numerical.py
+++ b/src/phonometry/underwater/propagation/numerical.py
@@ -78,6 +78,50 @@ _SOURCE_OUTSIDE = "'source_depth' must lie within the water column."
 #: always pressure-release, so its own coefficient is the -1 below.
 _BOTTOM_REFLECTION = {"pressure-release": -1.0, "rigid": 1.0}
 _SURFACE_REFLECTION = -1.0
+#: The fewest nodes a piecewise-linear polyline can carry, be it the
+#: sound-speed profile in depth or the bathymetry in range: two nodes define
+#: the single segment :func:`numpy.interp` needs.
+_MIN_POLYLINE_NODES = 2
+#: Floating-point slack, in metres, within which a polyline's first node
+#: counts as sitting exactly at its origin: the pressure-release surface
+#: z = 0 for the profile, the source r = 0 for the bathymetry.
+_ORIGIN_SLACK_M = 1e-9
+#: Floor on 'n_depth_points', the finite-difference depth grid the
+#: normal-mode Sturm-Liouville eigenvalue problem is discretised on; below
+#: this the tridiagonal discretisation is not meaningfully a grid.
+_MIN_MODE_GRID_POINTS = 8
+#: Floor on the integration steps per traced ray: a marched ray needs at
+#: least its two end range samples.
+_MIN_RAY_STEPS = 2
+#: The vertical, in degrees from the horizontal. Launch angles and the beam
+#: fan's half-angle must stay strictly inside it, so that every ray is a
+#: forward ray with a positive Snell invariant.
+_VERTICAL_DEG = 90.0
+#: Angular slack, in radians, for deciding a wedge image-fan rung lands
+#: exactly on the seam at pi, where the fan of images closes on itself and
+#: only the positive wrap keeps the rung.
+_SEAM_SLACK_RAD = 1e-9
+#: The shortest sound-speed profile that can hold a gradient discontinuity:
+#: a kink lives on an interior node between two segments, so fewer points
+#: leave nothing for the source-on-kink jet check (Jensen Sect. 3.7.4) to
+#: find.
+_MIN_KINK_PROFILE_POINTS = 3
+#: Depth-coincidence tolerance, in metres, deciding the source sits on a
+#: listed gradient-discontinuity depth of the profile and so provokes the
+#: spurious-jet warning of Jensen Sect. 3.7.4.
+_KINK_PROXIMITY_M = 1e-6
+#: Floor on the default beam receiver grid, which mirrors the interior
+#: depth grid of :func:`parabolic_equation` so the two fields land on the
+#: same depths: it must hold at least two receiver depths.
+_MIN_RECEIVER_DEPTHS = 2
+#: Floor on 'n_beams': the fan spacing ``launch[1] - launch[0]``, and the
+#: per-beam overlap condition, need at least two beams to exist.
+_MIN_FAN_BEAMS = 2
+#: Floor on 'n_depth_points', the interior sine-transform depth grid the
+#: split-step Fourier parabolic equation marches on; fewer points cannot
+#: resolve the vertical wavenumbers kz_m = m*pi/D the transform is built
+#: from.
+_MIN_PE_DEPTH_POINTS = 16
 
 
 def _clean_profile(
@@ -86,7 +130,7 @@ def _clean_profile(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     z = np.asarray(depths, dtype=np.float64)
     c = np.asarray(sound_speeds, dtype=np.float64)
-    if z.ndim != 1 or z.size < 2:
+    if z.ndim != 1 or z.size < _MIN_POLYLINE_NODES:
         msg = "'depths' must be a 1-D array of at least two points."
         raise ValueError(msg)
     if c.shape != z.shape:
@@ -98,7 +142,7 @@ def _clean_profile(
     if np.any(np.diff(z) <= 0.0):
         msg = "'depths' must be strictly increasing."
         raise ValueError(msg)
-    if abs(float(z[0])) > 1e-9:
+    if abs(float(z[0])) > _ORIGIN_SLACK_M:
         msg = "'depths' must start at the surface z = 0."
         raise ValueError(msg)
     if np.any(c <= 0.0):
@@ -126,12 +170,12 @@ def _clean_bathymetry(
     if bathymetry is None:
         return None
     pair = tuple(bathymetry)
-    if len(pair) != 2 or pair[0] is None or pair[1] is None:
+    if len(pair) != 2 or pair[0] is None or pair[1] is None:  # noqa: PLR2004
         msg = "'bathymetry' must be a (ranges_m, depths_m) pair of arrays."
         raise ValueError(msg)
     br = np.asarray(pair[0], dtype=np.float64).ravel()
     bd = np.asarray(pair[1], dtype=np.float64).ravel()
-    if br.size < 2 or bd.shape != br.shape:
+    if br.size < _MIN_POLYLINE_NODES or bd.shape != br.shape:
         msg = (
             "the two halves of 'bathymetry' must be 1-D"
             " arrays of equal length, at least two points."
@@ -143,7 +187,7 @@ def _clean_bathymetry(
     if np.any(np.diff(br) <= 0.0):
         msg = "the bathymetry ranges must be strictly increasing."
         raise ValueError(msg)
-    if abs(float(br[0])) > 1e-9:
+    if abs(float(br[0])) > _ORIGIN_SLACK_M:
         msg = "the bathymetry must start at the source, r = 0."
         raise ValueError(msg)
     if np.any(bd <= 0.0):
@@ -445,7 +489,7 @@ def normal_modes(
             20_000,
             max(400, int(np.ceil(60.0 * water_depth * f / float(np.min(c_prof))))),
         )
-    if int(n_depth_points) < 8:
+    if int(n_depth_points) < _MIN_MODE_GRID_POINTS:
         msg = "'n_depth_points' must be at least 8."
         raise ValueError(msg)
 
@@ -733,14 +777,14 @@ def ray_trace(
     if not (0.0 <= zs <= depth_at_source):
         raise ValueError(_SOURCE_OUTSIDE)
     rmax = require_positive(max_range, "max_range")
-    if int(n_steps) < 2:
+    if int(n_steps) < _MIN_RAY_STEPS:
         msg = "'n_steps' must be at least 2."
         raise ValueError(msg)
     angles = np.asarray(launch_angles_deg, dtype=np.float64).ravel()
     if angles.size == 0 or not np.all(np.isfinite(angles)):
         msg = "'launch_angles_deg' must be finite and non-empty."
         raise ValueError(msg)
-    if np.any(np.abs(angles) >= 90.0):
+    if np.any(np.abs(angles) >= _VERTICAL_DEG):
         msg = "'launch_angles_deg' must be within (-90, 90) degrees (forward rays)."
         raise ValueError(msg)
 
@@ -1291,14 +1335,14 @@ def eigenrays(
     if int(max_arrivals) < 1:
         msg = "'max_arrivals' must be at least 1."
         raise ValueError(msg)
-    if trace.launch_angles.size < 2:
+    if trace.launch_angles.size < 2:  # noqa: PLR2004
         msg = "'trace' must carry at least two rays to bracket between."
         raise ValueError(msg)
     if n_steps is None:
         ns = max(2, int(np.ceil(r_rec / float(r_grid[1] - r_grid[0]))) + 1)
     else:
         ns = int(n_steps)
-        if ns < 2:
+        if ns < _MIN_RAY_STEPS:
             msg = "'n_steps' must be at least 2."
             raise ValueError(msg)
 
@@ -1949,7 +1993,7 @@ def _fold_margins(
     valid = (
         ~sloped
         | (turned < np.pi - 1e-9)
-        | ((np.abs(turned - np.pi) <= 1e-9) & (wrap > 0))
+        | ((np.abs(turned - np.pi) <= _SEAM_SLACK_RAD) & (wrap > 0))
     )
     return margin, valid
 
@@ -2492,14 +2536,14 @@ def _check_source_on_kink(
     rather than a corner one, so it is worth saying out loud; moving the source
     by a metre, or handing in a profile without the kink, removes it.
     """
-    if z_prof.size < 3:
+    if z_prof.size < _MIN_KINK_PROFILE_POINTS:
         return
     grad = np.diff(c_prof) / np.diff(z_prof)
     # A jump of exactly zero is a node the profile runs straight through; any
     # jump at all is a kink, so the test is deliberately exact and carries no
     # tolerance (see :func:`phonometry._internal.rays._prepare_impulses`).
     kinked = z_prof[1:-1][np.diff(grad).astype(bool)]
-    if kinked.size and np.min(np.abs(kinked - source_depth)) <= 1e-6:
+    if kinked.size and np.min(np.abs(kinked - source_depth)) <= _KINK_PROXIMITY_M:
         _warn_beams(
             "'source_depth' sits on a gradient discontinuity of the profile,"
             " which concentrates the near-horizontal beams into a spurious jet;"
@@ -2551,7 +2595,7 @@ def _beam_receiver_grid(
     """
     if receiver_depths_m is None:
         n_z = int(n_depth_points)
-        if n_z < 2:
+        if n_z < _MIN_RECEIVER_DEPTHS:
             msg = "'n_depth_points' must be at least 2."
             raise ValueError(msg)
         dz = water_depth / (n_z + 1)
@@ -2680,7 +2724,7 @@ def _resolve_fan(
 ) -> _Fan:
     """The concrete fan a :class:`BeamFan` asks for, widths resolved."""
     theta_max = float(fan.max_angle_deg)
-    if not (0.0 < theta_max < 90.0):
+    if not (0.0 < theta_max < _VERTICAL_DEG):
         msg = "'max_angle_deg' must lie in (0, 90) degrees."
         raise ValueError(msg)
     # The width the fan's density is sized for has to exist before the fan
@@ -2700,7 +2744,7 @@ def _resolve_fan(
         if fan.n_beams is None
         else int(fan.n_beams)
     )
-    if n_fan < 2:
+    if n_fan < _MIN_FAN_BEAMS:
         msg = "'n_beams' must be at least 2."
         raise ValueError(msg)
     launch = np.linspace(-np.radians(theta_max), np.radians(theta_max), n_fan)
@@ -3380,7 +3424,7 @@ def parabolic_equation(
         msg = "'range_step' must not exceed 'max_range'."
         raise ValueError(msg)
     n = int(n_depth_points)
-    if n < 16:
+    if n < _MIN_PE_DEPTH_POINTS:
         msg = "'n_depth_points' must be at least 16."
         raise ValueError(msg)
 

--- a/src/phonometry/underwater/propagation/seabed_reflection.py
+++ b/src/phonometry/underwater/propagation/seabed_reflection.py
@@ -43,6 +43,9 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 
+# Upper edge of the grazing-angle domain: 90° is normal incidence.
+_NORMAL_INCIDENCE_DEG = 90.0
+
 
 def critical_angle(c1: float, c2: float) -> float:
     r"""Critical grazing angle :math:`\varphi_\mathrm{c} = \arccos(c_1/c_2)`, in
@@ -88,7 +91,7 @@ def reflection_coefficient(
     if phi.size == 0 or not np.all(np.isfinite(phi)):
         msg = "'grazing_angle' must be finite and non-empty."
         raise ValueError(msg)
-    if np.any(phi < 0.0) or np.any(phi > 90.0):
+    if np.any(phi < 0.0) or np.any(phi > _NORMAL_INCIDENCE_DEG):
         msg = "'grazing_angle' must be within [0, 90] degrees."
         raise ValueError(msg)
     r1 = require_positive(rho1, "rho1")

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -43,6 +43,9 @@ if TYPE_CHECKING:
 _BAR_PER_MPA = 10.0
 #: kg/cm² per bar (100 kPa = 1.019716 kg/cm²; 1 bar = 100 kPa).
 _KGCM2_PER_BAR = 1.019716
+#: Minimum depth samples in a profile: two points are the floor for a
+#: piecewise-linear profile and for ``np.gradient``'s finite differences.
+_MIN_POLYLINE_NODES = 2
 
 _MODELS = ("unesco", "del_grosso", "mackenzie", "medwin")
 #: Models that take a depth directly instead of a pressure.
@@ -328,7 +331,7 @@ def sound_speed_profile(
     :raises ValueError: If the inputs are invalid.
     """
     z = np.asarray(depths, dtype=np.float64)
-    if z.ndim != 1 or z.size < 2:
+    if z.ndim != 1 or z.size < _MIN_POLYLINE_NODES:
         msg = "'depths' must be a 1-D array of at least two depths."
         raise ValueError(msg)
     if np.any(z < 0.0) or not np.all(np.isfinite(z)):

--- a/src/phonometry/underwater/propagation/weston_regimes.py
+++ b/src/phonometry/underwater/propagation/weston_regimes.py
@@ -65,6 +65,10 @@ if TYPE_CHECKING:
 #: Regime labels, in order of increasing range.
 WESTON_REGIMES = ("spherical", "cylindrical", "mode-stripping", "single-mode")
 
+# Normal incidence, the largest grazing angle a ray can have: the upper edge
+# of the (0, 90] degree validity range for a 'critical_angle' override.
+_NORMAL_INCIDENCE_DEG = 90.0
+
 
 @dataclass(frozen=True)
 class WestonSeabed:
@@ -404,7 +408,7 @@ def _angle_and_gradient(
             raise ValueError(msg)
     else:
         deg = float(critical_angle)
-        if not np.isfinite(deg) or not (0.0 < deg <= 90.0):
+        if not np.isfinite(deg) or not (0.0 < deg <= _NORMAL_INCIDENCE_DEG):
             msg = "'critical_angle' must lie in (0, 90] degrees."
             raise ValueError(msg)
         psi_c = np.radians(deg)

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 
+#: Fewest points a range grid may have: two, the least that define a curve
+#: segment between two bracketing samples.
+_MIN_CURVE_POINTS = 2
+
 
 def _finite(value: float, name: str) -> float:
     scalar = float(value)
@@ -307,7 +311,7 @@ def detection_range(
     if rmax <= 1.0:
         msg = "'max_range' must exceed 1 m."
         raise ValueError(msg)
-    if int(n_points) < 2:
+    if int(n_points) < _MIN_CURVE_POINTS:
         msg = "'n_points' must be at least 2."
         raise ValueError(msg)
     options = {
@@ -378,7 +382,7 @@ def detection_range_from_curve(
     if r.shape != pl.shape:
         msg = "'propagation_loss' must have the same length as 'range_m'."
         raise ValueError(msg)
-    if r.size < 2 or np.any(np.diff(r) <= 0.0):
+    if r.size < _MIN_CURVE_POINTS or np.any(np.diff(r) <= 0.0):
         msg = "'range_m' must be strictly increasing with at least two samples."
         raise ValueError(msg)
     key = crossing.strip().lower()

--- a/src/phonometry/underwater/sources/ship_radiated_noise.py
+++ b/src/phonometry/underwater/sources/ship_radiated_noise.py
@@ -42,6 +42,13 @@ _SOURCE_DEPTH_FRACTION = 0.7
 _REFERENCE_DISTANCE = 1.0
 #: ISO 17208-1 standard depression angles (degrees) for the three hydrophones.
 _STANDARD_ANGLES = (15.0, 30.0, 45.0)
+#: Vertical depression angle (degrees); hydrophone angles must stay below it
+#: because the depth ``d = d_CPA * tan(angle)`` diverges at vertical.
+_VERTICAL_DEG = 90.0
+#: Upper edge (Hz) of the 5 dB low-frequency uncertainty bands (ISO 17208-2 §5).
+_UNCERTAINTY_LOW_BAND_MAX_HZ = 100.0
+#: Upper edge (Hz) of the 3 dB mid-frequency uncertainty bands (ISO 17208-2 §5).
+_UNCERTAINTY_MID_BAND_MAX_HZ = 16000.0
 
 
 def radiated_noise_level(rms_pressure: float, distance: float) -> float:
@@ -87,7 +94,7 @@ def hydrophone_depths(
         ang.size == 0
         or not np.all(np.isfinite(ang))
         or np.any(ang <= 0.0)
-        or np.any(ang >= 90.0)
+        or np.any(ang >= _VERTICAL_DEG)
     ):
         msg = "'angles' must be finite and lie in the open interval (0, 90) degrees."
         raise ValueError(msg)
@@ -112,9 +119,9 @@ def source_level_uncertainty(frequency: float) -> float:
     :raises ValueError: If the frequency is not positive.
     """
     f = _positive(frequency, "frequency")
-    if f <= 100.0:
+    if f <= _UNCERTAINTY_LOW_BAND_MAX_HZ:
         return 5.0
-    if f <= 16000.0:
+    if f <= _UNCERTAINTY_MID_BAND_MAX_HZ:
         return 3.0
     return 4.0
 

--- a/src/phonometry/underwater/sources/ship_traffic_noise.py
+++ b/src/phonometry/underwater/sources/ship_traffic_noise.py
@@ -46,6 +46,27 @@ _L_REF_M = 300.0 / 3.28084
 
 _MODELS = ("jomopans-echo", "randi", "wales-heitmeyer")
 
+#: Upper frequency bound, in Hz, of the cargo low-frequency hump in the
+#: JOMOPANS-ECHO reference spectrum: below it, cargo vessel classes switch to
+#: the hump parameter set (K=208, J=2, D_lo, f1=600/V_C).
+_CARGO_HUMP_MAX_HZ = 100.0
+
+#: Crossover frequency, in Hz, between the two branches of the RANDI 3.1
+#: average-ship baseline spectrum: the two-term log10 formula below it, the
+#: 173.2 - 18*log10(f) line at and above it.
+_RANDI_BASELINE_SPLIT_HZ = 500.0
+
+#: Upper edge, in Hz, of the flat region of the RANDI 3.1 frequency-dependent
+#: length-scaling factor d_f, which holds the constant value 8.1 up to this
+#: frequency (the sloped branch 22.3 - 9.77*log10(f) also evaluates to 8.1
+#: here, keeping the piecewise factor continuous).
+_RANDI_DF_PLATEAU_MAX_HZ = 28.4
+
+#: Frequency, in Hz, above which the RANDI 3.1 length-scaling factor d_f is
+#: zero; the point where its sloped branch 22.3 - 9.77*log10(f) reaches 0, so
+#: the factor again stays continuous.
+_RANDI_DF_CUTOFF_HZ = 191.6
+
 #: JOMOPANS-ECHO per-class parameters: ``class -> (V_C [kn], cargo, D_lo, D_hi)``
 #: (Table 1 and sheet *Parameters* of File S1). ``D_lo`` is the damping of the
 #: cargo low-frequency hump; ``D_hi`` the damping of the main spectrum.
@@ -93,7 +114,7 @@ def _jomopans_echo(
     v_c, cargo, d_lo, d_hi = _VESSEL_CLASSES[key]
     v = require_positive(speed_knots, "speed_knots")
     length = require_positive(length_m, "length_m")
-    hump = cargo & (f < 100.0)
+    hump = cargo & (f < _CARGO_HUMP_MAX_HZ)
     k = np.where(hump, 208.0, 191.0)
     j = np.where(hump, 2.0, 0.0)
     d = np.where(hump, d_lo, d_hi)
@@ -117,12 +138,12 @@ def _randi(
     lf = -10.0 * np.log10(
         10.0 ** (-1.06 * np.log10(f) - 14.34) + 10.0 ** (3.32 * np.log10(f) - 21.425)
     )
-    base = np.where(f < 500.0, lf, 173.2 - 18.0 * np.log10(f))
+    base = np.where(f < _RANDI_BASELINE_SPLIT_HZ, lf, 173.2 - 18.0 * np.log10(f))
     d_l = length_ft**1.15 / 3643.0
     d_f = np.where(
-        f <= 28.4,
+        f <= _RANDI_DF_PLATEAU_MAX_HZ,
         8.1,
-        np.where(f <= 191.6, 22.3 - 9.77 * np.log10(f), 0.0),
+        np.where(f <= _RANDI_DF_CUTOFF_HZ, 22.3 - 9.77 * np.log10(f), 0.0),
     )
     psd = (
         base

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 Complex = NDArray[np.complex128]
 
 __all__ = [
+    "BASIC_METHOD_MAX_CREST_FACTOR",
     "HAV_EAV_A8",
     "HAV_ELV_A8",
     "REFERENCE_ACCELERATION",
@@ -137,6 +138,10 @@ WBV_EAV_VDV = 9.1
 #: Whole-body VDV exposure limit value ``21 m/s^1,75`` (Directive
 #: 2002/44/EC, Article 3(2)(b), alternative dose metric).
 WBV_ELV_VDV = 21.0
+
+#: Largest crest factor for which the basic (r.m.s.) evaluation method is
+#: adequate (ISO 2631-1:1997, 6.2.2); :func:`crest_factor` warns above it.
+BASIC_METHOD_MAX_CREST_FACTOR = 9.0
 
 _Q_BUTTERWORTH = 1.0 / math.sqrt(2.0)
 
@@ -740,7 +745,7 @@ def crest_factor(signal: SignalInput) -> float:
     if rms <= 0.0:
         return 0.0
     cf = float(np.max(np.abs(x)) / rms)
-    if cf > 9.0:
+    if cf > BASIC_METHOD_MAX_CREST_FACTOR:
         warnings.warn(
             f"Crest factor {cf:.1f} exceeds 9; the basic r.m.s. method may be "
             "inadequate (ISO 2631-1, 6.2.2) - consider the VDV or running "

--- a/src/phonometry/vibration/machinery/diagnostics.py
+++ b/src/phonometry/vibration/machinery/diagnostics.py
@@ -108,6 +108,13 @@ if TYPE_CHECKING:
 #: Description of the shaft-rate line, shared by every family.
 _SHAFT_DESCRIPTION = "shaft rotational frequency"
 
+#: Exclusive upper bound of the bearing contact angle phi, in degrees: the
+#: rolling-contact factor g = (d/D) cos(phi) degenerates at a right angle.
+_MAX_CONTACT_ANGLE_DEG = 90.0
+
+#: Minimum magnetic pole count of an induction motor: one pole pair.
+_MIN_POLES = 2
+
 
 def _require_count(value: int, name: str, minimum: int = 1) -> int:
     """An integer parameter that must be at least *minimum*."""
@@ -386,7 +393,7 @@ def bearing_fault_frequencies(
         msg = "'element_diameter' must be smaller than 'pitch_diameter'."
         raise ValueError(msg)
     phi = require_non_negative(contact_angle_deg, "contact_angle_deg")
-    if phi >= 90.0:
+    if phi >= _MAX_CONTACT_ANGLE_DEG:
         msg = "'contact_angle_deg' must be below 90 degrees."
         raise ValueError(msg)
     race = require_choice(rotating_race, "rotating_race", ("inner", "outer"))
@@ -615,7 +622,7 @@ def induction_motor_frequencies(
     """
     fs = shaft_rate(speed_rpm)
     p = int(poles)
-    if p < 2 or p % 2:
+    if p < _MIN_POLES or p % 2:
         msg = "'poles' must be an even integer of at least 2."
         raise ValueError(msg)
     bars = _require_count(rotor_bars, "rotor_bars")

--- a/src/phonometry/vibration/structural/experimental_sea.py
+++ b/src/phonometry/vibration/structural/experimental_sea.py
@@ -104,6 +104,15 @@ __all__ = [
 #: used by the above-ring-frequency cylinder modal density (Norton Eq. 6.29).
 _BANDWIDTH_FACTOR: dict[str, float] = {"third": 1.122, "octave": 1.414}
 
+#: Largest ``x = f/f_r`` at which the sqrt-regime cylinder modal density
+#: (Norton Eq. 6.27) still applies; Eq. 6.28 takes over above it.
+_SQRT_REGIME_MAX_RING_RATIO = 0.48
+
+#: Largest ``x = f/f_r`` at which the linear-regime cylinder modal density
+#: (Norton Eq. 6.28) still applies; the bandwidth-averaged Eq. 6.29 takes
+#: over above it.
+_LINEAR_REGIME_MAX_RING_RATIO = 0.83
+
 
 # ---------------------------------------------------------------------------
 # Modal densities (Norton 6.4.1)
@@ -247,9 +256,9 @@ def cylindrical_shell_modal_density(
     base = s / (math.pi * c_l * t)
     low = 5.0 * base * np.sqrt(x)
     mid = 7.2 * base * x
-    # Eq. (6.29): the arccos arguments leave [-1, 1] just above the 0,83
-    # threshold for narrow bands, so clip them; the branch is only selected
-    # where the expression is meaningful anyway.
+    # Eq. (6.29): the arccos arguments leave [-1, 1] just above the
+    # _LINEAR_REGIME_MAX_RING_RATIO threshold for narrow bands, so clip them;
+    # the branch is only selected where the expression is meaningful anyway.
     arg_1 = np.clip(1.745 / (factor**2 * np.maximum(x, 1e-12) ** 2), -1.0, 1.0)
     arg_2 = np.clip(1.745 * factor**2 / np.maximum(x, 1e-12) ** 2, -1.0, 1.0)
     shape = 0.596 / (factor - 1.0 / factor)
@@ -258,7 +267,11 @@ def cylindrical_shell_modal_density(
         * base
         * (2.0 + shape * (factor * np.arccos(arg_1) - np.arccos(arg_2) / factor))
     )
-    n = np.where(x <= 0.48, low, np.where(x <= 0.83, mid, high))
+    n = np.where(
+        x <= _SQRT_REGIME_MAX_RING_RATIO,
+        low,
+        np.where(x <= _LINEAR_REGIME_MAX_RING_RATIO, mid, high),
+    )
     return np.asarray(n, dtype=np.float64)
 
 


### PR DESCRIPTION
## What and why

`PLR2004` is selected for `src`, and the 487 magic values it found there were read one at a time before it went on: 380 became named constants, 29 reach a symbol that already said it, and 85 lines keep their literal under a `noqa` that says why. The name states the concept rather than the number, so `if len(header) < 4` is `< _BLOCK_HEADER_BYTES` (a FLAC metadata block header is one type byte and three length bytes) and `if nominal >= 1000.0` is `>= _HZ_PER_KHZ`. Where a name would say less than the expression already does, the literal stays: `order == 2` sits under a docstring that says "Product order (2 or 3)", and the transcribed CIEDE2000 formula keeps the 180 and 360 degrees its published equations are written with.

Reading every site found things a rule never would. Absolute zero is in the tree twice, as the exact -273.15 and as the -273.0 that ISO 3741 writes into its own `273 + theta` arithmetic; they are `_ABS_ZERO_C` and `_ROUNDED_ABS_ZERO_C`, deliberately unmergeable. Four modules already spelled the 1 kHz reference `_REFERENCE_FREQUENCY`, so the new ones join them instead of inventing a fifth spelling. The RIFF wire magics now live once in `io/_chunks.py`, which closed a duplicate spelling of the bext chunk identifier and a sniffer table that had drifted from the name it was meant to match. A fiche's private frequency-label helper turned out to be byte-identical to `filters.frequencies._format_nominal_freq` and now calls it.

The strings are not part of this. `PLR2004` exempts `str` and `bytes` by default and stays that way, because a comparison against `"cremer"` or `"es"` is the API's own vocabulary and the literal is the name; only the format magics among them were named. `tests` and `scripts` are exempt too: the tests compare against printed oracle values, and the figure scripts lay out halves and angles, where a name for every number is noise.

## Validation

No new computation, and no numeric value moves: each constant carries the literal spelling it replaced, and every comparison keeps its direction and operands. The regenerated artifacts (API reference, llms, conformance) came out byte-identical and all 42 animation fingerprints stayed put.

Every edit was reviewed against the code by a second pass, which found eleven comments that stated something the code does not do, and fixed them: two wrong clause citations (the `(n - 1)` divisor is ISO 9614-1 equations (A.1)/(A.8), not the mean equations (A.2)/(A.9); the ECMA-418-2 formulae 56/57 are Clause 6.2.10, not 6.2.8), a sign claim on the CNOSSOS downhill thresholds that would have read as a 12 dB error if taken literally, and several guards described as symmetric that are one-sided.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files you touched
- [x] `mypy src scripts`
- [x] `bandit -r src` (any finding fails, including Low)
- [x] `pytest -q` (8958 passed, 16 skipped)

Regenerated where this change touches them:

- [x] `make conformance`: byte-identical, nothing to commit
- [x] `make api-docs`: byte-identical, nothing to commit
- [x] `make llms`: byte-identical, nothing to commit

Always:

- [x] CHANGELOG entry under `[Unreleased]`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

