### PR TITLE
Say which error each test is waiting for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Every `zip()` says whether its inputs must be the same length. `B905` is
+- Every test that expects an error says which error. `PT` is selected, and the
+  241 `pytest.raises(ValueError)` calls that named no message now name one.
+  This was already the habit rather than a new rule: 1755 of the 2065
+  `pytest.raises` in the suite passed `match=` before this, so what changed is
+  the stragglers. Each of the 241 was resolved by reading the guard it lands
+  on, not the test around it, because a test that catches any `ValueError` at
+  all passes when the wrong guard fires, and the wrong guard firing is exactly
+  the regression it was written to catch.
+
+  The fragment is the part of the message that does not move. That means the
+  parameter the guard is about, and not the sentence around it: not a bound,
+  which changes when the bound does; not the list of allowed values, which
+  grows when a value is added; and not wording that belongs to numpy, whose
+  shape-mismatch text is assembled inside a C extension and carries no
+  stability promise. Where a message is already just a parameter and a
+  predicate, as in `'frequencies' must be positive`, it is quoted whole,
+  because there is nothing volatile in it to drop.
+
+  Reading the guards turned up two tests that were passing without checking
+  what they claimed. `test_short_frequencies_raises_value_error_not_index_error`
+  waited on `frequencies`, a word three separate messages in that module
+  contain, and a test named for rejecting a non-positive frequency waited on
+  `must be positive`, which every positivity guard in its module shares. Both
+  now name their guard. Neither was reported by the linter, because both did
+  pass a `match=`; only reading them found it.
+
+  Alongside it, 44 `parametrize` decorators take the shape the other 467
+  already use, tuples for the names and a list for the values, and ten
+  assertions of the form `assert a is not None and b is not None` became two
+  assertions, so a failure says which of the two was missing. `B905` is
   selected, and the 162 calls it found were read one at a time: 158 pair
   arrays that are equal by construction and now say `strict=True`, and four
   consume the shorter input on purpose and say `strict=False` with a line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,12 +101,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Every test that expects an error says which error. `PT` is selected, and the
   241 `pytest.raises(ValueError)` calls that named no message now name one.
-  This was already the habit rather than a new rule: 1755 of the 2065
-  `pytest.raises` in the suite passed `match=` before this, so what changed is
-  the stragglers. Each of the 241 was resolved by reading the guard it lands
-  on, not the test around it, because a test that catches any `ValueError` at
-  all passes when the wrong guard fires, and the wrong guard firing is exactly
-  the regression it was written to catch.
+  This was already the habit rather than a new rule: of the 2075 `pytest.raises`
+  in the suite, 1795 passed `match=` before this, so what changed is the
+  stragglers. The 39 that still name no message are the ones the rule does not
+  ask about, and does not need to: `FrozenInstanceError`, `ModuleNotFoundError`
+  and `AttributeError` are raised by one thing each here, so the class is
+  already the whole assertion. `ValueError` is the one that is not, which is
+  why the rule asks about it. Each of the 241 was resolved by reading the guard
+  it lands on rather than the surrounding test, because a test that catches any
+  `ValueError` at all passes when the wrong guard fires, and the wrong guard
+  firing is the regression it was written to catch.
 
   The fragment is the part of the message that does not move. That means the
   parameter the guard is about, and not the sentence around it: not a bound,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,12 @@ select = [
     "D2", "D301",           # docstring shape: where the summary sits and how
                             # quotes and backslashes are spelled. Shape only;
                             # no rule here rewords prose.
+    "PT",                   # a test that expects an error says which one. Every
+                            # `pytest.raises` names a fragment of the message it
+                            # waits for, and the fragment is the part that does
+                            # not move: the parameter it is about, not the
+                            # sentence around it, not a bound, not a list of
+                            # allowed values, not wording numpy owns.
 ]
 ignore = [
     # TC006 quotes the first argument of `typing.cast`, which that function
@@ -203,10 +209,6 @@ ignore = [
 ]
 # Selected next, in their own review, because each is a change to code rather
 # than to its shape and the diff has to be readable to be checked:
-#   PT    (295) pytest idiom. 241 of them are `pytest.raises` without `match=`,
-#               and the habit here is already the other way: 1755 of the 2065
-#               `pytest.raises` in the suite do pass `match=`. These are the
-#               stragglers, not a style.
 #   PTH   (158) pathlib over os.path.
 #   PERF   (34) manual loops that build a list.
 

--- a/scripts/conformance/domains/building_prediction.py
+++ b/scripts/conformance/domains/building_prediction.py
@@ -306,7 +306,8 @@ def _chk_iso12999_annex_b_values() -> Outcome:
         ref.ISO12999_1_ANNEX_B_FREQ,
         one_decimal=True,
     )
-    assert res.c_50_5000 is not None and res.ctr_50_5000 is not None
+    assert res.c_50_5000 is not None
+    assert res.ctr_50_5000 is not None
     rw = float(res.rating)
     rw_c = rw + float(res.c_50_5000)
     rw_ctr = rw + float(res.ctr_50_5000)

--- a/scripts/figures/building.py
+++ b/scripts/figures/building.py
@@ -530,7 +530,8 @@ def generate_intensity_insulation(output_dir: str) -> None:
         np.full(16, lp1), l_in, measurement_area=sm, area=s, kc=kc
     )
     assert result.r_i_modified is not None
-    assert result.rating is not None and result.rating_modified is not None
+    assert result.rating is not None
+    assert result.rating_modified is not None
 
     x = np.arange(len(freqs))
     _fig, ax = plt.subplots(figsize=(10, 6.2))
@@ -1277,7 +1278,8 @@ def generate_extended_insulation_rating(output_dir: str) -> None:
     ext = building.weighted_rating_extended(
         [18.7, 19.2, 20.0, *r_core, 26.8, 29.2], freqs
     )
-    assert ext.measured is not None and ext.core.shifted_reference is not None
+    assert ext.measured is not None
+    assert ext.core.shifted_reference is not None
     assert ext.core.measured is not None
 
     _fig, ax = plt.subplots(figsize=(10, 6.2))
@@ -1573,7 +1575,8 @@ def generate_facade_field_insulation(output_dir: str) -> None:
         method="loudspeaker",
         frequencies=np.asarray(_THIRD_OCTAVE_16, float),
     )
-    assert fac.d_2m_n is not None and fac.r_prime is not None
+    assert fac.d_2m_n is not None
+    assert fac.r_prime is not None
     w = building.weighted_rating(fac.d_2m_nt)
 
     _fig, ax = plt.subplots(figsize=(10, 6.2))
@@ -1782,7 +1785,8 @@ def generate_lab_insulation_result(output_dir: str) -> None:
         ]
     )
     imp = building.lab_impact_insulation(li, t2, volume=50.0)
-    assert lab.rating is not None and imp.rating is not None
+    assert lab.rating is not None
+    assert imp.rating is not None
 
     _fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5.6))
     for ax in (ax1, ax2):

--- a/scripts/figures/building_design.py
+++ b/scripts/figures/building_design.py
@@ -1302,7 +1302,8 @@ def generate_single_panel_rating(output_dir: str) -> None:
         bands, mass, critical_frequency=fc, loss_factor=0.024
     )
     w = res.rating()
-    assert w.shifted_reference is not None and w.measured is not None
+    assert w.shifted_reference is not None
+    assert w.measured is not None
 
     _fig, ax = plt.subplots(figsize=(10, 6.2))
     x = _band_index_axis(ax, _THIRD_OCTAVE_16)
@@ -1401,7 +1402,8 @@ def generate_plateau_transmission_loss(output_dir: str) -> None:
 
     _fig, ax = plt.subplots(figsize=(10, 6.2))
     x = _band_index_axis(ax, nominal)
-    assert quick.plateau_start is not None and quick.plateau_end is not None
+    assert quick.plateau_start is not None
+    assert quick.plateau_end is not None
     idx_a = float(np.interp(np.log10(quick.plateau_start), np.log10(bands), x))
     idx_b = float(np.interp(np.log10(quick.plateau_end), np.log10(bands), x))
     ax.axvspan(

--- a/scripts/figures/io.py
+++ b/scripts/figures/io.py
@@ -110,7 +110,8 @@ def generate_signal_provenance(output_dir: str) -> None:
 
     origin = sig.source
     provenance = sig.provenance
-    assert origin is not None and provenance is not None
+    assert origin is not None
+    assert provenance is not None
     history_lines = provenance.coding_history.splitlines()
     appended = len(history_lines) - 1
     container = f"{origin.container}, {origin.bit_depth}-bit {origin.format_name}"

--- a/scripts/figures/simulation.py
+++ b/scripts/figures/simulation.py
@@ -199,7 +199,8 @@ def generate_elastic_halfspace_waves(output_dir: str) -> None:
     )
 
     _fig, ax = plt.subplots(figsize=(9.5, 5.4))
-    assert res.snapshots is not None and res.snapshot_times is not None
+    assert res.snapshots is not None
+    assert res.snapshot_times is not None
     vmax = 0.18 * float(np.abs(res.snapshots[-1]).max())
     res.plot(kind="snapshot", frame=-1, ax=ax, vmin=-vmax, vmax=vmax)
 

--- a/scripts/figures/vibration.py
+++ b/scripts/figures/vibration.py
@@ -56,7 +56,8 @@ def generate_junction_transmission(output_dir: str) -> None:
     # X-junction between a 100 mm and a 200 mm concrete plate (cL = 3200 m/s,
     # rho = 2400 kg/m^3 -> rho_s = 240 and 480 kg/m^2).
     res = vibration.junction_transmission("X", 0.1, 3200.0, 240.0, 0.2, 3200.0, 480.0)
-    assert res.straight is not None and res.straight_average is not None
+    assert res.straight is not None
+    assert res.straight_average is not None
     angles = res.angles_deg
 
     _fig, ax = plt.subplots(figsize=(10, 6.2))

--- a/site/src/content/docs/reference/api/building/structure-borne-power.md
+++ b/site/src/content/docs/reference/api/building/structure-borne-power.md
@@ -262,7 +262,7 @@ quantities.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if neither `loss_factor` nor `reverberation_time` is given. |
+| ValueError | if neither `loss_factor` nor `reverberation_time` is given, or if `velocity_level` or `loss_factor` is neither a scalar nor one value per band. |
 
 ## source_mobility_from_levels
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -123,28 +123,32 @@ def require_per_band(
 ) -> np.ndarray:
     """Broadcast *x* over the band axis, saying whose length disagrees.
 
-    ``np.broadcast_to`` accepts a scalar and an array of matching length and
-    rejects everything else, which is the rule wanted here. What it does not
-    do is name the culprit: it reports the two shapes it could not reconcile,
-    from inside its own C code, so the caller learns nothing about which of
-    its arguments was wrong.
+    A scalar applies to every band and an array of the band count is taken
+    band by band. Nothing else is: broadcasting alone would also stretch a
+    one-element array across every band, which is the shape a caller lands on
+    by computing one value where the bands needed several, and the answer that
+    comes back from repeating it looks perfectly ordinary.
+
+    ``np.broadcast_to`` is left to do the stretching once the shape is known
+    to be one of the two, because what it cannot do is name the culprit: it
+    reports the two shapes it failed to reconcile, from inside its own C code,
+    without saying which argument carried which.
 
     :param x: The per-band input (a scalar applies to every band).
     :param name: Parameter name used in the error message.
-    :param bands: The band axis to match, already coerced.
+    :param bands: The band axis to match, already coerced and 1-D.
     :param bands_name: Parameter name of the band axis, for the message.
     :return: The broadcast ``float64`` array, of ``bands.shape``.
     :raises ValueError: if *x* is neither a scalar nor of ``bands``' length.
     """
     arr = np.asarray(x, dtype=np.float64)
-    try:
-        return np.broadcast_to(arr, bands.shape).astype(np.float64)
-    except ValueError:
+    if arr.ndim != 0 and arr.shape != bands.shape:
         msg = (
             f"'{name}' must be a scalar or carry one value per band "
             f"({bands.size} in '{bands_name}'); got shape {arr.shape}."
         )
-        raise ValueError(msg) from None
+        raise ValueError(msg)
+    return np.broadcast_to(arr, bands.shape).astype(np.float64)
 
 
 def require_1d_signal(x: ArrayLike, name: str = "signal") -> np.ndarray:

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -118,6 +118,35 @@ def require_finite_array(x: ArrayLike, name: str) -> np.ndarray:
     return arr
 
 
+def require_per_band(
+    x: ArrayLike, name: str, bands: np.ndarray, bands_name: str = "frequency"
+) -> np.ndarray:
+    """Broadcast *x* over the band axis, saying whose length disagrees.
+
+    ``np.broadcast_to`` accepts a scalar and an array of matching length and
+    rejects everything else, which is the rule wanted here. What it does not
+    do is name the culprit: it reports the two shapes it could not reconcile,
+    from inside its own C code, so the caller learns nothing about which of
+    its arguments was wrong.
+
+    :param x: The per-band input (a scalar applies to every band).
+    :param name: Parameter name used in the error message.
+    :param bands: The band axis to match, already coerced.
+    :param bands_name: Parameter name of the band axis, for the message.
+    :return: The broadcast ``float64`` array, of ``bands.shape``.
+    :raises ValueError: if *x* is neither a scalar nor of ``bands``' length.
+    """
+    arr = np.asarray(x, dtype=np.float64)
+    try:
+        return np.broadcast_to(arr, bands.shape).astype(np.float64)
+    except ValueError:
+        msg = (
+            f"'{name}' must be a scalar or carry one value per band "
+            f"({bands.size} in '{bands_name}'); got shape {arr.shape}."
+        )
+        raise ValueError(msg) from None
+
+
 def require_1d_signal(x: ArrayLike, name: str = "signal") -> np.ndarray:
     """Coerce *x* to a float64 array and require a 1-D time series.
 

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -83,7 +83,7 @@ if TYPE_CHECKING:
     from ..._report.metadata import ReportMetadata
 
 
-from ..._internal.validation import require_positive
+from ..._internal.validation import require_per_band, require_positive
 from .flanking_transmission import total_loss_factor
 
 #: EN 15657 vibratory velocity reference ``v0`` (= ISO 1683 10^-9 m/s), m/s.
@@ -323,16 +323,13 @@ def reception_plate_power(
         when ``loss_factor`` is ``None``.
     :return: The :class:`StructureBornePowerResult`.
     :raises ValueError: if neither ``loss_factor`` nor ``reverberation_time``
-        is given.
+        is given, or if ``velocity_level`` or ``loss_factor`` is neither a
+        scalar nor one value per band.
     """
     freq = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
-    lv = np.broadcast_to(
-        np.asarray(velocity_level, dtype=np.float64), freq.shape
-    ).astype(np.float64)
+    lv = require_per_band(velocity_level, "velocity_level", freq)
     if loss_factor is not None:
