### PR TITLE
Make a result refuse to exist with spectra that disagree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `TonalCorrectionResult`. The message names the type, the axis and every
   count it was given.
 
+  How many axes there are is pinned as well as how long each one is, because
+  counting alone is not enough: an array of shape ``(paths, bands, 2)`` has
+  the right number of paths on its first axis and the right number of bands
+  on its second, so every count agrees and the extra axis travels on into
+  whatever indexes the field next.
+
 - Four guards that answered the wrong question, or could not answer at all.
 
   `sound_power_reverberation` named `background_levels` in its message but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Thirteen result types now refuse to exist carrying per-band arrays of
+  different lengths, which used to produce a fiche rather than an error.
+
+  A result dataclass is frozen, exported and has its constructor in the
+  generated reference, so one could be built, or replaced into, with a
+  spectrum that did not run over its own band axis. What that produced was
+  not a failure: a fiche prints one row per band under a single header, so
+  reportlab pads the short row out and the sheet then states a total summing
+  a band that appears nowhere in the column above it. An array one *too long*
+  is truncated by the same table, just as quietly, and the strips that report
+  a field indicator as a range print a range taken over the wrong set of
+  bands, which nothing downstream can object to because a range is well
+  formed whatever it was taken over.
+
+  Checking where the values are read would have to be repeated at every
+  renderer, every plot and every reader not written yet; checking when the
+  result is built covers all of them, in both directions. The types are
+  `DuctPathResult` (including its element rows and its contributions),
+  `SoundPowerIntensityResult` (on its band axis and its segment axis),
+  `SoundPowerResult`, `InstalledSourceResult`, `DetailedAirborneResult` and
+  `DetailedImpactResult` (on their band axis and their path axis),
+  `NCResult`, `RCResult`, `STIResult`, `FilterComplianceResult`,
+  `IntensityInstrumentComplianceResult`, `ImpulseProminenceResult` and
+  `TonalCorrectionResult`. The message names the type, the axis and every
+  count it was given.
+
 - Four guards that answered the wrong question, or could not answer at all.
 
   `sound_power_reverberation` named `background_levels` in its message but

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -120,7 +120,9 @@ def require_finite_array(x: ArrayLike, name: str) -> np.ndarray:
     return arr
 
 
-def require_axis_count(value: object, owner: str, name: str, axis: str = "band") -> int:
+def require_axis_count(
+    value: object, owner: str, name: str, axis: str = "band", *, rank: int | None
+) -> int:
     """The number of entries along the first axis of *value*.
 
     ``len()``, not ``np.shape()``: the first axis of a tuple of per-band
@@ -128,13 +130,23 @@ def require_axis_count(value: object, owner: str, name: str, axis: str = "band")
     try to stack them and raise about an inhomogeneous shape for a bank whose
     bands carry filters of different orders.
 
+    *rank* has no default and must be stated, because a count on its own says
+    nothing about how many axes there are: an array of shape ``(bands, 2)``
+    counts the right number of bands on its first axis and carries the second
+    one onward untouched. Pass ``None`` only where the rank is pinned
+    elsewhere, as :func:`require_ranks` does for a whole result at once.
+
     :param value: The field whose entries are counted.
     :param owner: Name of the type being checked, used in the error message.
     :param name: Field name used in the error message.
     :param axis: What the entries measure, singular, for the error message.
+    :param rank: The number of axes the field must have, or ``None`` when that
+        is checked elsewhere.
     :return: The number of entries.
-    :raises ValueError: if *value* is a single number rather than a sequence.
+    :raises ValueError: if *value* is a single number, or has another rank.
     """
+    if rank is not None:
+        require_axis_rank(value, owner, name, rank)
     try:
         return len(value)  # type: ignore[arg-type]
     except TypeError:
