### PR TITLE
Reach a path through Path, and build a list by saying so

### DIFF
--- a/.github/scripts/comment_pr.py
+++ b/.github/scripts/comment_pr.py
@@ -7,6 +7,7 @@ a collapsed section below it.
 
 import os
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 
 def parse_test_results(test_dir):
@@ -14,7 +15,7 @@ def parse_test_results(test_dir):
     total_tests = 0
     total_failures = 0
 
-    if not os.path.exists(test_dir):
+    if not Path(test_dir).exists():
         return "No test results found.", 0, 0
 
     # Distinguish between test results and coverage reports
@@ -23,21 +24,24 @@ def parse_test_results(test_dir):
 
     for root, _, filenames in os.walk(test_dir):
         for filename in filenames:
-            f_path = os.path.join(root, filename)
+            f_path = Path(root) / filename
             if filename.startswith("test-results-") and filename.endswith(".xml"):
                 test_files.append(f_path)
             elif filename == "coverage.xml":
                 # Extract version from parent directory name
-                version = os.path.basename(root).replace("test-results-", "")
+                version = Path(root).name.replace("test-results-", "")
                 coverage_files[version] = f_path
 
-    test_files.sort()
+    # Sorted as text, so the row order does not depend on whether the list
+    # holds strings or Path objects: a Path compares component by component,
+    # which reorders names where one is a prefix of another.
+    test_files.sort(key=str)
 
     summary.append("| Python Version | Tests | Failures | Coverage | Status |")
     summary.append("|---|---|---|---|---|")
 
     for f_path in test_files:
-        f_name = os.path.basename(f_path)
+        f_name = f_path.name
         try:
             tree = ET.parse(f_path)
             root = tree.getroot()
@@ -80,9 +84,9 @@ def parse_test_results(test_dir):
 
 def read_conformance_report():
     """Return the conformance-report Markdown, or a fallback notice."""
-    if os.path.exists("conformance_report.md"):
-        with open("conformance_report.md", encoding="utf-8") as f:
-            return f.read().strip()
+    report = Path("conformance_report.md")
+    if report.exists():
+        return report.read_text(encoding="utf-8").strip()
     return (
         "## Numerical conformance report\n\n"
         "⚠️ The conformance report could not be generated in this run."
@@ -116,8 +120,7 @@ def main():
 <a href="https://github.com/{repo}/actions/runs/{run_id}">full CI artifacts</a></sub>
 """
 
-    with open("pr_comment_body.md", "w", encoding="utf-8") as f:
-        f.write(body)
+    Path("pr_comment_body.md").write_text(body, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- A path is a `Path`, and a loop that only appends is a comprehension. `PTH`
+  and `PERF` are selected, and the 193 sites they found were read one at a
+  time, because the two spellings of a path are not the same type: a `Path`
+  prints like its string and compares unequal to it, so the sites worth
+  reading were the ones that hand their value to a sort, a comparison or a
+  dictionary key. One did. The CI comment builder sorted a list of artifact
+  paths, and sorting `Path` objects compares them component by component
+  rather than as text, which reorders the rows whenever one matrix name is a
+  prefix of another, as `3.13` is of `3.13-dev`. It sorts as text now, and
+  says so.
+
+  Half of what the rules found was one pair of lines copied fifty-four times.
+  Every fiche test carried its own `_assert_one_page` and its own
+  `_PDF_MAGIC`, in eight spellings, and forty-six of them also asserted a
+  non-zero file size, which could not fail: reading the first four bytes and
+  finding `%PDF` already proves the file holds four bytes. Converting each
+  copy would have carried the duplication into `pathlib`, so the assertion
+  that carries weight now lives once, in `tests/report_assertions.py`, and
+  the fifty-four copies are gone.
+
+  Fifteen sites keep the older spelling behind a `noqa` that says why: they
+  sit in the code that draws the animations, which is hashed into
+  `scripts/animation_fingerprints.txt`, so rewriting a line there asks for a
+  re-render of clips that would come back frame for frame identical.
+
 - Every test that expects an error says which error. `PT` is selected, and the
   241 `pytest.raises(ValueError)` calls that named no message now name one.
   This was already the habit rather than a new rule: of the 2075 `pytest.raises`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,15 @@ select = [
                             # not move: the parameter it is about, not the
                             # sentence around it, not a bound, not a list of
                             # allowed values, not wording numpy owns.
+    "PTH",                  # a path is a `Path`. Read one at a time: the two
+                            # spell the same destination but not the same type,
+                            # and a `Path` prints like its string while
+                            # comparing unequal to it, so the sites that hand
+                            # their value to a sort, a comparison or a
+                            # dictionary key were the ones worth reading.
+    "PERF",                 # a loop whose whole body is one `append` is a
+                            # comprehension, unless saying so costs more lines
+                            # than it saves
 ]
 ignore = [
     # TC006 quotes the first argument of `typing.cast`, which that function
@@ -207,11 +216,6 @@ ignore = [
     "D203",  # a blank line before a class docstring; D211 is the house shape
     "D213",  # the summary on the second line; D212 is the house shape
 ]
-# Selected next, in their own review, because each is a change to code rather
-# than to its shape and the diff has to be readable to be checked:
-#   PTH   (158) pathlib over os.path.
-#   PERF   (34) manual loops that build a list.
-
 [tool.ruff.lint.per-file-ignores]
 # `matplotlib.use("Agg")` has to run between `import matplotlib` and the first
 # `import matplotlib.pyplot`, and the scripts put the repository on `sys.path`

--- a/scripts/check_animation_freshness.py
+++ b/scripts/check_animation_freshness.py
@@ -72,12 +72,12 @@ def main() -> int:
     current = fp.fingerprints(_SCRIPTS.parent)
     stamped = fp.read_manifest()
     problems: list[str] = []
+    problems.extend(
+        f"{clip}: stamped in {fp.MANIFEST.name} but no longer a registered "
+        "clip; delete the line if the clip is gone"
+        for clip in sorted(set(stamped) - set(current))
+    )
 
-    for clip in sorted(set(stamped) - set(current)):
-        problems.append(
-            f"{clip}: stamped in {fp.MANIFEST.name} but no longer a registered "
-            "clip; delete the line if the clip is gone"
-        )
     for clip in sorted(current):
         expected = outputs(clip)
         missing = [name for name in expected if not (IMAGES / name).exists()]

--- a/scripts/check_doc_snippets.py
+++ b/scripts/check_doc_snippets.py
@@ -150,12 +150,12 @@ def _rebindings(tree: ast.AST, names: dict[str, int]) -> list[str]:
                         f"name imported from phonometry on line {names[name]}"
                     )
         elif isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id in names:
-                    reports.append(
-                        f"line {node.lineno}: '{target.id} = ...' rebinds the name "
-                        f"imported from phonometry on line {names[target.id]}"
-                    )
+            reports += [
+                f"line {node.lineno}: '{target.id} = ...' rebinds the name "
+                f"imported from phonometry on line {names[target.id]}"
+                for target in node.targets
+                if isinstance(target, ast.Name) and target.id in names
+            ]
     return reports
 
 
@@ -180,8 +180,10 @@ def check_shadowing(pages: list[pathlib.Path], *, carry: bool = True) -> list[st
             imported = _phonometry_imports(tree)
             seen = {**carried, **imported}
             if seen:
-                for report in _rebindings(tree, seen):
-                    failures.append(f"{_rel(page)} block {i}: {report}")
+                failures += [
+                    f"{_rel(page)} block {i}: {report}"
+                    for report in _rebindings(tree, seen)
+                ]
             # A block that rebinds a carried name owns it from here on.
             for node in ast.walk(tree):
                 if isinstance(node, ast.Assign):

--- a/scripts/check_errata_evidence.py
+++ b/scripts/check_errata_evidence.py
@@ -263,9 +263,11 @@ def _candidate_ratios(body: str) -> list[tuple[str, float]]:
     """Multiplicative claims stated in an entry, as (quotation, ratio)."""
     body = _plain(body)
     found: list[tuple[str, float]] = []
-    for pattern in (_TIMES, _FACTOR):
-        for match in pattern.finditer(body):
-            found.append((match.group(0), _number(match.group("value"))))
+    found.extend(
+        (match.group(0), _number(match.group("value")))
+        for pattern in (_TIMES, _FACTOR)
+        for match in pattern.finditer(body)
+    )
     for match in _DECIBEL.finditer(body):
         raw = match.group("value") or match.group("value2")
         decibels = _number(raw)

--- a/scripts/check_figure_language.py
+++ b/scripts/check_figure_language.py
@@ -232,9 +232,11 @@ def write_baseline(path: pathlib.Path, found: dict[str, set[str]]) -> None:
         "# in English belongs in ENGLISH_BY_DESIGN, with its reason.",
         "",
     ]
-    for stem in sorted(found):
-        for text in sorted(found[stem]):
-            lines.append(f"{stem}: {json.dumps(text, ensure_ascii=False)}")
+    lines.extend(
+        f"{stem}: {json.dumps(text, ensure_ascii=False)}"
+        for stem in sorted(found)
+        for text in sorted(found[stem])
+    )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
@@ -296,10 +298,11 @@ def report(
     """Compare the run against the baseline in both directions."""
     problems: list[str] = []
 
-    new: list[tuple[str, str]] = []
-    for stem in sorted(found):
-        for text in sorted(found[stem] - baseline.get(stem, set())):
-            new.append((stem, text))
+    new: list[tuple[str, str]] = [
+        (stem, text)
+        for stem in sorted(found)
+        for text in sorted(found[stem] - baseline.get(stem, set()))
+    ]
     if new:
         problems.append(
             f"{len({stem for stem, _ in new})} figure(s) ship untranslated "
@@ -322,8 +325,7 @@ def report(
                 if stem not in optional:
                     stale.extend((stem, text) for text in sorted(baseline[stem]))
                 continue
-            for text in sorted(baseline[stem] - found[stem]):
-                stale.append((stem, text))
+            stale.extend((stem, text) for text in sorted(baseline[stem] - found[stem]))
         if stale:
             problems.append(
                 f"{len(stale)} baseline line(s) are no longer true "

--- a/scripts/check_figures.py
+++ b/scripts/check_figures.py
@@ -116,10 +116,13 @@ def main() -> int:
     tracked = tracked_files(IMG_DIR)
     problems: list[str] = []
 
-    for path in sorted(disk - tracked):
-        problems.append(f"new figure not committed: {path}")
-    for path in sorted(tracked - disk):
-        problems.append(f"committed figure no longer generated: {path}")
+    problems.extend(
+        f"new figure not committed: {path}" for path in sorted(disk - tracked)
+    )
+    problems.extend(
+        f"committed figure no longer generated: {path}"
+        for path in sorted(tracked - disk)
+    )
 
     for path in sorted(disk & tracked):
         new = Path(path).read_bytes()

--- a/scripts/check_reports.py
+++ b/scripts/check_reports.py
@@ -149,12 +149,13 @@ def _problems() -> list[str]:
     """Collect every way the committed fiches differ from the regenerated ones."""
     disk = {str(p) for p in Path(REPORT_DIR).rglob("*") if p.is_file()}
     tracked = tracked_files(REPORT_DIR)
-    problems: list[str] = []
-
-    for path in sorted(disk - tracked):
-        problems.append(f"new fiche not committed: {path}")
-    for path in sorted(tracked - disk):
-        problems.append(f"committed fiche no longer generated: {path}")
+    problems: list[str] = [
+        f"new fiche not committed: {path}" for path in sorted(disk - tracked)
+    ]
+    problems += [
+        f"committed fiche no longer generated: {path}"
+        for path in sorted(tracked - disk)
+    ]
 
     for path in sorted(disk & tracked):
         new = Path(path).read_bytes()

--- a/scripts/check_subscript_slope.py
+++ b/scripts/check_subscript_slope.py
@@ -124,20 +124,26 @@ def math_regions(text: str, suffix: str) -> list[tuple[int, str]]:
     ``$$...$$`` and ``$...$`` in every file kind, plus the reStructuredText
     ``:math:`...``` roles and ``.. math::`` blocks the docstrings use.
     """
-    out: list[tuple[int, str]] = []
-    for m in re.finditer(r"\$\$(.+?)\$\$", text, re.DOTALL):
-        out.append((m.start(1), m.group(1)))
-    for m in re.finditer(r"(?<![$\\])\$(?!\$)([^$\n]+?)\$(?!\$)", text):
-        out.append((m.start(1), m.group(1)))
+    out: list[tuple[int, str]] = [
+        (m.start(1), m.group(1)) for m in re.finditer(r"\$\$(.+?)\$\$", text, re.DOTALL)
+    ]
+    out.extend(
+        (m.start(1), m.group(1))
+        for m in re.finditer(r"(?<![$\\])\$(?!\$)([^$\n]+?)\$(?!\$)", text)
+    )
     if suffix == ".py":
-        for m in re.finditer(r":math:`(.+?)`", text, re.DOTALL):
-            out.append((m.start(1), m.group(1)))
-        for m in re.finditer(
-            r"^([ \t]*)\.\. math::[ \t]*\n(.*?)(?=\n\s*\n|\Z)",
-            text,
-            re.DOTALL | re.MULTILINE,
-        ):
-            out.append((m.start(2), m.group(2)))
+        out.extend(
+            (m.start(1), m.group(1))
+            for m in re.finditer(r":math:`(.+?)`", text, re.DOTALL)
+        )
+        out.extend(
+            (m.start(2), m.group(2))
+            for m in re.finditer(
+                r"^([ \t]*)\.\. math::[ \t]*\n(.*?)(?=\n\s*\n|\Z)",
+                text,
+                re.DOTALL | re.MULTILINE,
+            )
+        )
     return out
 
 

--- a/scripts/conformance/domains/psychoacoustics.py
+++ b/scripts/conformance/domains/psychoacoustics.py
@@ -36,14 +36,12 @@ def _iso532_stationary_expected() -> tuple[float, float, float]:
 
 
 def _iso532_levels() -> np.ndarray:
-    levels = []
-    for line in (
-        (_DATA / "iso532_1" / "iso532_1_test_signal_1_levels.txt")
-        .read_text()
-        .splitlines()
-    ):
-        if ":" in line and not line.strip().startswith("#"):
-            levels.append(float(line.split(":")[1]))
+    path = _DATA / "iso532_1" / "iso532_1_test_signal_1_levels.txt"
+    levels = [
+        float(line.split(":")[1])
+        for line in path.read_text().splitlines()
+        if ":" in line and not line.strip().startswith("#")
+    ]
     return np.array(levels)
 
 
@@ -94,15 +92,14 @@ def _iso532_b5_signal(
     The 16-bit WAV is scaled per Annex B.1 (full scale = 100 dB SPL, so one
     full-scale unit is 2*sqrt(2) Pa peak).
     """
-    import glob
     import wave
 
     data = json.loads(
         (_DATA / "iso532_1" / "iso532_1_annexB_expected.json").read_text()
     )
     entry = data[f"Test signal {num}"]
-    matches = glob.glob(
-        str(_DATA / "iso532_1" / "Annex B.5" / f"Test signal {num} *.wav")
+    matches = sorted(
+        (_DATA / "iso532_1" / "Annex B.5").glob(f"Test signal {num} *.wav")
     )
     if not matches:
         msg = (
@@ -112,7 +109,7 @@ def _iso532_b5_signal(
         raise FileNotFoundError(msg)
     # WAV/RIFF is little-endian, so the dtype is fixed to '<i2'; a multi-channel
     # file keeps only channel 0.
-    with wave.open(matches[0]) as handle:
+    with wave.open(str(matches[0])) as handle:
         fs = handle.getframerate()
         n_channels = handle.getnchannels()
         raw = np.frombuffer(handle.readframes(handle.getnframes()), dtype="<i2")

--- a/scripts/diagrams/canvas.py
+++ b/scripts/diagrams/canvas.py
@@ -34,6 +34,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .i18n import lookup, visit
@@ -903,7 +904,7 @@ def _write(
             visit(name, lang)
             svg = SVG(900, height, th, lang)
             build(svg, th)
-            path = os.path.join(output_dir, f"{name}{lang_suffix}{th.suffix}.svg")
-            with open(path, "w", encoding="utf-8") as fh:
+            path = Path(output_dir) / f"{name}{lang_suffix}{th.suffix}.svg"
+            with path.open("w", encoding="utf-8") as fh:
                 fh.write(svg.render(title))
     print(f"Generated {name}.svg (+dark, +es, +es_dark)")

--- a/scripts/diagrams/i18n.py
+++ b/scripts/diagrams/i18n.py
@@ -10,15 +10,15 @@ both languages and are shared.
 
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 
 # The miss recorder sits at the top of ``scripts/``, next to the checker that
 # reads what it writes; guard the path the way the other cross-imports in
 # ``scripts/`` do (see check_figures.py).
-_SCRIPTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if _SCRIPTS not in sys.path:
-    sys.path.insert(0, _SCRIPTS)
+_SCRIPTS = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
 import figure_language_audit as _audit
 

--- a/scripts/diagrams/registry.py
+++ b/scripts/diagrams/registry.py
@@ -12,7 +12,7 @@ entry into ``output_dir``.
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 from .aircraft import (
     _d_aircraft_certification,
@@ -909,6 +909,6 @@ DIAGRAMS = {
 
 
 def generate_all(output_dir: str = ".github/images") -> None:
-    os.makedirs(output_dir, exist_ok=True)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
     for name, (builder, title, height) in DIAGRAMS.items():
         _write(output_dir, name, builder, title, height)

--- a/scripts/diagrams/simulation.py
+++ b/scripts/diagrams/simulation.py
@@ -437,9 +437,10 @@ def _d_elastic_fluid_solid(s: SVG, th: Theme) -> None:
     s.text(628, y_if + 74, "sediment 3500 / 2000", 11, th.muted, "start")
     s.circle(cx - 78, y_if - 92, 6.0, th.secondary)
     s.text(cx - 68, y_if - 96, "shot, 10 m up", 11, th.secondary, "start")
-    pts = []
-    for k in range(41):
-        pts.append(f"{cx - 46 + 2.7 * k:.1f} {y_if - 12 * math.sin(k * 0.9):.1f}")
+    pts = [
+        f"{cx - 46 + 2.7 * k:.1f} {y_if - 12 * math.sin(k * 0.9):.1f}"
+        for k in range(41)
+    ]
     s.path("M " + " L ".join(pts), stroke=th.accent, sw=2.2)
     for dy in (-34.0, 34.0):
         s.line(cx - 46, y_if + dy, cx + 62, y_if + dy, th.primary, 1.0, dash="3,4")

--- a/scripts/fdtd2d.py
+++ b/scripts/fdtd2d.py
@@ -11,12 +11,10 @@ changes.
 
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
-)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from phonometry.simulation.fdtd import (
     FDTD2D,

--- a/scripts/figures/__init__.py
+++ b/scripts/figures/__init__.py
@@ -36,7 +36,11 @@ for _threads_var in (
 
 # Add src to path to use the local package
 sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+    # The code that draws the clips is hashed into
+    # scripts/animation_fingerprints.txt, so rewriting this asks for a
+    # re-render that would draw the very same frames.
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")),  # noqa: PTH100, PTH118, PTH120
 )
 
 

--- a/scripts/figures/fields/pillar_hall.py
+++ b/scripts/figures/fields/pillar_hall.py
@@ -34,7 +34,10 @@ def _poster_ss_for(webm: str) -> float | None:
       the right edge (it leaves the 0.30 m view at 103 us) and both body
       fronts are drawn against their analytic arcs.
     """
-    name = os.path.basename(webm)
+    # The code that draws the clips is hashed into
+    # scripts/animation_fingerprints.txt, so rewriting this asks for a
+    # re-render that would draw the very same frames.
+    name = os.path.basename(webm)  # noqa: PTH119
     if _PILLAR_STEM in name:
         import fdtd2d
 

--- a/scripts/figures/i18n.py
+++ b/scripts/figures/i18n.py
@@ -23,7 +23,10 @@ from . import _publish
 # place. Guard the path the way the other cross-imports in ``scripts/`` do
 # (see check_figures.py), so an editor importing a single figure module also
 # resolves it.
-_SCRIPTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# The code that draws the clips is hashed into
+# scripts/animation_fingerprints.txt, so rewriting this asks for a
+# re-render that would draw the very same frames.
+_SCRIPTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # noqa: PTH100, PTH120
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
 

--- a/scripts/figures/io.py
+++ b/scripts/figures/io.py
@@ -10,8 +10,8 @@ the public API inside the generator, so the panel shows what a user's own
 and its site twins.
 """
 
-import os
 import tempfile
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -75,7 +75,7 @@ def generate_signal_provenance(output_dir: str) -> None:
         coding_history="A=PCM,F=48000,W=24,M=mono,T=SLM",
     )
     with tempfile.TemporaryDirectory() as tmp:
-        path = os.path.join(tmp, "night_p3.wav")
+        path = Path(tmp) / "night_p3.wav"
         io.write(
             path,
             io.Signal(data=_night_measurement(fs), fs=fs, calibration_factor=20.0),
@@ -121,7 +121,7 @@ def generate_signal_provenance(output_dir: str) -> None:
     first_sample = (f"{provenance.time_reference:,} samples").replace(",", " ")
     calibration = f"{sig.calibration_factor:.1f} Pa at full scale, from the sidecar"
     rows: tuple[tuple[str, str], ...] = (
-        ("File", os.path.basename(origin.path)),
+        ("File", Path(origin.path).name),
         ("Container", container),
         ("Sample rate", f"{sig.fs / 1000:g} kHz"),
         ("Recorded by", str(provenance.originator)),

--- a/scripts/figures/media.py
+++ b/scripts/figures/media.py
@@ -128,7 +128,10 @@ def _translate_str(s: str) -> str:
 
 def _anim_path(output_dir: str, stem: str, ext: str) -> str:
     """Animation output path with the active language + theme suffixes."""
-    return os.path.join(output_dir, f"{stem}{_LANG_SUFFIX}{_FILENAME_SUFFIX}.{ext}")
+    # The code that draws the clips is hashed into
+    # scripts/animation_fingerprints.txt, so rewriting this asks for a
+    # re-render that would draw the very same frames.
+    return os.path.join(output_dir, f"{stem}{_LANG_SUFFIX}{_FILENAME_SUFFIX}.{ext}")  # noqa: PTH118
 
 
 def _anim_figure() -> Any:
@@ -314,7 +317,7 @@ ssh -o BatchMode=yes -- {q_target} "rm -f {q_dir}/$rid"
         "w", suffix=".sh", prefix="ffmpeg-gpu-", delete=False
     ) as handle:
         handle.write(script)
-    os.chmod(handle.name, 0o755)
+    os.chmod(handle.name, 0o755)  # noqa: PTH101
     return handle.name
 
 
@@ -373,7 +376,7 @@ def _save_animation(
         except (RuntimeError, subprocess.CalledProcessError, OSError) as exc:
             print(f"  [gpu-encode] {stem}: {exc}; falling back to VP9")
         finally:
-            os.remove(wrapper)
+            os.remove(wrapper)  # noqa: PTH107
     if not saved:
         writer = FFMpegWriter(
             fps=rate_arg, codec="libvpx-vp9", extra_args=_vp9_extra_args()
@@ -389,7 +392,7 @@ def _save_animation(
     made_gif = False
     if make_gif and _LANG == "en":
         gif = _anim_path(output_dir, stem, "gif")
-        palette = os.path.join(output_dir, f".{stem}{_FILENAME_SUFFIX}_pal.png")
+        palette = os.path.join(output_dir, f".{stem}{_FILENAME_SUFFIX}_pal.png")  # noqa: PTH118
         vf = (
             f"fps={_GIF_FPS if gif_fps is None else gif_fps},"
             f"scale={_GIF_SCALE}:-1:flags=lanczos"
@@ -428,7 +431,7 @@ def _save_animation(
             ],
             check=True,
         )
-        os.remove(palette)
+        os.remove(palette)  # noqa: PTH107
         made_gif = True
     plt.close(fig)
     theme = "dark" if _FILENAME_SUFFIX else "light"

--- a/scripts/figures/perception.py
+++ b/scripts/figures/perception.py
@@ -3169,7 +3169,7 @@ def generate_sii_octave_masking_blindness(output_dir: str) -> None:
         "octave": ("--", COLOR_SECONDARY),
     }
     curves: dict[str, np.ndarray] = {}
-    for method, (_style, _color) in styles.items():
+    for method in styles:
         proc = speech.sii_procedure(method)
         freqs = np.asarray(proc.frequencies)
         curves[method] = np.array(

--- a/scripts/figures/registry.py
+++ b/scripts/figures/registry.py
@@ -14,6 +14,7 @@ silently degrouping a cached figure or dropping a clip's field builder.
 import os
 import sys
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import matplotlib.pyplot as plt
@@ -1160,15 +1161,15 @@ def generate_posters(output_dir: str) -> None:
     Used by ``--posters`` (`make posters`) to refresh the stills without the
     slow re-encode of the clips themselves.
     """
-    import glob
-
-    webms = sorted(glob.glob(os.path.join(output_dir, "anim_*.webm")))
+    # `_extract_poster` trims the `.webm` off the text it is handed and returns
+    # the poster path the same way, so the clips are named as text from here on.
+    webms = sorted(str(webm) for webm in Path(output_dir).glob("anim_*.webm"))
     if not webms:
         msg = f"no anim_*.webm files found in {output_dir}; run `make animations` first"
         raise RuntimeError(msg)
     for webm in webms:
         poster = _extract_poster(webm, _poster_ss_for(webm))
-        print(f"  {os.path.basename(webm)} -> {os.path.basename(poster)}")
+        print(f"  {Path(webm).name} -> {Path(poster).name}")
 
 
 _ANIMATIONS: dict[str, Callable[[str], None]] = {
@@ -1748,7 +1749,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     img_dir = ".github/images"
-    os.makedirs(img_dir, exist_ok=True)
+    Path(img_dir).mkdir(parents=True, exist_ok=True)
 
     do_figs = not (args.animations or args.posters) or args.do_all
     do_anim = args.animations or args.do_all

--- a/scripts/figures/schematics.py
+++ b/scripts/figures/schematics.py
@@ -5292,7 +5292,10 @@ def animate_feedback_howl(output_dir: str) -> None:
     ax_t.legend(loc="upper left", fontsize=7.5, framealpha=0.9, handlelength=1.4)
     limit_lines = []
     for c in colors[:2]:
-        limit_lines.append(ax_t.axhline(0.0, color=c, lw=1.1, ls=":", visible=False))
+        # The code that draws the clips is hashed into
+        # scripts/animation_fingerprints.txt, so rewriting this asks for a
+        # re-render that would draw the very same frames.
+        limit_lines.append(ax_t.axhline(0.0, color=c, lw=1.1, ls=":", visible=False))  # noqa: PERF401
 
     sweep = _ANIM_FRAMES - _ANIM_HOLD
     per_act = sweep // 3

--- a/scripts/figures/theme.py
+++ b/scripts/figures/theme.py
@@ -216,11 +216,14 @@ def save_figure(output_dir: str, filename: str, **kwargs: Any) -> None:
     across matplotlib builds and runs. In both cases ``filename`` may carry
     any extension; the real one is chosen here.
     """
-    stem = os.path.splitext(filename)[0]
+    # The code that draws the clips is hashed into
+    # scripts/animation_fingerprints.txt, so rewriting this asks for a
+    # re-render that would draw the very same frames.
+    stem = os.path.splitext(filename)[0]  # noqa: PTH122
     audit_figure(stem)
     _translate_figure(plt.gcf())
     ext = "webp" if stem in _RASTER_FIGURES else "svg"
-    path = os.path.join(output_dir, f"{stem}{_LANG_SUFFIX}{_FILENAME_SUFFIX}.{ext}")
+    path = os.path.join(output_dir, f"{stem}{_LANG_SUFFIX}{_FILENAME_SUFFIX}.{ext}")  # noqa: PTH118
     if ext == "svg":
         plt.rcParams["svg.hashsalt"] = "phonometry"
         # Text is drawn as outlines, not as <text>. Keeping it as text made a

--- a/scripts/generate_diagrams.py
+++ b/scripts/generate_diagrams.py
@@ -12,12 +12,12 @@ Run directly or via ``make graphs``.
 
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 
-_SCRIPTS = os.path.dirname(os.path.abspath(__file__))
-if _SCRIPTS not in sys.path:
-    sys.path.insert(0, _SCRIPTS)
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
 from diagrams import DIAGRAMS, generate_all
 from diagrams.canvas import DARK, LIGHT, SVG, Theme

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -33,15 +33,16 @@ unnoticed.
 from __future__ import annotations
 
 import argparse
-import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 # The fiche builders live in the ``reports`` package beside this file. Running
 # this script puts ``scripts/`` on the import path for free, but loading the
 # file by its path (as the test suite does) does not, so the directory is added
-# here and both entry points reach the same package.
-_SCRIPTS = os.path.dirname(os.path.abspath(__file__))
+# here and both entry points reach the same package. ``sys.path`` holds plain
+# strings, so the entry is spelled as text: a Path would never match the guard.
+_SCRIPTS = str(Path(__file__).resolve().parent)
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
 
@@ -144,9 +145,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
 #: Committed output directory for the example fiches.
-_DEFAULT_DIR = os.path.normpath(
-    os.path.join(os.path.dirname(__file__), "..", ".github", "reports")
-)
+_DEFAULT_DIR = Path(__file__).resolve().parent.parent / ".github" / "reports"
 
 #: Pixel width of the rendered WebP preview. A4 portrait at this width is ~1415
 #: px tall: crisp on the docs pages (shown at ~80 % column width) yet small
@@ -250,12 +249,12 @@ _FICHES: dict[str, Callable[[], _Fiche]] = {
 _EXAMPLES: list[Callable[[], _Fiche]] = list(_FICHES.values())
 
 
-def preview_path_for(pdf_path: str) -> str:
+def preview_path_for(pdf_path: str | Path) -> Path:
     """Return the WebP-preview path that pairs with ``pdf_path`` (``.pdf`` -> ``.webp``)."""
-    return os.path.splitext(pdf_path)[0] + ".webp"
+    return Path(pdf_path).with_suffix(".webp")
 
 
-def _write_preview(pdf_path: str) -> str:
+def _write_preview(pdf_path: Path) -> Path:
     """Rasterize the first page of ``pdf_path`` to a lossless WebP beside it.
 
     The preview is what the documentation embeds inline; it is not byte-compared
@@ -283,9 +282,9 @@ def _write_preview(pdf_path: str) -> str:
 
 
 def generate_reports(
-    output_dir: str,
+    output_dir: str | Path,
     examples: Sequence[Callable[[], _Fiche]] | None = None,
-) -> list[str]:
+) -> list[Path]:
     """Write every example fiche (PDF + WebP preview) into ``output_dir``.
 
     ``examples`` restricts the run to a subset of the registered factories
@@ -295,14 +294,19 @@ def generate_reports(
     each has a paired ``.webp`` preview next to it (see
     :func:`preview_path_for`).
     """
-    os.makedirs(output_dir, exist_ok=True)
-    written: list[str] = []
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
     for factory in _EXAMPLES if examples is None else examples:
         fiche = factory()
         result, metadata, name = fiche[0], fiche[1], fiche[2]
         kwargs: dict[str, Any] = fiche[3] if len(fiche) == 4 else {}
-        path = os.path.join(output_dir, name)
-        result.report(path, metadata=metadata, **kwargs)  # type: ignore[attr-defined]
+        path = directory / name
+        # ``report()`` takes a filename, and reportlab refuses anything that is
+        # not a string, so the path becomes text at that one boundary and stays
+        # a Path everywhere else.
+        dest = str(path)
+        result.report(dest, metadata=metadata, **kwargs)  # type: ignore[attr-defined]
         _write_preview(path)
         written.append(path)
     return written
@@ -313,7 +317,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", default=_DEFAULT_DIR)
     args = parser.parse_args()
-    for path in generate_reports(os.path.abspath(args.output_dir)):
+    for path in generate_reports(Path(args.output_dir).resolve()):
         print(f"wrote {path}")
         print(f"wrote {preview_path_for(path)}")
 

--- a/scripts/reports/building_design.py
+++ b/scripts/reports/building_design.py
@@ -10,8 +10,8 @@ predicts from it.
 
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -24,7 +24,10 @@ from phonometry import ReportMetadata
 # detailed-prediction fiches below show that same building, so they read it
 # from the same place rather than becoming a third transcription of a worked
 # example whose inputs the registry already records two corrections to.
-_TESTS = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "tests"))
+# parents[2] is the repository root from scripts/reports/<module>.py; the entry
+# stays text because sys.path holds strings and the membership test below has
+# to match the ones already there.
+_TESTS = str(Path(__file__).resolve().parents[2] / "tests")
 if _TESTS not in sys.path:
     sys.path.insert(0, _TESTS)
 