-        eta = np.broadcast_to(
-            np.asarray(loss_factor, dtype=np.float64), freq.shape
-        ).astype(np.float64)
+        eta = require_per_band(loss_factor, "loss_factor", freq)
     elif reverberation_time is not None:
         eta = np.asarray(plate_loss_factor(freq, reverberation_time), dtype=np.float64)
     else:

--- a/tests/aircraft/test_aircraft_noise_system.py
+++ b/tests/aircraft/test_aircraft_noise_system.py
@@ -54,19 +54,19 @@ def test_scalar_checks() -> None:
 
 
 def test_out_of_range_frequency_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'frequency' is not an IEC 61265 tabulated"):
         aircraft.verify_aircraft_noise_system(directional={20.0: {90: 0.5}})
 
 
 def test_out_of_range_angle_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angle' must lie in"):
         aircraft.verify_aircraft_noise_system(directional={4000.0: {0.0: 0.5}})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angle' must lie in"):
         aircraft.verify_aircraft_noise_system(directional={4000.0: {160.0: 0.5}})
 
 
 def test_linearity_rejects_unknown_key() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="linearity keys must be"):
         aircraft.verify_aircraft_noise_system(linearity={"refernce": 0.3})
 
 

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -145,7 +145,9 @@ def test_noy_floor_below_spld_is_zero() -> None:
 
 
 def test_noy_requires_24_bands() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'spl' must contain the 24 one-third-octave-band levels"
+    ):
         perceived_noisiness([1.0, 2.0, 3.0])
 
 
@@ -226,7 +228,7 @@ def test_epnl_single_element_dt_treated_as_scalar() -> None:
 
 def test_effective_perceived_noise_level_rejects_bad_shape() -> None:
     two_dimensional = np.zeros((5, 10))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"'spectra' must have shape \(K, 24\)"):
         effective_perceived_noise_level(two_dimensional)
 
 

--- a/tests/broadcast/test_broadcast_plot_i18n.py
+++ b/tests/broadcast/test_broadcast_plot_i18n.py
@@ -36,5 +36,5 @@ def test_program_loudness_es_and_bad_language() -> None:
     labels = [t.get_text() for t in ax.get_legend().get_texts()]
     assert any(s.startswith("Integrada") for s in labels)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/broadcast/test_program_loudness.py
+++ b/tests/broadcast/test_program_loudness.py
@@ -212,7 +212,7 @@ def test_k_weighting_response_plot() -> None:
         line.get_color() == "magenta" and line.get_linewidth() == 3.0
         for line in styled.get_lines()
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="fr")
     plt.close("all")
 

--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -105,7 +105,7 @@ TABLE2 = {
 }
 
 
-@pytest.mark.parametrize("situation,col", [("A", 0), ("B", 1), ("C", 2)])
+@pytest.mark.parametrize(("situation", "col"), [("A", 0), ("B", 1), ("C", 2)])
 def test_table2_airborne_every_band(situation, col):
     result = band_uncertainty("airborne", situation)
     assert list(result.frequencies) == FREQ_FULL
@@ -140,7 +140,7 @@ TABLE4 = {
 }
 
 
-@pytest.mark.parametrize("situation,col", [("B", 0), ("C", 1)])
+@pytest.mark.parametrize(("situation", "col"), [("B", 0), ("C", 1)])
 def test_table4_impact_every_band(situation, col):
     result = band_uncertainty("impact", situation)
     assert list(result.frequencies) == FREQ_IMPACT
@@ -285,8 +285,8 @@ TABLE3 = {
 }
 
 
-@pytest.mark.parametrize("quantity,values", list(TABLE3.items()))
-@pytest.mark.parametrize("situation,idx", [("A", 0), ("B", 1), ("C", 2)])
+@pytest.mark.parametrize(("quantity", "values"), list(TABLE3.items()))
+@pytest.mark.parametrize(("situation", "idx"), [("A", 0), ("B", 1), ("C", 2)])
 def test_table3_single_number(quantity, values, situation, idx):
     assert single_number_uncertainty(quantity, situation) == pytest.approx(values[idx])
 
@@ -301,7 +301,7 @@ def test_airborne_aliases_share_row():
 # Table 5 — impact single-number (ISO 717-2).
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
-    "quantity,expected",
+    ("quantity", "expected"),
     [("ln_w", (1.5, 1.0, 0.5)), ("ln_w+ci", (1.5, 1.0, 0.6))],
 )
 def test_table5_impact_single_number(quantity, expected):
@@ -343,7 +343,7 @@ TABLED2 = {
 }
 
 
