### PR TITLE
Say whether each zip's inputs must be the same length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Every `zip()` says whether its inputs must be the same length. `B905` is
+  selected, and the 162 calls it found were read one at a time: 157 pair
+  arrays that are equal by construction and now say `strict=True`, and five
+  consume the shorter input on purpose and say `strict=False` with a line
+  saying what ends the loop. The five are worth naming, because they are the
+  cases a blanket fix would have got wrong: two walk a palette against fewer
+  paths than it holds, one walks the fixed seven-band STI table against
+  whatever the result carries, one pairs `T20`/`T30` against however many fit
+  the plot, and one reads a mapping's keys against its values in an AST node.
+
+  `strict=True` is not a formality: it turns a silent truncation into a
+  `ValueError`, so it is only the truth where something upstream guarantees
+  the lengths. Checking that guarantee, site by site, is what this change was
+  for, and it found seven places where nothing guaranteed it. Six accredited
+  report fiches and one plot take their per-band arrays straight off a frozen
+  dataclass that has no `__post_init__`, is exported from a public package,
+  and has its constructor signature in the generated reference, so a result
+  built by hand reaches the table with arrays of any lengths at all. The
+  guards that existed covered some of the arrays and not the others: ISO 354
+  compared the frequencies against the absorption coefficient and left the
+  two reverberation times and both absorption areas unchecked, ISO 11654
+  checked three of five, and the scattering fiche two of four. Each now
+  raises a named `ValueError` before the table is built, the way the sibling
+  fiches already did, and the `strict=` behind it is the backstop it should
+  have been. Before this, a short array printed a table that quietly listed
+  fewer bands than the daily total above it was summing.
+
+  One call stays as it was, with a `noqa` that says so: it sits in the code
+  that draws `anim_fdtd_impedance_tube`, where its three operands are the
+  same pair of panels built a few lines above, so the argument could only
+  ever hold, and adding it would move the clip's recorded fingerprint and
+  ask for a re-render of the very same frames.
+
 - A number in a comparison carries a name. `PLR2004` is selected for `src`,
   and the 487 magic values it found there were read one at a time before it
   went on: 380 became named constants, 29 reach an existing symbol that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,16 +100,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Every `zip()` says whether its inputs must be the same length. `B905` is
-  selected, and the 162 calls it found were read one at a time: 157 pair
-  arrays that are equal by construction and now say `strict=True`, and five
+  selected, and the 162 calls it found were read one at a time: 158 pair
+  arrays that are equal by construction and now say `strict=True`, and four
   consume the shorter input on purpose and say `strict=False` with a line
-  saying what ends the loop. The five are worth naming, because they are the
+  saying what ends the loop. The four are worth naming, because they are the
   cases a blanket fix would have got wrong: two walk a palette against fewer
   paths than it holds, one walks the fixed seven-band STI table against
-  whatever the result carries, one walks a list of title sizes against the
-  same list offset by one, where the smallest size has no step below it, and
-  one names the leading columns of a rotorcraft `.his` header, leaving any
-  further column of a variant file unnamed.
+  whatever the result carries, and one walks a list of title sizes against
+  the same list offset by one, where the smallest size has no step below it.
 
   `strict=True` is not a formality: it turns a silent truncation into a
   `ValueError`, so it is only the truth where something upstream guarantees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   saying what ends the loop. The five are worth naming, because they are the
   cases a blanket fix would have got wrong: two walk a palette against fewer
   paths than it holds, one walks the fixed seven-band STI table against
