### PR TITLE
Print the counts the length checks were comparing

### DIFF
--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -76,7 +76,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from .insulation import (
     ImpactRatingResult,
     WeightedRatingResult,
@@ -207,9 +211,11 @@ def velocity_level_difference(
     """
     lv_i = _as_1d(source_level, "source_level")
     lv_j = _as_1d(receive_level, "receive_level")
-    if lv_i.size != lv_j.size:
-        msg = "'source_level' and 'receive_level' must share their length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "velocity_level_difference",
+        {"source_level": lv_i.size, "receive_level": lv_j.size},
+        "band",
+    )
     return np.asarray(lv_i - lv_j, dtype=np.float64)
 
 
@@ -232,9 +238,11 @@ def direction_averaged_level_difference(
     """
     a = _as_1d(dv_ij, "dv_ij")
     b = _as_1d(dv_ji, "dv_ji")
-    if a.size != b.size:
-        msg = "'dv_ij' and 'dv_ji' must share their length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "direction_averaged_level_difference",
+        {"dv_ij": a.size, "dv_ji": b.size},
+        "band",
+    )
     return np.asarray(0.5 * (a + b), dtype=np.float64)
 
 
@@ -568,9 +576,12 @@ def vibration_reduction_index(
     s_j = _positive(area_j, "area_j")
 
     freq = None if frequency is None else _positive_array(frequency, "frequency")
-    if freq is not None and freq.size != dv.size:
-        msg = "'frequency' must share the band count of the level input."
-        raise ValueError(msg)
+    if freq is not None:
+        require_equal_counts(
+            "vibration_reduction_index",
+            {"velocity_level_difference": dv.size, "frequency": freq.size},
+            "band",
+        )
 
     ts_given = (structural_reverberation_time_i is not None) + (
         structural_reverberation_time_j is not None
@@ -881,9 +892,15 @@ def normalized_flanking_level_difference(
     l2 = _as_1d(receive_level, "receive_level")
     area = _positive_array(absorption_area, "absorption_area")
     a0 = _positive(reference_area, "reference_area")
-    if not (l1.size == l2.size == area.size):
-        msg = "'source_level', 'receive_level' and 'absorption_area' must share their length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "normalized_flanking_level_difference",
+        {
+            "source_level": l1.size,
+            "receive_level": l2.size,
+            "absorption_area": area.size,
+        },
+        "band",
+    )
     d_n_f = l1 - l2 - 10.0 * np.log10(area / a0)
     rating = _maybe_rating(d_n_f, bands)
     return FlankingLevelDifferenceResult(d_n_f=d_n_f, rating=rating)
@@ -917,9 +934,11 @@ def normalized_flanking_impact_level(
     l2 = _as_1d(receive_level, "receive_level")
     area = _positive_array(absorption_area, "absorption_area")
     a0 = _positive(reference_area, "reference_area")
-    if l2.size != area.size:
-        msg = "'receive_level' and 'absorption_area' must share their length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "normalized_flanking_impact_level",
+        {"receive_level": l2.size, "absorption_area": area.size},
+        "band",
+    )
     l_n_f = l2 + 10.0 * np.log10(area / a0)
     rating: ImpactRatingResult | None = None
     if l_n_f.size in (16, 5):

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -73,7 +73,11 @@ import numpy as np
 
 from ..._internal.levels_math import energy_mean
 from ..._internal.types import as_float_or_array
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from .ratings import (
     _FREQ_THIRD_OCTAVE,
     ImpactRatingResult,
@@ -820,11 +824,13 @@ def airborne_insulation(
 
     # Compared by count, not by shape, so a `t2` that carries an extra axis
     # falls through to `_validate_reverberation`, which says that is what is
-    # wrong. Comparing shapes answered a (1, n) array against n bands with
-    # "must share the same band count", which was false: the counts matched.
-    if not (l1_bands.shape == l2_bands.shape and l1_bands.size == t.size):
-        msg = "'l1', 'l2' and 't2' must share the same band count."
-        raise ValueError(msg)
+    # wrong. Comparing shapes answered a (1, n) array against n bands with a
+    # band-count complaint, which was false: the counts matched.
+    require_equal_counts(
+        "airborne_insulation",
+        {"l1": l1_bands.size, "l2": l2_bands.size, "t2": t.size},
+        "band",
+    )
     _validate_reverberation(t, t0)
 
     d = l1_bands - l2_bands
@@ -895,11 +901,11 @@ def impact_insulation(
 
     # Compared by count, not by shape, so a `t2` that carries an extra axis
     # falls through to `_validate_reverberation`, which says that is what is
-    # wrong. Comparing shapes answered a (1, n) array against n bands with
-    # "must share the same band count", which was false: the counts matched.
-    if li_bands.size != t.size:
-        msg = "'li' and 't2' must share the same band count."
-        raise ValueError(msg)
+    # wrong. Comparing shapes answered a (1, n) array against n bands with a
+    # band-count complaint, which was false: the counts matched.
+    require_equal_counts(
+        "impact_insulation", {"li": li_bands.size, "t2": t.size}, "band"
+    )
     _validate_reverberation(t, t0)
 
     l_n_t = li_bands - 10.0 * np.log10(t / t0)
@@ -1033,11 +1039,13 @@ def facade_insulation(
 
     # Compared by count, not by shape, so a `t2` that carries an extra axis
     # falls through to `_validate_reverberation`, which says that is what is
-    # wrong. Comparing shapes answered a (1, n) array against n bands with
-    # "must share the same band count", which was false: the counts matched.
-    if not (l1_bands.shape == l2_bands.shape and l1_bands.size == t.size):
-        msg = "'l1_2m', 'l2' and 't2' must share the same band count."
-        raise ValueError(msg)
+    # wrong. Comparing shapes answered a (1, n) array against n bands with a
+    # band-count complaint, which was false: the counts matched.
+    require_equal_counts(
+        "facade_insulation",
+        {"l1_2m": l1_bands.size, "l2": l2_bands.size, "t2": t.size},
+        "band",
+    )
     _validate_reverberation(t, t0)
 
     d_2m = l1_bands - l2_bands

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -77,7 +77,11 @@ from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from .insulation import (
     WeightedRatingResult,
     _as_band_levels,
@@ -584,9 +588,14 @@ def combine_subareas(
         msg = "'l_in' must be a two-dimensional (subareas, bands) array."
         raise ValueError(msg)
     areas = np.asarray(measurement_area, dtype=np.float64)
-    if areas.ndim != 1 or areas.size != levels.shape[0]:
-        msg = "'measurement_area' must give one area per subarea (row of 'l_in')."
+    if areas.ndim != 1:
+        msg = "'measurement_area' must be a one-dimensional array of subarea areas."
         raise ValueError(msg)
+    require_equal_counts(
+        "combine_subareas",
+        {"measurement_area": areas.size, "l_in rows": levels.shape[0]},
+        "subarea",
+    )
     if not np.all(np.isfinite(levels)):
         msg = "'l_in' must contain only finite values."
         raise ValueError(msg)

--- a/src/phonometry/building/prediction/aperture_transmission.py
+++ b/src/phonometry/building/prediction/aperture_transmission.py
@@ -61,6 +61,7 @@ from scipy.special import j1, struve
 
 from ..._internal.validation import (
     require_choice,
+    require_equal_counts,
     require_positive,
     require_ranks,
     require_same_length,
@@ -390,19 +391,17 @@ def composite_transmission_loss(
         msg = "'areas' must be positive and finite."
         raise ValueError(msg)
     r = np.asarray(reduction_indices, dtype=np.float64)
+    if r.ndim not in (1, 2):
+        msg = "'reduction_indices' must be 1-D or 2-D."
+        raise ValueError(msg)
+    require_equal_counts(
+        "composite_transmission_loss",
+        {"areas": s.shape[0], "reduction_indices": r.shape[0]},
+        "element",
+    )
+    tau = 10.0 ** (-r / 10.0)
     if r.ndim == 1:
-        if r.shape[0] != s.shape[0]:
-            msg = "'reduction_indices' length must match 'areas'."
-            raise ValueError(msg)
-        tau = 10.0 ** (-r / 10.0)
         total_1d = float(np.sum(s * tau) / np.sum(s))
         return np.asarray(-10.0 * np.log10(total_1d), dtype=np.float64)
-    if r.ndim == 2:  # noqa: PLR2004
-        if r.shape[0] != s.shape[0]:
-            msg = "'reduction_indices' first axis must match 'areas'."
-            raise ValueError(msg)
-        tau = 10.0 ** (-r / 10.0)
-        total_2d = np.sum(s[:, None] * tau, axis=0) / np.sum(s)
-        return np.asarray(-10.0 * np.log10(total_2d), dtype=np.float64)
-    msg = "'reduction_indices' must be 1-D or 2-D."
-    raise ValueError(msg)
+    total_2d = np.sum(s[:, None] * tau, axis=0) / np.sum(s)
+    return np.asarray(-10.0 * np.log10(total_2d), dtype=np.float64)

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -466,7 +466,7 @@ def facade_sound_reduction(
     if frequencies is not None:
         require_equal_counts(
             "facade_sound_reduction",
-            {"frequencies": len(frequencies), "elements": r_prime.size},
+            {"frequencies": len(frequencies), "r_prime": r_prime.size},
         )
     r_45 = r_prime + 1.0
     r_tr_s = r_prime.copy()
@@ -529,12 +529,12 @@ def radiated_sound_power(
     if lp.size == 1:
         lp = np.full(r_prime.size, float(lp[0]))
     require_equal_counts(
-        "radiated_sound_power", {"lp_in": lp.size, "elements": r_prime.size}
+        "radiated_sound_power", {"lp_in": lp.size, "r_prime": r_prime.size}
     )
     if octave_bands is not None:
         require_equal_counts(
             "radiated_sound_power",
-            {"octave_bands": len(octave_bands), "elements": r_prime.size},
+            {"octave_bands": len(octave_bands), "r_prime": r_prime.size},
         )
     l_w = lp + float(c_d) - r_prime + 10.0 * log10(float(area) / _S0)
 

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -463,12 +463,11 @@ def facade_sound_reduction(
         msg = "'volume' must be positive."
         raise ValueError(msg)
     r_prime, element_r = _apparent_reduction(elements, float(area))
-    if frequencies is not None and len(frequencies) != r_prime.size:
-        msg = (
-            f"'frequencies' has {len(frequencies)} entries but the elements imply "
-            f"{r_prime.size} bands."
+    if frequencies is not None:
+        require_equal_counts(
+            "facade_sound_reduction",
+            {"frequencies": len(frequencies), "elements": r_prime.size},
         )
-        raise ValueError(msg)
     r_45 = r_prime + 1.0
     r_tr_s = r_prime.copy()
     d_2m_nt = r_prime + delta + 10.0 * log10(v / (6.0 * _T0 * float(area)))
@@ -529,15 +528,14 @@ def radiated_sound_power(
     lp = _as_array(lp_in, "lp_in")
     if lp.size == 1:
         lp = np.full(r_prime.size, float(lp[0]))
-    if lp.size != r_prime.size:
-        msg = "'lp_in' must match the element band count."
-        raise ValueError(msg)
-    if octave_bands is not None and len(octave_bands) != r_prime.size:
-        msg = (
-            f"'octave_bands' has {len(octave_bands)} entries but the elements imply "
-            f"{r_prime.size} bands."
+    require_equal_counts(
+        "radiated_sound_power", {"lp_in": lp.size, "elements": r_prime.size}
+    )
+    if octave_bands is not None:
+        require_equal_counts(
+            "radiated_sound_power",
+            {"octave_bands": len(octave_bands), "elements": r_prime.size},
         )
-        raise ValueError(msg)
     l_w = lp + float(c_d) - r_prime + 10.0 * log10(float(area) / _S0)
 
     l_w_dba: float | None = None

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -30,7 +30,11 @@ import numpy as np
 
 # Shared Welch-core defaults and helpers (single source of truth for the
 # segment policy across the spectral estimators).
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from ..io._resolve import apply_calibration, resolve_pair_fs
 from ..signals.spectra import (
     _DEFAULT_OVERLAP,
@@ -51,15 +55,20 @@ if TYPE_CHECKING:
 def _validate_pair(
     x: Signal | NDArray[np.float64] | list[float],
     y: Signal | NDArray[np.float64] | list[float],
+    owner: str,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Validate the input/output record pair of *owner*.
+
+    :param owner: Name of the entry point the caller invoked, so that the
+        length complaint names the function that was typed rather than this
+        validator, which two entry points share.
+    """
     xa = np.asarray(x, dtype=np.float64)
     ya = np.asarray(y, dtype=np.float64)
     if xa.ndim != 1 or ya.ndim != 1:
         msg = "'x' and 'y' must be one-dimensional."
         raise ValueError(msg)
-    if xa.size != ya.size:
-        msg = "'x' and 'y' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts(owner, {"x": xa.size, "y": ya.size}, "sample")
     if xa.size < _MIN_SAMPLES:
         msg = f"Signals too short for a spectral estimate: {xa.size} samples."
         raise ValueError(msg)
@@ -203,7 +212,7 @@ def transfer_function(
     :raises ValueError: If the inputs or parameters are invalid.
     """
     fs = resolve_pair_fs(x, y, fs)
-    xa, ya = _validate_pair(x, y)
+    xa, ya = _validate_pair(x, y, "transfer_function")
     fs_v = _positive(fs, "fs")
     if estimator not in ("H1", "H2"):
         msg = "'estimator' must be 'H1' or 'H2'."
@@ -280,7 +289,7 @@ def coherence(
     :raises ValueError: If the inputs or parameters are invalid.
     """
     fs = resolve_pair_fs(x, y, fs)
-    xa, ya = _validate_pair(x, y)
+    xa, ya = _validate_pair(x, y, "coherence")
     fs_v = _positive(fs, "fs")
     if not 0.0 <= float(overlap) < 1.0:
         msg = "'overlap' must be in [0, 1)."

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -436,9 +436,7 @@ def _validate_probe_signals(x1: np.ndarray, x2: np.ndarray) -> None:
     if x1.ndim != 1 or x2.ndim != 1:
         msg = "sound_intensity expects 1D pressure signals."
         raise ValueError(msg)
-    if x1.size != x2.size:
-        msg = f"Microphone signals must have the same length, got {x1.size} and {x2.size}."
-        raise ValueError(msg)
+    require_equal_counts("sound_intensity", {"p1": x1.size, "p2": x2.size}, "sample")
 
 
 def _validate_probe_medium(fs: int, spacing: float, rho: float, c: float) -> None:

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -67,7 +67,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -339,12 +343,11 @@ def verify_intensity_class(
     if measured.ndim != 1 or supplied.ndim != 1:
         msg = "verify_intensity_class expects 1D per-band arrays."
         raise ValueError(msg)
-    if measured.size != supplied.size:
-        msg = (
-            f"'residual_index' and 'frequencies' must have the same length, "
-            f"got {measured.size} and {supplied.size}."
-        )
-        raise ValueError(msg)
+    require_equal_counts(
+        "verify_intensity_class",
+        {"residual_index": measured.size, "frequencies": supplied.size},
+        "band",
+    )
     if measured.size == 0:
         msg = "At least one measurement band is required."
         raise ValueError(msg)

--- a/src/phonometry/environment/assessment/measurement.py
+++ b/src/phonometry/environment/assessment/measurement.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
+from ..._internal.validation import require_equal_counts
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -312,9 +313,11 @@ def tonal_seeking_survey(
     if lev.ndim != 1 or freq.ndim != 1:
         msg = "'levels' and 'frequencies' must be one-dimensional."
         raise ValueError(msg)
-    if lev.size != freq.size:
-        msg = "'levels' and 'frequencies' must share their length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "tonal_seeking_survey",
+        {"levels": lev.size, "frequencies": freq.size},
+        "band",
+    )
     if lev.size < _MIN_SURVEY_BANDS:
         msg = "Need at least three bands to test the neighbours."
         raise ValueError(msg)

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_counts
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -109,15 +111,15 @@ class Signal:
             msg = f"data must be 1-D or (channels, samples); got {data.ndim}-D"
             raise ValueError(msg)
         object.__setattr__(self, "data", np.ascontiguousarray(data))
-        if (
-            self.channel_labels is not None
-            and len(self.channel_labels) != data.shape[0]
-        ):
-            msg = (
-                f"{len(self.channel_labels)} channel labels for "
-                f"{data.shape[0]} channels"
+        if self.channel_labels is not None:
+            require_equal_counts(
+                type(self).__name__,
+                {
+                    "data": int(data.shape[0]),
+                    "channel_labels": len(self.channel_labels),
+                },
+                "channel",
             )
-            raise ValueError(msg)
         # Finiteness is checked alongside the sign: NaN and infinity pass
         # every comparison against zero, and an fs or calibration of NaN
         # would flow into durations and levels as a wrong number that

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_equal_counts
 from .reverberation_room_scattering import _positive_scalar
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -520,12 +521,14 @@ def random_incidence_diffusion(
         w = np.ones(d.size, dtype=np.float64)
     else:
         w = np.asarray(weights, dtype=np.float64)
-        if w.ndim != 1 or w.size != d.size:
-            msg = (
-                "'weights' must match the number of source positions "
-                f"({d.size}), got shape {w.shape}."
-            )
+        if w.ndim != 1:
+            msg = f"'weights' must be a 1-D sequence, got shape {w.shape}."
             raise ValueError(msg)
+        require_equal_counts(
+            "random_incidence_diffusion",
+            {"directional_coefficients": d.size, "weights": w.size},
+            "source position",
+        )
         if np.any(w < 0.0):
             msg = "'weights' values must be non-negative."
             raise ValueError(msg)

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -98,7 +98,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -307,17 +311,22 @@ def energy_sum_level(
 # (Clauses 5.3.2/5.3.3, Annex D)
 # --------------------------------------------------------------------------- #
 def _validate_spectrum(
-    levels: ArrayLike, frequencies: ArrayLike
+    levels: ArrayLike, frequencies: ArrayLike, owner: str
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-    """Coerce and validate a narrow-band ``(levels, frequencies)`` spectrum."""
+    """Coerce and validate a narrow-band ``(levels, frequencies)`` spectrum.
+
+    :param owner: Name of the entry point the caller invoked, so that the
+        line-count complaint names the function that was typed rather than
+        this validator, which four entry points share.
+    """
     lev = np.asarray(levels, dtype=np.float64)
     freq = np.asarray(frequencies, dtype=np.float64)
     if lev.ndim != 1 or freq.ndim != 1:
         msg = "'levels' and 'frequencies' must be one-dimensional."
         raise ValueError(msg)
-    if lev.size != freq.size:
-        msg = "'levels' and 'frequencies' must share their length."
-        raise ValueError(msg)
+    require_equal_counts(
+        owner, {"levels": lev.size, "frequencies": freq.size}, "spectral line"
+    )
     if lev.size == 0:
         msg = "'levels' and 'frequencies' must not be empty."
         raise ValueError(msg)
@@ -392,13 +401,18 @@ def _mean_narrowband_level_lines(
     tone_frequency: float,
     *,
     effective_bandwidth_factor: float = HANNING_BANDWIDTH_FACTOR,
+    owner: str = "mean_narrowband_level",
 ) -> tuple[float, list[int]]:
     """``LS`` plus the indices of the lines kept by the final iteration.
 
     The kept-line set is the ``M`` noise lines that Clause 6 uses in the
     uncertainty of the audibility (see :func:`audibility_uncertainty`).
+
+    :param owner: Name of the entry point the caller invoked, for the spectrum
+        complaints; the default is the entry point this body serves, and
+        :func:`analyze_spectrum` passes its own name.
     """
-    lev, freq = _validate_spectrum(levels, frequencies)
+    lev, freq = _validate_spectrum(levels, frequencies, owner)
     ft = _positive(tone_frequency, "tone_frequency")
     factor = _positive(effective_bandwidth_factor, "effective_bandwidth_factor")
     correction = 10.0 * np.log10(factor)
@@ -459,7 +473,7 @@ def tone_level(
     :return: Tone level ``LT``, in dB.
     :raises ValueError: If the spectrum is invalid or the levels are not finite.
     """
-    lev, freq = _validate_spectrum(levels, frequencies)
+    lev, freq = _validate_spectrum(levels, frequencies, "tone_level")
     ft = _positive(tone_frequency, "tone_frequency")
     ls = _finite(mean_narrowband_level, "mean_narrowband_level")
     peak = int(np.argmin(np.abs(freq - ft)))
@@ -691,7 +705,7 @@ def analyze_spectrum(
         their same-band FG combinations.
     :raises ValueError: If the spectrum is invalid or no audible tone is found.
     """
-    lev, freq = _validate_spectrum(levels, frequencies)
+    lev, freq = _validate_spectrum(levels, frequencies, "analyze_spectrum")
     df = _positive(line_spacing, "line_spacing")
     factor = _positive(effective_bandwidth_factor, "effective_bandwidth_factor")
     detected = _detect_tones(lev, freq, df, factor)
@@ -704,7 +718,11 @@ def analyze_spectrum(
             # Extended uncertainty U (Clause 6) from the K tone lines and the
             # M noise lines of the final Formula (6) iteration.
             _, kept = _mean_narrowband_level_lines(
-                lev, freq, float(freq[peak]), effective_bandwidth_factor=factor
+                lev,
+                freq,
+                float(freq[peak]),
+                effective_bandwidth_factor=factor,
+                owner="analyze_spectrum",
             )
             u = audibility_uncertainty(
                 lev[low : high + 1], lev[kept], float(freq[peak]), df
@@ -785,15 +803,17 @@ def combined_tone_level(
     :return: Combined tone level ``LT``, in dB.
     :raises ValueError: If the inputs are invalid or differ in length.
     """
-    lev, freq = _validate_spectrum(levels, frequencies)
+    lev, freq = _validate_spectrum(levels, frequencies, "combined_tone_level")
     fts = np.asarray(tone_frequencies, dtype=np.float64)
     lss = np.asarray(mean_narrowband_levels, dtype=np.float64)
-    if fts.ndim != 1 or lss.ndim != 1 or fts.size != lss.size:
-        msg = (
-            "'tone_frequencies' and 'mean_narrowband_levels' must be "
-            "one-dimensional and share their length."
-        )
+    if fts.ndim != 1 or lss.ndim != 1:
+        msg = "'tone_frequencies' and 'mean_narrowband_levels' must be one-dimensional."
         raise ValueError(msg)
+    require_equal_counts(
+        "combined_tone_level",
+        {"tone_frequencies": fts.size, "mean_narrowband_levels": lss.size},
+        "tone",
+    )
     if fts.size == 0:
         msg = "At least one tone is required."
         raise ValueError(msg)
@@ -1340,12 +1360,15 @@ def assess_tones(
             "must be one-dimensional."
         )
         raise ValueError(msg)
-    if not (freqs.size == lt.size == ls.size):
-        msg = (
-            "'tone_frequencies', 'tone_levels' and 'mean_narrowband_levels' "
-            "must share their length."
-        )
-        raise ValueError(msg)
+    require_equal_counts(
+        "assess_tones",
+        {
+            "tone_frequencies": freqs.size,
+            "tone_levels": lt.size,
+            "mean_narrowband_levels": ls.size,
+        },
+        "tone",
+    )
     if freqs.size == 0:
         msg = "At least one tone is required."
         raise ValueError(msg)

--- a/src/phonometry/signals/correlation.py
+++ b/src/phonometry/signals/correlation.py
@@ -56,7 +56,11 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from ..io._resolve import resolve_fs, resolve_pair_fs
 from ..io._signal import Signal
 from .spectra import (
@@ -287,9 +291,7 @@ def correlation(
     xa = _validate_signal(x, "x", context="a correlation estimate")
     is_auto = y is None
     ya = xa if y is None else _validate_signal(y, "y", context="a correlation estimate")
-    if xa.size != ya.size:
-        msg = "'x' and 'y' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts("correlation", {"x": xa.size, "y": ya.size}, "sample")
     if isinstance(x, Signal) or isinstance(y, Signal):
         fs = resolve_pair_fs(x, x if y is None else y, fs)
     elif fs is None:
@@ -803,9 +805,7 @@ def time_delay(
     xa = _validate_signal(x, "x", context="a time-delay estimate")
     ya = _validate_signal(y, "y", context="a time-delay estimate")
     fs = resolve_pair_fs(x, y, fs)
-    if xa.size != ya.size:
-        msg = "'x' and 'y' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts("time_delay", {"x": xa.size, "y": ya.size}, "sample")
     if float(np.std(xa)) <= 0.0 or float(np.std(ya)) <= 0.0:
         msg = (
             "'x' and 'y' must not be constant: there is no correlation peak to locate."
@@ -1027,9 +1027,9 @@ def align_impulse_responses(
     """
     ira = _validate_signal(ir, "ir", context=_DELAY_CONTEXT)
     refa = _validate_signal(reference, "reference", context=_DELAY_CONTEXT)
-    if ira.size != refa.size:
-        msg = "'ir' and 'reference' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "align_impulse_responses", {"ir": ira.size, "reference": refa.size}, "sample"
+    )
     fs_v = _positive(
         resolve_pair_fs(ir, reference, fs, names=("ir", "reference")), "fs"
     )

--- a/src/phonometry/signals/miso.py
+++ b/src/phonometry/signals/miso.py
@@ -176,10 +176,9 @@ def _validate_inputs(
         raise ValueError(msg)
     xs = [_validate_signal(x, f"inputs[{i}]") for i, x in enumerate(rows)]
     ya = _validate_signal(output, "output")
-    for i, x in enumerate(xs):
-        if x.size != ya.size:
-            msg = f"'inputs[{i}]' and 'output' must have the same length."
-            raise ValueError(msg)
+    counts = {f"inputs[{i}]": x.size for i, x in enumerate(xs)}
+    counts["output"] = ya.size
+    require_equal_counts("miso_coherence", counts, "sample")
     return xs, ya
 
 

--- a/src/phonometry/signals/spectra.py
+++ b/src/phonometry/signals/spectra.py
@@ -68,7 +68,11 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_counts,
+    require_ranks,
+    require_same_length,
+)
 from ..io._resolve import apply_calibration, resolve_fs, resolve_pair_fs
 
 if TYPE_CHECKING:
@@ -712,9 +716,9 @@ def cross_spectral_density(
     """
     xa = _validate_signal(x, "x")
     ya = _validate_signal(y, "y")
-    if xa.size != ya.size:
-        msg = "'x' and 'y' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "cross_spectral_density", {"x": xa.size, "y": ya.size}, "sample"
+    )
     fs_v = _positive(resolve_pair_fs(x, y, fs), "fs")
     scaling_v = _validate_scaling(scaling)
     seg, ovl = _validate_welch_params(xa.size, fs_v, nperseg, overlap)
@@ -945,9 +949,9 @@ def coherent_output_spectrum(
     """
     xa = _validate_signal(x, "x")
     ya = _validate_signal(y, "y")
-    if xa.size != ya.size:
-        msg = "'x' and 'y' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "coherent_output_spectrum", {"x": xa.size, "y": ya.size}, "sample"
+    )
     fs_v = _positive(resolve_pair_fs(x, y, fs), "fs")
     scaling_v = _validate_scaling(scaling)
     seg, ovl = _validate_welch_params(xa.size, fs_v, nperseg, overlap)
@@ -1009,9 +1013,11 @@ def _smoothing_validate(f: NDArray[np.float64], v: NDArray[np.float64]) -> None:
     if f.ndim != 1 or v.ndim != 1:
         msg = "'frequencies' and 'values' must be one-dimensional."
         raise ValueError(msg)
-    if f.size != v.size:
-        msg = "'frequencies' and 'values' must have the same length."
-        raise ValueError(msg)
+    require_equal_counts(
+        "fractional_octave_smoothing",
+        {"frequencies": f.size, "values": v.size},
+        "frequency",
+    )
     if f.size < _MIN_SMOOTHING_POINTS:
         msg = "At least two frequency points are required."
         raise ValueError(msg)

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -61,6 +61,7 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy import signal as sig
 
+from ..._internal.validation import require_equal_counts
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -1147,9 +1148,11 @@ def daily_vibration_exposure(
         labels = tuple(f"op {i + 1}" for i in range(ahv.size))
     else:
         labels = tuple(labels)
-        if len(labels) != ahv.size:
-            msg = "'labels' must match the number of operations."
-            raise ValueError(msg)
+        require_equal_counts(
+            "daily_vibration_exposure",
+            {"total_values": ahv.size, "labels": len(labels)},
+            "operation",
+        )
     partials = np.array(
         [daily_exposure(float(a), float(dt)) for a, dt in zip(ahv, t, strict=True)],
         dtype=np.float64,

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -204,7 +204,10 @@ def test_positions_are_energy_averaged() -> None:
 # --------------------------------------------------------------------------
 def test_band_count_mismatch_raises() -> None:
     outdoor, indoor_two_bands, rt = _flat(3, 70.0), _flat(2, 30.0), _flat(3, 0.5)
-    with pytest.raises(ValueError, match="share the same band count"):
+    with pytest.raises(
+        ValueError,
+        match=r"facade_insulation: 'l1_2m'.*'l2'.*'t2'.*one value per band",
+    ):
         building.facade_insulation(outdoor, indoor_two_bands, rt)
 
 

--- a/tests/building/measurement/test_flanking_transmission.py
+++ b/tests/building/measurement/test_flanking_transmission.py
@@ -396,7 +396,11 @@ def test_reverberation_time_needs_frequency() -> None:
 
 
 def test_frequency_band_count_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(
+        ValueError,
+        match=r"vibration_reduction_index: 'velocity_level_difference'.*"
+        r"'frequency'.*one value per band",
+    ):
         building.vibration_reduction_index(
             [5.0, 6.0], 2.0, 4.0, 4.0, frequency=[1000.0]
         )
@@ -408,7 +412,11 @@ def test_nonpositive_geometry_raises() -> None:
 
 
 def test_mismatched_level_lengths_raise() -> None:
-    with pytest.raises(ValueError, match="share their length"):
+    with pytest.raises(
+        ValueError,
+        match=r"velocity_level_difference: 'source_level'.*'receive_level'.*"
+        r"one value per band",
+    ):
         building.velocity_level_difference([1.0, 2.0], [1.0])
 
 

--- a/tests/building/measurement/test_impact_insulation.py
+++ b/tests/building/measurement/test_impact_insulation.py
@@ -270,7 +270,7 @@ def test_impact_rejects_length_mismatch() -> None:
     li_2_bands = np.array([60.0, 60.0])
     t2_1_band = np.array([0.5])
     with pytest.raises(
-        ValueError, match="'li' and 't2' must share the same band count"
+        ValueError, match=r"impact_insulation: 'li'.*'t2'.*one value per band"
     ):
         building.impact_insulation(li_2_bands, t2_1_band)
 

--- a/tests/building/measurement/test_insulation.py
+++ b/tests/building/measurement/test_insulation.py
@@ -314,7 +314,7 @@ def test_airborne_rejects_length_mismatch() -> None:
     one_time = np.array([0.5])
     with pytest.raises(
         ValueError,
-        match="'l1', 'l2' and 't2' must share the same band count",
+        match=r"airborne_insulation: 'l1'.*'l2'.*'t2'.*one value per band",
     ):
         building.airborne_insulation(two_bands, one_band, one_time)
 

--- a/tests/building/measurement/test_intensity_insulation.py
+++ b/tests/building/measurement/test_intensity_insulation.py
@@ -216,8 +216,10 @@ def test_combine_subareas_area_weighting() -> None:
 def test_combine_subareas_validation() -> None:
     with pytest.raises(ValueError, match="two-dimensional"):
         building.combine_subareas([40.0, 42.0], [5.0])
-    with pytest.raises(ValueError, match="one area per subarea"):
+    with pytest.raises(ValueError, match=r"'measurement_area'.*one value per subarea"):
         building.combine_subareas([[40.0, 42.0], [40.0, 42.0]], [5.0])
+    with pytest.raises(ValueError, match=r"'measurement_area' must be a one-dim"):
+        building.combine_subareas([[40.0], [42.0]], [[5.0], [5.0]])
     with pytest.raises(ValueError, match="non-zero"):
         building.combine_subareas([[40.0], [42.0]], [5.0, 0.0])
 

--- a/tests/building/prediction/test_aperture_transmission.py
+++ b/tests/building/prediction/test_aperture_transmission.py
@@ -60,8 +60,15 @@ def test_composite_matches_facade_energy_sum() -> None:
 
 
 def test_composite_rejects_bad_shape() -> None:
-    with pytest.raises(ValueError, match="length must match"):
+    match = (
+        r"composite_transmission_loss: 'areas' .* must each carry one value per element"
+    )
+    with pytest.raises(ValueError, match=match):
         building.composite_transmission_loss([1.0, 2.0], [40.0])
+    with pytest.raises(ValueError, match=match):
+        building.composite_transmission_loss([1.0, 2.0], np.zeros((3, 4)))
+    with pytest.raises(ValueError, match="'reduction_indices' must be 1-D or 2-D"):
+        building.composite_transmission_loss([1.0, 2.0], np.zeros((2, 3, 4)))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/building/prediction/test_facade.py
+++ b/tests/building/prediction/test_facade.py
@@ -434,7 +434,9 @@ def test_no_element_silently_dropped_when_names_unique() -> None:
 
 def test_frequencies_length_must_match_bands() -> None:
     elements = [building.FacadeElement(name="a", area=5.0, r=[40.0, 41.0, 42.0])]
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(
+        ValueError, match=r"'frequencies'.*must each carry one value per band"
+    ):
         building.facade_sound_reduction(
             elements,
             area=10.0,
@@ -445,13 +447,24 @@ def test_frequencies_length_must_match_bands() -> None:
 
 def test_octave_bands_length_must_match() -> None:
     elements = [building.FacadeElement(name="w", area=10.0, r=[40.0, 41.0])]
-    with pytest.raises(ValueError, match="octave_bands"):
+    with pytest.raises(
+        ValueError, match=r"'octave_bands'.*must each carry one value per band"
+    ):
         building.radiated_sound_power(
             elements,
             lp_in=[70.0, 71.0],
             area=10.0,
             octave_bands=[125],
         )
+
+
+def test_lp_in_length_must_match_bands() -> None:
+    """A per-band Lp,in that is not the element band count names both counts."""
+    elements = [building.FacadeElement(name="w", area=10.0, r=[40.0, 41.0])]
+    with pytest.raises(
+        ValueError, match=r"'lp_in'.*must each carry one value per band"
+    ):
+        building.radiated_sound_power(elements, lp_in=[70.0, 71.0, 72.0], area=10.0)
 
 
 def test_tau_rejects_non_positive_total_area() -> None:

--- a/tests/electroacoustics/test_frequency_response.py
+++ b/tests/electroacoustics/test_frequency_response.py
@@ -119,10 +119,14 @@ def test_response_curves_must_share_one_frequency_axis() -> None:
 
 
 def test_rejects_mismatched_lengths() -> None:
+    """Both entry points name themselves, not the validator they share."""
     x = np.zeros(1000)
     shorter_y = np.zeros(500)
-    with pytest.raises(ValueError, match="'x' and 'y' must have the same length"):
+    per_sample = r"'x'.*'y'.*one value per sample"
+    with pytest.raises(ValueError, match=rf"transfer_function: {per_sample}"):
         electroacoustics.transfer_function(x, shorter_y, FS)
+    with pytest.raises(ValueError, match=rf"coherence: {per_sample}"):
+        electroacoustics.coherence(x, shorter_y, FS)
 
 
 def test_rejects_bad_estimator_and_overlap() -> None:

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -244,7 +244,9 @@ def test_octave_fraction_and_limits() -> None:
 
 def test_validation_errors() -> None:
     good = np.random.default_rng(0).standard_normal(FS)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError, match=r"sound_intensity: 'p1'.*'p2'.*one value per sample"
+    ):
         emission.sound_intensity(good, good[:-1], FS, spacing=SPACING)
     with pytest.raises(ValueError, match="spacing"):
         emission.sound_intensity(good, good, FS, spacing=0.0)

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -313,7 +313,13 @@ def test_partial_band_set_is_range_limited() -> None:
 
 
 def test_mismatched_lengths_and_repeats_are_rejected() -> None:
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"verify_intensity_class: 'residual_index' .* must each carry "
+            r"one value per band"
+        ),
+    ):
         emission.verify_intensity_class([20.0, 20.0], [1000.0])
     with pytest.raises(ValueError, match="repeats"):
         emission.verify_intensity_class([20.0, 20.0], [1000.0, 1000.0])

--- a/tests/environment/assessment/test_measurement.py
+++ b/tests/environment/assessment/test_measurement.py
@@ -111,6 +111,17 @@ def test_survey_below_threshold_not_flagged() -> None:
     assert not environment.tonal_seeking_survey(levels, freqs)[1]
 
 
+def test_survey_names_both_band_counts() -> None:
+    """A level without a band centre is refused, naming what each input holds."""
+    with pytest.raises(
+        ValueError,
+        match=r"tonal_seeking_survey: 'levels' .* must each carry one value per band",
+    ):
+        environment.tonal_seeking_survey(
+            [40.0, 60.0, 40.0, 41.0], [100.0, 125.0, 160.0]
+        )
+
+
 # ---------------------------------------------------------------------------
 # Residual-noise correction (Formula 16, Annex I)
 # ---------------------------------------------------------------------------

--- a/tests/io/test_io_sidecar.py
+++ b/tests/io/test_io_sidecar.py
@@ -92,7 +92,10 @@ def test_mismatched_label_count_fails_loudly(tmp_path: Path) -> None:
     audio = tmp_path / "stereo.wav"
     write(audio, np.zeros((2, 8)), FS)
     write_sidecar(audio, 1.0, channel_labels=("only one",))
-    with pytest.raises(ValueError, match="channel labels"):
+    with pytest.raises(
+        ValueError,
+        match=r"Signal: .*'channel_labels' .* must each carry one value per channel",
+    ):
         read(audio)
 
 

--- a/tests/io/test_io_signal.py
+++ b/tests/io/test_io_signal.py
@@ -115,7 +115,10 @@ def test_source_metadata_travels_with_the_signal() -> None:
 
 def test_invalid_construction_is_rejected() -> None:
     tone = _tone()
-    with pytest.raises(ValueError, match="channel labels"):
+    with pytest.raises(
+        ValueError,
+        match=r"Signal: .*'channel_labels' .* must each carry one value per channel",
+    ):
         Signal(data=np.zeros((2, 10)), fs=FS, channel_labels=("FL",))
     with pytest.raises(ValueError, match="fs"):
         Signal(data=tone, fs=0)

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -482,6 +482,22 @@ def test_diffusion_weight_length_mismatch() -> None:
         directional_diffusion_coefficient([70.0, 72.0], area_weights=[1.0])
 
 
+def test_random_incidence_weight_length_mismatch() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"random_incidence_diffusion: 'directional_coefficients' .* 'weights' "
+            r".* must each carry one value per source position"
+        ),
+    ):
+        random_incidence_diffusion([0.5, 0.2, 0.2], weights=[1.0, 3.0])
+
+
+def test_random_incidence_rejects_two_dimensional_weights() -> None:
+    with pytest.raises(ValueError, match=r"'weights' must be a 1-D sequence"):
+        random_incidence_diffusion([0.5, 0.2], weights=[[1.0, 3.0], [1.0, 3.0]])
+
+
 def test_reverberation_uncertainty_requires_two() -> None:
     with pytest.raises(ValueError, match="'times' needs at least two measurements"):
         reverberation_time_uncertainty([6.0])

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -234,7 +234,13 @@ def test_mean_narrowband_level_few_lines_returns_unpruned_mean() -> None:
 
 
 def test_mean_narrowband_level_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError, match="share their length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"mean_narrowband_level: 'levels' .* 'frequencies' "
+            r".* must each carry one value per spectral line"
+        ),
+    ):
         psychoacoustics.mean_narrowband_level([50.0, 51.0], [100.0], 100.0)
 
 
@@ -429,7 +435,13 @@ def test_combined_tone_level_no_double_counting() -> None:
 
 
 def test_combined_tone_level_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError, match="share their length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"combined_tone_level: 'tone_frequencies' .* 'mean_narrowband_levels' "
+            r".* must each carry one value per tone"
+        ),
+    ):
         psychoacoustics.combined_tone_level(
             ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, [137.3], [49.0, 50.0]
         )
@@ -635,7 +647,13 @@ def test_mean_audibility_rejects_empty() -> None:
 
 
 def test_assess_tones_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError, match="share their length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"assess_tones: 'tone_frequencies' .* 'tone_levels' .* "
+            r"'mean_narrowband_levels' .* must each carry one value per tone"
+        ),
+    ):
         psychoacoustics.assess_tones([100.0, 200.0], [60.0], [50.0], 2.7)
 
 

--- a/tests/signals/test_correlation.py
+++ b/tests/signals/test_correlation.py
@@ -490,7 +490,9 @@ def test_alignment_of_identical_irs_is_a_no_op() -> None:
 
 def test_correlation_rejects_invalid_inputs() -> None:
     x = _white(16, n=4096)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError, match=r"correlation: 'x'.*'y'.*one value per sample"
+    ):
         ph.signals.correlation(x, x[:-1], FS)
     with pytest.raises(ValueError, match="normalization"):
         ph.signals.correlation(x, fs=FS, normalization="raw")  # type: ignore[arg-type]
@@ -526,7 +528,7 @@ def test_correlation_rejects_a_coefficient_of_another_length() -> None:
 def test_time_delay_rejects_invalid_inputs() -> None:
     x = _white(17, n=4096)
     y = np.roll(x, 5)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(ValueError, match=r"time_delay: 'x'.*'y'.*one value per sample"):
         ph.signals.time_delay(x, y[:-1], FS)
     with pytest.raises(ValueError, match="method"):
         ph.signals.time_delay(x, y, FS, method="fft")  # type: ignore[arg-type]
@@ -546,7 +548,10 @@ def test_time_delay_rejects_invalid_inputs() -> None:
 
 def test_ir_utilities_reject_invalid_inputs() -> None:
     ir = _bandlimited_pulse(1024, 300.0, 0.2)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError,
+        match=r"align_impulse_responses: 'ir'.*'reference'.*one value per sample",
+    ):
         ph.signals.align_impulse_responses(ir, ir[:-1], FS)
     with pytest.raises(ValueError, match="upsample"):
         ph.signals.impulse_response_delay(ir, FS, upsample=-2)

--- a/tests/signals/test_miso.py
+++ b/tests/signals/test_miso.py
@@ -434,7 +434,10 @@ def test_rejects_mismatched_length() -> None:
     x1 = _white(170, n=1 << 14)
     x2 = _white(171, n=1 << 13)
     y = _white(172, n=1 << 14)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError,
+        match=r"miso_coherence: 'inputs\[0\]' .* must each carry one value per sample",
+    ):
         ph.signals.miso_coherence([x1, x2], y, FS)
 
 

--- a/tests/signals/test_spectra.py
+++ b/tests/signals/test_spectra.py
@@ -408,7 +408,10 @@ def test_smoothing_zero_frequency_point_is_copied() -> None:
     ("kwargs", "match"),
     [
         ({"frequencies": [[1.0, 2.0]], "values": [1.0, 2.0]}, "one-dimensional"),
-        ({"frequencies": [1.0, 2.0], "values": [1.0]}, "same length"),
+        (
+            {"frequencies": [1.0, 2.0], "values": [1.0]},
+            r"'frequencies'.*'values'.*one value per frequency",
+        ),
         ({"frequencies": [1.0], "values": [1.0]}, "two frequency points"),
         ({"frequencies": [2.0, 1.0], "values": [1.0, 1.0]}, "increasing"),
         ({"frequencies": [1.0, np.nan], "values": [1.0, 1.0]}, "finite"),
@@ -474,7 +477,9 @@ def test_psd_rejects_invalid_inputs() -> None:
 )
 def test_two_channel_functions_reject_mismatched_lengths(func) -> None:
     x = _white(13)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError, match=rf"{func.__name__}: 'x'.*'y'.*one value per sample"
+    ):
         func(x, x[:-1], FS)
 
 

--- a/tests/vibration/human/test_human_vibration.py
+++ b/tests/vibration/human/test_human_vibration.py
@@ -457,7 +457,9 @@ def test_daily_vibration_exposure_result() -> None:
 def test_daily_vibration_exposure_default_labels_and_mismatch() -> None:
     result = hv.daily_vibration_exposure([2.0], [3600.0], kind="wbv")
     assert result.labels == ("op 1",)
-    with pytest.raises(ValueError, match="labels"):
+    with pytest.raises(
+        ValueError, match="'labels'.*must each carry one value per operation"
+    ):
         hv.daily_vibration_exposure(
             [2.0, 3.0], [1.0, 1.0], kind="hav", labels=["only-one"]
         )


### PR DESCRIPTION
A check that two inputs must be the same length said exactly that and no more: `'x' and 'y' must have the same length.` It named the fields, which is the hard half, and then withheld the two numbers it had just compared, so a reader went back to measure by hand what the exception had already measured for them.

Thirty of these move onto the shared helper, which prints the counts and names the entry point the caller actually typed rather than the private validator it happened to reach:

```
cross_spectral_density: 'x' (1000), 'y' (900) must each carry one value per sample.
normalized_flanking_level_difference: 'source_level' (3), 'receive_level' (2), 'absorption_area' (1) must each carry one value per band.
```

Eleven comparable checks stay exactly as they were, and that is the part worth reading. A message is not improved by being made uniform. Where one enumerates the shapes it will accept, because a scalar is deliberately broadcast to the band count, or names the clause of a standard, it is carrying more than a count and keeping it is the better answer.

## What this does not cover, and why

Two sites ask the same question written as `len({a.size, b.size, ...}) != 1` rather than as a pairwise comparison, and a hundred more compare `x.shape != y.shape` instead of a length. They are the same defect: of a hundred and one such messages, ninety-nine name both fields and print nothing they measured.

They are left for their own pull request for two reasons. They need a helper that does not exist yet, since the module has both a bound-to-an-object and a loose-arguments form for lengths but only the bound form for shapes. And at sixty files they fit under the review limits that this series of changes has spent several pull requests exceeding, so they are worth shipping where they can actually be read.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored input validation across multiple modules to use a centralized 'require_equal_counts' utility.</li>
<li>Replaced manual length checks with standardized validation calls in building measurement and prediction modules.</li>
<li>Updated signal processing and psychoacoustics modules to adopt the new validation pattern.</li>
<li>Added and updated corresponding unit tests to reflect the improved validation logic.</li>
</ul></div>

## Summary by Sourcery

Make equal-count validation errors more actionable by identifying the calling function, naming the compared inputs, and describing the expected count relationship.

Bug Fixes:
- Improve mismatched-length validation errors by reporting the compared counts and the relevant entry point.

Enhancements:
- Standardize comparable count checks across building, signal processing, acoustics, psychoacoustics, environment, I/O, materials, and vibration modules with the shared validation helper while preserving specialized validation messages where they provide more useful context.

Tests:
- Update validation tests to assert function names, input names, counts-oriented wording, and dimensionality handling for mismatched inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for mismatched band, sample, channel, frequency, subarea, and input counts across measurement, signal, acoustics, and vibration features.
  * Added clearer, operation-specific error messages identifying affected inputs and required values.
  * Correctly distinguishes invalid dimensions from count mismatches in several calculations, including composite transmission and diffusion analysis.
* **Tests**
  * Expanded regression coverage for malformed dimensions, missing values, invalid shapes, and mismatched input lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->