-@pytest.mark.parametrize("quantity,expected", list(TABLED2.items()))
+@pytest.mark.parametrize(("quantity", "expected"), list(TABLED2.items()))
 def test_tabled2_sigma_r95_single_number(quantity, expected):
     assert single_number_uncertainty(quantity, "A", upper_limit=True) == pytest.approx(
         expected
@@ -364,7 +364,7 @@ def test_sigma_r95_single_number_impact_absent():
 # Table 8 — coverage factors (Clause 8), every row.
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
-    "confidence,k",
+    ("confidence", "k"),
     [
         (0.68, 1.00),
         (0.80, 1.28),
@@ -379,7 +379,7 @@ def test_table8_two_sided(confidence, k):
 
 
 @pytest.mark.parametrize(
-    "confidence,k",
+    ("confidence", "k"),
     [
         (0.84, 1.00),
         (0.90, 1.28),
@@ -438,7 +438,7 @@ def test_coverage_minimum_k_is_one():
 
 
 def test_expanded_uncertainty_rejects_negative():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Standard uncertainty u must be non-negative"):
         insulation_expanded_uncertainty(-0.1)
 
 
@@ -554,7 +554,7 @@ def test_band_uncertainty_to_arrays_roundtrip():
 
 
 def test_prediction_input_rejects_bad_n():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="n must be a positive integer"):
         prediction_input_uncertainty(1.2, 1.0, 0)
 
 

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -202,21 +202,21 @@ def test_positions_are_energy_averaged() -> None:
 # --------------------------------------------------------------------------
 def test_band_count_mismatch_raises() -> None:
     outdoor, indoor_two_bands, rt = _flat(3, 70.0), _flat(2, 30.0), _flat(3, 0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="share the same band count"):
         building.facade_insulation(outdoor, indoor_two_bands, rt)
 
 
 def test_nonpositive_reverberation_raises() -> None:
     outdoor, indoor = _flat(3, 70.0), _flat(3, 30.0)
     rt_with_zero = np.array([0.5, 0.0, 0.5])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'t2' must contain positive"):
         building.facade_insulation(outdoor, indoor, rt_with_zero)
 
 
 def test_nonpositive_area_volume_raises() -> None:
     outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
     surface = _flat(3, 72.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'area' must be positive"):
         building.facade_insulation(
             outdoor,
             indoor,
@@ -253,7 +253,7 @@ def test_surface_area_and_volume_returns_r_prime() -> None:
 
 def test_invalid_method_raises() -> None:
     outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'method' must be"):
         building.facade_insulation(outdoor, indoor, rt, method="airplane")
 
 
@@ -275,7 +275,7 @@ def test_invalid_method_on_result_raises() -> None:
 def test_nonfinite_raises() -> None:
     outdoor_with_nan = np.array([70.0, np.nan, 70.0])
     indoor, rt = _flat(3, 30.0), _flat(3, 0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'l1_2m' must contain only finite values"):
         building.facade_insulation(outdoor_with_nan, indoor, rt)
 
 

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -278,5 +278,5 @@ def test_report_rejects_band_count_mismatch(tmp_path) -> None:
     )
     bad = dataclasses.replace(res, rating=short)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="matching per-band lengths"):
         bad.report(out)

--- a/tests/building/measurement/test_lab_insulation.py
+++ b/tests/building/measurement/test_lab_insulation.py
@@ -235,7 +235,7 @@ def test_airborne_t2_band_mismatch() -> None:
         building.lab_airborne_insulation(l1, l2, short_t2, area=10.0, volume=50.0)
 
 
-@pytest.mark.parametrize("area,volume", [(0.0, 50.0), (-1.0, 50.0)])
+@pytest.mark.parametrize(("area", "volume"), [(0.0, 50.0), (-1.0, 50.0)])
 def test_airborne_bad_area(area: float, volume: float) -> None:
     l1, l2, t2 = np.full(16, 80.0), np.full(16, 30.0), np.full(16, 0.8)
     with pytest.raises(ValueError, match="area"):
@@ -305,7 +305,7 @@ def test_plot_without_rating_raises() -> None:
 
 
 @pytest.mark.parametrize(
-    "r_name,rating_name",
+    ("r_name", "rating_name"),
     [
         ("ISO10140_5_B1_HEAVY_WALL_R", "ISO10140_5_B1_HEAVY_WALL_RATING"),
         ("ISO10140_5_B1_HEAVY_FLOOR_R", "ISO10140_5_B1_HEAVY_FLOOR_RATING"),
@@ -330,7 +330,7 @@ def test_reference_element_airborne_end_to_end(r_name: str, rating_name: str) ->
 
 
 @pytest.mark.parametrize(
-    "ln_name,rating_name",
+    ("ln_name", "rating_name"),
     [
         ("ISO10140_5_C1_FLOOR_C1C2_LN", "ISO10140_5_C1_FLOOR_C1C2_RATING"),
         ("ISO10140_5_C1_FLOOR_C3_LN", "ISO10140_5_C1_FLOOR_C3_RATING"),

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -135,22 +135,28 @@ def test_reception_plate_requires_eta_or_ts() -> None:
 
 
 @pytest.mark.parametrize(
-    ("name", "kwargs"),
+    ("name", "velocity", "kwargs"),
     [
-        ("velocity_level", {"loss_factor": 0.01}),
-        ("loss_factor", {"loss_factor": [0.01, 0.02, 0.03]}),
+        # Too short for the four bands.
+        ("velocity_level", [80.0, 82.0, 79.0], {"loss_factor": 0.01}),
+        ("loss_factor", 80.0, {"loss_factor": [0.01, 0.02, 0.03]}),
+        # One element, which broadcasting alone would stretch over all four.
+        ("velocity_level", [80.0], {"loss_factor": 0.01}),
+        ("loss_factor", 80.0, {"loss_factor": [0.01]}),
     ],
 )
 def test_reception_plate_rejects_a_per_band_input_of_the_wrong_length(
-    name: str, kwargs: dict
+    name: str, velocity: object, kwargs: dict
 ) -> None:
     """A per-band input that is neither scalar nor band-long names itself.
 
-    Both arguments reach ``np.broadcast_to``, whose own message is raised from
-    inside numpy and reports two shapes without saying which argument carried
-    which, so the guard is the library's own and names the parameter.
+    Both arguments used to reach ``np.broadcast_to`` unchecked, whose message
+    is raised from inside numpy and reports two shapes without saying which
+    argument carried which. The one-element cases are the reason the guard
+    cannot be broadcasting alone: numpy stretches a single value over every
+    band, and the level that comes back from four copies of one measurement
+    reads exactly like a measurement of four bands.
     """
-    velocity = [80.0, 82.0, 79.0] if name == "velocity_level" else 80.0
     with pytest.raises(ValueError, match=f"'{name}' must be a scalar or carry"):
         building.reception_plate_power(
             velocity,
@@ -159,6 +165,19 @@ def test_reception_plate_rejects_a_per_band_input_of_the_wrong_length(
             area=1.2,
             **kwargs,
         )
+
+
+def test_reception_plate_still_takes_a_scalar_for_every_band() -> None:
+    """A true scalar is the supported way to say "the same for all bands"."""
+    result = building.reception_plate_power(
+        80.0,
+        [500.0, 1000.0, 2000.0, 4000.0],
+        mass_per_area=25.0,
+        area=1.2,
+        loss_factor=0.01,
+    )
+    assert np.asarray(result.velocity_level).shape == (4,)
+    assert np.allclose(np.asarray(result.velocity_level), 80.0)
 
 
 def test_plot_returns_axes() -> None:

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -134,15 +134,30 @@ def test_reception_plate_requires_eta_or_ts() -> None:
         building.reception_plate_power(80.0, 1000.0, 25.0, 1.2)
 
 
-def test_reception_plate_velocity_shape_mismatch() -> None:
-    # a non-broadcastable velocity_level vs frequency length raises
-    with pytest.raises(ValueError):
+@pytest.mark.parametrize(
+    ("name", "kwargs"),
+    [
+        ("velocity_level", {"loss_factor": 0.01}),
+        ("loss_factor", {"loss_factor": [0.01, 0.02, 0.03]}),
+    ],
+)
+def test_reception_plate_rejects_a_per_band_input_of_the_wrong_length(
+    name: str, kwargs: dict
+) -> None:
+    """A per-band input that is neither scalar nor band-long names itself.
+
+    Both arguments reach ``np.broadcast_to``, whose own message is raised from
+    inside numpy and reports two shapes without saying which argument carried
+    which, so the guard is the library's own and names the parameter.
+    """
+    velocity = [80.0, 82.0, 79.0] if name == "velocity_level" else 80.0
+    with pytest.raises(ValueError, match=f"'{name}' must be a scalar or carry"):
         building.reception_plate_power(
-            [80.0, 82.0, 79.0],
+            velocity,
             [500.0, 1000.0, 2000.0, 4000.0],
             mass_per_area=25.0,
             area=1.2,
-            loss_factor=0.01,
+            **kwargs,
         )
 
 

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -334,7 +334,7 @@ def test_table_g1_direct_path_over_the_whole_range(impact) -> None:
     assert by_label["Dd"] == pytest.approx(ref.ISO12354_ANNEX_G1_PATHS["Dd"], abs=TOL)
 
 
-@pytest.mark.parametrize("label", ("Df1", "Df2", "Df3", "Df4"))
+@pytest.mark.parametrize("label", ["Df1", "Df2", "Df3", "Df4"])
 def test_table_g1_flanking_paths_from_100_hz(impact, label: str) -> None:
     """Table G.1, per-element flanking impact levels, 100 Hz to 5 kHz.
 
@@ -821,16 +821,25 @@ def test_rating_is_none_when_the_bands_do_not_cover_iso717() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "message"),
     [
-        {"critical_frequency": -1.0, "length1": 4.0, "length2": 2.75},
-        {"critical_frequency": 100.0, "length1": 0.0, "length2": 2.75},
-        {"critical_frequency": 100.0, "length1": 4.0, "length2": float("nan")},
+        (
+            {"critical_frequency": -1.0, "length1": 4.0, "length2": 2.75},
+            "'critical_frequency' must be positive",
+        ),
+        (
+            {"critical_frequency": 100.0, "length1": 0.0, "length2": 2.75},
+            "'length1' must be positive",
+        ),
+        (
+            {"critical_frequency": 100.0, "length1": 4.0, "length2": float("nan")},
+            "'length2' must be positive",
+        ),
     ],
 )
-def test_radiation_factor_rejects_invalid_geometry(kwargs: dict) -> None:
+def test_radiation_factor_rejects_invalid_geometry(kwargs: dict, message: str) -> None:
     """Non-positive or non-finite geometry is refused."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=message):
         building.bending_radiation_factor(BANDS, **kwargs)
 
 
@@ -864,7 +873,7 @@ def test_band_count_mismatch_is_reported(situ: dict) -> None:
 # --------------------------------------------------------------------------
 # .plot() coverage
 # --------------------------------------------------------------------------
-@pytest.mark.parametrize("language", ("en", "es"))
+@pytest.mark.parametrize("language", ["en", "es"])
 def test_detailed_airborne_plot_draws_bars_and_the_total(airborne, language) -> None:
     """The airborne renderer stacks one bar per path and overlays ``R'``."""
     plt = pytest.importorskip("matplotlib.pyplot")
@@ -877,7 +886,7 @@ def test_detailed_airborne_plot_draws_bars_and_the_total(airborne, language) -> 
     plt.close(ax.get_figure())
 
 
-@pytest.mark.parametrize("language", ("en", "es"))
+@pytest.mark.parametrize("language", ["en", "es"])
 def test_detailed_impact_plot_draws_bars_and_the_total(impact, language) -> None:
     """The impact renderer is the same figure with ``L'n`` overlaid."""
     plt = pytest.importorskip("matplotlib.pyplot")
@@ -889,7 +898,7 @@ def test_detailed_impact_plot_draws_bars_and_the_total(impact, language) -> None
     plt.close(ax.get_figure())
 
 
-@pytest.mark.parametrize("language", ("en", "es"))
+@pytest.mark.parametrize("language", ["en", "es"])
 def test_in_situ_element_plot_draws_both_spectra(situ: dict, language) -> None:
     """The element renderer draws ``Rsitu`` and ``Ln,situ``."""
     plt = pytest.importorskip("matplotlib.pyplot")
@@ -902,7 +911,7 @@ def test_in_situ_element_plot_draws_both_spectra(situ: dict, language) -> None:
 def test_plot_rejects_an_unknown_language(airborne) -> None:
     """Only the languages the renderers translate are accepted."""
     pytest.importorskip("matplotlib.pyplot")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         airborne.plot(language="fr")
 
 

--- a/tests/building/prediction/test_facade.py
+++ b/tests/building/prediction/test_facade.py
@@ -206,7 +206,9 @@ def test_rprime_cap_off_by_default() -> None:
     assert res.l_w[0] == pytest.approx(44.0)
 
 
-@pytest.mark.parametrize("shape,height,alpha,expected", ref.EN12354_3_ANNEX_C_DLFS)
+@pytest.mark.parametrize(
+    ("shape", "height", "alpha", "expected"), ref.EN12354_3_ANNEX_C_DLFS
+)
 def test_facade_shape_level_difference_table(
     shape: str, height: float, alpha: float, expected: float
 ) -> None:
@@ -288,7 +290,7 @@ def test_a_weighted_single_number() -> None:
 
 
 @pytest.mark.parametrize(
-    "width,height,distance,expected", ref.EN12354_4_ANNEX_G_ATTENUATION
+    ("width", "height", "distance", "expected"), ref.EN12354_4_ANNEX_G_ATTENUATION
 )
 def test_annex_e_attenuation(
     width: float, height: float, distance: float, expected: float

--- a/tests/building/prediction/test_orthotropic_panels.py
+++ b/tests/building/prediction/test_orthotropic_panels.py
@@ -623,7 +623,7 @@ def test_orthotropic_rejects_bad_input() -> None:
             critical_frequency_lower=4000.0,
             critical_frequency_upper=400.0,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'method' must be one of"):
         _fig627(BANDS, method="heckle")
     with pytest.raises(ValueError, match="must be positive"):
         building.orthotropic_transmission_loss(

--- a/tests/building/prediction/test_panel_transmission.py
+++ b/tests/building/prediction/test_panel_transmission.py
@@ -524,19 +524,35 @@ def test_plateau_plot_shades_the_coincidence_plateau() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "match"),
     [
-        {"material": "granite", "thickness_mm": 100.0},
-        {"material": "brick"},
-        {"mass_per_area": 231.0, "plateau_height": 37.0},
-        {"mass_per_area": 231.0, "plateau_height": 37.0, "frequency_ratio": 1.0},
-        {"mass_per_area": -1.0, "plateau_height": 37.0, "frequency_ratio": 4.5},
-        {"mass_per_area": 231.0, "plateau_height": 0.0, "frequency_ratio": 4.5},
+        (
+            {"material": "granite", "thickness_mm": 100.0},
+            "'material' must be one of",
+        ),
+        ({"material": "brick"}, "give 'thickness_mm' with 'material'"),
+        (
+            {"mass_per_area": 231.0, "plateau_height": 37.0},
+            "the plateau construction needs",
+        ),
+        (
+            {"mass_per_area": 231.0, "plateau_height": 37.0, "frequency_ratio": 1.0},
+            "'frequency_ratio' must be greater than",
+        ),
+        (
+            {"mass_per_area": -1.0, "plateau_height": 37.0, "frequency_ratio": 4.5},
+            "'mass_per_area' must be positive",
+        ),
+        (
+            {"mass_per_area": 231.0, "plateau_height": 0.0, "frequency_ratio": 4.5},
+            "'plateau_height' must be positive",
+        ),
     ],
 )
-def test_plateau_validation(kwargs: dict[str, object]) -> None:
-
-    with pytest.raises(ValueError):
+def test_plateau_validation(kwargs: dict[str, object], match: str) -> None:
+    # Each case must reach its own guard, so the expected message travels with
+    # the kwargs that provoke it.
+    with pytest.raises(ValueError, match=match):
         building.plateau_transmission_loss(P311_BANDS, **kwargs)  # type: ignore[arg-type]
 
 
@@ -572,7 +588,7 @@ def test_negative_field_correction_rejected() -> None:
 
 
 def test_unknown_coincidence_model_rejected() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'coincidence_model' must be one of"):
         building.single_panel_transmission_loss(
             BANDS, 15.0, critical_frequency=2000.0, coincidence_model="watters"
         )

--- a/tests/building/test_building_plots.py
+++ b/tests/building/test_building_plots.py
@@ -302,5 +302,5 @@ def test_wall_tie_plot_forwards_kwargs() -> None:
 )
 def test_plot_rejects_an_unknown_language(factory) -> None:
     result = factory()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="fr")

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -62,7 +62,7 @@ def test_nth_order_harmonic_distortion() -> None:
 
 def test_harmonic_distortion_rejects_order_below_two() -> None:
     tone = _tone(1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'order' must be at least"):
         electroacoustics.harmonic_distortion(tone, FS, fundamental=1000.0, order=1)
 
 
@@ -126,7 +126,7 @@ def test_thd_plus_noise_pure_tone_is_tiny() -> None:
 
 def test_thd_plus_noise_rejects_q_out_of_range() -> None:
     tone = _tone(1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'notch_q' must be within the AES17 range"):
         electroacoustics.thd_plus_noise(tone, FS, 1000.0, notch_q=5.0)
 
 
@@ -141,14 +141,14 @@ def test_weighted_thd_attenuates_low_harmonics() -> None:
 
 def test_weighted_thd_rejects_bad_notch_q() -> None:
     tone = _tone(1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'notch_q' must be within the AES17 range"):
         electroacoustics.weighted_thd(tone, FS, 1000.0, notch_q=5.0)
 
 
 def test_thd_plus_noise_rejects_fundamental_above_nyquist() -> None:
     # A fundamental at/above fs/2 cannot be notched (iirnotch would fail).
     tone = _tone(1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fundamental' must be below the Nyquist"):
         electroacoustics.thd_plus_noise(tone, FS, FS / 2.0)
 
 
@@ -234,7 +234,7 @@ def test_modulation_distortion_plot_marks_carrier_and_sidebands() -> None:
     ax_es = res.plot(language="es")
     assert ax_es.get_ylabel() == "Nivel respecto a la portadora [dB]"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
     # A hand-built result without the spectral fields cannot be plotted.
     bare = electroacoustics.ModulationDistortionResult(d2=0.1, d3=0.05, smpte=0.08)
@@ -327,13 +327,13 @@ def test_difference_frequency_dc_offset_not_counted() -> None:
 
 def test_difference_frequency_rejects_bad_args() -> None:
     tone = _tone(1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'f1' must be lower than 'f2'"):
         electroacoustics.difference_frequency_distortion(tone, FS, f1=2000.0, f2=1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'order' must be"):
         electroacoustics.difference_frequency_distortion(
             tone, FS, f1=1000.0, f2=2000.0, order=4
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'f1' must be lower than 'f2'"):
         electroacoustics.total_difference_frequency_distortion(tone, FS, 2000.0, 1000.0)
 
 
@@ -387,21 +387,21 @@ def test_harmonic_analysis_bundle_and_plot() -> None:
 )
 def test_rejects_non_finite_signal(func) -> None:  # type: ignore[no-untyped-def]
     bad = np.array([np.nan] * 100)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'signal' must be finite"):
         func(bad, FS)
 
 
 def test_rejects_bad_fs_and_kind() -> None:
     tone = _tone(1000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be a positive"):
         electroacoustics.thd(tone, 0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'kind' must be"):
         electroacoustics.thd(tone, FS, 1000.0, kind="X")  # type: ignore[arg-type]
 
 
 def test_rejects_too_short_signal() -> None:
     too_short = np.array([0.0, 1.0, 0.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'signal' must contain at least"):
         electroacoustics.thd(too_short, FS)
 
 
@@ -459,7 +459,7 @@ def test_itu_r_468_weighting_table_values() -> None:
     assert grid[int(np.argmax(curve))] == pytest.approx(6300.0, rel=1e-3)
     # DC blocks completely; negative/non-finite frequencies are rejected.
     assert electroacoustics.itu_r_468_weighting([0.0])[0] == -np.inf
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'frequencies' must be"):
         electroacoustics.itu_r_468_weighting([-100.0])
 
 
@@ -484,7 +484,7 @@ def test_weighted_thd_468_emphasises_6khz_products() -> None:
     assert w468 == pytest.approx(0.01 * 10.0 ** (12.2 / 20.0), rel=0.02)
     w_a = electroacoustics.weighted_thd(x, FS, 100.0, weighting="A")
     assert w468 / w_a == pytest.approx(10.0 ** (12.2 / 20.0), rel=0.05)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'weighting' must be"):
         electroacoustics.weighted_thd(x, FS, 100.0, weighting="B")  # type: ignore[arg-type]
 
 
@@ -636,9 +636,9 @@ def test_dynamic_range_full_scale_reference() -> None:
 
 def test_dynamic_range_rejects_bad_notch_q_and_full_scale() -> None:
     sig = _dbfs_sine_amplitude(-60.0) * _tone(997.0) + 1e-3 * _tone(2000.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'notch_q' must be within the AES17 range"):
         electroacoustics.dynamic_range(sig, FS, 997.0, notch_q=0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'full_scale' must be a positive"):
         electroacoustics.dynamic_range(sig, FS, 997.0, full_scale=0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'full_scale' must be a positive"):
         electroacoustics.idle_channel_noise(sig, FS, full_scale=-1.0)

--- a/tests/electroacoustics/test_electroacoustics_plot_i18n.py
+++ b/tests/electroacoustics/test_electroacoustics_plot_i18n.py
@@ -44,7 +44,7 @@ def test_harmonic_distortion_es() -> None:
     assert ax.get_ylabel() == "Nivel respecto al fundamental [dB]"
     assert ax.get_xlabel().startswith("Orden del armónico")
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -77,7 +77,7 @@ def test_swept_sine_distortion_es() -> None:
     single = res.plot(ax=ext, language="es")
     assert single.get_title() == "THD de barrido sinusoidal (Farina / Novak)"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -91,7 +91,7 @@ def test_feedback_stability_es() -> None:
     unstable = ph.electroacoustics.feedback_stability(0.0, 80.0, 80.0)
     assert "inestable" in unstable.plot(language="es").get_title()
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -102,7 +102,7 @@ def test_sound_reinforcement_geometry_es() -> None:
     assert "Lazo de realimentación" in ax.get_title()
     assert "Camino de realimentación" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         ph.electroacoustics.plot_sound_reinforcement_geometry(
             0.3, 4.0, 12.0, language="xx"
         )
@@ -114,7 +114,7 @@ def test_piston_impedance_es() -> None:
     assert "pistón circular con pantalla" in ax.get_title()
     assert "Impedancia de radiación normalizada" in ax.get_ylabel()
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -124,7 +124,7 @@ def test_piston_directivity_es() -> None:
     assert ax.name == "polar"
     assert ax.get_title() == "Directividad de un pistón circular con pantalla"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -194,9 +194,9 @@ def test_loudspeaker_characteristics_es() -> None:
         "Nivel de presión acústica [dB]"
     )
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown quantity"):
         res.plot(quantity="bogus")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -219,7 +219,7 @@ def test_microphone_characteristics_es() -> None:
         "Nivel de presión acústica [dB]"
     )
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown quantity"):
         res.plot(quantity="bogus")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/electroacoustics/test_frequency_response.py
+++ b/tests/electroacoustics/test_frequency_response.py
@@ -95,15 +95,15 @@ def test_result_fields_and_plot() -> None:
 def test_rejects_mismatched_lengths() -> None:
     x = np.zeros(1000)
     shorter_y = np.zeros(500)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'x' and 'y' must have the same length"):
         electroacoustics.transfer_function(x, shorter_y, FS)
 
 
 def test_rejects_bad_estimator_and_overlap() -> None:
     x = np.zeros(1000)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'estimator'"):
         electroacoustics.transfer_function(x, x, FS, estimator="H3")  # type: ignore[arg-type]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'overlap'"):
         electroacoustics.transfer_function(x, x, FS, overlap=1.0)
 
 
@@ -116,13 +116,13 @@ def test_high_overlap_does_not_crash() -> None:
 
 def test_rejects_bad_nperseg() -> None:
     x = np.zeros(1000)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'nperseg'"):
         electroacoustics.transfer_function(x, x, FS, nperseg=5000)
 
 
 def test_rejects_too_short_signal() -> None:
     too_short = np.zeros(10)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="too short for a spectral estimate"):
         electroacoustics.coherence(too_short, too_short, FS)
 
 

--- a/tests/electroacoustics/test_piston.py
+++ b/tests/electroacoustics/test_piston.py
@@ -166,7 +166,7 @@ def test_directivity_pattern_plot() -> None:
     assert ax.name == "polar"
     assert len(ax.lines) == 3
     assert "piston directivity" in ax.get_title()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -193,18 +193,18 @@ def test_directivity_pattern_validation() -> None:
     ka_one = [1.0]
     infinite_angles = [np.inf]
     empty_ka = np.empty(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'ka' must be non-negative"):
         electroacoustics.piston_directivity_pattern(-1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angles' must be finite"):
         electroacoustics.piston_directivity_pattern(ka_one, angles=infinite_angles)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'ka' must be a non-empty"):
         electroacoustics.piston_directivity_pattern(empty_ka)
 
 
 def test_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'radius' must be positive"):
         electroacoustics.radiating_piston(-1.0, [100.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'frequencies' must be positive"):
         electroacoustics.radiating_piston(0.1, [0.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'x' must be non-negative"):
         electroacoustics.piston_resistance(-1.0)

--- a/tests/emission/test_emission_plot_i18n.py
+++ b/tests/emission/test_emission_plot_i18n.py
@@ -43,5 +43,5 @@ def test_intensity_class_es() -> None:
     assert "Mínimo clase 1" in _labels(ax)
     assert "Región de aceptación clase 1" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -476,11 +476,15 @@ def test_non_positive_mean_cites_a23_only_for_the_surface_indicators() -> None:
     defines F1 over the M short-time samples at one position, states no such
     condition, so the F1 message must not claim A.2.3 backing.
     """
-    with pytest.raises(ValueError) as surface:
+    with pytest.raises(
+        ValueError, match="measurement surface is not positive"
+    ) as surface:
         emission.field_indicators([90.0, 90.0], [1e-3, -2e-3])
     assert "A.2.3" in str(surface.value)
 
-    with pytest.raises(ValueError) as temporal:
+    with pytest.raises(
+        ValueError, match="short-time normal intensity samples is not positive"
+    ) as temporal:
         emission.temporal_variability_indicator([1.0e-5, -3.0e-5])
     assert "A.2.3" not in str(temporal.value)
     assert "A.1" in str(temporal.value)

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -453,7 +453,7 @@ def test_sound_power_level_a_single_band_equals_level() -> None:
 def test_too_few_positions_raises() -> None:
     """Engineering hemisphere needs >= 10 positions (ISO 3744 clause 8.1.1)."""
     five_positions = np.full((5, 1), 60.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="microphone positions"):
         emission.sound_power_pressure(five_positions, "hemisphere", radius=2.0)
 
 
@@ -467,13 +467,13 @@ def test_survey_allows_four_positions() -> None:
 
 def test_missing_radius_raises() -> None:
     levels = np.full((10, 1), 60.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'radius' is required"):
         emission.sound_power_pressure(levels, "hemisphere")
 
 
 def test_invalid_surface_raises() -> None:
     levels = np.full((10, 1), 60.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'surface' must be"):
         emission.sound_power_pressure(levels, "sphere", radius=2.0)
 
 

--- a/tests/emission/test_sound_power_intensity.py
+++ b/tests/emission/test_sound_power_intensity.py
@@ -317,7 +317,7 @@ def test_short_frequencies_raises_value_error_not_index_error() -> None:
     intensity = np.column_stack([np.full(4, 5.0e-4), np.full(4, 5.0e-4)])
     levels = np.full((4, 2), 90.0)
     short_frequencies = np.array([1000.0])  # one freq, two bands
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(ValueError, match="'frequencies' length must match"):
         emission.sound_power_intensity(
             intensity,
             areas,
@@ -473,7 +473,7 @@ def test_a_weighting_screening_unavailable_warns_and_sums_all() -> None:
 def test_area_length_mismatch_raises() -> None:
     intensity = np.full((4, 1), 1e-4)
     three_areas = np.array([0.5, 0.5, 0.5])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'normal_intensity' first axis"):
         emission.sound_power_intensity(intensity, three_areas)
 
 
@@ -481,7 +481,7 @@ def test_pressure_levels_shape_mismatch_raises() -> None:
     intensity = np.full((4, 1), 1e-4)
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     two_band_levels = np.full((4, 2), 90.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'pressure_levels' must have shape"):
         emission.sound_power_intensity(
             intensity, areas, pressure_levels=two_band_levels
         )
@@ -490,7 +490,7 @@ def test_pressure_levels_shape_mismatch_raises() -> None:
 def test_non_positive_area_raises() -> None:
     intensity = np.full((4, 1), 1e-4)
     zero_area = np.array([0.5, 0.5, 0.5, 0.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="segment 'areas' must be positive"):
         emission.sound_power_intensity(intensity, zero_area)
 
 
@@ -505,5 +505,5 @@ def test_fewer_than_four_segments_warns() -> None:
 def test_bad_grade_raises() -> None:
     intensity = np.full((4, 1), 1e-4)
     areas = np.array([0.5, 0.5, 0.5, 0.5])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'grade' must be"):
         emission.sound_power_intensity(intensity, areas, grade="bogus")

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -348,14 +348,14 @@ def test_a_weighted_total_from_bands() -> None:
 # --------------------------------------------------------------------------
 def test_invalid_volume_raises() -> None:
     lp, t60, freqs = np.array([80.0]), np.array([1.5]), np.array([1000.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'volume' and 'surface_area'"):
         emission.sound_power_reverberation(lp, t60, -1.0, 210.0, freqs)
 
 
 def test_mismatched_shapes_raise() -> None:
     two_bands = np.array([80.0, 81.0])  # 2 levels against 1 band of T60/freq
     t60, freqs = np.array([1.5]), np.array([1000.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'frequencies' length must match"):
         emission.sound_power_reverberation(two_bands, t60, 200.0, 210.0, freqs)
 
 

--- a/tests/environment/propagation/test_air_absorption.py
+++ b/tests/environment/propagation/test_air_absorption.py
@@ -39,7 +39,7 @@ def _last_digit_ulp(value: float) -> float:
     return 10.0 ** (math.floor(math.log10(value)) - 2)
 
 
-@pytest.mark.parametrize("temp,rh,freq,alpha_km", ref.ISO9613_1_TABLE1)
+@pytest.mark.parametrize(("temp", "rh", "freq", "alpha_km"), ref.ISO9613_1_TABLE1)
 def test_table1_digit_exact(
     temp: float, rh: float, freq: float, alpha_km: float
 ) -> None:
@@ -159,17 +159,26 @@ def test_out_of_range_frequency_warns() -> None:
 
 
 @pytest.mark.parametrize(
-    "args,kwargs",
+    ("args", "kwargs", "match"),
     [
-        (([0.0, 1000.0],), {}),  # non-positive frequency
-        ((1000.0,), {"temperature": -273.15}),  # absolute zero
-        ((1000.0,), {"relative_humidity": -1.0}),  # negative RH
-        ((1000.0,), {"relative_humidity": 120.0}),  # > 100 %
-        ((1000.0,), {"pressure": 0.0}),  # non-positive pressure
+        # non-positive frequency
+        (([0.0, 1000.0],), {}, "'frequencies' must be positive"),
+        # absolute zero
+        (
+            (1000.0,),
+            {"temperature": -273.15},
+            "'temperature' must be above absolute zero",
+        ),
+        # negative RH
+        ((1000.0,), {"relative_humidity": -1.0}, "'relative_humidity' must be within"),
+        # > 100 %
+        ((1000.0,), {"relative_humidity": 120.0}, "'relative_humidity' must be within"),
+        # non-positive pressure
+        ((1000.0,), {"pressure": 0.0}, "'pressure' must be positive"),
     ],
 )
-def test_invalid_inputs_raise(args: tuple, kwargs: dict) -> None:
-    with pytest.raises(ValueError):
+def test_invalid_inputs_raise(args: tuple, kwargs: dict, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
         environment.air_attenuation(*args, **kwargs)
 
 

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -163,9 +163,9 @@ def test_ground_effect_requires_exactly_one_impedance_source(kwargs: dict) -> No
 
 
 def test_ground_effect_rejects_bad_geometry() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="heights must be non-negative"):
         environment.ground_effect(_BANDS, -1.0, 1.0, 20.0, impedance=10.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'distance' must be positive"):
         environment.ground_effect(_BANDS, 1.0, 1.0, 0.0, impedance=10.0)
 
 

--- a/tests/environment/propagation/test_refraction.py
+++ b/tests/environment/propagation/test_refraction.py
@@ -79,14 +79,16 @@ def test_log_linear_profile_matches_salomons_eq_4_5() -> None:
 
 
 def test_profile_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'gradient' must be finite"):
         linear_sound_speed_profile(np.nan)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="linear profile reaches a non-positive sound speed"
+    ):
         # A steep negative gradient drives the speed non-positive within range.
         linear_sound_speed_profile(-10.0, ground_speed=340.0, max_height=100.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'n_points' must be at least"):
         log_linear_sound_speed_profile(1.0, n_points=1)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'roughness_length' must be positive"):
         log_linear_sound_speed_profile(1.0, roughness_length=0.0)
 
 
@@ -104,9 +106,11 @@ def test_ray_curvature_radius_closed_form() -> None:
 
 
 def test_ray_curvature_radius_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'gradient' must be finite and non-zero"):
         ray_curvature_radius(0.0)  # straight ray
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match=r"'launch_angle_deg' must be within \(-90, 90\)"
+    ):
         ray_curvature_radius(0.1, launch_angle_deg=90.0)
 
 
@@ -119,7 +123,10 @@ def test_shadow_zone_distance_closed_form() -> None:
 
 
 def test_shadow_zone_requires_upward_refraction() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=r"'gradient' must be negative \(an upward-refracting profile\)",
+    ):
         shadow_zone_distance(0.1, 2.0, 2.0)  # downward refraction: no shadow
 
 
@@ -220,11 +227,15 @@ def test_ground_reflection_costs_no_accuracy() -> None:
 
 def test_ray_validation() -> None:
     prof = linear_sound_speed_profile(0.1)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'source_height' must be non-negative"):
         atmospheric_ray_paths(prof, source_height=-1.0, launch_angles_deg=[0.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match=r"'launch_angles_deg' must be within \(-90, 90\)"
+    ):
         atmospheric_ray_paths(prof, source_height=1.0, launch_angles_deg=[90.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'launch_angles_deg' must be finite and non-empty"
+    ):
         atmospheric_ray_paths(
             prof,
             source_height=1.0,
@@ -459,19 +470,23 @@ def test_pe_flow_resistivity_matches_impedance_path() -> None:
 
 def test_pe_validation() -> None:
     prof = _flat_profile()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'source_height' must be positive"):
         atmospheric_parabolic_equation(
             500.0, prof, source_height=0.0, impedance=Z_GRASS
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="provide exactly one of 'impedance' or 'flow_resistivity'"
+    ):
         # Neither impedance nor flow_resistivity.
         atmospheric_parabolic_equation(500.0, prof, source_height=2.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="provide exactly one of 'impedance' or 'flow_resistivity'"
+    ):
         # Both impedance and flow_resistivity.
         atmospheric_parabolic_equation(
             500.0, prof, source_height=2.0, impedance=Z_GRASS, flow_resistivity=2e5
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'range_step' must not exceed 'max_range'"):
         atmospheric_parabolic_equation(
             500.0,
             prof,

--- a/tests/environment/sources/test_cnossos_road.py
+++ b/tests/environment/sources/test_cnossos_road.py
@@ -230,7 +230,7 @@ def test_reference_conditions_reduce_to_table_f1(category: str) -> None:
     )
 
 
-@pytest.mark.parametrize("category", ("1", "2", "3"))
+@pytest.mark.parametrize("category", ["1", "2", "3"])
 def test_rolling_speed_law_is_exactly_logarithmic(category: str) -> None:
     """Doubling the speed adds exactly ``B_R lg 2`` to the rolling noise."""
     low = road_rolling_noise(category, 45.0)

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -122,7 +122,7 @@ def test_tonal_audibility_flat_spectrum_not_audible() -> None:
 
 
 def test_tonal_audibility_rejects_short_input() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="1-D and the same length"):
         wind_turbine_tonality([1.0, 2.0], [10.0, 12.0])
 
 

--- a/tests/filters/test_filters_plot_i18n.py
+++ b/tests/filters/test_filters_plot_i18n.py
@@ -58,7 +58,7 @@ def test_filter_class_es() -> None:
     assert "Máscara clase" in ax.get_title()
     assert ax.get_ylabel() == "Atenuación relativa [dB]"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -78,5 +78,5 @@ def test_parametric_eq_es_and_bad_language() -> None:
     assert "campana 1000 Hz" in _labels(axes)
     assert "Fase [grados]" in _labels(axes)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/filters/test_iec_compliance.py
+++ b/tests/filters/test_iec_compliance.py
@@ -69,7 +69,7 @@ SLOW_CASES = [
 ]
 
 
-@pytest.mark.parametrize("duration,ref,upper,lower", FAST_CASES)
+@pytest.mark.parametrize(("duration", "ref", "upper", "lower"), FAST_CASES)
 def test_fast_tone_burst_iec_table4(
     duration: float, ref: float, upper: float, lower: float
 ) -> None:
@@ -80,7 +80,7 @@ def test_fast_tone_burst_iec_table4(
     )
 
 
-@pytest.mark.parametrize("duration,ref,upper,lower", SLOW_CASES)
+@pytest.mark.parametrize(("duration", "ref", "upper", "lower"), SLOW_CASES)
 def test_slow_tone_burst_iec_table4(
     duration: float, ref: float, upper: float, lower: float
 ) -> None:
@@ -138,7 +138,7 @@ SEL_CASES = [
 ]
 
 
-@pytest.mark.parametrize("duration,ref,upper,lower", SEL_CASES)
+@pytest.mark.parametrize(("duration", "ref", "upper", "lower"), SEL_CASES)
 def test_sel_tone_burst_iec_table4(
     duration: float, ref: float, upper: float, lower: float
 ) -> None:

--- a/tests/filters/test_iec_weighting_table3.py
+++ b/tests/filters/test_iec_weighting_table3.py
@@ -58,7 +58,7 @@ _CLASS1_MISSES: dict[tuple[str, int], set[float]] = {
 
 
 @pytest.mark.parametrize("fs", [16000, 32000, 48000, 96000])
-@pytest.mark.parametrize("curve,column", [("A", 1), ("C", 2)])
+@pytest.mark.parametrize(("curve", "column"), [("A", 1), ("C", 2)])
 def test_weighting_within_class1_limits_table3(
     fs: int, curve: str, column: int
 ) -> None:

--- a/tests/filters/test_nominal_frequencies.py
+++ b/tests/filters/test_nominal_frequencies.py
@@ -141,7 +141,9 @@ def test_normalizedfreq_fraction1_and_invalid_fraction() -> None:
     freq = filters.normalized_frequencies(1)
     assert 1000 in freq
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Normalized frequencies only available for fraction"
+    ):
         filters.normalized_frequencies(5)
 
 

--- a/tests/filters/test_parametric_filters.py
+++ b/tests/filters/test_parametric_filters.py
@@ -190,9 +190,9 @@ def test_weighting_filter_class_direct_use() -> None:
     y_z = wf_z.filter(x)
     np.testing.assert_allclose(y_z, x)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Sample rate 'fs' must be positive"):
         filters.WeightingFilter(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Weighting curve must be"):
         filters.WeightingFilter(fs, curve="invalid")
 
 

--- a/tests/filters/test_stateful_octave_filter_bank.py
+++ b/tests/filters/test_stateful_octave_filter_bank.py
@@ -66,7 +66,7 @@ def test_resample_and_stateful():
 
     resampling_design = FilterDesign(resample=True)
     stateful_blocks = BlockProcessing(stateful=True)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Resampling and stateful"):
         OctaveFilterBank(
             48000,
             design=resampling_design,

--- a/tests/filters/test_weighting_class_verifier.py
+++ b/tests/filters/test_weighting_class_verifier.py
@@ -183,7 +183,7 @@ def test_deviation_evaluated_at_exact_base10_frequency() -> None:
 
 
 @pytest.mark.parametrize(
-    "fs,label", [(16000, 8000.0), (32000, 16000.0), (48000, 16000.0)]
+    ("fs", "label"), [(16000, 8000.0), (32000, 16000.0), (48000, 16000.0)]
 )
 def test_verdict_measures_the_resampled_path(fs: int, label: float) -> None:
     """The row nearest Nyquist is judged on what ``filter()`` really does.
@@ -236,7 +236,7 @@ def test_sweep_result_reported_for_compliant_filter() -> None:
         filters.verify_weighting_class(wf, sweep_points=8)
 
 
-@pytest.mark.parametrize("fs,expected", [(32000, 2), (24000, 2)])
+@pytest.mark.parametrize(("fs", "expected"), [(32000, 2), (24000, 2)])
 def test_plain_bilinear_degrades_to_class2(fs: int, expected: int) -> None:
     """Without oversampling the bilinear warping fails class 1 near Nyquist."""
     result = filters.verify_weighting_class(
@@ -247,9 +247,9 @@ def test_plain_bilinear_degrades_to_class2(fs: int, expected: int) -> None:
 
 
 def test_invalid_class_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="weighting_class must be"):
         filters.weighting_class_limits(0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="weighting_class must be"):
         filters.weighting_class_limits(3)
 
 

--- a/tests/hearing/test_occupational_exposure.py
+++ b/tests/hearing/test_occupational_exposure.py
@@ -306,14 +306,14 @@ def test_job_based_high_spread_triggers_c4_advisory():
 
 
 def test_task_based_requires_tasks():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="At least one task"):
         task_based_exposure([])
 
 
 def test_task_rejects_nonpositive_duration():
     # Task.__post_init__ is what rejects it: task_based_exposure never gets to
     # see an object with a non-positive duration.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'duration_hours' must be positive"):
         Task(samples=(85.0,), duration_hours=0.0)
 
 
@@ -330,7 +330,7 @@ def test_job_based_rejects_nonpositive_sample_duration():
 
 
 def test_job_based_requires_two_samples():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="At least two samples"):
         job_based_exposure([85.0], 8.0)
 
 
@@ -338,7 +338,7 @@ def test_duration_range_order_validated():
     reversed_range = Task(
         samples=(85.0, 85.0), duration_hours=4.0, duration_range=(6.0, 4.0)
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"duration_range must be \(T_min, T_max\)"):
         task_based_exposure([reversed_range])
 
 

--- a/tests/io/test_io_read.py
+++ b/tests/io/test_io_read.py
@@ -391,7 +391,7 @@ def test_info_answers_a_giant_rf64_from_its_headers_alone(
     assert bext.max_short_term_loudness == pytest.approx(-21.10)
 
     # The proof that no sample was touched: touching them is impossible.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="truncated recording"):
         read(path)
 
 

--- a/tests/materials/absorbers/test_absorption_rating.py
+++ b/tests/materials/absorbers/test_absorption_rating.py
@@ -175,12 +175,12 @@ def test_practical_mean_of_three() -> None:
 
 
 def test_practical_rejects_negative() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="alpha_s values must be non-negative"):
         practical_absorption_coefficient([-0.1] + [0.5] * 14)
 
 
 def test_practical_wrong_length() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"third_octave_alpha_s must have \d+ values"):
         practical_absorption_coefficient([0.5] * 14)
 
 
@@ -330,7 +330,7 @@ def test_from_third_octave_accepts_mapping() -> None:
 
 
 def test_from_third_octave_rejects_wrong_length() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"third_octave_alpha_s must have \d+ values"):
         weighted_absorption_from_third_octave([0.5] * 14)
 
 

--- a/tests/materials/absorbers/test_airflow_resistance.py
+++ b/tests/materials/absorbers/test_airflow_resistance.py
@@ -77,25 +77,34 @@ def test_quantity_chain_round_trip() -> None:
 
 
 def test_specific_resistance_requires_exactly_one_route() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Provide exactly one route"):
         specific_airflow_resistance(20000.0, 0.008, pressure_drop=20.0, velocity=0.125)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Provide exactly one route"):
         specific_airflow_resistance()
 
 
 @pytest.mark.parametrize(
-    "call",
+    ("call", "message"),
     [
-        lambda: airflow_resistance(-1.0, 0.001),
-        lambda: airflow_resistance(20.0, 0.0),
-        lambda: airflow_resistivity(160.0, 0.0),
-        lambda: linear_airflow_velocity(0.001, 0.0),
-        lambda: specific_airflow_resistance(-1.0, 0.008),
-        lambda: specific_airflow_resistance(pressure_drop=20.0, velocity=0.0),
+        (
+            lambda: airflow_resistance(-1.0, 0.001),
+            "'pressure_drop' must be non-negative",
+        ),
+        (lambda: airflow_resistance(20.0, 0.0), "'volume_flow_rate' must be positive"),
+        (lambda: airflow_resistivity(160.0, 0.0), "'thickness' must be positive"),
+        (lambda: linear_airflow_velocity(0.001, 0.0), "'area' must be positive"),
+        (
+            lambda: specific_airflow_resistance(-1.0, 0.008),
+            "'resistance' must be non-negative",
+        ),
+        (
+            lambda: specific_airflow_resistance(pressure_drop=20.0, velocity=0.0),
+            "'velocity' must be positive",
+        ),
     ],
 )
-def test_invalid_inputs_raise(call) -> None:  # type: ignore[no-untyped-def]
-    with pytest.raises(ValueError):
+def test_invalid_inputs_raise(call, message: str) -> None:  # type: ignore[no-untyped-def]
+    with pytest.raises(ValueError, match=message):
         call()
 
 
@@ -144,16 +153,28 @@ def test_static_velocity_above_limit_warns() -> None:
 
 
 @pytest.mark.parametrize(
-    "call",
+    ("call", "message"),
     [
-        lambda: static_airflow_resistance([1e-3], [12.0], 0.008),  # < 2 steps
-        lambda: static_airflow_resistance([1e-3, 2e-3], [12.0], 0.008),  # length
-        lambda: static_airflow_resistance([1e-3, -2e-3], [12.0, 24.0], 0.008),  # neg u
-        lambda: static_airflow_resistance([1e-3, 2e-3], [12.0, 24.0], 0.0),  # area
+        (  # < 2 steps
+            lambda: static_airflow_resistance([1e-3], [12.0], 0.008),
+            "At least two measurement steps",
+        ),
+        (  # length
+            lambda: static_airflow_resistance([1e-3, 2e-3], [12.0], 0.008),
+            "must have equal length",
+        ),
+        (  # neg u
+            lambda: static_airflow_resistance([1e-3, -2e-3], [12.0, 24.0], 0.008),
+            "All velocities must be positive",
+        ),
+        (  # area
+            lambda: static_airflow_resistance([1e-3, 2e-3], [12.0, 24.0], 0.0),
+            "'area' must be positive",
+        ),
     ],
 )
-def test_static_invalid_inputs_raise(call) -> None:  # type: ignore[no-untyped-def]
-    with pytest.raises(ValueError):
+def test_static_invalid_inputs_raise(call, message: str) -> None:  # type: ignore[no-untyped-def]
+    with pytest.raises(ValueError, match=message):
         call()
 
 
@@ -232,17 +253,22 @@ def test_alternating_frequency_out_of_range_warns() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "message"),
     [
-        {"frequency": 0.0},
-        {"cavity_volume": 0.0},
-        {"piston_stroke_specimen": 0.0},
-        {"piston_stroke_termination": 0.0},
-        {"static_pressure": 0.0},
-        {"kappa_prime": 0.0},
+        ({"frequency": 0.0}, "'frequency' must be positive"),
+        ({"cavity_volume": 0.0}, "'cavity_volume' must be positive"),
+        ({"piston_stroke_specimen": 0.0}, "'piston_stroke_specimen' must be positive"),
+        (
+            {"piston_stroke_termination": 0.0},
+            "'piston_stroke_termination' must be positive",
+        ),
+        ({"static_pressure": 0.0}, "'static_pressure' must be positive"),
+        ({"kappa_prime": 0.0}, "'kappa_prime' must be positive"),
     ],
 )
-def test_alternating_invalid_inputs_raise(kwargs: dict[str, float]) -> None:
+def test_alternating_invalid_inputs_raise(
+    kwargs: dict[str, float], message: str
+) -> None:
     base = {
         "piston_stroke_specimen": 14.0e-3,
         "piston_stroke_termination": 1.4e-3,
@@ -250,7 +276,7 @@ def test_alternating_invalid_inputs_raise(kwargs: dict[str, float]) -> None:
         "cavity_volume": 1.0e-3,
     }
     base.update(kwargs)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=message):
         alternating_airflow_resistance(60.0, 80.0, **base)
 
 
@@ -289,18 +315,20 @@ def test_effective_kappa_below_adiabatic() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "message"),
     [
-        {"cavity_surface": 0.0},
-        {"cavity_volume": 0.0},
-        {"frequency": 0.0},
-        {"specific_heat_ratio": 0.0},
+        ({"cavity_surface": 0.0}, "'cavity_surface' must be positive"),
+        ({"cavity_volume": 0.0}, "'cavity_volume' must be positive"),
+        ({"frequency": 0.0}, "'frequency' must be positive"),
+        ({"specific_heat_ratio": 0.0}, "'specific_heat_ratio' must be positive"),
     ],
 )
-def test_effective_kappa_invalid_inputs_raise(kwargs: dict[str, float]) -> None:
+def test_effective_kappa_invalid_inputs_raise(
+    kwargs: dict[str, float], message: str
+) -> None:
     base = {"cavity_surface": 0.0471, "cavity_volume": 7.854e-4, "frequency": 2.0}
     base.update(kwargs)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=message):
         effective_kappa(**base)
 
 

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -94,17 +94,19 @@ def test_air_density_reference_values() -> None:
 
 
 def test_air_property_domain_errors() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'temperature' must be positive"):
         speed_of_sound_iso(-1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'temperature' must exceed"):
         speed_of_sound_astm(-300.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'atmospheric_pressure' must be positive"):
         air_density_iso(293.0, -1.0)
 
 
 def test_characteristic_impedance_is_real_product() -> None:
     assert characteristic_impedance(RHO, C0) == pytest.approx(RC)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'density' and 'speed_of_sound' must be positive"
+    ):
         characteristic_impedance(-1.0, C0)
 
 
@@ -372,7 +374,7 @@ def test_swr_reflection_and_absorption() -> None:
 
 
 def test_swr_invalid_ratio() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Standing-wave ratio 's' must be"):
         standing_wave_reflection_magnitude(0.5)
 
 

--- a/tests/materials/absorbers/test_limp_frame.py
+++ b/tests/materials/absorbers/test_limp_frame.py
@@ -290,5 +290,5 @@ def test_limp_frame_criteria_match_the_printed_thresholds() -> None:
 def test_limp_frame_applicable_rejects_bad_input() -> None:
     with pytest.raises(ValueError, match="non-negative"):
         materials.limp_frame_applicable(-1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'criterion' must be one of"):
         materials.limp_frame_applicable(1.0e3, criterion="panneton")

--- a/tests/materials/absorbers/test_porous.py
+++ b/tests/materials/absorbers/test_porous.py
@@ -149,7 +149,7 @@ class TestDelanyBazley:
             delany_bazley(f, 10000.0, coefficients="nope")
         with pytest.raises(ValueError, match="8 values"):
             delany_bazley(f, 10000.0, coefficients=(1.0, 2.0))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="'flow_resistivity' must be positive"):
             delany_bazley(f, -1.0)
 
 

--- a/tests/materials/absorbers/test_slow_sound.py
+++ b/tests/materials/absorbers/test_slow_sound.py
@@ -312,7 +312,7 @@ def test_panel_accepts_multiple_resonators() -> None:
 # Critical coupling: the analytic perfect-absorption anchor
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "f0,angle", [(250.0, 0.0), (300.0, 0.0), (350.0, np.radians(20.0))]
+    ("f0", "angle"), [(250.0, 0.0), (300.0, 0.0), (350.0, np.radians(20.0))]
 )
 def test_critical_coupling_gives_perfect_absorption(f0: float, angle: float) -> None:
     """The designed geometry yields alpha ~ 1 at the design frequency."""
@@ -378,13 +378,13 @@ def test_critical_coupling_warns_when_infeasible() -> None:
 def test_invalid_inputs() -> None:
     res = _base_resonator()
     f = np.array([300.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="at least one resonator"):
         slit_helmholtz_absorber(f, [], slit_height=1e-3, lattice_step=3e-2, period=5e-2)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'slit_height' must not exceed 'period'"):
         slit_helmholtz_absorber(
             f, res, slit_height=6e-2, lattice_step=3e-2, period=5e-2
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angle' must satisfy"):
         slit_helmholtz_absorber(
             f, res, slit_height=1e-3, lattice_step=3e-2, period=5e-2, angle=np.pi / 2.0
         )

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -282,17 +282,19 @@ def test_no_sample_area_warning_at_limits() -> None:
 
 
 def test_negative_volume_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'volume' must be positive"):
         materials.absorption_area(3.0, -1.0)
 
 
 def test_zero_reverberation_time_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Reverberation times must be positive"):
         materials.absorption_area(0.0, 200.0)
 
 
 def test_negative_m_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Air attenuation coefficient 'm' must be non-negative"
+    ):
         materials.absorption_area(3.0, 200.0, m=-0.001)
 
 
@@ -314,12 +316,12 @@ def test_m_matching_shape_and_scalar_allowed() -> None:
 
 
 def test_negative_sample_area_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'sample_area' must be positive"):
         materials.absorption_coefficient(5.0, 3.0, 200.0, -10.0)
 
 
 def test_negative_t1_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Reverberation times must be positive"):
         materials.absorption_coefficient(-5.0, 3.0, 200.0, 10.0)
 
 

--- a/tests/materials/test_materials_plot_i18n.py
+++ b/tests/materials/test_materials_plot_i18n.py
@@ -171,7 +171,9 @@ _CASES = [
 ]
 
 
-@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+@pytest.mark.parametrize(
+    ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
+)
 def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
     result = build()
     ax = result.plot(language="es")
@@ -179,7 +181,9 @@ def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
     plt.close("all")
 
 
-@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+@pytest.mark.parametrize(
+    ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
+)
 def test_plot_rejects_unknown_language(name: str, build, spanish: str) -> None:
     result = build()
     with pytest.raises(ValueError, match="Unknown language"):

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -429,7 +429,7 @@ def test_trend_test_plot_renders_and_returns_axes() -> None:
     assert any("Runs $r$ =" in t for t in legend_texts)
     assert any("Sequence median" in t for t in legend_texts)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
     plt.close("all")
 

--- a/tests/metrology/test_metrology_plot_i18n.py
+++ b/tests/metrology/test_metrology_plot_i18n.py
@@ -54,7 +54,7 @@ def test_uncertainty_budget_es() -> None:
     assert ax.get_title().startswith("Presupuesto de incertidumbre (GUM)")
     assert "incertidumbre combinada" in ax.get_xlabel()
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")
 
 
@@ -108,7 +108,7 @@ def test_trend_test_es_and_bad_language() -> None:
     assert "Rachas $r$ =" in _labels(ax)
     assert "Mediana de la secuencia" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -126,7 +126,7 @@ def test_stationarity_test_es_and_bad_language() -> None:
     assert "Rachas $r$ =" in _labels(ax)
     assert "Mediana de la secuencia" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -137,7 +137,7 @@ def test_level_crossing_rate_es_and_bad_language() -> None:
     assert ax.get_ylabel() == "Cruces por segundo [1/s]"
     assert "Expectativa de Rice" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -148,5 +148,5 @@ def test_peak_statistics_es_and_bad_language() -> None:
     assert "Límite de Rayleigh" in _labels(ax)
     assert "Excedencia empírica de picos" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -182,9 +182,9 @@ def test_required_transmission_loss_callable_and_result_shape() -> None:
 
 
 def test_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'external_area' must be positive"):
         noise_control.enclosure_insertion_loss([20.0], -1.0, 5.0, 0.3)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'internal_absorption' must lie strictly in"):
         noise_control.enclosure_insertion_loss([20.0], 6.0, 5.0, 1.0)
     with pytest.raises(ValueError, match="model"):
         noise_control.enclosure_insertion_loss([20.0], 6.0, 5.0, 0.3, model="hansen")

--- a/tests/noise_control/test_hvac.py
+++ b/tests/noise_control/test_hvac.py
@@ -84,7 +84,7 @@ def test_elbow_lined_beats_unlined_high_freq() -> None:
 
 
 def test_elbow_round_rejects_options() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="neither vanes nor lining"):
         hvac.elbow_insertion_loss([500.0], 0.3, bend_type="round", lined=True)
 
 
@@ -156,7 +156,7 @@ def test_plot_and_validation() -> None:
     mpl.use("Agg")
     hvac.end_reflection_loss([125.0, 250.0], 0.3).plot()
     hvac.flow_noise_straight_duct([250.0, 500.0], 10.0, 0.04).plot()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'termination' must be"):
         hvac.end_reflection_loss([125.0], 0.3, termination="bad")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'mean_absorption' must lie strictly"):
         hvac.plenum_attenuation(0.1, 1.0, 20.0, 1.0)

--- a/tests/noise_control/test_room_to_room.py
+++ b/tests/noise_control/test_room_to_room.py
@@ -240,5 +240,5 @@ def test_plot_smoke() -> None:
     assert ax.get_title().startswith("Room-to-room transmission")
     ax_es = result.plot(language="es")
     assert ax_es.get_ylabel() == "Nivel [dB]"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="fr")

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -287,9 +287,9 @@ def test_insertion_loss_present_when_impedances_given() -> None:
 
 
 def test_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'frequencies' must be positive"):
         sl.expansion_chamber([0.0], 0.3, 0.04, 0.01)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'chamber_area' must be positive"):
         sl.expansion_chamber([100.0], 0.3, -0.04, 0.01)
     with pytest.raises(ValueError, match="must exceed"):
         sl.extended_tube_chamber([100.0], 0.3, 0.01, 0.02)

--- a/tests/psychoacoustics/loudness/test_ecma.py
+++ b/tests/psychoacoustics/loudness/test_ecma.py
@@ -146,19 +146,19 @@ def test_result_structure(ref_1k_40: psychoacoustics.EcmaLoudness) -> None:
 
 def test_invalid_field() -> None:
     tone = _tone(1000.0, 40.0, seconds=0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="field must be"):
         psychoacoustics.loudness_ecma(tone, FS, field="reverberant")
 
 
 def test_invalid_fs() -> None:
     tone = _tone(1000.0, 40.0, seconds=0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="fs must be positive"):
         psychoacoustics.loudness_ecma(tone, 0.0)
 
 
 def test_empty_signal() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="signal must not be empty"):
         psychoacoustics.loudness_ecma(empty, FS)
 
 

--- a/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
@@ -122,7 +122,7 @@ _C1_1KHZ = [
 ]
 
 
-@pytest.mark.parametrize("level_db, sone, phon", _C1_1KHZ)
+@pytest.mark.parametrize(("level_db", "sone", "phon"), _C1_1KHZ)
 def test_annex_c1_1khz_tone(mg_tone, level_db: float, sone: float, phon: float) -> None:
     """1 kHz tone 10-80 dB reaches the Annex C.1 peak long-term loudness."""
     res = mg_tone(1000.0, level_db)
@@ -149,7 +149,9 @@ _C1_OTHER = [
 ]
 
 
-@pytest.mark.parametrize("frequency, level_db, field, presentation, phon", _C1_OTHER)
+@pytest.mark.parametrize(
+    ("frequency", "level_db", "field", "presentation", "phon"), _C1_OTHER
+)
 def test_annex_c1_other_tones(
     mg_tone,
     frequency: float,
@@ -177,7 +179,9 @@ _C1_SONE = [
 ]
 
 
-@pytest.mark.parametrize("frequency, field, presentation, level_db, sone", _C1_SONE)
+@pytest.mark.parametrize(
+    ("frequency", "field", "presentation", "level_db", "sone"), _C1_SONE
+)
 def test_annex_c1_sone_values(
     mg_tone,
     frequency: float,
@@ -207,7 +211,7 @@ _C3_CASES = [
 ]
 
 
-@pytest.mark.parametrize("freqs, level_db, sone, phon", _C3_CASES)
+@pytest.mark.parametrize(("freqs", "level_db", "sone", "phon"), _C3_CASES)
 def test_annex_c3_multi_tone(
     freqs: list, level_db: float, sone: float, phon: float
 ) -> None:

--- a/tests/psychoacoustics/quality/test_annoyance.py
+++ b/tests/psychoacoustics/quality/test_annoyance.py
@@ -76,13 +76,13 @@ def test_pa_silence_is_zero() -> None:
 
 @pytest.mark.parametrize("bad", [-1.0, math.nan, math.inf])
 def test_pa_rejects_bad_inputs(bad: float) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'n5'.*non-negative"):
         psychoacoustics.psychoacoustic_annoyance(bad, 2.0, 0.5, 0.3)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'sharpness'.*non-negative"):
         psychoacoustics.psychoacoustic_annoyance(10.0, bad, 0.5, 0.3)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fluctuation_strength'.*non-negative"):
         psychoacoustics.psychoacoustic_annoyance(10.0, 2.0, bad, 0.3)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'roughness'.*non-negative"):
         psychoacoustics.psychoacoustic_annoyance(10.0, 2.0, 0.5, bad)
 
 

--- a/tests/psychoacoustics/quality/test_fluctuation_strength.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength.py
@@ -213,11 +213,11 @@ def test_signal_rejects_bad_inputs() -> None:
     empty = np.array([])
     with_nan = np.array([1.0, np.nan])
     valid = _am_tone(1000.0, 60.0, 1.0, 4.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'signal' must be one-dimensional"):
         psychoacoustics.fluctuation_strength(two_dimensional, _FS)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'signal' must not be empty"):
         psychoacoustics.fluctuation_strength(empty, _FS)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'signal' must be finite"):
         psychoacoustics.fluctuation_strength(with_nan, _FS)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         psychoacoustics.fluctuation_strength(valid, 0.0)

--- a/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
@@ -299,27 +299,27 @@ def test_result_structure(
 
 def test_invalid_field_raises() -> None:
     sig = _tone(1000.0, 60.0, 1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="field must be"):
         psychoacoustics.fluctuation_strength_ecma(sig, FS, field="bogus")
 
 
 def test_empty_signal_raises() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="signal must not be empty"):
         psychoacoustics.fluctuation_strength_ecma(empty, FS)
 
 
 @pytest.mark.parametrize("bad_fs", [0.0, -48000.0, float("nan"), float("inf")])
 def test_invalid_fs_raises(bad_fs: float) -> None:
     sig = _tone(1000.0, 60.0, 1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         psychoacoustics.fluctuation_strength_ecma(sig, bad_fs)
 
 
 def test_non_finite_signal_raises() -> None:
     sig = _tone(1000.0, 60.0, 1.0)
     sig[100] = np.nan
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'signal' must be finite"):
         psychoacoustics.fluctuation_strength_ecma(sig, FS)
 
 

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -143,13 +143,13 @@ def test_result_structure(
 
 def test_invalid_field_raises() -> None:
     tone = _tone(1000.0, 60.0, 0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="field.*'free'"):
         psychoacoustics.roughness_ecma(tone, FS, field="bogus")
 
 
 def test_empty_signal_raises() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="signal must not be empty"):
         psychoacoustics.roughness_ecma(empty, FS)
 
 

--- a/tests/psychoacoustics/quality/test_tonality_ecma.py
+++ b/tests/psychoacoustics/quality/test_tonality_ecma.py
@@ -276,19 +276,19 @@ def test_result_structure(ref_1k_40: psychoacoustics.EcmaTonality) -> None:
 
 def test_invalid_field() -> None:
     tone = _tone(1000.0, 40.0, seconds=0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="field must be"):
         psychoacoustics.tonality_ecma(tone, FS, field="reverberant")
 
 
 def test_invalid_fs() -> None:
     tone = _tone(1000.0, 40.0, seconds=0.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="fs must be positive"):
         psychoacoustics.tonality_ecma(tone, 0.0)
 
 
 def test_empty_signal() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="signal must not be empty"):
         psychoacoustics.tonality_ecma(empty, FS)
 
 

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -245,7 +245,7 @@ def test_mean_narrowband_level_rejects_unsorted_frequencies() -> None:
 
 
 def test_tone_level_rejects_non_finite_ls() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'mean_narrowband_level' must be finite"):
         psychoacoustics.tone_level(
             [50.0, 60.0, 50.0], [100.0, 102.7, 105.4], 102.7, float("nan")
         )
@@ -503,9 +503,9 @@ def test_resolve_separately_uses_more_prominent_tone() -> None:
 
 
 def test_resolve_separately_rejects_bad_input() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'tone1_frequency' must be a positive"):
         psychoacoustics.resolve_tones_separately(-1.0, 200.0, 1.0, 1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'audibility1' must be finite"):
         psychoacoustics.resolve_tones_separately(200.0, 260.0, math.nan, 1.0)
 
 
@@ -607,27 +607,29 @@ def test_plot_rejects_unknown_view() -> None:
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize("bad", [0.0, -1.0, float("nan"), float("inf")])
 def test_critical_bandwidth_rejects_bad_frequency(bad: float) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'tone_frequency' must be a positive"):
         psychoacoustics.critical_bandwidth_engineering(bad)
 
 
 def test_critical_band_level_rejects_bad_spacing() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'line_spacing' must be a positive"):
         psychoacoustics.critical_band_level(50.0, 137.3, 0.0)
 
 
 def test_audibility_rejects_non_finite() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'tone_level' must be finite"):
         psychoacoustics.audibility_from_levels(float("nan"), 60.0, -2.0)
 
 
 def test_energy_sum_rejects_empty() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'line_levels' must contain at least one line"
+    ):
         psychoacoustics.energy_sum_level([])
 
 
 def test_mean_audibility_rejects_empty() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'decisive_audibilities' must not be empty"):
         psychoacoustics.mean_audibility([])
 
 
@@ -637,7 +639,7 @@ def test_assess_tones_rejects_length_mismatch() -> None:
 
 
 def test_assess_tones_rejects_empty() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="At least one tone is required"):
         psychoacoustics.assess_tones([], [], [], 2.7)
 
 

--- a/tests/room/test_acoustics.py
+++ b/tests/room/test_acoustics.py
@@ -319,13 +319,13 @@ def test_rejects_bad_input() -> None:
     two_dimensional = np.zeros((2, 100))
     silent = np.zeros(100)
     decaying = exponential_ir(1.0, 1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="impulse response must be one-dimensional"):
         room.room_parameters(two_dimensional, FS)  # 2D
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'ir' is silent"):
         room.room_parameters(silent, FS)  # silent
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         room.room_parameters(decaying, 0)  # bad fs
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'ir' is silent"):
         room.decay_curve(silent, FS)  # silent
 
 

--- a/tests/room/test_image_source.py
+++ b/tests/room/test_image_source.py
@@ -161,7 +161,7 @@ def _energy_density_t60(res: room.ImageSourceResult, win: float = 0.008) -> floa
     return float(-60.0 / slope)
 
 
-@pytest.mark.parametrize("length,alpha", [(5.0, 0.12), (4.0, 0.15), (6.0, 0.1)])
+@pytest.mark.parametrize(("length", "alpha"), [(5.0, 0.12), (4.0, 0.15), (6.0, 0.1)])
 def test_cubic_room_recovers_eyring(length: float, alpha: float) -> None:
     dims = (length, length, length)
     volume = length**3
@@ -412,11 +412,11 @@ def test_coincident_source_receiver_rejected() -> None:
 
 
 def test_bad_dimension_and_fs() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'Lx' must be positive"):
         room.image_source_rir(
             (0.0, 4.0, 3.0), (1.0, 2.0, 1.5), (3.0, 2.0, 1.5), 0.2, fs=16000
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Sample rate 'fs'"):
         room.image_source_rir(
             (5.0, 4.0, 3.0), (1.0, 2.0, 1.5), (3.0, 2.0, 1.5), 0.2, fs=0
         )

--- a/tests/room/test_modes.py
+++ b/tests/room/test_modes.py
@@ -255,11 +255,11 @@ def test_plot_on_supplied_axes_draws_the_ladder_only() -> None:
 
 
 def test_other_validation_errors() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'max_frequency' must be positive"):
         room.room_modes(LONG_ROOM, max_frequency=0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'speed_of_sound' must be positive"):
         room.room_modes(LONG_ROOM, speed_of_sound=-1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'reverberation_time' must be positive"):
         room.room_modes(LONG_ROOM, reverberation_time=0.0)
     with pytest.raises(ValueError, match="non-negative integers"):
         room.room_mode_frequency((1, -1, 0), LONG_ROOM)

--- a/tests/room/test_room_plot_i18n.py
+++ b/tests/room/test_room_plot_i18n.py
@@ -140,7 +140,9 @@ _CASES = [
 ]
 
 
-@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+@pytest.mark.parametrize(
+    ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
+)
 def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
     result = build()
     ax = result.plot(language="es")
@@ -148,7 +150,9 @@ def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
     plt.close("all")
 
 
-@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+@pytest.mark.parametrize(
+    ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
+)
 def test_plot_rejects_unknown_language(name: str, build, spanish: str) -> None:
     result = build()
     with pytest.raises(ValueError, match="Unknown language"):

--- a/tests/room/test_steady_field.py
+++ b/tests/room/test_steady_field.py
@@ -37,7 +37,7 @@ def test_room_constant_domain() -> None:
         room.room_constant(100.0, 1.0)
     with pytest.raises(ValueError, match="strictly in"):
         room.room_constant(100.0, 0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'surface_area' must be positive"):
         room.room_constant(-1.0, 0.2)
 
 
@@ -155,16 +155,16 @@ def test_steady_state_field_custom_distances() -> None:
 
 
 def test_steady_field_validation() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'distance' must be positive"):
         room.steady_state_spl(90.0, -1.0, 25.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'room_constant' must be positive"):
         room.steady_state_spl(90.0, 1.0, -25.0)
     with pytest.raises(ValueError, match="source_model"):
         room.steady_state_spl(90.0, 1.0, 25.0, source_model="constant_intensity")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'reverberation_time' must be positive"):
         room.schroeder_frequency(-1.0, 200.0)
     empty = np.array([])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'distances' must be a non-empty"):
         room.steady_state_field(90.0, 100.0, 0.2, distances=empty)
 
 

--- a/tests/signals/test_levels.py
+++ b/tests/signals/test_levels.py
@@ -184,7 +184,7 @@ def test_lc_peak_multichannel_and_dbfs() -> None:
 
 
 @pytest.mark.parametrize(
-    "cycles,freq,ref,tol",
+    ("cycles", "freq", "ref", "tol"),
     [
         # BS EN 61672-1:2013 Table 5 (standard page 27): reference differences
         # LCpeak - LC and class 1 acceptance limits. Test frequencies are the
@@ -219,7 +219,7 @@ def test_lc_peak_iec_table5(cycles: float, freq: float, ref: float, tol: float) 
 
 
 @pytest.mark.parametrize(
-    "cycles,freq,ref,tol",
+    ("cycles", "freq", "ref", "tol"),
     [
         # Same BS EN 61672-1:2013 Table 5 cases as above, at a field-typical
         # 48 kHz (audit N2 I-1: the standard test ran only at 96 kHz, masking

--- a/tests/signals/test_parametrized_signals.py
+++ b/tests/signals/test_parametrized_signals.py
@@ -8,7 +8,7 @@ from phonometry import filters
 
 
 @pytest.mark.parametrize(
-    "fraction, expected_bands",
+    ("fraction", "expected_bands"),
     [
         (1, 11),  # Standard 1 octave bands in [12, 20000] approx
         (3, 33),  # Standard 1/3 octave

--- a/tests/signals/test_signals_plot_i18n.py
+++ b/tests/signals/test_signals_plot_i18n.py
@@ -53,7 +53,7 @@ def test_spectral_density_es_and_bad_language() -> None:
     assert "Densidad espectral de Welch" in ax.get_title()
     assert ax.get_xlabel() == "Frecuencia [Hz]"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -64,7 +64,7 @@ def test_multitaper_psd_es_and_bad_language() -> None:
     assert ax.get_xlabel() == "Frecuencia [Hz]"
     assert "de confianza" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -93,7 +93,7 @@ def test_spectrogram_es() -> None:
     assert ax.get_xlabel() == "Tiempo [s]"
     assert ax.get_ylabel() == "Frecuencia [Hz]"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -103,7 +103,7 @@ def test_zoom_fft_es() -> None:
     assert ax.get_title() == "FFT con zoom (Bendat y Piersol 11.5.4)"
     assert ax.get_ylabel() == "Espectro de potencia [dB]"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -113,7 +113,7 @@ def test_correlation_es() -> None:
     assert ax.get_title() == "Estimación de autocorrelación (Bendat y Piersol)"
     assert ax.get_xlabel() == "Retardo [s]"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -149,7 +149,7 @@ def test_aligned_impulse_response_es() -> None:
     assert "Alineación de la respuesta al impulso" in ax.get_title()
     assert "RI de referencia" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -173,7 +173,7 @@ def test_cepstrum_es() -> None:
     ax = res.plot(language="es")
     assert "Cepstro de potencia" in _titles(ax)
     assert "Quefrencia [ms]" in _labels(ax)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
     plt.close("all")
 
@@ -212,7 +212,7 @@ def test_tone_burst_es_and_bad_language() -> None:
     assert ax.get_xlabel() == "Tiempo [s]"
     assert "Envolvente de conmutación" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -226,7 +226,7 @@ def test_resampled_signal_es_and_bad_language() -> None:
     assert "Filtro antisolapamiento" in _labels(ax)
     assert "Borde de la banda de paso" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -237,7 +237,7 @@ def test_window_metrics_es_and_bad_language() -> None:
     assert "Pérdida de festoneado" in _labels(axes)
     assert "bins de la DFT" in _labels(axes)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -254,5 +254,5 @@ def test_inverse_filter_es() -> None:
     assert "Inversión regularizada (Kirkeby)" in ax.get_title()
     assert "Banda ecualizada" in _labels(ax)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/signals/test_synchronous_average.py
+++ b/tests/signals/test_synchronous_average.py
@@ -336,6 +336,6 @@ def test_plot_rejects_unknown_language() -> None:
     result = ph.signals.time_synchronous_average(
         _repeat(_periodic(PERIOD, M, (1.0,)), 4), FS, period=PERIOD
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="fr")
     plt.close("all")

--- a/tests/simulation/test_simulation_plot_i18n.py
+++ b/tests/simulation/test_simulation_plot_i18n.py
@@ -39,7 +39,7 @@ def test_fdtd_probes_es_and_bad_language() -> None:
     labels = [t.get_text() for t in ax.get_legend().get_texts()]
     assert any(s.startswith("sonda") for s in labels)
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -48,5 +48,5 @@ def test_fdtd_snapshot_es() -> None:
     ax = res.plot(kind="snapshot", frame=-1, language="es")
     assert ax.get_title().startswith("Campo de presión FDTD en $t$ =")
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(kind="snapshot", language="xx")

--- a/tests/speech/test_speech_plot_i18n.py
+++ b/tests/speech/test_speech_plot_i18n.py
@@ -44,7 +44,7 @@ def test_standard_speech_spectrum_es_and_bad_language() -> None:
     assert ax.get_ylabel() == "Nivel del espectro de voz [dB SPL]"
     assert ax.get_title() == "ANSI S3.5-1997 espectro de voz estándar"
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 
@@ -89,7 +89,7 @@ def test_sti_es() -> None:
     assert "Índice de transferencia de modulación MTI" in text
     assert "calificación" in text
     plt.close("all")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
 
 

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -72,7 +72,7 @@ def _analytic_decay_sti(t60: float) -> float:
 
 
 @pytest.mark.parametrize(
-    "bands, expected",
+    ("bands", "expected"),
     [
         ((0, 1), 0.127),  # 125 + 250 Hz
         ((1, 2), 0.279),  # 250 + 500 Hz
@@ -96,7 +96,7 @@ def test_weighting_factor_pairs(bands, expected):
 
 
 @pytest.mark.parametrize(
-    "m, expected_sti",
+    ("m", "expected_sti"),
     [
         (0.0, 0.0),
         (0.059351, 0.1),
@@ -210,7 +210,7 @@ def test_level_corrections_reduce_sti():
 
 
 @pytest.mark.parametrize(
-    "level, expected",
+    ("level", "expected"),
     [(60.0, -35.0), (65.0, -29.9), (80.0, -19.8), (100.0, -10.0)],
 )
 def test_masking_amdb_control_points(level, expected):

--- a/tests/test_diagram_canvas_math.py
+++ b/tests/test_diagram_canvas_math.py
@@ -199,7 +199,7 @@ def test_unbalanced_markup_raises() -> None:
 def test_multicharacter_script_without_braces_raises() -> None:
     # $f_max$ would silently set f with an m subscript and push "ax" back
     # to the baseline; the guard names the string and the ambiguous piece.
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="ambiguous script '_max'") as excinfo:
         _element("cut-off $f_max$ of the array")
     assert "'_max'" in str(excinfo.value)
     assert "'cut-off $f_max$ of the array'" in str(excinfo.value)
@@ -208,7 +208,9 @@ def test_multicharacter_script_without_braces_raises() -> None:
     # An opening bracket right after the script character is the same trap,
     # but braces around the whole tail would swallow the argument into the
     # subscript, so the advice must point at bracing the script alone.
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+        ValueError, match=r"ambiguous script '_n' before '\('"
+    ) as excinfo:
         _element("$f_n(2h)$")
     assert "ambiguous script '_n' before '('" in str(excinfo.value)
     assert "_{n}(...)" in str(excinfo.value)
@@ -218,7 +220,7 @@ def test_comma_glued_to_unbraced_script_raises() -> None:
     # $L_p,i$ would set p as the subscript and push ",i" back to the
     # baseline; the guard demands braces. A spaced-off comma is a list
     # separator and stays legal.
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="ambiguous comma '_p,i'") as excinfo:
         _element("$L_p,i$")
     assert "ambiguous comma '_p,i'" in str(excinfo.value)
     assert "'$L_p,i$'" in str(excinfo.value)
@@ -247,7 +249,7 @@ def test_comma_glued_to_unbraced_script_raises() -> None:
 def test_backslash_in_math_raises() -> None:
     # There are no LaTeX commands in the diagram composer; a backslash
     # would be published as a literal glyph.
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="backslash in math run") as excinfo:
         _element("$\\theta_0$ incidence")
     assert "backslash" in str(excinfo.value)
     # repr doubles the backslash in the quoted pieces of the message.
@@ -256,7 +258,7 @@ def test_backslash_in_math_raises() -> None:
 
 
 def test_unclosed_script_brace_raises_with_context() -> None:
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="unclosed script brace") as excinfo:
         _element("$L_{p$ level")
     assert "unclosed script brace" in str(excinfo.value)
     assert "'_{p'" in str(excinfo.value)
@@ -278,7 +280,9 @@ def test_consecutive_scripts_stay_legal() -> None:
 
 
 def test_nested_script_raises() -> None:
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+        ValueError, match="nested script '_1' inside a script"
+    ) as excinfo:
         _element("$L_{p_1}$")
     assert "nested script" in str(excinfo.value)
     assert "'$L_{p_1}$'" in str(excinfo.value)

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -157,7 +157,7 @@ def _assert_parity(
         np.testing.assert_allclose(got_f, ref_f, rtol=0.0, atol=rtol_peak * peak)
 
 
-@pytest.mark.parametrize("xp,tol", BACKENDS)
+@pytest.mark.parametrize(("xp", "tol"), BACKENDS)
 @pytest.mark.parametrize("direction", list(_WAVES))
 def test_plane_wave_directions_match_library(
     xp: Any, tol: float, direction: str
@@ -178,7 +178,7 @@ def test_plane_wave_directions_match_library(
     assert sim.time == pytest.approx(_STEPS * sim.dt)
 
 
-@pytest.mark.parametrize("xp,tol", BACKENDS)
+@pytest.mark.parametrize(("xp", "tol"), BACKENDS)
 @pytest.mark.parametrize("scenario", list(_scenarios()))
 def test_scenarios_match_library(xp: Any, tol: float, scenario: str) -> None:
     """Each engine feature (and their combination) reproduces the library."""

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -59,18 +59,18 @@ def test_cumulative_sel_differing_strikes() -> None:
 
 
 def test_cumulative_sel_rejects_empty() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'single_sels' must be a non-empty"):
         underwater.cumulative_sel([])
 
 
 def test_cumulative_sel_identical_rejects_zero_strikes() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'n_strikes' must be at least"):
         underwater.cumulative_sel_identical(180.0, 0)
 
 
 def test_cumulative_sel_identical_rejects_fractional_strikes() -> None:
     # A non-integer count must be rejected, not silently truncated to int().
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'n_strikes' must be a whole number"):
         underwater.cumulative_sel_identical(180.0, 1.9)  # type: ignore[arg-type]
 
 
@@ -89,7 +89,7 @@ def test_pile_strike_metrics_bundle_and_plot() -> None:
 
 def test_pile_strike_metrics_rejects_short_signal() -> None:
     too_short = np.array([1.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'pressure' must contain at least"):
         underwater.pile_strike_metrics(too_short, FS)
 
 

--- a/tests/underwater/sources/test_ship_radiated_noise.py
+++ b/tests/underwater/sources/test_ship_radiated_noise.py
@@ -49,9 +49,9 @@ def test_radiated_noise_level_closed_form() -> None:
 
 
 def test_radiated_noise_level_rejects_bad_input() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'rms_pressure'"):
         underwater.radiated_noise_level(0.0, 100.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'distance'"):
         underwater.radiated_noise_level(1e-6, -1.0)
 
 
@@ -96,15 +96,15 @@ def test_hydrophone_depths() -> None:
 
 
 def test_hydrophone_depths_rejects_bad_angles() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angles'"):
         underwater.hydrophone_depths(100.0, angles=(90.0,))
 
 
 def test_hydrophone_depths_rejects_non_finite_angles() -> None:
     # NaN/inf angles must be rejected, not silently yield NaN depths.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angles'"):
         underwater.hydrophone_depths(100.0, angles=(np.nan,))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'angles'"):
         underwater.hydrophone_depths(100.0, angles=(np.inf,))
 
 
@@ -127,5 +127,5 @@ def test_result_plot_smoke() -> None:
 def test_rejects_shape_mismatch() -> None:
     levels_2_bands = np.array([1.0, 2.0])
     frequencies_3_bands = np.array([100.0, 200.0, 300.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'rnl' and 'frequency'"):
         underwater.monopole_source_level(levels_2_bands, frequencies_3_bands, 8.0)

--- a/tests/underwater/test_sonar_equation.py
+++ b/tests/underwater/test_sonar_equation.py
@@ -87,7 +87,7 @@ def test_active_two_way_loss() -> None:
 
 
 def test_rejects_non_finite() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"'source_level'.*finite"):
         passive_sonar_equation(float("nan"), 80.0, 60.0)
 
 

--- a/tests/underwater/test_underwater_acoustics.py
+++ b/tests/underwater/test_underwater_acoustics.py
@@ -64,11 +64,11 @@ def test_rejects_invalid_signal() -> None:
     with_nan = np.array([np.nan, 1.0])
     valid_tone = _tone(500.0, 0.1, 1.0)
     silence = np.zeros(100)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'pressure' must be one-dimensional"):
         underwater.sound_pressure_level(two_dimensional)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'pressure' must be finite"):
         underwater.sound_pressure_level(with_nan)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be a positive"):
         underwater.sound_exposure_level(valid_tone, 0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'pressure' has no energy"):
         underwater.sound_pressure_level(silence)  # no energy

--- a/tests/vibration/machinery/test_diagnostics.py
+++ b/tests/vibration/machinery/test_diagnostics.py
@@ -323,19 +323,19 @@ class TestValidation:
     """Every invalid input is rejected with a ValueError."""
 
     @pytest.mark.parametrize(
-        "kwargs",
+        ("kwargs", "match"),
         [
-            {"speed_rpm": 0.0},
-            {"n_elements": 0},
-            {"element_diameter": 0.0},
-            {"pitch_diameter": 0.0},
-            {"contact_angle_deg": -1.0},
-            {"contact_angle_deg": 90.0},
-            {"rotating_race": "middle"},
+            ({"speed_rpm": 0.0}, "'speed_rpm' must be positive"),
+            ({"n_elements": 0}, "'n_elements' must be a positive integer"),
+            ({"element_diameter": 0.0}, "'element_diameter' must be positive"),
+            ({"pitch_diameter": 0.0}, "'pitch_diameter' must be positive"),
+            ({"contact_angle_deg": -1.0}, "'contact_angle_deg' must be non-negative"),
+            ({"contact_angle_deg": 90.0}, "'contact_angle_deg' must be below"),
+            ({"rotating_race": "middle"}, "'rotating_race' must be one of"),
         ],
     )
-    def test_bearing_rejects(self, kwargs: dict[str, object]) -> None:
-        with pytest.raises(ValueError):
+    def test_bearing_rejects(self, kwargs: dict[str, object], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
             bearing_fault_frequencies(**{**_P85, **kwargs})  # type: ignore[arg-type]
 
     def test_bearing_rejects_element_larger_than_pitch(self) -> None:
@@ -343,27 +343,32 @@ class TestValidation:
             bearing_fault_frequencies(2000.0, 15, 40.0, 34.0)
 
     @pytest.mark.parametrize(
-        "kwargs",
-        [{"n_teeth": 0}, {"harmonics": 0}, {"sidebands": -1}, {"sideband_rate": 0.0}],
+        ("kwargs", "match"),
+        [
+            ({"n_teeth": 0}, "'n_teeth' must be a positive integer"),
+            ({"harmonics": 0}, "'harmonics' must be a positive integer"),
+            ({"sidebands": -1}, "'sidebands' must be a non-negative integer"),
+            ({"sideband_rate": 0.0}, "'sideband_rate' must be positive"),
+        ],
     )
-    def test_gear_rejects(self, kwargs: dict[str, object]) -> None:
-        with pytest.raises(ValueError):
+    def test_gear_rejects(self, kwargs: dict[str, object], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
             gear_mesh_frequencies(1500.0, **{"n_teeth": 28, **kwargs})  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
-        "kwargs",
+        ("kwargs", "match"),
         [
-            {"poles": 3},
-            {"poles": 0},
-            {"rotor_bars": 0},
-            {"slip": 1.0},
-            {"slip": -0.1},
-            {"slot_harmonics": 0},
-            {"sidebands": -1},
+            ({"poles": 3}, "'poles' must be an even integer"),
+            ({"poles": 0}, "'poles' must be an even integer"),
+            ({"rotor_bars": 0}, "'rotor_bars' must be a positive integer"),
+            ({"slip": 1.0}, "'slip' must be below"),
+            ({"slip": -0.1}, "'slip' must be non-negative"),
+            ({"slot_harmonics": 0}, "'slot_harmonics' must be a positive integer"),
+            ({"sidebands": -1}, "'sidebands' must be a non-negative integer"),
         ],
     )
-    def test_motor_rejects(self, kwargs: dict[str, object]) -> None:
-        with pytest.raises(ValueError):
+    def test_motor_rejects(self, kwargs: dict[str, object], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
             induction_motor_frequencies(
                 1750.0, **{"poles": 4, "rotor_bars": 52, **kwargs}
             )  # type: ignore[arg-type]
@@ -374,11 +379,16 @@ class TestValidation:
             induction_motor_frequencies(3600.0, 4, 52, supply_frequency=60.0)
 
     @pytest.mark.parametrize(
-        "kwargs",
-        [{"n_blades": 0}, {"harmonics": 0}, {"n_vanes": 0}, {"lobe_orders": 0}],
+        ("kwargs", "match"),
+        [
+            ({"n_blades": 0}, "'n_blades' must be a positive integer"),
+            ({"harmonics": 0}, "'harmonics' must be a positive integer"),
+            ({"n_vanes": 0}, "'n_vanes' must be a positive integer"),
+            ({"lobe_orders": 0}, "'lobe_orders' must be a positive integer"),
+        ],
     )
-    def test_blade_rejects(self, kwargs: dict[str, object]) -> None:
-        with pytest.raises(ValueError):
+    def test_blade_rejects(self, kwargs: dict[str, object], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
             blade_pass_frequencies(3500.0, **{"n_blades": 6, **kwargs})  # type: ignore[arg-type]
 
     def test_unknown_line_name(self) -> None:

--- a/tests/vibration/structural/test_experimental_sea.py
+++ b/tests/vibration/structural/test_experimental_sea.py
@@ -365,7 +365,7 @@ class TestValidation:
 
     @pytest.mark.parametrize("bad", [0.0, -1.0])
     def test_non_positive_inputs(self, bad: float) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="'energy1' must be strictly positive"):
             power_injection_clf(500.0, bad, 0.1, 4.4e-3, 2.4e-3, 1.0, 1.0)
 
     def test_band_length_mismatch(self) -> None:
@@ -403,19 +403,28 @@ class TestValidation:
             power_injection_matrix(_ONE_BAND, energies, powers)
 
     def test_unknown_band(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="'band' must be one of"):
             cylindrical_shell_modal_density(500.0, 9.4, 0.003, 0.75, _CL, band="half")
 
     @pytest.mark.parametrize(
-        "call",
+        ("call", "message"),
         [
-            lambda: bar_modal_density(0.0, 5150.0),
-            lambda: bar_modal_density(1.0, 0.0),
-            lambda: beam_modal_density(100.0, 0.0, 7.8, 1.2e4),
-            lambda: flat_plate_modal_density(1.0, 0.0, 5150.0),
-            lambda: ring_frequency(0.0, 5150.0),
+            (lambda: bar_modal_density(0.0, 5150.0), "'length' must be positive"),
+            (
+                lambda: bar_modal_density(1.0, 0.0),
+                "'longitudinal_wave_speed' must be positive",
+            ),
+            (
+                lambda: beam_modal_density(100.0, 0.0, 7.8, 1.2e4),
+                "'length' must be positive",
+            ),
+            (
+                lambda: flat_plate_modal_density(1.0, 0.0, 5150.0),
+                "'thickness' must be positive",
+            ),
+            (lambda: ring_frequency(0.0, 5150.0), "'mean_radius' must be positive"),
         ],
     )
-    def test_non_positive_geometry(self, call) -> None:  # type: ignore[no-untyped-def]
-        with pytest.raises(ValueError):
+    def test_non_positive_geometry(self, call, message: str) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError, match=message):
             call()

--- a/tests/vibration/structural/test_junction_transmission.py
+++ b/tests/vibration/structural/test_junction_transmission.py
@@ -335,9 +335,13 @@ def test_kij_identical_plates_uses_common_critical_frequency() -> None:
 
 
 def test_kij_rejects_nonpositive_critical_frequency() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'critical_frequency_receiver' must be positive"
+    ):
         vibration.wave_vibration_reduction_index(0.1, 0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'critical_frequency_receiver' must be positive"
+    ):
         vibration.wave_vibration_reduction_index(0.1, -100.0)
 
 
@@ -445,28 +449,28 @@ def test_plot_returns_axes() -> None:
 # Validation.
 # ---------------------------------------------------------------------------
 def test_unknown_junction_rejected() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'junction' must be one of"):
         vibration.corner_transmission_coefficient(0.0, 1.0, 1.0, "Z")
 
 
 def test_negative_parameters_rejected() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'chi' must be positive"):
         vibration.corner_transmission_coefficient(0.0, -1.0, 1.0, "X")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'thickness1' must be positive"):
         vibration.junction_wave_parameters(-0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
 
 
 def test_out_of_range_angle_rejected() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"'angle' must lie in \[0, pi/2\]"):
         vibration.corner_transmission_coefficient(2.0, 1.0, 1.0, "X")  # > pi/2
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"'angle' must lie in \[0, pi/2\]"):
         vibration.corner_transmission_coefficient(-0.1, 1.0, 1.0, "X")
 
 
 def test_straight_section_undefined_for_t2_and_l() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="has no straight section"):
         vibration.straight_transmission_coefficient(0.0, 1.0, 1.0, "T2")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="has no straight section"):
         vibration.straight_transmission_coefficient(0.0, 1.0, 1.0, "L")
 
 
@@ -634,18 +638,18 @@ def test_norton_reciprocity_needs_the_plate_areas() -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "match"),
     [
-        {"thickness1": 0.0},
-        {"thickness2": -1.0},
-        {"density1": 0.0},
-        {"density2": 0.0},
-        {"wave_speed1": 0.0},
-        {"wave_speed2": 0.0},
-        {"incidence": "grazing"},
+        ({"thickness1": 0.0}, "'thickness1' must be positive"),
+        ({"thickness2": -1.0}, "'thickness2' must be positive"),
+        ({"density1": 0.0}, "'density1' must be positive"),
+        ({"density2": 0.0}, "'density2' must be positive"),
+        ({"wave_speed1": 0.0}, "'wave_speed1' must be positive"),
+        ({"wave_speed2": 0.0}, "'wave_speed2' must be positive"),
+        ({"incidence": "grazing"}, "'incidence' must be one of"),
     ],
 )
-def test_right_angle_validation(kwargs: dict[str, object]) -> None:
+def test_right_angle_validation(kwargs: dict[str, object], match: str) -> None:
     base: dict[str, object] = {
         "thickness1": _H1,
         "thickness2": _H2,
@@ -657,21 +661,21 @@ def test_right_angle_validation(kwargs: dict[str, object]) -> None:
     base.update(kwargs)
     thickness1 = base.pop("thickness1")
     thickness2 = base.pop("thickness2")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         vibration.right_angle_transmission_coefficient(thickness1, thickness2, **base)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "match"),
     [
-        {"n_connections": 0},
-        {"thickness1": 0.0},
-        {"surface_density1": 0.0},
-        {"wave_speed2": -1.0},
-        {"plate_area1": 0.0},
+        ({"n_connections": 0}, "'n_connections' must be a positive integer"),
+        ({"thickness1": 0.0}, "'thickness1' must be positive"),
+        ({"surface_density1": 0.0}, "'surface_density1' must be positive"),
+        ({"wave_speed2": -1.0}, "'wave_speed2' must be positive"),
+        ({"plate_area1": 0.0}, "'plate_area1' must be positive"),
     ],
 )
-def test_point_connection_validation(kwargs: dict[str, object]) -> None:
+def test_point_connection_validation(kwargs: dict[str, object], match: str) -> None:
     base: dict[str, object] = {
         "n_connections": 12,
         "thickness1": _H1,
@@ -684,12 +688,12 @@ def test_point_connection_validation(kwargs: dict[str, object]) -> None:
     }
     base.update(kwargs)
     n = base.pop("n_connections")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         vibration.point_connection_coupling_loss_factor(500.0, n, **base)  # type: ignore[arg-type]
 
 
 def test_point_connection_rejects_non_positive_frequency() -> None:
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'frequency' must be positive"):
         vibration.point_connection_coupling_loss_factor(
             [500.0, 0.0],
             12,


### PR DESCRIPTION
A test that expects an error should say which error. This selects `PT` and
gives a message fragment to the 241 `pytest.raises(ValueError)` calls that had
none.

This is the habit catching up with itself rather than a new rule: 1755 of the
2065 `pytest.raises` in the suite already passed `match=`. What is here is the
stragglers.

## Why a fragment, and which fragment

`match=` is a `re.search` over the message, so a bare `pytest.raises(ValueError)`
passes when *any* guard fires, including the wrong one, and the wrong guard
firing is exactly the regression the test was written to catch. Each of the 241
was resolved by opening the guard it actually lands on and working out which one
fires first for those arguments, not by reading the test around it.

The fragment is the part of the message that does not move: the parameter the
guard is about, and not the sentence around it.

- Not a bound. `Standing-wave ratio 's' must be` rather than `... must be >= 1`.
- Not the list of allowed values. `'termination' must be` rather than
  `... must be 'flush' or 'free'`, because the list grows when a value is added,
  and this library already spells the same guard both as `must be 'a' or 'b'`
  and as `must be one of {...}`.
- Not wording that belongs to somebody else. One test lands on numpy's
  shape-mismatch message, which is assembled inside a C extension and carries no
  stability promise, so it pins the one word that names the failure.
- But a message that is already just a parameter and a predicate,
  `'frequencies' must be positive`, is quoted whole. There is nothing volatile
  in it to drop, and trimming further would lose the predicate.

Every fragment names its parameter. A fragment without one is worth very little:
`non-negative` appears in 95 distinct messages in this library, `one-dimensional`
in 24 and `same length` in 21.

## Two tests that were passing without checking anything

Reading the guards turned up two `match=` that already existed and pinned
nothing. Neither is reported by the linter, because both do pass a `match=`.

- `test_short_frequencies_raises_value_error_not_index_error` waited on
  `frequencies`, a word three separate messages in that module contain.
- A test named for rejecting a non-positive frequency waited on
  `must be positive`, which every positivity guard in its module shares.

Both now name their guard.

## Also here

- 44 `parametrize` decorators take the shape the other 467 already use: a tuple
  for the names, a list for the values.
- Ten assertions of the form `assert a is not None and b is not None` became two
  assertions, so a failure says which of the two was missing.

## Checks

`ruff check .` and `ruff format --check .` clean with `PT` selected,
`mypy src scripts stub/src` clean, bandit clean, conformance 550/550 with the
claims check consistent, the 42 committed clips still fresh, and no generated
artifact moved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Make validation tests identify the specific errors they expect while tightening per-band input validation and test diagnostics.

New Features:
- Add validation for per-band inputs, rejecting non-scalar values whose length does not match the frequency bands and identifying the offending parameter.

Enhancements:
- Require expected error-message fragments across ValueError tests to ensure tests detect the intended validation guard.
- Improve failure diagnostics by splitting compound non-None assertions and standardize parametrization declarations.

Documentation:
- Document additional ValueError conditions for structure-borne power calculations.

Tests:
- Strengthen hundreds of exception tests with targeted message matching and add coverage for valid scalar and invalid per-band inputs.

Chores:
- Enable Ruff's PT rules for the test suite.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enforced explicit error message matching for all pytest.raises calls by enabling the PT linter rule.</li>
<li>Updated 241 pytest.raises(ValueError) calls to include specific match messages, improving test robustness.</li>
<li>Refactored compound assertions (e.g., 'assert a is not None and b is not None') into separate statements to provide clearer failure diagnostics.</li>
<li>Standardized 44 parametrize decorators to use the preferred tuple-for-names and list-for-values format.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for per-band inputs, ensuring scalar values or arrays match the number of frequency bands.
  * Improved error reporting for incompatible per-band input shapes.

* **Quality Improvements**
  * Strengthened validation checks with clearer, parameter-specific error messages.
  * Standardized test parametrization and independent assertions for more precise failure reporting.
  * Enabled additional validation-focused linting rules.

* **Documentation**
  * Updated the unreleased changelog with testing and validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->