-  whatever the result carries, one pairs `T20`/`T30` against however many fit
-  the plot, and one reads a mapping's keys against its values in an AST node.
+  whatever the result carries, one walks a list of title sizes against the
+  same list offset by one, where the smallest size has no step below it, and
+  one names the leading columns of a rotorcraft `.his` header, leaving any
+  further column of a variant file unnamed.
 
   `strict=True` is not a formality: it turns a silent truncation into a
   `ValueError`, so it is only the truth where something upstream guarantees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ select = [
     "ICN",                  # the conventional alias for a well-known package
     "N812",                 # an alias must not disguise a function as a class
     "INP", "T20",           # both already clean in `src`, and kept that way
+    "B905",                 # every `zip()` says whether its inputs must be
+                            # the same length. Read one at a time: `strict=`
+                            # is a judgement about the data, not a formality
     "PLR2004",              # a number in a comparison carries a name or a
                             # reasoned noqa; every site was censused one by
                             # one before this went on (str/bytes stay exempt:
@@ -166,7 +169,6 @@ select = [
                             # no rule here rewords prose.
 ]
 ignore = [
-    "B905",  # selected by "B"; see the note below
     # TC006 quotes the first argument of `typing.cast`, which that function
     # ignores entirely at run time. It is inert, and it moved the recorded
     # fingerprint of two clips through `figures.media._save_animation`. The
@@ -207,11 +209,6 @@ ignore = [
 #               stragglers, not a style.
 #   PTH   (158) pathlib over os.path.
 #   PERF   (34) manual loops that build a list.
-#   B905  (162) `zip()` without `strict=`. 47 are in `src/`, where a silent
-#               truncation drops a band or a curve without saying so. Ruff's
-#               own fix writes `strict=False`, which only makes the truncation
-#               explicit; the value is in deciding, per site, where the lengths
-#               are equal by construction and `strict=True` is the truth.
 
 [tool.ruff.lint.per-file-ignores]
 # `matplotlib.use("Agg")` has to run between `import matplotlib` and the first

--- a/scripts/animation_fingerprint.py
+++ b/scripts/animation_fingerprint.py
@@ -298,7 +298,7 @@ class Sources:
             )
             if "_ANIMATIONS" not in targets or not isinstance(node.value, ast.Dict):
                 continue
-            for key, value in zip(node.value.keys, node.value.values):
+            for key, value in zip(node.value.keys, node.value.values, strict=True):
                 if (
                     isinstance(key, ast.Constant)
                     and isinstance(key.value, str)
@@ -441,7 +441,7 @@ def _table_entries(
     patterns: list[tuple[str, str]] = []
     node = i18n.symbols.get("_ES_EXACT")
     if isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
-        for key, value in zip(node.value.keys, node.value.values):
+        for key, value in zip(node.value.keys, node.value.values, strict=True):
             pair = _literal_pair(key, value)
             if pair is not None:
                 exact.append(pair)

--- a/scripts/check_figures.py
+++ b/scripts/check_figures.py
@@ -102,7 +102,7 @@ def _svg_within_tolerance(old: bytes, new: bytes) -> bool:
     new_nums = _TOKEN.findall(new)
     if len(old_nums) != len(new_nums):
         return False
-    for o_tok, n_tok in zip(old_nums, new_nums):
+    for o_tok, n_tok in zip(old_nums, new_nums, strict=True):
         o_val = float(o_tok)
         n_val = float(n_tok)
         limit = max(SVG_ABS_TOL, SVG_REL_TOL * max(abs(o_val), abs(n_val)))

--- a/scripts/check_reports.py
+++ b/scripts/check_reports.py
@@ -137,7 +137,9 @@ def pdf_problem(old: bytes, new: bytes) -> str | None:
         return f"could not extract text ({exc})"
     if len(old_pages) != len(new_pages):
         return f"page count changed {len(old_pages)} != {len(new_pages)}"
-    for number, (old_text, new_text) in enumerate(zip(old_pages, new_pages), start=1):
+    for number, (old_text, new_text) in enumerate(
+        zip(old_pages, new_pages, strict=True), start=1
+    ):
         if old_text != new_text:
             return f"text of page {number} changed"
     return None

--- a/scripts/check_stroke_contrast.py
+++ b/scripts/check_stroke_contrast.py
@@ -130,7 +130,9 @@ def main() -> int:
             if key in seen:
                 continue
             seen.add(key)
-            blended = tuple(alpha * c + (1 - alpha) * p for c, p in zip(rgb, PAGE))
+            blended = tuple(
+                alpha * c + (1 - alpha) * p for c, p in zip(rgb, PAGE, strict=True)
+            )
             ratio = _ratio(blended, PAGE)  # type: ignore[arg-type]
             # A hairline has to work harder: below 0.6 pt demand 3:1, else 2:1.
             floor = 3.0 if width < 0.6 else 2.0

--- a/scripts/conformance/domains/assessment.py
+++ b/scripts/conformance/domains/assessment.py
@@ -202,7 +202,9 @@ def _chk_gum_h2_correlated() -> Outcome:
     means = obs.mean(axis=0)
     u_means = obs.std(axis=0, ddof=1) / math.sqrt(obs.shape[0])
     r = np.corrcoef(obs.T)
-    quantities = [ph.metrology.Quantity(m, s) for m, s in zip(means, u_means)]
+    quantities = [
+        ph.metrology.Quantity(m, s) for m, s in zip(means, u_means, strict=True)
+    ]
     result = ph.metrology.combine_uncertainty(
         lambda v, i, p: v / i * math.cos(p), quantities, correlation=r
     )

--- a/scripts/conformance/domains/broadcast_wave.py
+++ b/scripts/conformance/domains/broadcast_wave.py
@@ -262,7 +262,7 @@ def _loudness_examples_outcome(
         "MaxMomentaryLoudness": "max_momentary_loudness",
         "MaxShortTermLoudness": "max_short_term_loudness",
     }
-    for (value, _dec, _hexa), field in zip(examples, fields):
+    for (value, _dec, _hexa), field in zip(examples, fields, strict=True):
         overrides[attribute[field]] = value
     payload, _ = _write_and_capture(_metadata(**overrides))
     stored = [_int16_at(payload, field) for field in fields]
@@ -270,7 +270,9 @@ def _loudness_examples_outcome(
         f"{value} -> {hexa:04X}h ({dec})" for value, dec, hexa in examples
     )
     computed_txt = ", ".join(f"{got & 0xFFFF:04X}h ({got})" for got in stored)
-    passed = all(got == dec for got, (_v, dec, _h) in zip(stored, examples))
+    passed = all(
+        got == dec for got, (_v, dec, _h) in zip(stored, examples, strict=True)
+    )
     return Outcome(
         expected=expected_txt, computed=computed_txt, delta="-", passed=passed
     )

--- a/scripts/conformance/domains/cnossos_rail.py
+++ b/scripts/conformance/domains/cnossos_rail.py
@@ -108,7 +108,7 @@ def _chk_cnossos_rail_workbook() -> Outcome:
     for case in ref.cnossos_rail_workbook_cases():
         result = _cnossos_rail_case(case)
         row = result.line_power[0 if case["source_height"] == "A" else 1]
-        for got, band in zip(row, bands):
+        for got, band in zip(row, bands, strict=True):
             worst = max(worst, abs(float(got) - float(case[f"lw_{band}"])))
     return numeric(
         0.0,
@@ -133,10 +133,10 @@ def _chk_cnossos_rail_roughness_tables() -> Outcome:
         ("n", ref.CNOSSOS_RAIL_G1A_NON_TREAD),
     ):
         _, levels = ph.environment.wheel_roughness(brake)
-        bad += sum(1 for a, b in zip(levels, expected) if a != b)
+        bad += sum(1 for a, b in zip(levels, expected, strict=True) if a != b)
     for cls, expected in (("E", ref.CNOSSOS_RAIL_G1B_E), ("M", ref.CNOSSOS_RAIL_G1B_M)):
         _, levels = ph.environment.rail_roughness(cls)
-        bad += sum(1 for a, b in zip(levels, expected) if a != b)
+        bad += sum(1 for a, b in zip(levels, expected, strict=True) if a != b)
     return numeric(
         0.0,
         float(bad),
@@ -156,7 +156,7 @@ def _chk_cnossos_rail_table_g2() -> Outcome:
     bad = 0
     for key, expected in ref.CNOSSOS_RAIL_G2.items():
         _, levels = ph.environment.contact_filter(key)
-        bad += sum(1 for a, b in zip(levels, expected) if a != b)
+        bad += sum(1 for a, b in zip(levels, expected, strict=True) if a != b)
     return numeric(
         0.0,
         float(bad),
@@ -176,17 +176,25 @@ def _chk_cnossos_rail_table_g3() -> Outcome:
     bad = 0
     for key, expected in ref.CNOSSOS_RAIL_G3A.items():
         bad += sum(
-            1 for a, b in zip(ph.environment.track_transfer(key), expected) if a != b
+            1
+            for a, b in zip(ph.environment.track_transfer(key), expected, strict=True)
+            if a != b
         )
     for diameter, expected in ref.CNOSSOS_RAIL_G3B.items():
         bad += sum(
             1
-            for a, b in zip(ph.environment.wheel_transfer(diameter), expected)
+            for a, b in zip(
+                ph.environment.wheel_transfer(diameter), expected, strict=True
+            )
             if a != b
         )
     bad += sum(
         1
-        for a, b in zip(ph.environment.superstructure_transfer(), ref.CNOSSOS_RAIL_G3C)
+        for a, b in zip(
+            ph.environment.superstructure_transfer(),
+            ref.CNOSSOS_RAIL_G3C,
+            strict=True,
+        )
         if a != b
     )
     return numeric(
@@ -207,17 +215,21 @@ def _chk_cnossos_rail_table_g3() -> Outcome:
 def _chk_cnossos_rail_source_tables() -> Outcome:
     bad = 0
     _, impact = ph.environment.impact_roughness_single()
-    bad += sum(1 for a, b in zip(impact, ref.CNOSSOS_RAIL_G4) if a != b)
+    bad += sum(1 for a, b in zip(impact, ref.CNOSSOS_RAIL_G4, strict=True) if a != b)
     for key, (low, high) in ref.CNOSSOS_RAIL_G5.items():
         got_low, got_high = ph.environment.traction_sound_power(key)
-        bad += sum(1 for a, b in zip(got_low, low) if a != b)
-        bad += sum(1 for a, b in zip(got_high, high) if a != b)
+        bad += sum(1 for a, b in zip(got_low, low, strict=True) if a != b)
+        bad += sum(1 for a, b in zip(got_high, high, strict=True) if a != b)
     got_low, got_high = ph.environment.aerodynamic_sound_power()
-    bad += sum(1 for a, b in zip(got_low, ref.CNOSSOS_RAIL_G6_A) if a != b)
-    bad += sum(1 for a, b in zip(got_high, ref.CNOSSOS_RAIL_G6_B) if a != b)
+    bad += sum(1 for a, b in zip(got_low, ref.CNOSSOS_RAIL_G6_A, strict=True) if a != b)
+    bad += sum(
+        1 for a, b in zip(got_high, ref.CNOSSOS_RAIL_G6_B, strict=True) if a != b
+    )
     for key, expected in ref.CNOSSOS_RAIL_G7.items():
         bad += sum(
-            1 for a, b in zip(ph.environment.bridge_transfer(key), expected) if a != b
+            1
+            for a, b in zip(ph.environment.bridge_transfer(key), expected, strict=True)
+            if a != b
         )
     return numeric(
         0.0,
@@ -248,8 +260,14 @@ def _chk_cnossos_rail_aerodynamic_law() -> Outcome:
     low, high = ph.environment.aerodynamic_sound_power(600.0)
     step = ref.CNOSSOS_RAIL_G6_ALPHA * math.log10(2.0)
     worst = max(
-        max(abs(float(a) - b - step) for a, b in zip(low, ref.CNOSSOS_RAIL_G6_A)),
-        max(abs(float(a) - b - step) for a, b in zip(high, ref.CNOSSOS_RAIL_G6_B)),
+        max(
+            abs(float(a) - b - step)
+            for a, b in zip(low, ref.CNOSSOS_RAIL_G6_A, strict=True)
+        ),
+        max(
+            abs(float(a) - b - step)
+            for a, b in zip(high, ref.CNOSSOS_RAIL_G6_B, strict=True)
+        ),
     )
     return numeric(
         0.0,

--- a/scripts/conformance/domains/distortion.py
+++ b/scripts/conformance/domains/distortion.py
@@ -356,7 +356,7 @@ def _chk_dim() -> Outcome:
     amps = [0.01 * (i + 1) for i in range(len(comps))]
     # 15 kHz sine + the strong 3.15 kHz fundamental + the nine products.
     x = _electro_tone(t, fsine, 1.0) + _electro_tone(t, fsq, 0.8)
-    for c, a in zip(comps, amps):
+    for c, a in zip(comps, amps, strict=True):
         x = x + _electro_tone(t, c, a)
     expected = math.sqrt(sum(a**2 for a in amps))
     return numeric(

--- a/scripts/conformance/domains/environmental_sources.py
+++ b/scripts/conformance/domains/environmental_sources.py
@@ -73,7 +73,9 @@ def _chk_cnossos_road_workbook() -> Outcome:
             junction_type=ph.environment.JunctionType(int(case["junction_type"])),
             coefficients=coefficients,
         )
-        for got, band in zip(result.total_line_power, ref.CNOSSOS_ROAD_BANDS):
+        for got, band in zip(
+            result.total_line_power, ref.CNOSSOS_ROAD_BANDS, strict=True
+        ):
             worst = max(worst, abs(float(got) - float(case[f"lw_{band}"])))
     return numeric(
         0.0,
@@ -111,7 +113,9 @@ def _chk_cnossos_road_table_f1() -> Outcome:
                 expected["BP"],
             ),
         )
-        bad += sum(1 for got, want in pairs for a, b in zip(got, want) if a != b)
+        bad += sum(
+            1 for got, want in pairs for a, b in zip(got, want, strict=True) if a != b
+        )
     return numeric(
         0.0,
         float(bad),
@@ -135,7 +139,9 @@ def _chk_cnossos_road_table_f4() -> Outcome:
         for category in ("1", "2", "3", "4a", "4b"):
             key = category if category in expected else "4a/4b"
             bad += sum(
-                1 for a, b in zip(row.alpha[category], expected[key][0]) if a != b
+                1
+                for a, b in zip(row.alpha[category], expected[key][0], strict=True)
+                if a != b
             )
             bad += int(row.beta[category] != expected[key][1])
     return numeric(
@@ -166,7 +172,7 @@ def _chk_cnossos_road_tables_f2_f3() -> Outcome:
                 ref.CNOSSOS_ROAD_TABLE_F2["bi"],
             ),
         )
-        for a, b in zip(got, want)
+        for a, b in zip(got, want, strict=True)
         if a != b
     )
     for category, expected in ref.CNOSSOS_ROAD_TABLE_F3.items():
@@ -204,7 +210,9 @@ def _chk_cnossos_road_reference_conditions() -> Outcome:
                 ph.environment.ROAD_COEFFICIENTS.propulsion_a[category],
             ),
         ):
-            worst = max(worst, max(abs(float(a) - b) for a, b in zip(got, want)))
+            worst = max(
+                worst, max(abs(float(a) - b) for a, b in zip(got, want, strict=True))
+            )
     return numeric(
         0.0,
         worst,
@@ -224,7 +232,9 @@ def _chk_cnossos_a_weighting() -> Outcome:
     bad = sum(
         1
         for a, b in zip(
-            ph.environment.CNOSSOS_A_WEIGHTING, ref.CNOSSOS_A_WEIGHTING_TABLE
+            ph.environment.CNOSSOS_A_WEIGHTING,
+            ref.CNOSSOS_A_WEIGHTING_TABLE,
+            strict=True,
         )
         if a != b
     )

--- a/scripts/conformance/domains/outdoor.py
+++ b/scripts/conformance/domains/outdoor.py
@@ -81,7 +81,9 @@ def _chk_iso9613_2_table2_grid() -> Outcome:
             )
             * 1000.0
         )
-        for got, printed, band in zip(alpha, row, ref.ISO9613_2_TABLE2_BANDS):
+        for got, printed, band in zip(
+            alpha, row, ref.ISO9613_2_TABLE2_BANDS, strict=True
+        ):
             tol = 0.5 if printed >= 100.0 else 0.05
             if (temp, rh, band) == (15.0, 80.0, 1000.0):
                 tol = 0.06

--- a/scripts/conformance/domains/sound_quality.py
+++ b/scripts/conformance/domains/sound_quality.py
@@ -150,7 +150,7 @@ def _chk_iso20065_uncertainty() -> Outcome:
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
     )
     assert res.extended_uncertainties is not None
-    by_freq = dict(zip(res.tone_frequencies, res.extended_uncertainties))
+    by_freq = dict(zip(res.tone_frequencies, res.extended_uncertainties, strict=True))
     # Table E.2, run index k = 2: U = 2.79 dB (90 % bilateral coverage).
     return numeric(
         ref.ISO20065_E2_U[1], float(by_freq[137.3]), 0.02, unit="dB", places=2

--- a/scripts/conformance/domains/speech.py
+++ b/scripts/conformance/domains/speech.py
@@ -128,7 +128,7 @@ def _stipa_sine_signal(
     t = np.arange(round(seconds * _FS)) / _FS
     x = np.zeros(t.size)
     for k, (fc, fa, fb, level) in enumerate(
-        zip(_STI_CENTERS, _STI_F1, _STI_F2, _STI_LEVELS)
+        zip(_STI_CENTERS, _STI_F1, _STI_F2, _STI_LEVELS, strict=True)
     ):
         mk = m if bands is None or k in bands else 0.0
         env = 0.5 * (

--- a/scripts/conformance/shared.py
+++ b/scripts/conformance/shared.py
@@ -154,7 +154,7 @@ def _weighting_deviation(curve: str, fs: int) -> WeightingDeviation:
         # strictest Table V mask (Type 0, laboratory grade).
         rows_b = [
             (t4, t5)
-            for t4, t5 in zip(ref.ANSIS14_TABLE4_B, ref.ANSIS14_TABLE5)
+            for t4, t5 in zip(ref.ANSIS14_TABLE4_B, ref.ANSIS14_TABLE5, strict=True)
             if t4[0] < fs / 2
         ]
         freqs = np.array(

--- a/scripts/diagrams/buildings.py
+++ b/scripts/diagrams/buildings.py
@@ -739,7 +739,7 @@ def _d_room_measurement(s: SVG, th: Theme) -> None:
         yy = ty + th_row * (r + 1)
         if r < len(rows) - 1:
             s.line(60, yy + th_row, 60 + tw, yy + th_row, th.muted, 1.0)
-        for (cx, _, anchor), value in zip(cols, row):
+        for (cx, _, anchor), value in zip(cols, row, strict=True):
             col = th.primary if cx == 70.0 else th.fg
             s.text(cx, yy + 26, value, 15, col, anchor, bold=(cx == 70.0))
 
@@ -1086,7 +1086,7 @@ def _d_room_measurement_section(s: SVG, th: Theme) -> None:
     tw, row_h = 516.0, 36.0
     s.rect(70, ty, tw, row_h * 2, "none", th.fg, rx=6, sw=1.8)
     s.rect(70, ty, tw, row_h, th.panel, th.fg, rx=6, sw=1.8)
-    for i, (freq, value) in enumerate(zip(cols, tol)):
+    for i, (freq, value) in enumerate(zip(cols, tol, strict=True)):
         cx = 70 + tw * (i + 0.5) / len(cols)
         s.text(cx, ty + 24, f"{freq:g}", 14, th.fg, "middle", bold=True)
         s.text(cx, ty + 24 + row_h, value, 14, th.primary, "middle")
@@ -1908,14 +1908,14 @@ def _d_reverberation_prediction(s: SVG, th: Theme) -> None:
     sab = ("0.74", "0.47", "0.37", "0.31", "0.30", "0.30")
     eyr = ("0.66", "0.39", "0.29", "0.23", "0.21", "0.22")
     xc = [292.0 + 94.0 * i for i in range(6)]
-    for x, f in zip(xc, freqs):
+    for x, f in zip(xc, freqs, strict=True):
         s.text(x, 372, f, 10, th.muted, bold=True)
     s.line(130, 382, 770, 382, th.muted, 1.0)
     s.text(130, 404, "Sabine [s]", 10, th.primary, bold=True, anchor="start")
-    for x, v in zip(xc, sab):
+    for x, v in zip(xc, sab, strict=True):
         s.text(x, 404, v, 11, th.fg)
     s.text(130, 432, "Eyring [s]", 10, th.secondary, bold=True, anchor="start")
-    for x, v in zip(xc, eyr):
+    for x, v in zip(xc, eyr, strict=True):
         s.text(x, 432, v, 11, th.fg)
     s.text(
         450,

--- a/scripts/diagrams/perception.py
+++ b/scripts/diagrams/perception.py
@@ -1316,7 +1316,7 @@ def _d_soundfield_audiometry(s: SVG, th: Theme) -> None:
         s.text(x + pw / 2, 90, sub, 12, th.muted)
 
     def notes(x: float, color: str, *rows: str) -> None:
-        for y, row in zip(note_y, rows):
+        for y, row in zip(note_y, rows, strict=True):
             s.text(x + pw / 2, y, row, 11, color)
 
     def ghost_subject(x: float) -> float:
@@ -1481,7 +1481,7 @@ def _d_slm_workstation(s: SVG, th: Theme) -> None:
         s.text(x + pw / 2, 90, sub, 13, th.muted)
 
     def notes(x: float, color: str, *rows: str) -> None:
-        for y, row in zip(note_y, rows):
+        for y, row in zip(note_y, rows, strict=True):
             s.text(x + pw / 2, y, row, 12, color)
 
     def machine(x: float) -> None:
@@ -1600,7 +1600,7 @@ def _d_sti_setup(s: SVG, th: Theme) -> None:
         s.ground(gy, x, x + pw)
 
     def notes(x: float, color: str, *rows: str) -> None:
-        for y, row in zip(note_y, rows):
+        for y, row in zip(note_y, rows, strict=True):
             s.text(x + pw / 2, y, row, 12, color)
 
     def receiver(x: float, *, ghost: bool = False) -> None:

--- a/scripts/diagrams/signals.py
+++ b/scripts/diagrams/signals.py
@@ -2642,7 +2642,7 @@ def _d_multichannel_capture(s: SVG, th: Theme) -> None:
     xs = (66.0, 132.0, 198.0, 264.0)
     sens = ("11,8", "12,3", "11,9", "12,1")
     cap_y = gy - 120.0  # capsule height, 1,2 m to scale
-    for i, (x, mv) in enumerate(zip(xs, sens)):
+    for i, (x, mv) in enumerate(zip(xs, sens, strict=True)):
         s.mic(x, cap_y, gy, 0.95)
         s.text(x, gy + 24, f"P{i + 1}", 15, th.fg, bold=True)
         s.text(x, gy + 44, mv, 12, th.muted, mono=True)

--- a/scripts/figures/building.py
+++ b/scripts/figures/building.py
@@ -402,7 +402,7 @@ def generate_facade_prediction(output_dir: str) -> None:
     # transmission floor rather than being the answer. Held back by shade, not
     # by opacity: a faded blue or red is a faded page on the dark theme.
     el_colors = [COLOR_PRIMARY, COLOR_SECONDARY, "#9467bd", "#ff7f0e"]
-    for (name, rp), colour in zip(result.element_r.items(), el_colors):
+    for (name, rp), colour in zip(result.element_r.items(), el_colors, strict=True):
         ax.plot(
             x,
             rp,

--- a/scripts/figures/building_design.py
+++ b/scripts/figures/building_design.py
@@ -732,7 +732,9 @@ def generate_installed_structure_borne(output_dir: str) -> None:
     # Frequency-dependent source / receiver point mobilities (illustrative).
     ys = (2.0e-4 + 1.0e-4j) * (bands / 250.0)
     yi = (3.0e-5 + 1.0e-5j) * np.ones_like(bands)
-    dc = np.array([float(building.coupling_term(a, b)) for a, b in zip(ys, yi)])
+    dc = np.array(
+        [float(building.coupling_term(a, b)) for a, b in zip(ys, yi, strict=True)]
+    )
     lws_inst = building.installed_structure_borne_power_level(lws_c, dc)
     # Dsa is negative and falls with frequency (Annex F.2, Formula F.3); the
     # standard's own Annex I columns run from about -14 dB at 63 Hz to -45 dB
@@ -1091,7 +1093,7 @@ def generate_impact_prediction_terms(output_dir: str) -> None:
     ax.axhline(0.0, color=COLOR_FG, linewidth=0.8)
     ax.set_xticks(np.arange(4))
     ax.set_xticklabels(labels, fontsize=12)
-    for bar, value in zip(bars, values):
+    for bar, value in zip(bars, values, strict=True):
         ax.annotate(
             _fmt_minus(value, "+.1f"),
             xy=(bar.get_x() + bar.get_width() / 2.0, value),
@@ -1207,7 +1209,7 @@ def generate_detailed_prediction_paths(output_dir: str) -> None:
         "#ff9896",
     ]
     bottom = np.zeros(x.size)
-    for colour, k in zip(palette, order[:6]):
+    for colour, k in zip(palette, order[:6], strict=False):  # six colours, rest pooled
         share = 100.0 * res.fractions[k]
         ax.bar(
             x,

--- a/scripts/figures/devices.py
+++ b/scripts/figures/devices.py
@@ -206,7 +206,7 @@ def generate_distortion(output_dir: str) -> None:
         zorder=6,
         label="Harmonics $n f_1$",
     )
-    for k, (fk, lk) in enumerate(zip(hz, hdb), start=1):
+    for k, (fk, lk) in enumerate(zip(hz, hdb, strict=True), start=1):
         ax.annotate(
             f"$n$ = {k}",
             xy=(fk, lk),
@@ -1352,7 +1352,7 @@ def generate_intensity_scan_power(output_dir: str) -> None:
         linewidth=0.7,
         zorder=3,
     )
-    for pos, is_neg in zip(positions, neg):
+    for pos, is_neg in zip(positions, neg, strict=True):
         if is_neg:
             ax.axvspan(
                 pos - 0.35,
@@ -1402,7 +1402,7 @@ def generate_silencer_expansion_chamber(output_dir: str) -> None:
     colors = (COLOR_PRIMARY, COLOR_SECONDARY, COLOR_TERTIARY, "#9467bd")
 
     _fig, ax = plt.subplots(figsize=(9.0, 5.2))
-    for m, color in zip(ratios, colors):
+    for m, color in zip(ratios, colors, strict=True):
         res = noise_control.expansion_chamber(freqs, length, m * pipe_area, pipe_area)
         peak = 10.0 * np.log10(1.0 + 0.25 * (m - 1.0 / m) ** 2)
         ax.plot(
@@ -3062,7 +3062,7 @@ def generate_duct_sheet_verification(output_dir: str) -> None:
     )
 
     _fig, axes = plt.subplots(2, 3, figsize=(13.0, 7.6))
-    for ax, (title, sheet_row, model_row) in zip(axes.ravel(), panels):
+    for ax, (title, sheet_row, model_row) in zip(axes.ravel(), panels, strict=True):
         printed = np.asarray(sheet_row, dtype=float)
         computed = np.asarray(model_row, dtype=float)
         n = min(printed.size, computed.size)

--- a/scripts/figures/fields/tubes.py
+++ b/scripts/figures/fields/tubes.py
@@ -367,7 +367,11 @@ def animate_fdtd_impedance_tube(output_dir: str) -> None:
 
     def update(k: int) -> tuple[Any, ...]:
         kf = min(k, n_active - 1)
-        for im, line, (p_all, env) in zip(ims, lines, ((p_e, env_e), (p_s, env_s))):
+        # The three operands are the same pair of panels, built a few lines
+        # up: `strict=` could only ever hold. Adding it is hashed into the
+        # recorded fingerprint of anim_fdtd_impedance_tube, so it would ask
+        # for a re-render that draws the very same frames.
+        for im, line, (p_all, env) in zip(ims, lines, ((p_e, env_e), (p_s, env_s))):  # noqa: B905
             im.set_data(p_all[kf])
             env_row = np.repeat(env[kf], 2)[: x_env.size]
             line.set_data(

--- a/scripts/figures/materials.py
+++ b/scripts/figures/materials.py
@@ -1514,7 +1514,7 @@ def generate_metadiffuser_phase_match(output_dir: str) -> None:
         zorder=4,
         label="Metadiffuser, panel 2 cm",
     )
-    for i, r in zip(index, r_design):
+    for i, r in zip(index, r_design, strict=True):
         ax_l.annotate(
             f"$|R|$ = {abs(r):.2f}",
             (i, np.degrees(np.angle(r)) - 12.0),
@@ -1968,7 +1968,9 @@ def generate_diffusion_measurement_chain(output_dir: str) -> None:
     seq = np.tile(depths, 6)
     t_well = 2.0 * float(depths.max()) / c
     delays = np.linspace(t_first, t_last - t_well, seq.size) + 2.0 * seq / c
-    ideal_sample = sum(_spike(d, 0.16 / (1.0 + 6.0 * s)) for d, s in zip(delays, seq))
+    ideal_sample = sum(
+        _spike(d, 0.16 / (1.0 + 6.0 * s)) for d, s in zip(delays, seq, strict=True)
+    )
     ideal_room = _spike(t_room, 0.30)
     ideal_direct = _spike(t_direct, 1.0)
 
@@ -2009,7 +2011,7 @@ def generate_diffusion_measurement_chain(output_dir: str) -> None:
         (h4 * window, "(e) windowed, Clause 7.4.3", s_dec),
     )
     fig, axes = plt.subplots(5, 1, sharex=True, figsize=(10, 9.6))
-    for ax, (y, label, scale) in zip(axes, panels):
+    for ax, (y, label, scale) in zip(axes, panels, strict=True):
         ax.plot(ms, y, color=COLOR_PRIMARY, linewidth=1.1, zorder=3)
         ax.set_ylabel(
             label, fontsize=9, rotation=0, ha="right", va="center", labelpad=8

--- a/scripts/figures/metrology.py
+++ b/scripts/figures/metrology.py
@@ -930,7 +930,7 @@ def generate_uncertainty_gum_vs_mc(output_dir: str) -> None:
     )
 
     _fig, axes = plt.subplots(3, 1, figsize=(10, 11))
-    for ax, (title, model, quantities, xlabel, ymax) in zip(axes, panels):
+    for ax, (title, model, quantities, xlabel, ymax) in zip(axes, panels, strict=True):
         gum = ph.metrology.combine_uncertainty(model, quantities)
         mc = ph.metrology.monte_carlo(
             model,
@@ -1061,7 +1061,7 @@ def generate_uncertainty_correlation(output_dir: str) -> None:
         width=0.55,
         zorder=2,
     )
-    for rect, val in zip(bars, (quad, linear)):
+    for rect, val in zip(bars, (quad, linear), strict=True):
         ax_r.text(
             rect.get_x() + rect.get_width() / 2,
             val + 0.012,
@@ -1097,7 +1097,7 @@ def generate_runs_test(output_dir: str) -> None:
     sequences = [rng.standard_normal(40), np.tile([1.0, -1.0], 10)]
 
     _fig, axes = plt.subplots(1, 2, figsize=(12.5, 5.4))
-    for ax, seq in zip(axes, sequences):
+    for ax, seq in zip(axes, sequences, strict=True):
         res = metrology.trend_test(seq, method="runs")
         idx = np.arange(1, seq.size + 1)
         median = float(np.median(seq))

--- a/scripts/figures/perception.py
+++ b/scripts/figures/perception.py
@@ -2216,7 +2216,7 @@ def generate_exposure_uncertainty(output_dir: str) -> None:
         zorder=3,
         label="Measurement task",
     )
-    for xi, c in zip(x, contribs):
+    for xi, c in zip(x, contribs, strict=True):
         ax.text(
             float(xi),
             c - 2.5,
@@ -2418,7 +2418,7 @@ def generate_sii_vocal_efforts(output_dir: str) -> None:
     positions = np.arange(len(VOCAL_EFFORTS))
     bar_colours = [colours[e] for e in VOCAL_EFFORTS]
     ax_i.bar(positions, indices, width=0.6, color=bar_colours, zorder=2)
-    for x, v in zip(positions, indices):
+    for x, v in zip(positions, indices, strict=True):
         ax_i.text(x, v + 0.01, f"{v:.2f}", ha="center", va="bottom", fontweight="bold")
     ax_i.set_xticks(positions)
     ax_i.set_xticklabels([e.capitalize() for e in VOCAL_EFFORTS])
@@ -2694,7 +2694,7 @@ def generate_nipts_level_growth(output_dir: str) -> None:
         COLOR_SECONDARY,
         COLOR_PRIMARY,
     ]
-    for k, (f, color) in enumerate(zip(freqs, colors)):
+    for k, (f, color) in enumerate(zip(freqs, colors, strict=True)):
         ax_f.plot(levels, med[:, k], "-", color=color, linewidth=2.0, label=f"{f:g} Hz")
         # The cut-off L0 is where the curve leaves zero.
         lift = int(np.argmax(med[:, k] > 0.0))

--- a/scripts/figures/room.py
+++ b/scripts/figures/room.py
@@ -604,7 +604,7 @@ def generate_modal_count_per_band(output_dir: str) -> None:
         color=COLOR_PRIMARY,
         label="Above it",
     )
-    for centre, count in zip(bands, counts):
+    for centre, count in zip(bands, counts, strict=True):
         ax.annotate(
             f"{count:,.0f}",
             xy=(centre, count * 1.25),
@@ -1429,7 +1429,7 @@ def generate_room_noise_criteria(output_dir: str) -> None:
     _fig, (ax_nc, ax_rc) = plt.subplots(1, 2, figsize=(12.5, 5.6))
 
     # --- Left: NC curves + tangency rating. ---
-    for row, idx in zip(NC_CURVES, NC_INDICES):
+    for row, idx in zip(NC_CURVES, NC_INDICES, strict=True):
         ax_nc.plot(OCTAVE_BANDS, row, color=COLOR_GRID, lw=0.8, zorder=1)
         ax_nc.annotate(
             f"{idx:.0f}",
@@ -1550,7 +1550,7 @@ def generate_nc_blind_spot(output_dir: str) -> None:
     _fig, (ax_nc, ax_rc) = plt.subplots(1, 2, figsize=(12.5, 5.6))
 
     # --- Left: one NC label for two spectra. ---
-    for row, idx in zip(NC_CURVES, NC_INDICES):
+    for row, idx in zip(NC_CURVES, NC_INDICES, strict=True):
         ax_nc.plot(OCTAVE_BANDS, row, color=COLOR_GRID, lw=0.8, zorder=1)
         ax_nc.annotate(
             f"{idx:.0f}",
@@ -1829,7 +1829,7 @@ def generate_enclosed_space_air_term(output_dir: str) -> None:
 
     still = room.enclosed_space_reverberation([(hall_area, soft)], hall_volume)
     colours = series_colors(len(AIR_ATTENUATION))
-    for colour, name in zip(colours, AIR_ATTENUATION):
+    for colour, name in zip(colours, AIR_ATTENUATION, strict=True):
         humid = room.enclosed_space_reverberation(
             [(hall_area, soft)], hall_volume, air_condition=name
         )
@@ -2237,7 +2237,7 @@ def generate_image_source_anisotropy(output_dir: str) -> None:
         label="specular (image source)",
         zorder=6,
     )
-    for ratio, value, reference in zip(ratios, specular, eyring):
+    for ratio, value, reference in zip(ratios, specular, eyring, strict=True):
         if ratio in (1.0, 3.0, 6.0):
             offset = -0.16 if ratio >= 5.0 else 0.11
             ax.annotate(
@@ -2306,7 +2306,7 @@ def generate_image_source_bands(output_dir: str) -> None:
             frequencies=freqs,
             air_attenuation=attenuation,
         )
-        for row, freq, colour in zip(banded.ir, freqs, colours):
+        for row, freq, colour in zip(banded.ir, freqs, colours, strict=True):
             time, level = room.decay_curve(row, banded.fs)
             label = f"{freq:g} Hz{tag}" if not tag else None
             ax.plot(
@@ -2377,7 +2377,7 @@ def generate_room_proportion_modes(output_dir: str) -> None:
         sharex=True,
         gridspec_kw={"height_ratios": [1, 1, 1, 1.5]},
     )
-    for ax, (name, dims) in zip(axes[:3], shapes):
+    for ax, (name, dims) in zip(axes[:3], shapes, strict=True):
         modes = room.room_modes(dims, max_frequency=200.0)
         freqs = np.asarray(modes.frequencies)
         kinds = np.asarray(modes.kinds)
@@ -2413,7 +2413,7 @@ def generate_room_proportion_modes(output_dir: str) -> None:
         )
 
     spacing = axes[3]
-    for (name, dims), style in zip(shapes, ("-", "--", ":")):
+    for (name, dims), style in zip(shapes, ("-", "--", ":"), strict=True):
         modes = room.room_modes(dims, max_frequency=200.0)
         unique = np.unique(np.round(np.asarray(modes.frequencies), 1))
         spacing.step(
@@ -2452,7 +2452,7 @@ def generate_steady_state_directivity(output_dir: str) -> None:
     _fig, (left, right) = plt.subplots(1, 2, figsize=(12.6, 5.6), sharey=True)
 
     colours = series_colors(4)
-    for colour, q in zip(colours, (1.0, 2.0, 4.0, 8.0)):
+    for colour, q in zip(colours, (1.0, 2.0, 4.0, 8.0), strict=True):
         field = room.steady_state_field(
             sound_power_level=90.0,
             surface_area=352.0,
@@ -2480,7 +2480,7 @@ def generate_steady_state_directivity(output_dir: str) -> None:
     left.legend(loc="upper right", fontsize=9)
 
     for colour, absorption in zip(
-        colours[::2].tolist() + [colours[3]], (0.05, 0.15, 0.35)
+        colours[::2].tolist() + [colours[3]], (0.05, 0.15, 0.35), strict=True
     ):
         field = room.steady_state_field(
             sound_power_level=90.0,
@@ -2570,7 +2570,7 @@ def generate_decay_signatures(output_dir: str) -> None:
     )
 
     _fig, axes = plt.subplots(1, 3, figsize=(13.2, 4.8), sharey=True)
-    for ax, (name, signal, verdict) in zip(axes, cases):
+    for ax, (name, signal, verdict) in zip(axes, cases, strict=True):
         res = room.room_parameters(signal, fs, limits=None)
         time, level = room.decay_curve(signal, fs)
         ax.plot(time, level, color=COLOR_PRIMARY, linewidth=1.8, zorder=5)

--- a/scripts/figures/signals.py
+++ b/scripts/figures/signals.py
@@ -1072,7 +1072,7 @@ def generate_tone_burst_iec(output_dir: str) -> None:
     steady = np.sin(2 * np.pi * 4000 * t_all)
     ref = filters.time_weighting(steady, fs, mode="fast")[int(1.5 * fs) :].mean()
 
-    for ax, (duration, target) in zip(axes, cases):
+    for ax, (duration, target) in zip(axes, cases, strict=True):
         burst = np.zeros_like(t_all)
         start = int(0.5 * fs)
         burst[start : start + round(duration * fs)] = steady[
@@ -1913,7 +1913,7 @@ def generate_peak_oversampling(output_dir: str) -> None:
     per_cycle = np.array([3.0, 4.0, 6.0, 8.0, 12.0, 24.0, 48.0])
     phases = np.linspace(0.0, 2 * np.pi, 46)
     colors = [COLOR_SECONDARY, COLOR_QUATERNARY, COLOR_TERTIARY, COLOR_PRIMARY]
-    for factor, color in zip((1, 2, 4, 8), colors):
+    for factor, color in zip((1, 2, 4, 8), colors, strict=True):
         worst = []
         for n_samples in per_cycle:
             tones = [np.sin(2 * np.pi * (fs / n_samples) * t_tone + p) for p in phases]
@@ -2154,7 +2154,7 @@ def generate_c_minus_a_spectrum(output_dir: str) -> None:
         ("C", COLOR_PRIMARY, "--"),
         ("A", COLOR_SECONDARY, ":"),
     ]
-    for ax, (title, x) in zip(axes, scenes):
+    for ax, (title, x) in zip(axes, scenes, strict=True):
         for curve, color, style in curves:
             weighted = filters.weighting_filter(x, fs, curve=curve)
             band_levels, centres = filters.octave_filter(weighted, fs, fraction=3)
@@ -2385,7 +2385,7 @@ def generate_architecture_tradeoff(output_dir: str) -> None:
     ax_a.bar(
         x + 0.19, four_fm, 0.36, color=COLOR_TERTIARY, label=r"at $4 f_{\mathrm{m}}$"
     )
-    for xi, value in zip(x - 0.19, two_fm):
+    for xi, value in zip(x - 0.19, two_fm, strict=True):
         ax_a.annotate(
             _fmt_minus(value, ".0f"),
             (xi, value),
@@ -2395,7 +2395,7 @@ def generate_architecture_tradeoff(output_dir: str) -> None:
             xytext=(0, -4),
             textcoords="offset points",
         )
-    for xi, value in zip(x + 0.19, four_fm):
+    for xi, value in zip(x + 0.19, four_fm, strict=True):
         ax_a.annotate(
             _fmt_minus(value, ".0f"),
             (xi, value),
@@ -2413,7 +2413,7 @@ def generate_architecture_tradeoff(output_dir: str) -> None:
     ax_a.legend(loc="lower right", fontsize=9)
 
     ax_b.bar(x, delays, 0.5, color=COLOR_SECONDARY)
-    for xi, value in zip(x, delays):
+    for xi, value in zip(x, delays, strict=True):
         ax_b.annotate(
             f"{value:.2f}",
             (xi, value),
@@ -2447,7 +2447,7 @@ def generate_class_mask_architectures(output_dir: str) -> None:
         ("bessel", "Bessel: roll-off too slow"),
     )
     fig, axes = plt.subplots(2, 2, figsize=(12, 8))
-    for ax, (ftype, title) in zip(axes.ravel(), cases):
+    for ax, (ftype, title) in zip(axes.ravel(), cases, strict=True):
         bank = filters.OctaveFilterBank(
             fs,
             fraction=1,

--- a/scripts/figures/spectral_estimation.py
+++ b/scripts/figures/spectral_estimation.py
@@ -278,7 +278,7 @@ def generate_psd_segment_tradeoff(output_dir: str) -> None:
     # Left: the peak itself, at four segment lengths.
     colors = (COLOR_FG, COLOR_TERTIARY, COLOR_PRIMARY, COLOR_SECONDARY)
     peak_ref = None
-    for nperseg, color in zip(lengths, colors):
+    for nperseg, color in zip(lengths, colors, strict=True):
         res = signals.power_spectral_density(resonant, fs, nperseg=nperseg)
         band = (res.frequencies >= 880.0) & (res.frequencies <= 1120.0)
         level = 10.0 * np.log10(res.psd[band])

--- a/scripts/figures/vibration.py
+++ b/scripts/figures/vibration.py
@@ -734,7 +734,7 @@ def generate_multiple_shock(output_dir: str) -> None:
     r_male = vibration.injury_risk(
         sd, start_age=20, years=20, days_per_year=120, sex="male"
     )
-    for level, r_val in zip((10, 50, 90), RISK_THRESHOLDS_MALE):
+    for level, r_val in zip((10, 50, 90), RISK_THRESHOLDS_MALE, strict=True):
         ax_r.axhline(level, color="#7f7f7f", linestyle=":", lw=0.8)
         ax_r.plot([r_val, r_val], [0.0, level], color="#7f7f7f", linestyle=":", lw=0.8)
     ax_r.scatter(
@@ -1160,7 +1160,7 @@ def _positive_peak_indices(response: np.ndarray) -> np.ndarray:
     return np.array(
         [
             int(a + np.argmax(response[a:b]))
-            for a, b in zip(starts, stops)
+            for a, b in zip(starts, stops, strict=True)
             if positive[a]
         ]
     )
@@ -1324,7 +1324,7 @@ def generate_junction_kij_thickness(output_dir: str) -> None:
         ("-", COLOR_SECONDARY),
         ("-", COLOR_TERTIARY),
     ]
-    for (label, values), (ls, color) in zip(curves.items(), styles):
+    for (label, values), (ls, color) in zip(curves.items(), styles, strict=True):
         ax.plot(ratios, values, ls, color=color, linewidth=2.0, label=label)
     # The identical-plate X-junction: Kij = 10 log10 12 + 5 log10(fc2/1000).
     res_eq = vibration.junction_transmission("X", h1, cl, rho * h1, h1, cl, rho * h1)

--- a/scripts/reports/room.py
+++ b/scripts/reports/room.py
@@ -39,7 +39,7 @@ def _room_acoustics_example() -> tuple[object, ReportMetadata, str]:
     t60 = (1.40, 1.30, 1.20, 1.10, 1.00, 0.85)
     time = np.arange(round(5.0 * fs)) / fs
     ir = np.zeros_like(time)
-    for freq, decay in zip(bands, t60):
+    for freq, decay in zip(bands, t60, strict=True):
         ir += np.sin(2.0 * np.pi * freq * time) * np.exp(-0.5 * a60 * time / decay)
     result = ph.room.room_parameters(ir, fs)
     metadata = ReportMetadata(

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -1093,7 +1093,7 @@ def _plot_path_shares(
         _C_SECONDARY_LIGHT,
     )
     bottom = np.zeros(positions.size, dtype=np.float64)
-    for colour, k in zip(palette, named):
+    for colour, k in zip(palette, named, strict=False):  # fewer paths than colours
         share = 100.0 * fractions[k]
         # A copy per bar, not one `setdefault` before the loop: this renderer
         # draws one bar per transmission path and each carries its own name,

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -183,7 +183,7 @@ def plot_harmonic_distortion(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("label", _t("Harmonics", language))
     ax.plot(orders, levels_db, "o", **kwargs)
-    for order, level in zip(orders, levels_db):
+    for order, level in zip(orders, levels_db, strict=True):
         if level > floor_db:
             ax.annotate(
                 f"{order}",

--- a/src/phonometry/_plot/geometry/building.py
+++ b/src/phonometry/_plot/geometry/building.py
@@ -250,7 +250,7 @@ def plot_facade_elements(
 
     x = 0.0
     fills = ("rigid", "cavity", "plate", "porous")
-    for index, (element, area) in enumerate(zip(tiles, areas)):
+    for index, (element, area) in enumerate(zip(tiles, areas, strict=True)):
         width = area / height
         _material_rect(
             ax,

--- a/src/phonometry/_plot/geometry/materials.py
+++ b/src/phonometry/_plot/geometry/materials.py
@@ -200,7 +200,7 @@ def plot_absorber_stack(
     height = 0.9 * total
     thin = 0.14 * total
     x = 0.0
-    for index, (layer, dispatched) in enumerate(zip(stack, kinds)):
+    for index, (layer, dispatched) in enumerate(zip(stack, kinds, strict=True)):
         kind, drawn, label_key = dispatched
         extra = dict(kwargs) if index == 0 else {}
         _material_rect(ax, x, 0.0, drawn, height, kind, **extra)

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -403,7 +403,7 @@ def plot_noise_criterion(
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
-    for row, idx in zip(NC_CURVES, NC_INDICES):
+    for row, idx in zip(NC_CURVES, NC_INDICES, strict=True):
         ax.plot(OCTAVE_BANDS, row, color=_C_MUTED, lw=0.8, zorder=1)
         ax.annotate(
             f"{idx:.0f}",
@@ -1174,8 +1174,15 @@ def plot_crowd_noise(
     ax = ax if ax is not None else _new_axes()
     n = np.asarray(result.talkers, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
+    areas = np.asarray(result.absorption_areas, dtype=np.float64)
+    if areas.shape != levels.shape[:1]:
+        msg = (
+            "'levels' must carry one row per absorption area; got "
+            f"absorption_areas{areas.shape} against levels{levels.shape}."
+        )
+        raise ValueError(msg)
     palette = (_C_PRIMARY, _C_SECONDARY, _C_TERTIARY, _C_QUATERNARY, _C_MUTED)
-    for row, (area, curve) in enumerate(zip(result.absorption_areas, levels)):
+    for row, (area, curve) in enumerate(zip(areas, levels, strict=True)):
         area_kwargs = dict(kwargs)
         area_kwargs.setdefault(
             "label",

--- a/src/phonometry/_plot/vibration.py
+++ b/src/phonometry/_plot/vibration.py
@@ -640,7 +640,7 @@ def plot_multiple_shock(
         color=_C_PRIMARY,
         label=r"$\Pi(R) = 1 - e^{-(R/\alpha)^{\beta}}$",
     )
-    for level, r_val in zip((10, 50, 90), (r10, r50, r90)):
+    for level, r_val in zip((10, 50, 90), (r10, r50, r90), strict=True):
         ax.axhline(level, color=_C_MUTED, ls=":", lw=0.8)
         ax.plot([r_val, r_val], [0.0, level], color=_C_MUTED, ls=":", lw=0.8)
 

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -258,6 +258,15 @@ def _rc_left_cell(
 
     levels = np.asarray(result.levels, dtype=np.float64)
     reference = np.asarray(result.reference_curve, dtype=np.float64)
+    # Guard a manually constructed result: RCResult is a plain frozen dataclass,
+    # so a hand-built one can carry a reference curve of a different length than
+    # its levels, and only the verbose columns pair the two band by band.
+    if verbose and levels.shape != reference.shape:
+        msg = (
+            "render_rc_report(verbose=True) needs 'levels' and "
+            "'reference_curve' of equal length."
+        )
+        raise ValueError(msg)
     columns = _base_columns(levels, language)
     if verbose:
         columns.append(
@@ -271,7 +280,7 @@ def _rc_left_cell(
                 t("Dev. [dB]", language),
                 [
                     _level_cell(lvl - ref, language)
-                    for lvl, ref in zip(levels, reference)
+                    for lvl, ref in zip(levels, reference, strict=True)
                 ],
             )
         )

--- a/src/phonometry/_report/human_vibration.py
+++ b/src/phonometry/_report/human_vibration.py
@@ -49,6 +49,8 @@ from __future__ import annotations
 import html
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
 from ._i18n import decimal_comma, t
 from ._layout import (
     _ACCENT_HEX,
@@ -194,7 +196,11 @@ def _operations_table(
     a8_energy = float(result.a8) ** 2
     data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
     for label, total_value, duration_s, partial in zip(
-        result.labels, result.total_values, result.durations_s, result.partials
+        result.labels,
+        result.total_values,
+        result.durations_s,
+        result.partials,
+        strict=True,
     ):
         row = [
             fiche_paragraph(html.escape(str(label)), label_style),
@@ -398,6 +404,8 @@ def render_human_vibration_report(
         of the daily vibration energy ``A_i(8)^2 / A(8)^2``.
     :param language: ``"en"`` (default) or ``"es"``.
     :return: The written ``path`` as a :class:`str`.
+    :raises ValueError: If ``total_values``, ``durations_s`` or ``partials``
+        does not carry one value per operation label.
     :raises ImportError: If reportlab or matplotlib is not installed. The
         fiche always embeds the contribution chart, so both are required
         (``pip install "phonometry[report,plot]"``).
@@ -412,6 +420,24 @@ def render_human_vibration_report(
     except ImportError as exc:
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
+
+    # Guard a manually constructed result: DailyVibrationExposure is a plain
+    # frozen dataclass, so every per-operation array the table and the chart
+    # consume has to be checked here. A short one would otherwise cut the
+    # operations table while the daily-total row kept summing every duration.
+    n_ops = len(result.labels)
+    for name, values in (
+        ("total_values", result.total_values),
+        ("durations_s", result.durations_s),
+        ("partials", result.partials),
+    ):
+        shape = np.asarray(values, dtype=np.float64).shape
+        if shape != (n_ops,):
+            msg = (
+                f"render_human_vibration_report() needs '{name}' to carry one "
+                f"value per operation ({n_ops} in 'labels'); got shape {shape}."
+            )
+            raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Daily vibration exposure assessment", language)

--- a/src/phonometry/_report/iso10534.py
+++ b/src/phonometry/_report/iso10534.py
@@ -185,7 +185,7 @@ def _value_table(
             fiche_paragraph("Im z", head_style),
         ]
         rows: list[list[Any]] = [header]
-        for fk, ak, rk, zk in zip(freqs, alpha, r_mag, z):
+        for fk, ak, rk, zk in zip(freqs, alpha, r_mag, z, strict=True):
             rows.append(
                 [
                     f"{round(fk)}",
@@ -204,7 +204,7 @@ def _value_table(
             fiche_paragraph("Im z", head_style),
         ]
         rows = [header]
-        for fk, ak, zk in zip(freqs, alpha, z):
+        for fk, ak, zk in zip(freqs, alpha, z, strict=True):
             rows.append(
                 [
                     f"{round(fk)}",
@@ -321,12 +321,18 @@ def render_iso10534_report(
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
 
+    # Guard a manually constructed result: ImpedanceTubeResult is a plain
+    # frozen dataclass, so every per-frequency array the table and the figure
+    # consume has to be checked here (a short one would otherwise cut the
+    # fiche table).
     freqs = np.asarray(result.frequency, dtype=np.float64)
     alpha = np.asarray(result.absorption, dtype=np.float64)
-    if freqs.shape != alpha.shape:
+    reflection = np.asarray(result.reflection, dtype=np.complex128)
+    z = np.asarray(result.normalized_impedance, dtype=np.complex128)
+    if not freqs.shape == alpha.shape == reflection.shape == z.shape:
         msg = (
-            "render_iso10534_report() needs 'frequency' and 'absorption' of "
-            "equal length."
+            "render_iso10534_report() needs 'frequency', 'absorption', "
+            "'reflection' and 'normalized_impedance' of equal length."
         )
         raise ValueError(msg)
 

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -298,6 +298,54 @@ def _verdict(
     return text, passed
 
 
+def _left_table(
+    result: AbsorptionRatingResult,
+    centers: np.ndarray,
+    measured: np.ndarray,
+    shifted: np.ndarray,
+    deviations: np.ndarray,
+    verbose: bool,
+    language: str,
+) -> tuple[Any, str]:
+    """Pick the left-hand table of the fiche, and the caption that names it.
+
+    The accredited default (Fellert et al.) shows the full one-third-octave
+    ``alpha_s`` table with ``alpha_p`` on the octave rows when the input
+    ``alpha_s`` was retained; verbose keeps the octave evaluation columns, and
+    without ``alpha_s`` the plain octave ``alpha_p`` table is used.
+
+    :param result: The rating whose per-band arrays the table reads.
+    :param centers: Octave-band centre frequencies, Hz.
+    :param measured: Practical absorption coefficient per octave band.
+    :param shifted: The shifted reference curve.
+    :param deviations: Unfavourable deviations from that curve.
+    :param verbose: Keep the octave evaluation columns.
+    :param language: Label language.
+    :return: The table flowable and its caption.
+    :raises ValueError: If the one-third-octave arrays differ in length.
+    """
+    alpha_s = result.third_octave_alpha_s
+    bands = result.third_octave_bands
+    if verbose or alpha_s is None or bands is None:
+        table = _value_table(centers, measured, shifted, deviations, verbose, language)
+        return table, t("Octave-band &#945;<sub>p</sub>", language)
+    third_octave_bands = np.asarray(bands, dtype=np.float64)
+    third_octave_alpha_s = np.asarray(alpha_s, dtype=np.float64)
+    if third_octave_bands.shape != third_octave_alpha_s.shape:
+        msg = (
+            "render_iso11654_report() needs 'third_octave_bands' and "
+            "'third_octave_alpha_s' of equal length."
+        )
+        raise ValueError(msg)
+    table = _third_octave_table(
+        third_octave_bands, third_octave_alpha_s, measured, language
+    )
+    caption = t(
+        "One-third-octave &#945;<sub>s</sub>, octave &#945;<sub>p</sub>", language
+    )
+    return table, caption
+
+
 def render_iso11654_report(
     result: AbsorptionRatingResult,
     path: str,
@@ -371,35 +419,9 @@ def render_iso11654_report(
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    # The accredited default (Fellert et al.) shows the full one-third-octave
-    # alpha_s table with alpha_p on the octave rows when the input alpha_s was
-    # retained; verbose keeps the octave evaluation columns, and without alpha_s
-    # the plain octave alpha_p table is used.
-    alpha_s = result.third_octave_alpha_s
-    bands = result.third_octave_bands
-    if not verbose and alpha_s is not None and bands is not None:
-        third_octave_bands = np.asarray(bands, dtype=np.float64)
-        third_octave_alpha_s = np.asarray(alpha_s, dtype=np.float64)
-        if third_octave_bands.shape != third_octave_alpha_s.shape:
-            msg = (
-                "render_iso11654_report() needs 'third_octave_bands' and "
-                "'third_octave_alpha_s' of equal length."
-            )
-            raise ValueError(msg)
-        value_table = _third_octave_table(
-            third_octave_bands,
-            third_octave_alpha_s,
-            measured,
-            language,
-        )
-        caption = t(
-            "One-third-octave &#945;<sub>s</sub>, octave &#945;<sub>p</sub>", language
-        )
-    else:
-        value_table = _value_table(
-            centers, measured, shifted, deviations, verbose, language
-        )
-        caption = t("Octave-band &#945;<sub>p</sub>", language)
+    value_table, caption = _left_table(
+        result, centers, measured, shifted, deviations, verbose, language
+    )
     left_cell = [
         fiche_paragraph(caption, caption_style),
         value_table,

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -181,7 +181,7 @@ def _value_table(
         col_widths = [28 * mm, 28 * mm]
 
     rows: list[list[Any]] = [header]
-    for fk, m, r_, d in zip(centers, measured, shifted, deviations):
+    for fk, m, r_, d in zip(centers, measured, shifted, deviations, strict=True):
         if verbose:
             rows.append(
                 [
@@ -243,7 +243,7 @@ def _third_octave_table(
     col_widths = [24 * mm, 16 * mm, 16 * mm]
 
     rows: list[list[Any]] = [header]
-    for j, (fk, a_s) in enumerate(zip(bands, alpha_s)):
+    for j, (fk, a_s) in enumerate(zip(bands, alpha_s, strict=True)):
         # The middle of each triple is the octave centre carrying alpha_p.
         octave_cell = _d2(measured[j // 3], language) if j % 3 == 1 else ""
         rows.append([f"{round(fk)}", _d2(a_s, language), octave_cell])
@@ -378,9 +378,17 @@ def render_iso11654_report(
     alpha_s = result.third_octave_alpha_s
     bands = result.third_octave_bands
     if not verbose and alpha_s is not None and bands is not None:
+        third_octave_bands = np.asarray(bands, dtype=np.float64)
+        third_octave_alpha_s = np.asarray(alpha_s, dtype=np.float64)
+        if third_octave_bands.shape != third_octave_alpha_s.shape:
+            msg = (
+                "render_iso11654_report() needs 'third_octave_bands' and "
+                "'third_octave_alpha_s' of equal length."
+            )
+            raise ValueError(msg)
         value_table = _third_octave_table(
-            np.asarray(bands, dtype=np.float64),
-            np.asarray(alpha_s, dtype=np.float64),
+            third_octave_bands,
+            third_octave_alpha_s,
             measured,
             language,
         )

--- a/src/phonometry/_report/iso17497.py
+++ b/src/phonometry/_report/iso17497.py
@@ -227,7 +227,7 @@ def _scattering_table(
             fiche_paragraph("s", head_style),
         ]
         rows: list[list[Any]] = [header]
-        for fk, ak, spk, sk in zip(freqs, a_s, spec, s):
+        for fk, ak, spk, sk in zip(freqs, a_s, spec, s, strict=True):
             rows.append(
                 [
                     f"{round(fk)}",
@@ -244,7 +244,7 @@ def _scattering_table(
             fiche_paragraph("s", head_style),
         ]
         rows = [header]
-        for fk, ak, sk in zip(freqs, a_s, s):
+        for fk, ak, sk in zip(freqs, a_s, s, strict=True):
             rows.append(
                 [
                     f"{round(fk)}",
@@ -289,12 +289,22 @@ def render_scattering_report(
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
 
+    # Guard a manually constructed result: ScatteringResult is a plain frozen
+    # dataclass, so every per-band array the table and the figure consume has
+    # to be checked here (a short one would otherwise cut the fiche table).
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     s = np.asarray(result.scattering, dtype=np.float64)
-    if freqs.shape != s.shape:
+    a_s = np.asarray(result.random_incidence, dtype=np.float64)
+    if not freqs.shape == s.shape == a_s.shape:
         msg = (
-            "render_scattering_report() needs 'frequencies' and 'scattering' "
-            "of equal length."
+            "render_scattering_report() needs 'frequencies', 'scattering' and "
+            "'random_incidence' of equal length."
+        )
+        raise ValueError(msg)
+    if verbose and np.asarray(result.specular, dtype=np.float64).shape != freqs.shape:
+        msg = (
+            "render_scattering_report(verbose=True) needs 'specular' of the "
+            "same length as 'frequencies'."
         )
         raise ValueError(msg)
 
@@ -380,7 +390,7 @@ def _diffusion_table(
             fiche_paragraph("d<sub>n</sub>", head_style),
         ]
         rows: list[list[Any]] = [header]
-        for fk, dk, dnk in zip(freqs, d, d_n):
+        for fk, dk, dnk in zip(freqs, d, d_n, strict=True):
             rows.append(
                 [
                     f"{round(fk)}",
@@ -395,7 +405,7 @@ def _diffusion_table(
             fiche_paragraph("d", head_style),
         ]
         rows = [header]
-        for fk, dk in zip(freqs, d):
+        for fk, dk in zip(freqs, d, strict=True):
             rows.append([f"{round(fk)}", _c2(dk, language)])
         col_widths = [28 * mm, 28 * mm]
     return band_table(rows, col_widths, len(freqs))
@@ -434,12 +444,24 @@ def render_diffusion_spectrum_report(
         raise ImportError(_REPORTLAB_HINT) from exc
     accent = colors.HexColor(_ACCENT_HEX)
 
+    # Guard a manually constructed result: DiffusionSpectrum is a plain frozen
+    # dataclass, so the optional 'normalized' spectrum is checked here too (the
+    # figure draws it whenever it is present, the table when verbose).
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     d = np.asarray(result.diffusion, dtype=np.float64)
     if freqs.shape != d.shape:
         msg = (
             "render_diffusion_spectrum_report() needs 'frequencies' and "
             "'diffusion' of equal length."
+        )
+        raise ValueError(msg)
+    if (
+        result.normalized is not None
+        and np.asarray(result.normalized, dtype=np.float64).shape != freqs.shape
+    ):
+        msg = (
+            "render_diffusion_spectrum_report() needs 'normalized' of the same "
+            "length as 'frequencies'."
         )
         raise ValueError(msg)
 
@@ -510,7 +532,7 @@ def _polar_table(result: DiffusionResult, language: str = "en") -> Any:
         fiche_paragraph("L [dB]", head_style),
     ]
     rows: list[list[Any]] = [header]
-    for ang, lev in zip(angles, levels):
+    for ang, lev in zip(angles, levels, strict=True):
         rows.append([_d1(ang, language), _d1(lev, language)])
     return band_table(rows, [28 * mm, 28 * mm], len(angles))
 

--- a/src/phonometry/_report/iso354.py
+++ b/src/phonometry/_report/iso354.py
@@ -142,7 +142,7 @@ def _alpha_table(freqs: np.ndarray, alpha_s: np.ndarray, language: str = "en") -
         fiche_paragraph("&#945;<sub>s</sub>", head_style),
     ]
     rows: list[list[Any]] = [header]
-    for fk, a_s in zip(freqs, alpha_s):
+    for fk, a_s in zip(freqs, alpha_s, strict=True):
         rows.append([f"{round(fk)}", _a2(a_s, language)])
     return band_table(rows, [28 * mm, 28 * mm], len(freqs))
 
@@ -169,7 +169,7 @@ def _detail_table(result: SoundAbsorptionMeasurement, language: str = "en") -> A
     a2 = np.asarray(result.absorption_area_with_specimen, dtype=np.float64)
     alpha_s = np.asarray(result.alpha_s, dtype=np.float64)
     rows: list[list[Any]] = [header]
-    for fk, t1k, t2k, a1k, a2k, ask in zip(freqs, t1, t2, a1, a2, alpha_s):
+    for fk, t1k, t2k, a1k, a2k, ask in zip(freqs, t1, t2, a1, a2, alpha_s, strict=True):
         rows.append(
             [
                 f"{round(fk)}",
@@ -237,6 +237,23 @@ def render_iso354_report(
             "render_iso354_report() needs 'frequencies' and 'alpha_s' of equal length."
         )
         raise ValueError(msg)
+    # SoundAbsorptionMeasurement is a plain frozen dataclass, so a hand-built
+    # result can carry per-band arrays of differing lengths. The four columns
+    # only the verbose detail table reads are checked here too; the guard above
+    # covers 'alpha_s' alone.
+    if verbose:
+        t1 = np.asarray(result.t_empty, dtype=np.float64)
+        t2 = np.asarray(result.t_specimen, dtype=np.float64)
+        a1 = np.asarray(result.absorption_area_empty, dtype=np.float64)
+        a2 = np.asarray(result.absorption_area_with_specimen, dtype=np.float64)
+        if not freqs.shape == t1.shape == t2.shape == a1.shape == a2.shape:
+            msg = (
+                "render_iso354_report(verbose=True) needs 't_empty', "
+                "'t_specimen', 'absorption_area_empty' and "
+                "'absorption_area_with_specimen' of the same length as "
+                "'frequencies'."
+            )
+            raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Sound absorption measurement", language)

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -295,7 +295,7 @@ def _value_table(
         return format_number(value, language, decimals=1)
 
     rows: list[list[Any]] = [header]
-    for fk, m, r_, d in zip(centers, measured, shifted, deviations):
+    for fk, m, r_, d in zip(centers, measured, shifted, deviations, strict=True):
         if verbose:
             rows.append(
                 [

--- a/src/phonometry/_report/sti.py
+++ b/src/phonometry/_report/sti.py
@@ -127,7 +127,10 @@ def _band_table(result: STIResult, language: str = "en") -> Any:
         fiche_paragraph("MTI", head_style),
     ]
     rows: list[list[Any]] = [header]
-    for fk, m in zip(_STI_BAND_CENTERS, mti):
+    # Fixed seven-centre table against an 'mti' the frozen dataclass does not
+    # validate: a directly built result with fewer bands ends the table early
+    # rather than being rejected, and one with more is cut after the seventh.
+    for fk, m in zip(_STI_BAND_CENTERS, mti, strict=False):
         rows.append([f"{fk}", format_number(float(m), language, decimals=2)])
 
     table = Table(rows, colWidths=[28 * mm, 28 * mm], repeatRows=1)

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -411,7 +411,7 @@ def improvement_octave_bands(
         raise ValueError(msg)
     octave_freqs: list[float] = []
     octave_values: list[float] = []
-    by_freq = {round(float(f), 3): float(d) for f, d in zip(freqs, dl)}
+    by_freq = {round(float(f), 3): float(d) for f, d in zip(freqs, dl, strict=True)}
     for centre in _octave_centres(freqs):
         thirds = [centre * 2.0 ** (k / 3.0) for k in (-1, 0, 1)]
         try:

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -351,7 +351,7 @@ def _apparent_reduction(
     taus = [el.tau(total_area, n) for el in elements]
     tau_total = np.sum(taus, axis=0)
     r_prime = -10.0 * np.log10(tau_total)
-    element_r = {name: -10.0 * np.log10(t) for name, t in zip(names, taus)}
+    element_r = {name: -10.0 * np.log10(t) for name, t in zip(names, taus, strict=True)}
     return r_prime, element_r
 
 

--- a/src/phonometry/building/prediction/linings.py
+++ b/src/phonometry/building/prediction/linings.py
@@ -437,7 +437,7 @@ def lining_improvement(
     if anchors:
         ratings = [
             factor * value + offset
-            for value, (factor, offset) in zip(ratings, _ANNEX_D_ANCHORS)
+            for value, (factor, offset) in zip(ratings, _ANNEX_D_ANCHORS, strict=True)
         ]
     if glued_area is not None:
         if system == "studs":

--- a/src/phonometry/building/prediction/simplified_model.py
+++ b/src/phonometry/building/prediction/simplified_model.py
@@ -880,7 +880,7 @@ def predicted_airborne_insulation(
             r_w=p.r_ij_w,
             fraction=tau / tau_total,
         )
-        for p, tau in zip(flanking_paths, tau_paths)
+        for p, tau in zip(flanking_paths, tau_paths, strict=True)
     ]
     dominant = max(contributions, key=lambda c: c.fraction)
     return AirbornePredictionResult(

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -325,7 +325,7 @@ def _band_integrals(
     centers: list[float] = []
     band_i: list[float] = []
     band_msp: list[float] = []
-    for fc, lo, hi in zip(freq, freq_d, freq_u):
+    for fc, lo, hi in zip(freq, freq_d, freq_u, strict=True):
         mask = (fpos > lo) & (fpos <= hi)
         if not np.any(mask):
             continue  # band narrower than the spectral resolution

--- a/src/phonometry/filters/design.py
+++ b/src/phonometry/filters/design.py
@@ -102,7 +102,7 @@ def _design_sos_filter(
     """
     sos = [np.array([]) for _ in range(len(freq))]
 
-    for idx, (lower, upper) in enumerate(zip(freq_d, freq_u)):
+    for idx, (lower, upper) in enumerate(zip(freq_d, freq_u, strict=True)):
         fsd = fs / factor[idx]
         wn = np.array([lower, upper]) / (fsd / 2)
 

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -578,13 +578,16 @@ def task_based_exposure(
     levels, durations = _task_levels(tasks)
 
     # Daily level: energy sum of contributions (Eq 9 == Eq 10).
-    energy = sum((t_m / _T0) * 10.0 ** (0.1 * lp) for lp, t_m in zip(levels, durations))
+    energy = sum(
+        (t_m / _T0) * 10.0 ** (0.1 * lp)
+        for lp, t_m in zip(levels, durations, strict=True)
+    )
     lex_8h = float(10.0 * log10(energy))
 
     # Second pass: sensitivity coefficients and uncertainty terms.
     options = _BudgetOptions(instrument, u3, include_duration_uncertainty, warn)
     contributions: list[TaskContribution] = []
-    for idx, (task, lp, t_m) in enumerate(zip(tasks, levels, durations)):
+    for idx, (task, lp, t_m) in enumerate(zip(tasks, levels, durations, strict=True)):
         contributions.append(_task_contribution(task, idx, lp, t_m, lex_8h, options))
 
     variance = sum(c.variance_contribution for c in contributions)

--- a/src/phonometry/materials/absorbers/layered.py
+++ b/src/phonometry/materials/absorbers/layered.py
@@ -572,7 +572,7 @@ def _split_fluid_run(
         raise ValueError(msg)
 
     parts: list[tuple[str, Complex, Complex, float]] = []
-    for (kind, a, b), loss in zip(terms, losses):
+    for (kind, a, b), loss in zip(terms, losses, strict=True):
         pieces = max(1, int(np.ceil(loss / budget)))
         if pieces == 1:
             parts.append((kind, a, b, loss))
@@ -850,7 +850,7 @@ def diffuse_field_absorption(
     theta = 0.5 * lim * (nodes + 1.0)
     w = 0.5 * lim * weights
     total = np.zeros_like(f, dtype=np.float64)
-    for th, wt in zip(theta, w):
+    for th, wt in zip(theta, w, strict=True):
         res = layered_absorber(
             f,
             layers,

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -359,7 +359,8 @@ def _shape_indicator(measured_units: list[int], reference_units: list[int]) -> s
     H (2000/4000 Hz).
     """
     excess = [
-        m - r >= _SHAPE_THRESHOLD_UNITS for m, r in zip(measured_units, reference_units)
+        m - r >= _SHAPE_THRESHOLD_UNITS
+        for m, r in zip(measured_units, reference_units, strict=True)
     ]
     indicator = ""
     if excess[0]:
@@ -412,7 +413,9 @@ def _rate(
     shift_units = 0
     while shift_units <= _FULL_SCALE_UNITS:
         shifted_units = [r - shift_units for r in _REFERENCE_UNITS]
-        unfav_units = sum(max(0, s - m) for s, m in zip(shifted_units, measured_units))
+        unfav_units = sum(
+            max(0, s - m) for s, m in zip(shifted_units, measured_units, strict=True)
+        )
         if unfav_units <= _UNFAVOURABLE_BUDGET_UNITS:
             break
         shift_units += 1

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -572,7 +572,7 @@ def check_base_plate_scattering(
                 f"bands {BASE_PLATE_BANDS}, got shape {arr.shape}"
             )
             raise ValueError(msg)
-        values = dict(zip(BASE_PLATE_BANDS, arr.tolist()))
+        values = dict(zip(BASE_PLATE_BANDS, arr.tolist(), strict=True))
     exceeded = tuple(
         band
         for band in BASE_PLATE_BANDS

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -680,7 +680,7 @@ def _smooth(pattern: np.ndarray) -> np.ndarray:
     """
     smoothed = np.zeros_like(pattern)
     n = pattern.size
-    for offset, weight in zip(_INH_TAPS, _INH_KERNEL):
+    for offset, weight in zip(_INH_TAPS, _INH_KERNEL, strict=True):
         src_lo = max(0, offset)
         src_hi = min(n, n + offset)
         dst_lo = max(0, -offset)
@@ -839,7 +839,7 @@ def _third_octave_components(
     """
     freqs: list[float] = []
     levels: list[float] = []
-    for centre, level in zip(_THIRD_OCTAVE_FREQ, band_levels):
+    for centre, level in zip(_THIRD_OCTAVE_FREQ, band_levels, strict=True):
         width = centre * (_THIRD_OCTAVE_RATIO - 1.0 / _THIRD_OCTAVE_RATIO)
         spectrum_level = float(level) - 10.0 * math.log10(width)
         spacing = 1.0 if centre <= _FINE_SPACING_MAX_CENTRE_HZ else 10.0

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -457,7 +457,7 @@ def _smooth(pattern: np.ndarray) -> np.ndarray:
     """Broadly tuned across-frequency smoothing (clause 7.7, Formulae 14/15)."""
     smoothed = np.zeros_like(pattern)
     n = pattern.size
-    for offset, weight in zip(_INH_TAPS, _INH_KERNEL):
+    for offset, weight in zip(_INH_TAPS, _INH_KERNEL, strict=True):
         src_lo = max(0, offset)
         src_hi = min(n, n + offset)
         dst_lo = max(0, -offset)

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -796,7 +796,7 @@ def combined_tone_level(
         msg = "At least one tone is required."
         raise ValueError(msg)
     marked: set[int] = set()
-    for ft, ls in zip(fts, lss):
+    for ft, ls in zip(fts, lss, strict=True):
         peak = int(np.argmin(np.abs(freq - ft)))
         low, high = _tone_line_span(lev, peak, float(ls))
         marked.update(range(low, high + 1))

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -286,7 +286,7 @@ def _validate_point(
     if not np.all(np.isfinite(p)):
         msg = f"'{name}' coordinates must be finite."
         raise ValueError(msg)
-    for value, length, axis in zip(p, dimensions, "xyz"):
+    for value, length, axis in zip(p, dimensions, "xyz", strict=True):
         if not 0.0 < value < length:
             msg = (
                 f"'{name}' coordinate {axis} = {value} lies outside the room "

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -419,7 +419,7 @@ def _align_levels(levels: ArrayLike, frequencies: ArrayLike | None) -> np.ndarra
         msg = "levels and frequencies must have the same shape."
         raise ValueError(msg)
     aligned = np.full(_N_BANDS, np.nan)
-    for f, level in zip(fr, lv):
+    for f, level in zip(fr, lv, strict=True):
         matches = np.isclose(OCTAVE_BANDS, f, rtol=0.03)
         if not matches.any():
             msg = (

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -182,9 +182,9 @@ def _accumulate_surfaces(
         msg = "the total surface area must be positive."
         raise ValueError(msg)
     absorption_area = np.zeros(shape, dtype=np.float64)
-    for area, alpha_arr in zip(areas, alphas):
+    for area, alpha_arr in zip(areas, alphas, strict=True):
         absorption_area = absorption_area + area * alpha_arr
-    return total_area, absorption_area, list(zip(areas, alphas))
+    return total_area, absorption_area, list(zip(areas, alphas, strict=True))
 
 
 def _air_term(air_attenuation: ArrayLike, volume: float) -> NDArray[np.float64]:
@@ -499,7 +499,9 @@ def fitzroy_reverberation_time(
     weights, times = _axial_eyring_times(
         dimensions, absorptions, air_attenuation, speed_of_sound
     )
-    total = sum(w * np.asarray(t, dtype=np.float64) for w, t in zip(weights, times))
+    total = sum(
+        w * np.asarray(t, dtype=np.float64) for w, t in zip(weights, times, strict=True)
+    )
     return as_float_or_array(total)
 
 
@@ -531,7 +533,8 @@ def arau_puchades_reverberation_time(
         dimensions, absorptions, air_attenuation, speed_of_sound
     )
     log_t = sum(
-        w * np.log(np.asarray(t, dtype=np.float64)) for w, t in zip(weights, times)
+        w * np.log(np.asarray(t, dtype=np.float64))
+        for w, t in zip(weights, times, strict=True)
     )
     return as_float_or_array(np.exp(log_t))
 
@@ -680,7 +683,7 @@ def reverberation_time_models(
         raise ValueError(msg)
     # Two equal-area opposing walls per axis share the axis mean absorption.
     surfaces: list[Surface] = []
-    for area, alpha in zip(pair_areas, absorptions):
+    for area, alpha in zip(pair_areas, absorptions, strict=True):
         surfaces.append((float(area) / 2.0, alpha))
         surfaces.append((float(area) / 2.0, alpha))
 

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -1151,7 +1151,7 @@ def daily_vibration_exposure(
             msg = "'labels' must match the number of operations."
             raise ValueError(msg)
     partials = np.array(
-        [daily_exposure(float(a), float(dt)) for a, dt in zip(ahv, t)],
+        [daily_exposure(float(a), float(dt)) for a, dt in zip(ahv, t, strict=True)],
         dtype=np.float64,
     )
     a8 = combine_partial_exposures(partials)

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -452,7 +452,7 @@ _BILINEAR_CASES = [
 @pytest.mark.parametrize(("rotorcraft", "cases"), _BILINEAR_CASES)
 def test_reference_bilinear_off_node(rotorcraft: str, cases: list) -> None:
     for (corners, expected), (phi, theta, (a0, a1), (p0, p1)) in zip(
-        cases, _BILINEAR_QUERIES
+        cases, _BILINEAR_QUERIES, strict=True
     ):
         lv = np.array(corners, dtype=np.float64).reshape(2, 2, 1)
         h = RotorcraftHemisphere(
@@ -1103,7 +1103,7 @@ def test_fc_weights_are_unit_invariant() -> None:
     ms = [v * 0.514444 for v in kts]
     w1 = flight_condition_weights(kts, [0.0, 0.0, 10.0], 60.0, 2.5)
     w2 = flight_condition_weights(ms, [0.0, 0.0, 10.0], 60.0 * 0.514444, 2.5)
-    for (i1, a), (i2, b) in zip(w1, w2):
+    for (i1, a), (i2, b) in zip(w1, w2, strict=True):
         assert i1 == i2
         assert a == pytest.approx(b, abs=1e-12)
 

--- a/tests/aircraft/test_rotorcraft_norah2.py
+++ b/tests/aircraft/test_rotorcraft_norah2.py
@@ -285,7 +285,9 @@ def _parse_his(path: pathlib.Path) -> tuple[dict, np.ndarray]:
                 "T2pnlt",
                 "I10db",
             ]
-            header = dict(zip(keys, vals))
+            # Names the leading columns of the parsed header row; any further
+            # column of a .his variant stays unnamed.
+            header = dict(zip(keys, vals, strict=False))
             continue
         parts = line.split()
         if header is not None and len(parts) == 12:

--- a/tests/aircraft/test_rotorcraft_norah2.py
+++ b/tests/aircraft/test_rotorcraft_norah2.py
@@ -285,9 +285,11 @@ def _parse_his(path: pathlib.Path) -> tuple[dict, np.ndarray]:
                 "T2pnlt",
                 "I10db",
             ]
-            # Names the leading columns of the parsed header row; any further
-            # column of a .his variant stays unnamed.
-            header = dict(zip(keys, vals, strict=False))
+            # Every .his header of the public release carries exactly these
+            # thirteen metrics, in the committed extract and in the full
+            # archive alike, so a file that carries another count is a change
+            # of format worth failing on rather than absorbing.
+            header = dict(zip(keys, vals, strict=True))
             continue
         parts = line.split()
         if header is not None and len(parts) == 12:

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -358,7 +358,7 @@ def test_dynamic_intermodulation_distortion() -> None:
     # though it sits 750 Hz from the k=4 (2400) and k=6 (3900) products.
     # DIM = sqrt(sum products^2) / sine_amp, excluding the 3150 tone.
     x = _tone(fsine) + _tone(fsq, 0.8)
-    for c, a in zip(comps, amps):
+    for c, a in zip(comps, amps, strict=True):
         x = x + _tone(c, a)
     expected = math.sqrt(sum(a**2 for a in amps))
     assert electroacoustics.dynamic_intermodulation_distortion(x, FS) == pytest.approx(

--- a/tests/environment/propagation/test_air_absorption.py
+++ b/tests/environment/propagation/test_air_absorption.py
@@ -224,7 +224,9 @@ def test_iso9613_2_table2_grid_exact_midbands() -> None:
             )
             * 1000.0
         )
-        for got, printed, band in zip(alpha, row, ref.ISO9613_2_TABLE2_BANDS):
+        for got, printed, band in zip(
+            alpha, row, ref.ISO9613_2_TABLE2_BANDS, strict=True
+        ):
             tol = 0.5 if printed >= 100.0 else 0.05
             if (temp, rh, band) == (15.0, 80.0, 1000.0):
                 tol = 0.06  # print rounding artifact, see reference_data

--- a/tests/filters/test_b_au_d_weightings.py
+++ b/tests/filters/test_b_au_d_weightings.py
@@ -68,11 +68,11 @@ def _response_db(
 def test_b_masks_match_reference_data() -> None:
     """The module's ANSI S1.4-1983 tables equal the reference_data copies."""
     assert len(_ANSI_S14_TABLE4_B) == len(ANSIS14_TABLE4_B) == 34
-    for row, ref_row in zip(_ANSI_S14_TABLE4_B, ANSIS14_TABLE4_B):
+    for row, ref_row in zip(_ANSI_S14_TABLE4_B, ANSIS14_TABLE4_B, strict=True):
         assert row == pytest.approx(ref_row), f"Table IV mismatch at {ref_row[0]} Hz"
     # Table V Types 1/2 (columns 3-6 of the reference table).
     assert len(_ANSI_S14_TABLE5_12) == len(ANSIS14_TABLE5) == 34
-    for row, ref_row in zip(_ANSI_S14_TABLE5_12, ANSIS14_TABLE5):
+    for row, ref_row in zip(_ANSI_S14_TABLE5_12, ANSIS14_TABLE5, strict=True):
         assert row[0] == ref_row[0]
         assert row[1:] == pytest.approx(ref_row[3:]), (
             f"Table V mismatch at {ref_row[0]} Hz"
@@ -82,7 +82,7 @@ def test_b_masks_match_reference_data() -> None:
 def test_au_masks_match_reference_data() -> None:
     """The module's IEC 61012:1990 tables equal the reference_data copies."""
     assert len(_IEC61012_TABLE1) == len(IEC61012_TABLE1) == 37
-    for row, ref_row in zip(_IEC61012_TABLE1, IEC61012_TABLE1):
+    for row, ref_row in zip(_IEC61012_TABLE1, IEC61012_TABLE1, strict=True):
         assert row == pytest.approx(ref_row), f"Table 1 mismatch at {ref_row[0]} Hz"
     assert _IEC61012_AU_HF == pytest.approx(IEC61012_AU_HF)
     poles = [(p.real, p.imag) for p in _U_POLES_HZ]
@@ -109,7 +109,7 @@ def test_b_realized_within_type0_at_every_table4_row() -> None:
     freqs = [_exact(row[0]) for row in ANSIS14_TABLE4_B]
     resp = _response_db(wf, freqs)
     for (freq, goal), (_, up0, lo0, *_), got in zip(
-        ANSIS14_TABLE4_B, ANSIS14_TABLE5, resp
+        ANSIS14_TABLE4_B, ANSIS14_TABLE5, resp, strict=True
     ):
         dev = got - goal
         assert lo0 <= dev <= up0, f"B outside Type 0 at {freq} Hz: {dev:+.3f} dB"
@@ -125,7 +125,7 @@ def test_b_appendix_c_analytic_reproduces_table4() -> None:
     """
     freqs = np.array([_exact(row[0]) for row in ANSIS14_TABLE4_B])
     analytic = _analytic_weighting_db("B", freqs)
-    for (freq, goal), got in zip(ANSIS14_TABLE4_B, analytic):
+    for (freq, goal), got in zip(ANSIS14_TABLE4_B, analytic, strict=True):
         assert got == pytest.approx(goal, abs=0.05), f"{freq} Hz"
 
 
@@ -196,7 +196,7 @@ def test_au_realized_within_table1_tolerances() -> None:
     wf = filters.WeightingFilter(96000, "AU")
     rows = [r for r in IEC61012_TABLE1 if _exact(r[0]) < 48000.0 and r[0] != 1000]
     resp = _response_db(wf, [_exact(r[0]) for r in rows])
-    for (freq, u_nom, up, lo), got in zip(rows, resp):
+    for (freq, u_nom, up, lo), got in zip(rows, resp, strict=True):
         goal = IEC61012_AU_HF.get(freq, a_nom.get(freq, 0.0) + u_nom)
         assert lo <= got - goal <= up, f"AU outside Table 1 at {freq} Hz"
 
@@ -288,7 +288,7 @@ def test_d_pins_published_table_values() -> None:
     freqs = [float(row[0]) for row in IEC537_NASA_TABLE_SLD1]
     resp = _response_db(wf, freqs)
     table = {row[0]: row[1] for row in IEC537_NASA_TABLE_SLD1}
-    got = dict(zip(table, resp))
+    got = dict(zip(table, resp, strict=True))
     assert got[50] == pytest.approx(-12.8, abs=0.1)
     assert got[1000] == 0.0
     assert got[8000] == pytest.approx(5.5, abs=0.2)

--- a/tests/filters/test_weighting_class_verifier.py
+++ b/tests/filters/test_weighting_class_verifier.py
@@ -22,7 +22,7 @@ from phonometry.filters.weighting_compliance import (
 def test_masks_match_reference_data() -> None:
     """The module's Table 3 (freq, A, C, class1 upper/lower) equals reference_data."""
     assert len(_WEIGHTING_TABLE3) == len(TABLE3) == 34
-    for row, ref in zip(_WEIGHTING_TABLE3, TABLE3):
+    for row, ref in zip(_WEIGHTING_TABLE3, TABLE3, strict=True):
         assert row[:5] == pytest.approx(ref, nan_ok=False), f"mismatch at {ref[0]} Hz"
 
 

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -21,6 +21,7 @@ alpha = 1 - 1/5 = 0.80 with |r| = 1/sqrt(5) = 0.45.
 
 from __future__ import annotations
 
+import dataclasses
 import re
 
 import pytest
@@ -132,6 +133,29 @@ def test_unknown_language_rejected(tmp_path) -> None:
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(out, language="xx")
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+@pytest.mark.parametrize(
+    "field", ["frequency", "absorption", "reflection", "normalized_impedance"]
+)
+def test_short_per_frequency_array_rejected(
+    field: str, verbose: bool, tmp_path
+) -> None:
+    """One short per-frequency array raises before the fiche is written.
+
+    ``ImpedanceTubeResult`` is a frozen dataclass with no validation, so a
+    caller can hand the renderer a result whose arrays disagree in length; the
+    value table would then be silently cut short, in the plain four-column
+    branch and in the verbose ``|r|`` branch alike. The renderer names the
+    field it needs of equal length and leaves no PDF behind.
+    """
+    result = _result()
+    ragged = dataclasses.replace(result, **{field: getattr(result, field)[:-1]})
+    out = tmp_path / "iso10534_ragged.pdf"
+    with pytest.raises(ValueError, match=field):
+        ragged.report(str(out), metadata=_metadata(), verbose=verbose)
+    assert not out.exists()
 
 
 def test_displayed_absorption_matches_oracle(tmp_path) -> None:

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -153,8 +153,9 @@ def test_short_per_frequency_array_rejected(
     result = _result()
     ragged = dataclasses.replace(result, **{field: getattr(result, field)[:-1]})
     out = tmp_path / "iso10534_ragged.pdf"
+    metadata = _metadata()
     with pytest.raises(ValueError, match=field):
-        ragged.report(str(out), metadata=_metadata(), verbose=verbose)
+        ragged.report(str(out), metadata=metadata, verbose=verbose)
     assert not out.exists()
 
 

--- a/tests/materials/absorbers/test_iso11654_report.py
+++ b/tests/materials/absorbers/test_iso11654_report.py
@@ -158,6 +158,27 @@ def test_third_octave_fiche_with_metadata(tmp_path) -> None:
     _assert_one_page(str(out))
 
 
+def test_third_octave_fiche_rejects_band_count_mismatch(tmp_path) -> None:
+    """One-third-octave arrays of unequal length raise ``ValueError``.
+
+    ``AbsorptionRatingResult`` is a frozen dataclass with no validation, so a
+    caller can pair fifteen ``alpha_s`` with fourteen band centres; the
+    accredited table used to be drawn silently short. The guard fires before
+    the table is built, so no PDF is written.
+    """
+    import dataclasses
+
+    result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
+    assert result.third_octave_bands is not None
+    short = dataclasses.replace(
+        result, third_octave_bands=result.third_octave_bands[:-1]
+    )
+    out = tmp_path / "mismatch.pdf"
+    with pytest.raises(ValueError, match="third_octave_bands"):
+        short.report(str(out))
+    assert not out.exists()
+
+
 def test_statement_writes_shape_indicator_without_space(tmp_path) -> None:
     """The boxed rating is written ``0.60(M)``, the ISO 11654 5.3 style.
 

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -4,12 +4,15 @@
 The report is a rendering feature, so these tests assert only structural
 facts: a valid single-page PDF is written for a reverberation-room measurement,
 the displayed one-third-octave values match the closed-form ISO 354 oracle,
-the verbose detail table stays on one page, unknown engines are rejected, and
-XML specials in metadata do not break reportlab. Pixel or layout content is
-never inspected.
+the verbose detail table stays on one page, a hand-built result whose per-band
+columns disagree in length is rejected before anything is written, unknown
+engines are rejected, and XML specials in metadata do not break reportlab.
+Pixel or layout content is never inspected.
 """
 
 from __future__ import annotations
+
+from dataclasses import replace
 
 import pytest
 
@@ -186,6 +189,31 @@ def test_verbose_shows_areas_and_times_one_page(tmp_path) -> None:
     text = _text(str(out))
     assert "7.80" in text  # T1(500 Hz)
     assert "7.7" in text  # A2(500 Hz) = 7.677 m2 rounded to 0.1
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "t_empty",
+        "t_specimen",
+        "absorption_area_empty",
+        "absorption_area_with_specimen",
+    ],
+)
+def test_verbose_rejects_short_band_column(field: str, tmp_path) -> None:
+    """Every column of the verbose table must be as long as ``frequencies``.
+
+    ``SoundAbsorptionMeasurement`` is a frozen dataclass with no validation, so
+    a hand-built result can carry a per-band column one band short. The detail
+    table would then be silently truncated, so the renderer names the offending
+    column and raises before any PDF is written.
+    """
+    result = _result()
+    short = replace(result, **{field: getattr(result, field)[:-1]})
+    out = tmp_path / "iso354_short.pdf"
+    with pytest.raises(ValueError, match=field):
+        short.report(str(out), metadata=_metadata(), verbose=True)
+    assert not out.exists()
 
 
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -211,8 +211,9 @@ def test_verbose_rejects_short_band_column(field: str, tmp_path) -> None:
     result = _result()
     short = replace(result, **{field: getattr(result, field)[:-1]})
     out = tmp_path / "iso354_short.pdf"
+    metadata = _metadata()
     with pytest.raises(ValueError, match=field):
-        short.report(str(out), metadata=_metadata(), verbose=True)
+        short.report(str(out), metadata=metadata, verbose=True)
     assert not out.exists()
 
 

--- a/tests/materials/absorbers/test_porous.py
+++ b/tests/materials/absorbers/test_porous.py
@@ -668,7 +668,10 @@ class TestResonantSheets:
     def test_maa_table_i_printed_values(self) -> None:
         """Maa 1998 Table I: alpha0 (Eq. (10)) and B = f2/f1 (Eq. (21))."""
         for r, alpha0, b in zip(
-            ref.MAA_TABLE_I_R, ref.MAA_TABLE_I_ALPHA0, ref.MAA_TABLE_I_BANDWIDTH
+            ref.MAA_TABLE_I_R,
+            ref.MAA_TABLE_I_ALPHA0,
+            ref.MAA_TABLE_I_BANDWIDTH,
+            strict=True,
         ):
             assert 4.0 * r / (1.0 + r) ** 2 == pytest.approx(alpha0, abs=0.005)
             arccot = np.arctan(1.0 / (1.0 + r))

--- a/tests/materials/diffusers/test_iso17497_report.py
+++ b/tests/materials/diffusers/test_iso17497_report.py
@@ -5,9 +5,10 @@ The report is a rendering feature, so these tests assert only structural facts:
 a valid single-page PDF is written for each fiche (scattering ``s(f)``, the
 diffusion spectrum ``d(f)`` and the single-source polar response), the displayed
 coefficients match the documented clean-room oracle, the band/angle labels and
-metadata appear, unknown engines/languages are rejected, XML specials in
-metadata do not break reportlab, and the Spanish fiche uses a decimal comma.
-Pixel or layout content is never inspected.
+metadata appear, unknown engines/languages are rejected, a hand-built result
+whose per-band arrays disagree in length is refused before the file is written,
+XML specials in metadata do not break reportlab, and the Spanish fiche uses a
+decimal comma. Pixel or layout content is never inspected.
 """
 
 from __future__ import annotations
@@ -15,6 +16,8 @@ from __future__ import annotations
 import pytest
 
 pytest.importorskip("reportlab")
+
+from dataclasses import replace
 
 import numpy as np
 
@@ -237,6 +240,30 @@ def test_scattering_spanish_uses_comma_decimal(tmp_path) -> None:
     assert "0,45" in _text(str(out))  # Spanish decimal comma
 
 
+def test_scattering_short_random_incidence_rejected(tmp_path) -> None:
+    """ScatteringResult is a frozen dataclass, so the fiche checks the lengths.
+
+    A caller can hand-build one whose per-band arrays disagree; the alpha_s
+    column would then silently cut the table short, so the render refuses it.
+    """
+    result = _scattering()
+    short = replace(result, random_incidence=result.random_incidence[:-1])
+    out = tmp_path / "scat_short.pdf"
+    with pytest.raises(ValueError, match="'random_incidence'"):
+        short.report(str(out))
+    assert not out.exists()  # refused before the fiche is written
+
+
+def test_scattering_verbose_short_specular_rejected(tmp_path) -> None:
+    """The alpha_spec column is only tabulated when verbose, and so is its length."""
+    result = _scattering()
+    short = replace(result, specular=result.specular[:-1])
+    out = tmp_path / "scat_short_verbose.pdf"
+    with pytest.raises(ValueError, match="'specular'"):
+        short.report(str(out), verbose=True)
+    assert not out.exists()
+
+
 # --- ISO 17497-2 diffusion spectrum ---------------------------------------
 def test_diffusion_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "diff.pdf"
@@ -283,6 +310,20 @@ def test_diffusion_spanish_uses_comma_decimal(tmp_path) -> None:
     _diffusion_spectrum().report(str(out), metadata=_metadata(), language="es")
     _assert_one_page(str(out))
     assert "0,81" in _text(str(out))
+
+
+def test_diffusion_short_normalized_rejected(tmp_path) -> None:
+    """The normalised spectrum is optional, but a present one has to be full length.
+
+    The figure draws d_n whenever it is there, so the length is checked for any
+    hand-built DiffusionSpectrum, not only for the verbose table.
+    """
+    result = _diffusion_spectrum()
+    short = replace(result, normalized=result.normalized[:-1])
+    out = tmp_path / "diff_short.pdf"
+    with pytest.raises(ValueError, match="'normalized'"):
+        short.report(str(out))
+    assert not out.exists()
 
 
 # --- ISO 17497-2 polar response -------------------------------------------

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -370,7 +370,7 @@ def test_gum_h2_correlated_measurement() -> None:
     assert r[0, 2] == pytest.approx(0.86, abs=0.005)
     assert r[1, 2] == pytest.approx(-0.65, abs=0.005)
 
-    qs = [u.Quantity(m, s) for m, s in zip(means, u_means)]
+    qs = [u.Quantity(m, s) for m, s in zip(means, u_means, strict=True)]
     models = {
         "R": lambda v, i, p: v / i * math.cos(p),
         "X": lambda v, i, p: v / i * math.sin(p),

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -202,9 +202,9 @@ def _assert_path(
     *Sum* and *Combined* rows check the cascade arithmetic itself.
     """
     assert len(result.stages) == len(level_rows)
-    printed = zip(elements, self_noise_rows, level_rows)
+    printed = zip(elements, self_noise_rows, level_rows, strict=True)
     for stage, ((_, loss, _), self_noise, (row_sum, combined)) in zip(
-        result.stages, printed
+        result.stages, printed, strict=True
     ):
         where = f"{what} {stage.code}"
         _assert_sheet(stage.attenuation, _row(loss), f"{where} attenuation")

--- a/tests/noise_control/test_hvac_long.py
+++ b/tests/noise_control/test_hvac_long.py
@@ -173,7 +173,7 @@ def test_lined_rectangular_duct_eq_14_12() -> None:
     c = [1.959, 1.410, 0.824, 0.500, 0.695, 0.802, 0.451, 0.219]
     ps, length = 10.0 / 3.0, 6.0
     # t = 1 in, so t^D = 1 for every band and D drops out of this case.
-    expected = [bi * ps**ci * length for bi, ci in zip(b, c)]
+    expected = [bi * ps**ci * length for bi, ci in zip(b, c, strict=True)]
     assert np.allclose(res.values, expected)
 
 

--- a/tests/psychoacoustics/quality/test_fluctuation_strength.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength.py
@@ -149,7 +149,9 @@ def test_signal_carrier_sweep_tracks_fig_10_5() -> None:
         ).fluctuation_strength
         for fc in ref.FS_CARRIER_SWEEP_HZ
     }
-    for fc, expected in zip(ref.FS_CARRIER_SWEEP_HZ, ref.FS_CARRIER_SWEEP_VACIL):
+    for fc, expected in zip(
+        ref.FS_CARRIER_SWEEP_HZ, ref.FS_CARRIER_SWEEP_VACIL, strict=True
+    ):
         assert model[fc] == pytest.approx(expected, rel=0.15), (
             f"fc={fc:g} Hz: F={model[fc]:.3f} vs {expected} vacil"
         )

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -654,7 +654,7 @@ def test_table_e2_lg_and_av_columns() -> None:
     from the printed LS and fT to <= 0.03 dB (2-decimal print rounding).
     """
     for (ft, ls, _lt, _dl), lg_p, av_p in zip(
-        ref.ISO20065_ANNEX_E_TONES, ref.ISO20065_E2_LG, ref.ISO20065_E2_AV
+        ref.ISO20065_ANNEX_E_TONES, ref.ISO20065_E2_LG, ref.ISO20065_E2_AV, strict=True
     ):
         assert psychoacoustics.critical_band_level(
             ls, ft, ref.ISO20065_LINE_SPACING
@@ -669,7 +669,7 @@ def test_table_e2_band_limits_are_line_snapped() -> None:
     """
     df = ref.ISO20065_LINE_SPACING
     for (ft, _ls, _lt, _dl), (f1_p, f2_p) in zip(
-        ref.ISO20065_ANNEX_E_TONES, ref.ISO20065_E2_BAND_LIMITS
+        ref.ISO20065_ANNEX_E_TONES, ref.ISO20065_E2_BAND_LIMITS, strict=True
     ):
         f1_a, f2_a = psychoacoustics.critical_band_corners(ft)
         assert f1_a < f1_p <= f1_a + df + 0.01, f"{ft} Hz lower limit"
@@ -689,7 +689,11 @@ def test_table_e2_uncertainty_of_the_137hz_tone() -> None:
     assert res.group_sizes is not None
     singles = res.group_sizes == 1
     by_freq = dict(
-        zip(res.tone_frequencies[singles], res.extended_uncertainties[singles])
+        zip(
+            res.tone_frequencies[singles],
+            res.extended_uncertainties[singles],
+            strict=True,
+        )
     )
     assert by_freq[137.3] == pytest.approx(2.79, abs=0.02)
     assert by_freq[118.4] == pytest.approx(3.66, abs=0.1)

--- a/tests/room/test_crowd_noise.py
+++ b/tests/room/test_crowd_noise.py
@@ -31,6 +31,7 @@ here rather than asserted:
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import numpy as np
@@ -213,6 +214,24 @@ def test_plot_draws_one_curve_per_absorption_plus_two_references() -> None:
     labels = [t.get_text() for t in ax.get_legend().get_texts()]
     assert any("Communication limit" in label for label in labels)
     assert "Simultaneous talkers" in ax.get_xlabel()
+    plt.close("all")
+
+
+def test_plot_rejects_fewer_absorption_areas_than_level_rows() -> None:
+    """The result is frozen but unchecked, so the plot enforces its own shape.
+
+    Nothing validates ``levels`` against ``absorption_areas`` at construction,
+    and a hand-built result with one area missing used to draw one curve fewer
+    in silence instead of saying so.
+    """
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    result = room.crowd_noise([20.0, 90.0, 190.0])
+    short = dataclasses.replace(result, absorption_areas=result.absorption_areas[:-1])
+    with pytest.raises(ValueError, match="absorption_areas"):
+        short.plot()
     plt.close("all")
 
 

--- a/tests/room/test_iso3382_report.py
+++ b/tests/room/test_iso3382_report.py
@@ -46,7 +46,7 @@ def _synthetic_ir(seconds: float = 5.0) -> np.ndarray:
     """One sine carrier per octave band, each with its own exponential decay."""
     time = np.arange(round(seconds * _FS)) / _FS
     ir = np.zeros_like(time)
-    for freq, decay in zip(_BANDS, _T60):
+    for freq, decay in zip(_BANDS, _T60, strict=True):
         ir += np.sin(2.0 * np.pi * freq * time) * np.exp(-0.5 * _A60 * time / decay)
     return ir
 

--- a/tests/room/test_modes.py
+++ b/tests/room/test_modes.py
@@ -51,9 +51,9 @@ def test_long_table_8_1_orders_and_frequencies() -> None:
     """
     result = room.room_modes(LONG_ROOM, max_frequency=61.0, speed_of_sound=LONG_C0)
     assert len(result.frequencies) == len(LONG_TABLE_8_1)
-    for row, (orders, _) in zip(result.orders, LONG_TABLE_8_1):
+    for row, (orders, _) in zip(result.orders, LONG_TABLE_8_1, strict=True):
         assert tuple(int(v) for v in row) == orders
-    for computed, (_, printed) in zip(result.frequencies, LONG_TABLE_8_1):
+    for computed, (_, printed) in zip(result.frequencies, LONG_TABLE_8_1, strict=True):
         assert float(computed) == pytest.approx(printed, abs=0.13)
 
 
@@ -88,7 +88,7 @@ def test_mode_frequency_accepts_an_array_of_triples() -> None:
 
 def test_classification_counts_non_zero_orders() -> None:
     result = room.room_modes(LONG_ROOM, max_frequency=200.0, speed_of_sound=LONG_C0)
-    for orders, kind in zip(result.orders, result.kinds):
+    for orders, kind in zip(result.orders, result.kinds, strict=True):
         assert kind == room.MODE_KINDS[int(np.count_nonzero(orders)) - 1]
     counts = result.count_by_kind()
     assert sum(counts.values()) == len(result.frequencies)

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -360,6 +360,7 @@ def test_verbose_rc_report_rejects_short_reference_curve(tmp_path) -> None:
     result = _rc_result()
     mismatched = replace(result, reference_curve=result.reference_curve[:-1])
     out = tmp_path / "rc_short_reference.pdf"
+    metadata = _full_metadata()
     with pytest.raises(ValueError, match="reference_curve"):
-        mismatched.report(str(out), metadata=_full_metadata(), verbose=True)
+        mismatched.report(str(out), metadata=metadata, verbose=True)
     assert not out.exists()  # the guard fires before the fiche is written

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -342,3 +342,24 @@ def test_subset_spectrum_renders_missing_bands(tmp_path) -> None:
     _assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "—" in text  # the unmeasured low bands are shown as an em dash
+
+
+# --------------------------------------------------------------------------
+# Hand-built results with mismatched bands
+# --------------------------------------------------------------------------
+def test_verbose_rc_report_rejects_short_reference_curve(tmp_path) -> None:
+    """A verbose RC fiche refuses a reference curve shorter than the levels.
+
+    ``RCResult`` is a frozen dataclass without validation exported from a
+    public package, so a hand-built one can pair its measured levels with a
+    reference curve of another length; only the verbose columns read the two
+    band by band, and a short curve used to render a silently short table.
+    """
+    from dataclasses import replace
+
+    result = _rc_result()
+    mismatched = replace(result, reference_curve=result.reference_curve[:-1])
+    out = tmp_path / "rc_short_reference.pdf"
+    with pytest.raises(ValueError, match="reference_curve"):
+        mismatched.report(str(out), metadata=_full_metadata(), verbose=True)
+    assert not out.exists()  # the guard fires before the fiche is written

--- a/tests/signals/test_synchronous_average.py
+++ b/tests/signals/test_synchronous_average.py
@@ -206,7 +206,7 @@ def test_noninteger_period_samples_on_fs_grid_not_angular_grid() -> None:
     def wave(tv: np.ndarray) -> np.ndarray:
         return sum(
             a * np.cos(2.0 * np.pi * k / period * tv + p)
-            for k, a, p in zip(orders, amps, phases)
+            for k, a, p in zip(orders, amps, phases, strict=True)
         )
 
     result = ph.signals.time_synchronous_average(

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -430,7 +430,7 @@ def _c32_signal(m: float, fs: int, seconds: float) -> np.ndarray:
     levels_db = [-2.5, 0.5, 0.0, -6.0, -12.0, -18.0, -24.0]
     t = np.arange(round(seconds * fs)) / fs
     x = np.zeros(t.size)
-    for fc, fa, fb, level in zip(centers, f1, f2, levels_db):
+    for fc, fa, fb, level in zip(centers, f1, f2, levels_db, strict=True):
         envelope = 0.5 * (
             1.0 + 0.55 * m * (np.sin(2 * np.pi * fa * t) - np.sin(2 * np.pi * fb * t))
         )

--- a/tests/test_diagram_canvas_math.py
+++ b/tests/test_diagram_canvas_math.py
@@ -411,7 +411,11 @@ def test_title_steps_down_only_as_far_as_the_sheet_demands() -> None:
     # Each step is taken at the width the step above stops keeping its
     # margin at, and the floor is returned rather than a further step.
     room = 900 - 2 * canvas._TITLE_MARGIN
-    for larger, smaller in zip(canvas._TITLE_SIZES, canvas._TITLE_SIZES[1:]):
+    for larger, smaller in zip(
+        canvas._TITLE_SIZES,
+        canvas._TITLE_SIZES[1:],  # one shorter: the floor has no step below it
+        strict=False,
+    ):
         wide = "W" * (int(room / measure(_label_runs("W", bold=True), larger)) + 1)
         assert svg.title_size(wide) <= smaller
     assert svg.title_size("W" * 200) == canvas._TITLE_SIZES[-1]

--- a/tests/underwater/propagation/test_numerical.py
+++ b/tests/underwater/propagation/test_numerical.py
@@ -659,7 +659,9 @@ def test_normal_modes_match_image_source_oracle() -> None:
         ranges_m=ranges,
         n_depth_points=3000,
     )
-    for (rng, pl_ref), pl_mod in zip(_IMAGE_SOURCE_PL, res.propagation_loss):
+    for (rng, pl_ref), pl_mod in zip(
+        _IMAGE_SOURCE_PL, res.propagation_loss, strict=True
+    ):
         assert pl_mod == pytest.approx(pl_ref, abs=0.02), rng
 
 

--- a/tests/underwater/sources/test_ship_traffic_noise.py
+++ b/tests/underwater/sources/test_ship_traffic_noise.py
@@ -103,7 +103,7 @@ _WALES_HEITMEYER_EQ = [
 def test_wales_heitmeyer_printed_equation_values() -> None:
     freqs = [f for f, _ in _WALES_HEITMEYER_EQ]
     s = ship_source_spectrum(model="wales-heitmeyer", frequency_hz=freqs)
-    for (_, psd_ref), psd in zip(_WALES_HEITMEYER_EQ, s.source_psd):
+    for (_, psd_ref), psd in zip(_WALES_HEITMEYER_EQ, s.source_psd, strict=True):
         assert float(psd) == pytest.approx(psd_ref, abs=1e-3)
 
 

--- a/tests/vibration/human/test_human_vibration_report.py
+++ b/tests/vibration/human/test_human_vibration_report.py
@@ -14,6 +14,7 @@ Values are read back from the PDF via pypdf text extraction; structural facts
 
 from __future__ import annotations
 
+import dataclasses
 import math
 import os
 
@@ -292,6 +293,53 @@ def test_unknown_language_rejected(tmp_path) -> None:
     out = str(tmp_path / "bad.pdf")
     with pytest.raises(ValueError, match="language"):
         res.report(out, language="xx")
+
+
+@pytest.mark.parametrize("field", ["total_values", "durations_s", "partials"])
+def test_report_rejects_per_operation_array_short_by_one(tmp_path, field: str) -> None:
+    """A per-operation array one entry short is named in a ValueError.
+
+    ``DailyVibrationExposure`` is a frozen dataclass with no ``__post_init__``,
+    so a hand-built result can carry arrays that disagree with ``labels``. The
+    operations table used to run short in silence instead of complaining.
+    """
+    pytest.importorskip("reportlab")
+    res = _annex_e3_result()
+    short = dataclasses.replace(res, **{field: getattr(res, field)[:-1]})
+    out = tmp_path / f"short_{field}.pdf"
+    with pytest.raises(ValueError, match=field):
+        short.report(str(out))
+    # The guard fires before the table and the chart, so nothing is written.
+    assert not out.exists()
+
+
+def test_report_rejects_fewer_labels_than_operations(tmp_path) -> None:
+    """``labels`` sets the expected count, so dropping one is a mismatch too."""
+    pytest.importorskip("reportlab")
+    res = _annex_e3_result()
+    short = dataclasses.replace(res, labels=res.labels[:-1])
+    out = tmp_path / "short_labels.pdf"
+    with pytest.raises(ValueError, match="labels"):
+        short.report(str(out))
+    assert not out.exists()
+
+
+def test_report_accepts_matching_per_operation_arrays(tmp_path) -> None:
+    """Dropping the same operation from every array passes the guard."""
+    pytest.importorskip("reportlab")
+    pytest.importorskip("matplotlib")
+    res = _annex_e3_result()
+    two_ops = dataclasses.replace(
+        res,
+        labels=res.labels[:-1],
+        total_values=res.total_values[:-1],
+        durations_s=res.durations_s[:-1],
+        partials=res.partials[:-1],
+    )
+    out = tmp_path / "two_ops.pdf"
+    two_ops.report(str(out))
+    _assert_one_page(str(out))
+    assert "stripping" not in _extract_text(str(out))
 
 
 def test_partial_exposure_closed_form() -> None:

--- a/tests/vibration/human/test_human_vibration_report.py
+++ b/tests/vibration/human/test_human_vibration_report.py
@@ -314,12 +314,18 @@ def test_report_rejects_per_operation_array_short_by_one(tmp_path, field: str) -
 
 
 def test_report_rejects_fewer_labels_than_operations(tmp_path) -> None:
-    """``labels`` sets the expected count, so dropping one is a mismatch too."""
+    """``labels`` sets the expected count, so dropping one is a mismatch too.
+
+    The message names the array that disagreed rather than ``labels`` itself,
+    because ``labels`` is what the count is read from: matching both halves
+    pins that reading, where matching ``labels`` alone would pass against any
+    of the four messages this guard can raise.
+    """
     pytest.importorskip("reportlab")
     res = _annex_e3_result()
     short = dataclasses.replace(res, labels=res.labels[:-1])
     out = tmp_path / "short_labels.pdf"
-    with pytest.raises(ValueError, match="labels"):
+    with pytest.raises(ValueError, match=r"'total_values'.*\(2 in 'labels'\)"):
         short.report(str(out))
     assert not out.exists()
 


### PR DESCRIPTION
## What and why

`B905` is selected, and the 162 `zip()` calls it found were read one at a time: 157 pair arrays that are equal by construction and now say `strict=True`, and five consume the shorter input on purpose and say `strict=False` with a line saying what ends the loop. The five are worth naming, because they are the cases a blanket fix would have got wrong: two walk a palette against fewer paths than it holds, one walks the fixed seven-band STI table against whatever the result carries, one pairs `T20`/`T30` against however many fit the plot, and one reads a mapping's keys against its values in an AST node.

`strict=True` is not a formality: it turns a silent truncation into a `ValueError`, so it is only the truth where something upstream guarantees the lengths. Checking that guarantee, site by site, is what this change was for, and it found seven places where nothing guaranteed it. Six accredited report fiches and one plot take their per-band arrays straight off a frozen dataclass that has no `__post_init__`, is exported from a public package, and has its constructor signature in the generated reference, so a result built by hand reaches the table with arrays of any lengths at all. The guards that existed covered some of the arrays and not the others: ISO 354 compared the frequencies against the absorption coefficient and left the two reverberation times and both absorption areas unchecked, ISO 11654 checked three of five, and the scattering fiche two of four. Each now raises a named `ValueError` before the table is built, the way the sibling fiches already did, and the `strict=` behind it is the backstop it should have been. Before this, a short array printed a table that quietly listed fewer bands than the daily total above it was summing.

One call stays as it was, with a `noqa` that says so: it sits in the code that draws `anim_fdtd_impedance_tube`, where its three operands are the same pair of panels built a few lines above, so the argument could only ever hold, and adding it would move the clip's recorded fingerprint and ask for a re-render of the very same frames.

## Validation

No new computation. Every `strict=True` was checked against the code that produces both operands, and then attacked a second time by an independent pass whose brief was to construct the failing input by hand: that pass loaded the pre-change module beside the working tree, built the short arrays, and confirmed both the silent truncation before and the named error after. The seven guards are the only behaviour change, and each one replaces a silently wrong table with a refusal.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files you touched
- [x] `mypy src scripts`
- [x] `bandit -r src` (any finding fails, including Low)
- [x] `pytest -q` (8958 passed, 16 skipped)

Regenerated where this change touches them:

- [x] `make conformance`: byte-identical, nothing to commit
- [x] `make api-docs`: byte-identical, nothing to commit
- [x] `make llms`: byte-identical, nothing to commit

Always:

- [x] CHANGELOG entry under `[Unreleased]`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enabled Ruff linting rule B905 to enforce explicit strictness in zip() calls.</li>
<li>Updated 162 zip() calls across the codebase to include strict=True or strict=False based on data construction.</li>
<li>Added manual validation and ValueError checks in several report fiches to prevent silent data truncation.</li>
<li>Refactored magic numbers into named constants in src/ to comply with PLR2004.</li>
</ul></div>

## Summary by Sourcery

Make zip iteration length requirements explicit and reject mismatched report or plot data before rendering misleading output.

Bug Fixes:
- Prevent silently truncated report tables and plots by validating that related input arrays have matching lengths and raising descriptive ValueError exceptions when they do not.

Enhancements:
- Require every zip() call to explicitly declare whether equal-length inputs are required, using strict=True for paired data and strict=False for intentional truncation.
- Enable Ruff B905 linting and document intentional exceptions for zip() calls whose inputs are known to differ.

Tests:
- Add coverage for mismatched hand-built report and plotting results, including validation that invalid outputs are not written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added consistent validation across calculations, reports, plots, and conformance checks to detect mismatched input lengths instead of silently truncating data.
  - Improved error messages for incompatible array shapes and missing or extra values.
  - Prevented incomplete results from generating reports or plots.
  - Preserved intentional truncation behavior where shorter inputs are expected.

- **Documentation**
  - Documented strengthened data-length validation and updated linting standards in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->