### PR TITLE
Prove the GPU parity where the GPU is, and pin what this repo is built with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The FDTD GPU parity is proved where the GPU is, not only where the process
+  is. Those cases needed CuPy in this interpreter, so on a machine without a
+  CUDA card the whole GPU half of the file skipped and the engine went
+  unchecked. A card in this process is not the only way to reach one:
+  `fdtd_gpu_remote` already ships a packed job to a machine that has one,
+  which is the path the animation renders take. The same fifteen scenarios now
+  go that way and are compared against the library engine.
+
+  Two details decide whether such a test proves anything. It calls
+  `run_remote` rather than `submit`, because submitting falls back to a local
+  NumPy run when anything goes wrong, which is right for a render and wrong
+  for a test: the comparison would be NumPy against NumPy and would pass
+  without touching a GPU. And it asserts the backend that ran was `cupy`, for
+  the same reason. With no `PHONO_GPU_HOST` configured the cases skip in under
+  a second and say what to set, without opening a connection.
+
+- Every requirement is pinned. `requirements.txt` and `requirements-dev.txt`
+  used floors, and the two rendering stacks beside them used exact versions,
+  so a fresh `make install` landed on a newer reportlab and svglib than the
+  committed fiches were rendered with. Nothing was wrong with either version;
+  what was wrong is that `make reports` then showed drift in fiches nobody had
+  touched. Dependabot already watches these files weekly, so pinning turns an
+  upgrade into a pull request the suite votes on rather than a difference
+  between two machines.
+
+  The four packages that were behind (reportlab, svglib, lxml, webencodings,
+  all in the fiche chain) are now at the current release, and the 71 committed
+  fiches come out byte for byte identical under it. The figure stack was
+  already current, so no figure, plate or clip needed regenerating.
+
+  This pins the environment this repository is developed in. What the
+  published package asks of its users stays an open range in `pyproject.toml`,
+  because a library that pins its dependencies cannot be installed beside
+  anything else.
+
 - A path is a `Path`, and a loop that only appends is a comprehension. `PTH`
   and `PERF` are selected, and the 193 sites they found were read one at a
   time, because the two spellings of a path are not the same type: a `Path`

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ FIGURE_LANGUAGE_ENV = PHONOMETRY_FIGURE_LANGUAGE_AUDIT=$(FIGURE_LANGUAGE_DIR)
 # `[full]` rather than a bare `-e .`: a development environment wants every
 # optional path importable, numba included, so `make test-perf` can exercise
 # the jitted kernel here the way the tests-perf job does in CI. numba stays out
-# of requirements-dev.txt on purpose. The main test matrix installs that file,
+# of requirements-dev.txt on purpose: the main test matrix installs that file,
 # and numba caps numpy (`<2.6` today), so declaring it there would hold the
 # matrix back from the next numpy the day it ships, which is the one thing the
 # perf job's separate environment exists to prevent.

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,18 @@ FIGURE_ENV = OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
 FIGURE_LANGUAGE_DIR = build/figure-language
 FIGURE_LANGUAGE_ENV = PHONOMETRY_FIGURE_LANGUAGE_AUDIT=$(FIGURE_LANGUAGE_DIR)
 
+# `[full]` rather than a bare `-e .`: a development environment wants every
+# optional path importable, numba included, so `make test-perf` can exercise
+# the jitted kernel here the way the tests-perf job does in CI. numba stays out
+# of requirements-dev.txt on purpose. The main test matrix installs that file,
+# and numba caps numpy (`<2.6` today), so declaring it there would hold the
+# matrix back from the next numpy the day it ships, which is the one thing the
+# perf job's separate environment exists to prevent.
 install:
 	$(PYTHON) -m pip install --upgrade pip
 	$(PYTHON) -m pip install -r requirements.txt
 	$(PYTHON) -m pip install -r requirements-dev.txt
-	$(PYTHON) -m pip install -e .
+	$(PYTHON) -m pip install -e ".[full]"
 
 lint:
 	$(RUFF) check .