@@ -244,7 +256,9 @@ def require_same_length(
         if value is None:
             continue
         if index == 0:
-            counts[name] = require_axis_count(value, type(owner).__name__, name, axis)
+            counts[name] = require_axis_count(
+                value, type(owner).__name__, name, axis, rank=None
+            )
             continue
         shape = np.shape(value)
         if len(shape) <= index:

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -120,6 +120,28 @@ def require_finite_array(x: ArrayLike, name: str) -> np.ndarray:
     return arr
 
 
+def require_axis_count(value: object, owner: str, name: str, axis: str = "band") -> int:
+    """The number of entries along the first axis of *value*.
+
+    ``len()``, not ``np.shape()``: the first axis of a tuple of per-band
+    arrays is its length whatever the arrays hold, while ``np.shape`` would
+    try to stack them and raise about an inhomogeneous shape for a bank whose
+    bands carry filters of different orders.
+
+    :param value: The field whose entries are counted.
+    :param owner: Name of the type being checked, used in the error message.
+    :param name: Field name used in the error message.
+    :param axis: What the entries measure, singular, for the error message.
+    :return: The number of entries.
+    :raises ValueError: if *value* is a single number rather than a sequence.
+    """
+    try:
+        return len(value)  # type: ignore[arg-type]
+    except TypeError:
+        msg = f"{owner}: '{name}' must carry one value per {axis}, not a single number."
+        raise ValueError(msg) from None
+
+
 def require_equal_counts(
     owner: str, counts: Mapping[str, int], axis: str = "band"
 ) -> None:
@@ -177,18 +199,7 @@ def require_same_length(
         if value is None:
             continue
         if index == 0:
-            # len(), not np.shape(): the first axis of a tuple of per-band
-            # arrays is its length whatever the arrays hold, while np.shape
-            # would try to stack them and raise about an inhomogeneous shape
-            # for a bank whose bands carry filters of different orders.
-            try:
-                counts[name] = len(value)
-            except TypeError:
-                msg = (
-                    f"{type(owner).__name__}: '{name}' must carry one value "
-                    f"per {axis}, not a single number."
-                )
-                raise ValueError(msg) from None
+            counts[name] = require_axis_count(value, type(owner).__name__, name, axis)
             continue
         shape = np.shape(value)
         if len(shape) <= index:

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -176,15 +176,28 @@ def require_same_length(
         value = getattr(owner, name)
         if value is None:
             continue
+        if index == 0:
+            # len(), not np.shape(): the first axis of a tuple of per-band
+            # arrays is its length whatever the arrays hold, while np.shape
+            # would try to stack them and raise about an inhomogeneous shape
+            # for a bank whose bands carry filters of different orders.
+            try:
+                counts[name] = len(value)
+            except TypeError:
+                msg = (
+                    f"{type(owner).__name__}: '{name}' must carry one value "
+                    f"per {axis}, not a single number."
+                )
+                raise ValueError(msg) from None
+            continue
         shape = np.shape(value)
-        label = name if index == 0 else f"{name} (axis {index})"
         if len(shape) <= index:
             msg = (
                 f"{type(owner).__name__}: '{name}' must have an axis {index} "
                 f"to carry one value per {axis}; got shape {shape}."
             )
             raise ValueError(msg)
-        counts[label] = shape[index]
+        counts[f"{name} (axis {index})"] = shape[index]
     require_equal_counts(type(owner).__name__, counts, axis)
 
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from numpy.typing import ArrayLike
 
 
@@ -116,6 +118,74 @@ def require_finite_array(x: ArrayLike, name: str) -> np.ndarray:
         msg = f"'{name}' must contain only finite values."
         raise ValueError(msg)
     return arr
+
+
+def require_equal_counts(
+    owner: str, counts: Mapping[str, int], axis: str = "band"
+) -> None:
+    """Require every measured count to agree, naming each one that does not.
+
+    The sibling of :func:`require_same_length` for the counts a caller has
+    already measured: entries of a nested sequence, an axis picked out of a
+    two-dimensional field, anything whose label is not a plain attribute name.
+
+    The message lists every count it was given rather than picking out an odd
+    one, because among peers no count is authoritative and a majority winner
+    would be a guess. Where one quantity *is* authoritative, pass it and the
+    single suspect: two entries make the shortest true message there is.
+
+    :param owner: Name of the type being checked, used in the error message.
+    :param counts: Label to count, in the order they should be reported.
+    :param axis: What the counts measure, singular, for the error message.
+    :raises ValueError: if two of the counts disagree.
+    """
+    if len(set(counts.values())) <= 1:
+        return
+    listed = ", ".join(f"'{label}' ({n})" for label, n in counts.items())
+    msg = f"{owner}: {listed} must each carry one value per {axis}."
+    raise ValueError(msg)
+
+
+def require_same_length(
+    owner: object, *fields: str | tuple[str, int], axis: str = "band"
+) -> None:
+    """Require the named fields of *owner* to share one length.
+
+    Written for the ``__post_init__`` of a result dataclass, so that a result
+    whose per-band arrays disagree cannot be built at all. Validating here
+    rather than where the values are read covers the readers that do not
+    exist yet, and both directions of the mistake: an array one short raises
+    somewhere downstream, but an array one long is silently truncated by the
+    table that prints it, under a total that summed the whole of it.
+
+    A field may be given as ``"name"`` for a length along the first axis, or
+    as ``("name", i)`` when the axis in question is not the first one, as it
+    is not for a per-path-per-band array whose bands run along axis 1.
+
+    ``None`` fields are skipped: an absent optional quantity is not a
+    disagreement.
+
+    :param owner: The instance whose fields are compared.
+    :param fields: Field names, or ``(name, axis_index)`` pairs.
+    :param axis: What the lengths measure, singular, for the error message.
+    :raises ValueError: if two of the fields disagree, or one is a scalar.
+    """
+    counts: dict[str, int] = {}
+    for field in fields:
+        name, index = field if isinstance(field, tuple) else (field, 0)
+        value = getattr(owner, name)
+        if value is None:
+            continue
+        shape = np.shape(value)
+        label = name if index == 0 else f"{name} (axis {index})"
+        if len(shape) <= index:
+            msg = (
+                f"{type(owner).__name__}: '{name}' must have an axis {index} "
+                f"to carry one value per {axis}; got shape {shape}."
+            )
+            raise ValueError(msg)
+        counts[label] = shape[index]
+    require_equal_counts(type(owner).__name__, counts, axis)
 
 
 def require_per_band(

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -142,6 +142,51 @@ def require_axis_count(value: object, owner: str, name: str, axis: str = "band")
         raise ValueError(msg) from None
 
 
+def require_axis_rank(value: object, owner: str, name: str, rank: int) -> None:
+    """Require *value* to have exactly *rank* axes.
+
+    Counting an axis is not enough on its own: an array of shape
+    ``(paths, bands, 2)`` has the right number of paths on its first axis and
+    the right number of bands on its second, so every count agrees and the
+    extra axis travels on into whatever indexes the field next.
+
+    Only arrays are measured. A tuple of per-band entries is one axis of
+    entries whatever each entry holds, and asking numpy for its rank would
+    stack them and raise about an inhomogeneous shape.
+
+    :param value: The field whose axes are counted.
+    :param owner: Name of the type being checked, used in the error message.
+    :param name: Field name used in the error message.
+    :param rank: The number of axes the field must have.
+    :raises ValueError: if *value* has a different number of axes.
+    """
+    actual = value.ndim if isinstance(value, np.ndarray) else 1
+    if actual != rank:
+        axes = "one axis" if rank == 1 else f"{rank} axes"
+        msg = (
+            f"{owner}: '{name}' must have {axes}; got {actual}. "
+            "An extra axis passes every count and reaches the reader intact."
+        )
+        raise ValueError(msg)
+
+
+def require_ranks(owner: object, **ranks: int) -> None:
+    """Require each named field of *owner* to have the given number of axes.
+
+    The companion of :func:`require_same_length`, which pins how long an axis
+    is but not how many there are. ``None`` fields are skipped.
+
+    :param owner: The instance whose fields are measured.
+    :param ranks: Field name to the number of axes it must have.
+    :raises ValueError: if a field has a different number of axes.
+    """
+    for name, rank in ranks.items():
+        value = getattr(owner, name)
+        if value is None:
+            continue
+        require_axis_rank(value, type(owner).__name__, name, rank)
+
+
 def require_equal_counts(
     owner: str, counts: Mapping[str, int], axis: str = "band"
 ) -> None:

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -257,9 +257,11 @@ def _rc_left_cell(
 
     levels = np.asarray(result.levels, dtype=np.float64)
     reference = np.asarray(result.reference_curve, dtype=np.float64)
-    # Guard a manually constructed result: RCResult is a plain frozen dataclass,
-    # so a hand-built one can carry a reference curve of a different length than
-    # its levels, and only the verbose columns pair the two band by band.
+    # RCResult now refuses a reference curve of another *length* when it is
+    # built, so what is left here is the disagreement that survives that check:
+    # an extra axis. A curve of shape (n, 1) has n entries along axis 0 and
+    # passes construction, but the verbose column pairs the two band by band
+    # and would format a one-element array into every cell.
     if verbose and levels.shape != reference.shape:
         msg = (
             "render_rc_report(verbose=True) needs 'levels' and "

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -257,18 +257,9 @@ def _rc_left_cell(
 
     levels = np.asarray(result.levels, dtype=np.float64)
     reference = np.asarray(result.reference_curve, dtype=np.float64)
-    # RCResult now refuses a reference curve of another *length* when it is
-    # built, so what is left here is the disagreement that survives that check:
-    # an extra axis. A curve of shape (n, 1) has n entries along axis 0 and
-    # passes construction, but the verbose column pairs the two band by band
-    # and would format a one-element array into every cell.
-    if verbose and levels.shape != reference.shape:
-        msg = (
-            "render_rc_report(verbose=True) needs 'levels' and "
-            "'reference_curve' of the same shape; a curve with an extra axis "
-            "has the right number of entries but not the right shape."
-        )
-        raise ValueError(msg)
+    # No guard on the two agreeing: RCResult requires both to be
+    # one-dimensional and of one length when it is built, which leaves no
+    # shape for them to disagree in by the time they arrive here.
     columns = _base_columns(levels, language)
     if verbose:
         columns.append(

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -265,7 +265,8 @@ def _rc_left_cell(
     if verbose and levels.shape != reference.shape:
         msg = (
             "render_rc_report(verbose=True) needs 'levels' and "
-            "'reference_curve' of equal length."
+            "'reference_curve' of the same shape; a curve with an extra axis "
+            "has the right number of entries but not the right shape."
         )
         raise ValueError(msg)
     columns = _base_columns(levels, language)

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -1467,6 +1467,47 @@ def _path_matrix(paths: Sequence[BandPath], n_bands: int) -> np.ndarray:
     )
 
 
+def _require_paths_and_bands(result: Any, total: str) -> None:
+    """Reject a decomposition whose paths and bands do not line up.
+
+    Shared by the airborne and the impact result, which decompose different
+    quantities over the same two axes and print the same sheet: one row per
+    transmission path, a share column beside those rows, and a box holding the
+    single number of the whole.
+
+    ``fractions`` is indexed by path to name the dominant one, so an array
+    short of a path row yields a sheet listing fewer paths than the shares it
+    prints sum over, and the column stops reaching 100 % under a box that
+    still rates the whole.
+
+    :param result: The result being built.
+    :param total: Name of its per-band total, ``r_prime`` or ``l_prime_n``.
+    :raises ValueError: if the band or path axes disagree.
+    """
+    owner = type(result).__name__
+    require_same_length(result, "frequencies", total, ("fractions", 1))
+    bands = require_axis_count(result.frequencies, owner, "frequencies")
+    for i, path in enumerate(result.paths):
+        label = f"paths[{i}] ({path.label})"
+        require_equal_counts(
+            owner,
+            {
+                "frequencies": bands,
+                label: require_axis_count(path.values, owner, label),
+            },
+        )
+    require_equal_counts(
+        owner,
+        {
+            "paths": len(result.paths),
+            "fractions": require_axis_count(
+                result.fractions, owner, "fractions", "transmission path"
+            ),
+        },
+        "transmission path",
+    )
+
+
 def airborne_flanking_path(
     *,
     label: str,
@@ -1583,30 +1624,9 @@ class DetailedAirborneResult:
     def __post_init__(self) -> None:
         """Reject a decomposition whose paths and bands do not line up.
 
-        ``fractions`` is indexed by path to name the dominant one and printed
-        as a share column beside the path rows, so a fractions array short of
-        a path row yields a sheet listing fewer paths than the shares it
-        prints sum over: the column no longer reaches 100 %, under a box
-        holding the single-number rating of the whole transmission.
-
         :raises ValueError: if the band or path axes disagree.
         """
-        require_same_length(self, "frequencies", "r_prime", ("fractions", 1))
-        for i, path in enumerate(self.paths):
-            require_equal_counts(
-                type(self).__name__,
-                {
-                    "frequencies": len(self.frequencies),
-                    f"paths[{i}] ({path.label})": require_axis_count(
-                        path.values, type(self).__name__, f"paths[{i}]"
-                    ),
-                },
-            )
-        require_equal_counts(
-            type(self).__name__,
-            {"paths": len(self.paths), "fractions": len(self.fractions)},
-            "transmission path",
-        )
+        _require_paths_and_bands(self, "r_prime")
 
     @property
     def dominant(self) -> tuple[str, ...]:
@@ -1689,30 +1709,9 @@ class DetailedImpactResult:
     def __post_init__(self) -> None:
         """Reject a decomposition whose paths and bands do not line up.
 
-        ``fractions`` is indexed by path to name the dominant one and printed
-        as a share column beside the path rows, so a fractions array short of
-        a path row yields a sheet listing fewer paths than the shares it
-        prints sum over: the column no longer reaches 100 %, under a box
-        holding the single-number rating of the whole radiation.
-
         :raises ValueError: if the band or path axes disagree.
         """
-        require_same_length(self, "frequencies", "l_prime_n", ("fractions", 1))
-        for i, path in enumerate(self.paths):
-            require_equal_counts(
-                type(self).__name__,
-                {
-                    "frequencies": len(self.frequencies),
-                    f"paths[{i}] ({path.label})": require_axis_count(
-                        path.values, type(self).__name__, f"paths[{i}]"
-                    ),
-                },
-            )
-        require_equal_counts(
-            type(self).__name__,
-            {"paths": len(self.paths), "fractions": len(self.fractions)},
-            "transmission path",
-        )
+        _require_paths_and_bands(self, "l_prime_n")
 
     @property
     def dominant(self) -> tuple[str, ...]:

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -101,7 +101,6 @@ import numpy as np
 
 from ..._internal.validation import (
     require_axis_count,
-    require_axis_rank,
     require_choice,
     require_equal_counts,
     require_positive,
@@ -1489,15 +1488,14 @@ def _require_paths_and_bands(result: Any, total: str) -> None:
     owner = type(result).__name__
     require_ranks(result, frequencies=1, fractions=2, **{total: 1})
     require_same_length(result, "frequencies", total, ("fractions", 1))
-    bands = require_axis_count(result.frequencies, owner, "frequencies")
+    bands = require_axis_count(result.frequencies, owner, "frequencies", rank=None)
     for i, path in enumerate(result.paths):
         label = f"paths[{i}] ({path.label})"
-        require_axis_rank(path.values, owner, label, 1)
         require_equal_counts(
             owner,
             {
                 "frequencies": bands,
-                label: require_axis_count(path.values, owner, label),
+                label: require_axis_count(path.values, owner, label, rank=1),
             },
         )
     require_equal_counts(
@@ -1505,7 +1503,7 @@ def _require_paths_and_bands(result: Any, total: str) -> None:
         {
             "paths": len(result.paths),
             "fractions": require_axis_count(
-                result.fractions, owner, "fractions", "transmission path"
+                result.fractions, owner, "fractions", "transmission path", rank=None
             ),
         },
         "transmission path",

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -101,10 +101,12 @@ import numpy as np
 
 from ..._internal.validation import (
     require_axis_count,
+    require_axis_rank,
     require_choice,
     require_equal_counts,
     require_positive,
     require_positive_array,
+    require_ranks,
     require_same_length,
 )
 
@@ -1485,10 +1487,12 @@ def _require_paths_and_bands(result: Any, total: str) -> None:
     :raises ValueError: if the band or path axes disagree.
     """
     owner = type(result).__name__
+    require_ranks(result, frequencies=1, fractions=2, **{total: 1})
     require_same_length(result, "frequencies", total, ("fractions", 1))
     bands = require_axis_count(result.frequencies, owner, "frequencies")
     for i, path in enumerate(result.paths):
         label = f"paths[{i}] ({path.label})"
+        require_axis_rank(path.values, owner, label, 1)
         require_equal_counts(
             owner,
             {

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -100,6 +100,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..._internal.validation import (
+    require_axis_count,
     require_choice,
     require_equal_counts,
     require_positive,
@@ -1596,7 +1597,9 @@ class DetailedAirborneResult:
                 type(self).__name__,
                 {
                     "frequencies": len(self.frequencies),
-                    f"paths[{i}] {path.label!r}": len(path.values),
+                    f"paths[{i}] ({path.label})": require_axis_count(
+                        path.values, type(self).__name__, f"paths[{i}]"
+                    ),
                 },
             )
         require_equal_counts(
@@ -1700,7 +1703,9 @@ class DetailedImpactResult:
                 type(self).__name__,
                 {
                     "frequencies": len(self.frequencies),
-                    f"paths[{i}] {path.label!r}": len(path.values),
+                    f"paths[{i}] ({path.label})": require_axis_count(
+                        path.values, type(self).__name__, f"paths[{i}]"
+                    ),
                 },
             )
         require_equal_counts(

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -101,8 +101,10 @@ import numpy as np
 
 from ..._internal.validation import (
     require_choice,
+    require_equal_counts,
     require_positive,
     require_positive_array,
+    require_same_length,
 )
 
 if TYPE_CHECKING:
@@ -1577,6 +1579,32 @@ class DetailedAirborneResult:
     fractions: np.ndarray
     rating: WeightedRatingResult | None
 
+    def __post_init__(self) -> None:
+        """Reject a decomposition whose paths and bands do not line up.
+
+        ``fractions`` is indexed by path to name the dominant one and printed
+        as a share column beside the path rows, so a fractions array short of
+        a path row yields a sheet listing fewer paths than the shares it
+        prints sum over: the column no longer reaches 100 %, under a box
+        holding the single-number rating of the whole transmission.
+
+        :raises ValueError: if the band or path axes disagree.
+        """
+        require_same_length(self, "frequencies", "r_prime", ("fractions", 1))
+        for i, path in enumerate(self.paths):
+            require_equal_counts(
+                type(self).__name__,
+                {
+                    "frequencies": len(self.frequencies),
+                    f"paths[{i}] {path.label!r}": len(path.values),
+                },
+            )
+        require_equal_counts(
+            type(self).__name__,
+            {"paths": len(self.paths), "fractions": len(self.fractions)},
+            "transmission path",
+        )
+
     @property
     def dominant(self) -> tuple[str, ...]:
         """Label of the path carrying most energy in each band."""
@@ -1654,6 +1682,32 @@ class DetailedImpactResult:
     l_prime_n: np.ndarray
     fractions: np.ndarray
     rating: ImpactRatingResult | None
+
+    def __post_init__(self) -> None:
+        """Reject a decomposition whose paths and bands do not line up.
+
+        ``fractions`` is indexed by path to name the dominant one and printed
+        as a share column beside the path rows, so a fractions array short of
+        a path row yields a sheet listing fewer paths than the shares it
+        prints sum over: the column no longer reaches 100 %, under a box
+        holding the single-number rating of the whole radiation.
+
+        :raises ValueError: if the band or path axes disagree.
+        """
+        require_same_length(self, "frequencies", "l_prime_n", ("fractions", 1))
+        for i, path in enumerate(self.paths):
+            require_equal_counts(
+                type(self).__name__,
+                {
+                    "frequencies": len(self.frequencies),
+                    f"paths[{i}] {path.label!r}": len(path.values),
+                },
+            )
+        require_equal_counts(
+            type(self).__name__,
+            {"paths": len(self.paths), "fractions": len(self.fractions)},
+            "transmission path",
+        )
 
     @property
     def dominant(self) -> tuple[str, ...]:

--- a/src/phonometry/building/prediction/installed_structure_borne.py
+++ b/src/phonometry/building/prediction/installed_structure_borne.py
@@ -88,6 +88,7 @@ from ..._internal.validation import (
     require_choice,
     require_non_negative,
     require_positive,
+    require_ranks,
     require_same_length,
 )
 from .resilient_layers import TAPPING_HAMMER_MASS
@@ -1014,6 +1015,13 @@ class InstalledSourceResult:
 
         :raises ValueError: if the band or path axes disagree.
         """
+        require_ranks(
+            self,
+            frequencies=1,
+            total_level=1,
+            installed_power_level=1,
+            path_levels=2,
+        )
         require_same_length(
             self,
             "frequencies",

--- a/src/phonometry/building/prediction/installed_structure_borne.py
+++ b/src/phonometry/building/prediction/installed_structure_borne.py
@@ -88,6 +88,7 @@ from ..._internal.validation import (
     require_choice,
     require_non_negative,
     require_positive,
+    require_same_length,
 )
 from .resilient_layers import TAPPING_HAMMER_MASS
 
@@ -1000,6 +1001,26 @@ class InstalledSourceResult:
     total_level: np.ndarray
     installed_power_level: np.ndarray
     frequencies: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a prediction whose paths and bands do not line up.
+
+        The fiche prints one row per transmission path and, in its box, the
+        band-summed :attr:`overall_level`, which is computed from
+        ``total_level`` and not from the rows. A ``path_levels`` short of a
+        row therefore yields a sheet whose box sums a path that is nowhere in
+        the table, under a caption stating that the total is the energy sum of
+        the rows above.
+
+        :raises ValueError: if the band or path axes disagree.
+        """
+        require_same_length(
+            self,
+            "frequencies",
+            "total_level",
+            "installed_power_level",
+            ("path_levels", 1),
+        )
 
     @property
     def overall_level(self) -> float:

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -67,6 +67,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -423,6 +425,24 @@ class IntensityInstrumentComplianceResult:
     spacing: float
     spacing_offset_db: float
     range_limited: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject a verdict whose per-band entries disagree.
+
+        The fiche prints one row per band and, in its box, the overall class
+        of the whole instrument, so a band list short of an entry gives a
+        sheet whose verdict covers a band that is nowhere in its table.
+
+        :raises ValueError: if the per-band entries disagree.
+        """
+        require_same_length(
+            self,
+            "bands",
+            "frequency",
+            "residual_index",
+            "limit_class1",
+            "limit_class2",
+        )
 
     def reference_class(self) -> int:
         """The class whose mask the fiche and the plot read margins against.

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -67,7 +67,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_same_length
+from .._internal.validation import require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -435,6 +435,13 @@ class IntensityInstrumentComplianceResult:
 
         :raises ValueError: if the per-band entries disagree.
         """
+        require_ranks(
+            self,
+            frequency=1,
+            residual_index=1,
+            limit_class1=1,
+            limit_class2=1,
+        )
         require_same_length(
             self,
             "bands",

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -55,6 +55,7 @@ import numpy as np
 
 from .._internal.levels_math import energy_mean, energy_sum
 from .._internal.types import as_float_or_array
+from .._internal.validation import require_same_length
 from ._shared import (
     _S0,
     Grade,
@@ -239,6 +240,27 @@ class SoundPowerResult:
     sound_power_level_a: float
     uncertainty: float
     grade: str
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-band quantities disagree.
+
+        The boxed A-weighted total is summed over every band of
+        ``sound_power_level``, and the table beneath prints one row per band,
+        so a spectrum of another length gives a sheet whose headline number
+        sums bands its own table does not show.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_same_length(
+            self,
+            "frequencies",
+            "sound_power_level",
+            "surface_pressure_level",
+            "mean_pressure_level",
+            "background_correction",
+            "environmental_correction",
+            ("directivity_index", 1),
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -55,7 +55,7 @@ import numpy as np
 
 from .._internal.levels_math import energy_mean, energy_sum
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_same_length
+from .._internal.validation import require_ranks, require_same_length
 from ._shared import (
     _S0,
     Grade,
@@ -251,6 +251,16 @@ class SoundPowerResult:
 
         :raises ValueError: if any per-band quantity disagrees with the rest.
         """
+        require_ranks(
+            self,
+            frequencies=1,
+            sound_power_level=1,
+            surface_pressure_level=1,
+            mean_pressure_level=1,
+            background_correction=1,
+            environmental_correction=1,
+            directivity_index=2,
+        )
         require_same_length(
             self,
             "frequencies",

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 from .._internal.levels_math import energy_mean, weighted_energy_mean
+from .._internal.validation import require_same_length
 from ._shared import SoundPowerWarning, _a_weighting_corrections, _check_grade
 from .intensity import dynamic_capability_index
 
@@ -223,6 +224,41 @@ class SoundPowerIntensityResult:
     sound_power_level_a: float
     a_weighting_omitted_bands: np.ndarray | None
     grade: str
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-band quantities disagree.
+
+        The field indicators reach the fiche's measurement-basis strip as a
+        range rather than as a column, so a short or long indicator array
+        prints a range taken over the wrong set of bands, on a sheet whose
+        next sentence turns that range into a qualification verdict. Nothing
+        downstream can catch that, because a range is well formed whatever it
+        was taken over.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_same_length(
+            self,
+            "frequencies",
+            ("partial_power", 1),
+            ("partial_power_level", 1),
+            "sound_power",
+            "sound_power_level",
+            "negative_band",
+            "surface_pressure_intensity_index",
+            "negative_partial_power_index",
+            ("repeatability", 1),
+            "dynamic_capability_index",
+            "achieved_grade",
+            "a_weighting_omitted_bands",
+        )
+        require_same_length(
+            self,
+            "partial_power",
+            "partial_power_level",
+            "repeatability",
+            axis="measurement segment",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -99,7 +99,7 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 from .._internal.levels_math import energy_mean, weighted_energy_mean
-from .._internal.validation import require_same_length
+from .._internal.validation import require_ranks, require_same_length
 from ._shared import SoundPowerWarning, _a_weighting_corrections, _check_grade
 from .intensity import dynamic_capability_index
 
@@ -237,6 +237,21 @@ class SoundPowerIntensityResult:
 
         :raises ValueError: if any per-band quantity disagrees with the rest.
         """
+        require_ranks(
+            self,
+            frequencies=1,
+            partial_power=2,
+            partial_power_level=2,
+            sound_power=1,
+            sound_power_level=1,
+            negative_band=1,
+            surface_pressure_intensity_index=1,
+            negative_partial_power_index=1,
+            repeatability=2,
+            dynamic_capability_index=1,
+            achieved_grade=1,
+            a_weighting_omitted_bands=1,
+        )
         require_same_length(
             self,
             "frequencies",

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -64,6 +64,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from ..._internal.validation import require_same_length
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -129,6 +130,24 @@ class ImpulseProminenceResult:
     prominence: float
     adjustment: float
     assessment_period_min: float = DEFAULT_ASSESSMENT_PERIOD_MIN
+
+    def __post_init__(self) -> None:
+        """Reject a set of impulses whose per-impulse columns disagree.
+
+        The fiche prints one row per impulse and, above them, a prominence
+        taken over the whole set, so a column short of a row leaves a sheet
+        whose headline covers an impulse that is not in the table.
+
+        :raises ValueError: if the per-impulse columns disagree.
+        """
+        require_same_length(
+            self,
+            "onset_rates",
+            "level_differences",
+            "per_impulse",
+            "qualifies",
+            axis="impulse",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -64,7 +64,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from ..._internal.validation import require_same_length
+from ..._internal.validation import require_ranks, require_same_length
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -140,6 +140,13 @@ class ImpulseProminenceResult:
 
         :raises ValueError: if the per-impulse columns disagree.
         """
+        require_ranks(
+            self,
+            onset_rates=1,
+            level_differences=1,
+            per_impulse=1,
+            qualifies=1,
+        )
         require_same_length(
             self,
             "onset_rates",

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -85,7 +85,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_same_length
+from ..._internal.validation import require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -388,6 +388,13 @@ class TonalCorrectionResult:
 
         :raises ValueError: if the per-band columns disagree.
         """
+        require_ranks(
+            self,
+            frequencies=1,
+            levels=1,
+            differences=1,
+            band_corrections=1,
+        )
         require_same_length(
             self, "frequencies", "levels", "differences", "band_corrections"
         )

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -85,6 +85,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_same_length
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -376,6 +378,19 @@ class TonalCorrectionResult:
     band_corrections: np.ndarray
     correction: float
     governing_frequency: float | None
+
+    def __post_init__(self) -> None:
+        """Reject a correction whose per-band columns disagree.
+
+        The correction names a governing band, and the fiche tabulates the
+        levels, the differences and the per-band corrections beside the band
+        centres, so a column of another length names the wrong band.
+
+        :raises ValueError: if the per-band columns disagree.
+        """
+        require_same_length(
+            self, "frequencies", "levels", "differences", "band_corrections"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import signal
 
-from .._internal.validation import require_same_length
+from .._internal.validation import require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -421,6 +421,7 @@ class FilterComplianceResult:
 
         :raises ValueError: if the per-band entries disagree.
         """
+        require_ranks(self, band_frequencies=1)
         require_same_length(self, "bands", "sos", "band_frequencies", "factors")
 
     def available_classes(self) -> list[int]:

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -40,6 +40,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import signal
 
+from .._internal.validation import require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -409,6 +411,17 @@ class FilterComplianceResult:
     fs: float
     num_points: int
     range_limited: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject a verdict whose per-band entries disagree.
+
+        The fiche prints one row per band and, in its box, the overall class
+        of the whole bank, so a band list short of an entry gives a sheet
+        whose verdict covers a band that is nowhere in its table.
+
+        :raises ValueError: if the per-band entries disagree.
+        """
+        require_same_length(self, "bands", "sos", "band_frequencies", "factors")
 
     def available_classes(self) -> list[int]:
         """The performance classes carried by the per-band verdict dictionaries.

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -197,7 +197,7 @@ class DuctPathResult:
             self, "frequencies", "source_level", "room_effect", "received_level"
         )
         owner = type(self).__name__
-        bands = require_axis_count(self.frequencies, owner, "frequencies")
+        bands = require_axis_count(self.frequencies, owner, "frequencies", rank=None)
         for i, stage in enumerate(self.stages):
             for name in ("attenuation", "attenuated", "self_noise", "level"):
                 label = f"stages[{i}].{name}"
@@ -205,7 +205,9 @@ class DuctPathResult:
                     owner,
                     {
                         "frequencies": bands,
-                        label: require_axis_count(getattr(stage, name), owner, label),
+                        label: require_axis_count(
+                            getattr(stage, name), owner, label, rank=1
+                        ),
                     },
                 )
         for i, (name, level) in enumerate(self.contributions):
@@ -214,7 +216,7 @@ class DuctPathResult:
                 owner,
                 {
                     "frequencies": bands,
-                    label: require_axis_count(level, owner, label),
+                    label: require_axis_count(level, owner, label, rank=1),
                 },
             )
 

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -56,6 +56,7 @@ import numpy as np
 from .._internal.validation import (
     require_axis_count,
     require_equal_counts,
+    require_ranks,
     require_same_length,
 )
 from ._criterion import (
@@ -185,6 +186,13 @@ class DuctPathResult:
 
         :raises ValueError: if any spectrum disagrees with ``frequencies``.
         """
+        require_ranks(
+            self,
+            frequencies=1,
+            source_level=1,
+            room_effect=1,
+            received_level=1,
+        )
         require_same_length(
             self, "frequencies", "source_level", "room_effect", "received_level"
         )

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -53,7 +53,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_equal_counts, require_same_length
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_same_length,
+)
 from ._criterion import (
     as_band_spectrum,
     curve_of,
@@ -184,20 +188,26 @@ class DuctPathResult:
         require_same_length(
             self, "frequencies", "source_level", "room_effect", "received_level"
         )
-        bands = np.shape(self.frequencies)[0]
+        owner = type(self).__name__
+        bands = require_axis_count(self.frequencies, owner, "frequencies")
         for i, stage in enumerate(self.stages):
             for name in ("attenuation", "attenuated", "self_noise", "level"):
+                label = f"stages[{i}].{name}"
                 require_equal_counts(
-                    type(self).__name__,
+                    owner,
                     {
                         "frequencies": bands,
-                        f"stages[{i}].{name}": np.shape(getattr(stage, name))[0],
+                        label: require_axis_count(getattr(stage, name), owner, label),
                     },
                 )
-        for i, (label, level) in enumerate(self.contributions):
+        for i, (name, level) in enumerate(self.contributions):
+            label = f"contributions[{i}] ({name})"
             require_equal_counts(
-                type(self).__name__,
-                {"frequencies": bands, f"contributions[{i}] {label!r}": len(level)},
+                owner,
+                {
+                    "frequencies": bands,
+                    label: require_axis_count(level, owner, label),
+                },
             )
 
     # -- ratings ----------------------------------------------------------

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_counts, require_same_length
 from ._criterion import (
     as_band_spectrum,
     curve_of,
@@ -168,6 +169,36 @@ class DuctPathResult:
     target: float | None
     label: str
     contributions: tuple[tuple[str, np.ndarray], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Reject a sheet whose rows do not all run over the same bands.
+
+        The calculation sheet prints one row per element under a single band
+        header and a running total beneath them, so a row of the wrong length
+        is not a detail: reportlab pads the short row out to the header and
+        the sheet then shows a total summing a band that appears nowhere in
+        the column above it.
+
+        :raises ValueError: if any spectrum disagrees with ``frequencies``.
+        """
+        require_same_length(
+            self, "frequencies", "source_level", "room_effect", "received_level"
+        )
+        bands = np.shape(self.frequencies)[0]
+        for i, stage in enumerate(self.stages):
+            for name in ("attenuation", "attenuated", "self_noise", "level"):
+                require_equal_counts(
+                    type(self).__name__,
+                    {
+                        "frequencies": bands,
+                        f"stages[{i}].{name}": np.shape(getattr(stage, name))[0],
+                    },
+                )
+        for i, (label, level) in enumerate(self.contributions):
+            require_equal_counts(
+                type(self).__name__,
+                {"frequencies": bands, f"contributions[{i}] {label!r}": len(level)},
+            )
 
     # -- ratings ----------------------------------------------------------
     @property

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_same_length
+from .._internal.validation import require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -160,6 +160,7 @@ class NCResult:
 
         :raises ValueError: if 'frequencies' and 'levels' differ in length.
         """
+        require_ranks(self, frequencies=1, levels=1)
         require_same_length(self, "frequencies", "levels")
 
     @property
@@ -277,6 +278,7 @@ class RCResult:
 
         :raises ValueError: if the three do not share one length.
         """
+        require_ranks(self, frequencies=1, levels=1, reference_curve=1)
         require_same_length(self, "frequencies", "levels", "reference_curve")
 
     @property

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -38,6 +38,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike
@@ -150,6 +152,16 @@ class NCResult:
     method: str = "tangency"
     out_of_range: str | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a rating whose spectrum and band axis disagree.
+
+        The rating names a governing band, so a spectrum of the wrong length
+        names the wrong one.
+
+        :raises ValueError: if 'frequencies' and 'levels' differ in length.
+        """
+        require_same_length(self, "frequencies", "levels")
+
     @property
     def label(self) -> str:
         """The textual NC designation.
@@ -255,6 +267,17 @@ class RCResult:
     reference_curve: np.ndarray
     frequencies: np.ndarray
     levels: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a rating whose spectrum, curve and band axis disagree.
+
+        The fiche draws the reference curve over the measured spectrum and
+        tabulates both, so a curve of the wrong length is compared band by
+        band against the wrong bands.
+
+        :raises ValueError: if the three do not share one length.
+        """
+        require_same_length(self, "frequencies", "levels", "reference_curve")
 
     @property
     def label(self) -> str:

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 from scipy import signal
 
 from .._internal.utils import _typesignal
+from .._internal.validation import require_same_length
 from .._internal.warnings import PhonometryWarning
 from ..filters.core import OctaveFilterBank
 from ..filters.frequencies import nominal_frequencies
@@ -128,6 +129,16 @@ class STIResult:
     mtf: np.ndarray
     band_levels: np.ndarray | None
     rating: str
+
+    def __post_init__(self) -> None:
+        """Reject a result whose per-band quantities disagree.
+
+        ``mti`` is the per-band index the fiche tabulates beside the band
+        levels and the modulation matrix, all three on the same band axis.
+
+        :raises ValueError: if the band axes disagree.
+        """
+        require_same_length(self, "mti", ("mtf", 0), "band_levels")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 from scipy import signal
 
 from .._internal.utils import _typesignal
-from .._internal.validation import require_same_length
+from .._internal.validation import require_ranks, require_same_length
 from .._internal.warnings import PhonometryWarning
 from ..filters.core import OctaveFilterBank
 from ..filters.frequencies import nominal_frequencies
@@ -138,6 +138,7 @@ class STIResult:
 
         :raises ValueError: if the band axes disagree.
         """
+        require_ranks(self, mti=1, mtf=2, band_levels=1)
         require_same_length(self, "mti", ("mtf", 0), "band_levels")
 
     def plot(

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -924,3 +924,37 @@ def test_plot_pools_the_paths_beyond_the_named_set(airborne) -> None:
     # Every band's dominant path is named rather than pooled.
     assert set(airborne.dominant) <= set(labels)
     plt.close(ax.get_figure())
+
+
+# --------------------------------------------------------------------------
+# Paths and bands that do not line up
+# --------------------------------------------------------------------------
+def test_a_share_column_short_of_a_path_is_refused(airborne) -> None:
+    """The share column is printed beside the path rows and sums to 100 %.
+
+    A ``fractions`` array short of a path row leaves a sheet listing fewer
+    paths than the shares it prints sum over, so the column stops reaching
+    100 % under a box holding the rating of the whole transmission.
+    """
+    import dataclasses
+
+    with pytest.raises(ValueError, match="per transmission path"):
+        dataclasses.replace(airborne, fractions=airborne.fractions[:-1])
+
+
+def test_a_share_column_short_of_a_band_is_refused(airborne) -> None:
+    """``fractions`` is paths by bands: axis 1 is the one that carries bands."""
+    import dataclasses
+
+    with pytest.raises(ValueError, match=r"'fractions \(axis 1\)'"):
+        dataclasses.replace(airborne, fractions=airborne.fractions[:, :-1])
+
+
+def test_a_path_row_off_the_band_axis_is_refused(airborne) -> None:
+    """Every path row runs over the same bands as the frequency axis."""
+    import dataclasses
+
+    first = airborne.paths[0]
+    short = dataclasses.replace(first, values=first.values[:-1])
+    with pytest.raises(ValueError, match=r"'paths\[0\]"):
+        dataclasses.replace(airborne, paths=(short, *airborne.paths[1:]))

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -958,3 +958,19 @@ def test_a_path_row_off_the_band_axis_is_refused(airborne) -> None:
     short = dataclasses.replace(first, values=first.values[:-1])
     with pytest.raises(ValueError, match=r"'paths\[0\]"):
         dataclasses.replace(airborne, paths=(short, *airborne.paths[1:]))
+
+
+def test_a_share_column_with_an_extra_axis_is_refused(airborne) -> None:
+    """Counting the axes is not enough on its own: their number is pinned too.
+
+    A ``fractions`` of shape ``(paths, bands, 2)`` has the right number of
+    paths on its first axis and the right number of bands on its second, so
+    every count agrees. The extra axis then reaches ``dominant``, which feeds
+    array indices to a tuple.
+    """
+    import dataclasses
+
+    values = np.asarray(airborne.fractions)
+    three_dimensional = np.stack([values, values], axis=-1)
+    with pytest.raises(ValueError, match="'fractions' must have 2 axes"):
+        dataclasses.replace(airborne, fractions=three_dimensional)

--- a/tests/building/prediction/test_installed_structure_borne.py
+++ b/tests/building/prediction/test_installed_structure_borne.py
@@ -405,3 +405,54 @@ def test_prediction_frequencies_length_mismatch() -> None:
         building.installed_source_prediction(
             power_level, coupling, paths, frequencies=short_frequencies
         )
+
+
+# --------------------------------------------------------------------------
+# Quantities that do not run over the band axis
+# --------------------------------------------------------------------------
+def _annex_i_prediction() -> building.InstalledSourceResult:
+    """A two-path, six-band prediction, the shape the EN 12354-5 fiche prints."""
+    bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0])
+    return building.installed_source_prediction(
+        np.array([70.0, 68.0, 66.0, 64.0, 62.0, 60.0]),
+        np.array([-2.0, -2.0, -3.0, -3.0, -4.0, -4.0]),
+        [
+            {
+                "adjustment_term": np.full(6, 5.0),
+                "flanking_reduction_index": np.full(6, 45.0),
+                "element_area": 10.0,
+            },
+            {
+                "adjustment_term": np.full(6, 5.0),
+                "flanking_reduction_index": np.full(6, 50.0),
+                "element_area": 10.0,
+            },
+        ],
+        frequencies=bands,
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name", ["frequencies", "total_level", "installed_power_level"]
+)
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_a_per_band_quantity_off_the_band_axis_is_refused(
+    field_name: str, trim: bool
+) -> None:
+    """The band axis is pinned when the prediction is built, either direction."""
+    import dataclasses
+
+    result = _annex_i_prediction()
+    values = np.asarray(getattr(result, field_name))
+    wrong = values[:-1] if trim else np.append(values, values[-1])
+    with pytest.raises(ValueError, match=f"'{field_name}'"):
+        dataclasses.replace(result, **{field_name: wrong})
+
+
+def test_path_levels_are_pinned_on_their_band_axis_not_their_path_axis() -> None:
+    """``path_levels`` is paths by bands: axis 1 is the one that must agree."""
+    import dataclasses
+
+    result = _annex_i_prediction()
+    with pytest.raises(ValueError, match=r"'path_levels \(axis 1\)'"):
+        dataclasses.replace(result, path_levels=result.path_levels[:, :-1])

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -430,3 +430,21 @@ def test_result_phase_mismatch_matches_the_standalone_conversion() -> None:
         np.asarray(measured), np.asarray(_BANDS), 0.012
     )
     assert result.phase_mismatch() == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------------
+# Per-band entries that do not agree
+# --------------------------------------------------------------------------
+def test_an_instrument_verdict_refuses_per_band_entries_that_disagree() -> None:
+    """The fiche prints one row per band under the instrument's overall class."""
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0),
+        frequencies,
+        device="instrument",
+        spacing=0.025,
+    )
+    with pytest.raises(ValueError, match="'bands'"):
+        dataclasses.replace(result, bands=result.bands[:-1])

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -501,3 +501,41 @@ def test_plot_language_spanish_and_validation() -> None:
     assert ax_en.get_ylabel() == "Sound power level $L_W$ [dB]"
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
+
+
+# --------------------------------------------------------------------------
+# Per-band quantities that do not run over the band axis
+# --------------------------------------------------------------------------
+def _ten_position_determination() -> object:
+    """A ten-position, four-band ISO 3744 determination."""
+    return emission.sound_power_pressure(
+        np.tile(np.array([80.0, 78.0, 76.0, 74.0]), (10, 1)),
+        "hemisphere",
+        radius=2.0,
+        frequencies=np.array([250.0, 500.0, 1000.0, 2000.0]),
+    )
+
+
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_a_per_band_quantity_off_the_band_axis_is_refused(trim: bool) -> None:
+    """The boxed A-weighted total sums every band of ``sound_power_level``.
+
+    A spectrum of another length than the band axis gives a sheet whose
+    headline number sums bands its own table does not print.
+    """
+    import dataclasses
+
+    result = _ten_position_determination()
+    values = np.asarray(result.sound_power_level)
+    wrong = values[:-1] if trim else np.append(values, values[-1])
+    with pytest.raises(ValueError, match="'sound_power_level'"):
+        dataclasses.replace(result, sound_power_level=wrong)
+
+
+def test_the_directivity_index_is_pinned_on_its_band_axis() -> None:
+    """``directivity_index`` is positions by bands: axis 1 carries the bands."""
+    import dataclasses
+
+    result = _ten_position_determination()
+    with pytest.raises(ValueError, match=r"'directivity_index \(axis 1\)'"):
+        dataclasses.replace(result, directivity_index=result.directivity_index[:, :-1])

--- a/tests/emission/test_sound_power_intensity.py
+++ b/tests/emission/test_sound_power_intensity.py
@@ -507,3 +507,60 @@ def test_bad_grade_raises() -> None:
     areas = np.array([0.5, 0.5, 0.5, 0.5])
     with pytest.raises(ValueError, match="'grade' must be"):
         emission.sound_power_intensity(intensity, areas, grade="bogus")
+
+
+# --------------------------------------------------------------------------
+# Quantities that do not run over the band axis
+# --------------------------------------------------------------------------
+def _five_band_determination() -> object:
+    """A four-segment, five-band determination with every indicator populated."""
+    intensity = np.tile(np.array([6e-4, 5e-4, 4e-4, 3e-4, 2e-4]), (4, 1))
+    return emission.sound_power_intensity(
+        intensity,
+        np.full(4, 0.5),
+        frequencies=np.array([125.0, 250.0, 500.0, 1000.0, 2000.0]),
+        normal_intensity_2=intensity * 0.9,
+        pressure_levels=np.tile(np.full(5, 80.0), (4, 1)),
+        pressure_residual_index=12.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "sound_power_level",
+        "negative_band",
+        "surface_pressure_intensity_index",
+        "negative_partial_power_index",
+        "dynamic_capability_index",
+        "a_weighting_omitted_bands",
+    ],
+)
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_a_per_band_quantity_off_the_band_axis_is_refused(
+    field_name: str, trim: bool
+) -> None:
+    """Every per-band quantity is pinned to the band axis at construction.
+
+    The field indicators reach the fiche as a range rather than as a column,
+    so an array of the wrong length prints a range taken over the wrong set of
+    bands and nothing downstream can object: a range is well formed whatever
+    it was taken over. That is why the long direction matters as much as the
+    short one.
+    """
+    import dataclasses
+
+    result = _five_band_determination()
+    values = np.asarray(getattr(result, field_name))
+    wrong = values[:-1] if trim else np.append(values, values[-1])
+    with pytest.raises(ValueError, match=f"'{field_name}'"):
+        dataclasses.replace(result, **{field_name: wrong})
+
+
+def test_a_per_segment_quantity_off_the_segment_axis_is_refused() -> None:
+    """The segment axis is its own axis: repeatability is per segment and band."""
+    import dataclasses
+
+    result = _five_band_determination()
+    with pytest.raises(ValueError, match="measurement segment"):
+        dataclasses.replace(result, repeatability=result.repeatability[:-1])

--- a/tests/environment/assessment/test_impulse_prominence.py
+++ b/tests/environment/assessment/test_impulse_prominence.py
@@ -150,3 +150,24 @@ def test_assessment_period_defaults_and_validates() -> None:
     for bad in (0.0, -5.0, float("nan"), float("inf")):
         with pytest.raises(ValueError, match="assessment_period_min"):
             nt.impulse_prominence([1200.0], [32.0], assessment_period_min=bad)
+
+
+# --------------------------------------------------------------------------
+# Per-impulse columns that do not agree
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_per_impulse_columns_that_disagree_are_refused(trim: bool) -> None:
+    """The prominence is taken over the whole set the table prints.
+
+    A column short of a row leaves a sheet whose headline covers an impulse
+    that is not in the table; one row too long is truncated by the table.
+    """
+    import dataclasses
+
+    result = nt.impulse_prominence(
+        onset_rates=[12.0, 25.0, 40.0], level_differences=[8.0, 12.0, 20.0]
+    )
+    values = np.asarray(result.qualifies)
+    wrong = values[:-1] if trim else np.append(values, values[-1])
+    with pytest.raises(ValueError, match="per impulse"):
+        dataclasses.replace(result, qualifies=wrong)

--- a/tests/environment/assessment/test_spain.py
+++ b/tests/environment/assessment/test_spain.py
@@ -666,3 +666,16 @@ def test_round_reported_level_rejects_non_finite() -> None:
     """Rounding a non-finite level is an error rather than a silent NaN."""
     with pytest.raises(ValueError, match="finite"):
         rd.round_reported_level(math.inf)
+
+
+# --------------------------------------------------------------------------
+# Per-band columns that do not agree
+# --------------------------------------------------------------------------
+def test_a_tonal_correction_refuses_per_band_columns_that_disagree() -> None:
+    """The correction names a governing band, so the columns must line up."""
+    import dataclasses
+
+    frequencies = np.array([100.0, 125.0, 160.0, 200.0, 250.0])
+    result = rd.tonal_correction(np.array([50.0, 62.0, 51.0, 50.0, 49.0]), frequencies)
+    with pytest.raises(ValueError, match="'levels'"):
+        dataclasses.replace(result, levels=result.levels[:-1])

--- a/tests/filters/test_compliance.py
+++ b/tests/filters/test_compliance.py
@@ -257,3 +257,23 @@ def test_map_breakpoint_reproduces_table_f1() -> None:
         got = _map_breakpoint(exponent, 3)
         assert got == pytest.approx(omega, abs=5e-6), exponent
         assert 1.0 / got == pytest.approx(reciprocal, abs=5e-6), exponent
+
+
+# --------------------------------------------------------------------------
+# Per-band entries that do not agree
+# --------------------------------------------------------------------------
+def test_a_filter_verdict_refuses_per_band_entries_that_disagree() -> None:
+    """The fiche prints one row per band under the bank's overall class.
+
+    A band list short of an entry gives a sheet whose verdict covers a band
+    that is nowhere in its table.
+    """
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    with pytest.raises(ValueError, match="'bands'"):
+        dataclasses.replace(result, bands=result.bands[:-1])

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -26,6 +26,7 @@ tolerance is the 1 dB the sheet itself carries.
 from __future__ import annotations
 
 import dataclasses
+import re
 import warnings
 
 import numpy as np
@@ -443,3 +444,27 @@ def test_no_room_effect_at_all_is_still_allowed() -> None:
     """``None`` is an absent quantity, not a disagreement."""
     result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
     assert dataclasses.replace(result, room_effect=None).room_effect is None
+
+
+@pytest.mark.parametrize(
+    ("what", "build"),
+    [
+        (
+            "stages[0].attenuation",
+            lambda r: {"stages": (dataclasses.replace(r.stages[0], attenuation=3.0),)},
+        ),
+        ("contributions[0] (Supply)", lambda r: {"contributions": (("Supply", 3.0),)}),
+        ("frequencies", lambda r: {"frequencies": 500.0}),
+    ],
+    ids=["stage-row", "contribution", "band-axis"],
+)
+def test_a_single_number_where_a_spectrum_belongs_says_so(what, build) -> None:
+    """A scalar in a nested field is named, not left to numpy or to len().
+
+    Reaching the nested rows means indexing a shape or taking a length, and
+    both answer a scalar with an exception of their own that names neither the
+    field nor the type the guard promises to name.
+    """
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    with pytest.raises(ValueError, match=f"'{re.escape(what)}'"):
+        dataclasses.replace(result, **build(result))

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -467,3 +467,34 @@ def test_a_single_number_where_a_spectrum_belongs_says_so(what, build) -> None:
     scalar_field = build(result)
     with pytest.raises(ValueError, match=f"'{re.escape(what)}'"):
         dataclasses.replace(result, **scalar_field)
+
+
+@pytest.mark.parametrize(
+    ("what", "build"),
+    [
+        (
+            "stages[0].attenuation",
+            lambda r, wrong: {
+                "stages": (dataclasses.replace(r.stages[0], attenuation=wrong),)
+            },
+        ),
+        (
+            "contributions[0] (Supply)",
+            lambda r, wrong: {"contributions": (("Supply", wrong),)},
+        ),
+    ],
+    ids=["stage-row", "contribution"],
+)
+def test_a_nested_row_with_an_extra_axis_is_refused(what, build) -> None:
+    """The nested rows are pinned by their axes, not only by their length.
+
+    A row of shape ``(bands, 2)`` counts the right number of bands on its
+    first axis, so counting alone lets it into the sheet with a second axis
+    nobody asked for.
+    """
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    row = np.asarray(result.stages[0].attenuation)
+    two_dimensional = np.column_stack([row, row])
+    replacement = build(result, two_dimensional)
+    with pytest.raises(ValueError, match=f"'{re.escape(what)}' must have one axis"):
+        dataclasses.replace(result, **replacement)

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -25,6 +25,7 @@ tolerance is the 1 dB the sheet itself carries.
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 
 import numpy as np
@@ -399,3 +400,46 @@ def test_combine_of_one_path_is_that_path() -> None:
     same = combine_duct_paths([supply])
     assert np.allclose(same.received_level, supply.received_level)
     assert same.stages == ()
+
+
+# --------------------------------------------------------------------------
+# Rows that do not run over the analysis bands
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "field_name",
+    ["attenuation", "attenuated", "self_noise", "level"],
+)
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_a_stage_row_off_the_band_axis_is_refused(field_name: str, trim: bool) -> None:
+    """A calculation sheet cannot carry a row of the wrong width.
+
+    The sheet prints one row per element under a single band header with a
+    running total beneath, so reportlab pads a short row out to the header and
+    the total then sums a band that appears nowhere in the column above it. A
+    row one *too long* is truncated by the same table, just as quietly.
+    """
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    stage = result.stages[0]
+    row = np.asarray(getattr(stage, field_name))
+    wrong = row[:-1] if trim else np.append(row, row[-1])
+    with pytest.raises(ValueError, match=f"'stages\\[0\\]\\.{field_name}'"):
+        dataclasses.replace(
+            result,
+            stages=(
+                dataclasses.replace(stage, **{field_name: wrong}),
+                *result.stages[1:],
+            ),
+        )
+
+
+def test_a_room_effect_off_the_band_axis_is_refused() -> None:
+    """The room effect is applied band by band, so it must have the bands."""
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    with pytest.raises(ValueError, match="'room_effect'"):
+        dataclasses.replace(result, room_effect=np.zeros(len(OCTAVE_BANDS) - 1))
+
+
+def test_no_room_effect_at_all_is_still_allowed() -> None:
+    """``None`` is an absent quantity, not a disagreement."""
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    assert dataclasses.replace(result, room_effect=None).room_effect is None

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -423,21 +423,19 @@ def test_a_stage_row_off_the_band_axis_is_refused(field_name: str, trim: bool) -
     stage = result.stages[0]
     row = np.asarray(getattr(stage, field_name))
     wrong = row[:-1] if trim else np.append(row, row[-1])
+    # The stage itself carries no guard, so it is built outside the block:
+    # what is under test is the sheet refusing to hold it.
+    stages = (dataclasses.replace(stage, **{field_name: wrong}), *result.stages[1:])
     with pytest.raises(ValueError, match=f"'stages\\[0\\]\\.{field_name}'"):
-        dataclasses.replace(
-            result,
-            stages=(
-                dataclasses.replace(stage, **{field_name: wrong}),
-                *result.stages[1:],
-            ),
-        )
+        dataclasses.replace(result, stages=stages)
 
 
 def test_a_room_effect_off_the_band_axis_is_refused() -> None:
     """The room effect is applied band by band, so it must have the bands."""
     result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    one_band_short = np.zeros(len(OCTAVE_BANDS) - 1)
     with pytest.raises(ValueError, match="'room_effect'"):
-        dataclasses.replace(result, room_effect=np.zeros(len(OCTAVE_BANDS) - 1))
+        dataclasses.replace(result, room_effect=one_band_short)
 
 
 def test_no_room_effect_at_all_is_still_allowed() -> None:
@@ -466,5 +464,6 @@ def test_a_single_number_where_a_spectrum_belongs_says_so(what, build) -> None:
     field nor the type the guard promises to name.
     """
     result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    scalar_field = build(result)
     with pytest.raises(ValueError, match=f"'{re.escape(what)}'"):
-        dataclasses.replace(result, **build(result))
+        dataclasses.replace(result, **scalar_field)

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -306,3 +306,23 @@ def test_nc_verdict_long_hvac_receiver_spectrum() -> None:
     )
     assert res.out_of_range is None
     assert res.rating <= 30.0
+
+
+# --------------------------------------------------------------------------
+# A spectrum that does not run over its own band axis
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_an_nc_rating_refuses_levels_off_the_band_axis(trim: bool) -> None:
+    """The rating names a governing band, so the two axes must agree.
+
+    A spectrum of the wrong length would have the rating name a band the
+    levels never had.
+    """
+    import dataclasses
+
+    bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
+    result = rn.noise_criterion([50.0, 45.0, 40.0, 38.0, 35.0, 32.0, 30.0, 28.0], bands)
+    levels = np.asarray(result.levels)
+    wrong = levels[:-1] if trim else np.append(levels, levels[-1])
+    with pytest.raises(ValueError, match="'levels'"):
+        dataclasses.replace(result, levels=wrong)

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -351,23 +351,17 @@ def test_rc_result_refuses_a_reference_curve_of_another_length() -> None:
         replace(result, reference_curve=result.reference_curve[:-1])
 
 
-def test_verbose_rc_report_rejects_a_reference_curve_with_an_extra_axis(
-    tmp_path,
-) -> None:
-    """A curve of shape ``(n, 1)`` survives construction and is caught here.
+def test_rc_result_refuses_a_reference_curve_with_an_extra_axis() -> None:
+    """A curve of shape ``(n, 1)`` is refused for the axis, not the length.
 
-    It carries n entries along its first axis, so the length check that runs
-    when the result is built has nothing to object to; the verbose column is
-    where the extra axis would reach the page.
+    It carries n entries along its first axis, so every count agrees and only
+    the rank is wrong. Counting alone would let it through to the verbose
+    column, which pairs the two band by band and would format a one-element
+    array into every cell.
     """
     from dataclasses import replace
 
     result = _rc_result()
-    mismatched = replace(
-        result, reference_curve=np.asarray(result.reference_curve).reshape(-1, 1)
-    )
-    out = tmp_path / "rc_two_dimensional_reference.pdf"
-    metadata = _full_metadata()
-    with pytest.raises(ValueError, match="'reference_curve' of the same shape"):
-        mismatched.report(str(out), metadata=metadata, verbose=True)
-    assert not out.exists()  # the guard fires before the fiche is written
+    two_dimensional = np.asarray(result.reference_curve).reshape(-1, 1)
+    with pytest.raises(ValueError, match="'reference_curve' must have one axis"):
+        replace(result, reference_curve=two_dimensional)

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -21,6 +21,7 @@ RC-35(R)).
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 pytest.importorskip("reportlab")
@@ -335,20 +336,37 @@ def test_subset_spectrum_renders_missing_bands(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # Hand-built results with mismatched bands
 # --------------------------------------------------------------------------
-def test_verbose_rc_report_rejects_short_reference_curve(tmp_path) -> None:
-    """A verbose RC fiche refuses a reference curve shorter than the levels.
+def test_rc_result_refuses_a_reference_curve_of_another_length() -> None:
+    """A reference curve of another length cannot be paired with the levels.
 
-    ``RCResult`` is a frozen dataclass without validation exported from a
-    public package, so a hand-built one can pair its measured levels with a
-    reference curve of another length; only the verbose columns read the two
-    band by band, and a short curve used to render a silently short table.
+    ``RCResult`` is exported from a public package, so a hand-built one used
+    to be able to carry a curve of any length; only the verbose columns read
+    the two band by band, so the plain fiche rendered a silently short table.
+    Refusing the pairing at construction covers both fiches and the plot.
     """
     from dataclasses import replace
 
     result = _rc_result()
-    mismatched = replace(result, reference_curve=result.reference_curve[:-1])
-    out = tmp_path / "rc_short_reference.pdf"
-    metadata = _full_metadata()
-    with pytest.raises(ValueError, match="reference_curve"):
-        mismatched.report(str(out), metadata=metadata, verbose=True)
+    with pytest.raises(ValueError, match="'reference_curve'"):
+        replace(result, reference_curve=result.reference_curve[:-1])
+
+
+def test_verbose_rc_report_rejects_a_reference_curve_with_an_extra_axis(
+    tmp_path,
+) -> None:
+    """A curve of shape ``(n, 1)`` survives construction and is caught here.
+
+    It carries n entries along its first axis, so the length check that runs
+    when the result is built has nothing to object to; the verbose column is
+    where the extra axis would reach the page.
+    """
+    from dataclasses import replace
+
+    result = _rc_result()
+    mismatched = replace(
+        result, reference_curve=np.asarray(result.reference_curve).reshape(-1, 1)
+    )
+    out = tmp_path / "rc_two_dimensional_reference.pdf"
+    with pytest.raises(ValueError, match="'reference_curve' of equal length"):
+        mismatched.report(str(out), metadata=_full_metadata(), verbose=True)
     assert not out.exists()  # the guard fires before the fiche is written

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -367,6 +367,7 @@ def test_verbose_rc_report_rejects_a_reference_curve_with_an_extra_axis(
         result, reference_curve=np.asarray(result.reference_curve).reshape(-1, 1)
     )
     out = tmp_path / "rc_two_dimensional_reference.pdf"
+    metadata = _full_metadata()
     with pytest.raises(ValueError, match="'reference_curve' of the same shape"):
-        mismatched.report(str(out), metadata=_full_metadata(), verbose=True)
+        mismatched.report(str(out), metadata=metadata, verbose=True)
     assert not out.exists()  # the guard fires before the fiche is written

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -367,6 +367,6 @@ def test_verbose_rc_report_rejects_a_reference_curve_with_an_extra_axis(
         result, reference_curve=np.asarray(result.reference_curve).reshape(-1, 1)
     )
     out = tmp_path / "rc_two_dimensional_reference.pdf"
-    with pytest.raises(ValueError, match="'reference_curve' of equal length"):
+    with pytest.raises(ValueError, match="'reference_curve' of the same shape"):
         mismatched.report(str(out), metadata=_full_metadata(), verbose=True)
     assert not out.exists()  # the guard fires before the fiche is written

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -479,3 +479,27 @@ def test_annex_m_full_sti_worked_example() -> None:
     )
     assert result.sti == pytest.approx(IEC60268_16_ANNEX_M_STI, abs=0.005)
     assert round(result.sti, 2) == IEC60268_16_ANNEX_M_STI
+
+
+# --------------------------------------------------------------------------
+# Per-band quantities that do not run over the band axis
+# --------------------------------------------------------------------------
+def test_an_sti_result_refuses_an_mti_off_the_band_axis() -> None:
+    """The fiche tabulates ``mti`` beside the modulation matrix and the levels.
+
+    All three run over the same seven octave bands, so a per-band column of
+    another length is a table whose rows no longer describe one band each.
+    """
+    import dataclasses
+
+    from phonometry.speech.sti import STIResult
+
+    result = STIResult(
+        sti=0.75,
+        mti=np.full(7, 0.75),
+        mtf=np.full((7, 2), 0.75),
+        band_levels=np.full(7, 60.0),
+        rating="B",
+    )
+    with pytest.raises(ValueError, match="'mti'"):
+        dataclasses.replace(result, mti=result.mti[:-1])


### PR DESCRIPTION
A result dataclass is frozen, exported, and has its constructor in the generated reference. So one could be built, or replaced into, carrying per-band arrays that did not agree. What that produced was not an error.

Take the duct-borne calculation sheet. Shorten one element's attenuation row by a single band:

    duct_path(...) -> a stage row of 7 values under an 8-band header
    PDF written, no exception, 17024 bytes

The table keeps its fifteen rows. The element row comes out `['2', 'Elbow, 36 x 24 in, unlined', '0', '-1', '-2', '-3', '-3', '-3', '-3', '']`, padded by reportlab out to the header, and the running total beneath it sums a band that appears nowhere in the column above. That is the column a reader sums down, on a sheet in accredited format.

The EN 12354-5 prediction is the sharper version. Drop one transmission path:

    table:   1 transmission path
    box:     "Predicted normalised SPL Ln,s = 43.2 dB"   <- the sum of both
    caption: "Ln,s = 10 lg(SUM_j 10^(Ln,s,ij/10))"

The document prints a total summed over two paths, lists one, and states in its own caption that the total is the energy sum of the rows it shows.

## Where the check goes

Not at the renderers. Checking where the values are read means repeating the same check at every renderer, every plot and every reader not written yet, and it only ever catches the direction that happens to raise. An array one *too long* is truncated by the same table just as quietly, and the strips that report a field indicator as a range print a range taken over the wrong set of bands, which nothing downstream can object to, because a range is well formed whatever it was taken over.

Checking when the result is built covers all of them at once. Thirteen types carry it now: `DuctPathResult` (with its element rows and its contributions), `SoundPowerIntensityResult`, `SoundPowerResult`, `InstalledSourceResult`, `DetailedAirborneResult`, `DetailedImpactResult`, `NCResult`, `RCResult`, `STIResult`, `FilterComplianceResult`, `IntensityInstrumentComplianceResult`, `ImpulseProminenceResult` and `TonalCorrectionResult`. Two shared helpers do the work; the message names the type, the axis and every count it was given.

## Two shapes I had to measure rather than assume

`repeatability` in the ISO 9614-2 determination is per segment *and* per band, and `directivity_index` in the ISO 3744 determination is per position and per band the same way. I had grouped both on their first axis, and nine tests that pass a single band said otherwise. They are compared on the axis they actually carry now, and the segment axis is its own group with its own sentence.

That is also why the remaining result types are bounded work rather than guesswork: getting a group wrong fails tests.

## A guard kept, and its reason corrected

The verbose RC fiche still rejects a reference curve of shape `(n, 1)`. That curve has n entries along its first axis, so construction has nothing to object to, and the verbose column would format a one-element array into every cell. Its comment said `RCResult` was a plain frozen dataclass carrying whatever it was handed, which is no longer true, and now says what it does catch. The test that rested on the old premise is now two: one that the pairing is refused at construction, which covers the plain fiche and the plot as well, and one for the extra axis that reaches the renderer.

## One thing that would have been a regression

`np.shape()` on a tuple of per-band arrays tries to stack them and raises about an inhomogeneous shape when the bands carry filters of different orders, which is a bank the library builds happily. The first axis is counted with `len()`, which is what it means.

## What this does not close

Two of the cases behind this change are not length disagreements and are not fixed here. In EN 12354-5 a whole path row can be dropped without contradicting any length, because the path count is fixed by no other field; the invariant that does exist is numerical, and a tolerance on it is not reliable, since a path 20 dB below the total can be dropped without moving it. The RD 1367 period phases are the same family. Both need their own change.

## Checks

`ruff check .` and `ruff format --check .` clean, `mypy src scripts` clean, the conformance harness at 550 of 550 with no drift, and the suite at 9024 passed, 23 skipped, 0 failures.

## Summary by Sourcery

Validate result shapes at construction time so inconsistent spectra cannot produce misleading reports, plots, or ratings.

Bug Fixes:
- Reject construction of result objects whose per-band, per-path, per-segment, or per-impulse data have inconsistent lengths or dimensions, preventing misleading reports and plots.

Enhancements:
- Add shared validation for axis counts, ranks, and cross-field lengths across thirteen result types.
- Validate nested duct-path and detailed prediction decompositions against their band and path axes.
- Move RC reference-curve validation from report rendering into RCResult construction and clarify the remaining renderer guard.

Tests:
- Add coverage for short, long, scalar, extra-axis, and incorrectly aligned nested result data across the affected result types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to reject result data with mismatched band, frequency, path, segment, or impulse dimensions.
  - Improved error messages to identify affected fields, axes, and provided counts.
  - Added checks for invalid scalar or multidimensional values where spectra are required.
  - Preserved support for optional values when omitted.

- **Tests**
  - Added regression coverage across prediction, emissions, environmental, filtering, room acoustics, noise control, and speech results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->