### PR TITLE
Make the guards answer the question that was asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   is iterable, so the callers that wrote `times, levels = ...` keep working,
   the way `DecayCurve` replaced its own tuple return.
 
+### Fixed
+
+- Four guards that answered the wrong question, or could not answer at all.
+
+  `sound_power_reverberation` named `background_levels` in its message but
+  checked the shape one line *after* broadcasting it, so a spectrum of the
+  wrong length died inside `np.broadcast_to`, whose text reports two shapes
+  from inside numpy and names neither the argument nor the function. The check
+  runs first now and covers both wrong shapes with the one sentence.
+
+  `slit_helmholtz_absorber` let `resonator_geometry` travel two private frames
+  down to `helmholtz_resonator_impedance`, which calls the same value
+  `geometry`. A caller who mistyped the keyword was answered with the name of
+  a parameter that function does not have.
+
+  `_validate_area_inputs` was shared by four call sites and named none of
+  them. Reached through `absorption_coefficient(t1, t2, ..., m1=, m2=)`, a bad
+  `m1` reported a message about `'m'` and `'t60'`, neither of which is an
+  argument of that function. It takes the caller's names now, so three
+  messages changed text.
+
+  And `airborne_insulation` diagnosed the wrong defect. Given a reverberation
+  time carrying an extra axis, `(1, n)` against `n` bands, it said the band
+  counts differed, which was false: they matched, and the extra axis was the
+  problem. Its sibling `lab_airborne_insulation` had said so correctly all
+  along, because it compares sizes where this one compared shapes. The three
+  field-measurement pre-screens compare sizes now, so both halves of the
+  package give the same answer, and the dimensionality check they were masking
+  is reachable and tested rather than dead.
+
+  Two guards found in the same pass are left exactly as they were, and it is
+  worth saying why: the one in `io/_wav.py` cannot be reached from inside this
+  repository, but it is promised by its own docstring and it screens a file
+  header, and the one in `roughness_ecma` is one of three identical lines
+  across parallel front ends. A guard that cannot fire today is not always
+  dead weight. One that genuinely was, an early-out in `ecma` whose condition
+  the two branches above had already taken, is gone.
+
 ### Changed
 
 - The FDTD GPU parity is proved where the GPU is, not only where the process

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -751,7 +751,11 @@ def airborne_insulation(
     l2_bands = _as_band_levels(l2, "l2")
     t = np.asarray(t2, dtype=np.float64)
 
-    if not (l1_bands.shape == l2_bands.shape == t.shape):
+    # Compared by count, not by shape, so a `t2` that carries an extra axis
+    # falls through to `_validate_reverberation`, which says that is what is
+    # wrong. Comparing shapes answered a (1, n) array against n bands with
+    # "must share the same band count", which was false: the counts matched.
+    if not (l1_bands.shape == l2_bands.shape and l1_bands.size == t.size):
         msg = "'l1', 'l2' and 't2' must share the same band count."
         raise ValueError(msg)
     _validate_reverberation(t, t0)
@@ -822,7 +826,11 @@ def impact_insulation(
     li_bands = _as_band_levels(li, "li")
     t = np.asarray(t2, dtype=np.float64)
 
-    if li_bands.shape != t.shape:
+    # Compared by count, not by shape, so a `t2` that carries an extra axis
+    # falls through to `_validate_reverberation`, which says that is what is
+    # wrong. Comparing shapes answered a (1, n) array against n bands with
+    # "must share the same band count", which was false: the counts matched.
+    if li_bands.size != t.size:
         msg = "'li' and 't2' must share the same band count."
         raise ValueError(msg)
     _validate_reverberation(t, t0)
@@ -956,7 +964,11 @@ def facade_insulation(
     l2_bands = _as_band_levels(l2, "l2")
     t = np.asarray(t2, dtype=np.float64)
 
-    if not (l1_bands.shape == l2_bands.shape == t.shape):
+    # Compared by count, not by shape, so a `t2` that carries an extra axis
+    # falls through to `_validate_reverberation`, which says that is what is
+    # wrong. Comparing shapes answered a (1, n) array against n bands with
+    # "must share the same band count", which was false: the counts matched.
+    if not (l1_bands.shape == l2_bands.shape and l1_bands.size == t.size):
         msg = "'l1_2m', 'l2' and 't2' must share the same band count."
         raise ValueError(msg)
     _validate_reverberation(t, t0)

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -302,14 +302,19 @@ def _background_corrected_mean(
     raw_mean = _mean_level(levels)
     if arr.ndim == 2:  # noqa: PLR2004
         bg = np.asarray(background_levels, dtype=np.float64)
-        if bg.ndim == 1:
-            bg = np.broadcast_to(bg, arr.shape)
-        if bg.shape != arr.shape:
+        # Checked before the broadcast, not after it. A 1-D spectrum of the
+        # wrong length used to die inside `np.broadcast_to`, whose message
+        # reports two shapes from inside numpy and names neither the argument
+        # nor the function, so the caller never saw the sentence below.
+        expected = arr.shape[1:] if bg.ndim == 1 else arr.shape
+        if bg.shape != expected:
             msg = (
                 "'background_levels' must match the per-position 'levels' "
                 "shape or be a single (bands,) spectrum."
             )
             raise ValueError(msg)
+        if bg.ndim == 1:
+            bg = np.broadcast_to(bg, arr.shape)
         k1i, clamped = _k1_eq14(arr - bg, frequencies)
         corrected = energy_mean(arr - k1i, axis=0)
     else:

--- a/src/phonometry/materials/absorbers/slow_sound.py
+++ b/src/phonometry/materials/absorbers/slow_sound.py
@@ -73,7 +73,11 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.optimize import root
 
-from ..._internal.validation import require_positive, require_positive_array
+from ..._internal.validation import (
+    require_choice,
+    require_positive,
+    require_positive_array,
+)
 from ..._internal.warnings import PhonometryWarning
 from .porous import DEFAULT_AIR, AirProperties, Complex
 
@@ -685,6 +689,12 @@ def slit_helmholtz_absorber(
     if not 0.0 <= theta < np.pi / 2.0 - 1e-6:
         msg = "'angle' must satisfy 0 <= angle < pi/2 - 1e-6."
         raise ValueError(msg)
+    # Checked here rather than where it is used. The value travels down two
+    # private frames before `helmholtz_resonator_impedance` rejects it, and
+    # that function calls the parameter `geometry`, so a caller who mistyped
+    # `resonator_geometry` was told about an argument its signature does not
+    # have.
+    require_choice(resonator_geometry, "resonator_geometry", ("square", "slit"))
 
     omega = 2.0 * np.pi * f
     tm = _panel_transfer_matrix(

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -178,19 +178,42 @@ def attenuation_from_alpha(alpha: ArrayLike) -> NDArray[np.float64]:
 
 
 def _validate_area_inputs(
-    t: NDArray[np.float64], volume: float, m: NDArray[np.float64]
+    t: NDArray[np.float64],
+    volume: float,
+    m: NDArray[np.float64],
+    *,
+    t_name: str,
+    m_name: str,
 ) -> None:
+    """Reject the inputs of one area evaluation, naming the caller's arguments.
+
+    The names travel in because this helper is shared. Reached through
+    :func:`absorption_coefficient` the arguments are ``t1``/``m1`` and
+    ``t2``/``m2``, and a fixed message about ``t60`` and ``m`` would name two
+    parameters that function does not have.
+
+    :param t: Reverberation times, already coerced.
+    :param volume: Room volume, in cubic metres.
+    :param m: Air attenuation coefficient, already coerced.
+    :param t_name: What the caller calls *t*.
+    :param m_name: What the caller calls *m*.
+    :raises ValueError: for a non-positive volume or time, a negative
+        attenuation coefficient, or an *m* that is neither scalar nor of
+        *t*'s shape.
+    """
     if volume <= 0.0:
         msg = "'volume' must be positive."
         raise ValueError(msg)
     if np.any(t <= 0.0):
-        msg = "Reverberation times must be positive."
+        msg = f"'{t_name}' must be positive."
         raise ValueError(msg)
     if np.any(m < 0.0):
-        msg = "Air attenuation coefficient 'm' must be non-negative."
+        msg = f"'{m_name}' must be non-negative."
         raise ValueError(msg)
     if m.ndim != 0 and m.shape != t.shape:
-        msg = "'m' must be a scalar or an array matching the shape of 't60'."
+        msg = (
+            f"'{m_name}' must be a scalar or an array matching the shape of '{t_name}'."
+        )
         raise ValueError(msg)
 
 
@@ -201,16 +224,20 @@ def _absorption_area(
     temperature: float,
     speed_of_sound: float | None,
     m: ArrayLike,
+    t_name: str = "t60",
+    m_name: str = "m",
 ) -> NDArray[np.float64]:
     """Core Eq. (5)/(7) evaluation without the advisory volume warning.
 
     Shared by :func:`absorption_area` (which adds the ISO 354 clause 6.1.1
     volume advisory) and :func:`absorption_coefficient` (which advises the
-    volume once for the pair of measurements).
+    volume once for the pair of measurements). ``t_name`` and ``m_name`` are
+    what the public caller calls these two arguments, so a rejection names the
+    parameter that was actually passed.
     """
     t = np.asarray(t60, dtype=np.float64)
     m_arr = np.asarray(m, dtype=np.float64)
-    _validate_area_inputs(t, volume, m_arr)
+    _validate_area_inputs(t, volume, m_arr, t_name=t_name, m_name=m_name)
     c = _resolve_speed(temperature, speed_of_sound)
     return _SABINE * volume / (c * t) - 4.0 * volume * m_arr
 
@@ -333,6 +360,8 @@ def absorption_coefficient(
         temperature=temperature1,
         speed_of_sound=speed_of_sound1,
         m=m1,
+        t_name="t1",
+        m_name="m1",
     )
     a2 = _absorption_area(
         t2,
@@ -340,6 +369,8 @@ def absorption_coefficient(
         temperature=temperature2,
         speed_of_sound=speed_of_sound2,
         m=m2,
+        t_name="t2",
+        m_name="m2",
     )
     area_specimen = a2 - a1
     alpha_s = area_specimen / sample_area
@@ -567,10 +598,10 @@ def measure_sound_absorption(
     c = _resolve_speed(temperature, speed_of_sound)
     # A1/A2 reuse the Eq. (5)/(7) evaluation.
     a1 = _absorption_area(
-        t1, volume, temperature=temperature, speed_of_sound=c, m=m_arr
+        t1, volume, temperature=temperature, speed_of_sound=c, m=m_arr, t_name="t1"
     )
     a2 = _absorption_area(
-        t2, volume, temperature=temperature, speed_of_sound=c, m=m_arr
+        t2, volume, temperature=temperature, speed_of_sound=c, m=m_arr, t_name="t2"
     )
     # alpha_s reuses the validated Eq. (8)/(9) path (it also emits the volume,
     # sample-area and non-physical advisories exactly once).

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -487,10 +487,9 @@ def _average_bands_full(p_bands: list[np.ndarray], n_new: int) -> list[np.ndarra
         # fire: bands with N_B > 0 all sit at low index (0..24, block size
         # >= 2048), so their distance to the top band (>= 28) never limits the
         # symmetric reach (n_b <= 2).  Only the ``band`` lower-edge term bites.
+        # Never zero here: the two branches above have already taken every
+        # case that could make it so, which is why there is no early-out.
         reach = min(n_b, band, _CBF - 1 - band)
-        if reach == 0:
-            out.append(native)
-            continue
         # Sequential accumulation; bit-identical to np.mean over a stacked
         # axis-0 (numpy reduces a non-contiguous axis sequentially, so
         # pairwise summation never applies) while avoiding the stacked copy.

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -206,6 +206,16 @@ def test_band_count_mismatch_raises() -> None:
         building.facade_insulation(outdoor, indoor_two_bands, rt)
 
 
+def test_reverberation_time_with_an_extra_axis_raises() -> None:
+    """A `t2` carrying an extra axis is named for what is wrong with it.
+
+    The band counts match here, so a message about counts would be false.
+    """
+    outdoor, indoor = _flat(3, 70.0), _flat(3, 30.0)
+    with pytest.raises(ValueError, match="'t2' must be one-dimensional"):
+        building.facade_insulation(outdoor, indoor, np.full((1, 3), 0.5))
+
+
 def test_nonpositive_reverberation_raises() -> None:
     outdoor, indoor = _flat(3, 70.0), _flat(3, 30.0)
     rt_with_zero = np.array([0.5, 0.0, 0.5])

--- a/tests/building/measurement/test_impact_insulation.py
+++ b/tests/building/measurement/test_impact_insulation.py
@@ -274,6 +274,16 @@ def test_impact_rejects_length_mismatch() -> None:
         building.impact_insulation(li_2_bands, t2_1_band)
 
 
+def test_impact_rejects_reverberation_time_with_an_extra_axis() -> None:
+    """A `t2` carrying an extra axis is named for what is wrong with it.
+
+    The band counts match here, so a message about counts would be false.
+    """
+    li_2_bands = np.array([60.0, 60.0])
+    with pytest.raises(ValueError, match="'t2' must be one-dimensional"):
+        building.impact_insulation(li_2_bands, np.full((2, 1), 0.5))
+
+
 def test_impact_rejects_bad_reverberation_time() -> None:
     li = np.array([60.0])
     zero_t2 = np.array([0.0])

--- a/tests/building/measurement/test_insulation.py
+++ b/tests/building/measurement/test_insulation.py
@@ -318,6 +318,17 @@ def test_airborne_rejects_length_mismatch() -> None:
         building.airborne_insulation(two_bands, one_band, one_time)
 
 
+def test_airborne_rejects_reverberation_time_with_an_extra_axis() -> None:
+    """A `t2` carrying an extra axis is named for what is wrong with it.
+
+    The band counts match here, so a message about counts would be false.
+    """
+    two_bands = np.array([80.0, 80.0])
+    other_two_bands = np.array([40.0, 40.0])
+    with pytest.raises(ValueError, match="'t2' must be one-dimensional"):
+        building.airborne_insulation(two_bands, other_two_bands, np.full((1, 2), 0.5))
+
+
 def test_airborne_requires_both_area_and_volume() -> None:
     l1 = np.array([80.0])
     l2 = np.array([40.0])

--- a/tests/building/measurement/test_lab_insulation.py
+++ b/tests/building/measurement/test_lab_insulation.py
@@ -18,12 +18,17 @@ formulae, and consistency with the verified ISO 717-1/2 rating engine.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 import reference_data as ref
 
 from phonometry import building
 from phonometry.building.measurement.lab_insulation import LabInsulationWarning
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable
 
 # ISO 717-1 Table 3 airborne reference (100-3150 Hz, 16 bands).
 _REF_AIRBORNE = np.array(
@@ -349,3 +354,35 @@ def test_reference_floor_impact_end_to_end(ln_name: str, rating_name: str) -> No
     np.testing.assert_allclose(res.l_n, ln, atol=1e-9)
     assert res.rating is not None
     assert (res.rating.rating, res.rating.ci) == (lnw, ci)
+
+
+@pytest.mark.parametrize(
+    ("call", "shape"),
+    [
+        (
+            lambda t2: building.lab_airborne_insulation(
+                [80.0, 80.0, 80.0], [50.0, 50.0, 50.0], t2, area=10.0, volume=50.0
+            ),
+            (1, 3),
+        ),
+        (
+            lambda t2: building.lab_impact_insulation(
+                [80.0, 80.0, 80.0], t2, volume=50.0
+            ),
+            (3, 1),
+        ),
+    ],
+    ids=["airborne", "impact"],
+)
+def test_reverberation_time_with_an_extra_axis_says_so(
+    call: Callable[[np.ndarray], object], shape: tuple[int, int]
+) -> None:
+    """A `t2` carrying an extra axis is named for what is wrong with it.
+
+    The band counts match, so a message about counts would be false. This
+    guard was live and untested: nothing in the suite asserted its sentence,
+    so dropping it altogether left the suite green while a (1, n) array
+    broadcast its way to a wrongly shaped result.
+    """
+    with pytest.raises(ValueError, match="'t2' must be one-dimensional"):
+        call(np.full(shape, 0.5))

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -529,3 +529,32 @@ def test_comparison_background_correction_zero_without_background() -> None:
         np.array([90.0, 90.0]),
     )
     assert np.all(res.background_correction == 0.0)
+
+
+@pytest.mark.parametrize(
+    ("label", "background"),
+    [
+        ("1-D of the wrong length", np.full(5, 60.0)),
+        ("2-D of the wrong shape", np.full((3, 6), 60.0)),
+    ],
+)
+def test_background_levels_of_the_wrong_shape_name_themselves(
+    label: str, background: np.ndarray
+) -> None:
+    """Both wrong shapes reach the library's own message, not numpy's.
+
+    The 1-D case is the one that used to escape: it met `np.broadcast_to`
+    a line before the guard, and numpy reports two shapes from inside its own
+    code without naming the argument or the function.
+    """
+    levels = np.full((4, 6), 80.0)
+    frequencies = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+    with pytest.raises(ValueError, match="'background_levels' must match"):
+        emission.sound_power_reverberation(
+            levels,
+            np.full(6, 1.5),
+            200.0,
+            220.0,
+            frequencies,
+            background_levels=background,
+        )

--- a/tests/materials/absorbers/test_slow_sound.py
+++ b/tests/materials/absorbers/test_slow_sound.py
@@ -388,3 +388,24 @@ def test_invalid_inputs() -> None:
         slit_helmholtz_absorber(
             f, res, slit_height=1e-3, lattice_step=3e-2, period=5e-2, angle=np.pi / 2.0
         )
+
+
+def test_bad_geometry_names_the_argument_the_caller_passed() -> None:
+    """The message names `resonator_geometry`, which is what the signature has.
+
+    The value travels two private frames down to
+    `helmholtz_resonator_impedance`, which calls it `geometry`, so before this
+    guard a mistyped keyword was answered with the name of an argument this
+    function does not take.
+    """
+    res = _base_resonator()
+    f = np.array([300.0])
+    with pytest.raises(ValueError, match="'resonator_geometry' must be one of"):
+        slit_helmholtz_absorber(
+            f,
+            res,
+            slit_height=1e-3,
+            lattice_step=3e-2,
+            period=5e-2,
+            resonator_geometry="squre",
+        )

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -287,14 +287,12 @@ def test_negative_volume_raises() -> None:
 
 
 def test_zero_reverberation_time_raises() -> None:
-    with pytest.raises(ValueError, match="Reverberation times must be positive"):
+    with pytest.raises(ValueError, match="'t60' must be positive"):
         materials.absorption_area(0.0, 200.0)
 
 
 def test_negative_m_raises() -> None:
-    with pytest.raises(
-        ValueError, match="Air attenuation coefficient 'm' must be non-negative"
-    ):
+    with pytest.raises(ValueError, match="'m' must be non-negative"):
         materials.absorption_area(3.0, 200.0, m=-0.001)
 
 
@@ -321,7 +319,8 @@ def test_negative_sample_area_raises() -> None:
 
 
 def test_negative_t1_raises() -> None:
-    with pytest.raises(ValueError, match="Reverberation times must be positive"):
+    # `t1`, not `t60`: the message names the argument this function takes.
+    with pytest.raises(ValueError, match="'t1' must be positive"):
         materials.absorption_coefficient(-5.0, 3.0, 200.0, 10.0)
 
 


### PR DESCRIPTION
Four guards that answered the wrong question, and one early-out that could not answer at all.

## The three that named the wrong thing

`sound_power_reverberation` has a message that names `background_levels`, but the shape check sat one line *after* `np.broadcast_to`. A 1-D spectrum of the wrong length therefore died inside numpy, whose text reports two shapes from inside its own code and names neither the argument nor the function. The check runs before the broadcast now and covers both wrong shapes with the sentence that was already written for them.

`slit_helmholtz_absorber` forwarded `resonator_geometry` down two private frames to `helmholtz_resonator_impedance`, which calls the same value `geometry`. So a caller who mistyped the keyword was told about a parameter that function does not have. It is validated at the entry point now, through the shared `require_choice`.

`_validate_area_inputs` is shared by four call sites and named none of them. Reached through `absorption_coefficient(t1, t2, ..., m1=, m2=)`, a bad `m1` reported a message about `'m'` and `'t60'`, and neither is an argument of that function. It takes the caller's names now. Three messages change text, and the three tests that pinned them are re-pinned in the same commit.

## The one worth reading twice

`airborne_insulation`, given a reverberation time carrying an extra axis, `(1, n)` against `n` bands, said:

    'l1', 'l2' and 't2' must share the same band count.

That is false. All three carry `n` bands; the extra axis is the defect. Its sibling `lab_airborne_insulation`, on byte-identical input, had been answering correctly all along:

    't2' must be one-dimensional (one value per band).

The difference is that the lab module compares sizes where the field module compared shapes, so in the field module the dimensionality check downstream could never be reached and a wrong diagnosis was emitted in its place. Two modules of one package, one mistake, two answers, one of them wrong.

The three field pre-screens compare sizes now. Both halves agree, and the check they were masking is reachable, so it has the test it never had, at each of the three: beside the band-count test that was already there, in the file that owns that API.

The same guard's live twin in `lab_insulation.py` had no test either: 533 measurement tests never asserted its sentence, so deleting it outright left the suite green while a `(1, n)` array broadcast its way to a wrongly shaped result. That test is here too. Four entry points, one sentence, now pinned at all four.

## Two guards deliberately left alone

They were reported as dead and they are not dead weight:

- `io/_wav.py` cannot be reached from inside this repository today, but its
own docstring promises the raise and it screens a file header. Deleting it would make the documentation false.
- `roughness_ecma` is one of three identical lines across parallel front ends.

One genuinely was dead, an early-out in `ecma` whose condition the two branches above it had already taken, and it is gone, with a line saying why there is no early-out there.

## How this was checked

Every new test was run against the pre-change code first and fails there. The wrong-diagnosis claim was reproduced by hand before anything was edited, and both entry points were re-run afterwards to confirm they now give the same answer.

## Checks

`ruff check .` and `ruff format --check .` clean, `mypy src scripts stub/src` clean, and the artefact gates green (71 fiches, 42 clips). The 538 tests of `tests/building/measurement/` pass with the three new ones among them, and CI is green on the whole suite, the six matrix jobs and the conformance harness.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Improve validation behavior so guards reject malformed inputs with accurate, actionable error messages.

Bug Fixes:
- Correct misleading validation errors across insulation, sound power, absorber geometry, and sound absorption APIs so messages identify the actual invalid argument and defect.
- Ensure invalid background spectra are rejected before broadcasting and reverberation-time dimensionality errors are reported consistently across insulation entry points.
- Remove a redundant early exit in ECMA loudness band averaging.

Enhancements:
- Align shared area-input validation with the parameter names used by each public caller.

Documentation:
- Document the validation fixes and rationale in the changelog.

Tests:
- Add regression coverage for incorrect shapes, dimensionality errors, invalid geometry choices, and caller-specific validation messages.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Improved error reporting and validation logic for several functions by replacing shape-based checks with size-based checks or more specific validation.</li>
<li>Fixed incorrect error messages in `airborne_insulation`, `impact_insulation`, and `facade_insulation` that previously misdiagnosed dimensionality issues.</li>
<li>Corrected input validation in `sound_power_reverberation` to check shapes before broadcasting, preventing misleading numpy errors.</li>
<li>Refactored `_validate_area_inputs` to use caller-provided argument names for clearer error messages.</li>
<li>Removed redundant code in `ecma.py` and improved parameter handling in `slit_helmholtz_absorber`.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for sound power, insulation, and sound absorption calculations.
  * Added clearer errors for mismatched background levels, reverberation-time dimensions, and invalid area inputs.
  * Added validation for supported slit Helmholtz absorber geometries.
  * Corrected band-count checks to handle multidimensional inputs consistently.
  * Removed a redundant loudness-processing guard without changing supported behavior.

* **Documentation**
  * Updated the changelog with the latest validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