@@ -295,9 +302,25 @@ test:
 coverage:
 	$(TEST_ENV) $(PYTHON) -m pytest -n auto --cov=src/phonometry --cov-report=term-missing tests/
 
+# The jitted kernel, which the plain `test` target never reaches: conftest.py
+# disables the JIT by default so coverage can trace inside the kernels, and
+# `NUMBA_DISABLE_JIT=0` is what the tests-perf job in CI sets to exercise the
+# compiled path. This target is that job, run here. It needs the optional
+# extra: `pip install numba` (deliberately outside requirements-dev, since
+# numba caps numpy and the main matrix must stay free to move ahead of it).
+test-perf:
+	$(TEST_ENV) NUMBA_DISABLE_JIT=0 $(PYTHON) -m pytest -n auto tests/
+
+# The FDTD GPU parity, which needs a CUDA device. There is one either way: a
+# local CuPy install, or the machine named by PHONO_GPU_HOST in .env, which is
+# where the animation renders already run. With neither, every GPU case skips
+# and says which of the two is missing.
+test-gpu:
+	$(TEST_ENV) $(PYTHON) -m pytest -rs tests/test_fdtd_gpu_parity.py
+
 check: lint security test
 
 .PHONY: install lint format security snyk sonar graphs figure-contrast figure-language figures reports \
 	animations animation-freshness posters brand lighthouse \
-	llms pypi-readme api-docs site-reports conformance install-hooks test coverage check \
+	llms pypi-readme api-docs site-reports conformance install-hooks test test-perf test-gpu coverage check \
 	snippets snippets-static claims subscripts

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,35 @@
-ruff>=0.16.3
-mypy>=2.3.0
-bandit>=1.9.4
-types-setuptools>=84.0.0.20260812
-pytest>=9.1.1
-pytest-cov>=7.1.0
-pytest-xdist>=3.8.0  # parallel test execution (`pytest -n auto`); coverage is combined across workers by pytest-cov
-matplotlib>=3.11.1  # required by the result-object .plot() tests
-reportlab>=5.0.0  # required by the result-object .report() tests (ISO 717 PDF fiche)
-pystoi>=0.4.1  # test-only external cross-check for STOI/ESTOI (reproduces the authors' MATLAB); the library reimplements from the papers and never imports it at runtime
-svglib>=2.1.0
-pypdf>=6.16.0  # one-page assertion in the ISO 717 report tests
-pypdfium2>=5.13.0  # rasterizes the .report() PDFs to committed WebP previews (scripts/generate_reports.py); no system Poppler needed
-pyyaml>=6.0.2  # the repository-config tests parse .coderabbit.yaml and the workflow triggers; bandit already pulls it in, this makes the direct import declared
-soundfile>=0.14.0  # the [audio] extra: exercises the io backend dispatch and lossy-warning lane of the tests
+# The development and test environment, pinned exactly, on top of
+# requirements.txt. Same reasoning as that file: Dependabot proposes the
+# upgrades weekly and the suite decides.
+#
+# The rendering half is the part that had to be pinned rather than floored.
+# reportlab, svglib and pypdfium2 are the chain a fiche goes through on its way
+# to a page, and requirements-reports.txt fixes that chain for the staleness
+# check. While these two files disagreed, `make install` landed on a newer
+# reportlab and svglib than the committed fiches were rendered with, so a
+# developer running `make reports` saw drift in fiches nobody had touched.
+# The versions here are the versions there; bump them together.
+ruff==0.16.4
+mypy==2.3.1
+bandit==1.9.4
+types-setuptools==84.0.0.20260812
+
+pytest==9.1.1
+pytest-cov==7.1.0
+pytest-xdist==3.8.0  # parallel test execution (`pytest -n auto`); coverage is combined across workers by pytest-cov
+
+matplotlib==3.11.1  # required by the result-object .plot() tests
+reportlab==5.0.1  # required by the result-object .report() tests (ISO 717 PDF fiche)
+svglib==2.2.0
+pypdf==6.16.1  # one-page assertion in the ISO 717 report tests
+pypdfium2==5.13.0  # rasterizes the .report() PDFs to committed WebP previews (scripts/generate_reports.py); no system Poppler needed
+
+pystoi==0.4.1  # test-only external cross-check for STOI/ESTOI (reproduces the authors' MATLAB); the library reimplements from the papers and never imports it at runtime
+pyyaml==6.0.3  # the repository-config tests parse .coderabbit.yaml and the workflow triggers; bandit already pulls it in, this makes the direct import declared
+soundfile==0.14.0  # the [audio] extra: exercises the io backend dispatch and lossy-warning lane of the tests
+
+# numba is deliberately absent. The main test matrix installs this file, and
+# numba caps numpy (`<2.6` today), so declaring it here would hold the matrix
+# back from the next numpy the day it ships. It arrives through the `perf`
+# extra instead, which is what the tests-perf job installs and what
+# `make install` pulls in via `[full]`.