--- a/src/phonometry/_report/_layout.py
+++ b/src/phonometry/_report/_layout.py
@@ -22,6 +22,7 @@ import math
 import os
 import re
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -224,8 +225,9 @@ def render_figure_drawing(
     except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
         raise ImportError(_SVGLIB_HINT) from exc
 
-    svg_fd, svg_path = tempfile.mkstemp(suffix=".svg")
+    svg_fd, svg_name = tempfile.mkstemp(suffix=".svg")
     os.close(svg_fd)
+    svg_path = Path(svg_name)
     try:
         fig = Figure(figsize=figsize if figsize is not None else (5.8, 6.4))
         FigureCanvasAgg(fig)
@@ -277,8 +279,7 @@ def render_figure_drawing(
             fig.savefig(svg_path, format="svg")
         drawing = svg2rlg(svg_path)
     finally:
-        if os.path.exists(svg_path):
-            os.remove(svg_path)
+        svg_path.unlink(missing_ok=True)
     if drawing is None or not drawing.width:
         msg = "Could not convert the report plot to vector graphics."
         raise ValueError(msg)
@@ -399,10 +400,10 @@ def band_table(
     ]
     # Octave-band tables (5 rows, one per octave) have no triplets to group.
     if n_data != _OCTAVE_TABLE_ROWS:
-        for triplet_end in range(3, n_data, 3):
-            style_cmds.append(
-                ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
-            )
+        style_cmds.extend(
+            ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
+            for triplet_end in range(3, n_data, 3)
+        )
     if extra_styles:
         style_cmds += extra_styles
     table = Table(rows, colWidths=col_widths, repeatRows=1)
@@ -876,8 +877,7 @@ def footer_flow(
             lines.append(
                 f"<b>{t('Notes', language)}:</b> {html.escape(metadata.notes)}"
             )
-    for line in lines:
-        flow.append(fiche_paragraph(line, ident_style))
+    flow.extend(fiche_paragraph(line, ident_style) for line in lines)
 
     operator = metadata.operator if metadata is not None else None
     if operator:

--- a/src/phonometry/_report/_noise_control_fiche.py
+++ b/src/phonometry/_report/_noise_control_fiche.py
@@ -227,8 +227,7 @@ def render_noise_control_fiche(
         flow.extend(verdict_flow(text, passed, styles, language))
 
     basis_style_strip = measurement_basis_style()
-    for strip in basis_strips:
-        flow.append(fiche_paragraph(strip, basis_style_strip))
+    flow.extend(fiche_paragraph(strip, basis_style_strip) for strip in basis_strips)
     flow.extend(footer_flow(metadata, language, disclaimer=PREDICTION_DISCLAIMER))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/_sound_power_fiche.py
+++ b/src/phonometry/_report/_sound_power_fiche.py
@@ -362,10 +362,10 @@ def power_value_table(
     # A one-third-octave set groups by octave (a thin rule after every triplet),
     # as accredited sound-power tables print it; an octave set has no triplets.
     if fraction == _THIRD_OCTAVE_FRACTION:
-        for triplet_end in range(3, n, 3):
-            style_cmds.append(
-                ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
-            )
+        style_cmds.extend(
+            ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
+            for triplet_end in range(3, n, 3)
+        )
     table = Table(rows, colWidths=[w * mm for w in widths], repeatRows=1)
     table.setStyle(TableStyle(style_cmds))
     table.hAlign = "CENTER"
@@ -491,8 +491,9 @@ def render_sound_power_fiche(
         flow.extend(verdict_flow(text, passed, styles, language))
 
     basis_style_strip = measurement_basis_style()
-    for strip in copy.basis_strips:
-        flow.append(fiche_paragraph(strip, basis_style_strip))
+    flow.extend(
+        fiche_paragraph(strip, basis_style_strip) for strip in copy.basis_strips
+    )
     flow.extend(footer_flow(metadata, language, disclaimer=disclaimer))
 
     return build_document(path, flow, copy.title)

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -154,8 +154,7 @@ def _value_table(
 
     n_data = len(columns[0][1])
     rows: list[list[Any]] = [[fiche_paragraph(header, head) for header, _ in columns]]
-    for i in range(n_data):
-        rows.append([cells[i] for _, cells in columns])
+    rows.extend([cells[i] for _, cells in columns] for i in range(n_data))
 
     table = Table(rows, colWidths=col_widths, repeatRows=1)
     table.setStyle(

--- a/src/phonometry/_report/duct_path.py
+++ b/src/phonometry/_report/duct_path.py
@@ -230,11 +230,11 @@ def _sheet_table(
     if rows is None:
         rows = _visible_rows(result.table(), verbose)
     data: list[list[Any]] = [_band_header(frequencies, language)]
-    for row in rows:
-        data.append(
-            [row["code"], _element_label(row, language)]
-            + [_cell(v, language) for v in np.asarray(row["values"])]
-        )
+    data.extend(
+        [row["code"], _element_label(row, language)]
+        + [_cell(v, language) for v in np.asarray(row["values"])]
+        for row in rows
+    )
 
     accent = colors.HexColor(_ACCENT_HEX)
     light = colors.HexColor(_LIGHT_HEX)
@@ -480,8 +480,10 @@ def render_duct_path_report(
     )
 
     basis_style_strip = measurement_basis_style()
-    for strip in _basis_strips(result, language):
-        flow.append(fiche_paragraph(strip, basis_style_strip))
+    flow.extend(
+        fiche_paragraph(strip, basis_style_strip)
+        for strip in _basis_strips(result, language)
+    )
     flow.extend(footer_flow(metadata, language, disclaimer=PREDICTION_DISCLAIMER))
 
     _fit_to_one_page(flow, table_index, result, rows, verbose, language)

--- a/src/phonometry/_report/iec60268_5.py
+++ b/src/phonometry/_report/iec60268_5.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import html
 import os
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -212,15 +213,15 @@ def _drawing_from_figure(fig: Any, target_width: float, language: str = "en") ->
 
     for ax in fig.axes:
         localize_axes(ax, language)
-    svg_fd, svg_path = tempfile.mkstemp(suffix=".svg")
+    svg_fd, svg_name = tempfile.mkstemp(suffix=".svg")
     os.close(svg_fd)
+    svg_path = Path(svg_name)
     try:
         with mpl.rc_context({"svg.fonttype": "path"}):
             fig.savefig(svg_path, format="svg", bbox_inches="tight")
         drawing = svg2rlg(svg_path)
     finally:
-        if os.path.exists(svg_path):
-            os.remove(svg_path)
+        svg_path.unlink(missing_ok=True)
     if drawing is None or not drawing.width:
         msg = "Could not convert the report plot to vector graphics."
         raise ValueError(msg)

--- a/src/phonometry/_report/iso3382.py
+++ b/src/phonometry/_report/iso3382.py
@@ -238,19 +238,19 @@ def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
         fiche_paragraph("T<sub>s</sub> [ms]", head_style),
     ]
     rows: list[list[Any]] = [header]
-    for i in range(n):
-        rows.append(
-            [
-                labels[i],
-                _cell(t20[i], 2, language),
-                _cell(t30[i], 2, language),
-                _cell(edt[i], 2, language),
-                _cell(c50[i], 1, language),
-                _cell(c80[i], 1, language),
-                _cell(d50[i], 2, language),
-                _cell(ts[i], 0, language, scale=1000.0),
-            ]
-        )
+    rows.extend(
+        [
+            labels[i],
+            _cell(t20[i], 2, language),
+            _cell(t30[i], 2, language),
+            _cell(edt[i], 2, language),
+            _cell(c50[i], 1, language),
+            _cell(c80[i], 1, language),
+            _cell(d50[i], 2, language),
+            _cell(ts[i], 0, language, scale=1000.0),
+        ]
+        for i in range(n)
+    )
 
     col_widths = [
         24 * mm,
@@ -279,10 +279,10 @@ def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
     # grouping rule is gated on the band structure actually being one-third
     # octave rather than merely on the row count.
     if freq is not None and fraction == _THIRD_OCTAVE_FRACTION:
-        for triplet_end in range(3, n, 3):
-            style_cmds.append(
-                ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
-            )
+        style_cmds.extend(
+            ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
+            for triplet_end in range(3, n, 3)
+        )
     table = Table(rows, colWidths=col_widths, repeatRows=1)
     table.setStyle(TableStyle(style_cmds))
     return table

--- a/src/phonometry/_report/iso4871.py
+++ b/src/phonometry/_report/iso4871.py
@@ -367,9 +367,11 @@ def _declaration_table(
         ("TOPPADDING", (0, footnote_row), (-1, footnote_row), 5),
     ]
     # Zebra striping on the value rows and a light rule under each.
-    for i in range(first_value_row, footnote_row):
-        if (i - first_value_row) % 2 == 1:
-            style.append(("BACKGROUND", (0, i), (-1, i), light))
+    style.extend(
+        ("BACKGROUND", (0, i), (-1, i), light)
+        for i in range(first_value_row, footnote_row)
+        if (i - first_value_row) % 2 == 1
+    )
     # A vertical rule separating the label column from the mode columns.
     style.append(("LINEAFTER", (0, 3), (0, footnote_row - 1), 0.4, accent))
     table.setStyle(TableStyle(style))

--- a/src/phonometry/_report/rd1367.py
+++ b/src/phonometry/_report/rd1367.py
@@ -220,6 +220,51 @@ def _criterion_cell(
     return text
 
 
+def _result_row(
+    period: PeriodAssessment, label_style: Any, value_style: Any, language: str
+) -> list[Any]:
+    """The six cells of one period row of the Article 25.1 b results table.
+
+    Called only after the renderer has imported reportlab.
+    """
+    from ._layout import fiche_paragraph
+
+    return [
+        fiche_paragraph(t(_PERIOD_LABELS[period.period], language), label_style),
+        fiche_paragraph(_fmt(period.limit, language, decimals=0), value_style),
+        fiche_paragraph(
+            _criterion_cell(
+                period.max_phase_level,
+                period.phase_limit,
+                period.phase_pass,
+                language,
+            ),
+            value_style,
+        ),
+        fiche_paragraph(
+            _criterion_cell(
+                float(period.reported_level),
+                period.daily_limit,
+                period.daily_pass,
+                language,
+            ),
+            value_style,
+        ),
+        fiche_paragraph(
+            _criterion_cell(
+                None
+                if period.reported_long_term is None
+                else float(period.reported_long_term),
+                period.limit,
+                period.long_term_pass,
+                language,
+            ),
+            value_style,
+        ),
+        fiche_paragraph(_status_markup(period.complies, language), value_style),
+    ]
+
+
 def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
     """The per-period results table against the Article 25.1 b criteria.
 
@@ -244,45 +289,10 @@ def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
     ]
     widths = [24.0, 24.0, 32.0, 32.0, 32.0, 30.0]
     data: list[list[Any]] = [[fiche_paragraph(h, header_style) for h in headers]]
-    for period in result.periods:
-        data.append(
-            [
-                fiche_paragraph(
-                    t(_PERIOD_LABELS[period.period], language), label_style
-                ),
-                fiche_paragraph(_fmt(period.limit, language, decimals=0), value_style),
-                fiche_paragraph(
-                    _criterion_cell(
-                        period.max_phase_level,
-                        period.phase_limit,
-                        period.phase_pass,
-                        language,
-                    ),
-                    value_style,
-                ),
-                fiche_paragraph(
-                    _criterion_cell(
-                        float(period.reported_level),
-                        period.daily_limit,
-                        period.daily_pass,
-                        language,
-                    ),
-                    value_style,
-                ),
-                fiche_paragraph(
-                    _criterion_cell(
-                        None
-                        if period.reported_long_term is None
-                        else float(period.reported_long_term),
-                        period.limit,
-                        period.long_term_pass,
-                        language,
-                    ),
-                    value_style,
-                ),
-                fiche_paragraph(_status_markup(period.complies, language), value_style),
-            ]
-        )
+    data.extend(
+        _result_row(period, label_style, value_style, language)
+        for period in result.periods
+    )
     return stacked_table(data, [w * mm for w in widths])
 
 

--- a/tests/aircraft/test_epnl_report.py
+++ b/tests/aircraft/test_epnl_report.py
@@ -20,9 +20,9 @@ import pytest
 
 pytest.importorskip("reportlab")
 
-from phonometry import ReportMetadata, aircraft
+from report_assertions import assert_one_page
 
-_PDF_MAGIC = b"%PDF"
+from phonometry import ReportMetadata, aircraft
 
 
 def _flyover():
@@ -38,17 +38,6 @@ def _flyover():
     return aircraft.effective_perceived_noise_level(spectra, dt)
 
 
-def _assert_one_page(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
-
-
 def test_report_writes_one_page_pdf(tmp_path) -> None:
     """A computed flyover renders a one-page certification fiche."""
     result = _flyover()
@@ -56,7 +45,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "epnl.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -73,7 +62,7 @@ def test_passing_requirement_renders(tmp_path) -> None:
     limit = float(result.epnl) + 3.0
     out = tmp_path / "pass.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=limit))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_failing_requirement_renders(tmp_path) -> None:
@@ -82,7 +71,7 @@ def test_failing_requirement_renders(tmp_path) -> None:
     limit = float(result.epnl) - 3.0
     out = tmp_path / "fail.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=limit))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_full_metadata_renders_one_page(tmp_path) -> None:
@@ -101,14 +90,14 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _flyover().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_no_metadata_prediction_fiche(tmp_path) -> None:
     """With ``metadata=None`` a prediction fiche renders (no verdict row)."""
     out = tmp_path / "prediction.pdf"
     _flyover().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def _extract_text(path: str) -> str:
@@ -131,7 +120,7 @@ def test_verdict_follows_one_decimal_epnl_at_the_limit(tmp_path) -> None:
     result = dataclasses.replace(_flyover(), epnl=101.04)
     out = tmp_path / "boundary.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=101.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "EPNL = 101.0 EPNdB" in text
     assert "margin +0.0" in text
@@ -163,7 +152,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     result = _flyover()
     out = tmp_path / "epnl_es.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=101.0), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Certificación de ruido de aeronaves" in text
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -23,12 +23,13 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata
 from phonometry._report.broadcast import _verdict
 from phonometry.broadcast import program_loudness
 
 FS = 48000
-_PDF_MAGIC = b"%PDF"
 
 
 def _sine(level_dbfs: float, duration: float, freq: float = 1000.0) -> np.ndarray:
@@ -57,21 +58,6 @@ def _case1_result():
     return program_loudness(_steps(((-20.4, 20.0), (-30.4, 20.0))), FS)
 
 
-def _assert_pdf(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-
-
-def _assert_one_page(path: str) -> None:
-    _assert_pdf(path)
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
-
-
 def test_report_writes_one_page_pdf(tmp_path) -> None:
     """A measured programme renders a one-page compliance fiche."""
     result = _case1_result()
@@ -79,7 +65,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "loudness.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -106,7 +92,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _case1_result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_compliant_programme_passes(tmp_path) -> None:
@@ -117,7 +103,7 @@ def test_compliant_programme_passes(tmp_path) -> None:
     assert passed is True
     out = tmp_path / "pass.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=-23.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_non_compliant_true_peak_fails(tmp_path) -> None:
@@ -128,7 +114,7 @@ def test_non_compliant_true_peak_fails(tmp_path) -> None:
     assert passed is False
     out = tmp_path / "fail.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=-23.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_informational_rows_do_not_change_verdict(tmp_path) -> None:
@@ -145,7 +131,7 @@ def test_informational_rows_do_not_change_verdict(tmp_path) -> None:
     assert passed2 is True
     out = tmp_path / "info.pdf"
     tampered.report(str(out), metadata=ReportMetadata(requirement=-23.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def _extract_text(path: str) -> str:
@@ -180,7 +166,7 @@ def test_live_tolerance_applies_item_h_1_lu(tmp_path) -> None:
     result.report(
         str(out), metadata=ReportMetadata(requirement=-23.0), tolerance="live"
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "±1.0 LU" in text
     assert "item h" in text
@@ -217,7 +203,7 @@ def test_fiche_pins_displayed_numbers(tmp_path) -> None:
     result = _case1_result()
     out = tmp_path / "pins.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=-23.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # Independent expectation: the trimmed Case 1 steps land at -23.0 LUFS
     # (the -20/-30 dBFS analytic pair shifted by -0.4 dB). The printed sign is
@@ -235,7 +221,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     result = _case1_result()
     out = tmp_path / "program_es.pdf"
     result.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Conformidad de sonoridad de programa" in text
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator

--- a/tests/building/measurement/test_facade_field_report.py
+++ b/tests/building/measurement/test_facade_field_report.py
@@ -18,9 +18,9 @@ import pytest
 
 pytest.importorskip("reportlab")
 
-from phonometry import ReportMetadata, building
+from report_assertions import assert_one_page
 
-_PDF_MAGIC = b"%PDF"
+from phonometry import ReportMetadata, building
 
 #: ISO 717-1 Annex C Table C.1 measured curve; rated 30 (-2; -3) dB.
 _ANNEX_C_R = np.array(
@@ -47,18 +47,6 @@ _ANNEX_C_R = np.array(
 #: A receiving-room reverberation time equal to T0 = 0,5 s in every band, so
 #: D2m,nT = D2m and the fiche's rating is hand-computable.
 _T_AT_T0 = np.full(16, 0.5)
-
-
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -102,7 +90,7 @@ def test_dnt_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     """The D2m,nT fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3)."""
     out = tmp_path / "d2mnt.pdf"
     _facade_dnt().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "30 (-2; -3) dB" in text
     assert "ISO 16283-3:2016" in text
@@ -119,7 +107,7 @@ def test_r_prime_fiche(tmp_path) -> None:
     np.testing.assert_allclose(result.r_prime, _ANNEX_C_R, atol=1e-9)
     out = tmp_path / "rprime.pdf"
     result.report(str(out), quantity="r_prime")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Apparent sound reduction index" in text
     assert "loudspeaker method" in text
@@ -144,7 +132,7 @@ def test_r_prime_road_traffic_fiche_labelled_rtrs(tmp_path) -> None:
     np.testing.assert_allclose(result.r_prime, _ANNEX_C_R, atol=1e-9)
     out = tmp_path / "rtrs.pdf"
     result.report(str(out), quantity="r_prime")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "road traffic method" in text
     assert "tr,s" in text
@@ -158,7 +146,7 @@ def test_d_2m_n_fiche(tmp_path) -> None:
     assert result.d_2m_n is not None
     out = tmp_path / "d2mn.pdf"
     result.report(str(out), quantity="d_2m_n")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Normalized facade level difference" in _extract_text(str(out))
 
 
@@ -179,7 +167,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     )
     out = tmp_path / "verbose.pdf"
     _facade_dnt().report(str(out), metadata=metadata, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "PASS" in text  # D2m,nT,w = 30 dB >= 30 dB (higher is better)
     assert "Unfav. dev." in text
@@ -202,7 +190,7 @@ def test_spanish_fiche(tmp_path) -> None:
         metadata=ReportMetadata(requirement=30.0, laboratory="Ejemplo"),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Aislamiento acústico de fachada in situ" in text
     assert "CUMPLE" in text

--- a/tests/building/measurement/test_flanking_transmission_report.py
+++ b/tests/building/measurement/test_flanking_transmission_report.py
@@ -12,16 +12,14 @@ report tests.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
 
 pytest.importorskip("reportlab")
 
-from phonometry import ReportMetadata, building
+from report_assertions import assert_one_page
 
-_PDF_MAGIC = b"%PDF"
+from phonometry import ReportMetadata, building
 
 #: The ISO 10848 mandatory one-third-octave range (100 Hz to 5000 Hz, 18 bands).
 _FREQS = [
@@ -69,16 +67,6 @@ _DV = np.array(
         12.7,
     ]
 )
-
-
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -135,7 +123,7 @@ def test_kij_fiche_renders_single_number_and_basis(tmp_path) -> None:
     result = _kij_result()
     out = tmp_path / "kij.pdf"
     result.report(str(out), metadata=ReportMetadata(specimen="Rigid junction"))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert result.single_number is not None
     assert f"{result.single_number:.1f} dB" in text
@@ -150,7 +138,7 @@ def test_kij_fiche_verbose_adds_membership_column(tmp_path) -> None:
     """``verbose=True`` adds the single-number-membership column."""
     out = tmp_path / "kij_verbose.pdf"
     _kij_result().report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "In mean" in text
 
@@ -235,7 +223,7 @@ def test_kij_fiche_spanish(tmp_path) -> None:
 
     out = tmp_path / "kij_es.pdf"
     _kij_result().report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Índice de reducción vibracional de la unión" in text
     assert re.search(r"\d+,\d", text)
@@ -251,7 +239,7 @@ def test_dnf_fiche_rating_and_basis(tmp_path) -> None:
     assert rating is not None
     out = tmp_path / "dnf.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     expected = f"{rating.rating} ({rating.c:+d}; {rating.ctr:+d}) dB"
     assert expected in text
@@ -265,7 +253,7 @@ def test_dnf_fiche_verbose_and_verdict(tmp_path) -> None:
     _dnf_result().report(
         str(out), metadata=ReportMetadata(requirement=55.0), verbose=True
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "PASS" in text  # Dn,f,w = 60 dB >= 55 dB
     assert "Unfav. dev." in text
@@ -277,7 +265,7 @@ def test_dnf_fiche_part_selects_basis_designation(tmp_path) -> None:
     for part, designation in ((3, "ISO 10848-3:2006"), (4, "ISO 10848-4:2010")):
         out = tmp_path / f"dnf_part{part}.pdf"
         result.report(str(out), part=part)
-        _assert_one_page(str(out))
+        assert_one_page(str(out))
         text = _extract_text(str(out))
         assert designation in text
         assert "ISO 10848-2:2006" not in text
@@ -313,7 +301,7 @@ def test_lnf_fiche_rating_and_basis(tmp_path) -> None:
     assert rating is not None
     out = tmp_path / "lnf.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=55.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{rating.rating} ({rating.ci:+d}) dB" in text
     assert "ISO 10848-2:2006" in text
@@ -325,7 +313,7 @@ def test_lnf_fiche_part_selects_basis_designation(tmp_path) -> None:
     """``part=4`` names ISO 10848-4:2010 on the Ln,f basis line."""
     out = tmp_path / "lnf_part4.pdf"
     _lnf_result().report(str(out), part=4)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "ISO 10848-4:2010" in text
     assert "ISO 10848-2:2006" not in text
@@ -335,7 +323,7 @@ def test_lnf_fiche_spanish(tmp_path) -> None:
     """``language="es"`` renders the Spanish Ln,f fiche."""
     out = tmp_path / "lnf_es.pdf"
     _lnf_result().report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Aislamiento acústico por flancos a ruido de impactos" in text
     assert "ISO 10848-2:2006" in text  # the {standard} template is filled

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -31,10 +31,9 @@ from reference_data import (
 from reference_data import (
     ISO717_2_ANNEX_C1_LN as _IMPACT_LN,
 )
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
-
-_PDF_MAGIC = b"%PDF"
 
 #: Receiving-room reverberation time and volume that make the equivalent
 #: absorption area A = 0,16 V / T equal to 10 m2 in every band, so both the
@@ -59,18 +58,6 @@ def _impact_result(**kwargs) -> building.LabImpactInsulationResult:
     return building.lab_impact_insulation(li, _T_UNITY, **params)
 
 
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     """The concatenated text of every page."""
     from pypdf import PdfReader
@@ -89,7 +76,7 @@ def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     """The R fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3) dB."""
     out = tmp_path / "r.pdf"
     _airborne_result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "30 (-2; -3) dB" in text
     assert "ISO 10140-2:2010" in text
@@ -111,7 +98,7 @@ def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path) -> None:
     """The Ln fiche's rating is the published ISO 717-2 Annex C 79 (-11) dB."""
     out = tmp_path / "ln.pdf"
     _impact_result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     expected = f"{_IMPACT_EXPECTED['ln_w']} ({_IMPACT_EXPECTED['ci']:+d}) dB"
     assert expected in text
@@ -149,7 +136,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     )
     out = tmp_path / "verbose.pdf"
     _airborne_result().report(str(out), metadata=metadata, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "PASS" in text  # Rw = 30 dB >= 25 dB
     assert "100 mm autoclaved aerated concrete" in text
@@ -179,7 +166,7 @@ def test_octave_band_fiche_renders(tmp_path) -> None:
     assert result.rating is not None
     out = tmp_path / "octave.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Octave-band" in _extract_text(str(out))
 
 
@@ -194,7 +181,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
         verbose=True,
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "CUMPLE" in text
     assert re.search(r"\d+,\d", text)  # comma decimal separator
@@ -259,7 +246,7 @@ def test_manual_impact_result_renders(tmp_path) -> None:
     )
     out = tmp_path / "bare.pdf"
     bare.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_rejects_band_count_mismatch(tmp_path) -> None:

--- a/tests/building/measurement/test_iso15186_element_report.py
+++ b/tests/building/measurement/test_iso15186_element_report.py
@@ -22,12 +22,12 @@ import reference_data as ref
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata, building
 from phonometry.building.measurement.intensity_insulation import (
     IntensityElementNormalizedResult,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 _A0 = 10.0
 
@@ -61,18 +61,6 @@ def _octave_result() -> IntensityElementNormalizedResult:
     )
 
 
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     """The concatenated text of every page."""
     from pypdf import PdfReader
@@ -90,7 +78,7 @@ def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     """The DI,n,e fiche's rating is the published 30 (-2; -3) dB."""
     out = tmp_path / "dine.pdf"
     _element_result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "30 (-2; -3) dB" in text
     assert "ISO 15186-1:2000" in text
@@ -121,7 +109,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     )
     out = tmp_path / "verbose.pdf"
     _element_result().report(str(out), metadata=metadata, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "PASS" in text  # DI,n,e,w = 30 dB >= 25 dB
     assert "Trickle ventilator" in text
@@ -147,7 +135,7 @@ def test_octave_band_fiche_renders(tmp_path) -> None:
     assert result.rating is not None
     out = tmp_path / "octave.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Octave-band" in _extract_text(str(out))
 
 
@@ -161,7 +149,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
         metadata=ReportMetadata(requirement=25.0, laboratory="Ejemplo"),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "CUMPLE" in text
     assert "intensidad acústica" in " ".join(text.split())

--- a/tests/building/measurement/test_iso15186_report.py
+++ b/tests/building/measurement/test_iso15186_report.py
@@ -22,12 +22,12 @@ import reference_data as ref
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata, building
 from phonometry.building.measurement.intensity_insulation import (
     IntensityReductionResult,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 _RATING_FREQS = np.array(
     [
@@ -69,18 +69,6 @@ def _intensity_result(*, with_kc: bool = False) -> IntensityReductionResult:
     )
 
 
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     """The concatenated text of every page."""
     from pypdf import PdfReader
@@ -98,7 +86,7 @@ def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     """The RI fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3) dB."""
     out = tmp_path / "ri.pdf"
     _intensity_result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{ref.ISO15186_1_REF_RIW} (-2; -3) dB" in text
     assert "ISO 15186-1:2000" in text
@@ -134,7 +122,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     )
     out = tmp_path / "verbose.pdf"
     _intensity_result(with_kc=True).report(str(out), metadata=metadata, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "PASS" in text  # RI,w = 30 dB >= 25 dB
     assert "100 mm autoclaved aerated concrete" in text
@@ -171,7 +159,7 @@ def test_octave_band_fiche_renders(tmp_path) -> None:
     assert result.rating is not None
     out = tmp_path / "octave.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Octave-band" in _extract_text(str(out))
 
 
@@ -179,7 +167,7 @@ def test_octave_band_verbose_declares_band_resolution(tmp_path) -> None:
     """The verbose RI,M caption still declares the octave-band resolution."""
     out = tmp_path / "octave_verbose.pdf"
     _octave_result(with_kc=True).report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "Octave-band" in text  # band resolution stated (ISO 717-1 Clause 5.3)
     assert "Kc-modified" in text  # the RI,M column is present
@@ -189,7 +177,7 @@ def test_one_third_octave_verbose_declares_band_resolution(tmp_path) -> None:
     """The verbose RI,M caption declares the one-third-octave resolution."""
     out = tmp_path / "verbose_res.pdf"
     _intensity_result(with_kc=True).report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "One-third-octave" in text
     assert "Kc-modified" in text
@@ -206,7 +194,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
         verbose=True,
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "CUMPLE" in text
     assert "intensidad acústica" in " ".join(text.split())
@@ -245,7 +233,7 @@ def test_verbose_without_kc_renders_plain_table(tmp_path) -> None:
     """``verbose=True`` with no RI,M falls back to the two-column table."""
     out = tmp_path / "plain.pdf"
     _intensity_result(with_kc=False).report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "One-third-octave" in text
     assert "Kc-modified" not in text
@@ -310,7 +298,7 @@ def test_clause8_fpi_and_residual_columns(tmp_path) -> None:
     residual = np.full(16, 18.0)
     out = tmp_path / "fpi.pdf"
     result.report(str(out), fpi=fpi, residual_index=residual)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = " ".join(_extract_text(str(out)).split())
     assert "4.0" in text  # the FpI column values
     assert "18.0" in text  # the dpI0 column values
@@ -319,7 +307,7 @@ def test_clause8_fpi_and_residual_columns(tmp_path) -> None:
     _intensity_result(with_kc=True).report(
         str(out2), verbose=True, fpi=fpi, residual_index=residual
     )
-    _assert_one_page(str(out2))
+    assert_one_page(str(out2))
 
 
 def test_clause8_fpi_wrong_band_count_rejected(tmp_path) -> None:

--- a/tests/building/measurement/test_iso16251_report.py
+++ b/tests/building/measurement/test_iso16251_report.py
@@ -24,10 +24,9 @@ import pytest
 pytest.importorskip("reportlab")
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
-
-_PDF_MAGIC = b"%PDF"
 
 _FREQS = np.array(
     [
@@ -81,14 +80,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -101,13 +92,13 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "iso16251.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_metadata_one_page(tmp_path) -> None:
     out = tmp_path / "iso16251_meta.pdf"
     _result().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -143,7 +134,7 @@ def test_verbose_shows_reference_floor_column_one_page(tmp_path) -> None:
     """verbose=True adds the reference-floor L_n,r column and stays one page."""
     out = tmp_path / "iso16251_verbose.pdf"
     _result().report(str(out), metadata=_metadata(), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     # L_n,r(100 Hz) = 67 - 0 = 67.0 and L_n,r(500 Hz) = 70.5 - 15 = 55.5.
     assert "67.0" in text
@@ -216,7 +207,7 @@ def test_manual_result_without_ci_delta_omits_adaptation_term(tmp_path) -> None:
     )
     out = tmp_path / "iso16251_noci.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     assert "(+0)" not in text
     assert "15 dB" in text
@@ -225,21 +216,21 @@ def test_manual_result_without_ci_delta_omits_adaptation_term(tmp_path) -> None:
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     out = tmp_path / "iso16251_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Carpet <A> & <B> "edge"'))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_no_metadata_still_renders(tmp_path) -> None:
     """Without metadata the header still shows the measured frequency range."""
     out = tmp_path / "iso16251_bare.pdf"
     _result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "100 to 3150" in _text(str(out))
 
 
 def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "iso16251_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "15,0" in _text(str(out))  # Spanish decimal comma
 
 
@@ -251,4 +242,4 @@ def test_characterisation_headline_without_rating_bands(tmp_path) -> None:
     assert result.delta_lw is None
     out = tmp_path / "iso16251_norate.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))

--- a/tests/building/measurement/test_iso16283_report.py
+++ b/tests/building/measurement/test_iso16283_report.py
@@ -28,10 +28,9 @@ from reference_data import (
 from reference_data import (
     ISO717_2_ANNEX_C1_LN as _IMPACT_LN,
 )
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
-
-_PDF_MAGIC = b"%PDF"
 
 #: A receiving-room reverberation time equal to T0 = 0,5 s in every band:
 #: the standardized quantities then equal the raw ones exactly
@@ -44,18 +43,6 @@ def _airborne_result(**kwargs) -> building.AirborneInsulationResult:
     l1 = np.full(16, 90.0)
     l2 = l1 - np.asarray(_AIRBORNE_R, dtype=np.float64)
     return building.airborne_insulation(l1, l2, _T_AT_T0, **kwargs)
-
-
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -88,7 +75,7 @@ def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     """
     out = tmp_path / "dnt.pdf"
     _airborne_result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "30 (-2; -3) dB" in text
     assert "ISO 16283-1:2014" in text
@@ -110,7 +97,7 @@ def test_r_prime_fiche_hand_computed(tmp_path) -> None:
     assert np.allclose(result.r_prime, expected)
     out = tmp_path / "r_prime.pdf"
     result.report(str(out), quantity="r_prime")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Apparent sound reduction index" in text
 
@@ -126,7 +113,7 @@ def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path) -> None:
     result = building.impact_insulation(_IMPACT_LN, _T_AT_T0, volume=31.25)
     out = tmp_path / "lnt.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     expected = f"{_IMPACT_EXPECTED['ln_w']} ({_IMPACT_EXPECTED['ci']:+d}) dB"
     assert expected in text
@@ -147,7 +134,7 @@ def test_impact_l_n_fiche_hand_computed(tmp_path) -> None:
     assert np.allclose(result.l_n, _IMPACT_LN)
     out = tmp_path / "ln.pdf"
     result.report(str(out), quantity="l_n")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{_IMPACT_EXPECTED['ln_w']} ({_IMPACT_EXPECTED['ci']:+d}) dB" in text
     assert "Normalized impact sound pressure level" in text
@@ -173,7 +160,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     )
     out = tmp_path / "verbose.pdf"
     result.report(str(out), metadata=metadata, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "PASS" in text  # DnT,w = 30 dB >= 25 dB
 
@@ -203,7 +190,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
         verbose=True,
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "in situ" in text
     assert "CUMPLE" in text
@@ -257,7 +244,7 @@ def test_verbose_needs_measurement_chain(tmp_path) -> None:
     # The non-verbose form still renders from the quantity alone.
     out = tmp_path / "bare.pdf"
     bare.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_manual_impact_result_renders_without_chain(tmp_path) -> None:
@@ -266,7 +253,7 @@ def test_manual_impact_result_renders_without_chain(tmp_path) -> None:
     bare = building.ImpactInsulationResult(l_n_t=curve, l_n=None)
     out = tmp_path / "bare_impact.pdf"
     bare.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     rejected = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="measurement chain"):
         bare.report(rejected, verbose=True)

--- a/tests/building/measurement/test_iso717_report.py
+++ b/tests/building/measurement/test_iso717_report.py
@@ -25,28 +25,9 @@ from reference_data import (
 from reference_data import (
     ISO717_2_ANNEX_C1_LN as _IMPACT_LN,
 )
+from report_assertions import assert_one_page, assert_pdf
 
 from phonometry import ReportMetadata, building
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_pdf(path: str) -> None:
-    """A written report is a non-empty file beginning with ``%PDF``."""
-    with open(path, "rb") as handle:
-        head = handle.read(4)
-    import os
-
-    assert head == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-
-
-def _assert_one_page(path: str) -> None:
-    """The fiche is a single-page PDF beginning with ``%PDF``."""
-    _assert_pdf(path)
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
 
 
 def test_airborne_report_writes_pdf(tmp_path) -> None:
@@ -55,7 +36,7 @@ def test_airborne_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "airborne.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_pdf(str(out))
+    assert_pdf(str(out))
 
 
 def test_impact_report_writes_pdf(tmp_path) -> None:
@@ -65,7 +46,7 @@ def test_impact_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "impact.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_pdf(str(out))
+    assert_pdf(str(out))
 
 
 def test_panel_result_report_convenience(tmp_path) -> None:
@@ -93,7 +74,7 @@ def test_panel_result_report_convenience(tmp_path) -> None:
     )
     out = tmp_path / "panel.pdf"
     res.report(str(out))
-    _assert_pdf(str(out))
+    assert_pdf(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -134,7 +115,7 @@ def test_airborne_fiche_reproduces_iso717_1_annex_c1(tmp_path) -> None:
         [0, 0, 0, 0, 0.6, 3.3, 4.2, 3.4, 3.0, 1.5, 1.2, 1.5, 0.6, 1.0, 3.0, 8.5], float
     )
     assert np.allclose(deviations, expected, atol=0.05)
-    _assert_pdf(str(result.report(str(tmp_path / "airborne_c1.pdf"))))
+    assert_pdf(str(result.report(str(tmp_path / "airborne_c1.pdf"))))
 
 
 def test_impact_fiche_reproduces_iso717_2_annex_c1(tmp_path) -> None:
@@ -149,7 +130,7 @@ def test_impact_fiche_reproduces_iso717_2_annex_c1(tmp_path) -> None:
     assert result.unfavourable_sum == pytest.approx(
         _IMPACT_EXPECTED["unfavourable_sum"], abs=0.05
     )
-    _assert_pdf(str(result.report(str(tmp_path / "impact_c1.pdf"))))
+    assert_pdf(str(result.report(str(tmp_path / "impact_c1.pdf"))))
 
 
 def _full_metadata(**overrides) -> ReportMetadata:
@@ -206,7 +187,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     result.report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_full_metadata_renders_one_page(tmp_path) -> None:
@@ -214,7 +195,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     result = building.weighted_rating(_AIRBORNE_R)
     out = tmp_path / "airborne_meta.pdf"
     result.report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_verbose_renders_annex_c_table(tmp_path) -> None:
@@ -222,7 +203,7 @@ def test_verbose_renders_annex_c_table(tmp_path) -> None:
     result = building.weighted_rating(_AIRBORNE_R)
     out = tmp_path / "airborne_verbose.pdf"
     result.report(str(out), metadata=_full_metadata(), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
@@ -232,8 +213,8 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     result.report(str(passing), metadata=_full_metadata(requirement=25.0))
     result.report(str(failing), metadata=_full_metadata(requirement=52.0))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
 
 
 def test_impact_requirement_verdict_renders(tmp_path) -> None:
@@ -249,7 +230,7 @@ def test_impact_requirement_verdict_renders(tmp_path) -> None:
             laboratory="Phonometry Reference Laboratory",
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_metadata_rejects_negative_area() -> None:
@@ -340,7 +321,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     result = building.weighted_rating(_AIRBORNE_R)  # Rw = 30 dB, passes a 25 dB minimum
     out = tmp_path / "airborne_es.pdf"
     result.report(str(out), metadata=_full_metadata(requirement=25.0), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Índice de aislamiento acústico a ruido aéreo" in text
     assert "CUMPLE" in text

--- a/tests/building/measurement/test_structure_borne_power_report.py
+++ b/tests/building/measurement/test_structure_borne_power_report.py
@@ -16,14 +16,11 @@ the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
-
-_PDF_MAGIC = b"%PDF"
 
 _FREQS = np.array([125, 250, 500, 1000, 2000, 4000], dtype=float)
 # Spatial mean plate velocity level Lv (dB re 1e-9 m/s) per octave band.
@@ -31,15 +28,6 @@ _LV = np.array([88.0, 90.0, 86.0, 82.0, 78.0, 73.0])
 _MASS = 25.0  # plate mass per area m, kg/m^2
 _AREA = 1.2  # reception-plate area S, m^2
 _TS = 0.3  # structural reverberation time Ts, s
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -92,7 +80,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "en15657.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # Band-summed total to one decimal, boxed with its reference power.
@@ -125,7 +113,7 @@ def test_verbose_adds_loss_factor_column(tmp_path) -> None:
     res = _result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The 1 kHz loss factor eta = 2,2/(1000*0,3) = 0,0073 (four decimals).
     eta = _oracle_eta()
@@ -144,7 +132,7 @@ def test_third_octave_labels_and_caption(tmp_path) -> None:
     )
     out = tmp_path / "third.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "One-third-octave-band structure-borne sound power levels" in text
     for label in ("100", "125", "160", "800"):
@@ -184,7 +172,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Circulation pump" in text
@@ -201,7 +189,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Determinación de la potencia acústica estructural" in text
     assert "método de la placa de recepción" in text

--- a/tests/building/measurement/test_survey_insulation_report.py
+++ b/tests/building/measurement/test_survey_insulation_report.py
@@ -19,9 +19,9 @@ import pytest
 
 pytest.importorskip("reportlab")
 
-from phonometry import ReportMetadata, building
+from report_assertions import assert_one_page
 
-_PDF_MAGIC = b"%PDF"
+from phonometry import ReportMetadata, building
 
 #: Five octave bands (125 Hz to 2000 Hz), the ISO 10052 survey range.
 _OCTAVE = 5
@@ -29,18 +29,6 @@ _OCTAVE = 5
 #: A reverberation index of 0 dB in every band (T = T0), so the standardized
 #: quantities equal the raw ones and the rating is hand-checkable.
 _K0 = np.zeros(_OCTAVE)
-
-
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -82,7 +70,7 @@ def test_airborne_fiche_rating_and_basis(tmp_path) -> None:
     assert rating is not None
     out = tmp_path / "dnt.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{rating.rating} ({rating.c:+d}; {rating.ctr:+d}) dB" in text
     assert "ISO 10052:2021" in text
@@ -97,7 +85,7 @@ def test_airborne_r_prime_quantity(tmp_path) -> None:
     assert result.r_prime_rating is not None
     out = tmp_path / "rprime.pdf"
     result.report(str(out), quantity="r_prime")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Apparent sound reduction index" in text
 
@@ -117,7 +105,7 @@ def test_airborne_one_third_octave_caption(tmp_path) -> None:
     )
     out = tmp_path / "dnt_third.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "One-third-octave" in text
     assert "Octave-band" not in text
@@ -132,7 +120,7 @@ def test_airborne_verbose_and_verdict_pass(tmp_path) -> None:
     _airborne().report(
         str(out), metadata=ReportMetadata(requirement=40.0), verbose=True
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "PASS" in text  # DnT,w = 44 dB >= 40 dB
     assert "Unfav. dev." in text
@@ -156,7 +144,7 @@ def test_airborne_spanish(tmp_path) -> None:
         verbose=True,
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "método de control" in text
     assert "CUMPLE" in text
@@ -173,7 +161,7 @@ def test_impact_fiche_rating_and_basis(tmp_path) -> None:
     assert rating is not None
     out = tmp_path / "lnt.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=62.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{rating.rating} ({rating.ci:+d}) dB" in text
     assert "ISO 10052:2021" in text
@@ -199,7 +187,7 @@ def test_facade_fiche_rating_and_basis(tmp_path) -> None:
     assert rating is not None
     out = tmp_path / "d2mnt.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=33.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{rating.rating} ({rating.c:+d}; {rating.ctr:+d}) dB" in text
     assert "ISO 10052:2021" in text
@@ -211,7 +199,7 @@ def test_facade_spanish(tmp_path) -> None:
     """``language='es'`` renders the Spanish survey facade fiche."""
     out = tmp_path / "es.pdf"
     _facade().report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Aislamiento acústico de fachada in situ" in _extract_text(str(out))
 
 

--- a/tests/building/prediction/test_detailed_model_report.py
+++ b/tests/building/prediction/test_detailed_model_report.py
@@ -19,9 +19,10 @@ import reference_data as ref
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata, building
 
-_PDF_MAGIC = b"%PDF"
 _BANDS = np.asarray(ref.ISO12354_ANNEX_L_BANDS, dtype=np.float64)
 
 
@@ -58,18 +59,6 @@ def _annex_g_impact():
     )
 
 
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     """The concatenated, whitespace-normalised text of every page."""
     from pypdf import PdfReader
@@ -83,7 +72,7 @@ def test_detailed_airborne_fiche_boxes_the_annex_l_rating(tmp_path) -> None:
     """The detailed airborne fiche boxes R'w = 57 dB and names Clause 4.2."""
     out = tmp_path / "air.pdf"
     assert _annex_l_airborne().report(str(out)) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{ref.ISO12354_ANNEX_L1_R_PRIME_W} dB" in text
     assert "ISO 12354-1:2017" in text
@@ -113,7 +102,7 @@ def test_detailed_impact_fiche_boxes_the_annex_g_rating(tmp_path) -> None:
         ),
         verbose=True,
     ) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{ref.ISO12354_ANNEX_G1_L_PRIME_N_W} dB" in text
     assert "ISO 12354-2:2017" in text
@@ -127,7 +116,7 @@ def test_spanish_detailed_fiche_renders(tmp_path) -> None:
     """The fiches translate to Spanish like every other report."""
     out = tmp_path / "air_es.pdf"
     _annex_l_airborne().report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "ISO 12354-1:2017" in text
     assert "57 dB" in text

--- a/tests/building/prediction/test_installed_structure_borne_report.py
+++ b/tests/building/prediction/test_installed_structure_borne_report.py
@@ -16,14 +16,12 @@ engines/languages) complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
 
-_PDF_MAGIC = b"%PDF"
 _S0 = 10.0
 
 _BANDS = np.array([63, 125, 250, 500, 1000, 2000], dtype=float)
@@ -35,15 +33,6 @@ _DSA = np.array([-13.6, -17.3, -17.4, -20.0, -26.9, -32.9])
 _R_WALL_FLOOR = np.array([43.0, 46.0, 50.2, 54.7, 64.6, 73.0])
 _R_WALL_WALL = np.array([37.0, 41.2, 35.9, 37.7, 49.0, 57.8])
 _S_WALL = 12.8
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -124,7 +113,7 @@ def test_report_reads_as_prediction(tmp_path) -> None:
     out = tmp_path / "en12354_5.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Predicted" in text
     assert "not a measurement" in text
@@ -142,7 +131,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     res = _result()
     out = tmp_path / "values.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # Overall band-summed L_n,s to one decimal.
@@ -169,7 +158,7 @@ def test_nonverbose_hides_path_columns(tmp_path) -> None:
     res = _result()
     out = tmp_path / "compact.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The total is still shown; the wall-wall path column value need not appear.
     assert f"{_oracle_total()[0]:.1f}" in text
@@ -207,7 +196,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example dwelling" in text
     assert "WC flushing cistern" in text
@@ -223,7 +212,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Sonido estructural instalado previsto" in text
     assert "no una medición" in text
@@ -259,6 +248,6 @@ def test_scalar_source_level_fiche_renders(tmp_path) -> None:
     assert result.installed_power_level.shape == _BANDS.shape
     out = tmp_path / "scalar.pdf"
     result.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "70.0" in text  # the broadcast installed power level

--- a/tests/building/prediction/test_simplified_model_report.py
+++ b/tests/building/prediction/test_simplified_model_report.py
@@ -20,6 +20,8 @@ pytest.importorskip("reportlab")
 
 from typing import TYPE_CHECKING
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata, building
 from phonometry._i18n import fmt_minus
 
@@ -31,8 +33,6 @@ if TYPE_CHECKING:
         AirbornePredictionResult,
         ImpactPredictionResult,
     )
-
-_PDF_MAGIC = b"%PDF"
 
 
 def _annex_h3_airborne() -> AirbornePredictionResult:
@@ -86,18 +86,6 @@ def _annex_f_facade() -> FacadePredictionResult:
     )
 
 
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    import os
-
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     """The concatenated, whitespace-normalised text of every page."""
     from pypdf import PdfReader
@@ -112,7 +100,7 @@ def test_airborne_prediction_rating_pinned_to_annex_h3(tmp_path) -> None:
     out = tmp_path / "air.pdf"
     # report() returns the written path (part of the public contract).
     assert _annex_h3_airborne().report(str(out)) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{ref.EN12354_1_ANNEX_H3_RPRIME_W} dB" in text  # boxed R'w = 52 dB
     assert "EN 12354-1:2000" in text
@@ -133,7 +121,7 @@ def test_impact_prediction_rating_pinned_to_annex_e3(tmp_path) -> None:
     """The impact fiche boxes the Annex E.3 predicted L'n,w = 45 dB."""
     out = tmp_path / "imp.pdf"
     assert _annex_e3_impact().report(str(out)) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{ref.EN12354_2_ANNEX_E3_LPRIME_N_W} dB" in text  # boxed L'n,w = 45
     assert "EN 12354-2:2000" in text
@@ -197,7 +185,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _annex_h3_airborne().report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Separating wall Rs,w = 57 dB" in text
     assert "Phonometry Reference Laboratory" in text
@@ -207,7 +195,7 @@ def test_lightweight_fiche_without_metadata(tmp_path) -> None:
     """A fiche with no metadata is still a valid one-page prediction report."""
     out = tmp_path / "bare.pdf"
     _annex_e3_impact().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "prediction" in _extract_text(str(out))
 
 
@@ -222,7 +210,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
         verbose=True,
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "CUMPLE" in text  # R'w = 52 dB >= 50 dB
     assert "previsto" in text  # "predicted"
@@ -234,7 +222,7 @@ def test_impact_spanish_fiche_renders_translated(tmp_path) -> None:
     """The impact fiche also renders in Spanish."""
     out = tmp_path / "es_imp.pdf"
     _annex_e3_impact().report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "previsto" in text
     assert "rmula (21)" in text  # "fórmula (21)"
@@ -244,7 +232,7 @@ def test_facade_prediction_rating_pinned_to_annex_f(tmp_path) -> None:
     """The facade fiche boxes the Annex F predicted D2m,nT,w = 33 dB."""
     out = tmp_path / "facade.pdf"
     assert _annex_f_facade().report(str(out)) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"{ref.EN12354_3_ANNEX_F_D2MNT_W} dB" in text  # boxed D2m,nT,w = 33 dB
     assert "D2m,nT,w" in text
@@ -296,7 +284,7 @@ def test_facade_lightweight_fiche_without_metadata(tmp_path) -> None:
     """A facade fiche with no metadata is still a valid one-page prediction."""
     out = tmp_path / "bare.pdf"
     _annex_f_facade().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "prediction" in _extract_text(str(out))
 
 
@@ -309,7 +297,7 @@ def test_facade_spanish_fiche_renders_translated(tmp_path) -> None:
         verbose=True,
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "CUMPLE" in text  # D2m,nT,w = 33 dB >= 30 dB
     assert "previsto" in text  # "predicted"

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -21,14 +21,13 @@ rejected engines/languages.
 from __future__ import annotations
 
 import math
-import os
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, electroacoustics
 
-_PDF_MAGIC = b"%PDF"
 _R = 8.0
 _L0 = 90.0
 
@@ -44,15 +43,6 @@ def _flat_response() -> tuple[np.ndarray, np.ndarray]:
     above = f > f_b
     spl[above] = _L0 - 10.0 * (np.log2(f[above] / f_b) / np.log2(f_hi / f_b))
     return f, spl
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -281,7 +271,7 @@ def test_report_renders_one_page_with_rated_table(tmp_path) -> None:
     out = tmp_path / "loudspeaker.pdf"
     returned = result.report(str(out), metadata=md)
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     # The table cell labels can wrap across lines in the PDF text layer, so the
     # assertions use single-line fragments.
     text = _extract_text(str(out))
@@ -302,7 +292,7 @@ def test_report_without_optional_panels(tmp_path) -> None:
     )
     out = tmp_path / "loudspeaker_min.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
@@ -312,7 +302,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     result = _example_result()
     out = tmp_path / "loudspeaker_es.pdf"
     result.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Características del altavoz" in text
     assert "Impedancia nominal" in text

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -26,14 +26,13 @@ rejected engines/languages.
 from __future__ import annotations
 
 import math
-import os
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, electroacoustics
 
-_PDF_MAGIC = b"%PDF"
 _M_MV = 12.5
 _TOL = 3.0
 
@@ -49,15 +48,6 @@ def _flat_response() -> tuple[np.ndarray, np.ndarray]:
     above = f > f_b
     rel[above] = -_TOL * (np.log2(f[above] / f_b) / np.log2(f_hi / f_b))
     return f, rel
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -451,7 +441,7 @@ def test_report_renders_one_page_with_rated_table(tmp_path) -> None:
     out = tmp_path / "microphone.pdf"
     returned = result.report(str(out), metadata=md)
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     # The table cell labels can wrap across lines in the PDF text layer, so the
     # assertions use single-line fragments.
     text = _extract_text(str(out))
@@ -472,7 +462,7 @@ def test_report_without_optional_panels(tmp_path) -> None:
     )
     out = tmp_path / "microphone_min.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
@@ -482,7 +472,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     result = _example_result()
     out = tmp_path / "microphone_es.pdf"
     result.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Características del micrófono" in text
     assert "Sensibilidad en campo libre" in text

--- a/tests/emission/test_iso3741_report.py
+++ b/tests/emission/test_iso3741_report.py
@@ -22,18 +22,15 @@ languages) complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import (
     sound_power_comparison,
     sound_power_reverberation,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 # Standard octave-band A-weighting corrections Ck (dB), IEC 61672 / ISO 3744
 # Annex E Table E.2 (reused by ISO 3741 Annex F), at the example band centres.
@@ -55,15 +52,6 @@ _SURFACE = 240.0
 _T60 = 2.0
 _THETA = 20.0
 _PS = 101.325
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -131,7 +119,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "iso3741.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # A-weighted total to one decimal, boxed with its reference power.
@@ -187,7 +175,7 @@ def test_verbose_adds_absorption_and_waterhouse_columns(tmp_path) -> None:
     res = _result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "Cw" in flat
     text = _extract_text(str(out))
@@ -215,7 +203,7 @@ def test_comparison_method_reports_eq21(tmp_path) -> None:
     )
     out = tmp_path / "comparison.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "comparison method" in text
     assert "Eq. 21" in text
@@ -265,7 +253,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Air compressor" in text
@@ -285,7 +273,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Determinación de la potencia acústica" in text
     assert "cámara reverberante cualificada" in text

--- a/tests/emission/test_iso3744_report.py
+++ b/tests/emission/test_iso3744_report.py
@@ -18,15 +18,13 @@ facts (one page, rejected engines/languages) complete the rendering contract.
 from __future__ import annotations
 
 import math
-import os
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import sound_power_anechoic, sound_power_pressure
-
-_PDF_MAGIC = b"%PDF"
 
 # ISO 3744:2010 Annex E, Table E.2 octave-band A-weighting corrections Ck (dB).
 _CK_OCTAVE = {
@@ -42,15 +40,6 @@ _CK_OCTAVE = {
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000, 8000], dtype=float)
 _SURFACE_LP = np.array([70.0, 74, 78, 80, 79, 76, 71, 64])
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -113,7 +102,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "iso3744.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # A-weighted total to one decimal, boxed with its reference power.
@@ -166,7 +155,7 @@ def test_verbose_adds_correction_columns(tmp_path) -> None:
     res = _uniform_result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "K1" in flat
     assert "K2" in flat
@@ -213,7 +202,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Air compressor" in text
@@ -235,7 +224,7 @@ def test_precision_report_names_iso3745(tmp_path) -> None:
     )
     out = tmp_path / "precision.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "ISO 3745:2012" in text
     assert "precision method" in text
@@ -262,7 +251,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _uniform_result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Determinación de la potencia acústica" in text
     assert "método de ingeniería" in text

--- a/tests/emission/test_iso4871_report.py
+++ b/tests/emission/test_iso4871_report.py
@@ -15,15 +15,13 @@ translated Spanish output, and rejected engines/languages.
 from __future__ import annotations
 
 import math
-import os
 import pickle
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, emission
-
-_PDF_MAGIC = b"%PDF"
 
 
 def _annex_b_modes() -> tuple[
@@ -55,15 +53,6 @@ def _annex_b_declaration(**kwargs) -> emission.NoiseEmissionDeclaration:
         basic_standards="ISO 3744",
         **kwargs,
     )
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -258,7 +247,7 @@ def test_dual_number_report_renders_one_page(tmp_path) -> None:
     out = tmp_path / "iso4871.pdf"
     returned = decl.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "DECLARED DUAL-NUMBER" in text
     assert "Operating mode 1" in text
@@ -271,7 +260,7 @@ def test_single_number_report_renders_one_page(tmp_path) -> None:
     decl = _annex_b_declaration(form="single-number")
     out = tmp_path / "iso4871_single.pdf"
     decl.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "DECLARED SINGLE-NUMBER" in _extract_text(str(out))
 
 
@@ -329,7 +318,7 @@ def test_verification_verdict_renders_both_ways(tmp_path) -> None:
     decl = emission.NoiseEmissionDeclaration((mode1, mode2), basic_standards="ISO 3744")
     out = tmp_path / "iso4871_verify.pdf"
     decl.report(str(out), metadata=ReportMetadata(report_id="PHN-4871"))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Verification" in text
     assert "PASS" in text
@@ -342,7 +331,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     decl = _annex_b_declaration()
     out = tmp_path / "iso4871_es.pdf"
     decl.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Declaración de emisión sonora" in text
     assert "DOBLE NÚMERO" in text

--- a/tests/emission/test_iso7849_report.py
+++ b/tests/emission/test_iso7849_report.py
@@ -18,15 +18,12 @@ contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import sound_power_from_vibration
-
-_PDF_MAGIC = b"%PDF"
 
 # Standard octave-band A-weighting corrections Ck (dB), IEC 61672 / ISO 3744
 # Annex E Table E.2, at the example band centres.
@@ -42,15 +39,6 @@ _AREA = 1.6  # radiating area S, m^2
 # The fixed terms of Eq. 12/15: 10 lg(S/S0) and the impedance term 10 lg(411/400).
 _S_TERM = 10.0 * np.log10(_AREA / 1.0)
 _IMP_TERM = 10.0 * np.log10(411.0 / 400.0)
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -104,7 +92,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "iso7849.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # A-weighted total to one decimal, boxed with its reference power.
@@ -136,7 +124,7 @@ def test_survey_part1_basis_and_method(tmp_path) -> None:
     res = _survey_result()
     out = tmp_path / "survey.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "ISO/TS 7849-1:2009" in text
     assert "survey method" in text
@@ -156,7 +144,7 @@ def test_broadband_result_has_no_a_weighted_claim(tmp_path) -> None:
     assert np.isnan(res.sound_power_level_a)
     out = tmp_path / "broadband.pdf"
     res.report(str(out), metadata=ReportMetadata(requirement=80.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The unweighted total LW is boxed; nothing is labelled A-weighted.
     lw = float(85.0 + _S_TERM + _IMP_TERM)
@@ -178,7 +166,7 @@ def test_third_octave_labels_and_grouping(tmp_path) -> None:
     res = sound_power_from_vibration(lv, area=_AREA, frequencies=freqs)
     out = tmp_path / "third.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "One-third-octave-band sound power levels" in text
     for label in ("100", "125", "160", "800"):
@@ -196,7 +184,7 @@ def test_verbose_adds_radiation_factor_column(tmp_path) -> None:
     res = _engineering_result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The 500 Hz radiation factor 0.750 appears to three decimals.
     assert "0.750" in text
@@ -242,7 +230,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Gearbox casing" in text
@@ -262,7 +250,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _engineering_result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Determinación de la potencia acústica" in text
     assert "método de ingeniería" in text

--- a/tests/emission/test_iso9614_3_report.py
+++ b/tests/emission/test_iso9614_3_report.py
@@ -23,10 +23,9 @@ engines, languages and band counts) complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import (
@@ -35,8 +34,6 @@ from phonometry.emission import (
     precision_qualification,
     sound_power_intensity_precision,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 # Standard one-third-octave A-weighting corrections Ck (dB), IEC 61672 /
 # ISO 3744 Annex E Table E.1, at the example band centres.
@@ -102,15 +99,6 @@ def _render_stack() -> None:
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
     pytest.importorskip("matplotlib")
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -209,7 +197,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "iso9614_3.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # The A-weighted total heads the boxed statement.
@@ -293,7 +281,7 @@ def test_verbose_tabulates_annex_b_indicators(tmp_path) -> None:
     indicators, criteria = _qualification(np.full(_FREQS.size, 2.0))
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True, indicators=indicators, criteria=criteria)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     flat = "".join(text.split())
     for header in ("FT", "Fp|In|", "FpIn", "FS", "Qualified"):
@@ -384,7 +372,7 @@ def test_failing_band_is_omitted_and_named(tmp_path) -> None:
         criteria=criteria,
         residual_index=_RESIDUAL_INDEX,
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The boxed LWA is the total over the qualified bands, and the result's own
     # unscreened total is nowhere on the sheet.
@@ -416,7 +404,7 @@ def test_not_applicable_band_named_with_clause_9_2(tmp_path) -> None:
     indicators, criteria = _qualification(np.full(_FREQS.size, 2.0))
     out = tmp_path / "not_applicable.pdf"
     res.report(str(out), indicators=indicators, criteria=criteria)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "250 Hz (clause 9.2)" in text
     # The determinable 315 Hz band still prints its level.
@@ -477,7 +465,7 @@ def test_wide_band_set_is_paired_onto_one_page(tmp_path) -> None:
     res = _determination(intensity, freqs)
     out = tmp_path / "wide.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     for label in ("100", "3150"):
         assert label in text
@@ -540,7 +528,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     for value in (
         "Example works",
@@ -574,7 +562,7 @@ def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
         criteria=criteria,
         residual_index=_RESIDUAL_INDEX,
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     for spanish in (
         "Determinación de la potencia acústica",
@@ -676,7 +664,7 @@ def test_frequencies_none_falls_back_to_the_band_total(tmp_path) -> None:
     )
     out = tmp_path / "unbanded.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     total = 10.0 * np.log10(np.sum(10.0 ** (_oracle_lw() / 10.0)))
     assert f"Sound power level LW = {total:.1f} dB re 1 pW" in text
@@ -691,7 +679,7 @@ def test_odd_band_count_pairs_with_a_blank_row(tmp_path) -> None:
     res = _determination(intensity, freqs)
     out = tmp_path / "odd.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     lw = _oracle_lw(intensity)
     lw0 = lw - _oracle_normalization()

--- a/tests/emission/test_iso9614_report.py
+++ b/tests/emission/test_iso9614_report.py
@@ -18,15 +18,12 @@ the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import SoundPowerWarning, sound_power_intensity
-
-_PDF_MAGIC = b"%PDF"
 
 # Standard octave-band A-weighting corrections Ck (dB), IEC 61672 / ISO 3744
 # Annex E Table E.2, at the example band centres.
@@ -38,15 +35,6 @@ _INTENSITY = np.array([0.6e-4, 1.0e-4, 1.5e-4, 1.4e-4, 0.9e-4, 0.5e-4])
 _N_SEG = 6
 _SEG_AREA = 0.5
 _SURFACE = _N_SEG * _SEG_AREA  # 3.0 m^2
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -108,7 +96,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "iso9614.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # A-weighted total to one decimal, boxed with its reference power.
@@ -160,7 +148,7 @@ def test_verbose_adds_indicator_columns(tmp_path) -> None:
     res = _uniform_result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "FpI" in flat
     # Every band qualifies at engineering grade, so the grade cell reads "2".
@@ -193,7 +181,7 @@ def test_omitted_bands_listed_in_basis_strip(tmp_path) -> None:
     assert res.a_weighting_omitted_bands.tolist() == [True] + [False] * 5
     out = tmp_path / "omitted.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "10.6 b" in text
     assert "125 Hz" in text
@@ -236,7 +224,7 @@ def test_negative_band_reported_as_dash(tmp_path) -> None:
         )
     out = tmp_path / "negative.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The determinable 500 Hz band still prints its level.
     assert f"{_oracle_lw()[2]:.1f}" in text
@@ -261,7 +249,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Air compressor" in text
@@ -281,7 +269,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _uniform_result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Determinación de la potencia acústica" in text
     assert "intensidad acústica normal" in text

--- a/tests/environment/assessment/test_impulse_prominence_report.py
+++ b/tests/environment/assessment/test_impulse_prominence_report.py
@@ -20,10 +20,10 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata
 from phonometry.environment.assessment import impulsive_sound as nt
-
-_PDF_MAGIC = b"%PDF"
 
 # The documented three-impulse pile-driving set: (onset rate dB/s, level
 # difference dB). All three qualify (onset rate > 10 dB/s); the first governs.
@@ -41,17 +41,6 @@ def _result():
     return nt.impulse_prominence(_ONSET_RATES, _LEVEL_DIFFERENCES)
 
 
-def _assert_one_page(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -64,7 +53,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "impulse.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -119,7 +108,7 @@ def test_metadata_appears_and_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _result().report(str(out), metadata=md, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Pile-driving site, intermittent hammering" in text
     assert "Free field, 25 m from source" in text
@@ -137,8 +126,8 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     result.report(str(passing), metadata=ReportMetadata(requirement=p + 2.0))
     result.report(str(failing), metadata=ReportMetadata(requirement=p - 2.0))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
     assert "PASS" in _extract_text(str(passing)).replace("\n", " ")
     assert "FAIL" in _extract_text(str(failing)).replace("\n", " ")
 
@@ -161,7 +150,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     # The escaped values render back to their literal glyphs in the PDF text.
     assert "hammer <A> & pile" in text  # source/situation (specimen)
@@ -180,7 +169,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
         metadata=ReportMetadata(specimen="hincado de pilotes"),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Evaluación de la prominencia de sonidos impulsivos" in text
     assert "ajuste de L" in text
@@ -198,7 +187,7 @@ def test_verdict_compares_unrounded_prominence(tmp_path) -> None:
     out = tmp_path / "boundary.pdf"
     requirement = result.prominence - 1e-3  # just below the unrounded P
     result.report(str(out), metadata=ReportMetadata(requirement=requirement))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert result.prominence > requirement
     assert "FAIL" in text
@@ -210,7 +199,7 @@ def test_verdict_passes_at_the_requirement(tmp_path) -> None:
     result = _result()
     out = tmp_path / "atlimit.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=result.prominence))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "PASS" in _extract_text(str(out)).replace("\n", " ")
 
 
@@ -233,7 +222,7 @@ def test_oversized_impulse_set_stays_one_page(tmp_path) -> None:
         result = nt.impulse_prominence(onset_rates, level_differences)
     out = tmp_path / "big.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "more impulses of lower prominence" in text
     assert f"{result.prominence:.2f}" in text  # boxed governing P still present
@@ -289,7 +278,7 @@ def test_non_prominent_impulse_reports_zero_adjustment(tmp_path) -> None:
     result = nt.impulse_prominence([15.0], [5.0])
     out = tmp_path / "weak.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert result.prominence <= 5.0
     assert result.adjustment == 0.0
@@ -312,7 +301,7 @@ def test_non_qualifying_set_justifies_on_the_onset_gate(tmp_path) -> None:
     assert result.prominence > 5.0  # informational only
     out = tmp_path / "no_qualifying.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "No level rise qualifies as an impulse" in text
     assert "informational only" in text

--- a/tests/environment/assessment/test_rd1367_report.py
+++ b/tests/environment/assessment/test_rd1367_report.py
@@ -22,10 +22,10 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata
 from phonometry.environment.assessment import spain as rd
-
-_PDF_MAGIC = b"%PDF"
 
 
 def _measurements() -> dict[str, list[rd.NoisePhase]]:
@@ -53,17 +53,6 @@ def _result(**kwargs: object) -> rd.ActivityAssessment:
     )
 
 
-def _assert_one_page(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -75,7 +64,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "acta.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_language_rejected(tmp_path) -> None:
@@ -95,7 +84,7 @@ def test_fiche_defaults_to_spanish(tmp_path) -> None:
     """
     out = tmp_path / "acta_es.pdf"
     _result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Valoración acústica de actividad (RD 1367/2007)" in text
     assert "Fases de ruido" in text
@@ -112,7 +101,7 @@ def test_english_fiche_renders_one_page(tmp_path) -> None:
     """``language="en"`` renders the same fiche in English on one page."""
     out = tmp_path / "acta_en.pdf"
     _result().report(str(out), language="en")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Activity noise assessment (RD 1367/2007)" in text
     assert "Noise phases" in text
@@ -156,8 +145,8 @@ def test_verdict_fails_for_a_new_activity_and_passes_for_an_existing_one(
     existing = tmp_path / "existing.pdf"
     _result().report(str(new), language="en")
     _result(new_activity=False).report(str(existing), language="en")
-    _assert_one_page(str(new))
-    _assert_one_page(str(existing))
+    assert_one_page(str(new))
+    assert_one_page(str(existing))
 
     new_text = _extract_text(str(new)).replace("\n", " ")
     existing_text = _extract_text(str(existing)).replace("\n", " ")
@@ -193,7 +182,7 @@ def test_metadata_appears_and_stays_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _result().report(str(out), metadata=md, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Taller mecanico, horario 9 h a 21 h" in text
     assert "Sonometro integrador-promediador clase 1" in text
@@ -221,7 +210,7 @@ def test_report_escapes_xml_specials_in_metadata_and_phase_labels(tmp_path) -> N
     )
     out = tmp_path / "xml.pdf"
     result.report(str(out), metadata=md, language="en")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Taller <A> & <B>" in text
     assert "Ac & Co <Ltd>" in text
@@ -253,7 +242,7 @@ def test_three_period_fiche_stays_one_page(tmp_path) -> None:
         for verbose in (False, True):
             out = tmp_path / f"three_{language}_{verbose}.pdf"
             result.report(str(out), metadata=md, language=language, verbose=verbose)
-            _assert_one_page(str(out))
+            assert_one_page(str(out))
 
 
 def test_adjacent_premises_limit_row_renders(tmp_path) -> None:
@@ -269,7 +258,7 @@ def test_adjacent_premises_limit_row_renders(tmp_path) -> None:
         operating_days=303,
     )
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "anexo III tabla B2" in text
     assert "dormitorios" in text

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -14,17 +14,16 @@ measurement" wording and the verdict direction, like the sibling report tests.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 import phonometry as ph
 from phonometry import ReportMetadata, environment
 
-_PDF_MAGIC = b"%PDF"
 _BANDS = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
 
 
@@ -47,16 +46,6 @@ def _barrier(method: str = "exact") -> ph.environment.BarrierInsertionLoss:
     )
 
 
-def _assert_one_page(path: str) -> None:
-    """A written report is a non-empty single-page PDF."""
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     """The concatenated, whitespace-normalised text of every page."""
     from pypdf import PdfReader
@@ -73,7 +62,7 @@ def test_attenuation_with_emission_boxes_receiver_level(tmp_path) -> None:
     """With a source emission the fiche boxes the A-weighted downwind level."""
     out = tmp_path / "atten.pdf"
     assert _attenuation().report(str(out), source_emission=_emission()) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "LAT(DW) = 46.5 dB" in text  # boxed A-weighted downwind level
     assert "ISO 9613-2:1996" in text
@@ -88,7 +77,7 @@ def test_attenuation_without_emission_boxes_total_range(tmp_path) -> None:
     """Without a source emission the fiche boxes the total-attenuation range."""
     out = tmp_path / "bare.pdf"
     _attenuation().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Total attenuation A" in text
     assert "52.8" in text  # min total attenuation
@@ -150,7 +139,7 @@ def test_attenuation_metadata_header_and_distance(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _attenuation().report(str(out), metadata=metadata, source_emission=_emission())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Industrial fan plant" in text
     assert "Phonometry Reference Laboratory" in text
@@ -168,7 +157,7 @@ def test_attenuation_spanish_fiche(tmp_path) -> None:
         source_emission=_emission(),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "CUMPLE" in text  # 46.5 dB <= 50 dB
     assert "prevista" in text  # "predicted"
@@ -183,7 +172,7 @@ def test_barrier_report_structure_and_numbers(tmp_path) -> None:
     """The barrier fiche boxes the mean insertion loss and cites the model."""
     out = tmp_path / "bar.pdf"
     assert _barrier().report(str(out)) == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "IL = 12.9 dB" in text  # boxed mean insertion loss
     assert "prediction" in text
@@ -222,7 +211,7 @@ def test_barrier_kurze_anderson_model_cited(tmp_path) -> None:
     """The Kurze-Anderson method is named in the basis line."""
     out = tmp_path / "ka.pdf"
     _barrier(method="kurze_anderson").report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Kurze-Anderson" in _extract_text(str(out))
 
 
@@ -230,7 +219,7 @@ def test_barrier_lightweight_without_metadata(tmp_path) -> None:
     """A barrier fiche with no metadata is still a valid one-page prediction."""
     out = tmp_path / "bare.pdf"
     _barrier().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "prediction" in _extract_text(str(out))
 
 
@@ -238,7 +227,7 @@ def test_barrier_spanish_fiche(tmp_path) -> None:
     """``language="es"`` renders the Spanish barrier fiche."""
     out = tmp_path / "es.pdf"
     _barrier().report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "prevista" in text  # "predicted"
     assert "no una medici" in text  # "not a measurement"

--- a/tests/environment/sources/test_wind_turbine_tonality_report.py
+++ b/tests/environment/sources/test_wind_turbine_tonality_report.py
@@ -18,12 +18,12 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata
 from phonometry.environment.sources.wind_turbine import (
     wind_turbine_tonality,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 
 def _synthetic_tone() -> tuple[np.ndarray, np.ndarray]:
@@ -43,17 +43,6 @@ def _result():
     return wind_turbine_tonality(levels, freqs)
 
 
-def _assert_one_page(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
-
-
 def _extract_text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -66,7 +55,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "wt.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -115,7 +104,7 @@ def test_metadata_appears_and_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _result().report(str(out), metadata=md, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Horizontal-axis wind turbine, gearbox tone" in text
     assert "Ground board, downwind reference position" in text
@@ -131,8 +120,8 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     result.report(str(passing), metadata=ReportMetadata(requirement=delta + 2.0))
     result.report(str(failing), metadata=ReportMetadata(requirement=delta - 2.0))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
     assert "PASS" in _extract_text(str(passing)).replace("\n", " ")
     assert "FAIL" in _extract_text(str(failing)).replace("\n", " ")
 
@@ -150,7 +139,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
@@ -163,7 +152,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
         metadata=ReportMetadata(specimen="aerogenerador de eje horizontal"),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Evaluación de la audibilidad tonal de aerogenerador" in text
     assert "Decisión" in text
@@ -183,7 +172,7 @@ def test_decision_matches_displayed_audibility_at_boundary(tmp_path) -> None:
     assert result.is_audible is True  # raw flag is audible
     out = tmp_path / "boundary.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "The tone is not audible" in text
     assert "0.0 dB" in text
@@ -203,7 +192,7 @@ def test_no_identified_tone_reports_exclusion(tmp_path) -> None:
     result = wind_turbine_tonality(levels, freqs, tone_frequency=500.0)
     out = tmp_path / "notone.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert result.has_identified_tone is False
     assert result.is_audible is False

--- a/tests/filters/test_iec61260_report.py
+++ b/tests/filters/test_iec61260_report.py
@@ -12,30 +12,20 @@ verification itself is validated against the standard's Table 1 elsewhere
 
 from __future__ import annotations
 
-import os
 import pickle
 
 import pytest
 
 pytest.importorskip("reportlab")
 
-from phonometry import ReportMetadata, filters
+from report_assertions import assert_one_page
 
-_PDF_MAGIC = b"%PDF"
+from phonometry import ReportMetadata, filters
 
 
 def _class1_bank() -> filters.OctaveFilterBank:
     """A default Butterworth octave bank that meets IEC 61260-1:2014 class 1."""
     return filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def test_filter_class_compliance_carries_bank_data() -> None:
@@ -66,7 +56,7 @@ def test_class1_bank_reports_complies(tmp_path) -> None:
     out = tmp_path / "iec.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_1995_edition_reports_class0(tmp_path) -> None:
@@ -83,7 +73,7 @@ def test_1995_edition_reports_class0(tmp_path) -> None:
             measurement_standard="IEC 61260:1995", required_class=0
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_full_metadata_renders_one_page(tmp_path) -> None:
@@ -103,7 +93,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     result.report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -122,7 +112,7 @@ def test_required_class_pass_and_fail_both_render(tmp_path) -> None:
     assert result.overall_class == 1
     passing = tmp_path / "pass.pdf"
     result.report(str(passing), metadata=ReportMetadata(required_class=1))
-    _assert_one_page(str(passing))
+    assert_one_page(str(passing))
     # FAIL case: a low-order bank meets no class of the edition.
     failing_result = filters.filter_class_compliance(
         filters.OctaveFilterBank(fs=48000, fraction=1, order=1, limits=[500, 2000])
@@ -130,7 +120,7 @@ def test_required_class_pass_and_fail_both_render(tmp_path) -> None:
     assert failing_result.overall_class is None
     failing = tmp_path / "fail.pdf"
     failing_result.report(str(failing), metadata=ReportMetadata(required_class=1))
-    _assert_one_page(str(failing))
+    assert_one_page(str(failing))
 
 
 def test_required_class_missing_from_edition_rejected(tmp_path) -> None:
@@ -190,7 +180,7 @@ def test_non_compliant_bank_renders(tmp_path) -> None:
     assert result.overall_class is None
     out = tmp_path / "noncompliant.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_empty_bands_result_is_graceful() -> None:
@@ -231,7 +221,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     result = filters.filter_class_compliance(_class1_bank())
     out = tmp_path / "filter_es.pdf"
     result.report(str(out), metadata=ReportMetadata(required_class=1), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Conformidad de clase de filtro" in text
     assert "CUMPLE" in text

--- a/tests/hearing/test_iso9612_report.py
+++ b/tests/hearing/test_iso9612_report.py
@@ -18,9 +18,9 @@ the rendering contract.
 from __future__ import annotations
 
 import math
-import os
 
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.hearing import (
@@ -29,17 +29,6 @@ from phonometry.hearing import (
     job_based_exposure,
     task_based_exposure,
 )
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -92,7 +81,7 @@ def test_report_renders_hand_computed_values(tmp_path) -> None:
     out = tmp_path / "iso9612.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "82.4" in text  # LEX,8h to one decimal (Clause 15 e)
     assert "2.7" in text  # U to one decimal, stated separately
@@ -125,7 +114,7 @@ def test_annex_d_example_renders_pinned_numbers(tmp_path) -> None:
     res = task_based_exposure(tasks, warn=False)
     out = tmp_path / "annex_d.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "84.3" in text
     assert "3.2" in text
@@ -173,7 +162,7 @@ def test_job_based_report_renders_sampling_summary(tmp_path) -> None:
     )
     out = tmp_path / "job.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "job-based measurement (Clause 10)" in text
     assert "Sampling summary" in text
@@ -190,7 +179,7 @@ def test_full_day_report_renders(tmp_path) -> None:
     )
     out = tmp_path / "full_day.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "full-day measurement (Clause 11)" in text
     assert "90.1" in text
@@ -216,7 +205,7 @@ def test_metadata_header_and_instrumentation_override(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Lathe operators" in text
@@ -233,7 +222,7 @@ def test_verbose_adds_annex_c_columns(tmp_path) -> None:
     res = _two_task_result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "u1a,m" in flat
     assert "u1b,m" in flat
@@ -272,7 +261,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _two_task_result()
     out = tmp_path / "iso9612_es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Determinación de la exposición al ruido en el trabajo" in text
     assert "Nivel de exposición diario equivalente" in text

--- a/tests/hearing/test_noise_induced_hearing_loss_report.py
+++ b/tests/hearing/test_noise_induced_hearing_loss_report.py
@@ -14,23 +14,11 @@ English and Spanish fiches are exercised.
 
 from __future__ import annotations
 
-import os
-
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.hearing import NoiseInducedHearingLossWarning, htlan, nipts
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -53,7 +41,7 @@ def test_nipts_report_renders_annex_d_values(tmp_path) -> None:
     out = tmp_path / "nipts.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "12.9" in text  # median N50 at 4 kHz (Table D.2)
     assert "17.8" in text  # NIPTS at Q = 0.90, 4 kHz (worst tenth)
@@ -72,7 +60,7 @@ def test_nipts_verbose_adds_spread_columns(tmp_path) -> None:
     res = nipts(95.0, 20.0, 0.9)
     out = tmp_path / "nipts_v.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "du[dB]" in flat
     assert "dl[dB]" in flat
@@ -120,7 +108,7 @@ def test_nipts_outside_domain_prints_extrapolation_caveat(tmp_path) -> None:
         res = nipts(130.0, 60.0, 0.99)
     out = tmp_path / "extrapolated.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "outside the validated domain" in text
     assert "extrapolation" in text
@@ -138,7 +126,7 @@ def test_nipts_subset_boxes_peak_shift(tmp_path) -> None:
     res = nipts(95.0, 20.0, 0.9, frequencies=[500.0, 6000.0])
     out = tmp_path / "sub.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "peak NIPTS" in _extract_text(str(out))
 
 
@@ -153,7 +141,7 @@ def test_htlan_report_renders_components(tmp_path) -> None:
     res = htlan(60, "male", 95.0, 30.0, 0.5)
     out = tmp_path / "htlan.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # Regression guards, not normative oracles: the ISO 1999 Annex C example
     # pins the NIPTS chain (see tests/hearing/test_noise_induced_hearing_loss.py
@@ -177,7 +165,7 @@ def test_htlan_verbose_adds_compression_term(tmp_path) -> None:
     res = htlan(60, "male", 95.0, 30.0, 0.5)
     out = tmp_path / "htlan_v.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "N/120" in flat
 
@@ -212,7 +200,7 @@ def test_nipts_spanish_report(tmp_path) -> None:
     res = nipts(90.0, 20.0, 0.9)
     out = tmp_path / "nipts_es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Predicción de la pérdida auditiva inducida por ruido" in text
     assert "13,9" in text  # comma decimal separator
@@ -228,7 +216,7 @@ def test_htlan_spanish_report(tmp_path) -> None:
     res = htlan(60, "male", 95.0, 30.0, 0.5)
     out = tmp_path / "htlan_es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "edad y ruido" in text
     assert "hombre" in text

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -29,6 +29,7 @@ import pytest
 pytest.importorskip("reportlab")
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.materials import (
@@ -38,8 +39,6 @@ from phonometry.materials import (
     tube_wavenumber,
     two_microphone_impedance,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 _TEMPERATURE_K = 293.15  # 20 degC
 _DIAMETER, _SPACING, _X1 = 0.100, 0.050, 0.100
@@ -92,14 +91,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -112,13 +103,13 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "iso10534.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_metadata_one_page(tmp_path) -> None:
     out = tmp_path / "iso10534_meta.pdf"
     _result().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -179,7 +170,7 @@ def test_verbose_shows_reflection_column_one_page(tmp_path) -> None:
     """verbose=True adds the |r| column and stays one page."""
     out = tmp_path / "iso10534_verbose.pdf"
     _result().report(str(out), metadata=_metadata(), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     assert "0.45" in text  # |r|(500 Hz) = 1/sqrt(5)
 
@@ -187,21 +178,21 @@ def test_verbose_shows_reflection_column_one_page(tmp_path) -> None:
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     out = tmp_path / "iso10534_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Panel <A> & <B> "edge"'))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_no_metadata_still_renders(tmp_path) -> None:
     """Without metadata the header still shows the measured frequency range."""
     out = tmp_path / "iso10534_bare.pdf"
     _result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "400 to 1600" in _text(str(out))
 
 
 def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "iso10534_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0,80" in _text(str(out))  # Spanish decimal comma
 
 

--- a/tests/materials/absorbers/test_iso11654_report.py
+++ b/tests/materials/absorbers/test_iso11654_report.py
@@ -36,14 +36,13 @@ from reference_data import (
 from reference_data import (
     ISO11654_ANNEX_A2_INDICATOR as _A2_INDICATOR,
 )
+from report_assertions import assert_one_page, assert_pdf
 
 from phonometry import ReportMetadata
 from phonometry.materials import (
     weighted_absorption,
     weighted_absorption_from_third_octave,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 # Fifteen one-third-octave alpha_s (200 Hz to 5000 Hz) whose octave means are
 # the Annex A.2 practical coefficients (0.35, 1.00, 0.65, 0.60, 0.55).
@@ -66,30 +65,13 @@ _THIRD_OCTAVE_ALPHA_S = (
 )
 
 
-def _assert_pdf(path: str) -> None:
-    """A written report is a non-empty file beginning with ``%PDF``."""
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-
-
-def _assert_one_page(path: str) -> None:
-    """The fiche is a single-page PDF beginning with ``%PDF``."""
-    _assert_pdf(path)
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
-
-
 def test_absorption_report_writes_pdf(tmp_path) -> None:
     """A weighted absorption rating renders a PDF fiche."""
     result = weighted_absorption(_A1_ALPHA_P)
     out = tmp_path / "absorption.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_pdf(str(out))
+    assert_pdf(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -106,7 +88,7 @@ def test_fiche_reproduces_iso11654_annex_a1(tmp_path) -> None:
     assert result.alpha_w == pytest.approx(_A1_ALPHA_W)
     assert result.absorption_class == _A1_CLASS
     assert result.shape_indicator == _A1_INDICATOR
-    _assert_one_page(str(result.report(str(tmp_path / "a1.pdf"))))
+    assert_one_page(str(result.report(str(tmp_path / "a1.pdf"))))
 
 
 def test_fiche_reproduces_iso11654_annex_a2(tmp_path) -> None:
@@ -114,7 +96,7 @@ def test_fiche_reproduces_iso11654_annex_a2(tmp_path) -> None:
     result = weighted_absorption(_A2_ALPHA_P)
     assert result.alpha_w == pytest.approx(_A2_ALPHA_W)
     assert result.shape_indicator == _A2_INDICATOR
-    _assert_one_page(str(result.report(str(tmp_path / "a2.pdf"))))
+    assert_one_page(str(result.report(str(tmp_path / "a2.pdf"))))
 
 
 def test_third_octave_fiche_renders_and_round_trips(tmp_path) -> None:
@@ -147,7 +129,7 @@ def test_third_octave_fiche_renders_and_round_trips(tmp_path) -> None:
     )
     out = tmp_path / "third_octave.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_third_octave_fiche_with_metadata(tmp_path) -> None:
@@ -155,7 +137,7 @@ def test_third_octave_fiche_with_metadata(tmp_path) -> None:
     result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
     out = tmp_path / "third_octave_meta.pdf"
     result.report(str(out), metadata=_full_metadata(requirement=0.55))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_third_octave_fiche_rejects_band_count_mismatch(tmp_path) -> None:
@@ -207,7 +189,7 @@ def test_plain_rating_without_alpha_s_still_renders(tmp_path) -> None:
     assert result.third_octave_alpha_s is None
     out = tmp_path / "plain.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_verbose_renders_evaluation_table(tmp_path) -> None:
@@ -215,7 +197,7 @@ def test_verbose_renders_evaluation_table(tmp_path) -> None:
     result = weighted_absorption(_A2_ALPHA_P)
     out = tmp_path / "verbose.pdf"
     result.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def _full_metadata(**overrides) -> ReportMetadata:
@@ -244,7 +226,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     result = weighted_absorption(_A2_ALPHA_P)
     out = tmp_path / "meta.pdf"
     result.report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
@@ -254,8 +236,8 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     result.report(str(passing), metadata=_full_metadata(requirement=0.55))
     result.report(str(failing), metadata=_full_metadata(requirement=0.80))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
 
 
 def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
@@ -271,7 +253,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     result.report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def _extract_text(path: str) -> str:
@@ -292,7 +274,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
         metadata=ReportMetadata(requirement=0.55, temperature=21.4),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Índice de absorción acústica" in text
     assert "CUMPLE" in text

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -19,11 +19,10 @@ import pytest
 pytest.importorskip("reportlab")
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.materials import measure_sound_absorption
-
-_PDF_MAGIC = b"%PDF"
 
 # The committed clean-room example (V = 200 m3, S = 10.8 m2, 20 degC -> c = 343,
 # m = 0); alpha_s(500 Hz) = 0.33 and alpha_s(1000 Hz) = 0.61 by Eq. (8)/(9).
@@ -126,14 +125,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -146,13 +137,13 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "iso354.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_metadata_one_page(tmp_path) -> None:
     out = tmp_path / "iso354_meta.pdf"
     _result().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -185,7 +176,7 @@ def test_verbose_shows_areas_and_times_one_page(tmp_path) -> None:
     """verbose=True adds the T1/T2/A1/A2 columns and stays one page."""
     out = tmp_path / "iso354_verbose.pdf"
     _result().report(str(out), metadata=_metadata(), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     assert "7.80" in text  # T1(500 Hz)
     assert "7.7" in text  # A2(500 Hz) = 7.677 m2 rounded to 0.1
@@ -220,19 +211,19 @@ def test_verbose_rejects_short_band_column(field: str, tmp_path) -> None:
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     out = tmp_path / "iso354_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Panel <A> & <B> "edge"'))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_no_metadata_still_renders(tmp_path) -> None:
     """Without metadata the body still shows the result's physical conditions."""
     out = tmp_path / "iso354_bare.pdf"
     _result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "343" in _text(str(out))  # speed of sound from the result
 
 
 def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "iso354_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0,33" in _text(str(out))  # Spanish decimal comma

--- a/tests/materials/absorbers/test_iso9053_report.py
+++ b/tests/materials/absorbers/test_iso9053_report.py
@@ -21,12 +21,12 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import (
     ReportMetadata,
     materials,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 # The committed clean-room example: a 50 mm porous absorber in a 100 mm diameter
 # cell (A = pi*0.05^2 m2), stepped to 12 mm/s (below the 15 mm/s clause-7.5
@@ -70,14 +70,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _raw_text(path: str) -> str:
     """The extracted PDF text with its line breaks kept (for row anchoring)."""
     from pypdf import PdfReader
@@ -94,7 +86,7 @@ def test_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "airflow.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_displayed_values_match_oracle(tmp_path) -> None:
@@ -136,7 +128,7 @@ def test_metadata_and_fit_rows_appear(tmp_path) -> None:
 def test_no_metadata_still_renders(tmp_path) -> None:
     out = tmp_path / "airflow_bare.pdf"
     _result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "ISO 9053-1:2018" in _text(str(out))  # standard-basis line
 
 
@@ -147,7 +139,7 @@ def test_no_thickness_omits_resistivity(tmp_path) -> None:
     result = materials.static_airflow_resistance(u, dp, area=_AREA)
     out = tmp_path / "airflow_nod.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Airflow resistivity" not in _text(str(out))
 
 
@@ -168,13 +160,13 @@ def test_unknown_language_rejected(tmp_path) -> None:
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     out = tmp_path / "airflow_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Foam <A> & <B> "edge"'))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "airflow_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     # Spanish fixed strings and the decimal comma on the evaluation velocity.
     assert "Resistencia especifica al flujo de aire" in text.replace("í", "i")

--- a/tests/materials/diffusers/test_iso17497_report.py
+++ b/tests/materials/diffusers/test_iso17497_report.py
@@ -20,13 +20,12 @@ pytest.importorskip("reportlab")
 from dataclasses import replace
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import (
     ReportMetadata,
     materials,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 # The committed clean-room example: V = 200 m3, S = 10 m2, 20 degC (c = 343.2),
 # m = 0, symmetrical base plate (T1 = T3). See scripts/generate_reports.py.
@@ -158,14 +157,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -179,7 +170,7 @@ def test_scattering_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "scat.pdf"
     returned = _scattering().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_scattering_displayed_values_match_oracle(tmp_path) -> None:
@@ -200,7 +191,7 @@ def test_scattering_displayed_values_match_oracle(tmp_path) -> None:
 def test_scattering_verbose_shows_alpha_spec_one_page(tmp_path) -> None:
     out = tmp_path / "scat_v.pdf"
     _scattering().report(str(out), metadata=_metadata(), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0.13" in _text(str(out))  # alpha_spec(500 Hz) = 0.131 -> 0.13
 
 
@@ -223,20 +214,20 @@ def test_scattering_metadata_xml_specials_do_not_break(tmp_path) -> None:
     _scattering().report(
         str(out), metadata=_metadata(specimen='Panel <A> & <B> "edge"')
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_scattering_no_metadata_still_renders(tmp_path) -> None:
     out = tmp_path / "scat_bare.pdf"
     _scattering().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "100 to 5000" in _text(str(out))  # measured frequency range
 
 
 def test_scattering_spanish_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "scat_es.pdf"
     _scattering().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0,45" in _text(str(out))  # Spanish decimal comma
 
 
@@ -268,7 +259,7 @@ def test_scattering_verbose_short_specular_rejected(tmp_path) -> None:
 def test_diffusion_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "diff.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_diffusion_displayed_values_match_oracle(tmp_path) -> None:
@@ -294,7 +285,7 @@ def test_diffusion_omits_room_fields(tmp_path) -> None:
 def test_diffusion_verbose_shows_normalized_one_page(tmp_path) -> None:
     out = tmp_path / "diff_v.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata(), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0.35" in _text(str(out))  # d_n(500 Hz) = 0.347 -> 0.35
 
 
@@ -308,7 +299,7 @@ def test_diffusion_unknown_engine_rejected(tmp_path) -> None:
 def test_diffusion_spanish_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "diff_es.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0,81" in _text(str(out))
 
 
@@ -330,7 +321,7 @@ def test_diffusion_short_normalized_rejected(tmp_path) -> None:
 def test_polar_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "polar.pdf"
     _polar().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_polar_displays_coefficient_and_angles(tmp_path) -> None:
@@ -351,5 +342,5 @@ def test_polar_unknown_engine_rejected(tmp_path) -> None:
 def test_polar_spanish_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "polar_es.pdf"
     _polar().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "0,67" in _text(str(out))

--- a/tests/materials/resilient/test_iso9052_report.py
+++ b/tests/materials/resilient/test_iso9052_report.py
@@ -20,12 +20,12 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import (
     ReportMetadata,
     materials,
 )
-
-_PDF_MAGIC = b"%PDF"
 
 # The committed clean-room example: the standard 8 kg load plate over the
 # 0.04 m2 specimen (m't = 200 kg/m2, Clauses 5-6), a measured resonance of
@@ -71,14 +71,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _raw_text(path: str) -> str:
     """The extracted PDF text with its line breaks kept (for row anchoring)."""
     from pypdf import PdfReader
@@ -99,7 +91,7 @@ def test_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "dyn.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_displayed_values_match_oracle(tmp_path) -> None:
@@ -148,7 +140,7 @@ def test_metadata_fields_appear(tmp_path) -> None:
 def test_no_metadata_still_renders(tmp_path) -> None:
     out = tmp_path / "dyn_bare.pdf"
     _result().report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "EN 29052-1" in _text(str(out))  # standard-basis line
 
 
@@ -161,7 +153,7 @@ def test_high_resistivity_omits_gas_term(tmp_path) -> None:
         floor_mass_per_area=_MFLOOR,
     )
     result.report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Enclosed-gas stiffness" not in _text(str(out))
 
 
@@ -182,13 +174,13 @@ def test_unknown_language_rejected(tmp_path) -> None:
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     out = tmp_path / "dyn_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Layer <A> & <B> "edge"'))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_uses_comma_decimal(tmp_path) -> None:
     out = tmp_path / "dyn_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     # Each Spanish decimal comma is anchored to its labelled box statement.
     assert "Frecuencia de resonancia fr = 45,0 Hz" in text

--- a/tests/metrology/test_iec61043_report.py
+++ b/tests/metrology/test_iec61043_report.py
@@ -12,8 +12,6 @@ tests/metrology/test_intensity_compliance.py.
 
 from __future__ import annotations
 
-import os
-
 import matplotlib as mpl
 import pytest
 
@@ -23,10 +21,9 @@ pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 
 import reference_data as ref
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, emission
-
-_PDF_MAGIC = b"%PDF"
 
 _BANDS = [row[0] for row in ref.IEC61043_TABLE2]
 
@@ -53,25 +50,16 @@ def _metadata(**kwargs: object) -> ReportMetadata:
     return ReportMetadata(**base)  # type: ignore[arg-type]
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
-
-
 def test_compliant_chain_renders_one_page(tmp_path) -> None:
     result = _class1_chain()
     path = result.report(str(tmp_path / "iec61043.pdf"), metadata=_metadata())
-    _assert_one_page(path)
+    assert_one_page(path)
 
 
 def test_bare_fiche_without_metadata(tmp_path) -> None:
     """A fiche without metadata still renders body, result and disclaimer."""
     result = _class1_chain()
-    _assert_one_page(result.report(str(tmp_path / "bare.pdf")))
+    assert_one_page(result.report(str(tmp_path / "bare.pdf")))
 
 
 def _extract_text(path: str) -> str:
@@ -85,7 +73,7 @@ def _extract_text(path: str) -> str:
 def test_spanish_fiche_renders(tmp_path) -> None:
     result = _class1_chain()
     path = result.report(str(tmp_path / "es.pdf"), metadata=_metadata(), language="es")
-    _assert_one_page(path)
+    assert_one_page(path)
 
 
 def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
@@ -135,14 +123,14 @@ def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
 def test_required_class_verdict_both_ways(tmp_path) -> None:
     """The verdict row renders whether the chain meets the requirement or not."""
     passing = _class1_chain()
-    _assert_one_page(
+    assert_one_page(
         passing.report(str(tmp_path / "pass.pdf"), metadata=_metadata(required_class=1))
     )
     # 1 dB short of class 1 everywhere, so the chain lands on class 2.
     freqs, class1, _ = emission.residual_index_limits("instrument")
     failing = emission.intensity_class_compliance(class1 - 1.0, freqs)
     assert failing.overall_class == 2
-    _assert_one_page(
+    assert_one_page(
         failing.report(str(tmp_path / "fail.pdf"), metadata=_metadata(required_class=1))
     )
 
@@ -152,7 +140,7 @@ def test_non_compliant_chain_renders(tmp_path) -> None:
     freqs, _, class2 = emission.residual_index_limits("probe")
     result = emission.intensity_class_compliance(class2 - 2.0, freqs, device="probe")
     assert result.overall_class is None
-    _assert_one_page(result.report(str(tmp_path / "none.pdf"), metadata=_metadata()))
+    assert_one_page(result.report(str(tmp_path / "none.pdf"), metadata=_metadata()))
 
 
 def test_range_limited_note_renders(tmp_path) -> None:
@@ -161,7 +149,7 @@ def test_range_limited_note_renders(tmp_path) -> None:
     freqs, class1, _ = emission.residual_index_limits("processor", frequencies=bands)
     result = emission.intensity_class_compliance(class1, freqs, device="processor")
     assert result.range_limited is True
-    _assert_one_page(result.report(str(tmp_path / "partial.pdf"), metadata=_metadata()))
+    assert_one_page(result.report(str(tmp_path / "partial.pdf"), metadata=_metadata()))
 
 
 def test_range_limited_note_drops_the_class_wording_when_no_class_is_met(
@@ -184,7 +172,7 @@ def test_range_limited_note_drops_the_class_wording_when_no_class_is_met(
     assert result.range_limited is True
 
     path = result.report(str(tmp_path / "noclass.pdf"), metadata=_metadata())
-    _assert_one_page(path)
+    assert_one_page(path)
     text = _extract_text(path)
     assert "this verification covers the bands listed above" in text
     assert "the stated class attests" not in text

--- a/tests/noise_control/test_duct_path_report.py
+++ b/tests/noise_control/test_duct_path_report.py
@@ -12,25 +12,13 @@ complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.noise_control.duct_path import DuctElement, duct_path
 from phonometry.noise_control.hvac import OCTAVE_BANDS
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -101,7 +89,7 @@ def test_report_renders_the_published_sheet(tmp_path) -> None:
     out = tmp_path / "duct_path.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     assert "Duct-borne noise path calculation" in text
@@ -133,8 +121,8 @@ def test_non_verbose_sheet_drops_the_intermediate_rows(tmp_path) -> None:
     verbose = tmp_path / "verbose.pdf"
     res.report(str(plain))
     res.report(str(verbose), verbose=True)
-    _assert_one_page(str(plain))
-    _assert_one_page(str(verbose))
+    assert_one_page(str(plain))
+    assert_one_page(str(verbose))
     plain_text = _extract_text(str(plain))
     verbose_text = _extract_text(str(verbose))
     assert "Sum" not in plain_text
@@ -160,7 +148,7 @@ def test_metadata_header_and_requirement_override(tmp_path) -> None:
             requirement=20.0,
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example client" in text
     assert "EXAMPLE-DUCT" in text
@@ -184,7 +172,7 @@ def test_spanish_sheet(tmp_path) -> None:
     res = _supply()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es", verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Cálculo del trayecto de ruido por conductos" in text
     assert "Elemento" in text
@@ -213,7 +201,7 @@ def test_combined_paths_sheet_lists_its_contributions(tmp_path) -> None:
     both = combine_duct_paths([supply, other], label="Supply and return")
     out = tmp_path / "combined.pdf"
     both.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Supply path" in text
     assert "Return path" in text
@@ -247,7 +235,7 @@ def test_a_long_path_still_renders_on_one_page(tmp_path, verbose: bool) -> None:
             operator="phonometry",
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "elements omitted" in text
     # The head, the foot and the criterion survive the elision.

--- a/tests/noise_control/test_enclosure_report.py
+++ b/tests/noise_control/test_enclosure_report.py
@@ -16,29 +16,18 @@ engines/languages) complete the rendering contract.
 from __future__ import annotations
 
 import math
-import os
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, noise_control
-
-_PDF_MAGIC = b"%PDF"
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
 _PANEL_R = np.array([18, 22, 28, 33, 38, 42, 45], dtype=float)
 _S_E = 24.0  # external surface area, m^2
 _S_I = 30.0  # internal surface area, m^2
 _ALPHA = 0.30  # mean interior absorption
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -85,7 +74,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "enclosure.pdf"
     returned = res.report(str(out), metadata=ReportMetadata(requirement=20.0))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     # Mean insertion loss (boxed) to one decimal.
@@ -124,7 +113,7 @@ def test_verbose_adds_room_constant_column(tmp_path) -> None:
     res = _result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     r_i = _S_I * _ALPHA / (1.0 - _ALPHA)  # = 12.857... -> 12.9
     assert f"{r_i:.1f}" in text
@@ -142,7 +131,7 @@ def test_third_octave_labels_and_caption(tmp_path) -> None:
     )
     out = tmp_path / "third.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "One-third-octave-band insertion loss" in text
     for label in ("100", "125", "160", "630"):
@@ -185,7 +174,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     for token in (
         "Example works",
@@ -205,7 +194,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Pérdida por inserción de encapsulado de máquina" in text
     assert "Pérdida por inserción media" in text

--- a/tests/noise_control/test_hvac_report.py
+++ b/tests/noise_control/test_hvac_report.py
@@ -18,15 +18,13 @@ rendering contract.
 from __future__ import annotations
 
 import math
-import os
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.noise_control import hvac
-
-_PDF_MAGIC = b"%PDF"
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
 _U = 12.0  # flow velocity, m/s
@@ -35,15 +33,6 @@ _S = 0.04  # duct area, m^2
 #: Published octave-band A-weighting corrections (IEC 61672-1 / ISO 3744
 #: Annex E Table E.2), the clean-room oracle for the A-weighted total.
 _A_WEIGHT = np.array([-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0])
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -93,7 +82,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "hvac.pdf"
     returned = res.report(str(out), metadata=ReportMetadata(requirement=45.0))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     assert f"{_oracle_lwa():.1f}" in text  # A-weighted total (boxed)
@@ -125,7 +114,7 @@ def test_verbose_adds_a_weighting_columns(tmp_path) -> None:
     res = _result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # The 63 Hz and 2 kHz A-weighting corrections to one decimal. The sign is
     # the typographic minus the fiches print, not the ASCII hyphen `format`
@@ -163,7 +152,7 @@ def test_attenuation_report_mean_and_direction(tmp_path) -> None:
     mean_att = float(np.mean(res.values))
     out = tmp_path / "atten.pdf"
     res.report(str(out), metadata=ReportMetadata(requirement=1.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Octave-band attenuation" in text
     assert "Mean attenuation D" in text
@@ -181,7 +170,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Espectro de ruido de conducto de climatización" in text
     assert "Nivel de potencia acústica ponderado A" in text

--- a/tests/noise_control/test_silencer_report.py
+++ b/tests/noise_control/test_silencer_report.py
@@ -15,29 +15,17 @@ complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry.noise_control import silencers as sl
-
-_PDF_MAGIC = b"%PDF"
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
 _LENGTH = 0.5
 _S_EXP = 0.08
 _S_DUCT = 0.01
 _C = 343.0
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -73,7 +61,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     out = tmp_path / "silencer.pdf"
     returned = res.report(str(out), metadata=None)
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
 
     tl = _oracle_tl()
@@ -114,7 +102,7 @@ def test_insertion_loss_column_when_impedances_given(tmp_path) -> None:
     )
     out = tmp_path / "with_il.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "IL [dB]" in text
     # For the anechoic reference the insertion loss equals the transmission loss.
@@ -130,7 +118,7 @@ def test_resonator_reports_resonances(tmp_path) -> None:
     res = sl.helmholtz_resonator(f, 0.01, 1e-4, 0.02, 1e-3)
     out = tmp_path / "helmholtz.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Helmholtz resonator" in text
     assert "Resonance frequencies" in text
@@ -164,7 +152,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Pérdida por transmisión de silenciador reactivo" in text
     assert "Pérdida por transmisión media" in text

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -74,10 +74,12 @@ def _tone(
 
 
 def _levels_from_file() -> np.ndarray:
-    levels = []
-    for line in (DATA / "iso532_1_test_signal_1_levels.txt").read_text().splitlines():
-        if ":" in line and not line.strip().startswith("#"):
-            levels.append(float(line.split(":")[1]))
+    lines = (DATA / "iso532_1_test_signal_1_levels.txt").read_text().splitlines()
+    levels = [
+        float(line.split(":")[1])
+        for line in lines
+        if ":" in line and not line.strip().startswith("#")
+    ]
     return np.array(levels)
 
 
@@ -408,15 +410,13 @@ def test_time_varying_outputs() -> None:
 @requires_iso_data
 @pytest.mark.parametrize("num", list(range(14, 26)))
 def test_annex_b5_technical_signals(num: int) -> None:
-    import glob
-
-    matches = glob.glob(str(DATA / "Annex B.5" / f"Test signal {num} *.wav"))
+    matches = list((DATA / "Annex B.5").glob(f"Test signal {num} *.wav"))
     if not matches:
         pytest.skip(f"signal {num} not found")
     # Annex B.1: "0 dB (relative to full scale) shall correspond to a sound
     # pressure level of 100 dB" — a full-scale sine is 100 dB SPL (2 Pa RMS),
     # so one full-scale unit is 2*sqrt(2) Pa peak.
-    fullscale, fs = _read_wav_fullscale(matches[0])
+    fullscale, fs = _read_wav_fullscale(str(matches[0]))
     x = fullscale * (2.0 * np.sqrt(2.0))
     exp = EXPECTED[f"Test signal {num}"]
     # Each B.5 signal is validated in the sound field its ISO results

--- a/tests/psychoacoustics/test_iso1996_tone_report.py
+++ b/tests/psychoacoustics/test_iso1996_tone_report.py
@@ -19,10 +19,9 @@ import pytest
 pytest.importorskip("reportlab")
 
 import reference_data as ref
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, environment, psychoacoustics
-
-_PDF_MAGIC = b"%PDF"
 
 
 def _result():
@@ -30,17 +29,6 @@ def _result():
     return psychoacoustics.analyze_spectrum(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
     )
-
-
-def _assert_one_page(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -55,7 +43,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "tone.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -116,7 +104,7 @@ def test_metadata_appears_and_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _result().report(str(out), metadata=md, verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "Combustion engine, steady operation" in text
     assert "Free field, 3 m from source" in text
@@ -132,8 +120,8 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     result.report(str(passing), metadata=ReportMetadata(requirement=delta + 2.0))
     result.report(str(failing), metadata=ReportMetadata(requirement=delta - 2.0))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
     assert "PASS" in _extract_text(str(passing)).replace("\n", " ")
     assert "FAIL" in _extract_text(str(failing)).replace("\n", " ")
 
@@ -151,7 +139,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
@@ -164,7 +152,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
         metadata=ReportMetadata(specimen="motor de combustión"),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Evaluación de la audibilidad tonal" in text
     assert "ajuste tonal" in text
@@ -183,7 +171,7 @@ def test_absent_tone_reports_zero_adjustment(tmp_path) -> None:
     result = psychoacoustics.assess_tones([500.0], [40.0], [30.0], 2.0)
     out = tmp_path / "weak.pdf"
     result.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     # The tone sits below the masking threshold, so no adjustment applies.
     assert result.decisive_audibility < 0.0

--- a/tests/psychoacoustics/test_iso532_report.py
+++ b/tests/psychoacoustics/test_iso532_report.py
@@ -17,6 +17,8 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata, psychoacoustics
 
 # A shaped 28-band one-third-octave spectrum (25 Hz..12.5 kHz), descending.
@@ -54,26 +56,9 @@ _LEVELS = np.array(
     dtype=float,
 )
 
-_PDF_MAGIC = b"%PDF"
-
 
 def _result():
     return psychoacoustics.loudness_zwicker_from_spectrum(_LEVELS, field="free")
-
-
-def _assert_pdf(path: str) -> None:
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-
-
-def _assert_one_page(path: str) -> None:
-    _assert_pdf(path)
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
 
 
 def test_loudness_report_writes_pdf(tmp_path) -> None:
@@ -87,7 +72,7 @@ def test_loudness_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "loudness.pdf"
     returned = result.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -113,7 +98,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
@@ -124,8 +109,8 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     result.report(str(passing), metadata=ReportMetadata(requirement=n + 5.0))
     result.report(str(failing), metadata=ReportMetadata(requirement=max(n - 2.0, 0.1)))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
 
 
 def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
@@ -140,7 +125,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def _extract_text(path: str) -> str:
@@ -187,7 +172,7 @@ def test_time_varying_fiche_reports_nmax_percentiles_and_nt(tmp_path) -> None:
     assert result.field == "diffuse"
     out = tmp_path / "tv.pdf"
     result.report(str(out), metadata=ReportMetadata(requirement=result.loudness + 1.0))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out)).replace("\n", " ")
     assert "method for time-varying sounds (clause 6)" in text
     assert "Sound field: diffuse (D)" in text
@@ -209,7 +194,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
         metadata=ReportMetadata(specimen="ruido de electrodoméstico"),
         language="es",
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Índice de sonoridad" in text
     assert "Sonoridad total" in text

--- a/tests/report_assertions.py
+++ b/tests/report_assertions.py
@@ -1,0 +1,48 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""What a fiche test asserts about the file the report wrote.
+
+Fifty-four fiche tests each carried a private copy of this check, in eight
+spellings that differed only in wording, in where the imports sat, and in
+whether they also asserted a non-zero file size. That last assertion could not
+fail. Reading the first four bytes and finding ``%PDF`` already proves the file
+holds at least four bytes, so the size check was only ever reached when it was
+bound to pass. What survives is the pair that carries weight, written once.
+
+``pypdf`` is imported inside the functions on purpose: the fiche tests skip at
+import time when ``reportlab`` is missing, and a module-level import here would
+make the reader a hard dependency of every test that merely imports this file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: The four bytes a PDF opens with (ISO 32000-1, 7.5.2, "File Header").
+PDF_MAGIC = b"%PDF"
+
+
+def assert_pdf(path: str | Path) -> None:
+    """Assert the file at *path* opens as a PDF.
+
+    :param path: The file the report wrote.
+    :raises AssertionError: if the first four bytes are not ``%PDF``, which
+        covers an empty file, a truncated write and a wrong format alike.
+    """
+    with Path(path).open("rb") as handle:
+        assert handle.read(4) == PDF_MAGIC
+
+
+def assert_one_page(path: str | Path) -> None:
+    """Assert the file at *path* is a PDF of exactly one page.
+
+    A fiche that spills onto a second page is a layout regression rather than a
+    crash, so nothing else in the suite would catch it.
+
+    :param path: The file the report wrote.
+    :raises AssertionError: if the file is not a PDF, or does not parse as one
+        page exactly.
+    """
+    from pypdf import PdfReader
+
+    assert_pdf(path)
+    assert len(PdfReader(str(path)).pages) == 1

--- a/tests/room/test_enclosed_space_absorption_report.py
+++ b/tests/room/test_enclosed_space_absorption_report.py
@@ -23,9 +23,10 @@ pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata, room
 
-_PDF_MAGIC = b"%PDF"
 _VOLUME = 50.0
 _SURFACES = [
     (20.0, [0.05, 0.10, 0.20, 0.30, 0.40, 0.50, 0.55]),
@@ -65,14 +66,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -85,19 +78,19 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "enclosed.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_metadata_one_page(tmp_path) -> None:
     out = tmp_path / "enclosed_meta.pdf"
     _result().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_no_metadata_still_renders(tmp_path) -> None:
     out = tmp_path / "enclosed_bare.pdf"
     _result().report(str(out), metadata=None)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -158,7 +151,7 @@ def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
@@ -166,7 +159,7 @@ def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
 
     out = tmp_path / "enclosed_es.pdf"
     _result().report(str(out), metadata=_metadata(requirement=0.6), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     assert "Absorción acústica en un recinto" in text
     assert "Tiempo de reverberación objetivo" in text

--- a/tests/room/test_iso3382_3_report.py
+++ b/tests/room/test_iso3382_3_report.py
@@ -31,6 +31,7 @@ pytest.importorskip("pypdf")
 from typing import TYPE_CHECKING
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import (
     ReportMetadata,
@@ -40,7 +41,6 @@ from phonometry import (
 if TYPE_CHECKING:
     from phonometry.room import OpenPlanResult
 
-_PDF_MAGIC = b"%PDF"
 
 #: Documented measurement line and its exact closed-form single-number results.
 _POSITIONS = np.array([2.0, 3.0, 4.0, 6.0, 8.0, 11.0, 16.0])
@@ -54,18 +54,6 @@ _RP = 15.0
 
 def _result() -> OpenPlanResult:
     return room.open_plan_metrics(_POSITIONS, _SPL, _STI)
-
-
-def _assert_one_page(path: str) -> None:
-    """The fiche is a single-page PDF beginning with ``%PDF``."""
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -119,21 +107,21 @@ def test_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "openplan.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_full_metadata_one_page(tmp_path) -> None:
     """A full ReportMetadata renders a one-page accredited open-plan fiche."""
     out = tmp_path / "openplan_meta.pdf"
     _result().report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_bare_without_metadata(tmp_path) -> None:
     """metadata=None renders a bare characterisation fiche (no header)."""
     out = tmp_path / "bare.pdf"
     _result().report(str(out), metadata=None)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -180,8 +168,8 @@ def test_verdict_renders_both_ways(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     _result().report(str(passing), metadata=_full_metadata(requirement=7.0))
     _result().report(str(failing), metadata=_full_metadata(requirement=8.0))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
     assert "PASS" in _extract_text(str(passing))
     assert "FAIL" in _extract_text(str(failing))
 
@@ -210,7 +198,7 @@ def test_degenerate_result_renders_without_plot(tmp_path) -> None:
     assert not np.isfinite(res.d2s)
     out = tmp_path / "degenerate.pdf"
     res.report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "—" in _extract_text(str(out))  # em-dash empty-cell symbol
 
 
@@ -227,7 +215,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
@@ -236,7 +224,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 
     out = tmp_path / "openplan_es.pdf"
     _result().report(str(out), metadata=_full_metadata(requirement=7.0), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Acústica de oficinas diáfanas" in text
     assert "CUMPLE" in text

--- a/tests/room/test_iso3382_report.py
+++ b/tests/room/test_iso3382_report.py
@@ -27,10 +27,10 @@ pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, room
 
-_PDF_MAGIC = b"%PDF"
 _FS = 48000
 #: 6*ln(10): energy-decay-rate constant so exp(-A60*t/T) falls 60 dB in T s.
 _A60 = 6.0 * np.log(10.0)
@@ -53,18 +53,6 @@ def _synthetic_ir(seconds: float = 5.0) -> np.ndarray:
 
 def _result() -> room.RoomAcousticsResult:
     return room.room_parameters(_synthetic_ir(), _FS)
-
-
-def _assert_one_page(path: str) -> None:
-    """The fiche is a single-page PDF beginning with ``%PDF``."""
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -121,21 +109,21 @@ def test_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "room.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_full_metadata_one_page(tmp_path) -> None:
     """A full ReportMetadata renders a one-page accredited room fiche."""
     out = tmp_path / "room_meta.pdf"
     _result().report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_bare_without_metadata(tmp_path) -> None:
     """metadata=None renders a bare characterisation fiche (no header)."""
     out = tmp_path / "bare.pdf"
     _result().report(str(out), metadata=None)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -179,8 +167,8 @@ def test_mid_frequency_descriptor_and_verdict(tmp_path) -> None:
     failing = tmp_path / "fail.pdf"
     _result().report(str(passing), metadata=_full_metadata(requirement=1.30))
     _result().report(str(failing), metadata=_full_metadata(requirement=1.00))
-    _assert_one_page(str(passing))
-    _assert_one_page(str(failing))
+    assert_one_page(str(passing))
+    assert_one_page(str(failing))
     assert abs(_T_MID - 1.15) < 1e-9
     pass_text = _extract_text(str(passing))
     assert "1.15" in pass_text
@@ -238,7 +226,7 @@ def test_third_octave_report_renders(tmp_path) -> None:
     res = room.room_parameters(_synthetic_ir(), _FS, limits=(100.0, 5000.0), fraction=3)
     out = tmp_path / "thirds.pdf"
     res.report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "500 Hz and 1 kHz one-third-octave bands" in text
     assert "500-1000 Hz" not in text
@@ -298,7 +286,7 @@ def test_single_band_is_not_labeled_broadband(tmp_path) -> None:
     assert len(res.frequency) == 1
     out = tmp_path / "single_band.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Single-band parameters" in text
     assert "Broadband" not in text
@@ -316,7 +304,7 @@ def test_octave_report_many_bands_renders(tmp_path) -> None:
     assert len(res.frequency) > 6
     out = tmp_path / "octave_wide.pdf"
     res.report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Octave-band parameters" in _extract_text(str(out))
 
 
@@ -326,7 +314,7 @@ def test_broadband_report_renders(tmp_path) -> None:
     assert res.frequency is None
     out = tmp_path / "broadband.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "Broadband" in _extract_text(str(out))
 
 
@@ -365,7 +353,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
@@ -374,7 +362,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 
     out = tmp_path / "room_es.pdf"
     _result().report(str(out), metadata=_full_metadata(requirement=1.30), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Parámetros acústicos de salas" in text
     assert "CUMPLE" in text

--- a/tests/room/test_reverberation_prediction_report.py
+++ b/tests/room/test_reverberation_prediction_report.py
@@ -23,10 +23,10 @@ pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
 import numpy as np
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, room
 
-_PDF_MAGIC = b"%PDF"
 _MODELS = ("Sabine", "Eyring", "Millington-Sette", "Fitzroy", "Arau-Puchades")
 # A shoebox 8 x 5 x 3 m (V = 120 m3, S = 158 m2) with an anisotropic
 # absorption distribution over the octave bands (one treated wall pair).
@@ -59,14 +59,6 @@ def _metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert len(PdfReader(path).pages) == 1
-
-
 def _text(path: str) -> str:
     from pypdf import PdfReader
 
@@ -79,19 +71,19 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     out = tmp_path / "reverb.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_report_with_metadata_one_page(tmp_path) -> None:
     out = tmp_path / "reverb_meta.pdf"
     _result().report(str(out), metadata=_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_no_metadata_still_renders(tmp_path) -> None:
     out = tmp_path / "reverb_bare.pdf"
     _result().report(str(out), metadata=None)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_unknown_engine_rejected(tmp_path) -> None:
@@ -166,7 +158,7 @@ def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
@@ -174,7 +166,7 @@ def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
 
     out = tmp_path / "reverb_es.pdf"
     _result().report(str(out), metadata=_metadata(requirement=0.8), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _text(str(out))
     assert "Predicción del tiempo de reverberación" in text
     assert "Tiempo de reverberación objetivo" in text

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -27,10 +27,10 @@ pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
+from report_assertions import assert_one_page
+
 from phonometry import ReportMetadata
 from phonometry.room import noise_criteria as rn
-
-_PDF_MAGIC = b"%PDF"
 
 
 def _nc_result() -> rn.NCResult:
@@ -46,18 +46,6 @@ def _rc_result() -> rn.RCResult:
     levels = rn.rc_curve(35.0)
     levels[4] += 8.0  # 250 Hz rumble.
     return rn.room_criterion(levels)
-
-
-def _assert_one_page(path: str) -> None:
-    """The fiche is a single-page PDF beginning with ``%PDF``."""
-    import os
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    from pypdf import PdfReader
-
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -112,7 +100,7 @@ def test_nc_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "nc.pdf"
     returned = _nc_result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_rc_report_writes_pdf(tmp_path) -> None:
@@ -120,23 +108,23 @@ def test_rc_report_writes_pdf(tmp_path) -> None:
     out = tmp_path / "rc.pdf"
     returned = _rc_result().report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_reports_with_full_metadata_one_page(tmp_path) -> None:
     """A full ReportMetadata renders a one-page fiche for both ratings."""
     _nc_result().report(str(tmp_path / "nc_meta.pdf"), metadata=_full_metadata())
     _rc_result().report(str(tmp_path / "rc_meta.pdf"), metadata=_full_metadata())
-    _assert_one_page(str(tmp_path / "nc_meta.pdf"))
-    _assert_one_page(str(tmp_path / "rc_meta.pdf"))
+    assert_one_page(str(tmp_path / "nc_meta.pdf"))
+    assert_one_page(str(tmp_path / "rc_meta.pdf"))
 
 
 def test_reports_bare_without_metadata(tmp_path) -> None:
     """metadata=None renders a bare assessment fiche (no header)."""
     _nc_result().report(str(tmp_path / "nc_bare.pdf"), metadata=None)
     _rc_result().report(str(tmp_path / "rc_bare.pdf"), metadata=None)
-    _assert_one_page(str(tmp_path / "nc_bare.pdf"))
-    _assert_one_page(str(tmp_path / "rc_bare.pdf"))
+    assert_one_page(str(tmp_path / "nc_bare.pdf"))
+    assert_one_page(str(tmp_path / "rc_bare.pdf"))
 
 
 def test_verbose_reports_one_page(tmp_path) -> None:
@@ -147,8 +135,8 @@ def test_verbose_reports_one_page(tmp_path) -> None:
     _rc_result().report(
         str(tmp_path / "rc_v.pdf"), metadata=_full_metadata(), verbose=True
     )
-    _assert_one_page(str(tmp_path / "nc_v.pdf"))
-    _assert_one_page(str(tmp_path / "rc_v.pdf"))
+    assert_one_page(str(tmp_path / "nc_v.pdf"))
+    assert_one_page(str(tmp_path / "rc_v.pdf"))
 
 
 @pytest.mark.parametrize("factory", [_nc_result, _rc_result])
@@ -307,7 +295,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     )
     out = tmp_path / "xml.pdf"
     _nc_result().report(str(out), metadata=md)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
 
 
 def test_spanish_reports_render_translated(tmp_path) -> None:
@@ -322,8 +310,8 @@ def test_spanish_reports_render_translated(tmp_path) -> None:
     _rc_result().report(
         str(rc_out), metadata=_full_metadata(requirement=30.0), language="es"
     )
-    _assert_one_page(str(nc_out))
-    _assert_one_page(str(rc_out))
+    assert_one_page(str(nc_out))
+    assert_one_page(str(rc_out))
     nc_text = _extract_text(str(nc_out))
     assert "Calificación del ruido de salas" in nc_text
     assert "CUMPLE" in nc_text
@@ -339,7 +327,7 @@ def test_subset_spectrum_renders_missing_bands(tmp_path) -> None:
     levels = [40.0, 35.0, 30.0, 27.0, 22.0]
     out = tmp_path / "subset.pdf"
     rn.noise_criterion(levels, freqs).report(str(out), metadata=_full_metadata())
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "—" in text  # the unmeasured low bands are shown as an em dash
 

--- a/tests/speech/test_sii_report.py
+++ b/tests/speech/test_sii_report.py
@@ -13,24 +13,12 @@ back from the PDF via pypdf text extraction.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.speech import speech_intelligibility_index
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -62,7 +50,7 @@ def test_example_c2_renders_index_and_band_importance(tmp_path) -> None:
     out = tmp_path / "sii.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "SII = 0.851" in text
     # Band-importance function Ii at 2000 Hz (Table 3, four decimals).
@@ -77,7 +65,7 @@ def test_standard_speech_in_quiet_renders(tmp_path) -> None:
     assert res.sii == pytest.approx(0.995825, abs=1e-5)
     out = tmp_path / "quiet.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "SII = 0.996" in _extract_text(str(out))
 
 
@@ -91,7 +79,7 @@ def test_verbose_adds_disturbance_column(tmp_path) -> None:
     res = _example_c2()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     assert "Di[dB]" in flat
 
@@ -180,7 +168,7 @@ def test_metadata_header_renders(tmp_path) -> None:
             report_id="SII-1",
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Speech in office noise" in text
@@ -197,7 +185,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _example_c2()
     out = tmp_path / "sii_es.pdf"
     res.report(str(out), metadata=ReportMetadata(requirement=0.75), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Índice de inteligibilidad del habla" in text
     assert "SII = 0,851" in text
@@ -236,7 +224,7 @@ def test_non_default_procedure_fiche_names_its_procedure(
     res = speech_intelligibility_index("normal", np.full(n, 25.0), method=method)
     out = tmp_path / f"sii_{method}.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert basis in text
     assert caption in text
@@ -254,7 +242,7 @@ def test_non_default_procedure_fiche_renders_in_spanish(tmp_path) -> None:
     res = speech_intelligibility_index("normal", np.full(6, 25.0), method="octave")
     out = tmp_path / "sii_octave_es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "método de bandas de octava" in text
     assert "Audibilidad por bandas de octava" in text

--- a/tests/speech/test_sti_report.py
+++ b/tests/speech/test_sti_report.py
@@ -13,25 +13,13 @@ rejected engines/languages) complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.speech import sti_from_impulse_response
 from phonometry.speech.sti import _MOD_FREQS, _NUM_BANDS, _sti_from_mtf
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -69,7 +57,7 @@ def test_uniform_mtf_half_renders_sti_half(tmp_path) -> None:
     out = tmp_path / "sti.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "STI = 0.50" in text
     assert "Annex F): G" in text
@@ -84,7 +72,7 @@ def test_stipa_method_is_named(tmp_path) -> None:
     res = _sti_from_mtf(np.full((_NUM_BANDS, 2), 0.5))
     out = tmp_path / "stipa.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "STIPA, direct method" in _extract_text(str(out))
 
 
@@ -172,7 +160,7 @@ def test_decay_measurement_renders_its_own_value(tmp_path) -> None:
             requirement=0.5,
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert f"STI = {format_number(res.sti, 'en', decimals=2)}" in text
     assert f"Annex F): {res.rating}" in text
@@ -198,7 +186,7 @@ def test_metadata_header_renders(tmp_path) -> None:
             report_id="STI-1",
         ),
     )
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example works" in text
     assert "Public-address system" in text
@@ -215,7 +203,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _uniform_result(0.5)
     out = tmp_path / "sti_es.pdf"
     res.report(str(out), metadata=ReportMetadata(requirement=0.45), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Índice de transmisión del habla" in text
     assert "STI = 0,50" in text

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -71,11 +71,12 @@ def test_every_registered_fiche_is_committed() -> None:
     factory still writes the file it is registered under.
     """
     committed = pathlib.Path(_MODULE._DEFAULT_DIR)
-    missing = []
-    for name in _MODULE._FICHES:
-        for path in (committed / name, committed / _MODULE.preview_path_for(name)):
-            if not path.is_file():
-                missing.append(path.name)
+    missing = [
+        path.name
+        for name in _MODULE._FICHES
+        for path in (committed / name, committed / _MODULE.preview_path_for(name))
+        if not path.is_file()
+    ]
     assert not missing, (
         f"registered fiches with no committed render: {sorted(missing)} - "
         "run 'make reports' and commit the result"
@@ -99,7 +100,7 @@ def test_each_example_writes_a_one_page_pdf_and_preview(
     assert _MODULE._FICHES.get(p.name) is factory
     assert p.is_file()
     assert p.stat().st_size > 0
-    with open(p, "rb") as handle:
+    with p.open("rb") as handle:
         assert handle.read(4) == b"%PDF"
     assert len(PdfReader(str(p)).pages) == 1
     preview = pathlib.Path(_MODULE.preview_path_for(str(p)))

--- a/tests/test_golden_baseline.py
+++ b/tests/test_golden_baseline.py
@@ -16,7 +16,7 @@ tolerance for the same reason the figure CI gate is tolerance-based.
 
 from __future__ import annotations
 
-import os
+import pathlib
 import sys
 
 import matplotlib as mpl
@@ -25,7 +25,7 @@ mpl.use("Agg")
 import numpy as np
 import pytest
 
-_SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts")
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
 

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -263,9 +263,11 @@ def test_subpackage_reexports_cover_facade_imports() -> None:
         if len(parts) < 2 or parts[0].startswith("_"):
             continue
         pkg = importlib.import_module(f"phonometry.{parts[0]}")
-        for alias in node.names:
-            if not hasattr(pkg, alias.name):
-                missing.append(f"phonometry.{parts[0]}.{alias.name}")
+        missing.extend(
+            f"phonometry.{parts[0]}.{alias.name}"
+            for alias in node.names
+            if not hasattr(pkg, alias.name)
+        )
     assert not missing, (
         "facade imports not re-exported by their subpackage:\n" + "\n".join(missing)
     )

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -280,18 +280,18 @@ def test_no_renderer_defaults_a_label_on_the_shared_kwargs_inside_a_loop() -> No
         for node in ast.walk(tree):
             if not isinstance(node, ast.For | ast.While | ast.AsyncFor):
                 continue
-            for child in ast.walk(node):
-                if (
-                    isinstance(child, ast.Call)
-                    and isinstance(child.func, ast.Attribute)
-                    and child.func.attr == "setdefault"
-                    and isinstance(child.func.value, ast.Name)
-                    and child.func.value.id == "kwargs"
-                    and child.args
-                    and isinstance(child.args[0], ast.Constant)
-                    and child.args[0].value == "label"
-                ):
-                    offenders.append(f"{path.name}:{child.lineno}")
+            offenders.extend(
+                f"{path.name}:{child.lineno}"
+                for child in ast.walk(node)
+                if isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and child.func.attr == "setdefault"
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == "kwargs"
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+                and child.args[0].value == "label"
+            )
     assert not offenders, (
         "a label default on the shared kwargs inside a loop names every curve "
         f"after the first one: {offenders}. Take a copy per iteration."

--- a/tests/vibration/human/test_human_vibration_report.py
+++ b/tests/vibration/human/test_human_vibration_report.py
@@ -16,23 +16,12 @@ from __future__ import annotations
 
 import dataclasses
 import math
-import os
 
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.vibration import daily_vibration_exposure
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -75,7 +64,7 @@ def test_report_renders_annex_e3_numbers(tmp_path) -> None:
     out = tmp_path / "e3.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # Vibration total values (a_hv) per operation.
     assert "4.60" in text
@@ -104,7 +93,7 @@ def test_verbose_adds_energy_share_column(tmp_path) -> None:
     res = _annex_e3_result()
     out = tmp_path / "verbose.pdf"
     res.report(str(out), verbose=True)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     flat = "".join(_extract_text(str(out)).split())
     # Shares: 2.30^2/3.61^2 = 41 %, 2.12^2 = 35 %, 1.80^2 = 25 % (rounded).
     assert "41%" in flat
@@ -200,7 +189,7 @@ def test_whole_body_thresholds_and_basis(tmp_path) -> None:
     )
     out = tmp_path / "wbv.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "ISO 2631-1:1997" in text
     assert "0.50" in text  # EAV
@@ -248,7 +237,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example forestry contractor" in text
     assert "Forestry worker (right hand)" in text
@@ -267,7 +256,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _annex_e3_result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Evaluación de la exposición diaria a vibraciones" in text
     assert "Valor límite de exposición (ELV)" in text
@@ -344,7 +333,7 @@ def test_report_accepts_matching_per_operation_arrays(tmp_path) -> None:
     )
     out = tmp_path / "two_ops.pdf"
     two_ops.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     assert "stripping" not in _extract_text(str(out))
 
 

--- a/tests/vibration/human/test_multiple_shock_report.py
+++ b/tests/vibration/human/test_multiple_shock_report.py
@@ -15,10 +15,9 @@ rejected engines/languages) complete the rendering contract.
 
 from __future__ import annotations
 
-import os
-
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.vibration.human.multiple_shock import (
@@ -32,17 +31,6 @@ from phonometry.vibration.human.multiple_shock import (
     injury_probability,
     injury_risk,
 )
-
-_PDF_MAGIC = b"%PDF"
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -102,7 +90,7 @@ def test_report_renders_annex_c_numbers(tmp_path) -> None:
     out = tmp_path / "annex_c.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     # Acceleration dose Dz = daily dose Dzd = 55.97 m/s2 (Formula 3).
     assert "55.97" in text
@@ -174,7 +162,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example transport operator" in text
     assert "82 kg male operator (seated)" in text
@@ -195,7 +183,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _annex_c_male()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Riesgo para la salud por choques múltiples de cuerpo completo" in text
     assert "probabilidad moderada de un efecto adverso para la salud" in text

--- a/tests/vibration/structural/test_mobility_report.py
+++ b/tests/vibration/structural/test_mobility_report.py
@@ -14,28 +14,17 @@ contract.
 from __future__ import annotations
 
 import math
-import os
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.vibration import sdof_mobility_result
 from phonometry.vibration.structural.mechanical_mobility import MobilityResult
 
-_PDF_MAGIC = b"%PDF"
-
 _M, _K, _C = 2.0, 8000.0, 5.0
 _F0 = math.sqrt(_K / _M) / (2.0 * math.pi)  # ~10.066 Hz
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -68,7 +57,7 @@ def test_report_renders_peak_and_basis(tmp_path) -> None:
     out = tmp_path / "mobility.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Mechanical mobility measurement" in text
     assert "ISO 7626-1:2011" in text
@@ -92,7 +81,7 @@ def test_transfer_frf_labels_transfer(tmp_path) -> None:
     )
     out = tmp_path / "transfer.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "transfer mechanical mobility" in text
     assert "driving-point" not in text
@@ -113,7 +102,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example structures client" in text
     assert "Machine support bracket" in text
@@ -128,7 +117,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _driving_point_result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Medición de la movilidad mecánica" in text
     assert "en punto de excitación" in text

--- a/tests/vibration/structural/test_transfer_stiffness_report.py
+++ b/tests/vibration/structural/test_transfer_stiffness_report.py
@@ -16,15 +16,13 @@ contract.
 
 from __future__ import annotations
 
-import os
 import warnings
 
 import numpy as np
 import pytest
+from report_assertions import assert_one_page
 
 from phonometry import PhonometryWarning, ReportMetadata, vibration
-
-_PDF_MAGIC = b"%PDF"
 
 _FREQS = np.array(
     [
@@ -53,15 +51,6 @@ _FREQS = np.array(
     dtype=float,
 )
 _K, _C = 1.0e6, 80.0
-
-
-def _assert_one_page(path: str) -> None:
-    from pypdf import PdfReader
-
-    with open(path, "rb") as handle:
-        assert handle.read(4) == _PDF_MAGIC
-    assert os.path.getsize(path) > 0
-    assert len(PdfReader(path).pages) == 1
 
 
 def _extract_text(path: str) -> str:
@@ -103,7 +92,7 @@ def test_report_renders_plateau_and_basis(tmp_path) -> None:
     out = tmp_path / "transfer.pdf"
     returned = res.report(str(out))
     assert returned == str(out)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Dynamic transfer stiffness of a resilient element" in text
     assert "ISO 10846-1:2008" in text
@@ -132,7 +121,7 @@ def test_indirect_method_labels_blocking_mass(tmp_path) -> None:
         )
     out = tmp_path / "indirect.pdf"
     res.report(str(out))
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "indirect blocking-mass method (ISO 10846-3:2002)" in text
     assert "Blocking mass" in text
@@ -154,7 +143,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     )
     out = tmp_path / "meta.pdf"
     res.report(str(out), metadata=metadata)
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Example elastomers client" in text
     assert "Rubber vibration isolator" in text
@@ -169,7 +158,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     res = _direct_result()
     out = tmp_path / "es.pdf"
     res.report(str(out), language="es")
-    _assert_one_page(str(out))
+    assert_one_page(str(out))
     text = _extract_text(str(out))
     assert "Rigidez dinámica de transferencia de un elemento resiliente" in text
     assert "método directo" in text


### PR DESCRIPTION
`PTH` and `PERF` are selected. This is the last of the ruff adoption.

## The type, not the spelling

The 193 sites were read one at a time rather than converted in bulk, because
`os.path.join` returns a `str` and `Path(a) / b` returns a `Path`, and a `Path`
prints like its string while comparing unequal to it. So the sites worth
reading were the ones that hand the value to a sort, a comparison, or a
dictionary key, where the change is silent.

One of them was. `.github/scripts/comment_pr.py` collects the artifact paths
and sorts them. Sorting `str` is lexicographic over the whole path; sorting
`Path` goes component by component, so the separator drops out of the
comparison and the order changes whenever one directory name is a prefix of
another. The current matrix has no such pair, so nothing would have gone red;
add a `3.13-dev` alongside `3.13` and the table reorders. It sorts as text now,
with a line saying why.

## Half the findings were one pair of lines, copied

104 of the 193 were the same two lines in the fiche tests. Each of 54 files
carried its own `_assert_one_page` and its own `_PDF_MAGIC`, in eight spellings
that differed only in wording and in where the imports sat.

46 of them also asserted `os.path.getsize(path) > 0`, which cannot fail:
the line above it has already read the first four bytes and found `%PDF`, so
the file is known to hold at least four bytes by the time the size is checked.

Converting each copy would have carried the duplication into `pathlib`, so the
assertion that does carry weight now lives once in `tests/report_assertions.py`
and the 54 copies are gone. Checked before unifying: every one of them expects
exactly one page, and `_assert_pdf` is also called on its own, so the module
exposes both. Net −618 lines across those files.

## Fifteen sites keep the older spelling

They sit in the six modules that draw the animations, and that code is hashed
into `scripts/animation_fingerprints.txt`. Rewriting a line there marks every
clip it reaches as stale and asks for a re-render that would produce frame for
frame identical output. Each carries a `noqa` and a line saying so, which is
the same trade already made for `TC006` and for one `zip()`.

Worth recording how the boundary was found, because it is not obvious: asking
the fingerprint module for the closure named five modules, and reverting all
five left the gate still red. The sixth was `scripts/figures/__init__.py`,
which does not appear in a walk by module name but is hashed into every
fingerprint all the same. A comment is not in the AST, so the pragmas
themselves move nothing; verified after adding them.

## Also

- Two accumulators that folded their first rows into the initializer now start
  empty and `extend`, matching the sibling gate they are written to pair with.
- Four sites are left as loops on purpose, each with a reason.

## Checks

`ruff check .` and `ruff format --check .` clean with `PTH` and `PERF`
selected, `mypy src scripts stub/src` clean, bandit clean, conformance 550/550
with the claims check consistent, the generated API reference unchanged, the 42
committed clips still fresh, and the suite at 8985 passed, 16 skipped, 0
failures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when locating, generating, and validating report and diagram files.
  - Stabilized ordering of generated artifacts and test-result summaries.

- **Refactor**
  - Updated file and directory handling across report, diagram, and validation workflows for more reliable cross-platform operation.
  - Simplified report-generation interfaces to support path-based output locations.

- **Tests**
  - Centralized PDF validation checks, preserving coverage for valid, single-page report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->