### PR TITLE
Refuse mismatched per-band columns where the result is built

### DIFF
--- a/site/src/content/docs/reference/api/materials/uncertainty.md
+++ b/site/src/content/docs/reference/api/materials/uncertainty.md
@@ -84,8 +84,10 @@ AbsorptionUncertaintyResult(
 Standard and expanded uncertainty of an absorption quantity
 (ISO 12999-2).
 
-For the single-number quantities (`αw`, `DLα,NRD`) the frequency and value
-arrays are empty and the uncertainty arrays hold a single element.
+For the single-number quantities (`αw`, `DLα,NRD`) it is the frequency
+array alone that is empty; the value and the two uncertainty arrays each
+hold a single element. That empty `frequencies` is what marks a
+single-number result apart, and what `plot` refuses on.
 
 **Attributes**
 
@@ -94,7 +96,7 @@ arrays are empty and the uncertainty arrays hold a single element.
 | `quantity` | `"absorption_coefficient"`, `"equivalent_area"`, `"practical_coefficient"`, `"weighted_coefficient"` or `"single_number_rating"`. |
 | `condition` | `"reproducibility"` (`σR`) or `"repeatability"` (`σr`). |
 | `frequencies` | Band centre frequencies, in Hz (empty for single numbers). |
-| `values` | The input quantity per band (empty for single numbers). |
+| `values` | The input quantity per band (one element for single numbers). |
 | `standard_uncertainty` | Standard uncertainty `u` (`σR`/`σr`), one per band. |
 | `coverage_factor` | Coverage factor `k` (Table 3). |
 | `expanded_uncertainty` | Exact $U = k\,u$ (Formula (10)), one per band. |

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -194,7 +194,11 @@ def require_ranks(owner: object, **ranks: int) -> None:
     """
     for name, rank in ranks.items():
         value = getattr(owner, name)
-        if value is None:
+        # A bare number is left alone. Several entry points take a single
+        # frequency and hand back a result of nought-dimensional arrays; that
+        # is not an extra axis, it is no axis, and a mixture of scalars and
+        # arrays is caught by the length check instead.
+        if value is None or np.ndim(value) == 0:
             continue
         require_axis_rank(value, type(owner).__name__, name, rank)
 
@@ -244,17 +248,26 @@ def require_same_length(
     ``None`` fields are skipped: an absent optional quantity is not a
     disagreement.
 
+    A result whose every field is a bare number is left alone. Several entry
+    points take a single frequency and hand back a result of nought-dimensional
+    arrays, and there is no axis there to disagree about; only a mixture of
+    scalars and arrays is a mistake, and that is what the count below reports.
+
     :param owner: The instance whose fields are compared.
     :param fields: Field names, or ``(name, axis_index)`` pairs.
     :param axis: What the lengths measure, singular, for the error message.
     :raises ValueError: if two of the fields disagree, or one is a scalar.
     """
+    present = [
+        (field if isinstance(field, tuple) else (field, 0))
+        for field in fields
+        if getattr(owner, field[0] if isinstance(field, tuple) else field) is not None
+    ]
+    if all(np.ndim(getattr(owner, name)) == 0 for name, _ in present):
+        return
     counts: dict[str, int] = {}
-    for field in fields:
-        name, index = field if isinstance(field, tuple) else (field, 0)
+    for name, index in present:
         value = getattr(owner, name)
-        if value is None:
-            continue
         if index == 0:
             counts[name] = require_axis_count(
                 value, type(owner).__name__, name, axis, rank=None

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -1175,12 +1175,6 @@ def plot_crowd_noise(
     n = np.asarray(result.talkers, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
     areas = np.asarray(result.absorption_areas, dtype=np.float64)
-    if areas.shape != levels.shape[:1]:
-        msg = (
-            "'levels' must carry one row per absorption area; got "
-            f"absorption_areas{areas.shape} against levels{levels.shape}."
-        )
-        raise ValueError(msg)
     palette = (_C_PRIMARY, _C_SECONDARY, _C_TERTIARY, _C_QUATERNARY, _C_MUTED)
     for row, (area, curve) in enumerate(zip(areas, levels, strict=True)):
         area_kwargs = dict(kwargs)

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -37,6 +37,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -357,6 +359,26 @@ class NpdLevelResult:
     table_distances: NDArray[np.float64]
     table_levels: NDArray[np.float64]
 
+    def __post_init__(self) -> None:
+        """Reject a curve whose levels do not run over the distances beside them.
+
+        The figure draws two distance axes: the interpolated sweep, 200 points
+        wide by default, and the tabulated points of the NPD table itself, ten
+        of them in the ANP database. They are independent, so each level array
+        is pinned to the
+        distances it belongs with and never to the other's. Left unchecked, a
+        level array of the wrong length reaches ``ax.plot`` as the y of an x it
+        does not match, and matplotlib's complaint is about two shapes, naming
+        neither the field nor which of the two axes it came from.
+
+        :raises ValueError: if a level array disagrees with its own distances.
+        """
+        require_ranks(self, distance=1, level=1, table_distances=1, table_levels=1)
+        require_same_length(self, "distance", "level", axis="query distance")
+        require_same_length(
+            self, "table_distances", "table_levels", axis="tabulated distance"
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -589,6 +611,24 @@ class FlightSegmentState:
     landing_roll: NDArray[np.bool_] | list[bool] | None = None
     bank: NDArray[np.float64] | list[float] | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a bundle whose fields describe different numbers of segments.
+
+        All three say something about the same segments of one path, so a
+        bundle whose fields disagree with each other is wrong for every path
+        there is, not just for the one it is eventually passed with. The event
+        entry points do compare each field against the path they were handed,
+        but one at a time and only there, so the first field they happen to
+        validate is the one blamed -- and a bundle built once and reused across
+        several paths is re-reported against each of them in turn. Checking
+        here names the two fields that disagree, at the point where they were
+        put together.
+
+        :raises ValueError: if two of the fields cover different segment counts.
+        """
+        require_ranks(self, ground_roll=1, landing_roll=1, bank=1)
+        require_same_length(self, "ground_roll", "landing_roll", "bank", axis="segment")
+
 
 #: An airborne, unbanked movement: the default of the event entry points (one
 #: shared instance, as the bundle is frozen).
@@ -610,6 +650,25 @@ class FlyoverResult:
     metric: str
     segment_levels: NDArray[np.float64]
     observer: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Pin how many axes the event's two arrays have, and tie neither to the other.
+
+        They measure different things: ``segment_levels`` runs over the
+        segments of the flight path and ``observer`` over the three coordinates
+        of one receiver. The two lengths coincide for the four-point path that
+        happens to make three segments, and a check that read that coincidence
+        as a shared axis would reject every path of any other length.
+
+        The rank is worth pinning even so. The bar chart draws one bar per
+        entry of ``segment_levels``, and ``observer`` is carried through
+        untouched for the reader to place the result on a map; a second axis on
+        either passes every count there is and arrives intact at whatever draws
+        it.
+
+        :raises ValueError: if either array has more than one axis.
+        """
+        require_ranks(self, segment_levels=1, observer=1)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1290,6 +1349,23 @@ class NoiseContourResult:
     y: NDArray[np.float64]
     level: NDArray[np.float64]
     metric: str
+
+    def __post_init__(self) -> None:
+        """Reject a contour whose level grid does not match the axes beside it.
+
+        ``contourf`` is handed ``x``, ``y`` and the grid together and reads the
+        grid as ``(len(y), len(x))``. A grid off by a row, or built the other
+        way round, raises from inside matplotlib about two shapes it cannot
+        attribute to a field, and says nothing about which axis it was that
+        disagreed. The two axes are pinned separately because they are
+        independent: a sweep asks for as many x as it likes and as many y, and
+        one count over both would reject every grid that is not square.
+
+        :raises ValueError: if the level grid disagrees with the x or y axis.
+        """
+        require_ranks(self, x=1, y=1, level=2)
+        require_same_length(self, "y", ("level", 0), axis="grid row")
+        require_same_length(self, "x", ("level", 1), axis="grid column")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/aircraft/anp_fleet.py
+++ b/src/phonometry/aircraft/anp_fleet.py
@@ -41,6 +41,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from .airport_noise import (
     AerodromeAtmosphere,
     FlightSegmentState,
@@ -175,6 +181,29 @@ class AnpNpdCurves:
     distances: NDArray[np.float64]
     levels: NDArray[np.float64]
 
+    def __post_init__(self) -> None:
+        """Reject a curve set whose level table does not match its own two axes.
+
+        The table's axes are what say which power setting and which slant
+        distance every level belongs to, and this class is where a CSV export
+        becomes one: a malformed export reaches the Doc 29 chain, the ``.plot()``
+        and :meth:`level` as a table whose entries are attached to the wrong
+        settings, and each of those reports it, if at all, as a shape it could
+        not use rather than as the aircraft whose table was short. Checking on
+        construction names the export where it was read.
+
+        The two axes are pinned separately because they are independent: the
+        bundled database holds sets of anything from two power settings to ten
+        over the same ten distances, so one count over both would reject all
+        but the handful whose two axes happen to be equally long.
+
+        :raises ValueError: if the level table disagrees with the powers or the
+            distances.
+        """
+        require_ranks(self, powers=1, distances=1, levels=2)
+        require_same_length(self, "powers", "levels", axis="power setting")
+        require_same_length(self, "distances", ("levels", 1), axis="slant distance")
+
     def level(
         self, power: float, distance: NDArray[np.float64] | list[float] | float
     ) -> NDArray[np.float64]:
@@ -222,6 +251,37 @@ class AnpProfile:
     path: NDArray[np.float64]
     ground_roll: NDArray[np.bool_]
     landing_roll: NDArray[np.bool_]
+
+    def __post_init__(self) -> None:
+        """Reject a profile whose roll masks do not cover its path's segments.
+
+        The masks are per segment and the path is per point, so an ``N``-point
+        trajectory takes masks of ``N-1``; ``path`` is the authority here and
+        the masks are what have to follow it. The figure marks the runway by
+        OR-ing the two masks and folding the result onto both endpoints of
+        every roll span, so a mask of any other length raises from numpy about
+        operands it could not broadcast, naming neither the mask nor the
+        profile it was read from. The Doc 29 chain does check the masks, but
+        against the path it was handed at the call, so it reports the trajectory
+        rather than the export the pair actually came from.
+
+        :raises ValueError: if a mask does not carry one entry per path segment.
+        """
+        require_ranks(self, path=2, ground_roll=1, landing_roll=1)
+        owner = type(self).__name__
+        require_equal_counts(
+            owner,
+            {
+                "path segments": len(self.path) - 1,
+                "ground_roll": require_axis_count(
+                    self.ground_roll, owner, "ground_roll", "segment", rank=None
+                ),
+                "landing_roll": require_axis_count(
+                    self.landing_roll, owner, "landing_roll", "segment", rank=None
+                ),
+            },
+            "segment",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/aircraft/atmospheric_absorption.py
+++ b/src/phonometry/aircraft/atmospheric_absorption.py
@@ -26,7 +26,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_non_negative, require_positive_array
+from .._internal.validation import (
+    require_non_negative,
+    require_positive_array,
+    require_ranks,
+    require_same_length,
+)
 from ..environment.propagation.air_absorption import air_attenuation
 
 if TYPE_CHECKING:
@@ -81,6 +86,36 @@ class AircraftBandAttenuation:
     temperature: float
     relative_humidity: float
     pressure: float
+
+    def __post_init__(self) -> None:
+        """Reject an attenuation whose arrays do not all run over the same bands.
+
+        Every array here is one value per one-third-octave band of the same
+        spectrum: the band attenuation the certification correction subtracts,
+        the pure-tone mid-band attenuation it was regressed from, and the
+        coefficient behind that. An array of another length either stops the
+        figure, which draws two of them against ``frequency`` on one pair of
+        axes and gets matplotlib's complaint about an x and a y that name
+        neither field, or -- where it has collapsed to a single value -- is
+        broadcast by numpy over the whole spectrum, correcting every band of a
+        measured flyover by one band's attenuation without a word.
+
+        :raises ValueError: if a per-band array disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequency=1,
+            band_attenuation=1,
+            midband_attenuation=1,
+            coefficient=1,
+        )
+        require_same_length(
+            self,
+            "frequency",
+            "band_attenuation",
+            "midband_attenuation",
+            "coefficient",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -522,6 +524,31 @@ class EPNLResult:
     duration_correction: float
     epnl: float
     band_limits: tuple[int, int]
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-record histories disagree.
+
+        The certification sheet states PNLTM, the duration correction and the
+        10 dB-down record window over the result's own PNLT-versus-time figure,
+        and that figure draws both histories against ``times`` and shades the
+        window between ``times[kF]`` and ``times[kL]``. Let the histories
+        disagree and the sheet is not produced at all: matplotlib refuses an x
+        and a y of different first dimensions, from inside the render, naming
+        neither the field nor the axis it was counting. Raising here says which
+        of the four disagreed, and says it before a determination nobody can
+        report has been handed on as one.
+
+        ``frequencies`` is deliberately outside the group. It runs over the 24
+        one-third-octave bands the noy law is tabulated on, not over the
+        records of the flyover, and the two lengths have nothing to say to each
+        other.
+
+        :raises ValueError: if the per-record arrays disagree.
+        """
+        require_ranks(self, frequencies=1, times=1, pnl=1, tone_correction=1, pnlt=1)
+        require_same_length(
+            self, "times", "pnl", "tone_correction", "pnlt", axis="record"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -59,6 +59,8 @@ from .._internal.validation import (
     require_choice,
     require_positive,
     require_positive_array,
+    require_ranks,
+    require_same_length,
 )
 from .rotorcraft_propagation import (
     _C,
@@ -127,6 +129,27 @@ class RotorcraftHemisphere:
     polar: NDArray[np.float64]
     levels: NDArray[np.float64]
     distance: float = _RH
+
+    def __post_init__(self) -> None:
+        """Reject a hemisphere whose grid does not span its own axes.
+
+        Three axes meet in ``levels``, and every reader addresses one of them
+        through the axis beside it. An angle axis longer than the grid it
+        indexes runs the Eq. 13 lookup off the end of ``levels`` towards the
+        far side of the hemisphere, with an index message that names neither
+        array; one shorter clamps every query to a boundary well inside the
+        measured grid, so a direction the hemisphere does cover comes back as
+        the level of that boundary bin. The band axis fails more quietly
+        still: the directivity plot picks the band to draw by searching
+        ``frequencies``, so a band grid of the wrong length labels the curve
+        with a frequency the levels beside it were never computed at.
+
+        :raises ValueError: if the level grid disagrees with an angle or band axis.
+        """
+        require_ranks(self, frequencies=1, azimuth=1, polar=1, levels=3)
+        require_same_length(self, "azimuth", "levels", axis="azimuth angle")
+        require_same_length(self, "polar", ("levels", 1), axis="polar angle")
+        require_same_length(self, "frequencies", ("levels", 2))
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -780,6 +803,45 @@ class FlightPathKinematics:
     bank_angle: NDArray[np.float64]
     path_angle: NDArray[np.float64]
 
+    def __post_init__(self) -> None:
+        """Reject a track whose per-point quantities do not line up.
+
+        Every quantity here is a central difference taken *at* a track point,
+        so the eight arrays are eight columns of one table and mean something
+        only read row by row. The event chain reads them exactly that way,
+        and with no check of its own, because these values arrive as a result
+        rather than as user input: point ``k`` supplies the airspeed and path
+        angle that select the hemisphere and the heading and bank that orient
+        it. A column of the wrong length runs that walk off its end, or
+        leaves a tail no point of the track claims, and the profile plot pairs
+        the same columns against ``times`` to draw them.
+
+        :raises ValueError: if a per-point quantity disagrees with ``times``.
+        """
+        require_ranks(
+            self,
+            times=1,
+            positions=2,
+            ground_speed=1,
+            airspeed=1,
+            heading=1,
+            curvature=1,
+            bank_angle=1,
+            path_angle=1,
+        )
+        require_same_length(
+            self,
+            "times",
+            "positions",
+            "ground_speed",
+            "airspeed",
+            "heading",
+            "curvature",
+            "bank_angle",
+            "path_angle",
+            axis="track point",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -958,6 +1020,47 @@ class RotorcraftEventResult:
     pnltm: float
     epnl: float
 
+    def __post_init__(self) -> None:
+        """Reject an event whose history or spectrum does not line up.
+
+        Two axes meet in ``band_levels``: one row per emission step, one
+        column per band. Every other array is per step, and the time-history
+        plot pairs ``times`` with ``a_levels`` point by point, then reads the
+        10 dB-down window back out at those same indices. A per-step quantity
+        of the wrong length shifts the geometry against the levels it was
+        computed from, so a reader that takes the step of ``LASmax`` and asks
+        for the slant distance and emission angle there is answered from
+        another instant of the flyover; a band axis of the wrong length does
+        the same to the spectrum the perceived-noise metrics were taken over.
+
+        :raises ValueError: if a per-step or per-band quantity disagrees.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            emission_times=1,
+            times=1,
+            distance=1,
+            azimuth=1,
+            polar=1,
+            band_levels=2,
+            a_levels=1,
+            pnlt=1,
+        )
+        require_same_length(self, "frequencies", ("band_levels", 1))
+        require_same_length(
+            self,
+            "emission_times",
+            "times",
+            "distance",
+            "azimuth",
+            "polar",
+            "band_levels",
+            "a_levels",
+            "pnlt",
+            axis="emission step",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -984,6 +1087,22 @@ class RotorcraftNoiseContourResult:
     y: NDArray[np.float64]
     level: NDArray[np.float64]
     metric: str
+
+    def __post_init__(self) -> None:
+        """Reject a grid whose levels do not span its own coordinates.
+
+        The contour map takes the two coordinate axes and the level grid
+        separately and pairs them by position. Matplotlib refuses most
+        mismatches, but with a message about dimensions that names no field of
+        this result and arrives long after the grid was built; the one it
+        cannot refuse is a square grid handed over transposed, which draws a
+        plausible footprint over ground that was never evaluated.
+
+        :raises ValueError: if the level grid disagrees with ``x`` or ``y``.
+        """
+        require_ranks(self, x=1, y=1, level=2)
+        require_same_length(self, "y", "level", axis="grid row")
+        require_same_length(self, "x", ("level", 1), axis="grid column")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1211,6 +1330,60 @@ class _EventSetup:
     band_integrated: bool
     terrain: tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]] | None
     terrain_resolution: float
+
+    def __post_init__(self) -> None:
+        """Reject a setup whose three axes do not line up.
+
+        The per-receiver pass walks all three axes by index: the Eq. 3-10
+        weights name a database condition, each track point contributes its
+        own position, orientation and offset, and the absorption coefficient
+        multiplies the source spectrum band by band. Each piece is validated
+        as it is assembled but not against the others, which leaves two holes:
+        ``path_angles`` first meets the rest of the database inside the
+        vectorised pass, and the four track-state arrays skip the per-point
+        check on the branch that derives them from the track kinematics.
+        Pinning the axes here names the one that disagrees before a single
+        step is flown.
+
+        ``ground_elevation``, ``sigma``, ``triangles`` and ``terrain`` stay
+        out of the groups: the first two are a scalar or one value per
+        *receiver*, an axis this setup does not carry; the triangulation runs
+        over its own count of triangles, three vertices to a row; and
+        ``terrain`` is an ``(x, y, z)`` triple whose grids are the elevation
+        model's own. The threes of the last two are a triangle's corners and
+        a coordinate's names, not a band count they happen to agree with.
+
+        :raises ValueError: if the database, track or band axes disagree.
+        """
+        require_ranks(
+            self,
+            airspeeds=1,
+            path_angles=1,
+            frequencies=1,
+            times=1,
+            positions=2,
+            speed=1,
+            gamma=1,
+            heading=1,
+            bank=1,
+            offsets=1,
+            alpha=1,
+        )
+        require_same_length(
+            self, "hemispheres", "airspeeds", "path_angles", axis="flight condition"
+        )
+        require_same_length(self, "frequencies", "alpha")
+        require_same_length(
+            self,
+            "times",
+            "positions",
+            "speed",
+            "gamma",
+            "heading",
+            "bank",
+            "offsets",
+            axis="track point",
+        )
 
 
 def _event_setup(

--- a/src/phonometry/aircraft/rotorcraft_propagation.py
+++ b/src/phonometry/aircraft/rotorcraft_propagation.py
@@ -61,6 +61,8 @@ from .._internal.validation import (
     require_non_negative,
     require_positive,
     require_positive_array,
+    require_ranks,
+    require_same_length,
 )
 
 if TYPE_CHECKING:
@@ -366,6 +368,20 @@ class MeanGroundPlaneResult:
     distances: NDArray[np.float64]
     heights: NDArray[np.float64]
 
+    def __post_init__(self) -> None:
+        """Reject a section whose vertices do not pair up.
+
+        The guidance fits one line through the whole polyline, so ``slope``
+        and ``intercept`` describe exactly the vertices carried here and no
+        others. A section with more heights than distances is a profile the
+        reported fit was never taken over, and the section plot pairs the two
+        arrays vertex by vertex to draw that profile against that same line.
+
+        :raises ValueError: if ``distances`` and ``heights`` disagree.
+        """
+        require_ranks(self, distances=1, heights=1)
+        require_same_length(self, "distances", "heights", axis="section vertex")
+
     def height(self, distance: float | NDArray[np.float64]) -> NDArray[np.float64]:
         r"""The plane height :math:`a\,d + b` at ``distance``, in metres."""
         return np.asarray(
@@ -579,6 +595,31 @@ class TerrainScreeningResult:
     receiver: tuple[float, float]
     distances: NDArray[np.float64]
     heights: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Reject a section whose spectrum or profile does not line up.
+
+        Two unrelated axes meet in this result. ``adjustment`` is added to the
+        received level band by band in the Doc 32 Eq. 23 chain, where a
+        spectrum one entry short or long shifts every band against the
+        frequency its attenuation was computed at, and the shifted chain still
+        sums to a perfectly ordinary level. ``distances`` and ``heights`` are
+        the section the screening regime was decided on, which the geometry
+        plot pairs vertex by vertex to draw the terrain the line of sight was
+        tested against.
+
+        :raises ValueError: if the spectrum or the section vertices disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            adjustment=1,
+            diffraction_points=2,
+            distances=1,
+            heights=1,
+        )
+        require_same_length(self, "frequencies", "adjustment")
+        require_same_length(self, "distances", "heights", axis="section vertex")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 from .._internal.peaks import inter_sample_peak
 from .._internal.types import as_float_or_array
 from .._internal.utils import _typesignal
-from .._internal.validation import require_positive
+from .._internal.validation import require_positive, require_ranks, require_same_length
 
 _EMPTY_SIGNAL = "Input signal 'x' cannot be empty."
 
@@ -279,6 +279,36 @@ class KWeightingResponse:
     shelf_db: np.ndarray
     highpass_db: np.ndarray
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a response whose curves do not all run over the same grid.
+
+        The plot lays the two stages under the combined curve on one shared
+        frequency axis, and the combined magnitude is meant to be their sum, so
+        a curve of another length is a curve read against the wrong
+        frequencies. What the reader takes from the figure are the two
+        landmarks the whole measurement is anchored to, the +4 dB shelf plateau
+        and the 0.69 dB gain at 997 Hz that the ``-0.691`` of Formula 2
+        cancels, and a shifted curve still shows both of them, just at the
+        wrong place on the axis.
+
+        :raises ValueError: if any curve disagrees with ``frequencies``.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            magnitude_db=1,
+            shelf_db=1,
+            highpass_db=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "magnitude_db",
+            "shelf_db",
+            "highpass_db",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -706,6 +736,47 @@ class ProgramLoudnessResult:
     true_peak_per_channel: np.ndarray
     channel_weights: np.ndarray
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a measurement whose series or channel columns disagree.
+
+        Three independent axes run through an EBU Mode measurement and none may
+        be pinned to another: the momentary series is read over a 400 ms window
+        every 10 ms, the short-term series over a 3 s window every 100 ms, and
+        the channel columns count loudspeakers. Within each axis, though, the
+        two arrays are one set of readings seen twice, so they are checked pair
+        by pair.
+
+        The fiche prints the momentary and short-term maxima as headline
+        figures and the series themselves as the plot below, so a reading
+        without its time is a maximum taken over a stretch of programme the
+        graph does not show. The channel columns never reach the sheet at all,
+        only their maximum does, which is exactly why they are checked here: a
+        weight vector that does not cover every channel leaves a headline true
+        peak for a channel the programme loudness never counted, and no reader
+        downstream is in a position to notice.
+
+        :raises ValueError: if the two arrays of any of the three axes
+            disagree.
+        """
+        require_ranks(
+            self,
+            momentary=1,
+            momentary_time=1,
+            short_term=1,
+            short_term_time=1,
+            true_peak_per_channel=1,
+            channel_weights=1,
+        )
+        require_same_length(
+            self, "momentary", "momentary_time", axis="momentary reading"
+        )
+        require_same_length(
+            self, "short_term", "short_term_time", axis="short-term reading"
+        )
+        require_same_length(
+            self, "true_peak_per_channel", "channel_weights", axis="channel"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -76,6 +76,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from .insulation import (
     ImpactRatingResult,
     WeightedRatingResult,
@@ -331,6 +332,28 @@ class VibrationReductionResult:
     k_ij: np.ndarray
     single_number: float | None
     bracketed: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a junction whose per-band columns do not share a band set.
+
+        The ISO 10848-1 junction fiche prints one row per band under a single
+        frequency header, brackets the rows whose modal overlap disqualifies
+        them, and states beside the boxed Annex A mean how many bands were
+        averaged and how many bracketed. Each of those steps pairs the arrays
+        by position, and each of them refuses a disagreement without naming a
+        field: the in-mean mask crosses ``bracketed`` with the Annex A range
+        and raises a broadcast error, the value table reads ``k_ij`` row by row
+        and raises an ``IndexError`` from inside its loop, and the ``Kij(f)``
+        curve the fiche embeds raises matplotlib's shape message. What none of
+        them names is the field that disagrees, and none of them questions the
+        boxed Annex A mean either: it is carried already formed, not recomputed
+        from the arrays the table prints beside it.
+
+        :raises ValueError: if the frequencies, ``Kij`` and the bracketing mask
+            do not agree on how many bands there are.
+        """
+        require_ranks(self, frequencies=1, k_ij=1, bracketed=1)
+        require_same_length(self, "frequencies", "k_ij", "bracketed")
 
     def octave_bands(self) -> VibrationReductionResult:
         r"""Combine one-third-octave ``Kij`` into octave bands.

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from .insulation import (
     impact_improvement_adaptation_term,
     weighted_impact_improvement,
@@ -192,6 +193,24 @@ class FloorCoveringImprovementResult:
     limited: np.ndarray
     delta_lw: int | None
     ci_delta: int | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an improvement spectrum whose columns cover different bands.
+
+        The ISO 16251-1 fiche prints one row per band and prefixes ``>`` to the
+        bands that only reached the 1,3 dB limit of measurement, which is the
+        difference between a measured improvement and a lower bound on one.
+        That prefix is taken from ``limited`` by position, so a mask of another
+        length claims the limit for bands that were never near it and drops it
+        from the bands that were. ``ΔLw`` is rated over the 100 Hz to 3150 Hz
+        sub-range located inside ``frequencies``, so an axis of another length
+        rates a different stretch of spectrum from the one tabulated beside it.
+
+        :raises ValueError: if the frequencies, the improvement and the
+            limit-of-measurement mask do not agree on how many bands there are.
+        """
+        require_ranks(self, frequencies=1, improvement=1, limited=1)
+        require_same_length(self, "frequencies", "improvement", "limited")
 
     def octave_bands(self) -> tuple[np.ndarray, np.ndarray]:
         """Return ``(octave_freqs, ΔLoct)`` via Formula (5) (needs 16 1/3-oct bands)."""

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -106,6 +106,8 @@ from ..._internal.validation import (
     require_choice,
     require_finite_array,
     require_positive,
+    require_ranks,
+    require_same_length,
 )
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -409,6 +411,43 @@ class HeavyImpactSourceCheck:
     within_tolerance: np.ndarray
     passed: bool
 
+    def __post_init__(self) -> None:
+        """Reject a check whose measurement and printed spectrum differ in length.
+
+        The conformance figure draws the measured ``LFE`` inside a tolerance
+        band built band by band from ``nominal`` and ``tolerance``, and crosses
+        the bands ``within_tolerance`` reports as failing. Every column is
+        paired to the others by position, so one of another length holds a
+        measured band up against the printed limits of a different octave, and
+        ``passed`` beside the figure is the verdict on exactly that pairing.
+
+        The five octaves are fixed by the standard, so the check reads as a
+        band count rather than as a range; it is written here because the type
+        is exported and can be built directly from figures the tables never
+        supplied.
+
+        :raises ValueError: if any per-band column disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            measured=1,
+            nominal=1,
+            tolerance=1,
+            deviation=1,
+            within_tolerance=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "measured",
+            "nominal",
+            "tolerance",
+            "deviation",
+            "within_tolerance",
+            axis="octave band",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -542,6 +581,36 @@ class StandardizedMaximumImpactResult:
     volume: float
     reverberation_time: np.ndarray
 
+    def __post_init__(self) -> None:
+        """Reject a standardization whose per-band columns disagree.
+
+        The figure draws ``measured`` and ``standardized`` against one
+        frequency axis and shades the standardization correction as the gap
+        between them, so a curve of another length shades the distance between
+        two different bands. The correction and the reverberation time it came
+        from are carried alongside rather than recomputed, and they are what a
+        report quotes to justify the shift, so a reader has nothing left to
+        check the pair against.
+
+        :raises ValueError: if any per-band column disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            measured=1,
+            standardized=1,
+            reverberation_correction=1,
+            reverberation_time=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "measured",
+            "standardized",
+            "reverberation_correction",
+            "reverberation_time",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -666,6 +735,21 @@ class AWeightedMaximumImpactResult:
     corrected: np.ndarray
     unrounded: float
     rating: int
+
+    def __post_init__(self) -> None:
+        """Reject a rating whose bands and weightings do not line up.
+
+        The figure bars ``corrected`` over the band axis with the unweighted
+        ``levels`` drawn above it and the single number as a horizontal line.
+        The Table D.3 correction falls by nearly 30 dB across the rating range,
+        so a column one band out draws a contribution decibels away from the
+        band it sits over, while the line above it, summed before the result
+        was built, still reads as the right answer.
+
+        :raises ValueError: if any per-band column disagrees with the rest.
+        """
+        require_ranks(self, frequencies=1, levels=1, a_weighting=1, corrected=1)
+        require_same_length(self, "frequencies", "levels", "a_weighting", "corrected")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -73,6 +73,7 @@ import numpy as np
 
 from ..._internal.levels_math import energy_mean
 from ..._internal.types import as_float_or_array
+from ..._internal.validation import require_ranks, require_same_length
 from .ratings import (
     _FREQ_THIRD_OCTAVE,
     ImpactRatingResult,
@@ -178,6 +179,29 @@ class AirborneInsulationResult:
     t2: np.ndarray | None = None
     t0: float | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a measurement whose per-band columns cover different bands.
+
+        The verbose ISO 16283-1 table prints the measurement chain a band at a
+        time, ``L1``, ``L2``, ``T`` and the reported quantity in one row, and
+        the plot lays ``D``, ``DnT`` and ``R'`` over one band-index axis: this
+        result carries no band centres, so the curves are drawn against
+        ``Band 1`` onwards rather than against frequency. Both pair the columns
+        by position, so a chain column longer than the rest is printed only as
+        far as the frequency header, setting a source-room level beside a
+        receiving-room level from a different band, and the sheet shows a
+        derivation that never took place. The quantities are carried already
+        formed rather than recomputed from the chain printed next to them, so
+        nothing downstream compares the two.
+
+        ``None`` stands for a quantity the measurement did not produce, so it
+        is passed over rather than counted.
+
+        :raises ValueError: if any per-band column disagrees with the rest.
+        """
+        require_ranks(self, d=1, dnt=1, r_prime=1, l1=1, l2=1, t2=1)
+        require_same_length(self, "d", "dnt", "r_prime", "l1", "l2", "t2")
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -275,6 +299,27 @@ class ImpactInsulationResult:
     li: np.ndarray | None = None
     t2: np.ndarray | None = None
     t0: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a measurement whose per-band columns cover different bands.
+
+        The verbose ISO 16283-2 table prints ``Li``, ``T`` and the reported
+        level in one row per band, and the plot lays ``L'nT`` beside ``L'n``
+        over one band-index axis: this result carries no band centres either,
+        so the curves are drawn against ``Band 1`` onwards rather than against
+        frequency. Both pair the columns by position, so a chain column longer
+        than the rest is printed only as far as the frequency header and shows
+        an impact level next to the reverberation time of a different band. The
+        levels are carried already formed, not recomputed from the chain beside
+        them, so nothing downstream compares the two.
+
+        ``None`` stands for a quantity the measurement did not produce, so it
+        is passed over rather than counted.
+
+        :raises ValueError: if any per-band column disagrees with the rest.
+        """
+        require_ranks(self, l_n_t=1, l_n=1, li=1, t2=1)
+        require_same_length(self, "l_n_t", "l_n", "li", "t2")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -380,13 +425,35 @@ class FacadeInsulationResult:
     method: str = "loudspeaker"
 
     def __post_init__(self) -> None:
-        """Reject a ``method`` other than ``"loudspeaker"`` or ``"road_traffic"``."""
+        """Reject an unknown ``method``, or columns that cover different bands.
+
+        An unknown source would be rendered and rated as the loudspeaker
+        quantity ``R'45``, so it is refused first.
+
+        The band check is the one the readers cannot make. The ISO 16283-3
+        fiche reports one quantity at a time and counts that curve alone, the
+        16 core one-third-octave bands the ISO 717-1 rating needs; the columns
+        beside it are never looked at, so a result carrying seventeen values of
+        ``D2m`` next to sixteen of ``D2m,nT`` writes a clean sheet that says
+        nothing about the disagreement. The plot is what does pair them, every
+        available quantity against ``frequencies``, and all it can answer with
+        is matplotlib's shape message, which names neither the field nor the
+        result.
+
+        ``None`` stands for a quantity the measurement did not produce, so it
+        is passed over rather than counted.
+
+        :raises ValueError: if ``method`` is unknown, or a per-band column
+            disagrees with the rest.
+        """
         if self.method not in _FACADE_CORRECTION:
             msg = (
                 "'method' must be 'loudspeaker' or 'road_traffic', got "
                 f"{self.method!r}."
             )
             raise ValueError(msg)
+        require_ranks(self, d_2m=1, d_2m_nt=1, d_2m_n=1, r_prime=1, frequencies=1)
+        require_same_length(self, "d_2m", "d_2m_nt", "d_2m_n", "r_prime", "frequencies")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -77,6 +77,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from .insulation import (
     WeightedRatingResult,
     _as_band_levels,
@@ -181,6 +182,23 @@ class IntensityReductionResult:
     rating_modified: WeightedRatingResult | None
     area: float | None = None
     measurement_area: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a result whose two indices were measured over different bands.
+
+        The verbose ISO 15186-1 fiche annexes ``RI,M`` beside ``RI`` as a
+        second column of one band table. It measures ``FpI`` and ``δpI0``
+        against the reported band count before admitting them, because the
+        caller passes those to :meth:`report`; the modified index arrives on
+        the result itself and is admitted unmeasured. So the one column that
+        invites a comparison band by band -- the same index before and after
+        the ``Kc`` adaptation -- is the one nothing lines up, and the surplus
+        entries of a longer array are dropped by the table without a word.
+
+        :raises ValueError: if ``r_i`` and ``r_i_modified`` disagree.
+        """
+        require_ranks(self, r_i=1, r_i_modified=1)
+        require_same_length(self, "r_i", "r_i_modified")
 
     def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
         """Plot ``RI`` against the shifted ISO 717-1 reference curve.

--- a/src/phonometry/building/measurement/lab_insulation.py
+++ b/src/phonometry/building/measurement/lab_insulation.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from ..._internal.warnings import PhonometryWarning
 from .insulation import (
     ImpactRatingResult,
@@ -109,6 +110,23 @@ class LabAirborneInsulationResult:
     r: np.ndarray
     absorption: np.ndarray
     rating: WeightedRatingResult | None
+
+    def __post_init__(self) -> None:
+        """Reject a result whose index and absorption area span different bands.
+
+        The verbose ISO 10140-2 fiche prints ``A`` beside ``R`` in one band
+        table, and the renderer checks the reported curve against the rating
+        but never ``absorption``: the table walks the band centres and reads
+        each column at that band, so an absorption area one entry too long
+        simply loses its tail with nothing said, while one entry too short
+        reaches the reader as an ``IndexError`` from inside the table
+        builder. Either way the sheet that documents how ``R`` was formed
+        from ``A`` is the last place the mismatch could have been caught.
+
+        :raises ValueError: if ``r`` and ``absorption`` disagree.
+        """
+        require_ranks(self, r=1, absorption=1)
+        require_same_length(self, "r", "absorption")
 
     def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
         """Plot ``R`` against the shifted ISO 717-1 reference curve.
@@ -197,6 +215,22 @@ class LabImpactInsulationResult:
     l_n: np.ndarray
     absorption: np.ndarray
     rating: ImpactRatingResult | None
+
+    def __post_init__(self) -> None:
+        """Reject a result whose level and absorption area span different bands.
+
+        ``A`` is what normalizes ``Li`` into ``Ln``, and the verbose
+        ISO 10140-3 fiche prints the two side by side so a reader can follow
+        that step band by band. Nothing downstream keeps them aligned: the
+        renderer validates the reported curve against the rating and leaves
+        ``absorption`` alone, and the table indexes each column at the band
+        centre it is on, quietly dropping a surplus entry and raising an
+        ``IndexError`` from the table builder for a missing one.
+
+        :raises ValueError: if ``l_n`` and ``absorption`` disagree.
+        """
+        require_ranks(self, l_n=1, absorption=1)
+        require_same_length(self, "l_n", "absorption")
 
     def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
         """Plot ``Ln`` against the shifted ISO 717-2 reference curve.

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -66,6 +66,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.levels_math import energy_sum
+from ..._internal.validation import require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -365,6 +366,28 @@ class WeightedRatingResult:
     shifted_reference: np.ndarray | None = None
     quantity: str = "airborne"
 
+    def __post_init__(self) -> None:
+        """Reject a rating whose three band curves do not line up.
+
+        The three arrays are the record of which bands the single number was
+        rated over, and a fiche reads them as exactly that: ISO 717-1
+        Clause 5.3 makes it declare whether the rating came from
+        one-third-octave or octave bands, and it settles that from the length
+        of ``band_centers`` alone. The renderers do compare the three, but
+        only once a report is asked for, which can be long after the rating
+        was built and passed on; :meth:`plot` compares nothing and hands the
+        curves to matplotlib, whose complaint about first dimensions names
+        neither the field nor the type it came from.
+
+        The three arrays default to ``None`` on a rating built from the
+        single numbers alone, and an absent curve is skipped rather than read
+        as a disagreement.
+
+        :raises ValueError: if the band curves supplied disagree.
+        """
+        require_ranks(self, band_centers=1, measured=1, shifted_reference=1)
+        require_same_length(self, "band_centers", "measured", "shifted_reference")
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -466,6 +489,28 @@ class ImpactRatingResult:
     measured: np.ndarray | None = None
     shifted_reference: np.ndarray | None = None
     quantity: str = "impact"
+
+    def __post_init__(self) -> None:
+        """Reject a rating whose three band curves do not line up.
+
+        Shading the bands where the measurement rises *above* the shifted
+        reference -- the sign opposite to airborne -- is a comparison of one
+        curve against the other, band for band, and :meth:`plot` makes it
+        without first asking whether the two run over the same bands. The
+        band centres carry as much: ISO 717-2 Clause 4.4 makes the fiche
+        declare whether the rating came from one-third-octave or octave
+        bands, and their length alone settles it. The renderers refuse a
+        mismatch, but not until a report is asked for, and a rating is
+        usually built long before that.
+
+        The three arrays default to ``None`` on a rating built from the
+        single numbers alone, and an absent curve is skipped rather than read
+        as a disagreement.
+
+        :raises ValueError: if the band curves supplied disagree.
+        """
+        require_ranks(self, band_centers=1, measured=1, shifted_reference=1)
+        require_same_length(self, "band_centers", "measured", "shifted_reference")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1010,6 +1055,26 @@ class ExtendedWeightedRatingResult:
     band_centers: np.ndarray | None = None
     measured: np.ndarray | None = None
 
+    def __post_init__(self) -> None:
+        """Reject an enlarged-range rating whose curve and bands disagree.
+
+        The Annex B plot shades from the ends of ``band_centers`` in to the
+        ends of the core 100-3150 Hz axis, to mark which part of the curve is
+        the enlarged range, and only afterwards draws ``measured`` against
+        those same centres. The shading is therefore laid down before
+        anything has compared the two lengths: centres that are not this
+        curve's own axis put the enlarged-range mark where the curve does not
+        reach, and what the caller is finally handed is matplotlib
+        complaining about first dimensions.
+
+        ``core`` is not compared here: it carries the 16 core bands whatever
+        the enlarged range is, and checks its own three curves.
+
+        :raises ValueError: if ``band_centers`` and ``measured`` disagree.
+        """
+        require_ranks(self, band_centers=1, measured=1)
+        require_same_length(self, "band_centers", "measured")
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -1058,6 +1123,25 @@ class ExtendedImpactRatingResult:
     core: ImpactRatingResult
     band_centers: np.ndarray | None = None
     measured: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an enlarged-range rating whose curve and bands disagree.
+
+        The band centres are the record of which bands ``CI,50-2500`` was
+        summed over, and the plot reads them a second time to mark which part
+        of ``measured`` lies outside the core 100-3150 Hz set -- shading that
+        span from the ends of the centres before it has looked at the curve
+        at all. Centres that are not this curve's own axis therefore mis-mark
+        the enlarged range first and fail second, in matplotlib's words
+        rather than the library's.
+
+        ``core`` is not compared here: it carries the 16 core bands whatever
+        the enlarged range is, and checks its own three curves.
+
+        :raises ValueError: if ``band_centers`` and ``measured`` disagree.
+        """
+        require_ranks(self, band_centers=1, measured=1)
+        require_same_length(self, "band_centers", "measured")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -83,7 +83,12 @@ if TYPE_CHECKING:
     from ..._report.metadata import ReportMetadata
 
 
-from ..._internal.validation import require_per_band, require_positive
+from ..._internal.validation import (
+    require_per_band,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from .flanking_transmission import total_loss_factor
 
 #: EN 15657 vibratory velocity reference ``v0`` (= ISO 1683 10^-9 m/s), m/s.
@@ -215,6 +220,30 @@ class StructureBornePowerResult:
     mass_per_area: float
     area: float
     frequencies: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a plate result whose per-band quantities disagree.
+
+        The EN 15657 fiche prints ``Lv``, ``eta`` and ``L_Ws`` as columns of
+        one band table whose row count comes from ``L_Ws`` alone, so a
+        companion array one entry longer is not refused, merely cut off at
+        that count. ``frequencies`` fares worse than being cut off: the
+        octave grouping the labels are printed in is inferred from the whole
+        of it, so a surplus band the sheet never shows still decides how the
+        bands it does show are named and grouped.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            power_level=1,
+            velocity_level=1,
+            loss_factor=1,
+            frequencies=1,
+        )
+        require_same_length(
+            self, "power_level", "velocity_level", "loss_factor", "frequencies"
+        )
 
     @property
     def total_level(self) -> float:

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -72,6 +72,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from .insulation import (
     ImpactRatingResult,
     WeightedRatingResult,
@@ -356,6 +357,26 @@ class SurveyAirborneResult:
     rating: WeightedRatingResult | None
     r_prime_rating: WeightedRatingResult | None
 
+    def __post_init__(self) -> None:
+        """Reject a survey whose quantities do not run over one band set.
+
+        All four are the same level difference plus a correction, so they run
+        over the same bands whenever the library forms them; the check is
+        what keeps that true of a result assembled by hand or rebuilt with
+        :func:`dataclasses.replace`. Only the reported curve is read again
+        downstream: the field fiche takes exactly one of ``d_nt`` and
+        ``r_prime``, whichever :meth:`report` was asked for, and already
+        refuses a curve that disagrees with the band arrays of its rating,
+        while :meth:`plot` draws from the rating alone. ``d``, ``d_n`` and
+        the quantity left unreported are handed to the reader and never
+        looked at again, so a band too many or too few in them is a
+        disagreement nothing downstream would ever raise.
+
+        :raises ValueError: if the per-band quantities disagree.
+        """
+        require_ranks(self, d=1, d_nt=1, d_n=1, r_prime=1)
+        require_same_length(self, "d", "d_nt", "d_n", "r_prime")
+
     def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
         """Plot ``DnT`` against the shifted ISO 717-1 reference curve.
 
@@ -454,6 +475,25 @@ class SurveyImpactResult:
     l_n: np.ndarray | None
     rating: ImpactRatingResult | None
 
+    def __post_init__(self) -> None:
+        """Reject a survey whose impact levels do not run over one band set.
+
+        The three are the same level plus a correction and run over one band
+        set whenever the library forms them; the check is what keeps that
+        true of a result assembled by hand or rebuilt with
+        :func:`dataclasses.replace`. The impact fiche reads ``l_nt`` and
+        nothing else, and already refuses a curve that disagrees with the
+        band arrays of its ISO 717-2 rating; :meth:`plot` draws from the
+        rating alone. ``l_i`` and ``l_n`` reach neither a page nor an axis:
+        they are quantities the library forms once and hands to the reader,
+        so a band too many or too few in either is a disagreement nothing
+        downstream would ever raise.
+
+        :raises ValueError: if the per-band levels disagree.
+        """
+        require_ranks(self, l_i=1, l_nt=1, l_n=1)
+        require_same_length(self, "l_i", "l_nt", "l_n")
+
     def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
         """Plot ``L'nT`` against the shifted ISO 717-2 reference curve."""
         if self.rating is None:
@@ -534,6 +574,24 @@ class SurveyFacadeResult:
     d_2m_n: np.ndarray | None
     rating: WeightedRatingResult | None
 
+    def __post_init__(self) -> None:
+        """Reject a facade survey whose quantities span different band sets.
+
+        The facade fiche is the airborne sheet with ``D2m,nT`` in the column,
+        and it reads that curve alone, already refusing one that disagrees
+        with the band arrays of its rating; ``d_2m`` and ``d_2m_n`` reach
+        neither the sheet nor :meth:`plot`, which draws from the rating. The
+        library forms all
+        three over one band set, and this check is the only thing that stops
+        a result assembled by hand or rebuilt with
+        :func:`dataclasses.replace` from carrying a normalized form that
+        covered a different span of bands with nobody left to notice.
+
+        :raises ValueError: if the per-band quantities disagree.
+        """
+        require_ranks(self, d_2m=1, d_2m_nt=1, d_2m_n=1)
+        require_same_length(self, "d_2m", "d_2m_nt", "d_2m_n")
+
     def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
         """Plot ``D2m,nT`` against the shifted ISO 717-1 reference curve."""
         if self.rating is None:
@@ -607,6 +665,11 @@ class SurveyServiceEquipmentResult:
         the receiving-room volume was not supplied.
     """
 
+    # No __post_init__ axis check here, unlike the three insulation results
+    # above. Clause 6.3.3 admits three scalar readings as readily as three
+    # banded ones, so these quantities are a single weighted number as often
+    # as they are one value per band, and this module builds them both ways.
+    # Requiring a band axis would refuse the survey's ordinary global reading.
     l_xy: np.ndarray
     l_xy_nt: np.ndarray
     l_xy_n: np.ndarray | None

--- a/src/phonometry/building/prediction/aperture_transmission.py
+++ b/src/phonometry/building/prediction/aperture_transmission.py
@@ -59,7 +59,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.special import j1, struve
 
-from ..._internal.validation import require_choice, require_positive
+from ..._internal.validation import (
+    require_choice,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -122,6 +127,23 @@ class ApertureTransmissionResult:
     width: float | None = None
     radius: float | None = None
     depth: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an aperture whose coefficient and band axis disagree.
+
+        The aperture is rarely the end of the calculation: its ``R(f)`` goes
+        on to :func:`composite_transmission_loss` beside the wall it pierces,
+        or into an enclosure leak, where it is combined band by band with
+        spectra that came from elsewhere. Numpy pairs a one-element
+        coefficient with any band axis at all rather than refuse, so a
+        coefficient that lost its band axis returns a composite ``R`` that is
+        the right length, finite, and about a slit that was evaluated at one
+        frequency only.
+
+        :raises ValueError: if the two per-band arrays disagree.
+        """
+        require_ranks(self, frequencies=1, transmission_coefficient=1)
+        require_same_length(self, "frequencies", "transmission_coefficient")
 
     @property
     def transmission_loss(self) -> np.ndarray:

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -111,6 +111,8 @@ from ..._internal.validation import (
     require_choice,
     require_finite_array,
     require_positive,
+    require_ranks,
+    require_same_length,
 )
 
 if TYPE_CHECKING:
@@ -270,6 +272,36 @@ class CeilingAttenuationResult:
     max_deficiency: float
     rating: int
 
+    def __post_init__(self) -> None:
+        """Reject a rating whose curves do not share the contour band set.
+
+        ASTM E413 is a contour fitted band by band: the sum of the
+        deficiencies and the largest of them are what stop the contour rising,
+        and the plot draws the data against that fitted contour. A curve
+        shorter than the sixteen bands leaves the drawing to pair the
+        remaining values with the wrong frequencies, and the two numbers
+        printed in the title are then sums over a set that the picture beneath
+        them does not show.
+
+        :raises ValueError: if the per-band curves disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            measured=1,
+            rounded=1,
+            shifted_reference=1,
+            deficiencies=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "measured",
+            "rounded",
+            "shifted_reference",
+            "deficiencies",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -384,6 +416,38 @@ class PlenumFlankingResult:
     epsilon: float
     plenum_height: float
     ceiling_length: float
+
+    def __post_init__(self) -> None:
+        """Reject a plenum path whose spectra do not run over the same bands.
+
+        The plot shades the gap between ``RS + RR`` and ``Rcl`` to show what
+        the plenum costs, and that sum is taken with numpy's own rules: a
+        one-band ceiling on either side is stretched across the other's whole
+        axis instead of being refused, so the shaded penalty is drawn against
+        a ceiling that was only ever evaluated in one band. ``frequencies``
+        stays optional, since a result built without a band axis is not a
+        result whose bands disagree.
+
+        :raises ValueError: if the per-band spectra disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            reduction_index=1,
+            transmission_factor=1,
+            reduction_index_source=1,
+            reduction_index_receiving=1,
+            penalty=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "reduction_index",
+            "transmission_factor",
+            "reduction_index_source",
+            "reduction_index_receiving",
+            "penalty",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -1331,6 +1331,43 @@ class InSituElementResult:
     sound_reduction_index: np.ndarray
     impact_level: np.ndarray
 
+    def __post_init__(self) -> None:
+        """Reject an element whose in-situ spectra do not share a band axis.
+
+        This result is an input as much as an output:
+        :func:`airborne_flanking_path` and :func:`impact_flanking_path` take
+        the absorption length of *this* element and of another, and combine
+        the two sound reduction indices band by band into one path. A
+        spectrum that lost its band axis is stretched over its partner's
+        rather than refused, and the path that comes back is the right length
+        with the right units, so it takes its row in the sheet and its share
+        of the transmitted energy without anything having gone visibly wrong.
+
+        :raises ValueError: if the per-band spectra disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            radiation_factor=1,
+            forced_radiation_factor=1,
+            total_loss_factor=1,
+            reverberation_time=1,
+            absorption_length=1,
+            sound_reduction_index=1,
+            impact_level=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "radiation_factor",
+            "forced_radiation_factor",
+            "total_loss_factor",
+            "reverberation_time",
+            "absorption_length",
+            "sound_reduction_index",
+            "impact_level",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -71,6 +71,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -204,6 +211,47 @@ class FacadePredictionResult:
     frequencies: np.ndarray | None = None
     elements: tuple[FacadeElement, ...] | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a prediction whose element rows and bands do not line up.
+
+        The fiche prints one row per façade element and rates each row on its
+        own through the ISO 717-1 curve fit, which recognises a spectrum by
+        how many values it holds: a row carrying the wrong band set is still
+        rated, against a reference curve for bands the façade was not
+        predicted on, and the ``Rp,w`` it prints looks like every other row of
+        the table. The verbose sheet then gives that same row a share of the
+        transmitted energy, summed over whatever bands it holds, so a row one
+        band too long claims energy the façade never transmitted and the sheet
+        can name the wrong element as the limiting one.
+
+        ``elements`` is the geometry :meth:`plot_geometry` draws, one patch per
+        element beside the table's one row per element, so the two views must
+        describe the same façade.
+
+        :raises ValueError: if the per-band quantities disagree, if an element
+            partial index does not run over the predicted bands, or if the
+            retained geometry holds a different number of elements.
+        """
+        require_ranks(self, r_prime=1, r_45=1, r_tr_s=1, d_2m_nt=1, frequencies=1)
+        require_same_length(self, "r_prime", "r_45", "r_tr_s", "d_2m_nt", "frequencies")
+        owner = type(self).__name__
+        bands = require_axis_count(self.r_prime, owner, "r_prime", rank=None)
+        for name, partial in self.element_r.items():
+            label = f"element_r[{name!r}]"
+            require_equal_counts(
+                owner,
+                {
+                    "r_prime": bands,
+                    label: require_axis_count(partial, owner, label, rank=1),
+                },
+            )
+        if self.elements is not None:
+            require_equal_counts(
+                owner,
+                {"elements": len(self.elements), "element_r": len(self.element_r)},
+                "façade element",
+            )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -305,6 +353,21 @@ class RadiatedPowerResult:
     r_prime: np.ndarray
     l_w_dba: float | None = None
     frequencies: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a radiated power whose bands and band centres disagree.
+
+        The plot draws one bar per band from ``l_w`` on a categorical axis and
+        takes the tick labels from ``frequencies``, placing one tick per label
+        rather than one per bar: a band centre too few leaves the last bars
+        anonymous, one too many hangs a centre past the end of the row. The
+        bars keep their heights either way, so the figure reads as a spectrum
+        whose levels sit at frequencies they were never computed for.
+
+        :raises ValueError: if the per-band quantities disagree.
+        """
+        require_ranks(self, l_w=1, r_prime=1, frequencies=1)
+        require_same_length(self, "l_w", "r_prime", "frequencies")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/prediction/masonry_cavity_wall.py
+++ b/src/phonometry/building/prediction/masonry_cavity_wall.py
@@ -82,7 +82,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_finite_array, require_positive
+from ..._internal.validation import (
+    require_finite_array,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from ...vibration.structural.point_mobility import infinite_plate_mobility
 
 if TYPE_CHECKING:
@@ -186,6 +191,35 @@ class WallTieCouplingResult:
     ties_per_area: float
     tie_stiffness: float | None
     rigid_coupling_loss_factor: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject spectra that do not share one frequency axis.
+
+        The figure shades the gap between ``coupling_loss_factor`` and the
+        rigid ceiling, and that shaded band is the answer the reader takes
+        away: how much isolation the resilient tie buys over a screw. A gap
+        can only be read where both curves are given at the same frequency,
+        and ``connector_mobility`` is the term that opens it, so a spectrum of
+        another length puts the comparison between different frequencies while
+        the shading still looks like an amount of isolation.
+
+        :raises ValueError: if the per-frequency spectra disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            coupling_loss_factor=1,
+            connector_mobility=1,
+            rigid_coupling_loss_factor=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "coupling_loss_factor",
+            "connector_mobility",
+            "rigid_coupling_loss_factor",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -97,6 +97,8 @@ from ..._internal.validation import (
     require_choice,
     require_non_negative,
     require_positive,
+    require_ranks,
+    require_same_length,
 )
 from ...vibration.structural.radiation_efficiency import coincidence_frequency
 
@@ -276,6 +278,24 @@ class SoundReductionResult:
     plateau_start: float | None = None
     plateau_end: float | None = None
     critical_frequency_upper: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a predicted spectrum that does not match its band centres.
+
+        :meth:`rating` and :meth:`report` hand ``transmission_loss`` alone to
+        the ISO 717-1 curve fit, which recognises the band set by how many
+        values arrive: 16 are read as the one-third-octave bands from 100 Hz
+        and 5 as the octave bands from 125 Hz, whatever ``frequencies`` says
+        the prediction covers. A spectrum longer than its own band centres is
+        therefore rated against a reference curve for bands the construction
+        was never evaluated on, and the rating fiche prints the standard
+        centres beside it, so nothing on the sheet recalls the axis the
+        prediction was actually made over.
+
+        :raises ValueError: if the spectrum and the band centres disagree.
+        """
+        require_ranks(self, frequencies=1, transmission_loss=1)
+        require_same_length(self, "frequencies", "transmission_loss")
 
     @property
     def transmission_coefficient(self) -> np.ndarray:

--- a/src/phonometry/building/prediction/resilient_layers.py
+++ b/src/phonometry/building/prediction/resilient_layers.py
@@ -187,6 +187,10 @@ _DELTA_LW_SCREED = (13.0, -14.2, 20.8)
 #: ``(−0,21 m' − 5,45) lg(s') + 0,46 m' + 23,8``.
 _DELTA_LW_ASPHALT = (-0.21, -5.45, 0.46, 23.8)
 
+#: The axis the tapping machine's force spectrum runs over, one third-octave
+#: band holding several of its lines.
+_FOURIER_LINE_AXIS = "Fourier line"
+
 #: Band width of the mean-square force (Hopkins Eq. 3.91).
 BandWidth = Literal["third", "octave"]
 #: Floating-floor construction of ISO 12354-2:2017 Annex C.
@@ -686,10 +690,10 @@ class CoveringImprovementResult:
             line_improvement=1,
         )
         require_same_length(self, "frequencies", "improvement", "two_line")
-        require_same_length(self, "lines", "line_improvement", axis="Fourier line")
+        require_same_length(self, "lines", "line_improvement", axis=_FOURIER_LINE_AXIS)
         owner = type(self).__name__
         lines = require_axis_count(
-            self.lines, owner, "lines", "Fourier line", rank=None
+            self.lines, owner, "lines", _FOURIER_LINE_AXIS, rank=None
         )
         for name in ("bare", "covered"):
             label = f"{name}.frequencies"
@@ -701,11 +705,11 @@ class CoveringImprovementResult:
                         getattr(self, name).frequencies,
                         owner,
                         label,
-                        "Fourier line",
+                        _FOURIER_LINE_AXIS,
                         rank=1,
                     ),
                 },
-                "Fourier line",
+                _FOURIER_LINE_AXIS,
             )
 
     def plot(

--- a/src/phonometry/building/prediction/resilient_layers.py
+++ b/src/phonometry/building/prediction/resilient_layers.py
@@ -77,9 +77,13 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import numpy as np
 
 from ..._internal.validation import (
+    require_axis_count,
     require_choice,
+    require_equal_counts,
     require_positive,
     require_positive_array,
+    require_ranks,
+    require_same_length,
 )
 
 if TYPE_CHECKING:
@@ -485,6 +489,30 @@ class TappingForceResult:
     upper_limit: float
     band: str = "third"
 
+    def __post_init__(self) -> None:
+        """Reject a force spectrum whose per-band quantities disagree.
+
+        ``mean_square_force`` and the power input derived from it are band
+        quantities, not samples of a curve: Eq. (3.91) weights each Fourier
+        component by the width of the band it falls in, so a value belongs to
+        one band centre and to no other. A quantity of the wrong length slides
+        the spectrum along the frequency axis, and a force spectrum shifted by
+        a band or two is still a plausible one, read as a floor of a different
+        impedance rather than as a mistake.
+
+        :raises ValueError: if the per-band quantities disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            peak_force=1,
+            mean_square_force=1,
+            power_input=1,
+        )
+        require_same_length(
+            self, "frequencies", "peak_force", "mean_square_force", "power_input"
+        )
+
     @property
     def power_input_level(self) -> np.ndarray:
         r"""Power input level :math:`10 \log_{10}(W_\mathrm{in}/1~\text{pW})`, in dB
@@ -631,6 +659,54 @@ class CoveringImprovementResult:
     line_improvement: np.ndarray
     bare: TappingForceResult
     covered: TappingForceResult
+
+    def __post_init__(self) -> None:
+        """Reject an improvement whose bands and Fourier lines do not line up.
+
+        Two axes meet in this result and they are not interchangeable:
+        ``improvement`` and ``two_line`` are band values, while
+        ``line_improvement`` runs over the tapping machine's Fourier lines, of
+        which one third-octave band holds several. Keeping them apart is the
+        point of the model, because the per-line ratio carries exact nulls at
+        odd multiples of ``fco`` that the band value averages away, so a
+        per-line array the length of the band set would be read against the
+        band centres and put those nulls at frequencies where the covering has
+        none. ``bare`` and ``covered`` are evaluated at ``lines`` too: their
+        force spectra are the two sides of the ratio, line for line.
+
+        :raises ValueError: if the per-band or the per-line quantities
+            disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            improvement=1,
+            two_line=1,
+            lines=1,
+            line_improvement=1,
+        )
+        require_same_length(self, "frequencies", "improvement", "two_line")
+        require_same_length(self, "lines", "line_improvement", axis="Fourier line")
+        owner = type(self).__name__
+        lines = require_axis_count(
+            self.lines, owner, "lines", "Fourier line", rank=None
+        )
+        for name in ("bare", "covered"):
+            label = f"{name}.frequencies"
+            require_equal_counts(
+                owner,
+                {
+                    "lines": lines,
+                    label: require_axis_count(
+                        getattr(self, name).frequencies,
+                        owner,
+                        label,
+                        "Fourier line",
+                        rank=1,
+                    ),
+                },
+                "Fourier line",
+            )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -914,6 +990,21 @@ class FloatingFloorImprovementResult:
     slope: float
     limiting_frequency: float | None = None
     delta_lw: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an improvement that does not match its band centres.
+
+        The figure draws ``improvement`` against ``frequencies`` and marks the
+        resonance on the same axis, and the whole reading of a floating floor
+        is where its improvement starts: 0 dB at ``fo``, then one straight
+        slope above it. A curve shifted along the band axis still shows that
+        shape, only with its knee at the wrong frequency, which is the one
+        number the drawing stage takes from the prediction.
+
+        :raises ValueError: if the improvement and the band centres disagree.
+        """
+        require_ranks(self, frequencies=1, improvement=1)
+        require_same_length(self, "frequencies", "improvement")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -84,6 +84,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -374,6 +376,46 @@ class DbHrGlobalIndexResult:
     spectrum_levels: np.ndarray
     band_contributions: np.ndarray
     reference: str
+
+    def __post_init__(self) -> None:
+        """Reject an index whose four band columns do not share one band set.
+
+        Formula (A.5) is a single energy sum over the eighteen one-third-octave
+        bands 100 Hz to 5 kHz, and these four arrays are the four columns of
+        the table that sum is read off: the band centre, the insulation
+        ``X_i``, the normalised spectrum ``L_x,i`` of the Annex A table named
+        in ``reference``, and their difference. Swapping a column for one of
+        another length leaves ``value``, ``intermediate`` and ``reported``
+        alone, since the sum closed over the bands it was handed at
+        construction, so the index stops answering to the columns beside it.
+        The plot does refuse most such results, because the bars and the
+        transmitted-level curve go on positions taken from ``frequencies``
+        and matplotlib compares the lengths itself, but its refusal names
+        neither the field nor the result; and a column holding a single value
+        slips past even that, broadcast into one identical bar per band.
+        ``spectrum_levels`` is read by no plot and no sheet, so a spectrum
+        belonging to a different band set reaches the reader with nothing
+        between it and the table it is quoted under. Equal lengths are the
+        most this can ask for: four columns of eighteen values read off
+        different Annex A tables agree here, and always will.
+
+        :raises ValueError: if the four per-band columns disagree in length,
+            or if one of them carries an axis beyond the band axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            band_values=1,
+            spectrum_levels=1,
+            band_contributions=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "band_values",
+            "spectrum_levels",
+            "band_contributions",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import apply_calibration, resolve_fs
 
 if TYPE_CHECKING:
@@ -679,6 +680,22 @@ class HarmonicDistortionResult:
     thd_r: float
     thd_plus_noise: float
     sinad_db: float
+
+    def __post_init__(self) -> None:
+        """Reject a result whose two harmonic axes are of different lengths.
+
+        The frequencies and the amplitudes are the one list of harmonics
+        written down twice, the nth frequency naming the nth amplitude. No
+        reader re-derives either from the other, so a pairing that ran short
+        goes uncontested: ``zip`` stops at the shorter of the two and the
+        table it fills loses a harmonic that the THD quoted above it summed.
+
+        :raises ValueError: if the two disagree in length.
+        """
+        require_ranks(self, harmonic_frequencies=1, harmonic_amplitudes=1)
+        require_same_length(
+            self, "harmonic_frequencies", "harmonic_amplitudes", axis="harmonic"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -30,6 +30,7 @@ import numpy as np
 
 # Shared Welch-core defaults and helpers (single source of truth for the
 # segment policy across the spectral estimators).
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import apply_calibration, resolve_pair_fs
 from ..signals.spectra import (
     _DEFAULT_OVERLAP,
@@ -109,6 +110,38 @@ class FrequencyResponseResult:
     phase: NDArray[np.float64]
     coherence: NDArray[np.float64]
     estimator: str
+
+    def __post_init__(self) -> None:
+        """Reject an estimate whose curves do not share one frequency axis.
+
+        The five fields are one Welch frequency axis and the four quantities
+        read off it, so the Bode magnitude is plotted against ``frequencies``
+        point for point and the coherence panel beneath it is the quality
+        flag of those same points. The panels select their positive-frequency
+        part with a mask cut from ``frequencies``, which turns a curve of the
+        wrong length into an index error raised from inside the plotter,
+        naming neither the field nor the two lengths; ``response``, which
+        nothing downstream re-derives, disagrees without a word.
+
+        :raises ValueError: if the five curves do not share one length.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            response=1,
+            magnitude_db=1,
+            phase=1,
+            coherence=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "response",
+            "magnitude_db",
+            "phase",
+            "coherence",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/intermodulation.py
+++ b/src/phonometry/electroacoustics/intermodulation.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs
 from .distortion import (
     _amplitude_spectrum,
@@ -114,6 +115,28 @@ class ModulationDistortionResult:
     carrier_amplitude: float | None = None
     sideband_frequencies: NDArray[np.float64] | None = None
     sideband_amplitudes: NDArray[np.float64] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a sideband spectrum whose two halves do not correspond.
+
+        14.12.7 names the products the pair enumerates -- ``f2 ± f1`` and
+        ``f2 ± 2f1`` -- and the correspondence between them is the whole of
+        the measurement: the nth amplitude is the amplitude *of* the nth
+        frequency, and ``d2`` and ``d3`` are sums over that same enumeration.
+        A pair of unequal length has lost it, and the spectrum then states an
+        amplitude for a product it does not name, or names a product whose
+        amplitude the per-order ratios above it nonetheless counted.
+
+        Both fields are optional: a result carrying only the ratios states no
+        spectrum at all, and an absent half is skipped rather than read as a
+        disagreement.
+
+        :raises ValueError: if the two disagree in length.
+        """
+        require_ranks(self, sideband_frequencies=1, sideband_amplitudes=1)
+        require_same_length(
+            self, "sideband_frequencies", "sideband_amplitudes", axis="sideband"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -52,7 +52,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_positive
+from .._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -373,6 +377,50 @@ class LoudspeakerCharacteristics:
     polar_db: NDArray[np.float64] | None
     polar_frequency: float | None
     directivity_index_db: float | None
+
+    def __post_init__(self) -> None:
+        """Reject a data sheet whose curves do not each pair up.
+
+        The fiche draws four curves the standard treats separately -- the
+        on-axis response of Clause 21, the impedance modulus of 16.2, the
+        distortion against frequency of 24.1 and the polar pattern of 23.1 --
+        and each is a pair of arrays that has to line up point for point.
+        Each pair is checked on its own and never against another, because
+        the four are measured on grids of their own choosing: a data sheet
+        sampling the response at 120 frequencies, the impedance at 61 and the
+        pattern at 73 angles is an ordinary one, and linking them would
+        refuse it.
+
+        Nothing downstream re-establishes the pairing. The fiche decides
+        whether to print a panel from the presence of the frequency array
+        alone, and :attr:`minimum_impedance` scans the modulus through a mask
+        cut from the impedance frequencies, so a half-length curve surfaces
+        as an index error from inside a renderer rather than at the point the
+        result was assembled.
+
+        The three ``(lo, hi)`` band edges are left out of every group: they
+        state the ends of a range rather than run along one, and their length
+        of two is a property of the pair, not of any curve.
+
+        :raises ValueError: if either half of a curve disagrees with the other.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            spl_db=1,
+            impedance_frequencies=1,
+            impedance_modulus=1,
+            thd_frequencies=1,
+            thd_percent=1,
+            polar_angles_deg=1,
+            polar_db=1,
+        )
+        require_same_length(self, "frequencies", "spl_db", axis="frequency")
+        require_same_length(
+            self, "impedance_frequencies", "impedance_modulus", axis="frequency"
+        )
+        require_same_length(self, "thd_frequencies", "thd_percent", axis="frequency")
+        require_same_length(self, "polar_angles_deg", "polar_db", axis="angle")
 
     @property
     def characteristic_sensitivity_pa(self) -> float:

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -67,7 +67,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_positive
+from .._internal.validation import require_positive, require_ranks, require_same_length
 from .loudspeaker import _as_curve, _threshold_crossing
 
 if TYPE_CHECKING:
@@ -431,6 +431,55 @@ class MicrophoneCharacteristics:
     directivity_index_db: float | None
     powering: str | None
     supply_current_ma: float | None
+
+    def __post_init__(self) -> None:
+        """Reject a data sheet whose paired curves disagree along their axis.
+
+        Each rated characteristic reaches the IEC 60268-4 fiche as one curve
+        against its own abscissa, and every panel reads the pair positionally:
+        the ``n``-th response level belongs to the ``n``-th frequency, the
+        ``n``-th polar level to the ``n``-th angle of incidence. Nothing
+        reconciles a disagreement on the way there -- every panel hands the
+        pair straight to matplotlib -- so a member one entry short, or one
+        entry long, raises ``x and y must have same first dimension`` from
+        inside the drawing code, naming neither the field nor the result and
+        only once that curve is asked for by :meth:`plot` or by the fiche. By
+        then the sensitivity level, the effective frequency range, the
+        directivity index and the equivalent noise level have long been
+        computed from the arrays as they were given. The check moves the
+        complaint to construction and names the pair that disagrees.
+
+        The four abscissae are independent quantities and are checked apart:
+        a fine free-field response beside a coarse polar and a one-third-octave
+        noise spectrum is the ordinary case, not a disagreement.
+
+        :raises ValueError: if either member of a paired curve disagrees with
+            the other.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            response_db=1,
+            distortion_spl_db=1,
+            distortion_thd_percent=1,
+            noise_frequencies=1,
+            noise_band_levels_db=1,
+            polar_angles_deg=1,
+            polar_db=1,
+        )
+        require_same_length(self, "frequencies", "response_db", axis="frequency")
+        require_same_length(
+            self, "polar_angles_deg", "polar_db", axis="angle of incidence"
+        )
+        require_same_length(
+            self, "noise_frequencies", "noise_band_levels_db", axis="band"
+        )
+        require_same_length(
+            self,
+            "distortion_spl_db",
+            "distortion_thd_percent",
+            axis="sound pressure level",
+        )
 
     @property
     def sensitivity_v_per_pa(self) -> float:

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -82,7 +82,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import special
 
-from .._internal.validation import require_positive
+from .._internal.validation import require_positive, require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -207,6 +207,33 @@ class PistonDirectivity:
     ka: np.ndarray
     directivity: np.ndarray
     directivity_db: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a bundle whose pattern matrix does not match its two grids.
+
+        The matrix is indexed by position on both sides: :meth:`plot` loops
+        over :attr:`ka` and reads row ``i`` as the pattern of ``ka[i]``,
+        drawing its columns over :attr:`angles`. Neither pairing is recorded
+        anywhere else, and only one of the ways they can disagree is quiet.
+        A matrix one row short runs that loop off the end of it, and the row
+        that is not there comes back as an ``IndexError`` out of NumPy; a
+        column count that differs in either direction is refused by matplotlib
+        with ``x and y must have same first dimension``. Both come from inside
+        the drawing code and name no field. A matrix one row too many is the
+        silent one: the loop stops at the last ``ka``, so the extra pattern is
+        never drawn -- no curve, no legend entry and no complaint.
+
+        :raises ValueError: if the pattern matrix disagrees with either grid.
+        """
+        require_ranks(self, angles=1, ka=1, directivity=2, directivity_db=2)
+        require_same_length(self, "ka", "directivity", "directivity_db", axis="pattern")
+        require_same_length(
+            self,
+            "angles",
+            ("directivity", 1),
+            ("directivity_db", 1),
+            axis="polar angle",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -344,6 +371,53 @@ class RadiatingPistonResult:
     radius: float
     speed_of_sound: float
     density: float
+
+    def __post_init__(self) -> None:
+        """Reject a piston result whose quantities disagree along an axis.
+
+        The impedance quantities are one curve each over the same frequency
+        axis, and :meth:`plot` draws two of them against a third; the
+        directivity pattern crosses that axis with the angle grid, carrying
+        the frequencies down its rows and the angles across its columns, and
+        :meth:`plot_geometry` picks one row by ``frequency_index`` to overlay
+        the far-field lobe. That row is a positional lookup into an array that
+        states nowhere how long it ought to be, so a pattern short of the
+        frequency count draws the lobe of one frequency under the ``ka`` of
+        another, silently and to scale. The angle axis is the loud half: a
+        column count that disagrees with :attr:`angles` is already refused
+        further down, by ``'angles' and 'directivity' must match.`` from the
+        drawing helper. The check keeps it here so that one is raised at
+        construction, against the result that carries it, instead of on the
+        way to a figure.
+
+        :raises ValueError: if a per-frequency quantity, or the pattern's
+            angle axis, disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            ka=1,
+            resistance=1,
+            reactance=1,
+            radiation_resistance=1,
+            radiation_reactance=1,
+            directivity_index=1,
+            angles=1,
+            directivity=2,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "ka",
+            "resistance",
+            "reactance",
+            "radiation_resistance",
+            "radiation_reactance",
+            "directivity_index",
+            "directivity",
+            axis="frequency",
+        )
+        require_same_length(self, "angles", ("directivity", 1), axis="polar angle")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/swept_sine.py
+++ b/src/phonometry/electroacoustics/swept_sine.py
@@ -60,6 +60,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import apply_calibration, resolve_fs
 
 if TYPE_CHECKING:
@@ -245,6 +246,61 @@ class SweptSineDistortionResult:
     duration: float
     rate: float
     method: str
+
+    def __post_init__(self) -> None:
+        """Reject a separation whose three axes disagree.
+
+        Order, frequency and excitation frequency are three different axes and
+        the readers cross them: :meth:`plot` labels row ``k`` of
+        :attr:`harmonic_responses` as order ``k + 1``, band-limits it to
+        ``[n f1, n f2]`` computed from that label, and draws the survivors over
+        :attr:`frequencies`; the THD panel pairs :attr:`thd` with
+        :attr:`thd_frequencies` point by point. A row missing from the response
+        matrix moves every higher order down one label and band-limits it to
+        the window of an order it is not, which leaves a plausible curve drawn
+        in the wrong place and nothing said anywhere. The THD pair is not
+        silent, only anonymous: it reaches matplotlib as it stands, so a curve
+        that disagrees with its abscissa raises
+        ``x and y must have same first dimension`` from inside the panel,
+        naming neither field. No panel reads :attr:`distortion_ratios` at all,
+        so a row of it that runs over other excitation frequencies arrives
+        intact at whoever draws it against :attr:`thd_frequencies` by hand.
+
+        The window length of :attr:`harmonic_irs` is deliberately not tied to
+        :attr:`frequencies`: the responses are the half-spectrum of the
+        windowed impulse responses, so the two axes differ by construction and
+        pinning them together would reject every result this module builds.
+
+        :raises ValueError: if the harmonic, frequency or excitation-frequency
+            axis disagrees across the fields that share it.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            harmonic_responses=2,
+            harmonic_irs=2,
+            delays=1,
+            thd_frequencies=1,
+            thd=1,
+            distortion_ratios=2,
+        )
+        require_same_length(
+            self, "frequencies", ("harmonic_responses", 1), axis="frequency"
+        )
+        require_same_length(
+            self,
+            "harmonic_responses",
+            "harmonic_irs",
+            "delays",
+            axis="harmonic order",
+        )
+        require_same_length(
+            self,
+            "thd_frequencies",
+            "thd",
+            ("distortion_ratios", 1),
+            axis="excitation frequency",
+        )
 
     @property
     def n_harmonics(self) -> int:

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -68,6 +68,12 @@ if TYPE_CHECKING:
 
 from .._internal.levels_math import energy_mean
 from .._internal.utils import _typesignal
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from ..filters.frequencies import _genfreqs
 from ..signals.spectra import (
     _MIN_SAMPLES,
@@ -158,6 +164,44 @@ class IntensityResult:
     max_valid_frequency: float
     spacing: float | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a measurement whose per-band arrays do not share the bands.
+
+        The band figure draws Lp and LI against ``frequency`` and lays the
+        pressure-intensity index over them as one bar per band. A bar chart
+        takes a single height for a whole row of bars without objecting, so
+        an index of one value paints every band with the reactivity of one of
+        them, under a title stating the total; the lengths matplotlib does
+        object to are reported as two shapes it could not broadcast, from
+        inside the figure call, naming neither the field nor the result.
+
+        Either the band ``fraction`` was requested and all seven arrays are
+        present, or none of them is; ``None`` is not a disagreement.
+
+        :raises ValueError: if two of the per-band arrays disagree in length,
+            or one is a single number.
+        """
+        require_ranks(
+            self,
+            frequency=1,
+            intensity=1,
+            intensity_level=1,
+            pressure_level=1,
+            pressure_intensity_index=1,
+            direction=1,
+            bias_correction=1,
+        )
+        require_same_length(
+            self,
+            "frequency",
+            "intensity",
+            "intensity_level",
+            "pressure_level",
+            "pressure_intensity_index",
+            "direction",
+            "bias_correction",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -222,6 +266,54 @@ class FieldIndicators:
     f4: float | np.ndarray
     frequency: np.ndarray | None = None
     f1: float | np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject indicators that do not all describe the same bands.
+
+        The figure draws F2 and F3 against ``frequency`` and puts F4 and F1
+        on the twin axis, where a short indicator is not read as short: F4
+        arrives as one bar per band and a bar chart takes a single height for
+        the whole row, while F1 is broadcast onto the band axis outright, so
+        one value is drawn as a flat line across every band against the
+        Table B.3 limit, and the figure shows a field qualified over the
+        whole spectrum. :meth:`field_is_stationary` answers from the same
+        array, band by band.
+
+        An indicator is a scalar for a single-band surface and an array for a
+        per-band one, the shape :func:`field_indicators` gives it following
+        its input, so a scalar is counted here as the one band it describes.
+        That is what makes a scalar F1 beside a five-band F2 the
+        disagreement it is, rather than a shape the pair is free to take.
+
+        The rank each count is taken under is pinned beside it, because an
+        indicator of shape ``(bands, 2)`` counts one value per band on its
+        first axis and so clears every count above. Matplotlib reads a
+        two-column y as two series, and F2 and F3 are drawn that way: a
+        two-column one of either comes out as a pair of curves over the same
+        band centres, entered in the legend twice under the one label, with
+        nothing raised and no sign of which curve the surface was measured
+        for. The other three stop, each somewhere else and none of them
+        naming the field or the result: the bar chart on a height it cannot
+        broadcast to the band centres, the F1 line on an operand with more
+        dimensions than the axis remapping allows, and the frequency axis on
+        tick locations that are not one-dimensional.
+
+        :raises ValueError: if two indicators, or the band centres beside
+            them, span different numbers of bands, or one of them carries an
+            extra axis.
+        """
+        owner = type(self).__name__
+        counts: dict[str, int] = {}
+        for name in ("frequency", "f1", "f2", "f3", "f4"):
+            value = getattr(self, name)
+            if value is None:
+                continue
+            counts[name] = (
+                1
+                if np.ndim(value) == 0
+                else require_axis_count(value, owner, name, rank=1)
+            )
+        require_equal_counts(owner, counts)
 
     def field_is_stationary(
         self, limit: float = TEMPORAL_VARIABILITY_LIMIT

--- a/src/phonometry/emission/sound_power_anechoic.py
+++ b/src/phonometry/emission/sound_power_anechoic.py
@@ -47,6 +47,7 @@ import numpy as np
 
 from .._internal.levels_math import energy_mean, energy_sum, weighted_energy_mean
 from .._internal.types import as_float_or_array
+from .._internal.validation import require_ranks, require_same_length
 from ._shared import _S0, SoundPowerWarning, _a_weighting_corrections
 
 if TYPE_CHECKING:
@@ -287,6 +288,61 @@ class PrecisionSoundPowerResult:
     uncertainty: float
     uncertainty_bands: np.ndarray
     coverage_factor: float
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-band quantities disagree.
+
+        The fiche takes its row count from ``sound_power_level`` and its row
+        labels from ``frequencies``, so a longer band axis labels the rows
+        with the first of its centres and drops the rest without a word,
+        while the boxed A-weighted total was summed at construction over the
+        whole spectrum and states a number for bands the table beside it does
+        not show. The meteorological ``C3`` reaches the measurement-basis
+        strip as a range rather than as a column, and a range is well formed
+        whatever set of bands it was taken over.
+
+        ``background_correction`` and ``directivity_index`` carry the
+        microphone positions on their first axis and the bands on their
+        second, so the band axis to pin is index 1. The positions are an axis
+        of their own: ``K1i`` is the correction applied to position ``i``
+        (Eq. 11) and ``DIi`` the deviation of that same position from the
+        surface average (Eq. 21), so whoever reads the surface reads the two
+        side by side, and two different position counts leave no position
+        ``i`` to read.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            or the two per-position arrays cover different positions.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            sound_power_level=1,
+            surface_pressure_level=1,
+            mean_pressure_level=1,
+            background_correction=2,
+            c3=1,
+            directivity_index=2,
+            non_uniformity_index=1,
+            uncertainty_bands=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "sound_power_level",
+            "surface_pressure_level",
+            "mean_pressure_level",
+            ("background_correction", 1),
+            "c3",
+            ("directivity_index", 1),
+            "non_uniformity_index",
+            "uncertainty_bands",
+        )
+        require_same_length(
+            self,
+            "background_correction",
+            "directivity_index",
+            axis="microphone position",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -758,6 +758,27 @@ class PrecisionFieldIndicators:
     f_pi_signed: np.ndarray
     fs: np.ndarray
 
+    def __post_init__(self) -> None:
+        """Reject indicators that do not all span the same bands.
+
+        The four indicators are what clause 10 f) 1) has the report state,
+        band by band in the verbose table and as a range in the
+        measurement-basis strip, and they are read against each other before
+        that: :func:`precision_qualification` forms criterion 3 from the
+        difference of the two pressure-intensity indicators and criterion 4
+        from ``fs``, taking its band count from ``f_pi_signed`` alone. An
+        indicator carrying a single value is broadcast into the difference
+        for every band, so one band's reading qualifies the whole spectrum;
+        one of another length raises from inside numpy about two shapes,
+        naming neither indicator. ``ft`` is absent unless time-window
+        intensities were supplied, which is not a disagreement.
+
+        :raises ValueError: if two of the indicators span different numbers
+            of bands.
+        """
+        require_ranks(self, ft=1, f_pi_unsigned=1, f_pi_signed=1, fs=1)
+        require_same_length(self, "ft", "f_pi_unsigned", "f_pi_signed", "fs")
+
 
 @dataclass(frozen=True)
 class PrecisionCriteria:
@@ -786,6 +807,42 @@ class PrecisionCriteria:
     criterion_4: np.ndarray
     criterion_5: np.ndarray | None
     qualified: np.ndarray | None
+
+    def __post_init__(self) -> None:
+        """Reject a verdict set whose criteria do not span the same bands.
+
+        ``qualified`` is the conjunction of the others, and a conjunction is
+        taken with numpy's broadcasting: a criterion carrying a single value
+        decides every band at once, so a five-band determination can be
+        qualified, and its A-weighted total taken over the bands the fiche
+        keeps (clause 10 f) 2)), on one band's verdict. The criteria come
+        from separately measured scans and reach this type without ever
+        having been compared with each other: criterion 5 is formed from its
+        own pair of field-non-uniformity spectra, whose length nothing else
+        constrains. A criterion is ``None`` when its inputs were not
+        supplied, which is not a disagreement.
+
+        :raises ValueError: if two of the criteria span different numbers of
+            bands.
+        """
+        require_ranks(
+            self,
+            criterion_1=1,
+            criterion_2=1,
+            criterion_3=1,
+            criterion_4=1,
+            criterion_5=1,
+            qualified=1,
+        )
+        require_same_length(
+            self,
+            "criterion_1",
+            "criterion_2",
+            "criterion_3",
+            "criterion_4",
+            "criterion_5",
+            "qualified",
+        )
 
 
 def _check_report_bands(
@@ -866,6 +923,44 @@ class PrecisionIntensityResult:
     not_applicable_band: np.ndarray
     surface_area: float
     sound_power_level_a: float
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-band quantities disagree.
+
+        The fiche prints one row per band, taking the row count from
+        ``sound_power_level`` and the labels from ``frequencies``, so a
+        longer band axis labels the rows with the first of its centres and
+        says nothing about the rest, while the boxed A-weighted total was
+        summed at construction over the whole spectrum and states a number
+        for bands the table beside it does not show. ``not_applicable_band``
+        marks the rows outside the method (clause 9.2) and joins the
+        qualification mask that drops bands from that total, a boolean array
+        combined with another: one value in it marks every band at once.
+
+        ``partial_power`` carries the partial surfaces on its first axis and
+        the bands on its second, so its band axis is index 1; the partial
+        surfaces are its own axis, shared with no other field.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            partial_power=2,
+            sound_power=1,
+            sound_power_level=1,
+            sound_power_level_normalized=1,
+            not_applicable_band=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            ("partial_power", 1),
+            "sound_power",
+            "sound_power_level",
+            "sound_power_level_normalized",
+            "not_applicable_band",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 from .._internal.levels_math import energy_mean, energy_sum
+from .._internal.validation import require_ranks, require_same_length
 from ._shared import (
     SoundPowerWarning,
     _a_weighting_corrections,
@@ -127,6 +128,38 @@ class ReverberationSoundPowerResult:
     speed_of_sound: float
     sound_power_level_a: float
     method: str
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-band quantities disagree.
+
+        The fiche prints one row per band under a single header, and the row
+        count comes from ``sound_power_level`` alone: every other column
+        (``Lp``, and ``K1``, ``A``, ``Cw`` in the verbose table) is indexed
+        alongside it, and ``frequencies`` names the bands those rows are
+        labelled with. A quantity one entry short therefore cannot be read at
+        all, and one entry too long is dropped by the table without a word,
+        under a boxed ``LWA`` that was summed over the whole of it.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            sound_power_level=1,
+            mean_pressure_level=1,
+            absorption_area=1,
+            waterhouse_correction=1,
+            background_correction=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "sound_power_level",
+            "mean_pressure_level",
+            "absorption_area",
+            "waterhouse_correction",
+            "background_correction",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -59,7 +59,11 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 
-from .._internal.validation import require_positive
+from .._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 #: Reference vibratory velocity ``v0`` (ISO/TS 7849, Equation 3), m/s.
 REFERENCE_VELOCITY: float = 5.0e-8
@@ -274,6 +278,36 @@ class VibrationSoundPowerResult:
     radiation_factor: np.ndarray
     area: float
     frequencies: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a determination whose per-band quantities disagree.
+
+        The fiche prints one row per band under a single header, taking the
+        row count from ``sound_power_level`` and reading ``velocity_level``
+        (and ``radiation_factor`` in the verbose table) at the same indices,
+        so a short array cannot be read to the end of the sheet and a long one
+        is dropped by it silently. ``frequencies`` are worse than truncated:
+        they pick the A-weighting corrections that :attr:`sound_power_level_a`
+        adds band by band, and a single stray frequency broadcasts its one
+        correction across every band, boxing an ``LWA`` that no band of the
+        table supports.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            velocity_level=1,
+            sound_power_level=1,
+            radiation_factor=1,
+            frequencies=1,
+        )
+        require_same_length(
+            self,
+            "velocity_level",
+            "sound_power_level",
+            "radiation_factor",
+            "frequencies",
+        )
 
     @property
     def total_level(self) -> float:

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -498,6 +498,22 @@ class ImpulsiveSoundResult:
     laeq: float
     adjusted_laeq: float
 
+    def __post_init__(self) -> None:
+        """Reject a trace whose levels and time axis are of different lengths.
+
+        The result holds two accounts of when its samples were taken: the
+        times, and the ``dt`` the onsets were located and timed with. The two
+        are the same account only while there is one time per level. Where
+        there is not, the figure draws the trace on one of them and marks the
+        onsets on the other, and the governing onset -- the one the category
+        and the ``KI`` adjustment come from -- is annotated at a moment the
+        curve beneath it never reaches.
+
+        :raises ValueError: if ``times`` and ``levels`` disagree.
+        """
+        require_ranks(self, times=1, levels=1)
+        require_same_length(self, "times", "levels", axis="sample")
+
     @property
     def governing_onset(self) -> ImpulseOnset | None:
         """The qualifying onset with the highest prominence, or ``None``."""
@@ -549,6 +565,21 @@ class LevelHistory:
     times: np.ndarray
     levels: np.ndarray
     dt: float
+
+    def __post_init__(self) -> None:
+        """Reject a trace whose levels and time axis are of different lengths.
+
+        The history is handed on as a pair, and it unpacks as one, so whoever
+        receives it puts the two arrays together again: a window taken as
+        ``levels[times > t]`` needs them to index alike, and the plot draws
+        one against the other. A pair whose halves disagree is not a level
+        history at all, so it is refused where it is made rather than at each
+        place it is opened.
+
+        :raises ValueError: if ``times`` and ``levels`` disagree.
+        """
+        require_ranks(self, times=1, levels=1)
+        require_same_length(self, "times", "levels", axis="sample")
 
     def __iter__(self) -> Iterator[np.ndarray]:
         """Yield ``times`` then ``levels`` so the result unpacks like a tuple."""

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -72,6 +72,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from ..._internal.warnings import PhonometryWarning
 from ...materials.absorbers.sound_absorption import attenuation_from_alpha
 
@@ -331,17 +332,49 @@ class AtmosphericAttenuation:
     distance: float | None = None
 
     def __post_init__(self) -> None:
-        """Validate the ``distance`` invariant on any construction path.
+        """Validate the ``distance`` invariant and the curve it belongs to.
 
         A propagation distance must be finite and non-negative; enforcing it
         here (rather than only in :func:`atmospheric_attenuation`) keeps direct
         construction of the frozen result and the factory consistent.
+
+        The rest of the result is a single curve: every entry of
+        :attr:`attenuation_coefficient` is Eq. (5) evaluated at the frequency
+        in the same position of :attr:`frequencies`, which is why the factory
+        derives both from the one array the caller passed. :meth:`plot` reads
+        them as that pair, in one ``semilogx`` call of alpha against the
+        frequencies, and neither way of breaking the pairing is reported in
+        those terms. Two different lengths are matplotlib's ``x and y must
+        have same first dimension, but have shapes (6,) and (3,)``, raised
+        from inside the plotter for a coefficient both shorter and longer than
+        its frequencies, naming neither field, nor this result, nor which of
+        the two shapes is the frequency axis. An extra axis is not reported at
+        all: a coefficient of shape ``(6, 2)`` -- the shape a caller lands on
+        by stacking the coefficients of two atmospheres -- is drawn silently as
+        two curves over the one frequency axis, with the single set of stored
+        conditions printed twice in the legend, once per curve; a
+        ``(6, 2)`` frequency array draws the same two curves just as quietly,
+        over limits taken from the whole of it.
+
+        A pair of nought-dimensional arrays is left alone: there is no axis
+        there to disagree about. The factory never builds one -- it stores a
+        single frequency as a length-one array -- but a direct construction
+        from a scalar evaluation does, and a scalar paired with an array is
+        still refused as a coefficient that carries no value per frequency.
+
+        :raises ValueError: if ``distance`` is negative or non-finite, or if
+            the coefficient and the frequency axis do not carry one value each
+            per frequency, or either of them carries an extra axis.
         """
         if self.distance is not None and (
             not np.isfinite(self.distance) or self.distance < 0.0
         ):
             msg = "'distance' must be a finite, non-negative number of metres."
             raise ValueError(msg)
+        require_ranks(self, frequencies=1, attenuation_coefficient=1)
+        require_same_length(
+            self, "frequencies", "attenuation_coefficient", axis="frequency"
+        )
 
     @property
     def total_attenuation(self) -> NDArray[np.float64] | None:

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from .air_absorption import air_attenuation
 
 if TYPE_CHECKING:
@@ -284,6 +285,41 @@ class OutdoorAttenuation:
     a_bar: NDArray[np.float64]
     a_total: NDArray[np.float64]
     d_omega: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Reject a breakdown whose terms do not all run over the same bands.
+
+        The prediction sheet lays the terms out as columns of one table, a row
+        per entry of :attr:`frequencies`, and closes on a boxed figure taken
+        over the whole of a column: the octave-band range of the total
+        attenuation, or the A-weighted downwind level when a source emission
+        is supplied. A term shorter than the bands stops the render partway
+        down the table; a term longer is cut off by it and still counted in
+        the boxed figure underneath, so the sheet states a result over bands
+        that appear nowhere in the table above it.
+
+        :raises ValueError: if any term disagrees with ``frequencies``.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            a_div=1,
+            a_atm=1,
+            a_gr=1,
+            a_bar=1,
+            a_total=1,
+            d_omega=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "a_div",
+            "a_atm",
+            "a_gr",
+            "a_bar",
+            "a_total",
+            "d_omega",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -54,7 +54,11 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..._internal.rays import march_rays
-from ..._internal.validation import require_positive
+from ..._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -99,6 +103,22 @@ class EffectiveSoundSpeedProfile:
     heights: NDArray[np.float64]
     sound_speeds: NDArray[np.float64]
     description: str = ""
+
+    def __post_init__(self) -> None:
+        """Reject a profile with more heights than speeds, or the reverse.
+
+        A profile is a polyline: each height is a node and each sound speed is
+        the value at that node, and the atmosphere between them is whatever
+        the interpolation makes of the pair. The tracer and the solver both
+        re-derive this check on the way in, because a profile they cannot
+        interpolate is no profile at all; making it here means the profile
+        that reaches them, and the one a reader plots or samples with
+        :meth:`speed_at`, was already a polyline when it was built.
+
+        :raises ValueError: if ``heights`` and ``sound_speeds`` disagree.
+        """
+        require_ranks(self, heights=1, sound_speeds=1)
+        require_same_length(self, "heights", "sound_speeds", axis="profile node")
 
     def speed_at(self, height: ArrayLike) -> NDArray[np.float64]:
         """Piecewise-linear effective sound speed at one or more heights."""
@@ -351,6 +371,53 @@ class AtmosphericRayResult:
     ground_reflections: NDArray[np.int_]
     source_height: float
 
+    def __post_init__(self) -> None:
+        """Reject a solution whose rays and marched paths do not line up.
+
+        Two axes run through this result and neither is safe to leave open.
+        Along the first, one ray: the figure draws ray ``i`` from row ``i`` of
+        the ranges and row ``i`` of the heights, and the turning points and
+        ground reflections beside it count what happened on that same ray. An
+        array carrying a ray more than the rest is simply not drawn, and the
+        turning points and reflections of the ray nobody sees are still there
+        to be counted. Along the second, one range sample: the range and the
+        height of a sample are read as a pair, and a path traced over a
+        different number of samples than the ranges it is drawn against is not
+        a shorter path but a differently shaped one. The samples are the
+        columns the shared marcher lays down, launch point included, so the
+        axis is one longer than the steps that made it and is named for what
+        it counts, as it is on the ocean tracer this one shares that marcher
+        with.
+
+        :raises ValueError: if the per-ray or per-sample axes disagree.
+        """
+        require_ranks(
+            self,
+            launch_angles=1,
+            ranges=2,
+            heights=2,
+            travel_times=2,
+            turning_points=1,
+            ground_reflections=1,
+        )
+        require_same_length(
+            self,
+            "launch_angles",
+            "ranges",
+            "heights",
+            "travel_times",
+            "turning_points",
+            "ground_reflections",
+            axis="ray",
+        )
+        require_same_length(
+            self,
+            ("ranges", 1),
+            ("heights", 1),
+            ("travel_times", 1),
+            axis="range sample",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -521,6 +588,24 @@ class AtmosphericPEResult:
     relative_level: NDArray[np.float64]
     source_height: float
     normalized_impedance: complex
+
+    def __post_init__(self) -> None:
+        """Reject a field that does not fit the grid it is quoted on.
+
+        The field is drawn as one image stretched over the extent of the two
+        grids, from the first range to the last and the first height to the
+        last, so a field of the wrong shape draws without complaint and every
+        level in the picture is read off at a range and a height that are not
+        its own. :meth:`level_at_height` fails the same quiet way: it picks a
+        row by searching ``heights`` and returns that row of the field, which
+        for a mismatched pair is an ordinary-looking level-versus-range curve
+        taken at some other height than the one asked for.
+
+        :raises ValueError: if the field disagrees with either grid.
+        """
+        require_ranks(self, ranges=1, heights=1, relative_level=2)
+        require_same_length(self, "heights", "relative_level", axis="height")
+        require_same_length(self, "ranges", ("relative_level", 1), axis="range")
 
     def level_at_height(self, height: float) -> NDArray[np.float64]:
         """Relative sound level versus range at the grid height nearest ``height``."""

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -1707,6 +1707,12 @@ _SQUEAL_TRAIN_MODERATE_RADIUS = 500.0
 _SQUEAL_TRAM_RADIUS = 200.0
 _SQUEAL_MINIMUM_TRACK_LENGTH = 50.0
 
+#: The spectral axis CNOSSOS-EU tabulates rolling and traction noise over.
+_THIRD_OCTAVE_AXIS = "1/3-octave band"
+
+#: The axis of the two source heights the method splits every spectrum over.
+_SOURCE_HEIGHT_AXIS = "source height"
+
 
 # ---------------------------------------------------------------------------
 # Small helpers
@@ -2409,24 +2415,24 @@ class RailwayEmissionResult:
             self,
             "third_octave_frequencies",
             ("third_octave_line_power", 1),
-            axis="1/3-octave band",
+            axis=_THIRD_OCTAVE_AXIS,
         )
         require_same_length(
             self,
             "heights",
             "line_power",
             "third_octave_line_power",
-            axis="source height",
+            axis=_SOURCE_HEIGHT_AXIS,
         )
         owner = type(self).__name__
         heights = require_axis_count(
-            self.heights, owner, "heights", "source height", rank=None
+            self.heights, owner, "heights", _SOURCE_HEIGHT_AXIS, rank=None
         )
         bands = require_axis_count(
             self.third_octave_frequencies,
             owner,
             "third_octave_frequencies",
-            "1/3-octave band",
+            _THIRD_OCTAVE_AXIS,
             rank=None,
         )
         for name, pair in self.components.items():
@@ -2436,10 +2442,10 @@ class RailwayEmissionResult:
                 {
                     "heights": heights,
                     label: require_axis_count(
-                        pair, owner, label, "source height", rank=None
+                        pair, owner, label, _SOURCE_HEIGHT_AXIS, rank=None
                     ),
                 },
-                "source height",
+                _SOURCE_HEIGHT_AXIS,
             )
             for i, spectrum in enumerate(pair):
                 entry = f"{label}[{i}]"
@@ -2448,10 +2454,10 @@ class RailwayEmissionResult:
                     {
                         "third_octave_frequencies": bands,
                         entry: require_axis_count(
-                            spectrum, owner, entry, "1/3-octave band", rank=1
+                            spectrum, owner, entry, _THIRD_OCTAVE_AXIS, rank=1
                         ),
                     },
-                    "1/3-octave band",
+                    _THIRD_OCTAVE_AXIS,
                 )
 
     def plot(

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -80,6 +80,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -2369,6 +2376,83 @@ class RailwayEmissionResult:
     components: dict[str, tuple[NDArray[np.float64], NDArray[np.float64]]] = field(
         default_factory=dict
     )
+
+    def __post_init__(self) -> None:
+        """Reject an emission whose three axes do not each line up.
+
+        The same emission is carried on three axes, and every reading of it
+        pairs a position on one with a position on another: a row of
+        :attr:`line_power` with the source height that names it, a value with
+        the band it is quoted at, a component spectrum with the 1/3-octave
+        grid it was resampled onto. None of that pairing is checked where it
+        happens -- the chart lays its two marker lines over the octave bars by
+        row order, and the source breakdown is read band by band against
+        :attr:`third_octave_frequencies` -- so an axis one entry out does not
+        announce itself. It attributes the noise to the wrong band, or to the
+        wrong one of the two source heights, and the level it reports there is
+        an ordinary number in an ordinary place.
+
+        :raises ValueError: if the band, 1/3-octave or source-height axes
+            disagree.
+        """
+        require_ranks(
+            self,
+            third_octave_frequencies=1,
+            frequencies=1,
+            heights=1,
+            third_octave_line_power=2,
+            line_power=2,
+            total_line_power=1,
+        )
+        require_same_length(self, "frequencies", ("line_power", 1), "total_line_power")
+        require_same_length(
+            self,
+            "third_octave_frequencies",
+            ("third_octave_line_power", 1),
+            axis="1/3-octave band",
+        )
+        require_same_length(
+            self,
+            "heights",
+            "line_power",
+            "third_octave_line_power",
+            axis="source height",
+        )
+        owner = type(self).__name__
+        heights = require_axis_count(
+            self.heights, owner, "heights", "source height", rank=None
+        )
+        bands = require_axis_count(
+            self.third_octave_frequencies,
+            owner,
+            "third_octave_frequencies",
+            "1/3-octave band",
+            rank=None,
+        )
+        for name, pair in self.components.items():
+            label = f"components[{name!r}]"
+            require_equal_counts(
+                owner,
+                {
+                    "heights": heights,
+                    label: require_axis_count(
+                        pair, owner, label, "source height", rank=None
+                    ),
+                },
+                "source height",
+            )
+            for i, spectrum in enumerate(pair):
+                entry = f"{label}[{i}]"
+                require_equal_counts(
+                    owner,
+                    {
+                        "third_octave_frequencies": bands,
+                        entry: require_axis_count(
+                            spectrum, owner, entry, "1/3-octave band", rank=1
+                        ),
+                    },
+                    "1/3-octave band",
+                )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/environment/sources/cnossos_road.py
+++ b/src/phonometry/environment/sources/cnossos_road.py
@@ -54,6 +54,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -887,6 +889,55 @@ class RoadEmissionResult:
     line_power: NDArray[np.float64]
     total_line_power: NDArray[np.float64]
     source_height: float = ROAD_SOURCE_HEIGHT
+
+    def __post_init__(self) -> None:
+        """Reject an emission whose categories and bands do not line up.
+
+        Two axes have to hold. The band axis is the one the A-weighted line
+        power reads: it adds the eight weights of 2.5.5 to the spectrum
+        term by term, so a spectrum of a single band is stretched over all
+        eight by numpy and returns an ordinary-looking dB(A) figure summed
+        over seven bands that were never computed. The category axis is the
+        one the chart reads: it takes the curves from the rows of
+        ``line_power`` and their names from ``categories`` in one strict
+        zip, so a spectrum is never drawn under another category's label.
+        What that zip cannot do is say what went wrong. It raises ``zip()
+        argument 2 is longer than argument 1`` from inside the drawing code,
+        naming neither the result nor either field, and it raises only if
+        the emission is ever plotted: one read for its numbers alone carries
+        the disagreement to the end. Refusing it here names both fields, at
+        the point where the two counts were chosen.
+
+        :raises ValueError: if a per-category array disagrees with
+            ``categories``, or a per-band one with ``frequencies``.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            rolling=2,
+            propulsion=2,
+            vehicle_power=2,
+            line_power=2,
+            total_line_power=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            ("rolling", 1),
+            ("propulsion", 1),
+            ("vehicle_power", 1),
+            ("line_power", 1),
+            "total_line_power",
+        )
+        require_same_length(
+            self,
+            "categories",
+            "rolling",
+            "propulsion",
+            "vehicle_power",
+            "line_power",
+            axis="vehicle category",
+        )
 
     @property
     def a_weighted_line_power(self) -> float:

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -217,6 +218,23 @@ class WindTurbineTonalityResult:
     has_identified_tone: bool
     frequencies: NDArray[np.float64]
     levels: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Reject a spectrum whose lines and levels do not pair up.
+
+        The fiche puts the whole Formula 30 to 34 chain beside a drawing of
+        the spectrum it was taken from, and that drawing pairs the two arrays
+        line by line. The pairing is what the reader checks the numbers
+        against: it is where the tone is seen standing above the masking
+        level, inside the critical band the metrics table names. Two arrays
+        of different lengths cannot be paired, so the frequency read off the
+        drawing is not the one the tonality was computed at.
+
+        :raises ValueError: if ``frequencies`` and ``levels`` differ in
+            length, or either is not a 1-D spectrum.
+        """
+        require_ranks(self, frequencies=1, levels=1)
+        require_same_length(self, "frequencies", "levels", axis="spectral line")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/filters/equalizer.py
+++ b/src/phonometry/filters/equalizer.py
@@ -65,6 +65,7 @@ import numpy as np
 from scipy import signal
 
 from .._internal.utils import _sos_initial_state, _sos_state_mismatch
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import (
     like_input,
     refuse_foreign_rate,
@@ -444,6 +445,44 @@ class EQResponseResult:
     sos: NDArray[np.float64]
     fs: float
     sections: tuple[EQSection, ...]
+
+    def __post_init__(self) -> None:
+        """Reject a response whose curves and sections do not line up.
+
+        The response carries two independent axes, the evaluation grid and
+        the cascade, and the figure reads both by position: every curve is
+        drawn against ``frequencies``, and each row of
+        ``section_magnitude_db`` is labelled with the :class:`EQSection`
+        standing at the same place in ``sections``. A cascade taller than
+        that list therefore loses its surplus rows from the plot with no word
+        said, and one shorter than it labels a row with the parameters of a
+        biquad it was not computed from. The ``sos`` block is the third
+        reading of the same axis: it leaves here to be filtered with, so a
+        cascade of a different height is no longer the one the curves
+        describe.
+
+        :raises ValueError: if the frequency or the section axis disagrees
+            across the fields that share it.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            magnitude_db=1,
+            phase_rad=1,
+            section_magnitude_db=2,
+            sos=2,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "magnitude_db",
+            "phase_rad",
+            ("section_magnitude_db", 1),
+            axis="evaluation frequency",
+        )
+        require_same_length(
+            self, "section_magnitude_db", "sos", "sections", axis="section"
+        )
 
     def plot(
         self,

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from .._internal.warnings import PhonometryWarning
 from .threshold import age_threshold
 
@@ -168,6 +169,39 @@ class NiptsResult:
     spread_upper: np.ndarray
     spread_lower: np.ndarray
 
+    def __post_init__(self) -> None:
+        """Reject a prediction whose spectra do not all cover the same frequencies.
+
+        The fiche prints one row per audiometric frequency, reading the median
+        and the fractile value at that row's position, and beneath the table it
+        boxes a representative shift averaged over the 2/3/4 kHz positions of
+        those same arrays; the plot draws the fractile band from the median and
+        the two spreads against a single frequency axis. Everything pairs by
+        position, so a spectrum one entry short stops the renderer far from
+        here, and one entry long is dropped from the table without a word, in
+        both cases after its values have been read against frequencies other
+        than the ones they were computed for.
+
+        :raises ValueError: if any spectrum disagrees with ``frequencies``.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            median=1,
+            value=1,
+            spread_upper=1,
+            spread_lower=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "median",
+            "value",
+            "spread_upper",
+            "spread_lower",
+            axis="audiometric frequency",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -259,6 +293,30 @@ class HtlanResult:
     htla: np.ndarray
     nipts: np.ndarray
     threshold: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a threshold whose three components cover different frequencies.
+
+        Formula (1) combines the age component and the noise component one
+        audiometric frequency at a time, and the fiche prints that combination
+        the same way: ``H``, ``N`` and ``H'`` side by side on one row per
+        frequency, with a representative threshold boxed beneath from the
+        2/3/4 kHz positions of the combined array. Table and plot alike pair
+        the columns by position, so a component of another length sets an age
+        threshold beside a noise shift belonging to a different frequency and
+        the sheet shows a combination that was never computed.
+
+        :raises ValueError: if any component disagrees with ``frequencies``.
+        """
+        require_ranks(self, frequencies=1, htla=1, nipts=1, threshold=1)
+        require_same_length(
+            self,
+            "frequencies",
+            "htla",
+            "nipts",
+            "threshold",
+            axis="audiometric frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/hearing/threshold.py
+++ b/src/phonometry/hearing/threshold.py
@@ -28,6 +28,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike
@@ -203,6 +205,38 @@ class AgeThresholdResult:
     spread_upper: np.ndarray
     spread_lower: np.ndarray
     threshold: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a distribution whose spectra do not all cover the same frequencies.
+
+        The plot draws the fractile band by adding the two spreads to the
+        median against a single frequency axis, and the age component reaches
+        the ISO 1999 combined threshold the same way, added to the noise
+        component one audiometric frequency at a time. Both pair by position,
+        so a spectrum of another length shifts the band onto frequencies it
+        was not computed for; where the mismatch does surface, it surfaces as
+        matplotlib complaining that x and y differ in size, which says nothing
+        about which of the two spectra was the wrong one.
+
+        :raises ValueError: if any spectrum disagrees with ``frequencies``.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            median=1,
+            spread_upper=1,
+            spread_lower=1,
+            threshold=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "median",
+            "spread_upper",
+            "spread_lower",
+            "threshold",
+            axis="audiometric frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -54,6 +54,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike, NDArray
@@ -247,6 +254,84 @@ class AbsorptionRatingResult:
     shifted_reference: NDArray[np.float64]
     third_octave_alpha_s: NDArray[np.float64] | None = None
     third_octave_bands: NDArray[np.float64] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a rating whose curves do not run over their own bands.
+
+        The evaluation table of the fiche prints one row per octave -- the
+        band, its practical coefficient, the shifted reference there and the
+        unfavourable deviation between them -- and totals that last column
+        beneath the rows, against the 0,10 budget of Clause 4.2. The deviation
+        column is a subtraction of two of these curves, and numpy stretches a
+        curve carrying a single value across the others rather than refuse it,
+        so the total can be taken over a reference the rows above it never
+        showed. :meth:`plot` shades the same deviations between the same two
+        curves.
+
+        The two band axes are different sets, so they are checked apart: the
+        rating runs over the five octaves of Clause 4.1, while the ``alpha_s``
+        retained from ISO 354 runs over the fifteen one-third octaves each
+        octave was averaged from. Apart is not independent, though. The
+        accredited table of the fiche prints the two side by side, and it
+        finds the octave belonging to one-third-octave row ``j`` by
+        arithmetic, reading ``measured[j // 3]``: three one-third octaves to
+        every octave, or the column does not line up. A retained ``alpha_s``
+        longer than three times the rating runs that lookup off the end of
+        ``measured`` and the fiche dies mid-table on a bare ``IndexError``
+        naming neither field; a shorter one writes a table short of rows
+        whose practical-coefficient column stops before the last octave,
+        with nothing on the page to say that octave was left out. Both
+        one-third-octave fields are absent together for a rating built from
+        octave coefficients alone, which is not a disagreement.
+
+        :raises ValueError: if the octave curves disagree with each other, if
+            the retained one-third-octave ``alpha_s`` disagrees with its band
+            centres, or if it does not hold three bands per rating octave.
+        """
+        require_ranks(
+            self,
+            band_centers=1,
+            measured=1,
+            shifted_reference=1,
+            third_octave_alpha_s=1,
+            third_octave_bands=1,
+        )
+        require_same_length(
+            self,
+            "band_centers",
+            "measured",
+            "shifted_reference",
+            axis="octave band",
+        )
+        require_same_length(
+            self,
+            "third_octave_alpha_s",
+            "third_octave_bands",
+            axis="one-third-octave band",
+        )
+        if self.third_octave_alpha_s is not None:
+            owner = type(self).__name__
+            require_equal_counts(
+                owner,
+                {
+                    "third_octave_alpha_s": require_axis_count(
+                        self.third_octave_alpha_s,
+                        owner,
+                        "third_octave_alpha_s",
+                        "one-third-octave band",
+                        rank=None,
+                    ),
+                    "3 x band_centers": 3
+                    * require_axis_count(
+                        self.band_centers,
+                        owner,
+                        "band_centers",
+                        "octave band",
+                        rank=None,
+                    ),
+                },
+                "one-third-octave band",
+            )
 
     @property
     def rating_label(self) -> str:

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -141,6 +141,10 @@ _CLASS_TABLE: tuple[tuple[int, str], ...] = (
 )
 _NOT_CLASSIFIED = "Not classified"
 
+#: The axis the measured absorption is reported over before it is collected
+#: into the octave bands the rating is read from.
+_THIRD_OCTAVE_AXIS = "one-third-octave band"
+
 
 # --- rounding helpers ----------------------------------------------------
 
@@ -307,7 +311,7 @@ class AbsorptionRatingResult:
             self,
             "third_octave_alpha_s",
             "third_octave_bands",
-            axis="one-third-octave band",
+            axis=_THIRD_OCTAVE_AXIS,
         )
         if self.third_octave_alpha_s is not None:
             owner = type(self).__name__
@@ -318,7 +322,7 @@ class AbsorptionRatingResult:
                         self.third_octave_alpha_s,
                         owner,
                         "third_octave_alpha_s",
-                        "one-third-octave band",
+                        _THIRD_OCTAVE_AXIS,
                         rank=None,
                     ),
                     "3 x band_centers": 3
@@ -330,7 +334,7 @@ class AbsorptionRatingResult:
                         rank=None,
                     ),
                 },
-                "one-third-octave band",
+                _THIRD_OCTAVE_AXIS,
             )
 
     @property

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -59,6 +59,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -442,6 +443,43 @@ class SoundAbsorptionMeasurement:
     absorption_area_empty: NDArray[np.float64]
     absorption_area_with_specimen: NDArray[np.float64]
     alpha_s: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Reject a measurement whose per-band quantities do not agree.
+
+        Every quantity here belongs to one one-third-octave band, and the
+        ISO 354 test report states them side by side: the verbose table of the
+        fiche prints the band, its two reverberation times, its two equivalent
+        absorption areas and its ``alpha_s`` on a single row, and :meth:`plot`
+        places ``alpha_s`` on the ``frequencies`` axis point by point. Neither
+        reading can say which column is the odd one out, and
+        :attr:`equivalent_absorption_area` cannot even say that there is one:
+        Eq. (8) is a subtraction of two of these columns, so a column carrying
+        a single value is stretched over the whole spectrum by numpy and the
+        area comes back the right length, the same figure under every band.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            t_empty=1,
+            t_specimen=1,
+            air_attenuation=1,
+            absorption_area_empty=1,
+            absorption_area_with_specimen=1,
+            alpha_s=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "t_empty",
+            "t_specimen",
+            "air_attenuation",
+            "absorption_area_empty",
+            "absorption_area_with_specimen",
+            "alpha_s",
+        )
 
     @property
     def equivalent_absorption_area(self) -> NDArray[np.float64]:

--- a/src/phonometry/materials/absorbers/uncertainty.py
+++ b/src/phonometry/materials/absorbers/uncertainty.py
@@ -47,6 +47,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -186,14 +188,16 @@ class AbsorptionUncertaintyResult:
     r"""Standard and expanded uncertainty of an absorption quantity
     (ISO 12999-2).
 
-    For the single-number quantities (``αw``, ``DLα,NRD``) the frequency and value
-    arrays are empty and the uncertainty arrays hold a single element.
+    For the single-number quantities (``αw``, ``DLα,NRD``) it is the frequency
+    array alone that is empty; the value and the two uncertainty arrays each
+    hold a single element. That empty ``frequencies`` is what marks a
+    single-number result apart, and what :meth:`plot` refuses on.
 
     :ivar quantity: ``"absorption_coefficient"``, ``"equivalent_area"``,
         ``"practical_coefficient"``, ``"weighted_coefficient"`` or ``"single_number_rating"``.
     :ivar condition: ``"reproducibility"`` (``σR``) or ``"repeatability"`` (``σr``).
     :ivar frequencies: Band centre frequencies, in Hz (empty for single numbers).
-    :ivar values: The input quantity per band (empty for single numbers).
+    :ivar values: The input quantity per band (one element for single numbers).
     :ivar standard_uncertainty: Standard uncertainty ``u`` (``σR``/``σr``), one per band.
     :ivar coverage_factor: Coverage factor ``k`` (Table 3).
     :ivar expanded_uncertainty: Exact :math:`U = k\,u` (Formula (10)), one
@@ -207,6 +211,41 @@ class AbsorptionUncertaintyResult:
     standard_uncertainty: np.ndarray
     coverage_factor: float
     expanded_uncertainty: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a result whose value and uncertainty spectra disagree.
+
+        The uncertainty is reported per band and read per band: :meth:`plot`
+        draws the value curve and the ``±U`` ribbon around it point by point
+        on the ``frequencies`` axis, and :attr:`lower` and :attr:`upper` form
+        the reported interval by subtracting and adding the two arrays. Those
+        two properties are the reason a disagreement here has to be refused at
+        construction: numpy broadcasts a one-element uncertainty across the
+        whole spectrum without complaint, so an interval built from the wrong
+        band count still comes back the right length for the table that prints
+        it, stating a coverage the measurement never had.
+
+        The single-number quantities of Clause 7 (``αw``, ``DLα,NRD``) have no
+        spectrum: an empty ``frequencies`` is what marks them apart, and what
+        :meth:`plot` refuses on. The band axis is therefore pinned to the
+        frequencies only where the result has any.
+
+        :raises ValueError: if the value and uncertainty arrays disagree, or
+            if a band result carries a different number of values than
+            frequencies.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            values=1,
+            standard_uncertainty=1,
+            expanded_uncertainty=1,
+        )
+        require_same_length(
+            self, "values", "standard_uncertainty", "expanded_uncertainty"
+        )
+        if np.size(self.frequencies):
+            require_same_length(self, "frequencies", "values")
 
     @property
     def reported_expanded_uncertainty(self) -> np.ndarray:

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -76,6 +76,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import special
 
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from ..io._resolve import resolve_fs
 from ..signals.spectra import _positive, _validate_signal, power_spectral_density
 
@@ -351,6 +357,38 @@ class TrendTestResult:
     alpha: float
     median: float | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a sequence that disagrees with the count it was tested at.
+
+        The verdict is a statement about one sequence of :attr:`n`
+        observations: the statistic was counted on that sequence, and the
+        null mean, the standard deviation, the acceptance region and the
+        p-value all follow from the count. The plot then draws
+        :attr:`values` against a sample index counted out of the declared
+        :attr:`n` rather than out of the array beside it, so a sequence of
+        another length is a plot of a different record than the one the
+        legend rates. Matplotlib does refuse to draw the two against each
+        other, but from inside the renderer and about first dimensions,
+        naming neither the field nor the result; the declared count is the
+        authority here, and checking it at construction says which sequence
+        moved.
+
+        :raises ValueError: if the tested sequence spans a different number
+            of observations than the declared count.
+        """
+        require_ranks(self, values=1)
+        owner = type(self).__name__
+        require_equal_counts(
+            owner,
+            {
+                "n": self.n,
+                "values": require_axis_count(
+                    self.values, owner, "values", "observation", rank=None
+                ),
+            },
+            "observation",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -541,6 +579,36 @@ class StationarityTestResult:
     segment_duration: float
     fs: float
 
+    def __post_init__(self) -> None:
+        """Reject a test whose per-segment sequences disagree.
+
+        The verdict is a statement about one sequence of segment values, and
+        everything the reader is shown has to be that same sequence: the plot
+        draws the values against a segment index counted out of
+        :attr:`n_segments` rather than out of the array beside it, and
+        :attr:`segment_times` places those values on the record's time axis
+        while nothing downstream re-derives it. A sequence of another length
+        than the count it is drawn against is a plot of a different record
+        than the one the legend rates, so the declared count is taken as the
+        authority here and the two sequences have to follow it.
+
+        :raises ValueError: if either per-segment sequence disagrees with the
+            other or with the declared number of segments.
+        """
+        require_ranks(self, segment_values=1, segment_times=1)
+        require_same_length(self, "segment_values", "segment_times", axis="segment")
+        owner = type(self).__name__
+        require_equal_counts(
+            owner,
+            {
+                "n_segments": self.n_segments,
+                "segment_values": require_axis_count(
+                    self.segment_values, owner, "segment_values", "segment", rank=None
+                ),
+            },
+            "segment",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -722,6 +790,29 @@ class LevelCrossingResult:
     sigma: float
     duration: float
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a result whose per-level quantities disagree.
+
+        The comparison this result exists for is level by level: each measured
+        rate belongs beside the Rice expectation at the same level, and the
+        plot draws the expectation as a curve indexed by the order that sorts
+        :attr:`levels`. An expectation array longer than the levels is
+        therefore not caught anywhere: that order reaches only as many of its
+        entries as there are levels, so the curve is drawn from part of one
+        expectation while the markers beside it were measured against
+        another, and the plot is well formed either way. One that is short
+        raises about an index from inside the renderer instead, naming
+        neither array.
+
+        The scalar zero-crossing rates stand outside the group: they describe
+        the single level zero, whatever levels were asked for.
+
+        :raises ValueError: if the levels, the measured rates or the Rice
+            expectations span different numbers of levels.
+        """
+        require_ranks(self, levels=1, rates=1, rice_rates=1)
+        require_same_length(self, "levels", "rates", "rice_rates", axis="level")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -62,6 +62,9 @@ _PSD_EIGENVALUE_TOLERANCE = 1e-8
 # is np.std(output, ddof=1), undefined for fewer than two samples.
 _MIN_TRIALS = 2
 
+#: The axis a budget runs over, one entry per quantity that feeds the result.
+_INPUT_QUANTITY_AXIS = "input quantity"
+
 
 class UncertaintyWarning(PhonometryWarning):
     """A GUM propagation fell back outside its nominal assumptions."""
@@ -193,7 +196,7 @@ class UncertaintyResult:
         """
         require_ranks(self, sensitivities=1, contributions=1)
         require_same_length(
-            self, "sensitivities", "contributions", axis="input quantity"
+            self, "sensitivities", "contributions", axis=_INPUT_QUANTITY_AXIS
         )
         if self.names:
             owner = type(self).__name__
@@ -204,12 +207,12 @@ class UncertaintyResult:
                         self.contributions,
                         owner,
                         "contributions",
-                        "input quantity",
+                        _INPUT_QUANTITY_AXIS,
                         rank=None,
                     ),
                     "names": len(self.names),
                 },
-                "input quantity",
+                _INPUT_QUANTITY_AXIS,
             )
 
     def expanded(

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -43,6 +43,12 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
 
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from .._internal.warnings import PhonometryWarning
 
 Model = Callable[..., float]
@@ -149,6 +155,62 @@ class UncertaintyResult:
     contributions: np.ndarray
     effective_dof: float
     names: tuple[str, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        r"""Reject a budget whose per-input quantities disagree.
+
+        A budget is read as one row per input quantity: the sensitivity
+        coefficient, the contribution :math:`\lvert c_i \rvert u(x_i)` it
+        gives and the label that says which input the row is about. Of the
+        three, only the contributions and the labels are ever read together:
+        the plot draws one bar per contribution and then sets :attr:`names`
+        as the tick labels of the bar positions, which matplotlib refuses in
+        either direction with a message about a ``FixedLocator`` and two
+        counts, naming neither the field nor the budget. The coefficients are
+        read by nobody at all -- nothing downstream compares them with the
+        contributions -- so a budget carrying a sensitivity that no
+        contribution was computed from is drawn without complaint, under a
+        combined-uncertainty line that spans the whole.
+
+        Counting the rows is not enough on its own, so the rank is pinned
+        beside the length. A coefficient array of shape
+        ``(inputs, 2)`` has the right number of inputs on its first axis and
+        agrees with the contributions on every count, and since nothing reads
+        it the second axis is never noticed at all. Give the *contributions*
+        that shape and the count still agrees, but the extra axis travels into
+        ``barh``, which refuses it from inside numpy with a message about a
+        shape mismatch between ``'width'`` and ``'y'`` -- ``'width'`` being
+        ``barh``'s own argument, not the input quantity that may well be
+        called that.
+
+        An empty :attr:`names` is not a disagreement: it is the unlabelled
+        budget the plot fills in with ``x1``, ``x2``, ... itself, which is why
+        the labels are counted only when there are some.
+
+        :raises ValueError: if the coefficients or the contributions carry
+            more than one axis, or if the coefficients, the contributions or
+            the labels span different numbers of input quantities.
+        """
+        require_ranks(self, sensitivities=1, contributions=1)
+        require_same_length(
+            self, "sensitivities", "contributions", axis="input quantity"
+        )
+        if self.names:
+            owner = type(self).__name__
+            require_equal_counts(
+                owner,
+                {
+                    "contributions": require_axis_count(
+                        self.contributions,
+                        owner,
+                        "contributions",
+                        "input quantity",
+                        rank=None,
+                    ),
+                    "names": len(self.names),
+                },
+                "input quantity",
+            )
 
     def expanded(
         self, coverage: float = 0.95, *, coverage_factor_override: float | None = None

--- a/src/phonometry/noise_control/duct_modes.py
+++ b/src/phonometry/noise_control/duct_modes.py
@@ -44,7 +44,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_non_negative, require_positive
+from .._internal.validation import (
+    require_non_negative,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from .._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -110,6 +115,42 @@ class DuctModeResult:
     mach: float
     section: str
     label: str
+
+    def __post_init__(self) -> None:
+        """Reject a ladder whose curves do not all describe the same modes.
+
+        The cut-on chart labels one tick per entry of ``modes`` and plots both
+        cut-on curves against those ticks, so the mode order a frequency is
+        read under is the order standing at its position in ``modes`` and
+        nothing else. A count that disagrees mislabels nothing: the chart is
+        the only reader that pairs the two, and it stops with matplotlib's
+        complaint about an x and a y whose first dimensions differ, which
+        names neither the curve nor the result it came from. There is no
+        fiche behind the chart to truncate a column quietly, and no reader
+        pairs :attr:`axial_wavenumber` with the modes at all, so a ladder
+        that is never plotted carries its disagreement to the caller with
+        nothing raised anywhere. The check is what names the field, and what
+        names it where the ladder was built rather than where it is drawn.
+
+        The rank half is the silent one. An extra axis still counts one entry
+        per mode on its first, so it passes every length above: a
+        ``(mode, 2)`` stack of two flow states draws one extra curve per
+        column, all of them under the same legend entry, and
+        :attr:`plane_wave_limit` minimises over the whole stack instead of
+        over the ladder it claims to describe.
+
+        :raises ValueError: if the mode orders and the per-mode arrays
+            disagree, or a per-mode array carries an extra axis.
+        """
+        require_ranks(self, cut_on=1, cut_on_no_flow=1, axial_wavenumber=1)
+        require_same_length(
+            self,
+            "modes",
+            "cut_on",
+            "cut_on_no_flow",
+            "axial_wavenumber",
+            axis="mode",
+        )
 
     @property
     def plane_wave_limit(self) -> float:

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -67,7 +67,12 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import numpy as np
 
-from .._internal.validation import require_choice, require_positive
+from .._internal.validation import (
+    require_choice,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from ..room.steady_field import room_constant
 
 #: Interior build-up correction models. The value is the additive floor inside
@@ -109,6 +114,40 @@ class EnclosureResult:
     external_area: float
     internal_area: float
     room_constant: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a sheet whose columns do not all run over the same bands.
+
+        The enclosure fiche prints one row per band -- nominal frequency, panel
+        ``R``, correction ``C`` and net ``IL`` side by side, with the interior
+        room constant ``R_i`` added in the verbose table -- and it sizes that
+        table from ``insertion_loss`` alone, while the boxed figures average
+        each column whole. A panel ``R`` one entry longer than the ``IL`` is
+        therefore truncated out of the printed rows and still counted in the
+        mean, so the sheet states a mean ``R`` that the column above it does
+        not average to. A column one entry *short* hides differently: an
+        ``R_i`` short of a band renders an ordinary-looking plain sheet and
+        fails only when someone asks for the verbose one.
+
+        :raises ValueError: if the per-band quantities disagree, or one of them
+            carries an extra axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            panel_transmission_loss=1,
+            correction=1,
+            insertion_loss=1,
+            room_constant=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "panel_transmission_loss",
+            "correction",
+            "insertion_loss",
+            "room_constant",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -78,7 +78,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_choice, require_positive
+from .._internal.validation import (
+    require_choice,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from ..room.steady_field import room_constant
 
 if TYPE_CHECKING:
@@ -448,6 +453,23 @@ class HvacSpectrumResult:
     values: np.ndarray
     quantity: str
     label: str
+
+    def __post_init__(self) -> None:
+        """Reject a spectrum whose values do not run over its own bands.
+
+        The HVAC fiche takes the number of rows it prints from ``values`` and
+        the nominal frequency labelling each one from ``frequencies``, so the
+        two lengths have to be the same for a row to say which band it is. One
+        value short and the sheet simply stops before the last band the result
+        names, boxing a mean attenuation over the bands that survived rather
+        than the ones the caption declares; one value long and the rows run
+        past the last label there is.
+
+        :raises ValueError: if ``values`` does not carry one entry per band, or
+            either field carries an extra axis.
+        """
+        require_ranks(self, frequencies=1, values=1)
+        require_same_length(self, "frequencies", "values")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/noise_control/room_to_room.py
+++ b/src/phonometry/noise_control/room_to_room.py
@@ -70,6 +70,8 @@ from .._internal.validation import (
     require_choice,
     require_non_negative,
     require_positive,
+    require_ranks,
+    require_same_length,
 )
 from ._criterion import (
     as_band_spectrum,
@@ -211,6 +213,55 @@ class RoomToRoomResult:
     criterion: str
     target: float | None
     label: str
+
+    def __post_init__(self) -> None:
+        """Reject a chain whose rows do not all run over the same bands.
+
+        :meth:`table` writes the chain out as one row per link under a single
+        band header, and the flanking row it inserts between them is built to
+        the length of :attr:`frequencies` alone. A spectrum of another length
+        is therefore not a row that fails to print: nothing pads it out or
+        trims it, so the sheet carries a row of one band count beside rows of
+        another and the reader lays a receiving-room level against a
+        source-room level that ran over other bands. The two spectra the
+        required row reads, :attr:`source_level` and
+        :attr:`receiving_absorption`, do stop a sheet with a target declared,
+        because :meth:`table` computes that row on its way out; but they stop
+        it on a bare ``operands could not be broadcast together`` that names
+        neither the field nor the result, and they do not stop it at all on
+        the single number of the next paragraph.
+
+        :attr:`required_transmission_loss` is the same mistake with no visible
+        seam at all. It subtracts the criterion curve, which is sampled at
+        :attr:`frequencies`, from :attr:`source_level` and divides the
+        partition area by :attr:`receiving_absorption`; with a receiving room
+        whose absorption was given as one number where the bands needed
+        several, that one number is broadcast over the whole spectrum, and the
+        property specifies a partition, band by band, against the absorption
+        the room has in a single band.
+
+        :raises ValueError: if any spectrum disagrees with ``frequencies``.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            source_level=1,
+            transmission_loss=1,
+            receiving_absorption=1,
+            noise_reduction=1,
+            received_level=1,
+            source_power_level=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "source_level",
+            "transmission_loss",
+            "receiving_absorption",
+            "noise_reduction",
+            "received_level",
+            "source_power_level",
+        )
 
     # -- verdicts ---------------------------------------------------------
     @property

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -114,7 +114,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from .._internal.validation import require_non_negative, require_positive
+from .._internal.validation import (
+    require_non_negative,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from .duct_modes import plane_wave_limit as _plane_wave_limit
 from .duct_modes import warn_above_plane_wave_limit
 
@@ -458,6 +463,50 @@ class ReactiveSilencerResult:
     geometry: dict[str, float] | None = None
     plane_wave_limit: float | None = None
     chain: SilencerChain | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a device whose curves do not all run over the same grid.
+
+        The fiche of :meth:`report` sizes its table from
+        :attr:`transmission_loss` and takes the nominal frequency of each row
+        from :attr:`frequencies`, so a grid of another length relabels every
+        row of the sheet with the frequency of a different point. An
+        :attr:`insertion_loss` one value short stops the table where it runs
+        out; one value long is truncated by the same table while the boxed
+        mean above it still averages the whole of it, and the sheet then
+        states a mean insertion loss over a frequency that appears nowhere in
+        its column.
+
+        :attr:`transfer_matrix` is pinned to three axes because two of them
+        are its own: the four-pole matrix is 2x2 at every frequency, and a
+        stack that lost the frequency axis would still count two rows on its
+        first one and pass any check that only counted.
+
+        :attr:`resonances` is left out of the grid: it counts the notable
+        frequencies of the device -- one tuning frequency for a Helmholtz
+        resonator, the odd quarter-wave multiples that fall inside the range
+        for a branch tube -- and has nothing to do with how finely the
+        response was sampled.
+
+        :raises ValueError: if the curves disagree, or the matrix is not a
+            stack of four-poles over frequency.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            transmission_loss=1,
+            insertion_loss=1,
+            transfer_matrix=3,
+            resonances=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "transmission_loss",
+            "insertion_loss",
+            "transfer_matrix",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/loudness/contours.py
+++ b/src/phonometry/psychoacoustics/loudness/contours.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -183,6 +185,32 @@ class EqualLoudnessContours:
     phons: tuple[float, ...]
     contours: np.ndarray
     threshold: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a family whose contours do not span the grid they are drawn on.
+
+        Two independent axes meet in ``contours``, and both are read by
+        position: every row is drawn against the whole of ``frequencies``,
+        and row ``i`` belongs to ``phons[i]``. A row of the wrong width, or a
+        threshold of the wrong length, cannot be drawn against that grid at
+        all, and says so from inside matplotlib, about a first dimension,
+        naming neither the field nor this result; a row count that disagrees
+        with ``phons`` pairs each contour with a level that is not its own,
+        which the chart's strict pairing catches only once someone draws it
+        and a reader indexing the two together never catches.
+
+        The two lengths are checked apart because nothing relates them: a
+        grid of eight frequencies would otherwise be taken as agreement with
+        the eight levels of the default family.
+
+        :raises ValueError: if a contour row, the threshold or the level list
+            disagrees with the axis it is drawn against.
+        """
+        require_ranks(self, frequencies=1, phons=1, contours=2, threshold=1)
+        require_same_length(
+            self, "frequencies", ("contours", 1), "threshold", axis="frequency"
+        )
+        require_same_length(self, "phons", ("contours", 0), axis="loudness level")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -59,7 +59,11 @@ if TYPE_CHECKING:
     from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
-from ..._internal.validation import require_1d_signal
+from ..._internal.validation import (
+    require_1d_signal,
+    require_ranks,
+    require_same_length,
+)
 
 # --------------------------------------------------------------------------
 # Global constants (Clause 5)
@@ -263,6 +267,44 @@ class EcmaLoudness:
     time: np.ndarray
     loudness_vs_time: np.ndarray
     field: str
+
+    def __post_init__(self) -> None:
+        """Reject a result whose band and time traces do not line up.
+
+        Two axes run through this result, and each is read by pairing arrays
+        index for index: the average specific loudness against the
+        critical-band-rate scale of the 53 auditory bands, and the
+        time-dependent loudness against its block times. Where the chart draws
+        such a pair a mismatch does stop it, but from inside matplotlib, about
+        a first dimension, whenever someone next plots; ``centre_frequencies``
+        it never draws, so a band axis that disagrees there is caught by
+        nobody and F(z) is reported for a band other than the one whose
+        loudness stands beside it.
+
+        The two axes are checked apart because nothing relates them: the band
+        count is fixed by the standard, whereas the number of 187,5 Hz blocks
+        follows the length of the recording, and a 53-block recording is no
+        evidence that either is right.
+
+        :raises ValueError: if the per-band or the per-block quantities
+            disagree among themselves.
+        """
+        require_ranks(
+            self,
+            specific_loudness=1,
+            bark=1,
+            centre_frequencies=1,
+            time=1,
+            loudness_vs_time=1,
+        )
+        require_same_length(
+            self,
+            "specific_loudness",
+            "bark",
+            "centre_frequencies",
+            axis="auditory band",
+        )
+        require_same_length(self, "time", "loudness_vs_time", axis="time block")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -52,7 +52,11 @@ if TYPE_CHECKING:
     from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
-from ..._internal.validation import require_1d_signal
+from ..._internal.validation import (
+    require_1d_signal,
+    require_ranks,
+    require_same_length,
+)
 from ..erb_scale import CAM_C, ERB_C1, ERB_C2, erb_bandwidth, frequency_from_cam
 
 # ---------------------------------------------------------------------------
@@ -538,6 +542,32 @@ class MooreGlasbergLoudness:
     centre_frequencies: np.ndarray
     field: str
     presentation: str
+
+    def __post_init__(self) -> None:
+        """Reject a pattern that does not run over one ERB-number grid.
+
+        The three arrays are one axis read three ways - the sample i of the
+        ERB-number scale, the centre frequency fc(i) of the auditory filter
+        sitting there, and the specific loudness N'(i) that filter produced -
+        so they mean something only index for index. The chart pairs the
+        scale with the pattern and takes the ends of the scale for its x
+        limits, so a disagreement between those two surfaces late and
+        obscurely, as a matplotlib complaint about a first dimension.
+        ``centre_frequencies`` is not drawn at all: a mismatch there reaches
+        the reader intact, naming the wrong filter for every value of the
+        pattern, and the total loudness printed in the title was integrated
+        over a grid the answer no longer describes.
+
+        :raises ValueError: if the three disagree.
+        """
+        require_ranks(self, specific=1, erb_number=1, centre_frequencies=1)
+        require_same_length(
+            self,
+            "erb_number",
+            "specific",
+            "centre_frequencies",
+            axis="auditory filter",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
 
     from ...io._signal import Signal
 
+from ..._internal.validation import require_ranks, require_same_length
 from .moore_glasberg import (
     _ERB_C1,
     _ERB_C2,
@@ -377,6 +378,44 @@ class MooreGlasbergTimeVaryingLoudness:
     percentiles: dict[float, float]
     field: str
     presentation: str
+
+    def __post_init__(self) -> None:
+        """Reject traces that do not share the frame axis they are drawn on.
+
+        The frame axis is the only thing that says when any sample happened,
+        and the chart pairs it with the short-term and the long-term traces to
+        draw them, so a trace of another length stops the figure with a
+        matplotlib complaint about a first dimension rather than anything
+        naming the field - and stops it only when someone draws it, while
+        ``n_max`` and the percentiles quoted from that trace were taken over
+        the whole of it either way.
+
+        The two loudness levels are held to the same length for a plainer
+        reason: neither is ever drawn. Each is its own trace mapped phon by
+        phon through Table 5, so one of another length is read as though it
+        still were, reporting at every index the level of a different instant,
+        with nothing anywhere to catch it.
+
+        :raises ValueError: if a trace or a level curve disagrees with the
+            frame axis.
+        """
+        require_ranks(
+            self,
+            time=1,
+            short_term_loudness=1,
+            long_term_loudness=1,
+            short_term_loudness_level=1,
+            long_term_loudness_level=1,
+        )
+        require_same_length(
+            self,
+            "time",
+            "short_term_loudness",
+            "long_term_loudness",
+            "short_term_loudness_level",
+            "long_term_loudness_level",
+            axis="frame",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -35,7 +35,11 @@ if TYPE_CHECKING:
 from scipy import signal
 
 from ..._internal.utils import _typesignal
-from ..._internal.validation import require_positive
+from ..._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from ._zwicker_data import (
     A0_TRANSMISSION,
     DCB_ADAPTATION,
@@ -128,6 +132,45 @@ class ZwickerLoudness:
     time: np.ndarray | None = None
     loudness_vs_time: np.ndarray | None = None
     field: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a loudness-vs-time trace that does not match its own time axis.
+
+        ``time`` and ``loudness_vs_time`` are one axis written down twice: the
+        constructor decimates the 2000 Hz weighted series to 500 Hz and builds
+        both from the same ``num_out`` (clause 6.5). Everything that reads them
+        reads them as a pair, and only as a pair, so a disagreement is never
+        arithmetic that comes out wrong -- it is a plot that stops or a panel
+        that lies.
+
+        Lengths that disagree stop the plot, but badly. Both directions end in
+        the same place, matplotlib's ``ValueError: x and y must have same first
+        dimension, but have shapes (300,) and (150,)``, raised from inside
+        ``Axes.plot`` several frames below the caller: it names the two shapes
+        and neither field, so nothing says which of the two is wrong or that
+        the object was already malformed when it was built. ``.report()`` dies
+        the same way and writes no PDF at all, the clause 7 f) panel taking the
+        whole fiche down with it. And it only stops the drawing that is
+        actually attempted: ``plot(ax=...)`` skips the time panel by
+        construction, so it returns an ordinary specific-loudness axes with its
+        title and its one line, and the broken trace goes unmentioned.
+
+        An extra axis is worse, because nothing stops at all. A
+        ``loudness_vs_time`` of shape (300, 2) has 300 rows and passes any
+        count, and matplotlib reads a two-column y as two series: the N(t)
+        panel comes out with two curves, both labelled ``$N(t)$``, and
+        ``.report()`` renders the full PDF without a word. A ``time`` of shape
+        (300, 2) does the same. Hence the rank pin beside the length one: the
+        count alone cannot tell a trace from a pair of them.
+
+        The stationary result is not affected: it leaves both fields ``None``,
+        and an absent optional quantity is passed over rather than counted.
+
+        :raises ValueError: if ``time`` and ``loudness_vs_time`` are not both
+            one-dimensional and of one length.
+        """
+        require_ranks(self, time=1, loudness_vs_time=1)
+        require_same_length(self, "time", "loudness_vs_time", axis="time step")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -109,7 +109,12 @@ if TYPE_CHECKING:
     from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
-from ..._internal.validation import require_1d_signal, require_positive
+from ..._internal.validation import (
+    require_1d_signal,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from ..loudness.ecma import (
     _CBF,
     _F_CENTRE,
@@ -218,6 +223,67 @@ class EcmaFluctuationStrength:
     fluctuation_strength_vs_time: np.ndarray
     specific_fluctuation_strength_vs_time: np.ndarray
     field: str
+
+    def __post_init__(self) -> None:
+        """Reject a result whose curves disagree with the axes they are drawn on.
+
+        Two independent axes meet in this result. The auditory bands are the
+        53 of the standard's filter bank whatever the signal, while the 50 Hz
+        frames are however many the signal ran to, so they are pinned
+        separately; the time-dependent specific fluctuation strength is the
+        one field measured along both.
+
+        The time trace is a single ``plot`` call pairing ``time`` with
+        ``fluctuation_strength_vs_time``. A length short or long by one
+        reaches matplotlib, which raises about x and y differing in their
+        first dimension and names neither field, from a call several frames
+        below the one the caller made.
+
+        The heatmap fails far more quietly. A caller who supplies an ``ax``
+        gets only the time trace, so a specific-fluctuation table or a
+        ``bark`` of the wrong length is drawn nowhere and ``plot`` returns as
+        if all were well -- and that is true of the short direction and the
+        long one alike. Even the full figure lets one shape through: a table
+        one entry short on *both* axes is exactly the shape ``pcolormesh``
+        expects once ``shading="auto"`` reads the two axes as cell corners, so
+        it draws a complete heatmap, spanning the whole time and Bark_HMS
+        range, one cell coarser than the run it claims to show, without a word
+        from anywhere.
+
+        Rank has to be pinned as well as length, because gaining or losing an
+        axis passes every count: the specific table averaged down to one axis
+        leaves the time trace untouched and only ``pcolormesh`` notices,
+        unpacking its shape into two names and reporting that it got one
+        value; a ``time`` of one column plots against the trace by broadcast,
+        and it is the shaded fill underneath that stops, naming matplotlib's
+        own ``'x'`` rather than the field that carried the extra axis.
+
+        :raises ValueError: if the per-band or per-frame quantities disagree.
+        """
+        require_ranks(
+            self,
+            specific_fluctuation_strength=1,
+            bark=1,
+            centre_frequencies=1,
+            time=1,
+            fluctuation_strength_vs_time=1,
+            specific_fluctuation_strength_vs_time=2,
+        )
+        require_same_length(
+            self,
+            "bark",
+            "centre_frequencies",
+            "specific_fluctuation_strength",
+            ("specific_fluctuation_strength_vs_time", 1),
+            axis="auditory band",
+        )
+        require_same_length(
+            self,
+            "time",
+            "fluctuation_strength_vs_time",
+            "specific_fluctuation_strength_vs_time",
+            axis="50 Hz frame",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -62,7 +62,11 @@ if TYPE_CHECKING:
     from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
-from ..._internal.validation import require_1d_signal
+from ..._internal.validation import (
+    require_1d_signal,
+    require_ranks,
+    require_same_length,
+)
 from ..loudness.ecma import (
     _CBF,
     _EPS,
@@ -210,6 +214,61 @@ class EcmaRoughness:
     roughness_vs_time: np.ndarray
     specific_roughness_vs_time: np.ndarray
     field: str
+
+    def __post_init__(self) -> None:
+        """Reject a result whose curves disagree with the axes they are drawn on.
+
+        Both panels of the figure pair an axis with something drawn against
+        it: the time-dependent roughness R(l50) as a line over time, and the
+        specific roughness R'(l50, z) as a heatmap over time and the
+        critical-band-rate scale. A time axis one step short or one long
+        reaches matplotlib, which raises ``x and y must have same first
+        dimension, but have shapes (30,) and (31,)`` from inside the line
+        call and names neither field. A step count that disagrees only in
+        ``specific_roughness_vs_time`` is the quieter mistake: drawing the
+        whole figure raises ``Dimensions of C (53, 30) should be one smaller
+        than X(31) and Y(53)`` out of ``pcolormesh``, but a caller who
+        supplies an ``ax`` gets the time panel alone, so that field is read
+        nowhere and the figure comes out looking perfectly ordinary. The same
+        two outcomes follow a ``bark`` of the wrong length, which is the
+        heatmap's other axis; ``specific_roughness`` is quieter still,
+        drawn by no panel at all and only raising the unnamed shape error
+        where the documented snippet pairs it with ``bark``.
+
+        The two axes are independent: the 53 auditory bands are the
+        standard's filter bank whatever the signal, while the 50 Hz grid runs
+        as long as the signal did, so they are pinned separately. Ranks go
+        with the lengths, because a count alone passes an extra axis on
+        untouched: a ``bark`` of shape ``(53, 1)`` counts 53 bands and is
+        drawn by ``pcolormesh`` without a word.
+
+        :raises ValueError: if the per-band or per-time-step quantities
+            disagree, or one of them carries an extra axis.
+        """
+        require_ranks(
+            self,
+            specific_roughness=1,
+            bark=1,
+            centre_frequencies=1,
+            time=1,
+            roughness_vs_time=1,
+            specific_roughness_vs_time=2,
+        )
+        require_same_length(
+            self,
+            "bark",
+            "centre_frequencies",
+            "specific_roughness",
+            ("specific_roughness_vs_time", 1),
+            axis="auditory band",
+        )
+        require_same_length(
+            self,
+            "time",
+            "roughness_vs_time",
+            "specific_roughness_vs_time",
+            axis="time step",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -43,7 +43,11 @@ if TYPE_CHECKING:
     from ...io._signal import Signal
 
 from ..._internal.utils import _typesignal
-from ..._internal.validation import require_1d_signal
+from ..._internal.validation import (
+    require_1d_signal,
+    require_ranks,
+    require_same_length,
+)
 from ..loudness.ecma import (
     _CBF,
     _EPS,
@@ -98,6 +102,51 @@ class EcmaTonality:
     tonality_vs_time: np.ndarray
     tonal_frequency_vs_time: np.ndarray
     field: str
+
+    def __post_init__(self) -> None:
+        """Reject a result whose curves disagree with the axes they are drawn on.
+
+        The figure this result draws is two panels, and each is one call
+        pairing an axis with a curve: the average specific tonality over the
+        critical-band-rate scale, and the time-dependent tonality over time.
+        A curve of the wrong length reaches matplotlib, which raises about x
+        and y differing in their first dimension and names neither field, from
+        a call several frames below the one the caller made. Worse, a caller
+        who supplies an ``ax`` gets only the specific-tonality panel, so a time
+        axis that disagrees is drawn nowhere and goes unnoticed until somebody
+        asks for the whole figure.
+
+        The two axes are independent of each other: the auditory bands are the
+        53 of the standard's filter bank whatever the signal, while the blocks
+        are however many the signal ran to, so they are pinned separately.
+
+        :raises ValueError: if the per-band or per-block quantities disagree.
+        """
+        require_ranks(
+            self,
+            specific_tonality=1,
+            bark=1,
+            centre_frequencies=1,
+            tonal_frequencies=1,
+            time=1,
+            tonality_vs_time=1,
+            tonal_frequency_vs_time=1,
+        )
+        require_same_length(
+            self,
+            "bark",
+            "centre_frequencies",
+            "specific_tonality",
+            "tonal_frequencies",
+            axis="auditory band",
+        )
+        require_same_length(
+            self,
+            "time",
+            "tonality_vs_time",
+            "tonal_frequency_vs_time",
+            axis="time block",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -98,6 +98,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import ArrayLike, NDArray
@@ -1095,6 +1097,60 @@ class ToneAudibilityResult:
     audibilities: NDArray[np.float64]
     extended_uncertainties: NDArray[np.float64] | None = None
     group_sizes: NDArray[np.int_] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject an assessment whose per-tone quantities disagree in length.
+
+        The fiche prints one row per entry of ``tone_frequencies`` under a
+        single header and reads every other quantity at that row's index, so a
+        quantity one entry short raises an ``IndexError`` from inside the table
+        builder, about an axis and a size, naming neither the tone it was on
+        nor the column it was reading.
+
+        An entry too *many* is the quiet one. The table stops at the last
+        frequency, so the extra tone is dropped from the sheet without a word,
+        while :attr:`decisive_audibility` maxes over the whole array
+        regardless. If that extra entry happens to be the loudest, the fiche
+        fails hunting for the row to emphasise and reports that an integer is
+        not in a list; if it is not the loudest, the sheet renders, reads as
+        complete, and is missing an audible tone that the assessment behind it
+        did find.
+
+        The optional quantities are skipped when absent: :func:`assess_tones`
+        builds a result from bare levels, which carries neither the per-line
+        uncertainties nor the Step 3 grouping, and that is not a disagreement.
+
+        :raises ValueError: if any per-tone quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            tone_frequencies=1,
+            tone_levels=1,
+            mean_narrowband_levels=1,
+            critical_bandwidths=1,
+            lower_corners=1,
+            upper_corners=1,
+            critical_band_levels=1,
+            masking_indices=1,
+            audibilities=1,
+            extended_uncertainties=1,
+            group_sizes=1,
+        )
+        require_same_length(
+            self,
+            "tone_frequencies",
+            "tone_levels",
+            "mean_narrowband_levels",
+            "critical_bandwidths",
+            "lower_corners",
+            "upper_corners",
+            "critical_band_levels",
+            "masking_indices",
+            "audibilities",
+            "extended_uncertainties",
+            "group_sizes",
+            axis="tone entry",
+        )
 
     @property
     def audible(self) -> NDArray[np.bool_]:

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.utils import _typesignal
+from .._internal.validation import require_ranks, require_same_length
 from ..filters.core import OctaveFilterBank
 from ..io._resolve import apply_calibration, resolve_fs
 
@@ -156,6 +157,60 @@ class RoomAcousticsResult:
     t20_valid: np.ndarray
     t30_valid: np.ndarray
     curvature: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a result whose parameters do not run over the same bands.
+
+        The ISO 3382 fiche prints one row per band, taking the row count from
+        ``t30`` and reading every other parameter at that row's index, with
+        the band label of the row taken from ``frequency``. A parameter one
+        entry longer than the rest is dropped off the end of the table; one
+        entry shorter raises an index error from inside reportlab, naming
+        neither the field nor the two lengths. Worse than either, the boxed
+        mid-frequency reverberation time is read by looking the 500 Hz and
+        1000 Hz bands up in ``frequency`` and taking ``t30`` at the index
+        found there, so a band axis that has slipped against the parameters
+        quotes another band's decay time under the "500-1000 Hz" label, on a
+        sheet whose verdict row then compares that number with the target.
+
+        The validity flags travel the same axis: the plot greys and hatches
+        the bars of the bands they reject, and a flag array of another length
+        greys the wrong ones.
+
+        :raises ValueError: if any per-band array disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            frequency=1,
+            edt=1,
+            t20=1,
+            t30=1,
+            c50=1,
+            c80=1,
+            d50=1,
+            ts=1,
+            dynamic_range=1,
+            edt_valid=1,
+            t20_valid=1,
+            t30_valid=1,
+            curvature=1,
+        )
+        require_same_length(
+            self,
+            "frequency",
+            "edt",
+            "t20",
+            "t30",
+            "c50",
+            "c80",
+            "d50",
+            "ts",
+            "dynamic_range",
+            "edt_valid",
+            "t20_valid",
+            "t30_valid",
+            "curvature",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -437,6 +492,29 @@ class DecayCurve:
     time: np.ndarray
     level: np.ndarray
     band: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a curve whose two halves are not the same curve.
+
+        ``time`` and ``level`` are one sampled decay read off by position:
+        the plot draws the levels against the times point for point, and each
+        straight-line fit cuts its evaluation range as a mask over ``level``
+        and indexes ``time`` with it, so a decay time is only ever as right as
+        the pairing. Nothing downstream re-establishes it, and the dataclass
+        unpacks as ``time, level = decay_curve(...)``, which sends the two
+        arrays on into code that never sees this class again. Left to be
+        discovered there, the halves are reported by matplotlib or numpy as a
+        pair of shapes, from inside whatever finally drew them, which for a
+        curve computed once and plotted later is a long way from the point
+        the two parted company.
+
+        ``band`` is a single centre frequency labelling the whole curve, not
+        an axis, and is left out.
+
+        :raises ValueError: if ``time`` and ``level`` differ in length.
+        """
+        require_ranks(self, time=1, level=1)
+        require_same_length(self, "time", "level", axis="sample")
 
     def __iter__(self) -> Iterator[np.ndarray]:
         """Yield ``time`` then ``level`` so the result unpacks like a tuple."""

--- a/src/phonometry/room/crowd_noise.py
+++ b/src/phonometry/room/crowd_noise.py
@@ -81,7 +81,11 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_positive
+from .._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -254,6 +258,33 @@ class CrowdNoiseResult:
     sound_power_level: float
     directivity: float
     communication_level: float
+
+    def __post_init__(self) -> None:
+        """Reject a grid whose levels do not span its two axes.
+
+        :attr:`levels` is a surface over two independent axes -- one row per
+        absorption area, one column per occupancy -- and the plot reads it as
+        such, drawing one curve per row against :attr:`talkers` and labelling
+        that curve with the area at the same position in
+        :attr:`absorption_areas`. Neither count slips quietly once it gets
+        there: a row count that has slipped is ``zip(..., strict=True)``
+        refusing to pair the areas with the curves, a column count that has
+        slipped is matplotlib's complaint about two shapes. Both are raised
+        from inside the plotter and in the language of the machinery --
+        numbered arguments, bare shapes -- naming neither the fields that
+        disagree nor the result they came from. Checking here names them, and
+        names them before the grid is handed to a plot at all.
+
+        The two axes are checked separately and never against each other:
+        comparing occupancies with absorption areas would refuse the ordinary
+        study of twenty occupancies against three areas.
+
+        :raises ValueError: if ``levels`` does not carry one row per
+            absorption area and one column per talker count.
+        """
+        require_ranks(self, talkers=1, absorption_areas=1, levels=2)
+        require_same_length(self, "absorption_areas", "levels", axis="absorption area")
+        require_same_length(self, "talkers", ("levels", 1), axis="talker count")
 
     def speech_to_noise(self) -> np.ndarray:
         """Speech-to-noise ratio for every point of :attr:`levels`, dB."""

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -43,7 +43,12 @@ if TYPE_CHECKING:
 
 
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_fraction, require_positive
+from .._internal.validation import (
+    require_fraction,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 # ---------------------------------------------------------------------------
 # Normative constants.
@@ -234,6 +239,25 @@ class ReverberationResult:
     reverberation_time: np.ndarray
     volume: float
     object_fraction: float
+
+    def __post_init__(self) -> None:
+        """Reject a prediction whose bands do not line up.
+
+        The fiche walks ``frequencies`` and prints ``absorption_area`` and
+        ``reverberation_time`` at each band's index, so a spectrum longer than
+        the band axis simply stops being printed while the boxed
+        mid-frequency descriptor beneath the table -- picked by looking the
+        500 Hz and 1000 Hz bands up in ``frequencies`` and reading ``T`` and
+        ``A`` at the index found there -- states a number belonging to another
+        band under a "500-1000 Hz" label. A spectrum shorter than the band
+        axis raises an index error from inside reportlab, about neither field.
+
+        :raises ValueError: if the two spectra and the band axis disagree.
+        """
+        require_ranks(self, frequencies=1, absorption_area=1, reverberation_time=1)
+        require_same_length(
+            self, "frequencies", "absorption_area", "reverberation_time"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -74,7 +74,14 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_positive
+from .._internal.validation import (
+    require_axis_count,
+    require_axis_rank,
+    require_equal_counts,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -225,6 +232,108 @@ class ImageSourceResult:
     receiver: tuple[float, float, float]
     max_order: int
     speed_of_sound: float
+
+    def __post_init__(self) -> None:
+        """Reject a table whose images, coordinates or bands do not line up.
+
+        The reflectogram draws one stem per image, placed at that image's
+        arrival time, levelled by its amplitude, coloured by its reflection
+        order and measured against the ``1 / r`` envelope of its own distance:
+        five arrays read side by side at the same index, with the plan-view
+        lattice reading ``image_positions`` against the same ``orders``. A
+        table of two lengths stops that drawing call with a bare numpy
+        complaint -- ``boolean index did not match indexed array along axis 0;
+        size of axis is 24 but size of corresponding boolean axis is 25``
+        where the mask comes from another array, ``index 25 is out of bounds
+        for axis 0 with size 25`` where the envelope is sorted by another
+        array's order -- naming neither the field that slipped nor the result
+        it came from, one short and one long alike. :attr:`direct_time` says
+        nothing at all: it locates the nearest image in ``distances`` and
+        returns whatever ``times`` holds at that position, so a ``times`` one
+        short at the front, the arrivals being sorted, hands back the first
+        reflection at 10.7 ms as the direct sound that arrived at 7.3 ms.
+
+        The room lengths, the two points and the second axis of
+        ``image_positions`` are one coordinate count written four times, of
+        which only ``dimensions`` is read in a way that ever complains: the
+        reflectogram unpacks it three at a time for its title, so
+        a room of two lengths stops it with ``not enough values to unpack
+        (expected 3, got 2)`` and a room of four with ``too many values to
+        unpack (expected 3)``, neither of which names a field or a result.
+        The plan view reads x and y out of the lattice and takes the source
+        and the receiver the same way, so a point that lost its height and a
+        lattice that lost its height column both draw a perfectly ordinary
+        figure and say nothing; only a reader that takes the height column,
+        as the guide's plan of the images sharing the source's own height
+        does, raises ``index 2 is out of bounds for axis 1 with size 2``, and
+        a fourth column raises nothing anywhere. That silence is why the count
+        is held here rather than left to the readers. The four are held to one
+        another rather than to the number three, because three is a constant
+        of the shoebox this module builds and what a hand-edited result gets
+        wrong is one of the four, not all of them at once.
+
+        ``ir`` and ``amplitudes`` are the sampled and the exact view of the
+        same set of bands, and they grow their band axis together: both are
+        one-dimensional for a broadband model and two-dimensional for a
+        per-band one. That pairing is what is required here, rather than a
+        fixed number of axes for either. The exact table is the one asked
+        first, since the response is sampled from it, and its own shape then
+        says which of its axes carries the images; holding it in turn to the
+        response's number of axes is what bounds it, since a third axis on the
+        exact table clears every count it meets -- its bands still line up
+        along axis 0 and its images along axis 1 -- and reaches the
+        reflectogram as an amplitude per image that is really a pair, where
+        masking it by reflection order is numpy's complaint above.
+
+        A band count that disagrees, on the other hand, raises nothing at all.
+        The reflectogram draws band 0 whatever the height of the table, and
+        ``frequencies`` labels the bands without any reader in this library
+        reading it back, so a label list of the wrong length surfaces only in
+        the caller's own table: pairing the labels with the rows of ``ir``
+        drops the band that has no label -- three rows printed for a four-band
+        response, the 2 kHz energy gone with nothing to say it was ever there
+        -- while a label too many leaves that same table looking complete and
+        raises ``index 4 is out of bounds for axis 0 with size 4`` only if the
+        rows are taken by label instead. A scalar passed for ``frequencies``
+        reaches the result as a nought-dimensional array naming the single
+        band it describes, counted here as the one band it is.
+
+        :raises ValueError: if the image, coordinate or band axes disagree.
+        """
+        owner = type(self).__name__
+        require_ranks(self, times=1, distances=1, orders=1, image_positions=2)
+        require_same_length(
+            self, "times", "distances", "orders", "image_positions", axis="image"
+        )
+        require_same_length(
+            self,
+            "dimensions",
+            "source",
+            "receiver",
+            ("image_positions", 1),
+            axis="coordinate",
+        )
+        banded = np.ndim(self.amplitudes) > 1
+        require_axis_rank(self.ir, owner, "ir", 2 if banded else 1)
+        require_same_length(
+            self, "times", ("amplitudes", 1) if banded else "amplitudes", axis="image"
+        )
+        require_axis_rank(self.amplitudes, owner, "amplitudes", np.ndim(self.ir))
+        bands: dict[str, int] = {}
+        if self.frequencies is not None:
+            bands["frequencies"] = (
+                1
+                if np.ndim(self.frequencies) == 0
+                else require_axis_count(self.frequencies, owner, "frequencies", rank=1)
+            )
+        if banded:
+            bands["ir"] = require_axis_count(self.ir, owner, "ir", rank=None)
+            bands["amplitudes"] = require_axis_count(
+                self.amplitudes, owner, "amplitudes", rank=None
+            )
+        else:
+            bands["ir"] = 1
+        require_equal_counts(owner, bands)
 
     @property
     def direct_time(self) -> float:

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -71,6 +71,7 @@ import numpy as np
 from scipy import signal
 
 from .._internal.utils import _typesignal
+from .._internal.validation import require_ranks, require_same_length
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import (
     apply_calibration,
@@ -851,6 +852,45 @@ class ShapedSweepResult:
     group_delay: np.ndarray
     f_range: tuple[float, float]
     crest_factor_db: float
+
+    def __post_init__(self) -> None:
+        """Reject synthesis metadata that does not lie on one frequency grid.
+
+        The three arrays are the synthesis FFT grid written down three times:
+        the magnitude is the band-limited target evaluated bin by bin on
+        :attr:`frequencies`, and the group delay is the running sum of that
+        magnitude's power over the same bins, so the length they share is the
+        grid's own and nothing downstream re-derives the pairing.
+
+        The spectrum panel of :meth:`plot` normalises the target to its
+        in-band maximum by masking :attr:`frequencies` for the band and
+        applying that mask to the dB curve built from :attr:`magnitude`.
+        A grid and a magnitude of different lengths stop there, in either
+        direction, with numpy's ``IndexError`` about a boolean index and two
+        axis sizes -- a message that names neither field nor the result they
+        came from. :attr:`group_delay` has no reader at all: the plot never
+        opens it, so a trajectory of the wrong length raises nothing anywhere
+        and travels out to the caller, whose own pairing of it against
+        :attr:`frequencies` is what finally fails, one call site away from the
+        synthesis that built it.
+
+        The rank half is the silent one. A magnitude of shape ``(bin, 2)``
+        carries one row per bin and so passes every length check above, and
+        the plot draws its second column as a second dashed curve under the
+        single "Synthesis target" legend entry -- having first normalised both
+        by the larger of the two, which pushes the genuine target down by the
+        distance between the columns (12 dB for a second column four times the
+        first) while the Welch spectrum, normalised on its own, stays put. The
+        sweep is then read as missing a target it actually follows.
+
+        :raises ValueError: if the grid, the imposed magnitude and the group
+            delay span different numbers of bins, or one of them carries an
+            extra axis.
+        """
+        require_ranks(self, frequencies=1, magnitude=1, group_delay=1)
+        require_same_length(
+            self, "frequencies", "magnitude", "group_delay", axis="frequency bin"
+        )
 
     def __array__(self, dtype: Any = None) -> np.ndarray:
         """Return the sweep samples as an array (optionally recast)."""

--- a/src/phonometry/room/modes.py
+++ b/src/phonometry/room/modes.py
@@ -67,7 +67,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_positive
+from .._internal.validation import require_positive, require_ranks, require_same_length
 from .steady_field import schroeder_frequency
 
 if TYPE_CHECKING:
@@ -254,6 +254,66 @@ class RoomModesResult:
     speed_of_sound: float
     max_frequency: float
     schroeder_frequency: float | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a mode table whose triples, frequencies and kinds have slipped.
+
+        The three columns are one enumeration written three ways: the lattice
+        of order triples is cut at the frequency limit and sorted, and the
+        frequency and the kind of every surviving row are measured and read
+        off that same table. A result whose columns disagree is read
+        differently by each reader, and the reader that notices is not the one
+        that answers the question.
+
+        The ladder of :meth:`plot` picks a family out with ``kinds == kind``
+        and indexes the frequencies with the result, so a kind column of
+        another length arrives at numpy as a boolean index of the wrong size.
+        On the six modes of Long's 7 x 5 x 3 m room a kind column one short
+        raised ``IndexError: boolean index did not match indexed array along
+        axis 0; size of axis is 6 but size of corresponding boolean axis is
+        5``, from inside the drawing call and naming neither column. One long
+        raises the same way, and so does a frequency column of either wrong
+        length.
+
+        :meth:`count_by_kind` reads the kind column on its own and so says
+        nothing at all. On those same six modes a kind column one short
+        tallied ``{'axial': 4, 'tangential': 1, 'oblique': 0}``, five modes,
+        and one long tallied seven: a census of a room whose ladder has six
+        rungs, silent in both directions.
+
+        ``orders`` passes both readers untouched whatever its length, since
+        neither indexes it. What a slipped triple table breaks is the pairing
+        of a mode with its own frequency, which is how the enumeration is
+        meant to be read. With the triples one row short, ``orders[-1]`` and
+        ``frequencies[-1]`` came back as ``[0 0 1]`` at 60.0 Hz, and
+        ``[0 0 1]`` is the 57.3 Hz mode: the triple names one mode and the
+        number beside it another, with nothing raised. Zipping the two columns
+        instead drops the last mode without a word.
+
+        The ranks are pinned as well as the lengths, because a column that
+        carries an extra axis satisfies every count and travels on. A triple
+        table stacked into ``(modes, 3, 2)`` keeps its six rows, draws and
+        tallies exactly as before, and hands ``orders[0]`` back as a 3 x 2
+        block that :func:`room_mode_frequency` then refuses, complaining about
+        its own argument rather than about the result. A frequency column of
+        shape ``(modes, 1)`` draws the ladder at the right frequencies and
+        then fails ``float(frequencies[0])`` with ``TypeError: only
+        0-dimensional arrays can be converted to Python scalars``. A kind
+        column of that shape tallies correctly and raises ``IndexError: too
+        many indices for array: array is 1-dimensional, but 2 were indexed``
+        from the ladder.
+
+        The room lengths and the width of the triple table are one coordinate
+        count written twice, and it is not pinned by the rank: a triple table
+        two columns wide draws and tallies in silence, and is refused only
+        later, by :func:`room_mode_frequency`, in the same words it uses for a
+        bad argument of its own.
+
+        :raises ValueError: if the mode or the coordinate axes disagree.
+        """
+        require_ranks(self, orders=2, frequencies=1, kinds=1)
+        require_same_length(self, "orders", "frequencies", "kinds", axis="mode")
+        require_same_length(self, "dimensions", ("orders", 1), axis="coordinate")
 
     @property
     def volume(self) -> float:

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -76,7 +76,12 @@ if TYPE_CHECKING:
 from numpy.typing import ArrayLike, NDArray
 
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_non_negative, require_positive
+from .._internal.validation import (
+    require_non_negative,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 # ---------------------------------------------------------------------------
 # Constants.
@@ -567,6 +572,53 @@ class ReverberationModelResult:
     volume: float
     surface_area: float
 
+    def __post_init__(self) -> None:
+        """Reject a prediction whose five curves and band axis disagree.
+
+        Both readers take the six arrays for one band axis written down six
+        times. ``plot()`` draws each curve against ``frequencies`` point for
+        point, so a disagreement of length surfaces as matplotlib's ``x and y
+        must have same first dimension, but have shapes (6,) and (5,)``: two
+        bare shapes, naming neither the result nor which of the six arrays
+        carries which. The fiche walks ``frequencies`` and reads every curve
+        at that band's index, so a curve one entry short raises ``IndexError:
+        index 5 is out of bounds for axis 0 with size 5`` from inside the row
+        loop, naming no field at all. One entry long is quieter: the table
+        stops at the last frequency and the extra value simply never appears
+        -- a seventh Arau-Puchades time appended to a six-band prediction
+        leaves a table that ends at the 4000 Hz row looking exactly as it
+        would have -- and the fiche fails only afterwards, when it draws the
+        same figure the plot would have drawn.
+
+        The extra axis is the silent one. A curve of shape ``(bands, 1)``
+        counts the right number of bands, and ``plot()`` draws the column as
+        an ordinary line and hands back axes indistinguishable from a correct
+        figure. Only the fiche notices, with ``TypeError: only 0-dimensional
+        arrays can be converted to Python scalars`` raised while formatting a
+        table cell.
+
+        :raises ValueError: if the five curves and the band axis disagree, or
+            any of them carries an extra axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            sabine=1,
+            eyring=1,
+            millington_sette=1,
+            fitzroy=1,
+            arau_puchades=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "sabine",
+            "eyring",
+            "millington_sette",
+            "fitzroy",
+            "arau_puchades",
+        )
+
     @property
     def models(self) -> dict[str, np.ndarray]:
         """The five reverberation-time curves keyed by model name."""
@@ -733,7 +785,10 @@ def reverberation_time_models(
         n_bands = curve_bands
         freq = np.arange(1.0, n_bands + 1.0, dtype=np.float64)
     else:
-        freq = np.asarray(frequencies, dtype=np.float64)
+        # A single frequency is a band axis of one, as `frequencies=None`
+        # already produces: the five curves are 1-D whatever is passed, so a
+        # nought-dimensional axis beside them is a mixture no reader can walk.
+        freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
         if curve_bands not in (1, freq.size):
             msg = (
                 f"'frequencies' has {freq.size} bands but the per-band "

--- a/src/phonometry/room/steady_field.py
+++ b/src/phonometry/room/steady_field.py
@@ -81,7 +81,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_choice, require_positive
+from .._internal.validation import (
+    require_choice,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -287,6 +292,42 @@ class SteadyFieldResult:
     room_constant: float
     sound_power_level: float
     directivity: float
+
+    def __post_init__(self) -> None:
+        """Reject a field whose curves do not run over its own distances.
+
+        :attr:`direct`, :attr:`reverberant` and :attr:`total` are three levels
+        sampled at the same places, and the plot draws each of them against
+        :attr:`distances` point for point, so the four arrays are one curve
+        read off by position. A level array of another length is matplotlib
+        refusing the pair -- ``x and y must have same first dimension, but
+        have shapes (30,) and (29,)`` -- in both directions, one short and one
+        long alike. That message carries two bare shapes and names neither the
+        field that slipped nor the result it came from, and it arrives partway
+        through the drawing: a caller who passed an axes of their own keeps
+        whichever curves came first, the direct field for a reverberant one
+        that has slipped, both of them for the total.
+
+        Length alone would not catch the worse mistake, so the rank is pinned
+        too. A level array of shape ``(n, 2)`` has ``n`` rows and satisfies
+        every count, and matplotlib reads each of its columns as a separate
+        line: the figure comes back with an extra curve in the same colour and
+        dash as the real one, a second identical entry in the legend, and a
+        vertical range stretched to cover it. Nothing is raised and nothing is
+        said.
+
+        The critical distance, the room constant, the source power and the
+        directivity label the whole field rather than any point of it, and are
+        left out.
+
+        :raises ValueError: if the direct, reverberant or total levels do not
+            carry one value per distance, or any of the four is not a plain
+            one-dimensional curve.
+        """
+        require_ranks(self, distances=1, direct=1, reverberant=1, total=1)
+        require_same_length(
+            self, "distances", "direct", "reverberant", "total", axis="distance"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/cepstrum.py
+++ b/src/phonometry/signals/cepstrum.py
@@ -71,6 +71,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs
 from .spectra import _positive, _validate_signal
 
@@ -204,6 +205,22 @@ class CepstrumResult:
     nfft: int
     linear_phase_samples: int
 
+    def __post_init__(self) -> None:
+        """Reject a cepstrum that does not run over its own quefrency axis.
+
+        :meth:`plot` draws the pair over the unambiguous first half of the
+        axis, slicing both arrays at ``nfft // 2 + 1``, so a disagreement
+        past that point never reaches the figure at all: the curve is drawn,
+        looks ordinary, and the samples that were never paired with a
+        quefrency are simply not there. The ``nfft`` the slice is cut from is
+        recorded separately from either array, so nothing else is in a
+        position to notice.
+
+        :raises ValueError: if the two axes disagree in length.
+        """
+        require_ranks(self, quefrencies=1, cepstrum=1)
+        require_same_length(self, "quefrencies", "cepstrum", axis="quefrency")
+
     def invert(self) -> NDArray[np.float64]:
         """Reconstruct the record from a complex cepstrum.
 
@@ -334,6 +351,37 @@ class LifterResult:
     mode: str
     fs: float
     nfft: int
+
+    def __post_init__(self) -> None:
+        """Reject a split whose two panels do not run over their own axes.
+
+        The result carries two independent axes, and they are not the same
+        length: the log spectra live on the ``nfft // 2 + 1`` bins of a real
+        transform, the cepstrum on the full ``nfft`` quefrencies the lifter
+        window was applied to. Each is checked against its own companions
+        only. :meth:`plot` overlays :attr:`spectrum_db` and
+        :attr:`liftered_db` on one frequency grid to show that the two
+        modes are complementary in dB, a reading that a curve of another
+        length turns into a comparison of two different bands; and it draws
+        the cepstrum panel through the same ``nfft // 2 + 1`` slice as
+        :class:`CepstrumResult`, which hides any disagreement past the
+        midpoint rather than reporting it.
+
+        :raises ValueError: if the spectra disagree with each other, or the
+            cepstrum with its quefrency axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            spectrum_db=1,
+            liftered_db=1,
+            quefrencies=1,
+            cepstrum=1,
+        )
+        require_same_length(
+            self, "frequencies", "spectrum_db", "liftered_db", axis="frequency"
+        )
+        require_same_length(self, "quefrencies", "cepstrum", axis="quefrency")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -483,6 +531,27 @@ class EchoDetectionResult:
     search_range: tuple[float, float]
     fs: float
     nfft: int
+
+    def __post_init__(self) -> None:
+        """Reject a detection whose cepstrum and quefrency axis disagree.
+
+        :attr:`delay_samples` is a position in :attr:`cepstrum` and
+        :attr:`delay` is a time on :attr:`quefrencies`; the report of the
+        echo is the claim that those are the same place. :meth:`plot` states
+        it that way, marking the reflection coefficient at the interpolated
+        delay on top of a curve it slices at ``nfft // 2 + 1``, so a
+        mismatched pair puts the marker beside the peak it was read from
+        instead of on it, and past the midpoint the disagreement is cut away
+        before it can be seen.
+
+        :attr:`search_range` stays out of the check: it names the two ends
+        of the band that was searched, so its length of two belongs to the
+        pair and not to any axis.
+
+        :raises ValueError: if the two axes disagree in length.
+        """
+        require_ranks(self, quefrencies=1, cepstrum=1)
+        require_same_length(self, "quefrencies", "cepstrum", axis="quefrency")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/correlation.py
+++ b/src/phonometry/signals/correlation.py
@@ -56,6 +56,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs, resolve_pair_fs
 from ..io._signal import Signal
 from .spectra import (
@@ -168,6 +169,23 @@ class CorrelationResult:
     fs: float
     n_samples: int
     duration: float
+
+    def __post_init__(self) -> None:
+        """Reject an estimate whose three curves do not share one lag axis.
+
+        The three are read as columns of one table: :meth:`plot` draws
+        :attr:`values` against :attr:`lags`, and :meth:`random_error` turns
+        :attr:`coefficient` into an error per lag, position by position,
+        without ever looking at :attr:`lags` again. Nothing downstream can
+        catch a coefficient of another length, because what comes back is a
+        well-formed error curve; it is simply indexed by a lag axis it was
+        never measured on, and the reader pairs it with the delay that
+        Bendat & Piersol's Eq. 8.129 uncertainty is quoted for.
+
+        :raises ValueError: if the two estimates disagree with the lag axis.
+        """
+        require_ranks(self, lags=1, values=1, coefficient=1)
+        require_same_length(self, "lags", "values", "coefficient", axis="lag")
 
     def random_error(self, signal_bandwidth: float) -> NDArray[np.float64]:
         r"""Normalized random error of the estimate at each lag.
@@ -507,6 +525,24 @@ class TimeDelayResult:
     delay_interval: tuple[float, float] | None
     signal_bandwidth: float | None
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a delay estimate whose curve does not run over its lags.
+
+        The curve is the evidence for the number: :meth:`plot` draws it
+        against :attr:`lags` and rules :attr:`delay` across it, so the figure
+        asserts that the marked delay is where the peak is. A curve of
+        another length shifts the peak away from the estimate the searcher
+        actually located, and the estimate is reported as a scalar that
+        carries no record of the axis it was found on.
+
+        :attr:`delay_interval` is left out: it holds the two ends of the
+        95 % interval, a pair rather than a curve.
+
+        :raises ValueError: if the curve disagrees with the lag axis.
+        """
+        require_ranks(self, lags=1, correlation=1)
+        require_same_length(self, "lags", "correlation", axis="lag")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -916,6 +952,23 @@ class AlignedImpulseResponseResult:
     delay: float
     delay_samples: float
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a pair of impulse responses that are not comparable.
+
+        The point of the result is that the two records can now be read
+        sample against sample -- averaged into an ensemble, subtracted,
+        overlaid. :meth:`plot` does exactly that, building one time axis from
+        :attr:`reference` and drawing both traces on it. Two records of
+        different lengths were never comparable in the first place, and
+        :attr:`delay_samples`, a fractional shift stated in samples of a rate
+        both are supposed to share, has no meaning between them.
+
+        :raises ValueError: if the aligned record and the reference differ
+            in length.
+        """
+        require_ranks(self, aligned=1, reference=1)
+        require_same_length(self, "aligned", "reference", axis="sample")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/envelope.py
+++ b/src/phonometry/signals/envelope.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs
 from .spectra import _positive, _validate_signal
 
@@ -102,6 +103,43 @@ class EnvelopeResult:
     signal_fs: float
     decimation_factor: int
     antialias: bool
+
+    def __post_init__(self) -> None:
+        """Reject outputs that do not all run over the decimated time axis.
+
+        The three analytic-signal quantities are one account of the record
+        over :attr:`times`, and the reader takes them that way: :meth:`plot`
+        stacks the envelope panel and the instantaneous-frequency panel on a
+        shared time axis, so the moment a modulation peaks in the upper panel
+        is read against the frequency directly below it. Decimation is what
+        makes that fragile -- the envelope goes through a filter and the
+        phase through plain subsampling, and only the output rate ties the
+        two results together afterwards.
+
+        :attr:`signal` is deliberately left out. It is the analysed record at
+        full rate, kept for the plot's background trace and drawn on a time
+        axis of its own built from :attr:`signal_fs`; it matches
+        :attr:`times` only when no decimation was asked for, and pinning the
+        two together would reject every decimated result the module produces.
+
+        :raises ValueError: if an output disagrees with the time axis.
+        """
+        require_ranks(
+            self,
+            times=1,
+            envelope=1,
+            phase=1,
+            instantaneous_frequency=1,
+            signal=1,
+        )
+        require_same_length(
+            self,
+            "times",
+            "envelope",
+            "phase",
+            "instantaneous_frequency",
+            axis="output sample",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -248,6 +286,31 @@ class EnvelopeSpectrumResult:
     fs: float
     nfft: int
     band: tuple[float, float] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a result whose two panels do not run over their own axes.
+
+        The result carries the two halves of Bendat & Piersol's Figure 13.11
+        chain, and they are measured on different axes that are not the same
+        length: the detected envelope over the record's ``n`` samples, its
+        amplitude spectrum over the ``nfft // 2 + 1`` bins of the transform
+        that was taken of it. Each is checked against its own companion only.
+        :meth:`plot` draws them as two panels, the envelope against
+        :attr:`times` above and the modulation lines against
+        :attr:`frequencies` below, and reads a line's height as the
+        modulation depth carried by the envelope in the panel above -- which
+        holds only while each panel's pair is one measurement.
+
+        :attr:`band` states the two edges of the optional band-pass front
+        end, so it is a pair rather than an axis and stays out of both
+        groups.
+
+        :raises ValueError: if the spectrum disagrees with its frequency
+            axis, or the envelope with its time axis.
+        """
+        require_ranks(self, frequencies=1, amplitude=1, times=1, envelope=1)
+        require_same_length(self, "frequencies", "amplitude", axis="frequency")
+        require_same_length(self, "times", "envelope", axis="sample")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.utils import _typesignal
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import apply_calibration
 from ..io._resolve import resolve_fs as _resolve_signal_fs
 from ..io._signal import Signal
@@ -109,6 +110,47 @@ class InverseFilterResult:
     fs: float
     flatness_db: float
     max_gain_db: float
+
+    def __post_init__(self) -> None:
+        r"""Reject a design whose spectra do not share one frequency grid.
+
+        The three spectra and the regularization profile are the design at
+        one frequency each, and the figure multiplies them together to make
+        its central claim: :meth:`plot` forms the equalized magnitude
+        :math:`\lvert H \, H_{\mathrm{inv}} \rvert` as an
+        elementwise product of :attr:`response_spectrum` and
+        :attr:`spectrum`, then draws it over :attr:`frequencies` with the
+        equalized band shaded and the achieved flatness in the title. Numpy
+        will broadcast a single-bin array across the whole grid without a
+        word, which is the shape a caller lands on by designing at one
+        frequency where the band needed the grid, and the flat 0 dB line
+        that comes back is precisely what the figure is meant to show.
+
+        :attr:`inverse` is deliberately left out. It is the filter in the
+        time domain, ``n_fft`` samples, while the spectra live on the
+        ``n_fft // 2 + 1`` bins of the real transform of it; the two lengths
+        are different measurements of the same design and pinning them
+        together would reject every filter the module produces.
+
+        :raises ValueError: if a spectrum or the profile disagrees with the
+            frequency grid.
+        """
+        require_ranks(
+            self,
+            inverse=1,
+            frequencies=1,
+            spectrum=1,
+            response_spectrum=1,
+            regularization=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "spectrum",
+            "response_spectrum",
+            "regularization",
+            axis="frequency",
+        )
 
     def __array__(self, dtype: Any = None) -> np.ndarray:
         """Return the inverse-filter samples as an array."""

--- a/src/phonometry/signals/miso.py
+++ b/src/phonometry/signals/miso.py
@@ -58,6 +58,11 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from ..io._resolve import resolve_fs, resolve_pair_fs, resolve_samples
 from ..io._signal import Signal
 from .spectra import (
@@ -452,6 +457,81 @@ class MISOCoherenceResult:
     nperseg: int
     overlap: float
     scaling: str
+
+    def __post_init__(self) -> None:
+        """Reject a result whose arrays do not span its own two axes.
+
+        Every array here is written on one frequency axis and one input axis,
+        and both are read back unchecked. The figure indexes every curve it
+        draws with a single boolean mask built from :attr:`frequencies` alone,
+        so a per-band array of another length stops it from inside numpy
+        (``boolean index did not match indexed array along axis 0; size of
+        axis is 257 but size of corresponding boolean axis is 256``), naming
+        neither the field nor the result, on the short array and the long one
+        alike -- but only for the arrays it draws. :attr:`ordinary_coherence`,
+        :attr:`multiple_coherence_random_error` and
+        :attr:`coherent_output_random_error` are on no panel, so a mismatch
+        there reaches the reader untouched: a random error quoted per band
+        under a frequency axis it was never measured on.
+
+        :meth:`dominant_input` is the quiet one, on both axes. It promises one
+        index per entry of :attr:`frequencies` and takes the argmax of
+        :attr:`coherent_output_spectra` without looking at either the
+        frequency axis or :attr:`n_inputs`: a band axis one short returned 256
+        answers for a 257-bin result, and one row too many made it answer
+        ``2`` in every band of a two-input measurement, an original input
+        index that names no input. That extra row is dropped from both panels
+        of the figure without a word, though it carried more output power than
+        the two real inputs together; a missing row instead stops the loop
+        over :attr:`n_inputs` on numpy's ``index 2 is out of bounds for axis 0
+        with size 2``. :attr:`order` is read by no renderer, so one shorter or
+        longer than the inputs passes the figure intact and silently breaks
+        the only promise it carries, that ``partial_coherence[order[k]]`` is
+        the input conditioned on ``order[:k]``.
+
+        :raises ValueError: if a per-band array disagrees with the frequency
+            axis, or the per-input arrays, the conditioning order and
+            :attr:`n_inputs` disagree on the number of inputs.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            ordinary_coherence=2,
+            multiple_coherence=1,
+            partial_coherence=2,
+            coherent_output_spectra=2,
+            output_psd=1,
+            noise_psd=1,
+            multiple_coherence_random_error=1,
+            coherent_output_random_error=2,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            ("ordinary_coherence", 1),
+            "multiple_coherence",
+            ("partial_coherence", 1),
+            ("coherent_output_spectra", 1),
+            "output_psd",
+            "noise_psd",
+            "multiple_coherence_random_error",
+            ("coherent_output_random_error", 1),
+            axis="frequency",
+        )
+        require_same_length(
+            self,
+            "order",
+            "ordinary_coherence",
+            "partial_coherence",
+            "coherent_output_spectra",
+            "coherent_output_random_error",
+            axis="input",
+        )
+        require_equal_counts(
+            type(self).__name__,
+            {"order": len(self.order), "n_inputs": self.n_inputs},
+            "input",
+        )
 
     def dominant_input(self) -> NDArray[np.intp]:
         """Index of the input contributing the most output power per bin.

--- a/src/phonometry/signals/multitaper.py
+++ b/src/phonometry/signals/multitaper.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs
 from .spectra import (
     _positive,
@@ -132,6 +133,74 @@ class MultitaperSpectralDensityResult:
     resolution_bandwidth: float
     adaptive: bool
     scaling: str
+
+    def __post_init__(self) -> None:
+        r"""Reject an estimate whose columns leave one of its two axes.
+
+        The frequency columns are one rfft grid written down several
+        times, and the four the figure draws are the only ones a mismatch
+        stops. :meth:`plot` builds a single positive-frequency mask from
+        :attr:`frequencies` and applies it to :attr:`psd`,
+        :attr:`ci_lower` and :attr:`ci_upper`, so a length that disagrees
+        raises numpy's ``boolean index did not match indexed array along
+        axis 0; size of axis is 513 but size of corresponding boolean
+        axis is 512`` -- which names sizes and never a field, and quotes
+        them for whichever array is being indexed rather than for the one
+        that is wrong, so a short :attr:`frequencies` is reported against
+        the confidence bound the mask reached first.
+
+        The rest is silent, in both directions. :attr:`degrees_of_freedom`
+        reaches the figure only as the mean of its interior bins, printed
+        in the legend beside the confidence level: hand this density the
+        dof of another estimate and the band drawn from the correct
+        :attr:`ci_lower` and :attr:`ci_upper` is labelled
+        :math:`\bar\nu` = 5.2 where the interval it shows carries 10.6, on
+        a figure that is otherwise complete. One entry too many is quieter
+        still -- the mean barely moves -- but the halved bin documented
+        above as the Nyquist one is then no longer the last.
+        :attr:`random_error` and :attr:`weights` are drawn by nothing at
+        all: they are further columns of the same table,
+        :math:`\sqrt{2/\nu}` beside its :math:`\nu` and the combination
+        that produced the density beside the density, and the reader who
+        pairs them position by position is the one that pays.
+
+        :attr:`eigenvalues` and the taper axis of :attr:`weights` are
+        pinned separately, because how many bins the record has and how
+        many tapers were averaged over it are two independent sizes. That
+        pair is silent throughout: an extra :math:`\lambda_k` changes the
+        :math:`\sum_j \lambda_j` a reader normalizes by, so the uniform
+        weights this class documents as :math:`\lambda_k / \sum_j
+        \lambda_j` come out 0.127 for *every* taper where they are 0.144,
+        the ones actually present included; an extra row of
+        :attr:`weights` makes the combination sum to 1.0009 rather than
+        the 1 its own definition asserts.
+
+        :raises ValueError: if a column disagrees with the frequency axis
+            or with the taper axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            psd=1,
+            ci_lower=1,
+            ci_upper=1,
+            degrees_of_freedom=1,
+            random_error=1,
+            weights=2,
+            eigenvalues=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "psd",
+            "ci_lower",
+            "ci_upper",
+            "degrees_of_freedom",
+            "random_error",
+            ("weights", 1),
+            axis="frequency bin",
+        )
+        require_same_length(self, "eigenvalues", "weights", axis="taper")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/phase.py
+++ b/src/phonometry/signals/phase.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from .cepstrum import _fold_causal
 
 if TYPE_CHECKING:
@@ -265,6 +266,71 @@ class PhaseDecompositionResult:
     excess_group_delay: NDArray[np.float64]
     minimum_phase_response: NDArray[np.complex128]
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a decomposition whose parts do not lie on one frequency grid.
+
+        The eight arrays are one response written down eight times.
+        :func:`phase_decomposition` derives every one of them from the same
+        ``rfft`` grid: the axis is ``linspace(0, fs/2, response.size)``, the
+        magnitude and the measured phase are the modulus and the argument of
+        that response, the minimum phase is the argument of the cepstral
+        reconstruction read back on the same bins, the excess phase is their
+        difference, and both group delays are gradients over the same
+        spacing. No length here is anything but the response's own.
+
+        Seven of the eight are read through a single boolean mask in
+        :meth:`plot`, which drops DC by comparing :attr:`frequencies` against
+        zero and applies that one mask to every curve. A field of another
+        length stops there, in either direction, with numpy's ``IndexError``
+        about a boolean index and two axis sizes -- the two numbers swap
+        round according to which field is at fault, and the message names
+        neither the field nor the result it came from.
+        :attr:`minimum_phase_response` has no reader at all: the figure never
+        opens it, so a complex response of the wrong length raises nothing
+        anywhere and travels out whole. It is the one field of the eight a
+        caller transforms back to a record, and ``irfft`` of 256 bins is a
+        perfectly ordinary 510-sample answer where the 257 bins of the
+        decomposition meant 512 -- a record two samples short of the one it
+        claims to be the minimum-phase version of.
+
+        The rank half is the silent one throughout. A field of shape
+        ``(bin, 2)`` carries one row per bin and so satisfies every length
+        check above, and ``semilogx`` draws its second column as a second
+        curve on the same panel, under a legend that names the doubled curve
+        twice: four lines and two "Excess phase (all-pass)" entries on the
+        phase panel for an excess phase of that shape, three lines and two
+        "Group delay" entries on the group-delay panel, two lines on the
+        magnitude panel, which carries no legend at all to give it away. No
+        warning is raised in any of them.
+
+        :raises ValueError: if the frequency axis, the magnitude, the three
+            phases, the two group delays and the reconstructed response span
+            different numbers of bins, or one of them carries an extra axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            magnitude=1,
+            phase=1,
+            minimum_phase=1,
+            excess_phase=1,
+            group_delay=1,
+            excess_group_delay=1,
+            minimum_phase_response=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "magnitude",
+            "phase",
+            "minimum_phase",
+            "excess_phase",
+            "group_delay",
+            "excess_group_delay",
+            "minimum_phase_response",
+            axis="frequency bin",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/spectra.py
+++ b/src/phonometry/signals/spectra.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import apply_calibration, resolve_fs, resolve_pair_fs
 
 if TYPE_CHECKING:
@@ -413,6 +414,34 @@ class SpectralDensityResult:
     overlap: float
     scaling: str
 
+    def __post_init__(self) -> None:
+        """Reject a density whose band does not sit on its own frequency axis.
+
+        The four array fields are one Welch frequency axis and the three
+        curves read off it: the density, and the two chi-square bounds the
+        figure fills between as the confidence band. The plotter cuts a
+        positive-frequency mask from ``frequencies`` and applies it to the
+        other three, so a curve of the wrong length raises, in both
+        directions, ``IndexError: boolean index did not match indexed array
+        along axis 0; size of axis is 128 but size of corresponding boolean
+        axis is 129`` from inside numpy: two sizes, neither the field that
+        carries the wrong one nor the result it came from, and by then the
+        figure has been created and is left open. Refusing the result at
+        construction names both instead.
+
+        :raises ValueError: if the axis and the three curves do not share one
+            length.
+        """
+        require_ranks(self, frequencies=1, psd=1, ci_lower=1, ci_upper=1)
+        require_same_length(
+            self,
+            "frequencies",
+            "psd",
+            "ci_lower",
+            "ci_upper",
+            axis="frequency",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -579,6 +608,52 @@ class CrossSpectralDensityResult:
     nperseg: int
     overlap: float
     scaling: str
+
+    def __post_init__(self) -> None:
+        r"""Reject a cross-spectrum whose curves do not share one axis.
+
+        The seven array fields are one Welch frequency axis and the six
+        quantities computed on it, all of them from the single
+        :math:`\hat{G}_{xy}` the same segment averaging returned. The figure
+        cuts a positive-frequency mask from ``frequencies`` and applies it to
+        ``magnitude``, ``phase``, ``phase_std`` and ``coherence``, so any of
+        those five out of step raises, short or long, ``IndexError: boolean
+        index did not match indexed array along axis 0; size of axis is 128
+        but size of corresponding boolean axis is 129`` from inside numpy -
+        two sizes, and neither the field nor the result.
+
+        The other two are worse off, because nothing draws them. A wrong
+        length in ``csd`` or in ``magnitude_random_error`` renders the full
+        three-panel figure without a word (measured: every panel drawn over
+        the same 128 positive bins, no warning raised), and what reaches the
+        caller is a complex spectrum, or a per-bin random error, that no
+        longer lines up bin for bin with the magnitude and phase taken from
+        it.
+
+        :raises ValueError: if the axis and the six curves do not share one
+            length.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            csd=1,
+            magnitude=1,
+            phase=1,
+            coherence=1,
+            magnitude_random_error=1,
+            phase_std=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "csd",
+            "magnitude",
+            "phase",
+            "coherence",
+            "magnitude_random_error",
+            "phase_std",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -748,6 +823,64 @@ class CoherentOutputSpectrumResult:
     nperseg: int
     overlap: float
     scaling: str
+
+    def __post_init__(self) -> None:
+        r"""Reject a split whose parts do not share one frequency axis.
+
+        The ten array fields are one Welch frequency axis and the nine
+        quantities read off it: the measured output autospectrum, the two
+        parts it splits into, the coherence that splits it, and the ratios
+        and errors derived from those. They are the same axis written down
+        ten times, so :math:`\hat{G}_{yy} = \hat{G}_{vv} + \hat{G}_{nn}`
+        holds bin for bin.
+
+        Only five of the ten are drawn. ``output_psd``, ``coherent_psd``
+        and ``noise_psd`` go on the spectra panel and ``snr_db`` on the one
+        below it, all masked by the positive-frequency part of
+        ``frequencies``, so a wrong length in those five raises, short or
+        long, ``IndexError: boolean index did not match indexed array along
+        axis 0; size of axis is 128 but size of corresponding boolean axis is
+        129`` from inside numpy, naming two sizes and neither the field nor
+        the result.
+
+        ``coherence``, ``snr``, ``random_error``, ``snr_random_error`` and
+        ``coherence_bias`` are drawn by nothing at all. A wrong length in any
+        of the five returns the complete two-panel figure with no warning
+        (measured: the three spectra and the SNR trace all drawn over the
+        same 128 positive bins), so the figure looks exactly as it should
+        while the coherence and the Eq. 9.73 and 9.75 errors the caller reads
+        beside it are off by a bin against the axis they are quoted on.
+
+        :raises ValueError: if the axis and the nine curves do not share one
+            length.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            output_psd=1,
+            coherent_psd=1,
+            noise_psd=1,
+            coherence=1,
+            snr=1,
+            snr_db=1,
+            random_error=1,
+            snr_random_error=1,
+            coherence_bias=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "output_psd",
+            "coherent_psd",
+            "noise_psd",
+            "coherence",
+            "snr",
+            "snr_db",
+            "random_error",
+            "snr_random_error",
+            "coherence_bias",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/synchronous_average.py
+++ b/src/phonometry/signals/synchronous_average.py
@@ -83,6 +83,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs
 from .spectra import _positive
 from .test_signals import _validate_1d_finite, fractional_delay
@@ -202,6 +203,45 @@ class SynchronousAverageResult:
     residual_rms: float
     comb_frequencies: NDArray[np.float64]
     comb_response: NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        """Reject an average whose two curves do not run over their own axis.
+
+        The figure draws two panels from two independent axes, and each one
+        is a pair. Above, the averaged waveform against :attr:`times`: the
+        panel is read as one period, so a waveform longer than its time axis
+        is not merely clipped but redraws the tail of the period on top of
+        its head. Below, the comb magnitude against :attr:`comb_frequencies`,
+        converted to orders and annotated with a harmonic line at every
+        integer up to the last one the axis reaches -- so a response of the
+        wrong length puts the teeth of McFadden Eq. 8 somewhere other than
+        the harmonics the lines mark them at, which is the whole claim the
+        panel makes.
+
+        The two axes are pinned separately because they are separate: the
+        waveform runs over :attr:`samples_per_period` samples of the sampling
+        grid, the comb over a frequency grid whose density is chosen for the
+        plot alone.
+
+        :attr:`residual` spans the whole analysed record,
+        ``n_averages * samples_per_period`` samples rather than one period,
+        so it belongs to neither pair and stays out of both.
+
+        :raises ValueError: if the waveform disagrees with its time axis, or
+            the comb response with its frequency axis.
+        """
+        require_ranks(
+            self,
+            period_waveform=1,
+            times=1,
+            residual=1,
+            comb_frequencies=1,
+            comb_response=1,
+        )
+        require_same_length(self, "times", "period_waveform", axis="period sample")
+        require_same_length(
+            self, "comb_frequencies", "comb_response", axis="comb-filter frequency"
+        )
 
     @property
     def amplitude_snr_gain(self) -> float:

--- a/src/phonometry/signals/test_signals.py
+++ b/src/phonometry/signals/test_signals.py
@@ -57,6 +57,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import apply_calibration, like_input, resolve_fs
 from .spectra import _positive
@@ -249,6 +250,24 @@ class ToneBurstResult:
     repetition_rate: float | None
     period_samples: int | None
     duty_cycle: float | None
+
+    def __post_init__(self) -> None:
+        """Reject a burst whose gate does not cover the record it gates.
+
+        :attr:`envelope` is not an independent curve but a statement about
+        :attr:`signal`: it is ``amplitude`` exactly where the gate of Clause
+        A2.1 is open and zero everywhere else, which is what makes the record
+        readable as an integral number of full periods. The figure draws both
+        on one time axis built from the length of :attr:`signal`, mirroring
+        the envelope above and below the waveform, so an envelope of another
+        length stops describing this record: shorter, the gate appears to
+        close before the last burst has sounded; longer, it stays open over
+        silence that is not there.
+
+        :raises ValueError: if the envelope disagrees with the signal.
+        """
+        require_ranks(self, signal=1, envelope=1)
+        require_same_length(self, "signal", "envelope", axis="sample")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -487,6 +506,30 @@ class ResampledSignalResult:
     stopband_edge_hz: float
     stopband_attenuation_db: float
     transition_width: float
+
+    def __post_init__(self) -> None:
+        """Reject a record or a filter that carries an axis nobody reads.
+
+        The two arrays here measure nothing in common and are deliberately
+        left unpinned against each other: :attr:`signal` runs over the
+        resampled record, whose length follows the rate ratio, while
+        :attr:`filter_taps` runs over the Kaiser design, whose length follows
+        the transition width and the attenuation. A 24576-sample record
+        beside a 1891-tap filter is the ordinary case, and any equality
+        between the two would reject it.
+
+        What both must be is flat. :attr:`n_taps` reports ``filter_taps.size``
+        and the figure evaluates the magnitude response from the taps, so a
+        second axis on either one is counted into the total and filtered as
+        though it were more of the same filter -- a channel of a
+        multichannel record read as extra samples, a bank of designs read as
+        one long impulse response -- and both the reported tap count and the
+        plotted spec come out of a filter that was never designed.
+
+        :raises ValueError: if the record or the taps carry more than one
+            axis.
+        """
+        require_ranks(self, signal=1, filter_taps=1)
 
     @property
     def n_taps(self) -> int:

--- a/src/phonometry/signals/time_frequency.py
+++ b/src/phonometry/signals/time_frequency.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import resolve_fs
 from .spectra import (
     _DEFAULT_OVERLAP,
@@ -150,6 +151,31 @@ class SpectrogramResult:
     nperseg: int
     overlap: float
     scaling: str
+
+    def __post_init__(self) -> None:
+        """Reject a display whose raster does not match the plane it is on.
+
+        :attr:`power` is drawn as a single raster image whose extent is built
+        from the ends of :attr:`frequencies` and :attr:`times` rather than
+        from the image itself, so ``imshow`` stretches whatever grid it is
+        given across those two spans without complaint. A power array with
+        the wrong number of rows therefore does not fail: it rescales, and
+        every tone in the display lands at a frequency it was never measured
+        at, on a plot that still carries a correctly labelled axis. The same
+        holds along time, where a column count that disagrees slides the
+        whole record forwards or backwards under a time axis that looks
+        right.
+
+        The two axes are pinned separately and the segment axis of
+        :attr:`power` is its second one, because the array is stored as
+        ``(frequencies, times)`` -- one row per bin, one column per segment.
+
+        :raises ValueError: if the power grid disagrees with either axis of
+            the time-frequency plane.
+        """
+        require_ranks(self, times=1, frequencies=1, power=2)
+        require_same_length(self, "frequencies", "power", axis="frequency bin")
+        require_same_length(self, "times", ("power", 1), axis="segment")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -295,6 +321,32 @@ class ZoomFFTResult:
     resolution_bandwidth: float
     window: str
     n_points: int
+
+    def __post_init__(self) -> None:
+        """Reject a zoom spectrum whose lines do not sit on its own grid.
+
+        The three spectral quantities are one measurement seen three ways:
+        :attr:`amplitude` is the modulus of :attr:`spectrum` and
+        :attr:`power` its mean square, both taken bin by bin, and all three
+        are read against :attr:`frequencies`. The whole point of the zoom is
+        that a line's position on that grid is the answer -- which of two
+        sidebands is which, how far the hum sits from the tone -- so an array
+        of another length does not merely plot short: it shifts every line
+        onto a neighbour's frequency while the axis limits, taken from the
+        first and last grid points, still say the band was covered.
+
+        :raises ValueError: if any spectral quantity disagrees with the zoom
+            grid.
+        """
+        require_ranks(self, frequencies=1, spectrum=1, amplitude=1, power=1)
+        require_same_length(
+            self,
+            "frequencies",
+            "spectrum",
+            "amplitude",
+            "power",
+            axis="grid point",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/simulation/elastic_fdtd.py
+++ b/src/phonometry/simulation/elastic_fdtd.py
@@ -73,6 +73,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.optimize import brentq
 
+from .._internal.validation import require_ranks, require_same_length
 from .fdtd import (
     _SIDES,
     Field2D,
@@ -81,6 +82,7 @@ from .fdtd import (
     _positive_finite,
     _positive_map,
     _probe_indices,
+    _require_grid_axes,
     _resolve_sponge_sides,
     _run_recording,
     _sigma_map,
@@ -1026,6 +1028,43 @@ class ElasticFDTDResult:
     snapshot_field: str
     obstacle_mask: NDArray[np.bool_] | None
     free_sides: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Reject a run whose probes, fields, time axis and grid disagree.
+
+        ``signals`` is indexed one probe and one field at a time, and neither
+        index carries a name of its own: the probe plot draws the trace at
+        ``signals[k, j]`` under the position of probe ``k`` and the symbol of
+        ``probe_fields[j]``. A field axis longer than ``probe_fields`` then
+        leaves its surplus traces out of the picture without a word, and one
+        shorter runs off the end of the array being drawn. The snapshot plot
+        stamps its frame across an extent taken from ``shape``, which turns a
+        frame recorded on a different grid into a plausible field over a
+        domain it never covered.
+
+        :raises ValueError: if the probe, field, time-step, snapshot or grid
+            axes disagree.
+        """
+        require_ranks(
+            self,
+            times=1,
+            signals=3,
+            probes=2,
+            probe_positions=2,
+            snapshots=3,
+            snapshot_times=1,
+            obstacle_mask=2,
+        )
+        require_same_length(self, "signals", "probes", "probe_positions", axis="probe")
+        require_same_length(
+            self, ("probes", 1), ("probe_positions", 1), axis="coordinate"
+        )
+        require_same_length(self, "probe_fields", ("signals", 1), axis="recorded field")
+        require_same_length(self, "times", ("signals", 2), axis="time step")
+        require_same_length(self, "snapshots", "snapshot_times", axis="snapshot")
+        _require_grid_axes(
+            type(self).__name__, self.shape, self.snapshots, self.obstacle_mask
+        )
 
     @property
     def size(self) -> tuple[float, float]:

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -46,6 +46,11 @@ from typing import TYPE_CHECKING, Any, Protocol
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from .._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from .ntff import ContourPhasors
 
 if TYPE_CHECKING:
@@ -1167,6 +1172,42 @@ class FDTD2D:
         return _run_recording(self, steps, record_every, decimate)
 
 
+def _require_grid_axes(
+    owner: str,
+    shape: tuple[int, int],
+    snapshots: NDArray[np.float64] | None,
+    obstacle_mask: NDArray[np.bool_] | None,
+) -> None:
+    """Require every whole-domain raster to cover the grid ``shape`` names.
+
+    Shared by the acoustic and the elastic result, which record different
+    fields over the same domain and hand them to the same snapshot renderer.
+    That renderer takes the physical extent of the picture from ``shape``
+    alone and draws the obstacle map on top of it as a second image over the
+    same extent, so a raster recorded on a different grid is stretched to fit
+    a domain it never covered, with the geometry landing on cells that were
+    never simulated. Neither imshow nor the eye objects: the frame is a
+    perfectly ordinary field plot of the wrong thing.
+
+    :param owner: Name of the result type being checked, for the message.
+    :param shape: The grid the run covered, ``(ny, nx)``.
+    :param snapshots: Recorded frames, ``(n_frames, ny, nx)``, or ``None``.
+    :param obstacle_mask: Rigid-cell map, ``(ny, nx)``, or ``None``.
+    :raises ValueError: if a raster disagrees with ``shape``.
+    """
+    ny, nx = shape
+    rows = {"shape (rows)": ny}
+    columns = {"shape (columns)": nx}
+    if snapshots is not None:
+        rows["snapshots (axis 1)"] = snapshots.shape[1]
+        columns["snapshots (axis 2)"] = snapshots.shape[2]
+    if obstacle_mask is not None:
+        rows["obstacle_mask"] = obstacle_mask.shape[0]
+        columns["obstacle_mask (axis 1)"] = obstacle_mask.shape[1]
+    require_equal_counts(owner, rows, "grid row")
+    require_equal_counts(owner, columns, "grid column")
+
+
 @dataclass(frozen=True)
 class FDTDResult:
     r"""Frozen result of a :func:`fdtd_simulation` run.
@@ -1199,6 +1240,44 @@ class FDTDResult:
     snapshots: NDArray[np.float64] | None
     snapshot_times: NDArray[np.float64] | None
     obstacle_mask: NDArray[np.bool_] | None
+
+    def __post_init__(self) -> None:
+        """Reject a run whose probes, time axis and grid do not line up.
+
+        Every reader of a run is a picture, and neither picture can defend
+        itself. The probe plot pairs each row of ``pressures`` with the label
+        built from the matching row of ``probe_positions``, so a positions
+        array of another length surfaces only at drawing time, as a zip that
+        reports two lengths and names neither array, an entire run after the
+        mistake was made. The snapshot plot does not surface it at all: it
+        stamps the frame across an extent taken from ``shape``, which turns a
+        frame recorded on a different grid into a plausible field over a
+        domain it never covered.
+
+        :raises ValueError: if the probe, time-step, snapshot or grid axes
+            disagree.
+        """
+        require_ranks(
+            self,
+            times=1,
+            pressures=2,
+            probes=2,
+            probe_positions=2,
+            snapshots=3,
+            snapshot_times=1,
+            obstacle_mask=2,
+        )
+        require_same_length(
+            self, "pressures", "probes", "probe_positions", axis="probe"
+        )
+        require_same_length(
+            self, ("probes", 1), ("probe_positions", 1), axis="coordinate"
+        )
+        require_same_length(self, "times", ("pressures", 1), axis="time step")
+        require_same_length(self, "snapshots", "snapshot_times", axis="snapshot")
+        _require_grid_axes(
+            type(self).__name__, self.shape, self.snapshots, self.obstacle_mask
+        )
 
     @property
     def size(self) -> tuple[float, float]:

--- a/src/phonometry/simulation/ntff.py
+++ b/src/phonometry/simulation/ntff.py
@@ -105,7 +105,48 @@ class ContourPhasors:
     segment: float
 
     def __post_init__(self) -> None:
-        """Check positive scalars, matched shapes and finite samples; coerce dtypes."""
+        """Reject a contour whose geometry and phasors disagree; coerce dtypes.
+
+        The four arrays are one axis written down four times: sample ``i`` of
+        ``pressure`` and of ``normal_velocity`` belongs to the point at row
+        ``i`` of ``positions``, facing along row ``i`` of ``normals``. Nothing
+        downstream carries a sample index of its own, so this is the only
+        place they can be held to one axis:
+        :func:`far_field_from_contour` multiplies the four row by row and
+        sums the products over the contour, and the sum it returns is one
+        value per observation angle, with the sample axis already gone.
+
+        A field one sample short or one long is caught, but only by numpy and
+        only from inside that sum, as a broadcast error that prints the two
+        shapes it could not reconcile and names neither array: on a contour
+        of 96 samples read at 72 angles, a ``pressure`` one short raises
+        ``operands could not be broadcast together with shapes (72,96) (95,)``
+        in the far-field branch and the same two shapes the other way round
+        in the finite-``distance`` one.
+
+        A field collapsed to a single sample is not caught at all. One value
+        computed where the contour needed one per point broadcasts over the
+        whole contour, and the pattern that comes back has exactly the
+        expected length and an entirely ordinary shape; measured on an
+        off-centre monopole enclosed by that circle, it is wrong over parts
+        of its arc by 3.7 dB when ``pressure`` collapses, 8.4 dB for
+        ``normal_velocity``, 16 dB for ``positions`` and 32 dB for
+        ``normals``. Counting samples is not the whole of it either, which is
+        why the shapes are required whole rather than compared in length: a
+        ``pressure`` of shape ``(n, 2)`` carries the right number of samples
+        on its first axis and passes any count, and nothing but the shape
+        stops the second axis travelling into the sum.
+
+        The coerced arrays are stored back, so hand-built instances (lists,
+        mixed dtypes) behave exactly like probe-built ones downstream. That
+        conversion is also why the shapes are measured on the local arrays
+        rather than on the fields: a rank read off the fields as given would
+        see one axis in the documented list form and refuse it.
+
+        :raises ValueError: for a non-positive ``frequency`` or ``segment``,
+            for arrays that do not share one sample axis in the shapes above,
+            or for a non-finite sample.
+        """
         if not np.isfinite(self.frequency) or self.frequency <= 0.0:
             msg = "frequency must be positive and finite"
             raise ValueError(msg)

--- a/src/phonometry/speech/objective_intelligibility.py
+++ b/src/phonometry/speech/objective_intelligibility.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
 from ..io._resolve import apply_calibration, resolve_pair_fs
 
 if TYPE_CHECKING:
@@ -109,6 +110,27 @@ class STOIResult:
     band_scores: NDArray[np.float64] | None
     band_frequencies: NDArray[np.float64]
     sample_rate: int
+
+    def __post_init__(self) -> None:
+        """Reject a result whose per-band quantities disagree.
+
+        :attr:`band_scores` and :attr:`band_frequencies` are the two halves of
+        one bar chart, the bar heights and the band each bar is labelled with,
+        and every reader pairs them by position. Matplotlib does notice the
+        mismatch, but only when the chart is drawn and only as a complaint
+        about tick locations outnumbering labels, which names neither field
+        and arrives long after the result was built, returned and passed on.
+        Refusing it here puts the error where the mistake is.
+
+        :attr:`segment_scores` runs over the 384 ms analysis segments, an axis
+        no other field measures: it is pinned to one dimension and left out of
+        the band group, since the number of segments follows the length of the
+        speech and has no reason to match the fifteen bands.
+
+        :raises ValueError: if the band axes disagree.
+        """
+        require_ranks(self, segment_scores=1, band_scores=1, band_frequencies=1)
+        require_same_length(self, "band_scores", "band_frequencies")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -46,6 +46,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -516,6 +523,71 @@ class _BandProcedure:
     bandwidth_offset_db: float
     spread_decades: np.ndarray | None
 
+    def __post_init__(self) -> None:
+        """Reject a band table whose columns do not line up.
+
+        This is the table the standard prints as one of its Tables 1 to 4, and
+        the whole module reads the band count off one column of it: every
+        spectrum a caller passes is measured against ``band_importance``, while
+        the spread of masking walks ``spread_decades`` row by row over the
+        length of the *noise* vector. A masking matrix belonging to another
+        procedure is therefore never indexed past its edge; the walk reads its
+        leading block and returns an index built from another procedure's band
+        separations, in the right shape and the right units, some way off the
+        published one.
+
+        :attr:`band_edges` bounds the same bands from outside, so it carries
+        one value more than they do rather than one each, and is checked
+        against the band count with that offset applied.
+
+        :raises ValueError: if the band axes disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            band_edges=1,
+            band_importance=1,
+            internal_noise=1,
+            speech_spectrum=1,
+            bandwidth_db=1,
+            spread_decades=2,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "band_importance",
+            "internal_noise",
+            "speech_spectrum",
+            "bandwidth_db",
+            "spread_decades",
+            ("spread_decades", 1),
+        )
+        _require_closing_edge(self)
+
+
+def _require_closing_edge(table: _BandProcedure | SIIProcedure) -> None:
+    """Require ``band_edges`` to bound the bands: one limit more than bands.
+
+    The band limits are the axis the band-importance step is drawn over, and
+    the step plots one importance value per limit (the last one repeated to
+    close the final band). Both procedure types carry the same pair of fields
+    with the same offset between them, so both check it here.
+
+    :param table: The band table whose two fields are compared.
+    :raises ValueError: if the limits do not bound the bands.
+    """
+    owner = type(table).__name__
+    bands = require_axis_count(
+        table.band_importance, owner, "band_importance", rank=None
+    )
+    edges = require_axis_count(
+        table.band_edges, owner, "band_edges", "band limit", rank=None
+    )
+    require_equal_counts(
+        owner,
+        {"band_importance": bands, "band_edges, less its closing limit": edges - 1},
+    )
+
 
 def _masking_geometry(edges: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     r"""Masking-slope bandwidth term and band separation from band limits.
@@ -669,6 +741,41 @@ class SIIResult:
     level_distortion: np.ndarray
     method: str = "one-third-octave"
 
+    def __post_init__(self) -> None:
+        """Reject a result whose per-band quantities disagree.
+
+        The fiche prints one row per band under a single header, walking
+        :attr:`frequencies` and reading the other spectra at the same index, so
+        the frequency column alone decides how many rows the table has. A
+        spectrum one band too long therefore loses its last band off the bottom
+        of the sheet without a word: :attr:`speech_spectrum` and
+        :attr:`disturbance` are tabulated and nothing else re-reads them, so
+        the band that vanished is nowhere on the page to contradict the boxed
+        ``SII`` beside it, and every number that did print is well formed.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(
+            self,
+            band_audibility=1,
+            band_importance=1,
+            frequencies=1,
+            speech_spectrum=1,
+            disturbance=1,
+            masking=1,
+            level_distortion=1,
+        )
+        require_same_length(
+            self,
+            "band_audibility",
+            "band_importance",
+            "frequencies",
+            "speech_spectrum",
+            "disturbance",
+            "masking",
+            "level_distortion",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -773,6 +880,29 @@ class StandardSpeechSpectrum:
     frequencies: np.ndarray
     vocal_efforts: tuple[str, ...]
     levels: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a spectrum table whose rows or columns do not line up.
+
+        :attr:`levels` is the Table 3 block itself, one row per vocal effort
+        and one column per band, and both of its axes are named by another
+        field: the plot walks the effort names, drawing row ``i`` under the
+        label of effort ``i`` over one evenly spaced position per band, with
+        :attr:`frequencies` as the tick labels of that categorical axis rather
+        than as coordinates. A surplus row is the quiet direction, and the one
+        worth catching: the walk never reaches it, so a spectrum that was
+        asked for is missing from a figure that looks complete and carries no
+        sign it was dropped. The other two ways they can disagree are loud but
+        name no field. A surplus effort name walks the loop off the end of the
+        block, and the row that is not there comes back as an ``IndexError``
+        out of NumPy; a band count that differs from the columns is refused by
+        matplotlib with ``x and y must have same first dimension``.
+
+        :raises ValueError: if the band or vocal-effort axes disagree.
+        """
+        require_ranks(self, frequencies=1, levels=2)
+        require_same_length(self, "frequencies", ("levels", 1))
+        require_same_length(self, "vocal_efforts", "levels", axis="vocal effort")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1052,6 +1182,42 @@ class SIIProcedure:
     band_importance: np.ndarray
     internal_noise: np.ndarray
     speech_spectrum: np.ndarray
+
+    def __post_init__(self) -> None:
+        """Reject a band table whose columns do not line up.
+
+        This is one of the standard's Tables 1 to 4 handed over to be read
+        column by column: the documented way to use :attr:`band_edges` is to
+        take band ``i`` as running from ``band_edges[i]`` to
+        ``band_edges[i + 1]``, which quietly bounds the wrong band, or runs off
+        the end, as soon as the limits and the bands disagree.
+
+        The step plot refuses such a table too, but only by comparing its own
+        closed importance array against the limits, so the length it names
+        belongs to neither field and the reader is left to work out which
+        column was wrong. Both are checked here instead, :attr:`band_edges`
+        against the band count with the offset it is defined to carry: one
+        value more than the bands, because it bounds them from outside rather
+        than labelling them.
+
+        :raises ValueError: if the band axes disagree.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            band_edges=1,
+            band_importance=1,
+            internal_noise=1,
+            speech_spectrum=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "band_importance",
+            "internal_noise",
+            "speech_spectrum",
+        )
+        _require_closing_edge(self)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/bioacoustics/audiograms.py
+++ b/src/phonometry/underwater/bioacoustics/audiograms.py
@@ -43,6 +43,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -165,6 +167,23 @@ class AudiogramResult:
     in_air: bool
     best_frequency: float
     best_threshold: float
+
+    def __post_init__(self) -> None:
+        """Reject an audiogram whose threshold does not run over its frequencies.
+
+        An audiogram is a curve, and every threshold on it means the frequency
+        standing beside it. The drawing is the loud half of a mismatch:
+        matplotlib refuses a pair of unequal length outright. The quiet half is
+        already in the result, because ``best_frequency`` and
+        ``best_threshold`` were picked out of the two arrays by a single index,
+        so a threshold array offset from the frequency axis leaves the sensible
+        pair of numbers that name this animal's best hearing reading off two
+        different points of the curve.
+
+        :raises ValueError: if ``threshold`` disagrees with ``frequencies``.
+        """
+        require_ranks(self, frequencies=1, threshold=1)
+        require_same_length(self, "frequencies", "threshold", axis="frequency")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/bioacoustics/weighting.py
+++ b/src/phonometry/underwater/bioacoustics/weighting.py
@@ -61,6 +61,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -580,6 +582,23 @@ class AuditoryWeightingResult:
     group: str
     weighted_tts_onset: float
 
+    def __post_init__(self) -> None:
+        """Reject a filter whose two curves do not run over its frequencies.
+
+        ``W(f)`` and ``E(f)`` are one band-pass shape read twice against one
+        frequency axis, and the identity that ties them, :math:`E = K + C - W`,
+        holds frequency by frequency and in no other way. That is how the
+        assessment uses them: :func:`weighted_exposure` adds ``weighting`` to a
+        band spectrum term by term, so a curve offset from its own axis charges
+        each band the attenuation of a different one, quietly and without ever
+        leaving the range of plausible dB.
+
+        :raises ValueError: if either curve disagrees with ``frequencies``.
+        """
+        require_same_length(
+            self, "frequencies", "weighting", "exposure_function", axis="frequency"
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -722,6 +741,26 @@ class WeightedExposureResult:
     exceeds_tts: bool
     guidance: str
     group: str
+
+    def __post_init__(self) -> None:
+        """Reject an assessment whose band rows do not all run over the bands.
+
+        Everything this result is consulted for hangs on totals that were
+        summed over a whole array: ``cumulative_sel`` is an energy sum of every
+        entry of ``weighted_band_sel``, the margins are that number less a
+        published criterion, and ``exceeds_injury`` is the verdict those
+        margins carry. A spectrum longer than ``frequencies`` therefore lands
+        an exceedance on a band with no centre frequency to name it, and one
+        shorter drops a band from the exposure without dropping it from the
+        picture. The figure is the only reader that would object, and it
+        objects after the verdict has already been formed.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest.
+        """
+        require_ranks(self, frequencies=1, band_sel=1, weighting=1, weighted_band_sel=1)
+        require_same_length(
+            self, "frequencies", "band_sel", "weighting", "weighted_band_sel"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/propagation/closed_form.py
+++ b/src/phonometry/underwater/propagation/closed_form.py
@@ -38,6 +38,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -234,6 +236,25 @@ class PropagationLossResult:
     absorption_coefficient: float
     law: str
     model: str
+
+    def __post_init__(self) -> None:
+        """Reject a loss curve whose terms do not run over the same ranges.
+
+        The three curves are one decomposition, and it is a decomposition only
+        range by range: ``pl`` is ``spreading + absorption`` at each entry of
+        ``range_m``. That is what a reader takes it apart for -- to subtract
+        the absorption and put back the one a different water would charge, or
+        to read the spreading law's exponent off its own term -- and every one
+        of those operations is elementwise. A term of another length is not
+        obviously wrong to look at, since all three are losses in dB of
+        entirely plausible size; it is wrong because each of its values then
+        answers for a range the row beside it did not come from.
+
+        :raises ValueError: if any curve disagrees with ``range_m``.
+        """
+        require_same_length(
+            self, "range_m", "pl", "spreading", "absorption", axis="range"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/propagation/numerical.py
+++ b/src/phonometry/underwater/propagation/numerical.py
@@ -57,7 +57,11 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import numpy as np
 
 from ..._internal.rays import DynamicRays, SlopingBoundary, march_rays
-from ..._internal.validation import require_positive
+from ..._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from .closed_form import _ABSORPTION_MODELS, _M_PER_KM, seawater_absorption
 from .seabed_reflection import reflection_coefficient
 
@@ -379,6 +383,38 @@ class NormalModeResult:
     receiver_depth: float
     source_depth: float
 
+    def __post_init__(self) -> None:
+        r"""Reject a modal solution whose three axes do not line up.
+
+        A mode is a wavenumber and a shape together. Eq. 5.17 sums
+        :math:`\Psi_m(z_\mathrm{s})\,\Psi_m(z_\mathrm{r})\,e^{i k_{rm} r}/\sqrt{k_{rm}}`
+        over ``m``, pairing each row of ``mode_functions`` with the
+        ``wavenumbers`` entry of the same index and each column of that row
+        with a ``mode_depths`` entry, and a caller re-synthesising the field
+        at some other depth pairs them the same way. The figure states the
+        mode count in its legend by measuring ``wavenumbers`` alone, which
+        makes that count a claim about ``mode_functions`` rather than about
+        the array it was read from.
+
+        The three axes are pinned separately because nothing relates them:
+        how many modes propagate, how fine the depth grid the eigenproblem
+        was discretised on is, and how many ranges the loss slice was asked
+        for are three independent sizes.
+
+        :raises ValueError: if the mode, depth or range axes disagree.
+        """
+        require_ranks(
+            self,
+            wavenumbers=1,
+            mode_depths=1,
+            mode_functions=2,
+            ranges=1,
+            propagation_loss=1,
+        )
+        require_same_length(self, "wavenumbers", "mode_functions", axis="mode")
+        require_same_length(self, "mode_depths", ("mode_functions", 1), axis="depth")
+        require_same_length(self, "ranges", "propagation_loss", axis="range")
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -675,6 +711,71 @@ class RayTraceResult:
     bathymetry_ranges: NDArray[np.float64] | None = None
     bathymetry_depths: NDArray[np.float64] | None = None
 
+    def __post_init__(self) -> None:
+        """Reject a fan whose per-ray histories do not line up.
+
+        The six history arrays are one block, one row per ray and one column
+        per range sample. The figure draws row ``i`` of ``depths`` against row
+        ``i`` of ``ranges``, and :func:`eigenrays` sorts ``launch_angles`` into
+        an order it then indexes ``depths`` with to raise its brackets, so the
+        launch fan is as much a row of that block as the histories are. A block
+        one row short makes both of those read past their array; a block with a
+        row to spare is the quieter mistake, because the drawing loop is bounded
+        by ``ranges`` alone and simply stops, leaving a ray out of the picture
+        with nothing to say it was ever traced.
+
+        ``profile_depths`` and ``profile_speeds`` are the medium itself, the
+        polyline the marcher interpolates and the one :func:`eigenrays` flies
+        fresh rays through; ``bathymetry_ranges`` and ``bathymetry_depths`` are
+        the bottom polyline on the same terms, absent together for a level
+        bottom. Four axes in all, pinned apart because rays, range samples,
+        profile nodes and bathymetry nodes are four unrelated counts.
+
+        :raises ValueError: if the ray, sample, profile or bathymetry axes
+            disagree.
+        """
+        require_ranks(
+            self,
+            launch_angles=1,
+            ranges=2,
+            depths=2,
+            travel_times=2,
+            arc_lengths=2,
+            surface_reflections=2,
+            bottom_reflections=2,
+            profile_depths=1,
+            profile_speeds=1,
+            bathymetry_ranges=1,
+            bathymetry_depths=1,
+        )
+        require_same_length(
+            self,
+            "launch_angles",
+            "ranges",
+            "depths",
+            "travel_times",
+            "arc_lengths",
+            "surface_reflections",
+            "bottom_reflections",
+            axis="ray",
+        )
+        require_same_length(
+            self,
+            ("ranges", 1),
+            ("depths", 1),
+            ("travel_times", 1),
+            ("arc_lengths", 1),
+            ("surface_reflections", 1),
+            ("bottom_reflections", 1),
+            axis="range sample",
+        )
+        require_same_length(
+            self, "profile_depths", "profile_speeds", axis="profile node"
+        )
+        require_same_length(
+            self, "bathymetry_ranges", "bathymetry_depths", axis="bathymetry node"
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -951,6 +1052,45 @@ class EigenrayResult:
     receiver_depth: float
     source_depth: float
     water_depth: float
+
+    def __post_init__(self) -> None:
+        r"""Reject an arrival list whose per-arrival arrays disagree.
+
+        Every array here is read by position against the others, as the class
+        states above: the pressure the list stands for is
+        :math:`\sum_j a_j e^{i\omega\tau_j}`, which pairs ``amplitudes``
+        with ``travel_times`` entry by entry, and the figure hangs each stem
+        at a time taken from one array, at a height taken from a second and
+        in a colour taken from the sum of two more. Where the odd array
+        carries a single value it does not fail against the rest, it
+        broadcasts into them, and what comes back is one arrival's amplitude
+        charged to the whole fan, or one arrival's boundary count colouring
+        every path in the picture.
+
+        :raises ValueError: if two of the per-arrival arrays disagree in
+            length.
+        """
+        require_ranks(
+            self,
+            launch_angles=1,
+            arrival_angles=1,
+            travel_times=1,
+            amplitudes=1,
+            surface_reflections=1,
+            bottom_reflections=1,
+            caustic_crossings=1,
+        )
+        require_same_length(
+            self,
+            "launch_angles",
+            "arrival_angles",
+            "travel_times",
+            "amplitudes",
+            "surface_reflections",
+            "bottom_reflections",
+            "caustic_crossings",
+            axis="eigenray",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1607,6 +1747,76 @@ class GaussianBeamResult:
     water_depth: float
     bathymetry_ranges: NDArray[np.float64] | None = None
     bathymetry_depths: NDArray[np.float64] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a beam solution whose grids do not describe its field.
+
+        The field is drawn as a single raster whose extent is built from the
+        ends of ``ranges`` and ``depths`` rather than from the image, so
+        ``imshow`` stretches whatever grid it is handed across those two spans
+        without complaint. A loss field with the wrong number of columns is
+        therefore not refused but rescaled, and every caustic and shadow zone
+        in it lands at a range it was never computed at, under an axis that
+        still reads correctly. ``pressure`` is the field that loss was taken
+        from, cell for cell, and the cell-by-cell subtraction against a
+        parabolic-equation field that this class is documented to support
+        needs both of them on the grid they claim.
+
+        The beam histories are a second block on two axes of their own: one
+        row per beam of the fan, one column per marching step, with
+        ``launch_angles`` and ``initial_beam_widths`` naming the beams those
+        rows belong to. Their step grid is finer than, and independent of,
+        ``ranges``, which is exactly why it cannot be pinned to it.
+
+        :raises ValueError: if the field, beam, step or bathymetry axes
+            disagree.
+        """
+        require_ranks(
+            self,
+            ranges=1,
+            depths=1,
+            propagation_loss=2,
+            pressure=2,
+            launch_angles=1,
+            ray_ranges=2,
+            ray_depths=2,
+            beam_widths=2,
+            wavefront_curvatures=2,
+            initial_beam_widths=1,
+            bathymetry_ranges=1,
+            bathymetry_depths=1,
+        )
+        require_same_length(
+            self, "depths", "propagation_loss", "pressure", axis="receiver depth"
+        )
+        require_same_length(
+            self,
+            "ranges",
+            ("propagation_loss", 1),
+            ("pressure", 1),
+            axis="range",
+        )
+        require_same_length(
+            self,
+            "launch_angles",
+            "initial_beam_widths",
+            "ray_ranges",
+            "ray_depths",
+            "beam_widths",
+            "wavefront_curvatures",
+            axis="beam",
+        )
+        require_same_length(
+            self,
+            ("ray_ranges", 1),
+            ("ray_depths", 1),
+            ("beam_widths", 1),
+            ("wavefront_curvatures", 1),
+            axis="marching step",
+        )
+        require_same_length(
+            self, "bathymetry_ranges", "bathymetry_depths", axis="bathymetry node"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -3360,6 +3570,24 @@ class ParabolicEquationResult:
     depths: NDArray[np.float64]
     propagation_loss: NDArray[np.float64]
     source_depth: float
+
+    def __post_init__(self) -> None:
+        """Reject a field that does not fill the grid it is labelled with.
+
+        The same raster and the same hazard as :class:`GaussianBeamResult`:
+        the drawn extent comes from the ends of ``ranges`` and ``depths`` and
+        never from the array, so a field of another shape is stretched to fit
+        and the picture stays entirely plausible while every cell in it moves.
+
+        The two axes are pinned apart because nothing ties their sizes: the
+        range grid follows ``range_step`` across ``max_range`` and the depth
+        grid follows ``n_depth_points``.
+
+        :raises ValueError: if the loss field disagrees with either grid.
+        """
+        require_ranks(self, ranges=1, depths=1, propagation_loss=2)
+        require_same_length(self, "depths", "propagation_loss", axis="depth")
+        require_same_length(self, "ranges", ("propagation_loss", 1), axis="range")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/propagation/seabed_reflection.py
+++ b/src/phonometry/underwater/propagation/seabed_reflection.py
@@ -37,7 +37,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_positive
+from ..._internal.validation import (
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -133,6 +137,54 @@ class BottomLossResult:
     reflection_coefficient: NDArray[np.complex128]
     critical_angle: float | None
 
+    def __post_init__(self) -> None:
+        r"""Reject a loss curve that does not run over its own angles.
+
+        The three arrays are one angle sweep written down three times:
+        :func:`bottom_reflection_loss` evaluates ``R`` once at the angles it
+        was handed and takes :math:`-20 \log_{10} \lvert R \rvert` of that
+        very array, so entry ``i`` of each is the same grazing angle. Nothing
+        in the result records which angle an entry belongs to except its
+        position.
+
+        Only two of the three are drawn: :func:`plot_bottom_loss` calls
+        ``ax.plot(grazing_angle, reflection_loss)``, so a disagreement
+        between those two stops the figure with matplotlib's own complaint,
+        ``x and y must have same first dimension, but have shapes (5,) and
+        (91,)`` -- shapes only, neither field named, and the reader is left to
+        work out which of the two was short. ``reflection_coefficient`` is
+        never read by the figure at all, so a short one is drawn straight past
+        in silence: the picture comes out complete over 91 angles while the
+        coefficient beside it holds 5, waiting for whoever pairs ``R`` with
+        the angles next. A single-entry ``R`` is the quietest of the lot,
+        because numpy broadcasts it: one angle's reflection coefficient
+        spreads over all 91 and the arithmetic returns a full-length answer
+        with no complaint anywhere.
+
+        The ranks are pinned because a count cannot see an extra axis. A
+        ``reflection_loss`` of shape ``(91, 2)`` -- two sediments stacked, or
+        ``(angle, value)`` pairs kept in one array -- has 91 on its first axis
+        like everything else, passes the length check, and reaches matplotlib,
+        which quietly draws both columns: the figure comes back with two
+        curves and the legend row ``Bottom loss`` printed twice.
+
+        :raises ValueError: if the three arrays disagree, or one carries an
+            axis beyond the angle sweep.
+        """
+        require_ranks(
+            self,
+            grazing_angle=1,
+            reflection_loss=1,
+            reflection_coefficient=1,
+        )
+        require_same_length(
+            self,
+            "grazing_angle",
+            "reflection_loss",
+            "reflection_coefficient",
+            axis="grazing angle",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
@@ -222,6 +274,51 @@ class SeabedReflection:
     c1: float
     rho2: float
     c2: float
+
+    def __post_init__(self) -> None:
+        r"""Reject a reflection record whose four columns are not one sweep.
+
+        :func:`seabed_reflection` evaluates ``R`` once over the angles it was
+        given and derives ``|R|`` and the bottom loss from that same array, so
+        the four arrays are one grazing-angle sweep recorded four times and
+        entry ``i`` of each belongs to the same angle. The class carries the
+        interface parameters precisely so that the record is self-contained;
+        an angle axis that fits none of the three quantities beside it makes
+        it self-contained about the wrong sweep.
+
+        :func:`plot_seabed_reflection` draws only ``|R|``: against a
+        mismatched ``grazing_angle`` it stops with matplotlib's ``x and y must
+        have same first dimension, but have shapes (91,) and (5,)`` (the same
+        both ways round, and either way the message names shapes rather than
+        fields). The other two never reach the figure, and that is where the
+        silence is: a ``bottom_loss`` of 5 entries beside 91 angles draws a
+        complete ``|R|`` curve over all 91, and the loss in decibels -- the
+        quantity a sonar budget actually spends -- is wrong and unmentioned.
+
+        The ranks are pinned because a count passes an extra axis through. A
+        ``magnitude`` of shape ``(91, 2)`` counts 91 on its first axis exactly
+        as a single sweep does, and matplotlib draws every column it is given:
+        the figure comes back carrying two ``|R|`` curves and repeating the
+        ``$|R|$`` legend row, with nothing to say which sediment is which.
+
+        :raises ValueError: if the four arrays disagree, or one carries an
+            axis beyond the angle sweep.
+        """
+        require_ranks(
+            self,
+            grazing_angle=1,
+            reflection_coefficient=1,
+            magnitude=1,
+            bottom_loss=1,
+        )
+        require_same_length(
+            self,
+            "grazing_angle",
+            "reflection_coefficient",
+            "magnitude",
+            "bottom_loss",
+            axis="grazing angle",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -35,6 +35,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -298,6 +300,43 @@ class SoundSpeedProfile:
     sound_speed: NDArray[np.float64]
     gradient: NDArray[np.float64]
     model: str
+
+    def __post_init__(self) -> None:
+        """Reject a profile whose three columns are not one water column.
+
+        The three arrays are one depth axis written down three times:
+        :func:`sound_speed_profile` broadcasts the temperature and the salinity
+        onto ``depths``, evaluates the equation there, and hands the same array
+        to ``np.gradient``. Nothing else in the library builds this result.
+
+        The loud half of a mismatch is ``sound_speed``, which the figure draws
+        against ``depth``: matplotlib stops both a short and a long one, but
+        with its own ``x and y must have same first dimension, but have shapes
+        (120,) and (121,)``, which names neither column and arrives from the
+        drawing rather than from the profile that was wrong all along.
+
+        The quiet half is ``gradient``, which no figure reads: short or long,
+        the profile still plots without complaint. It is the column a reader
+        takes the result apart for, since the sound-channel axis is where
+        ``dc/dz`` turns from negative to positive and the ray curvature radius
+        is ``c`` over its magnitude, and both of those read an entry of
+        ``gradient`` beside the depth of the same index. Carrying the gradient
+        of the same water column sampled on 25 depths onto a 121-depth profile
+        leaves +0.017 (m/s)/m standing at 500 m where this water's own value
+        there is -0.032: rays bending up where they in fact bend down, on a
+        radius of 89 km instead of 46 km.
+
+        The ranks are pinned as well because a count alone passes an extra
+        axis on. Two scenarios stacked column-wise into ``sound_speed`` as an
+        ``(n, 2)`` array carry one value per depth by every measure, and the
+        figure quietly draws two curves under the one legend entry that names
+        a single model.
+
+        :raises ValueError: if ``sound_speed`` or ``gradient`` disagrees with
+            ``depth``, or if a column carries more than one axis.
+        """
+        require_ranks(self, depth=1, sound_speed=1, gradient=1)
+        require_same_length(self, "depth", "sound_speed", "gradient", axis="depth")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/propagation/weston_regimes.py
+++ b/src/phonometry/underwater/propagation/weston_regimes.py
@@ -56,7 +56,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.special import erf
 
-from ..._internal.validation import require_positive
+from ..._internal.validation import require_positive, require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -464,6 +464,65 @@ class WestonPropagationResult:
     source_depth: float
     receiver_depth: float
     seabed: str
+
+    def __post_init__(self) -> None:
+        r"""Reject a column that does not run over the result's own ranges.
+
+        The nine arrays are one table indexed by ``range_m``: the composite
+        loss, the factor it was taken from, the label of the regime in force,
+        and the four regime laws evaluated at every range whether or not they
+        are in force there. A column of another length answers for ranges the
+        row beside it did not come from.
+
+        Six of the nine reach :meth:`plot`, and there the mistake stops the
+        figure without saying whose it is -- matplotlib refuses with ``x and y
+        must have same first dimension, but have shapes (40,) and (39,)``,
+        which carries two shapes and neither the field nor the result they
+        belong to, so the six are indistinguishable from it.
+
+        The other three the figure never draws, so nothing complains at all.
+        A ``regime`` column computed on a 41-point grid and handed to a
+        40-point range axis builds, plots its full seven lines, and then puts
+        the onset of mode stripping at 1075 m where the aligned result puts it
+        at 885 m. A one-element ``propagation_factor`` broadcasts rather than
+        raising: :math:`-10 \log_{10} F` checked against ``propagation_loss``
+        comes back 49 dB adrift instead of nought, and the figure is drawn in
+        full either way.
+
+        The ranks are pinned with the lengths because a range grid handed in
+        two-dimensional stays two-dimensional through every column and agrees
+        with itself on every count; it survives construction and dies in
+        :meth:`plot` on numpy's ambiguous truth value, raised while testing
+        whether a regime boundary falls inside the axis.
+
+        :raises ValueError: if a column has the wrong number of axes, or a
+            length other than ``range_m``'s.
+        """
+        require_ranks(
+            self,
+            range_m=1,
+            propagation_loss=1,
+            propagation_factor=1,
+            regime=1,
+            spherical=1,
+            cylindrical=1,
+            mode_stripping=1,
+            single_mode=1,
+            multipath=1,
+        )
+        require_same_length(
+            self,
+            "range_m",
+            "propagation_loss",
+            "propagation_factor",
+            "regime",
+            "spherical",
+            "cylindrical",
+            "mode_stripping",
+            "single_mode",
+            "multipath",
+            axis="range",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -46,6 +46,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_ranks, require_same_length
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
@@ -107,6 +109,59 @@ class SonarEquationResult:
     detection_threshold: float
     target_strength: float | None
     reverberation_limited: bool
+
+    def __post_init__(self) -> None:
+        """Reject a solution whose three loss-axis quantities disagree.
+
+        The sonar equation is solved one propagation loss at a time: both
+        entry points take the loss array and subtract the same term balance
+        from every entry of it, so :attr:`snr` and :attr:`signal_excess` are
+        that axis written down twice more. Nothing pairs the three afterwards
+        except position.
+
+        The mistake is loud in one direction only. :meth:`plot` sorts by
+        propagation loss and reads the signal excess through that sort order,
+        so a short ``signal_excess`` arrives at numpy as an out-of-range fancy
+        index: ``IndexError: index 3 is out of bounds for axis 0 with size
+        3``, an axis and a size, naming neither the field nor the result it
+        came from. A long one says nothing at all. The sort order holds one
+        entry per loss, so the curve is drawn from as many signal-excess
+        values as there are losses and the tail is dropped in silence -- and
+        the tail is the half that matters, because signal excess falls as
+        loss grows and its last values are the negative ones. Five excesses
+        from 20 dB down to -20 dB plotted against three losses drew
+        ``[20, 10, 0]``: a curve that stops dead on the detection limit and
+        never crosses it, under the ``SE = 0`` line and the figure-of-merit
+        line drawn across it as usual, in a figure whose whole subject is
+        where that crossing falls.
+
+        :attr:`snr` has no reader in the library, which is why it is checked
+        here rather than left to one. It is the same excess before the
+        detection threshold comes off, read as ``res.snr[i]`` beside
+        ``res.propagation_loss[i]``, so an offset one is wrong by an ordinary
+        number of decibels with nothing downstream to disagree.
+
+        The ranks are pinned as well as the lengths, because a count cannot
+        see an extra axis. ``_finite_array`` widens a scalar and never narrows
+        a grid, so before this check a two-dimensional ``propagation_loss``
+        handed to either entry point came back as three arrays of that same
+        shape, first axes agreeing perfectly. The plot's sort then indexed a
+        ``(3, 2)`` pair into a ``(3, 2, 2)`` one, and matplotlib refused that
+        with ``x and y can be no greater than 2D, but have shapes (3, 2, 2)
+        and (3, 2, 2)`` -- its own complaint, about two shapes that appear
+        nowhere in the result.
+
+        :raises ValueError: if the three quantities disagree in length, or
+            one carries an axis the loss axis does not.
+        """
+        require_ranks(self, propagation_loss=1, signal_excess=1, snr=1)
+        require_same_length(
+            self,
+            "propagation_loss",
+            "signal_excess",
+            "snr",
+            axis="propagation loss",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/sources/ambient_noise.py
+++ b/src/phonometry/underwater/sources/ambient_noise.py
@@ -36,6 +36,8 @@ from ..._internal.validation import (
     require_non_negative,
     require_positive,
     require_positive_array,
+    require_ranks,
+    require_same_length,
 )
 
 if TYPE_CHECKING:
@@ -138,6 +140,39 @@ class AmbientNoiseResult:
     thermal: NDArray[np.float64]
     shipping: NDArray[np.float64] | None
     wind_speed_knots: float
+
+    def __post_init__(self) -> None:
+        """Reject a spectrum whose components do not run over its frequencies.
+
+        A Wenz chart is read by where its curves meet -- the frequency at
+        which the wind curve gives way to the thermal floor is taken straight
+        off the picture -- and the composite level drawn above them is stated
+        to be the energy sum of exactly the components drawn beneath it.
+        Nothing in the result records which frequency an entry belongs to
+        except its position, so a component of another length was summed over
+        a different set of frequencies than the ones the chart puts it under.
+
+        :func:`ocean_ambient_noise` already measures ``shipping`` against the
+        frequencies it was handed, but a frozen result is a value that gets
+        rebuilt: substituting a measured shipping spectrum through
+        :func:`dataclasses.replace` re-enters this constructor and nothing
+        else, and the composite level that comes through with it was summed
+        without the curve now beside it.
+
+        :raises ValueError: if a component disagrees with the frequency axis.
+        """
+        require_ranks(
+            self, frequency=1, spectrum_level=1, wind=1, thermal=1, shipping=1
+        )
+        require_same_length(
+            self,
+            "frequency",
+            "spectrum_level",
+            "wind",
+            "thermal",
+            "shipping",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from ...io._resolve import SignalInput, resolve_fs
 from ..acoustics import (
     _positive,
@@ -184,6 +185,29 @@ class StrikeSelSpectrum:
     broadband_sel: float
     fraction: int
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a band spectrum whose levels do not match its band centres.
+
+        The two arrays state one measurement twice over -- a nominal centre
+        frequency, and the exposure the band at that frequency carries -- and
+        only position pairs them. :attr:`total_sel` is then a stored number
+        claiming to be the energy sum of exactly those bands, which no reader
+        can re-derive: a ``band_sel`` longer than ``frequencies`` keeps a
+        total that counted a band the centre list never reaches, and one
+        shorter keeps a total missing a band the table will print.
+
+        The pairing is also what the assessment downstream consumes.
+        :func:`~phonometry.underwater.bioacoustics.weighting.weighted_exposure`
+        takes both arrays and weights each band by the hearing group's
+        sensitivity at whatever centre landed opposite it; those weighting
+        curves fall by tens of decibels across a decade, so a misaligned
+        spectrum returns an injury margin that reads like any other.
+
+        :raises ValueError: if the band levels disagree with the centres.
+        """
+        require_ranks(self, frequencies=1, band_sel=1)
+        require_same_length(self, "frequencies", "band_sel")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/sources/ship_radiated_noise.py
+++ b/src/phonometry/underwater/sources/ship_radiated_noise.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_ranks, require_same_length
 from ..acoustics import UNDERWATER_REFERENCE_PRESSURE, _positive
 
 if TYPE_CHECKING:
@@ -158,6 +159,38 @@ class ShipSourceLevelResult:
     source_level: NDArray[np.float64]
     source_depth: float
     sound_speed: float
+
+    def __post_init__(self) -> None:
+        """Reject a source-level spectrum whose curves disagree on frequency.
+
+        ISO 17208-2 converts band by band: the source level of a band is its
+        radiated noise level plus the Lloyd's-mirror correction evaluated at
+        that band's own frequency, and it is reported per one-third-octave
+        band with the expanded uncertainty its frequency selects
+        (:func:`source_level_uncertainty` -- 5 dB, 3 dB or 4 dB by band).
+        Only position ties the three curves to :attr:`frequencies`, so a
+        curve of another length reports each level against a frequency other
+        than the one it was computed at, and quotes it with the uncertainty
+        belonging to that other band. Every number on such a sheet is inside
+        its plausible range, which is why nothing further down objects.
+
+        :raises ValueError: if a curve disagrees with the frequency axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            radiated_noise_level=1,
+            surface_correction=1,
+            source_level=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "radiated_noise_level",
+            "surface_correction",
+            "source_level",
+            axis="frequency",
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/sources/ship_traffic_noise.py
+++ b/src/phonometry/underwater/sources/ship_traffic_noise.py
@@ -35,7 +35,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_positive, require_positive_array
+from ..._internal.validation import (
+    require_positive,
+    require_positive_array,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -186,6 +191,32 @@ class ShipTrafficSpectrum:
     vessel_class: str | None
     speed_knots: float | None
     length_m: float | None
+
+    def __post_init__(self) -> None:
+        r"""Reject a predicted spectrum whose levels do not match its bands.
+
+        The two level arrays are one prediction in two units, and what
+        converts between them is the band's own centre frequency:
+        :attr:`band_level` is :attr:`source_psd` plus
+        :math:`10 \log_{10}(0.231 f)`, worth about 4 dB in the 10 Hz band and
+        about 39 dB in the 31.5 kHz band of the default set. Nothing records
+        which band a level was converted at except its position beside
+        :attr:`frequency`, so a level array of another length publishes a
+        spectral-density level and a band level that refer to different
+        bands, as one spectrum.
+
+        That spectrum is meant to travel: the module offers ``source_psd``
+        as the shipping input of
+        :func:`~phonometry.underwater.sources.ambient_noise.ocean_ambient_noise`
+        and as a source to be placed at range, and either use pairs it with
+        a frequency axis taken from the same result.
+
+        :raises ValueError: if a level array disagrees with the frequency axis.
+        """
+        require_ranks(self, frequency=1, source_psd=1, band_level=1)
+        require_same_length(
+            self, "frequency", "source_psd", "band_level", axis="frequency"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/vibration/structural/experimental_sea.py
+++ b/src/phonometry/vibration/structural/experimental_sea.py
@@ -83,6 +83,8 @@ from ..._internal.validation import (
     require_choice,
     require_positive,
     require_positive_array,
+    require_ranks,
+    require_same_length,
 )
 
 if TYPE_CHECKING:
@@ -312,6 +314,57 @@ class PowerInjectionResult:
     modal_density1: NDArray[np.float64] | None
     modal_density2: NDArray[np.float64] | None
     method: str
+
+    def __post_init__(self) -> None:
+        """Reject a loss-factor budget whose per-band quantities disagree.
+
+        The whole budget is read band against band. :meth:`plot` draws the
+        four loss factors on one frequency axis, where it is the ordering of
+        the curves in each band that says whether the two subsystems are
+        weakly enough coupled for SEA to hold at all, and
+        :attr:`transmitted_power`, :attr:`dissipated_power`,
+        :attr:`coupling_strength` and :attr:`modal_density_ratio` multiply and
+        divide these arrays element by element. Numpy stretches a
+        single-element array over every band rather than objecting, which is
+        the shape a caller lands on by measuring one band where the spectrum
+        needed several, and the power balance that comes back reads like an
+        ordinary answer for a system nobody measured.
+
+        The modal densities are optional: the two-drive inversion determines
+        all four loss factors without them, and an absent quantity is not a
+        disagreement.
+
+        :raises ValueError: if the per-band quantities do not share one band
+            axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            coupling_loss_factor12=1,
+            coupling_loss_factor21=1,
+            internal_loss_factor1=1,
+            internal_loss_factor2=1,
+            energy1=1,
+            energy2=1,
+            input_power1=1,
+            input_power2=1,
+            modal_density1=1,
+            modal_density2=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "coupling_loss_factor12",
+            "coupling_loss_factor21",
+            "internal_loss_factor1",
+            "internal_loss_factor2",
+            "energy1",
+            "energy2",
+            "input_power1",
+            "input_power2",
+            "modal_density1",
+            "modal_density2",
+        )
 
     @property
     def input_power(self) -> NDArray[np.float64]:

--- a/src/phonometry/vibration/structural/junction_transmission.py
+++ b/src/phonometry/vibration/structural/junction_transmission.py
@@ -172,7 +172,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.integrate import quad
 
-from ..._internal.validation import require_choice, require_positive
+from ..._internal.validation import (
+    require_choice,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -682,6 +687,34 @@ class JunctionTransmissionResult:
     straight_average: float | None
     thickness1: float | None = None
     thickness2: float | None = None
+
+    def __post_init__(self) -> None:
+        r"""Reject coefficients that do not lie on the junction's angle grid.
+
+        :attr:`corner` and :attr:`straight` are :math:`\tau(\theta)` sampled
+        at :attr:`angles_deg`, and the grid is the only thing that says at
+        which angle each sample was taken: it is where the cut-off
+        :math:`\theta_\mathrm{co} = \arcsin\chi` is read off, and beyond it
+        the corner coefficient is identically zero. A curve of another length
+        therefore describes a junction transmitting at angles nobody
+        computed, and says so only when :meth:`plot` reaches matplotlib,
+        which complains about two first dimensions without naming either
+        curve. The straight section exists only for the X and T-junction (1)
+        constants, so ``None`` there is not a disagreement.
+
+        The grid is compared with nothing else the result carries: ``chi``,
+        ``psi``, the two critical frequencies and the angular averages are
+        single numbers describing the junction as a whole, and the averages in
+        particular are integrals over all incidence angles rather than samples
+        of the grid.
+
+        :raises ValueError: if the transmission coefficients do not lie on the
+            incidence-angle grid.
+        """
+        require_ranks(self, angles_deg=1, corner=1, straight=1)
+        require_same_length(
+            self, "angles_deg", "corner", "straight", axis="incidence angle"
+        )
 
     @property
     def corner_reduction_index(self) -> float:

--- a/src/phonometry/vibration/structural/mechanical_mobility.py
+++ b/src/phonometry/vibration/structural/mechanical_mobility.py
@@ -82,7 +82,12 @@ if TYPE_CHECKING:
     from ..._report.metadata import ReportMetadata
 
 
-from ..._internal.validation import require_non_negative, require_positive
+from ..._internal.validation import (
+    require_non_negative,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 # ---------------------------------------------------------------------------
 # FRF taxonomy (ISO 7626-1 Table 1).
@@ -298,6 +303,41 @@ class RigidMassCalibrationResult:
     quantity: str
     tolerance: float
 
+    def __post_init__(self) -> None:
+        """Reject a calibration whose per-frequency quantities disagree.
+
+        The check of 7.5.2 is a verdict on a frequency range, and
+        :attr:`within_tolerance` is what carries it frequency by frequency.
+        :meth:`plot` selects the passing points with ``frequencies[within]``
+        and colours the rest as failures, so a mask of another length is
+        numpy's complaint about a boolean index that does not match the array
+        it indexes, raised from inside the plotter and naming neither field.
+        :attr:`passed` protests less: nothing re-derives it, so a mask
+        covering part of the measured range leaves an overall pass standing
+        over the frequencies it happened to reach, and the drift the
+        calibration exists to catch sits in the ones it did not.
+
+        :raises ValueError: if the per-frequency quantities do not share one
+            frequency axis.
+        """
+        require_ranks(
+            self,
+            frequencies=1,
+            measured=1,
+            expected=1,
+            deviation=1,
+            within_tolerance=1,
+        )
+        require_same_length(
+            self,
+            "frequencies",
+            "measured",
+            "expected",
+            "deviation",
+            "within_tolerance",
+            axis="frequency",
+        )
+
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes | np.ndarray:
@@ -427,6 +467,24 @@ class MobilityResult:
     frequencies: np.ndarray
     mobility: np.ndarray
     driving_point: bool = True
+
+    def __post_init__(self) -> None:
+        """Reject an FRF whose mobility does not lie on its frequency axis.
+
+        The fiche boxes one number, the peak of ``|Y|``, and dates it: it
+        takes the peak out of :attr:`mobility`, reads the frequency at that
+        same index out of :attr:`frequencies`, and states the measured range
+        from :attr:`frequencies` alone. Two axes of different lengths pair a
+        peak drawn from one of them with a range drawn from the other, so the
+        boxed resonance can sit outside the range printed beside it; where
+        the peak falls past the end of the shorter axis it is instead an
+        index error out of the renderer, naming neither field.
+
+        :raises ValueError: if the mobility does not carry one value per
+            frequency.
+        """
+        require_ranks(self, frequencies=1, mobility=1)
+        require_same_length(self, "frequencies", "mobility", axis="frequency")
 
     @property
     def magnitude(self) -> np.ndarray:

--- a/src/phonometry/vibration/structural/radiation_efficiency.py
+++ b/src/phonometry/vibration/structural/radiation_efficiency.py
@@ -67,7 +67,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_choice, require_positive
+from ..._internal.validation import (
+    require_choice,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -132,6 +137,28 @@ class RadiationEfficiencyResult:
     length_y: float
     boundary: str
     baffle: str
+
+    def __post_init__(self) -> None:
+        r"""Reject an efficiency that does not carry one value per band.
+
+        :attr:`radiation_efficiency` is only ever meaningful against the band
+        it was evaluated in: which of the three expressions of method no. 1
+        produced a given value depends on where that band sits relative to
+        :attr:`critical_frequency`, so a band axis of another length reads the
+        below-coincidence value as an above-coincidence one. :meth:`plot`
+        draws ``sigma`` against :attr:`frequencies` and marks ``fc`` on the
+        same axis, and the radiation factor that
+        :func:`~phonometry.emission.sound_power_from_vibration` takes from
+        :attr:`radiation_efficiency` is applied to a velocity level band by
+        band, so a spectrum that has slipped against its own frequencies
+        scales the plate's vibration by the efficiency of a band it was never
+        evaluated in.
+
+        :raises ValueError: if the efficiency does not carry one value per
+            band.
+        """
+        require_ranks(self, frequencies=1, radiation_efficiency=1)
+        require_same_length(self, "frequencies", "radiation_efficiency")
 
     @property
     def radiation_index(self) -> np.ndarray:

--- a/src/phonometry/vibration/structural/transfer_stiffness.py
+++ b/src/phonometry/vibration/structural/transfer_stiffness.py
@@ -67,7 +67,12 @@ if TYPE_CHECKING:
     from ..._report.metadata import ReportMetadata
 
 
-from ..._internal.validation import require_non_negative, require_positive
+from ..._internal.validation import (
+    require_non_negative,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from ..._internal.warnings import PhonometryWarning
 from .mechanical_mobility import convert_frf
 
@@ -316,6 +321,29 @@ class TransferStiffnessResult:
     frequencies: np.ndarray
     transfer_stiffness: np.ndarray
     blocking_mass: float | None = None
+
+    def __post_init__(self) -> None:
+        r"""Reject a spectrum whose stiffnesses do not run over its own frequencies.
+
+        The fiche characterises the element by its low-frequency plateau: it
+        takes the lowest entry of ``frequencies`` and reads
+        :math:`|k_{2,1}|`, ``L_k`` and ``eta`` at that same position of
+        ``transfer_stiffness``, then prints them together, the level as the
+        boxed representative value and the magnitude beside it stated *at that
+        frequency*. Let the two lengths differ and a position stops meaning
+        the same measurement in both, so the sheet hangs one frequency's
+        stiffness on another frequency's label, while the frequency range in
+        the same table still spans the whole of ``frequencies``, including
+        lines the spectrum never valued. A value too many at the end is the
+        same mistake in the other direction, and just as invisible: nothing on
+        a sheet that is well formed either way says how many stiffnesses there
+        were.
+
+        :raises ValueError: if ``transfer_stiffness`` does not carry one value
+            per frequency, or either field carries an extra axis.
+        """
+        require_ranks(self, frequencies=1, transfer_stiffness=1)
+        require_same_length(self, "frequencies", "transfer_stiffness", axis="frequency")
 
     @property
     def magnitude(self) -> np.ndarray:

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -974,3 +974,32 @@ def test_a_share_column_with_an_extra_axis_is_refused(airborne) -> None:
     three_dimensional = np.stack([values, values], axis=-1)
     with pytest.raises(ValueError, match="'fractions' must have 2 axes"):
         dataclasses.replace(airborne, fractions=three_dimensional)
+
+
+def test_a_path_without_a_share_row_is_refused_on_the_impact_result(impact) -> None:
+    """The impact result decomposes its own quantity over the same two axes.
+
+    It shares the check with the airborne result, so nothing above would go
+    red if this class stopped running it, and the path axis is the direction
+    that stays quiet: with a path appended and ``fractions`` left as it was,
+    ``plot`` drew and ``report`` wrote a sheet whose rows and whose shares
+    disagree about how many paths there are, neither of them complaining.
+    """
+    import dataclasses
+
+    extra = dataclasses.replace(impact.paths[0], label="extra")
+    with pytest.raises(ValueError, match="per transmission path"):
+        dataclasses.replace(impact, paths=(*impact.paths, extra))
+
+
+def test_an_impact_total_off_the_band_axis_is_refused(impact) -> None:
+    """``L'n`` runs over the frequencies the same paths were summed over.
+
+    One band too long, the total is drawn against the frequency axis, and
+    matplotlib refuses the two shapes it was handed without naming either
+    field: ``x and y must have same first dimension``.
+    """
+    import dataclasses
+
+    with pytest.raises(ValueError, match="'l_prime_n'"):
+        dataclasses.replace(impact, l_prime_n=np.append(impact.l_prime_n, 99.0))

--- a/tests/materials/absorbers/test_absorption_uncertainty.py
+++ b/tests/materials/absorbers/test_absorption_uncertainty.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 import reference_data as ref
@@ -183,6 +185,41 @@ def test_negative_rating_raises() -> None:
 def test_non_finite_raises() -> None:
     with pytest.raises(ValueError, match="finite"):
         materials.sound_absorption_coefficient_uncertainty([np.nan], [1000])
+
+
+@pytest.mark.parametrize(
+    "field", ["values", "standard_uncertainty", "expanded_uncertainty", "frequencies"]
+)
+def test_spectra_of_unequal_length_are_refused(field: str) -> None:
+    """A band result cannot hold one spectrum shorter than the rest.
+
+    ``lower`` and ``upper`` are subtractions of two of these arrays, so a
+    one-element column would be stretched over the whole spectrum by numpy
+    and the interval would still come back the right length for the table
+    that prints it, stating a coverage the measurement never had.
+    """
+    res = materials.sound_absorption_coefficient_uncertainty(
+        ref.ISO12999_2_TABLE4_ALPHA_S, ref.ISO12999_2_TABLE4_FREQ
+    )
+    with pytest.raises(ValueError, match=f"'{field}'"):
+        dataclasses.replace(res, **{field: getattr(res, field)[:-1]})
+
+
+def test_single_number_carries_a_value_without_a_spectrum() -> None:
+    """The Clause 7 single numbers are exempt from the band-axis check.
+
+    ``frequencies`` is empty there while ``values`` holds the one number, so
+    the frequency axis is pinned only where the result has one; folding it
+    into the unconditional group would make ``αw`` unconstructible.
+    """
+    for res in (
+        materials.weighted_coefficient_uncertainty(0.7),
+        materials.single_number_rating_uncertainty(8.1),
+    ):
+        assert res.frequencies.shape == (0,)
+        assert res.values.shape == (1,)
+        assert res.standard_uncertainty.shape == (1,)
+        assert res.expanded_uncertainty.shape == (1,)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/materials/absorbers/test_absorption_uncertainty.py
+++ b/tests/materials/absorbers/test_absorption_uncertainty.py
@@ -201,8 +201,9 @@ def test_spectra_of_unequal_length_are_refused(field: str) -> None:
     res = materials.sound_absorption_coefficient_uncertainty(
         ref.ISO12999_2_TABLE4_ALPHA_S, ref.ISO12999_2_TABLE4_FREQ
     )
+    one_short = getattr(res, field)[:-1]
     with pytest.raises(ValueError, match=f"'{field}'"):
-        dataclasses.replace(res, **{field: getattr(res, field)[:-1]})
+        dataclasses.replace(res, **{field: one_short})
 
 
 def test_single_number_carries_a_value_without_a_spectrum() -> None:

--- a/tests/materials/absorbers/test_iso11654_report.py
+++ b/tests/materials/absorbers/test_iso11654_report.py
@@ -140,25 +140,39 @@ def test_third_octave_fiche_with_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_third_octave_fiche_rejects_band_count_mismatch(tmp_path) -> None:
-    """One-third-octave arrays of unequal length raise ``ValueError``.
+def test_third_octave_arrays_of_unequal_length_are_refused() -> None:
+    """Fifteen ``alpha_s`` cannot be paired with fourteen band centres.
 
-    ``AbsorptionRatingResult`` is a frozen dataclass with no validation, so a
-    caller can pair fifteen ``alpha_s`` with fourteen band centres; the
-    accredited table used to be drawn silently short. The guard fires before
-    the table is built, so no PDF is written.
+    The accredited table used to be drawn silently short. The refusal was the
+    renderer's; the rating refuses to hold the pairing at all now, so the
+    plot and any other reader are covered by the same sentence.
     """
     import dataclasses
 
     result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
     assert result.third_octave_bands is not None
-    short = dataclasses.replace(
-        result, third_octave_bands=result.third_octave_bands[:-1]
-    )
-    out = tmp_path / "mismatch.pdf"
-    with pytest.raises(ValueError, match="third_octave_bands"):
-        short.report(str(out))
-    assert not out.exists()
+    with pytest.raises(ValueError, match="'third_octave_bands'"):
+        dataclasses.replace(result, third_octave_bands=result.third_octave_bands[:-1])
+
+
+@pytest.mark.parametrize("bands", [12, 18])
+def test_third_octave_arrays_must_hold_three_bands_per_octave(bands: int) -> None:
+    """A matched pair is not enough: the table needs three of them per octave.
+
+    The accredited table reads ``measured[j // 3]`` on row ``j``, so eighteen
+    matched one-third octaves against a five-octave rating run the lookup off
+    the end of ``measured`` and twelve write a table that stops an octave
+    early without saying so.
+    """
+    import dataclasses
+
+    result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
+    with pytest.raises(ValueError, match="'3 x band_centers'"):
+        dataclasses.replace(
+            result,
+            third_octave_alpha_s=np.full(bands, 0.5),
+            third_octave_bands=np.linspace(200.0, 5000.0, bands),
+        )
 
 
 def test_statement_writes_shape_indicator_without_space(tmp_path) -> None:

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -191,21 +191,17 @@ def test_verbose_shows_areas_and_times_one_page(tmp_path) -> None:
         "absorption_area_with_specimen",
     ],
 )
-def test_verbose_rejects_short_band_column(field: str, tmp_path) -> None:
-    """Every column of the verbose table must be as long as ``frequencies``.
+def test_a_short_band_column_is_refused(field: str) -> None:
+    """Every per-band column must be as long as ``frequencies``.
 
-    ``SoundAbsorptionMeasurement`` is a frozen dataclass with no validation, so
-    a hand-built result can carry a per-band column one band short. The detail
-    table would then be silently truncated, so the renderer names the offending
-    column and raises before any PDF is written.
+    A column one band short would leave the detail table silently truncated.
+    The refusal used to be the renderer's, and only on the verbose sheet; the
+    measurement refuses to exist that way now, which covers the plain sheet
+    and the plot with it.
     """
     result = _result()
-    short = replace(result, **{field: getattr(result, field)[:-1]})
-    out = tmp_path / "iso354_short.pdf"
-    metadata = _metadata()
-    with pytest.raises(ValueError, match=field):
-        short.report(str(out), metadata=metadata, verbose=True)
-    assert not out.exists()
+    with pytest.raises(ValueError, match=f"'{field}'"):
+        replace(result, **{field: getattr(result, field)[:-1]})
 
 
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -200,8 +200,9 @@ def test_a_short_band_column_is_refused(field: str) -> None:
     and the plot with it.
     """
     result = _result()
+    one_short = getattr(result, field)[:-1]
     with pytest.raises(ValueError, match=f"'{field}'"):
-        replace(result, **{field: getattr(result, field)[:-1]})
+        replace(result, **{field: one_short})
 
 
 def test_metadata_xml_specials_do_not_break(tmp_path) -> None:

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -10,6 +10,7 @@ of the four-rectangular additive model (Supplement 1 Table 3, clause 9.2.3).
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import numpy as np
@@ -400,3 +401,36 @@ def test_monte_carlo_matches_supplement1_table2_gaussian() -> None:
     assert mc.standard_uncertainty == pytest.approx(2.0, abs=0.01)
     assert mc.interval[0] == pytest.approx(-GUMS1_TABLE2_INTERVAL_95, abs=0.03)
     assert mc.interval[1] == pytest.approx(GUMS1_TABLE2_INTERVAL_95, abs=0.03)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("names", ("a",), r"'names'.*one value per input quantity"),
+        ("names", ("a", "b", "c"), r"'names'.*one value per input quantity"),
+        (
+            "sensitivities",
+            np.ones(3),
+            r"'sensitivities'.*one value per input quantity",
+        ),
+        ("sensitivities", np.ones((2, 2)), r"'sensitivities' must have one axis"),
+        ("contributions", np.ones((2, 2)), r"'contributions' must have one axis"),
+    ],
+)
+def test_budget_rows_must_line_up(field: str, value: object, match: str) -> None:
+    """A budget whose rows disagree is refused when built, not when drawn.
+
+    The plot pairs the contributions with the labels and refuses a mismatch
+    only from inside matplotlib, and it never reads the sensitivity
+    coefficients at all, so an extra or missing coefficient reaches the chart
+    unremarked.
+    """
+    good = u.combine_uncertainty(_add2, [u.Quantity(1.0, 0.1), u.Quantity(2.0, 0.2)])
+    with pytest.raises(ValueError, match=match):
+        dataclasses.replace(good, **{field: value})
+
+
+def test_unlabelled_budget_is_not_a_disagreement() -> None:
+    """An empty ``names`` is the budget the plot labels ``x1``, ``x2``, ... itself."""
+    good = u.combine_uncertainty(_add2, [u.Quantity(1.0, 0.1), u.Quantity(2.0, 0.2)])
+    assert dataclasses.replace(good, names=()).names == ()

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -11,6 +11,7 @@ ship in ``tests/data/iso532_1/`` (see its README for provenance and ISO
 attribution); ``ISO532_1_TESTDATA`` overrides the location.
 """
 
+import dataclasses
 import json
 import os
 import pathlib
@@ -399,6 +400,52 @@ def test_time_varying_outputs() -> None:
     assert res.n5 is not None
     assert res.n10 is not None
     assert res.n5 >= res.n10
+
+
+def test_trace_that_disagrees_with_its_time_axis_is_refused() -> None:
+    """``time`` and ``loudness_vs_time`` are one axis, so they are pinned as one.
+
+    Left to the reader, either direction ends in matplotlib's "x and y must
+    have same first dimension", raised from ``Axes.plot`` about two shapes and
+    neither field name -- and ``.report()`` then writes no PDF at all.
+    """
+    res = psychoacoustics.loudness_zwicker(_tone(1000.0, 70.0, seconds=0.5), FS)
+    assert res.loudness_vs_time is not None
+    for trace in (
+        res.loudness_vs_time[:-1],
+        np.append(res.loudness_vs_time, res.loudness_vs_time[-1]),
+    ):
+        with pytest.raises(ValueError, match="'loudness_vs_time'"):
+            dataclasses.replace(res, loudness_vs_time=trace)
+
+
+def test_an_extra_axis_on_the_trace_is_refused() -> None:
+    """Counting the steps is not enough; the rank is pinned too.
+
+    A ``loudness_vs_time`` of shape ``(steps, 2)`` counts the steps right and
+    matplotlib reads its two columns as two series: the clause 7 f) panel comes
+    out with two curves both labelled N(t), and ``.report()`` renders the whole
+    fiche without a word.
+    """
+    res = psychoacoustics.loudness_zwicker(_tone(1000.0, 70.0, seconds=0.5), FS)
+    assert res.time is not None
+    assert res.loudness_vs_time is not None
+    with pytest.raises(ValueError, match="'loudness_vs_time' must have one axis"):
+        dataclasses.replace(
+            res, loudness_vs_time=np.column_stack([res.loudness_vs_time] * 2)
+        )
+    with pytest.raises(ValueError, match="'time' must have one axis"):
+        dataclasses.replace(res, time=res.time[:, None])
+
+
+def test_stationary_result_keeps_its_absent_trace() -> None:
+    """The stationary methods leave both fields ``None``, which is not a gap."""
+    for res in (
+        psychoacoustics.loudness_zwicker_from_spectrum(np.full(28, 60.0)),
+        psychoacoustics.loudness_zwicker(_tone(1000.0, 70.0), FS, stationary=True),
+    ):
+        assert res.time is None
+        assert res.loudness_vs_time is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
@@ -14,6 +14,7 @@ modulation depth, an unmodulated tone and silence give ~0) plus
 result-structure guards.
 """
 
+import dataclasses
 import importlib
 
 import numpy as np
@@ -295,6 +296,98 @@ def test_result_structure(
     assert np.all(res.specific_fluctuation_strength >= 0.0)
     assert np.all(res.fluctuation_strength_vs_time >= 0.0)
     assert res.field == "free"
+
+
+@pytest.mark.parametrize("trim", [True, False])
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
+def test_a_trace_off_its_time_axis_is_refused(
+    ref_calibration: psychoacoustics.EcmaFluctuationStrength, trim: bool
+) -> None:
+    """The time panel is one ``plot`` call pairing ``time`` with F(l50).
+
+    A trace of another length reaches matplotlib, which raises about x and y
+    differing in their first dimension and names neither field, from a call
+    several frames below the one the caller made. Short and long fail the
+    same way, which is the only mismatch here that never passes silently.
+    """
+    trace = ref_calibration.fluctuation_strength_vs_time
+    wrong = trace[:-1] if trim else np.append(trace, trace[-1])
+    with pytest.raises(ValueError, match="'fluctuation_strength_vs_time'"):
+        dataclasses.replace(ref_calibration, fluctuation_strength_vs_time=wrong)
+
+
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
+def test_a_specific_table_short_on_both_axes_is_refused(
+    ref_calibration: psychoacoustics.EcmaFluctuationStrength,
+) -> None:
+    """The one mismatch the heatmap draws instead of refusing.
+
+    A table one entry short along time *and* along the bands is exactly the
+    shape ``pcolormesh`` expects once ``shading="auto"`` reads the two axes as
+    cell corners, so the full figure draws a complete heatmap spanning the
+    whole time and Bark_HMS range, one cell coarser than the run it claims to
+    show, without a word from anywhere. Short on one axis only is refused by
+    ``pcolormesh``, but only when the caller asked for the whole figure.
+    """
+    table = ref_calibration.specific_fluctuation_strength_vs_time
+    with pytest.raises(
+        ValueError, match=r"'specific_fluctuation_strength_vs_time \(axis 1\)'"
+    ):
+        dataclasses.replace(
+            ref_calibration, specific_fluctuation_strength_vs_time=table[:-1, :-1]
+        )
+
+
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
+def test_a_specific_table_that_lost_its_band_axis_is_refused(
+    ref_calibration: psychoacoustics.EcmaFluctuationStrength,
+) -> None:
+    """Counting the frames says nothing about how many axes carry them.
+
+    Averaged down to one axis the table still has one entry per 50 Hz frame,
+    so every length agrees and the time panel is drawn unharmed; only
+    ``pcolormesh`` notices, unpacking the shape into two names and reporting
+    that it got one value -- and only for the two-panel figure, since a
+    caller-supplied ``ax`` never reaches the heatmap at all.
+    """
+    flat = ref_calibration.specific_fluctuation_strength_vs_time.mean(axis=1)
+    with pytest.raises(ValueError, match="'specific_fluctuation_strength_vs_time'"):
+        dataclasses.replace(ref_calibration, specific_fluctuation_strength_vs_time=flat)
+
+
+@pytest.mark.parametrize(
+    "field", ["bark", "centre_frequencies", "specific_fluctuation_strength"]
+)
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
+def test_a_band_axis_off_the_filter_bank_is_refused(
+    ref_calibration: psychoacoustics.EcmaFluctuationStrength, field: str
+) -> None:
+    """The 53 bands are the standard's filter bank, however long the signal.
+
+    ``bark`` is the heatmap's y axis, and the other two name and summarise
+    those same bands for the caller. A ``bark`` of another length makes
+    ``pcolormesh`` refuse the whole table when the full figure is drawn, and
+    nothing at all when the caller supplies an ``ax``: only the time panel is
+    drawn then, so the disagreement goes nowhere and ``plot`` returns as if
+    all were well.
+    """
+    column = np.asarray(getattr(ref_calibration, field))
+    with pytest.raises(ValueError, match=f"'{field}'"):
+        dataclasses.replace(ref_calibration, **{field: column[:-1]})
+
+
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
+def test_a_time_axis_with_a_second_axis_is_refused(
+    ref_calibration: psychoacoustics.EcmaFluctuationStrength,
+) -> None:
+    """A column of times counts the frames correctly and is still not an axis.
+
+    ``plot`` broadcasts it against the trace without complaint; the shaded
+    fill underneath is what stops, with ``'x' is not 1-dimensional`` -- naming
+    matplotlib's own parameter, not the field that carried the extra axis.
+    """
+    with pytest.raises(ValueError, match="'time'"):
+        dataclasses.replace(ref_calibration, time=ref_calibration.time[:, None])
 
 
 def test_invalid_field_raises() -> None:

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -10,6 +10,8 @@ modulation rate and falls off toward low and high rates, grows with modulation
 depth, an unmodulated tone and silence give ~0) plus result-structure guards.
 """
 
+import dataclasses
+
 import numpy as np
 import pytest
 
@@ -139,6 +141,76 @@ def test_result_structure(
     assert np.all(res.specific_roughness >= 0.0)
     assert np.all(res.roughness_vs_time >= 0.0)
     assert res.field == "free"
+
+
+def test_a_time_grid_that_does_not_match_its_curves_is_refused(
+    ref_calibration: psychoacoustics.EcmaRoughness,
+) -> None:
+    """The 50 Hz grid, the roughness trace and the heatmap are one axis.
+
+    The trace is drawn against the grid, and matplotlib answers a mismatch
+    with "x and y must have same first dimension, but have shapes (30,) and
+    (31,)", naming neither field. A heatmap of the wrong number of time steps
+    is quieter still: it raises out of ``pcolormesh`` only when the whole
+    figure is drawn, and a caller who supplies an ``ax`` never draws that
+    panel at all.
+    """
+    with pytest.raises(ValueError, match="'time'"):
+        dataclasses.replace(ref_calibration, time=ref_calibration.time[:-1])
+    trace = ref_calibration.roughness_vs_time
+    with pytest.raises(ValueError, match="'roughness_vs_time'"):
+        dataclasses.replace(ref_calibration, roughness_vs_time=np.append(trace, 0.0))
+    heat = ref_calibration.specific_roughness_vs_time
+    with pytest.raises(ValueError, match="'specific_roughness_vs_time'"):
+        dataclasses.replace(ref_calibration, specific_roughness_vs_time=heat[:-1])
+
+
+def test_a_band_axis_shorter_than_the_bands_is_refused(
+    ref_calibration: psychoacoustics.EcmaRoughness,
+) -> None:
+    """The 53 auditory bands are one axis across four fields.
+
+    ``bark`` is the heatmap's second axis, so a short one raises out of
+    ``pcolormesh`` about the dimensions of C, X and Y; the average specific
+    roughness is drawn by no panel of the built-in figure and reaches the
+    documented ``plot(res.bark, res.specific_roughness)`` snippet intact.
+    """
+    with pytest.raises(ValueError, match="'bark'"):
+        dataclasses.replace(ref_calibration, bark=ref_calibration.bark[:-1])
+    with pytest.raises(ValueError, match="'specific_roughness'"):
+        dataclasses.replace(
+            ref_calibration,
+            specific_roughness=ref_calibration.specific_roughness[:-1],
+        )
+    with pytest.raises(ValueError, match="'specific_roughness_vs_time"):
+        dataclasses.replace(
+            ref_calibration,
+            specific_roughness_vs_time=ref_calibration.specific_roughness_vs_time[
+                :, :-1
+            ],
+        )
+
+
+def test_an_extra_axis_on_the_curves_is_refused(
+    ref_calibration: psychoacoustics.EcmaRoughness,
+) -> None:
+    """Counting the steps and the bands is not enough; the ranks are pinned.
+
+    A ``bark`` of shape ``(53, 1)`` counts 53 bands and ``pcolormesh`` draws
+    it without a word, and a heatmap of shape ``(steps, bands, 1)`` counts
+    both axes right before it reaches the same call.
+    """
+    with pytest.raises(ValueError, match="'bark' must have one axis"):
+        dataclasses.replace(ref_calibration, bark=ref_calibration.bark[:, None])
+    with pytest.raises(
+        ValueError, match="'specific_roughness_vs_time' must have 2 axes"
+    ):
+        dataclasses.replace(
+            ref_calibration,
+            specific_roughness_vs_time=ref_calibration.specific_roughness_vs_time[
+                :, :, None
+            ],
+        )
 
 
 def test_invalid_field_raises() -> None:

--- a/tests/room/test_crowd_noise.py
+++ b/tests/room/test_crowd_noise.py
@@ -217,22 +217,16 @@ def test_plot_draws_one_curve_per_absorption_plus_two_references() -> None:
     plt.close("all")
 
 
-def test_plot_rejects_fewer_absorption_areas_than_level_rows() -> None:
-    """The result is frozen but unchecked, so the plot enforces its own shape.
+def test_fewer_absorption_areas_than_level_rows_is_refused() -> None:
+    """One area missing draws one curve fewer, so the pairing is refused.
 
-    Nothing validates ``levels`` against ``absorption_areas`` at construction,
-    and a hand-built result with one area missing used to draw one curve fewer
-    in silence instead of saying so.
+    The refusal used to be the plot's own, which left the same result free to
+    be handed to anything else. It is refused when the result is built now,
+    which covers the plot and every other reader at once.
     """
-    matplotlib = pytest.importorskip("matplotlib")
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-
     result = room.crowd_noise([20.0, 90.0, 190.0])
-    short = dataclasses.replace(result, absorption_areas=result.absorption_areas[:-1])
-    with pytest.raises(ValueError, match="absorption_areas"):
-        short.plot()
-    plt.close("all")
+    with pytest.raises(ValueError, match="'absorption_areas'"):
+        dataclasses.replace(result, absorption_areas=result.absorption_areas[:-1])
 
 
 @pytest.mark.parametrize(

--- a/tests/room/test_image_source.py
+++ b/tests/room/test_image_source.py
@@ -27,6 +27,7 @@ Oracles, from strongest to softest:
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import numpy as np
@@ -420,6 +421,112 @@ def test_bad_dimension_and_fs() -> None:
         room.image_source_rir(
             (5.0, 4.0, 3.0), (1.0, 2.0, 1.5), (3.0, 2.0, 1.5), 0.2, fs=0
         )
+
+
+def test_extra_axis_on_the_amplitude_table_is_refused() -> None:
+    """A third axis on ``amplitudes`` passes every count, so pin the rank.
+
+    Its bands still line up along axis 0 and its images along axis 1, and the
+    reflectogram then masks the whole table by reflection order and reports a
+    boolean index that did not match, naming no field.
+    """
+    res = room.image_source_rir(
+        (5.0, 4.0, 3.0),
+        (1.0, 1.0, 1.5),
+        (3.0, 2.5, 1.2),
+        np.array([0.1, 0.2, 0.3, 0.15]),
+        fs=8000,
+        max_order=2,
+        frequencies=[125.0, 250.0, 500.0, 1000.0],
+    )
+    paired = np.repeat(res.amplitudes[:, :, None], 2, axis=2)
+    with pytest.raises(ValueError, match="'amplitudes' must have 2 axes"):
+        dataclasses.replace(res, amplitudes=paired)
+
+
+def test_a_reflection_table_of_two_lengths_is_refused() -> None:
+    """The exact table is one row per image, ``amplitudes`` included.
+
+    The reflectogram masks the amplitudes by reflection order and reports a
+    boolean index that did not match, naming no field, and ``direct_time``
+    reports nothing at all: it takes the position of the nearest image from
+    ``distances`` and reads ``times`` there, so a ``times`` one short at the
+    front returns the first reflection as the direct sound.
+    """
+    res = room.image_source_rir(
+        (5.0, 4.0, 3.0), (1.0, 1.0, 1.5), (3.0, 2.5, 1.2), 0.2, fs=8000, max_order=2
+    )
+    for amplitudes in (res.amplitudes[:-1], np.append(res.amplitudes, 1e-3)):
+        with pytest.raises(ValueError, match="'amplitudes'"):
+            dataclasses.replace(res, amplitudes=amplitudes)
+    with pytest.raises(ValueError, match="'times'"):
+        dataclasses.replace(res, times=res.times[1:])
+    banded = room.image_source_rir(
+        (5.0, 4.0, 3.0),
+        (1.0, 1.0, 1.5),
+        (3.0, 2.5, 1.2),
+        np.array([0.1, 0.2, 0.3, 0.15]),
+        fs=8000,
+        max_order=2,
+        frequencies=[125.0, 250.0, 500.0, 1000.0],
+    )
+    with pytest.raises(ValueError, match=r"'amplitudes \(axis 1\)'"):
+        dataclasses.replace(banded, amplitudes=banded.amplitudes[:, :-1])
+
+
+def test_band_labels_must_match_the_bands_they_label() -> None:
+    """``frequencies`` names the rows of ``ir`` and of ``amplitudes``.
+
+    No reader in the library reads the labels back -- the reflectogram draws
+    band 0 and never names it -- so a label list of the wrong length is
+    silent: pairing the labels with the rows drops the band that has no
+    label, and one label too many leaves that table looking complete.
+    """
+    res = room.image_source_rir(
+        (5.0, 4.0, 3.0),
+        (1.0, 1.0, 1.5),
+        (3.0, 2.5, 1.2),
+        np.array([0.1, 0.2, 0.3, 0.15]),
+        fs=8000,
+        max_order=2,
+        frequencies=[125.0, 250.0, 500.0, 1000.0],
+    )
+    for frequencies in ([125.0, 250.0, 500.0], [125.0, 250.0, 500.0, 1000.0, 2000.0]):
+        with pytest.raises(ValueError, match="'frequencies'"):
+            dataclasses.replace(res, frequencies=np.asarray(frequencies))
+    with pytest.raises(ValueError, match="'ir'"):
+        dataclasses.replace(res, ir=res.ir[:-1])
+    with pytest.raises(ValueError, match="'amplitudes'"):
+        dataclasses.replace(res, amplitudes=res.amplitudes[:-1])
+    # A scalar frequency is the one band it names, not a missing axis.
+    single = room.image_source_rir(
+        (5.0, 4.0, 3.0),
+        (1.0, 1.0, 1.5),
+        (3.0, 2.5, 1.2),
+        0.2,
+        fs=8000,
+        max_order=2,
+        frequencies=1000.0,
+    )
+    assert np.ndim(single.frequencies) == 0
+    assert single.ir.shape[0] == 1
+
+
+def test_a_point_missing_a_coordinate_is_refused() -> None:
+    """The room, the two points and the lattice carry one coordinate count.
+
+    The reflectogram unpacks the room lengths three at a time, but the plan
+    view reads only x and y out of the lattice and out of each point, so a
+    source that lost its height draws an ordinary figure and says nothing.
+    What refuses the point is this construction check, not any reader.
+    """
+    res = room.image_source_rir(
+        (5.0, 4.0, 3.0), (1.0, 1.0, 1.5), (3.0, 2.5, 1.2), 0.2, fs=8000, max_order=2
+    )
+    with pytest.raises(ValueError, match="'source'"):
+        dataclasses.replace(res, source=(1.0, 1.0))
+    with pytest.raises(ValueError, match="'image_positions"):
+        dataclasses.replace(res, image_positions=res.image_positions[:, :2])
 
 
 def test_reflectogram_plot_smoke() -> None:

--- a/tests/room/test_modes.py
+++ b/tests/room/test_modes.py
@@ -15,6 +15,7 @@ Oracles, all independent of this implementation:
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import numpy as np
@@ -272,3 +273,91 @@ def test_other_validation_errors() -> None:
         room.room_mode_count(-1.0, LONG_ROOM)
     with pytest.raises(ValueError, match="non-negative and finite"):
         room.room_modal_density(math.inf, LONG_ROOM)
+
+
+def _long_table_result() -> room.RoomModesResult:
+    """Long Table 8.1 as a result: six modes, four axial and two tangential."""
+    return room.room_modes(LONG_ROOM, max_frequency=61.0, speed_of_sound=LONG_C0)
+
+
+@pytest.mark.parametrize(
+    ("field", "slice_"),
+    [("orders", slice(None, -1)), ("frequencies", slice(None, -1))],
+)
+def test_a_column_short_of_a_mode_is_refused(field: str, slice_: slice) -> None:
+    """The three columns are one enumeration, and only one reader complains.
+
+    The ladder masks the frequencies with ``kinds == kind`` and raises numpy's
+    "boolean index did not match indexed array" from inside the drawing call,
+    naming no column; ``count_by_kind`` reads the kinds alone and tallies five
+    modes for a six-rung ladder without a word; and ``orders`` is read by
+    neither, so a triple table one row short leaves ``orders[-1]`` holding the
+    ``(0, 0, 1)`` triple of the 57.3 Hz mode against the 60.0 Hz frequency
+    beside it.
+    """
+    result = _long_table_result()
+    short = getattr(result, field)[slice_]
+    with pytest.raises(ValueError, match=f"'{field}'.*per mode"):
+        dataclasses.replace(result, **{field: short})
+
+
+def test_a_kind_column_of_another_length_is_refused() -> None:
+    """A kind column one long tallies seven modes on a six-mode ladder."""
+    result = _long_table_result()
+    longer = np.concatenate([result.kinds, result.kinds[:1]])
+    with pytest.raises(ValueError, match="'kinds' \\(7\\).*per mode"):
+        dataclasses.replace(result, kinds=longer)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("orders", "stacked", "'orders' must have 2 axes"),
+        ("frequencies", "column", "'frequencies' must have one axis"),
+        ("kinds", "column", "'kinds' must have one axis"),
+    ],
+)
+def test_an_extra_axis_on_a_column_is_refused(
+    field: str, value: str, match: str
+) -> None:
+    """Counting the modes leaves an extra axis free to reach the reader.
+
+    A triple table stacked into ``(modes, 3, 2)`` keeps its six rows, so it
+    draws and tallies exactly as a sound one does, and hands ``orders[0]``
+    back as a 3 x 2 block; a frequency column of shape ``(modes, 1)`` draws
+    the ladder at the right frequencies and then fails ``float`` on a single
+    entry; a kind column of that shape tallies correctly and raises "too many
+    indices for array" from the ladder.
+    """
+    result = _long_table_result()
+    original = getattr(result, field)
+    reshaped = (
+        np.stack([original, original], axis=-1)
+        if value == "stacked"
+        else original.reshape(-1, 1)
+    )
+    with pytest.raises(ValueError, match=match):
+        dataclasses.replace(result, **{field: reshaped})
+
+
+def test_a_triple_missing_a_coordinate_is_refused() -> None:
+    """The room lengths and the width of the triple table are one count.
+
+    The rank check does not pin it: a two-column triple table has one row per
+    mode and draws and tallies in silence, and is caught only later, by
+    :func:`room_mode_frequency`, complaining about its own argument.
+    """
+    result = _long_table_result()
+    with pytest.raises(ValueError, match="'orders \\(axis 1\\)'.*per coordinate"):
+        dataclasses.replace(result, orders=result.orders[:, :2])
+    with pytest.raises(ValueError, match="'dimensions' \\(2\\).*per coordinate"):
+        dataclasses.replace(result, dimensions=(7.0, 5.0))
+
+
+def test_an_empty_enumeration_is_accepted() -> None:
+    """A limit below the fundamental leaves no modes, and that is not a slip."""
+    result = room.room_modes(LONG_ROOM, max_frequency=1.0)
+    assert result.orders.shape == (0, 3)
+    assert result.frequencies.shape == (0,)
+    assert result.kinds.shape == (0,)
+    assert result.count_by_kind() == dict.fromkeys(room.modes.MODE_KINDS, 0)

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -14,6 +14,7 @@ default ``c0 = 343 m/s`` (``k = 0.161113...``).
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import numpy as np
@@ -203,6 +204,50 @@ def test_reverberation_time_models_bundle() -> None:
         "Fitzroy",
         "Arau-Puchades",
     }
+
+
+def test_model_curves_must_run_over_one_band_axis() -> None:
+    """Curves off the band axis are refused when built, not when read.
+
+    The fiche walks ``frequencies`` and reads each curve at that band's index,
+    so a curve one entry short raises a bare index error from inside the row
+    loop and one entry long is dropped off the end of the table; ``plot()``
+    reports matplotlib's two shapes and names neither field. An extra axis is
+    the silent one: it counts one entry per band, so ``plot()`` draws the
+    column as an ordinary line and returns a figure that looks right.
+    """
+    good = room.reverberation_time_models(
+        DIMS, (0.2, 0.15, 0.3), frequencies=[125.0, 250.0, 500.0, 1000.0]
+    )
+    per_band = "one value per band"
+    curves = ("sabine", "eyring", "millington_sette", "fitzroy", "arau_puchades")
+    cases: list[tuple[str, np.ndarray, str]] = [
+        ("frequencies", good.frequencies[:-1], per_band),
+        ("frequencies", np.append(good.frequencies, 2000.0), per_band),
+        ("frequencies", np.column_stack([good.frequencies] * 2), "must have one axis"),
+    ]
+    for name in curves:
+        curve = getattr(good, name)
+        cases += [
+            (name, curve[:-1], per_band),
+            (name, np.append(curve, curve[-1]), per_band),
+            (name, np.column_stack([curve] * 2), "must have one axis"),
+        ]
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_models_single_frequency_is_a_band_axis_of_one() -> None:
+    """A scalar ``frequencies`` labels one band, as ``None`` already does.
+
+    The five curves are made 1-D whatever is passed, so a nought-dimensional
+    band axis beside them would be a mixture the table cannot walk.
+    """
+    res = room.reverberation_time_models(DIMS, (0.2, 0.2, 0.2), frequencies=1000.0)
+    assert res.frequencies.shape == (1,)
+    assert res.frequencies[0] == pytest.approx(1000.0)
+    assert res.sabine.shape == (1,)
 
 
 def test_models_scalar_absorption_broadcasts() -> None:

--- a/tests/room/test_shaped_sweep.py
+++ b/tests/room/test_shaped_sweep.py
@@ -18,6 +18,8 @@ Validation strategy (closed-form, not self-consistency):
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 from scipy import signal
@@ -188,6 +190,33 @@ def test_rejects_bad_inputs() -> None:
     non_finite = (np.array([100.0, 200.0]), np.array([0.0, np.inf]))
     with pytest.raises(ValueError, match="finite"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=non_finite)
+
+
+def test_synthesis_metadata_must_lie_on_one_grid() -> None:
+    """Metadata off the synthesis grid is refused when built, not when drawn.
+
+    The plot masks ``frequencies`` for the band and applies that mask to the
+    dB curve built from ``magnitude``, so a length disagreement surfaces only
+    as numpy's complaint about a boolean index and two axis sizes, naming
+    neither field. Nothing reads ``group_delay`` at all. And an extra axis
+    counts one row per bin, so it passes every length check and reaches the
+    plot as a second dashed curve under the one "Synthesis target" label.
+    """
+    good = room.shaped_sweep_signal(FS, 100.0, 5000.0, 0.5)
+    per_bin = "one value per frequency bin"
+    cases = (
+        ("frequencies", good.frequencies[:-1], per_bin),
+        ("magnitude", good.magnitude[:-1], per_bin),
+        ("magnitude", np.append(good.magnitude, 1.0), per_bin),
+        ("group_delay", good.group_delay[:-1], per_bin),
+        ("group_delay", np.append(good.group_delay, good.group_delay[-1]), per_bin),
+        ("frequencies", np.column_stack([good.frequencies] * 2), "must have one axis"),
+        ("magnitude", np.column_stack([good.magnitude] * 2), "must have one axis"),
+        ("group_delay", np.column_stack([good.group_delay] * 2), "must have one axis"),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
 
 
 def test_result_behaves_like_array() -> None:

--- a/tests/room/test_steady_field.py
+++ b/tests/room/test_steady_field.py
@@ -10,6 +10,7 @@ one numeric anchor the source texts print: Kuttruff's classroom example
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import numpy as np
@@ -166,6 +167,36 @@ def test_steady_field_validation() -> None:
     empty = np.array([])
     with pytest.raises(ValueError, match="'distances' must be a non-empty"):
         room.steady_state_field(90.0, 100.0, 0.2, distances=empty)
+
+
+def test_field_curves_must_run_over_one_distance_grid() -> None:
+    """Curves off the distance grid are refused when built, not when drawn.
+
+    The plot draws each level against ``distances`` point for point, so a
+    length disagreement surfaces only as matplotlib's "x and y must have same
+    first dimension" and two bare shapes, naming neither field nor result. An
+    extra axis is worse: it counts one row per distance, passes every length
+    check, and reaches the plot as a second curve in the same colour and dash,
+    under a repeated legend entry.
+    """
+    good = room.steady_state_field(90.0, 100.0, 0.2)
+    per_distance = "one value per distance"
+    cases = (
+        ("distances", good.distances[:-1], per_distance),
+        ("direct", good.direct[:-1], per_distance),
+        ("direct", np.append(good.direct, good.direct[-1]), per_distance),
+        ("reverberant", good.reverberant[:-1], per_distance),
+        ("reverberant", np.append(good.reverberant, 0.0), per_distance),
+        ("total", good.total[:-1], per_distance),
+        ("total", np.append(good.total, good.total[-1]), per_distance),
+        ("distances", np.column_stack([good.distances] * 2), "must have one axis"),
+        ("direct", np.column_stack([good.direct] * 2), "must have one axis"),
+        ("reverberant", np.column_stack([good.reverberant] * 2), "must have one axis"),
+        ("total", np.column_stack([good.total] * 2), "must have one axis"),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
 
 
 def test_steady_field_plot_smoke() -> None:

--- a/tests/signals/test_multitaper.py
+++ b/tests/signals/test_multitaper.py
@@ -21,6 +21,8 @@ on the same record.
 
 from __future__ import annotations
 
+import dataclasses
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -285,6 +287,71 @@ def test_multitaper_rejects_invalid_inputs() -> None:
         ph.signals.multitaper_psd(x, FS, scaling="bogus")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="confidence"):
         ph.signals.multitaper_psd(x, FS, confidence=1.5)
+
+
+def test_multitaper_columns_must_share_the_frequency_axis() -> None:
+    """A column off the rfft grid is refused when built, not when drawn.
+
+    The plot masks ``frequencies`` for the positive bins and applies that
+    mask to ``psd``, ``ci_lower`` and ``ci_upper``, so those three surface
+    only as numpy's complaint about a boolean index and two axis sizes,
+    naming neither the field nor the one that is wrong. The rest is silent:
+    ``degrees_of_freedom`` reaches the legend as the mean of its interior
+    bins, so a dof array from another estimate relabels the drawn band with
+    a nu-bar it does not have, and nothing reads ``random_error`` or
+    ``weights`` at all. An extra axis passes every count, so the ranks are
+    pinned too.
+    """
+    good = ph.signals.multitaper_psd(_white(39, n=1024), FS)
+    per_bin = "one value per frequency bin"
+    cases = (
+        ("frequencies", good.frequencies[:-1], per_bin),
+        ("psd", good.psd[:-1], per_bin),
+        ("psd", np.append(good.psd, good.psd[-1]), per_bin),
+        ("ci_lower", good.ci_lower[:-1], per_bin),
+        ("ci_upper", good.ci_upper[:-1], per_bin),
+        ("degrees_of_freedom", good.degrees_of_freedom[:-1], per_bin),
+        (
+            "degrees_of_freedom",
+            np.append(good.degrees_of_freedom, 999.0),
+            per_bin,
+        ),
+        ("random_error", good.random_error[:-1], per_bin),
+        ("psd", np.column_stack([good.psd] * 2), "must have one axis"),
+        ("weights", good.weights[0], "must have 2 axes"),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
+    for weights in (
+        good.weights[:, :-1],
+        np.hstack([good.weights, good.weights[:, :1]]),
+    ):
+        with pytest.raises(ValueError, match=rf"'weights \(axis 1\)'.*{per_bin}"):
+            dataclasses.replace(good, weights=weights)
+
+
+def test_multitaper_eigenvalues_and_weights_must_share_the_taper_axis() -> None:
+    """The per-taper pair is refused when built; no plot ever reads it.
+
+    ``lambda_k`` and the weights it drives are two columns of one table, and
+    an extra ``lambda_k`` moves the ``sum_j lambda_j`` that a reader
+    normalizes by, so the uniform limit lambda_k/sum_j lambda_j comes out
+    wrong for every taper, the ones actually present included. An extra row
+    of ``weights`` breaks the sum to unity the field's own definition
+    asserts. Neither shows on the figure.
+    """
+    good = ph.signals.multitaper_psd(_white(40, n=1024), FS)
+    per_taper = "one value per taper"
+    cases = (
+        ("eigenvalues", good.eigenvalues[:-1]),
+        ("eigenvalues", np.append(good.eigenvalues, good.eigenvalues[-1])),
+        ("weights", good.weights[:-1]),
+        ("weights", np.vstack([good.weights, good.weights[:1]])),
+    )
+    for field, value in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{per_taper}"):
+            dataclasses.replace(good, **{field: value})
 
 
 def test_multitaper_plot_line_and_confidence_band() -> None:

--- a/tests/signals/test_phase.py
+++ b/tests/signals/test_phase.py
@@ -13,6 +13,8 @@ excess phase; ``minimum_phase`` is idempotent and phase-blind).
 
 from __future__ import annotations
 
+import dataclasses
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -229,6 +231,40 @@ def test_validation_errors() -> None:
         ph.signals.group_delay(good, -1.0)
     with pytest.raises(ValueError, match="fs"):
         ph.signals.phase_decomposition(good, 0.0)
+
+
+def test_decomposition_parts_must_lie_on_one_grid() -> None:
+    """A part off the response grid is refused when built, not when drawn.
+
+    The plot masks ``frequencies`` for DC and applies that one mask to seven
+    of the eight arrays, so a length disagreement surfaces only as numpy's
+    complaint about a boolean index and two axis sizes, naming neither field.
+    Nothing reads ``minimum_phase_response`` at all. And an extra axis counts
+    one row per bin, so it passes every length check and reaches the plot as
+    a second curve on its panel, doubling that curve's legend entry.
+    """
+    good = ph.signals.phase_decomposition(_biquad_response(), FS)
+    per_bin = "one value per frequency bin"
+    fields = (
+        "frequencies",
+        "magnitude",
+        "phase",
+        "minimum_phase",
+        "excess_phase",
+        "group_delay",
+        "excess_group_delay",
+        "minimum_phase_response",
+    )
+    for field in fields:
+        value = np.asarray(getattr(good, field))
+        cases = (
+            (value[:-1], per_bin),
+            (np.append(value, value[-1]), per_bin),
+            (np.column_stack([value] * 2), "must have one axis"),
+        )
+        for wrong, fragment in cases:
+            with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+                dataclasses.replace(good, **{field: wrong})
 
 
 def test_magnitude_zeros_are_floored_not_fatal() -> None:

--- a/tests/signals/test_spectra.py
+++ b/tests/signals/test_spectra.py
@@ -18,6 +18,8 @@ Bendat & Piersol's; it lives in ``test_multitaper.py``.
 
 from __future__ import annotations
 
+import dataclasses
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -474,6 +476,94 @@ def test_two_channel_functions_reject_mismatched_lengths(func) -> None:
     x = _white(13)
     with pytest.raises(ValueError, match="same length"):
         func(x, x[:-1], FS)
+
+
+def test_density_band_must_sit_on_its_own_frequency_axis() -> None:
+    """The chi-square band is refused when it does not match the density.
+
+    The plot cuts the positive-frequency mask from ``frequencies`` and
+    applies it to ``psd``, ``ci_lower`` and ``ci_upper``, so all four reach
+    the reader only as numpy's complaint about a boolean index and two axis
+    sizes, naming neither the field nor the result, and leaving an open
+    figure behind. An extra axis passes every count, so the ranks are pinned
+    too.
+    """
+    good = ph.signals.power_spectral_density(_white(40, n=4096), FS, nperseg=256)
+    per_frequency = "one value per frequency"
+    cases = (
+        ("frequencies", good.frequencies[:-1], per_frequency),
+        ("psd", good.psd[:-1], per_frequency),
+        ("psd", np.append(good.psd, good.psd[-1]), per_frequency),
+        ("ci_lower", good.ci_lower[:-1], per_frequency),
+        ("ci_upper", np.append(good.ci_upper, good.ci_upper[-1]), per_frequency),
+        ("psd", np.column_stack([good.psd] * 2), "must have one axis"),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_cross_spectrum_curves_must_share_one_frequency_axis() -> None:
+    """A cross-spectrum whose seven curves disagree cannot be built.
+
+    Five of them are drawn against the positive-frequency mask and surface
+    as numpy's boolean-index complaint, which names two sizes and neither
+    the field nor the result. The other two are silent: nothing plots
+    ``csd`` or ``magnitude_random_error``, so the three-panel figure comes
+    out complete and ordinary while the complex spectrum the caller reads no
+    longer lines up with the magnitude and phase taken from it.
+    """
+    x, y, _ = _known_snr_pair(8, n=4096)
+    good = ph.signals.cross_spectral_density(x, y, FS, nperseg=256)
+    per_frequency = "one value per frequency"
+    for field in (
+        "frequencies",
+        "csd",
+        "magnitude",
+        "phase",
+        "coherence",
+        "magnitude_random_error",
+        "phase_std",
+    ):
+        curve = getattr(good, field)
+        for value in (curve[:-1], np.append(curve, curve[-1])):
+            with pytest.raises(ValueError, match=rf"'{field}'.*{per_frequency}"):
+                dataclasses.replace(good, **{field: value})
+    with pytest.raises(ValueError, match=r"'coherence' must have one axis"):
+        dataclasses.replace(good, coherence=np.column_stack([good.coherence] * 2))
+
+
+def test_coherent_output_split_must_share_one_frequency_axis() -> None:
+    """The ten curves of the split are refused unless they agree.
+
+    Only ``output_psd``, ``coherent_psd``, ``noise_psd`` and ``snr_db``
+    reach the figure, so those raise from inside numpy's boolean index. The
+    remaining five - the coherence and the Eq. 9.73 and 9.75 errors - are
+    drawn by nothing at all, and a wrong length there returns the complete
+    two-panel figure without a word while the quantities quoted beside it
+    sit a bin off the axis they are quoted on.
+    """
+    x, y, _ = _known_snr_pair(9, n=4096)
+    good = ph.signals.coherent_output_spectrum(x, y, FS, nperseg=256)
+    per_frequency = "one value per frequency"
+    for field in (
+        "frequencies",
+        "output_psd",
+        "coherent_psd",
+        "noise_psd",
+        "coherence",
+        "snr",
+        "snr_db",
+        "random_error",
+        "snr_random_error",
+        "coherence_bias",
+    ):
+        curve = getattr(good, field)
+        for value in (curve[:-1], np.append(curve, curve[-1])):
+            with pytest.raises(ValueError, match=rf"'{field}'.*{per_frequency}"):
+                dataclasses.replace(good, **{field: value})
+    with pytest.raises(ValueError, match=r"'snr_db' must have one axis"):
+        dataclasses.replace(good, snr_db=np.column_stack([good.snr_db] * 2))
 
 
 def test_default_nperseg_targets_4hz_resolution() -> None:

--- a/tests/simulation/test_fdtd_ntff.py
+++ b/tests/simulation/test_fdtd_ntff.py
@@ -50,6 +50,8 @@ levels by less than 0.01 dB).
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 from scipy.special import hankel2
@@ -545,3 +547,66 @@ def test_contour_phasors_subtract_mismatch() -> None:
         base.subtract(harmonic)
     with pytest.raises(ValueError, match="different contours"):
         base.subtract(shifted)
+
+
+def _square_contour(n_side: int = 4) -> dict[str, Any]:
+    """Hand-built phasors on a square contour, the form the docstring invites."""
+    side = np.linspace(-0.5, 0.5, n_side)
+    positions = np.concatenate(
+        [
+            np.stack((side, np.full(n_side, -0.5)), axis=1),
+            np.stack((np.full(n_side, 0.5), side), axis=1),
+            np.stack((side[::-1], np.full(n_side, 0.5)), axis=1),
+            np.stack((np.full(n_side, -0.5), side[::-1]), axis=1),
+        ]
+    )
+    normals = np.sign(positions) * (np.abs(positions) >= 0.5)
+    n = positions.shape[0]
+    return {
+        "frequency": F0,
+        "positions": positions,
+        "normals": normals,
+        "pressure": np.exp(1j * K0 * positions[:, 0]),
+        "normal_velocity": np.full(n, 0.01 + 0j),
+        "segment": 1.0 / n_side,
+    }
+
+
+def test_contour_phasors_shape_mismatch_refused() -> None:
+    """Every sample-axis mismatch is refused at construction, both directions.
+
+    Without this the mistake reaches numpy inside the integral, which names
+    no field, or, when a quantity collapses to a single sample, reaches
+    nobody: it broadcasts over the whole contour and hands back a far-field
+    pattern of exactly the expected length.
+    """
+    fields = _square_contour()
+    assert isinstance(ContourPhasors(**fields), ContourPhasors)
+    n = fields["positions"].shape[0]
+    per_sample = ("positions", "normals", "pressure", "normal_velocity")
+    for name in per_sample:
+        good = np.asarray(fields[name])
+        for bad in (good[:-1], np.concatenate([good, good[:1]]), good[:1]):
+            with pytest.raises(ValueError, match="for the same n >= 1"):
+                ContourPhasors(**{**fields, name: bad})
+    # An extra axis carries the right number of samples past any count.
+    for name in ("pressure", "normal_velocity"):
+        with pytest.raises(ValueError, match="for the same n >= 1"):
+            ContourPhasors(**{**fields, name: np.asarray(fields[name])[np.newaxis]})
+    with pytest.raises(ValueError, match="for the same n >= 1"):
+        ContourPhasors(**{**fields, "positions": np.zeros((n, 3))})
+
+
+def test_contour_phasors_accepts_hand_built_lists() -> None:
+    """Lists coerce to the probe-built arrays, as the class docstring promises."""
+    fields = _square_contour()
+    listed = {
+        name: (value.tolist() if isinstance(value, np.ndarray) else value)
+        for name, value in fields.items()
+    }
+    built = ContourPhasors(**listed)
+    assert built.positions.dtype == np.float64
+    assert built.pressure.dtype == np.complex128
+    assert np.allclose(built.normals, fields["normals"])
+    pattern = far_field_from_contour(built, [0.0, 90.0])
+    assert pattern.shape == (2,)

--- a/tests/underwater/propagation/test_seabed_reflection.py
+++ b/tests/underwater/propagation/test_seabed_reflection.py
@@ -8,6 +8,7 @@ angle ``arccos(c1/c2)``; and total reflection (``|R| = 1``) below it.
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 
 import matplotlib as mpl
@@ -172,3 +173,65 @@ def test_seabed_reflection_no_critical_angle_for_slow_bottom() -> None:
 def test_seabed_reflection_plot_smoke() -> None:
     res = seabed_reflection(np.linspace(0.0, 90.0, 91), **_WATER, **_SAND)
     assert res.plot() is not None
+
+
+_PER_ANGLE = "one value per grazing angle"
+_ONE_AXIS = "must have one axis"
+
+
+def test_bottom_loss_columns_must_run_over_one_angle_sweep() -> None:
+    """A loss curve off its angle axis is refused when built, not when read.
+
+    ``.plot()`` draws ``reflection_loss`` against ``grazing_angle``, so that
+    half of a mismatch surfaces only as matplotlib's "x and y must have same
+    first dimension" and two bare shapes, naming neither field.
+    ``reflection_coefficient`` reaches no figure at all: a short one is drawn
+    straight past in silence, and a single-entry one is quieter still,
+    because numpy broadcasts it over every angle. An extra axis is silent
+    too: an ``(n, 2)`` column carries one value per angle by every count and
+    puts a second curve in the picture under a repeated legend row.
+    """
+    good = bottom_reflection_loss(np.linspace(0.0, 90.0, 91), **_WATER, **_SAND)
+    cases = (
+        ("grazing_angle", good.grazing_angle[:-1], _PER_ANGLE),
+        ("reflection_loss", good.reflection_loss[:-1], _PER_ANGLE),
+        ("reflection_loss", np.append(good.reflection_loss, 0.0), _PER_ANGLE),
+        ("reflection_coefficient", good.reflection_coefficient[:1], _PER_ANGLE),
+        ("grazing_angle", np.column_stack([good.grazing_angle] * 2), _ONE_AXIS),
+        ("reflection_loss", np.column_stack([good.reflection_loss] * 2), _ONE_AXIS),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_seabed_reflection_columns_must_run_over_one_angle_sweep() -> None:
+    """The bundled record is refused unless its four columns are one sweep.
+
+    ``.plot()`` draws only ``magnitude`` against ``grazing_angle``; the
+    complex ``R`` and the bottom loss beside them reach no figure, so a
+    ``bottom_loss`` of the wrong length lets a complete ``|R|`` curve be drawn
+    over every angle while the decibels a sonar budget spends are wrong and
+    unmentioned. An ``(n, 2)`` column passes every count and doubles the
+    curve.
+    """
+    good = seabed_reflection(np.linspace(0.0, 90.0, 91), **_WATER, **_SAND)
+    cases = (
+        ("grazing_angle", good.grazing_angle[:-1], _PER_ANGLE),
+        ("magnitude", good.magnitude[:-1], _PER_ANGLE),
+        ("bottom_loss", good.bottom_loss[:-1], _PER_ANGLE),
+        ("bottom_loss", np.append(good.bottom_loss, 0.0), _PER_ANGLE),
+        ("reflection_coefficient", good.reflection_coefficient[:1], _PER_ANGLE),
+        ("magnitude", np.column_stack([good.magnitude] * 2), _ONE_AXIS),
+        ("bottom_loss", np.column_stack([good.bottom_loss] * 2), _ONE_AXIS),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_scalar_angle_still_builds_both_results() -> None:
+    # A single grazing angle is one angle, not an extra axis: the rank check
+    # must not refuse the one-entry sweep the scalar entry points return.
+    assert bottom_reflection_loss(90.0, **_WATER, **_SAND).reflection_loss.shape == (1,)
+    assert seabed_reflection(90.0, **_WATER, **_SAND).magnitude.shape == (1,)

--- a/tests/underwater/propagation/test_sound_speed.py
+++ b/tests/underwater/propagation/test_sound_speed.py
@@ -12,6 +12,8 @@ Equations 1.2 to 1.4, printed p. 20).
 
 from __future__ import annotations
 
+import dataclasses
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -227,6 +229,37 @@ def test_profile_gradient_and_shape() -> None:
 def test_profile_requires_increasing_depths() -> None:
     with pytest.raises(ValueError, match="increasing"):
         sound_speed_profile([0.0, 100.0, 50.0], 10.0, 35.0)
+
+
+def test_profile_columns_must_run_over_one_depth_grid() -> None:
+    """Columns off the depth grid are refused when built, not when read.
+
+    The figure draws ``sound_speed`` against ``depth``, so that half of a
+    mismatch surfaces only as matplotlib's "x and y must have same first
+    dimension" and two bare shapes, naming neither column. ``gradient``
+    reaches no figure at all and is silent in both directions, yet the depth
+    of the sound-channel axis and the ray curvature radius are read off it
+    entry by entry beside ``depth``. An extra axis is quieter still: an
+    ``(n, 2)`` column carries one value per depth by every count and draws a
+    second curve under the one legend entry that names a single model.
+    """
+    good = sound_speed_profile(np.linspace(0.0, 3000.0, 21), 12.0, 35.0)
+    per_depth = "one value per depth"
+    one_axis = "must have one axis"
+    cases = (
+        ("depth", good.depth[:-1], per_depth),
+        ("sound_speed", good.sound_speed[:-1], per_depth),
+        ("sound_speed", np.append(good.sound_speed, 1500.0), per_depth),
+        # np.diff is the obvious hand-rolled gradient, and it is one short.
+        ("gradient", np.diff(good.sound_speed) / np.diff(good.depth), per_depth),
+        ("gradient", np.append(good.gradient, 0.0), per_depth),
+        ("depth", np.column_stack([good.depth] * 2), one_axis),
+        ("sound_speed", np.column_stack([good.sound_speed] * 2), one_axis),
+        ("gradient", np.column_stack([good.gradient] * 2), one_axis),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
 
 
 def test_profile_plot_smoke() -> None:

--- a/tests/underwater/test_sonar_equation.py
+++ b/tests/underwater/test_sonar_equation.py
@@ -7,6 +7,8 @@ pure arithmetic, independent of the implementation.
 
 from __future__ import annotations
 
+import dataclasses
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -96,6 +98,59 @@ def test_plot_smoke() -> None:
         150.0, np.linspace(40.0, 110.0, 40), 55.0, detection_threshold=8.0
     )
     assert res.plot() is not None
+
+
+_PER_LOSS = "one value per propagation loss"
+_ONE_AXIS = "must have one axis"
+
+
+def test_solution_columns_must_run_over_one_loss_axis() -> None:
+    """A solution off its own loss axis is refused when built, not when read.
+
+    ``.plot()`` sorts by propagation loss and reads the signal excess through
+    that sort order, so a short ``signal_excess`` surfaces only as numpy's
+    "index 3 is out of bounds for axis 0 with size 3" -- an axis and a size,
+    naming neither field. A long one is silent: the sort order holds one entry
+    per loss, so the tail is dropped without a word, and the tail is the half
+    that carries the negative excesses. ``snr`` reaches no figure at all and
+    is silent in both directions, yet it is read entry by entry beside
+    ``propagation_loss``. An extra axis is quieter still: an ``(n, 2)`` column
+    carries one value per loss by every count.
+    """
+    good = passive_sonar_equation(
+        150.0, np.linspace(60.0, 110.0, 6), 57.0, detection_threshold=8.0
+    )
+    cases = (
+        ("propagation_loss", good.propagation_loss[:-1], _PER_LOSS),
+        ("signal_excess", good.signal_excess[:-1], _PER_LOSS),
+        ("signal_excess", np.append(good.signal_excess, -20.0), _PER_LOSS),
+        ("snr", good.snr[:-1], _PER_LOSS),
+        ("snr", np.append(good.snr, -12.0), _PER_LOSS),
+        ("propagation_loss", np.column_stack([good.propagation_loss] * 2), _ONE_AXIS),
+        ("signal_excess", np.column_stack([good.signal_excess] * 2), _ONE_AXIS),
+        ("snr", np.column_stack([good.snr] * 2), _ONE_AXIS),
+    )
+    for field, value, fragment in cases:
+        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_entry_points_refuse_a_grid_of_losses() -> None:
+    """A two-dimensional loss input is refused where it is handed over.
+
+    The coercion only widens a scalar, so a grid passes straight through and
+    every derived quantity takes its shape: all three first axes agree and no
+    count notices. The plot's sort then indexes an ``(n, 2)`` pair into an
+    ``(n, 2, 2)`` one, and matplotlib complains about shapes that appear
+    nowhere in the result.
+    """
+    grid = np.array([[60.0, 70.0], [80.0, 90.0], [100.0, 110.0]])
+    for call in (
+        lambda: passive_sonar_equation(150.0, grid, 57.0),
+        lambda: active_sonar_equation(200.0, grid, 10.0, 50.0),
+    ):
+        with pytest.raises(ValueError, match=rf"'propagation_loss'.*{_ONE_AXIS}"):
+            call()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Result types now refuse per-band columns that disagree in length at construction, instead of leaving the disagreement for whichever reader trips over it first.

The library carries most measurements as a frozen result holding several arrays that are the same bands written down more than once: a source level, a receiving level, a reverberation time and the quantity derived from them. Nothing was checking that they covered the same bands. Whether a mismatch was noticed at all depended entirely on which reader opened the result, and the readers are not consistent: some pair the columns with `zip`, which stops at the shorter one and drops a band without a word; some index the longer one by position and raise `IndexError` from inside a table loop; some hand both to matplotlib, which answers with the shapes and nothing else. In each case the message names neither the fields that disagree nor the result they came from.

Checking at construction moves the refusal to the one place every reader passes through, and lets it name the class and the fields. 159 result types gain the check, through shared helpers rather than a hand-rolled comparison per class.

To find them I instrumented the suite and recorded the real shape of every array on every result it built, then cross-checked each guard against the fields whose lengths were measured to move together. Co-variation is evidence rather than proof, so three groups that the census flagged are deliberately left unguarded, and I have written down why: `FacadeElement` carries `Dn,e` or `R` as mutually exclusive alternatives, one for a small element and one for an element with area, so pairing them would refuse a legitimate facade; `_EventSetup` holds a terrain as vertices and triangles, which are different counts in any mesh that is not the small regular ones the suite happens to use; and the four flight quantities of `RotorcraftTrackState` sit on the track conceptually but any one of them may be a constant while the others vary.

Three of the holes were live, and I reproduced each before closing it:

- `FacadeInsulationResult` accepted 17 values of `D2m` beside 16 of `D2m,nT` and 16 band centres, and `report()` wrote a clean ISO 16283-3 sheet. The fiche reports one quantity at a time and counts that curve alone, so the columns beside it were never looked at.
- `AbsorptionRatingResult` accepted one-third-octave arrays that were not three per octave. Eighteen of them against a five-octave rating ran the accredited table's `measured[j // 3]` lookup off the end and died with a bare `IndexError`; twelve wrote a table that stopped an octave early and said nothing.
- `SonarEquationResult` accepted a `signal_excess` longer than its `propagation_loss`, and the plot drew the pair against the shorter one without a word. What the tail drops is the part that goes negative, so the curve stopped dead on `SE = 0` and never crossed it, in a figure whose whole subject is where that crossing falls.

The rest of the change is prose. Each guard documents what actually goes wrong without it, and I checked those sentences by running the code rather than by reading it, which is how the two holes above turned up. Where a docstring already made a claim about a reader, several turned out to be describing behaviour the code does not have: a plot said to draw against a frequency axis that is index-only and carries no band centres, a short column said to be padded out silently when in fact it raises and the silent case is the long one, a fiche said to read a field it never opens. Those are corrected to what I measured.

The same pass fixed a defect in the published API reference: `AbsorptionUncertaintyResult` was documented as leaving `values` empty for the single-number quantities, when it holds one element and it is `frequencies` alone that is empty.

Guards are added where a length can settle the question. The results whose rows only a numerical invariant can pin are left for separate work.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Validate shared result axes and grid shapes at construction so malformed data is rejected consistently before any reader, report, or plot consumes it.

Bug Fixes:
- Reject mismatched result arrays during construction with errors that identify the result fields and axis involved.
- Prevent malformed per-band, per-sample, per-grid, and related result data from being silently truncated, broadcast, or misaligned by downstream readers.
- Correct handling of scalar inputs and single-number results so valid zero-dimensional and empty-frequency cases remain supported.

Enhancements:
- Apply shared rank and length validation across the library's result dataclasses, covering independent axes separately where appropriate.
- Centralize grid-shape validation for simulation raster results and strengthen validation of nested result axes and declared counts.
- Document the measured behavior and rationale for newly guarded result types, including intentionally unguarded conceptual or alternative-axis data.

Documentation:
- Correct the AbsorptionUncertaintyResult API reference to state that single-number results contain one value and uncertainty entry while only frequencies is empty.

Tests:
- Expand coverage for construction-time validation across building, materials, metrology, psychoacoustics, room acoustics, signals, simulation, underwater propagation, and related result types.
- Add regression tests for mismatched lengths, extra axes, scalar inputs, optional fields, nested grids, and valid single-number or empty-result cases.

Chores:
- Remove redundant plotting-time crowd-noise shape validation now that result construction enforces the invariant.
- Normalize scalar frequency handling for reverberation-time model results.