--- a/requirements-reports.txt
+++ b/requirements-reports.txt
@@ -12,12 +12,14 @@
 # in any of these moves the rendered pixels well past that tolerance.
 #
 # Bump these together with a fresh `make reports` regeneration (generate the
-# fiches with exactly this stack, then commit both). Generated from the
-# maintainer's venv that produced the committed fiches.
-reportlab==5.0.0
-svglib==2.1.0
+# fiches with exactly this stack, then commit both), and with the matching
+# pins in requirements-dev.txt, which installs the same chain for the
+# `.report()` tests. Generated from the maintainer's venv that produced the
+# committed fiches.
+reportlab==5.0.1
+svglib==2.2.0
 pypdfium2==5.13.0
-lxml==6.1.1
+lxml==6.1.2
 cssselect2==0.9.0
 tinycss2==1.5.1
-webencodings==0.5.1
+webencodings==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,27 @@
-contourpy>=1.3.3
-cycler>=0.12.1
-fonttools>=4.63.0
-kiwisolver>=1.5.0
-matplotlib>=3.11.1
-numpy>=2.5.2
-packaging>=26.3
-pillow>=12.3.0
-pyparsing>=3.3.2
-python-dateutil>=2.9.0.post0
-scipy>=1.18.0
-six>=1.17.0
+# The environment this repository is developed and tested in, pinned exactly.
+#
+# `==` rather than `>=`, for the reason the two locked files beside this one
+# already give: what a check compares is what the installed stack produced, so
+# a floor lets a fresh install land on a different stack than the one the
+# committed artefacts came from and report drift nobody caused. Dependabot
+# watches this file weekly, so an upgrade arrives as a pull request that runs
+# the whole suite rather than as a silent difference between two machines.
+#
+# These are pins for *this* repository. The constraints the published package
+# puts on its users live in pyproject.toml and stay open ranges: a library that
+# pins its dependencies cannot be installed alongside anything else.
+matplotlib==3.11.1
+numpy==2.5.2
+scipy==1.18.0
+
+# matplotlib's own chain, pinned with it: they decide SVG text layout and WebP
+# encoding, which is what scripts/check_figures.py compares.
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.63.0
+kiwisolver==1.5.0
+packaging==26.3
+pillow==12.3.0
+pyparsing==3.3.2
+python-dateutil==2.9.0.post0
+six==1.17.0

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -51,6 +51,30 @@ def _cupy_or_none() -> Any:
 
 _CUPY = _cupy_or_none()
 
+
+def _remote_or_none() -> Any:
+    """The configured GPU host when it answers, else None.
+
+    A CUDA card is not the only way to reach one. ``fdtd_gpu_remote`` already
+    ships a job to a machine that has one, and that is the path the animation
+    renders take, so the same parity can be proved on a workstation with no
+    GPU of its own: what is under test is the engine, not the local hardware.
+    """
+    fdtd_gpu_remote.load_env()
+    config = fdtd_gpu_remote.RemoteConfig.from_env()
+    if not config.host or not fdtd_gpu_remote.remote_available(config):
+        return None
+    return config
+
+
+_REMOTE = _remote_or_none()
+
+#: Skip mark for the cases that need the remote GPU.
+_needs_remote = pytest.mark.skipif(
+    _REMOTE is None,
+    reason="no PHONO_GPU_HOST answers (set it in .env to run the GPU parity here)",
+)
+
 BACKENDS = [
     pytest.param(np, 1e-12, id="numpy"),
     pytest.param(
@@ -66,6 +90,16 @@ BACKENDS = [
 _NY, _NX = 60, 80
 _DX = 0.01
 _STEPS = 200
+
+#: Relative to the run peak. The GPU reassociates the update sums, so the two
+#: engines agree to ULP scale rather than bit for bit, as the local `cupy`
+#: parameter above already allows.
+_GPU_TOL = 1e-10
+
+#: One remote job is an SSH round trip plus a Docker start, measured at about
+#: six seconds for these grids. The ceiling is generous enough that a cold
+#: image pull does not turn a slow run into a red one.
+_REMOTE_TIMEOUT_S = 180.0
 
 
 def _scenarios() -> dict[str, dict[str, Any]]:
@@ -461,3 +495,51 @@ def test_load_env_real_environment_wins(
     assert values == {"PHONO_GPU_HOST": "file-host", "PHONO_GPU_NAME": "lab GPU"}
     assert os.environ["PHONO_GPU_HOST"] == "env-host"  # real env wins
     assert os.environ["PHONO_GPU_NAME"] == "lab GPU"  # quotes stripped
+
+
+def _remote_frames(
+    kwargs: dict[str, Any], wave: dict[str, Any], direction: str
+) -> list[np.ndarray]:
+    """The same scenario, stepped on the remote GPU, frame by frame.
+
+    ``run_remote`` rather than ``submit``: submitting falls back to a local
+    NumPy run when anything goes wrong, which for a render is the right call
+    and for a test is the wrong one. A silent fallback here would compare
+    NumPy against NumPy and pass while proving nothing about the GPU.
+    """
+    c, rest = _split_c(kwargs)
+    job = fdtd_gpu_remote.build_job(
+        c,
+        _DX,
+        shape=(_NY, _NX),
+        steps=_STEPS,
+        sample_steps=[50, 100, 150, 200],
+        plane_waves=[{"direction": direction, **wave}],
+        **rest,
+    )
+    result = fdtd_gpu_remote.run_remote(job, _REMOTE, timeout=_REMOTE_TIMEOUT_S)
+    # The backend the job actually ran on is the whole point of the exercise:
+    # the runner picks NumPy when CuPy is missing on the far side, and that
+    # result would satisfy every tolerance below without touching a GPU.
+    assert result["backend"] == "cupy"
+    assert int(result["cells"]) == _NY * _NX
+    return list(np.asarray(result["frames"]))
+
+
+@_needs_remote
+@pytest.mark.parametrize("direction", list(_WAVES))
+def test_plane_wave_directions_match_library_on_the_remote_gpu(direction: str) -> None:
+    """A plane packet in each direction reproduces the library on the GPU."""
+    wave = _WAVES[direction]
+    fields = _reference({}, wave, direction)
+    _assert_parity(fields, _remote_frames({}, wave, direction), _GPU_TOL)
+
+
+@_needs_remote
+@pytest.mark.parametrize("scenario", list(_scenarios()))
+def test_scenarios_match_library_on_the_remote_gpu(scenario: str) -> None:
+    """Each engine feature reproduces the library on the GPU."""
+    kwargs = _scenarios()[scenario]
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    fields = _reference(kwargs, wave, "down")
+    _assert_parity(fields, _remote_frames(kwargs, wave, "down"), _GPU_TOL)


### PR DESCRIPTION
Two things that turned out to be the same conversation: what this repository
is developed with, and where its GPU tests can run.

## The GPU parity now runs where the GPU is

The FDTD parity cases needed CuPy in this interpreter, so on a machine without
a CUDA card the whole GPU half of the file skipped and the engine went
unchecked. A card in this process is not the only way to reach one:
`fdtd_gpu_remote` already ships a packed job to a machine that has one, which
is the path the animation renders take. The same fifteen scenarios (four wave
directions and eleven engine features) now go that way and are compared
against the library engine. They pass against the configured card in 63
seconds.

Two details decide whether a test like this proves anything:

- It calls `run_remote`, not `submit`. Submitting falls back to a local NumPy
  run when anything goes wrong, which is right for a render and wrong for a
  test: the comparison would be NumPy against NumPy and would pass without
  touching a GPU.
- It asserts the backend that ran was `cupy`, for the same reason. The runner
  picks NumPy when CuPy is missing on the far side, and that result would
  satisfy every tolerance without a GPU anywhere.

Checked from a fresh clone, since that is the case that matters for anyone
else: with no `.env`, the cases skip and say what to set, the run exits 0, and
it takes 0.85 s because the probe returns before opening a connection. A stale
`.env` pointing at a host that no longer answers degrades the same way, on a
timeout.

`make test-gpu` runs them. `make test-perf` is the CI jitted-kernel job run
here, and `make install` pulls the `full` extra so both have what they need.
numba stays out of `requirements-dev.txt` on purpose: the main test matrix
installs that file, and numba caps numpy (`<2.6` today), so declaring it there
would hold the matrix back from the next numpy the day it ships, which is the
one thing the perf job's separate environment exists to prevent.

## Every requirement is pinned

`requirements.txt` and `requirements-dev.txt` used floors while
`requirements-figures.txt` and `requirements-reports.txt` used exact versions,
and the two disagreed. A `pip install --dry-run` of a clean environment from
the first two landed on reportlab 5.0.1 and svglib 2.2.0, while the fiche
stack pins 5.0.0 and 2.1.0 and the committed fiches were rendered with those.
Nothing was wrong with either version. What was wrong is that the same
repository described its own environment two ways, so `make reports` on a
fresh checkout showed drift in fiches nobody had touched.

Dependabot already watches these files weekly, so pinning turns an upgrade
into a pull request the suite votes on rather than a silent difference between
two machines.

All thirty declared packages were checked against the current release. Four
were behind, all of them in the fiche chain: reportlab 5.0.1, svglib 2.2.0,
lxml 6.1.2, webencodings 0.6.1. They are pinned at those versions now, and
`make reports` under them produces the 71 committed fiches byte for byte
identical, so nothing needed regenerating. The figure stack was already
current, so no figure, no plate and no clip moved either.

What the published package asks of *its* users stays an open range in
`pyproject.toml`. A library that pins its dependencies cannot be installed
beside anything else.

## Checks

`ruff check .` and `ruff format --check .` clean, `mypy src scripts stub/src`
clean, bandit clean, conformance 550/550 with the claims check consistent, the
generated API reference unchanged, and the three artefact gates green: 71
fiches, 2796 figures, 42 clips. Suite: 9000 passed, 16 skipped, 0 failures.
The 16 are the local-CuPy cases, which need a card in this process, and the
jitted-kernel case, which needs `NUMBA_DISABLE_JIT=0` and is what
`make test-perf` is for.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Pinned all development and runtime dependencies to exact versions to prevent environment drift and ensure consistent test results.</li>
<li>Updated the FDTD GPU parity tests to support remote execution via `fdtd_gpu_remote` and added a dedicated `test-gpu` Makefile target.</li>
<li>Modified the `install` Makefile target to use `.[full]` to ensure optional dependencies like `numba` are available for performance testing.</li>
<li>Added a `test-perf` Makefile target to explicitly run performance tests with JIT enabled.</li>
<li>Updated several rendering-related packages (reportlab, svglib, lxml, webencodings) to their current versions.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote GPU parity coverage for FDTD wave directions and scenarios.
  * Added commands for performance testing and CUDA GPU testing.
  * Installation now includes the full optional feature set.

* **Bug Fixes**
  * Remote GPU checks now skip safely when no GPU host is configured.

* **Documentation**
  * Documented reproducible, exactly pinned development and testing dependencies.
  * Updated report-rendering dependency pins while preserving existing report outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->