### PR TITLE
Give the shape comparisons the shape they compared

### DIFF
--- a/site/src/content/docs/reference/api/building/insulation.md
+++ b/site/src/content/docs/reference/api/building/insulation.md
@@ -313,7 +313,7 @@ curve (Annex F); pass the desired 16-band quantity to
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If band counts differ, if `method` is unknown, if `t2`/`t0`/`area`/`volume` are not positive, if `area` is given without `surface_level`, if `surface_level` and `area` are given without `volume`, if `frequencies` is given with a length that differs from the band count, or if inputs are non-finite. Supplying `surface_level` alone is not an error: `r_prime` simply stays `None`. |
+| ValueError | If band counts differ, if `method` is unknown, if `t2`/`t0`/`area`/`volume` are not positive, if `area` is given without `surface_level`, if `surface_level` and `area` are given without `volume`, if `frequencies` is given with a shape that differs from the band axis, or if inputs are non-finite. Supplying `surface_level` alone is not an error: `r_prime` simply stays `None`. |
 
 ## FacadeInsulationResult
 

--- a/site/src/content/docs/reference/api/building/uncertainty.md
+++ b/site/src/content/docs/reference/api/building/uncertainty.md
@@ -394,7 +394,7 @@ and is not reproduced here.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | Mismatched lengths, empty input, or negative `u_i`. |
+| ValueError | Mismatched shapes, empty input, or negative `u_i`. |
 
 ## uncertain_value
 

--- a/site/src/content/docs/reference/api/materials/reverberation-room-scattering.md
+++ b/site/src/content/docs/reference/api/materials/reverberation-room-scattering.md
@@ -346,7 +346,7 @@ per-band specular `alpha_spec` (Eq. (4)) and random-incidence `alpha_s`
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if the three inputs differ in length, are empty, or any `alpha_s` equals 1. |
+| ValueError | if the three inputs differ in shape, the band centres are empty or not 1-D, or any `alpha_s` equals 1. |
 
 ## scattering_coefficient_uncertainty
 

--- a/site/src/content/docs/reference/api/materials/road-absorption.md
+++ b/site/src/content/docs/reference/api/materials/road-absorption.md
@@ -594,7 +594,7 @@ Clause 6.6 step 5); Part 1 does not mandate clipping, so pass
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If `frequency` and `absorption` differ in length or are empty. |
+| ValueError | If `frequency` and `absorption` differ in shape or are empty. |
 
 ## PART1_FREQUENCY_RANGE
 

--- a/site/src/content/docs/reference/api/materials/scattering-diffusion.md
+++ b/site/src/content/docs/reference/api/materials/scattering-diffusion.md
@@ -109,7 +109,7 @@ are carried through when supplied.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if the inputs differ in length, are empty or not 1-D. |
+| ValueError | if the inputs differ in shape, are empty or not 1-D. |
 
 ## DiffusionResult
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -331,6 +331,32 @@ def require_same_length(
     require_equal_counts(type(owner).__name__, counts, axis)
 
 
+def require_equal_shapes(
+    owner: str, shapes: Mapping[str, tuple[int, ...]], quantity: str = "point"
+) -> None:
+    """Require every shape to agree, naming each one that does not.
+
+    What :func:`require_equal_counts` is to :func:`require_same_length`, this
+    is to :func:`require_same_shape`: the form for values a caller is holding
+    loose, where there is no instance to read the fields off. An entry point
+    validating two of its own arguments is the usual case.
+
+    Shape rather than length, because two grids of the same height agree on
+    every count and can still disagree about every value in them.
+
+    :param owner: Name of the entry point, used in the error message. The one
+        the caller typed, not the private validator it reached.
+    :param shapes: Label to shape, in the order they should be reported.
+    :param quantity: What one element is, singular, for the error message.
+    :raises ValueError: if two of the shapes disagree.
+    """
+    if len(set(shapes.values())) <= 1:
+        return
+    listed = ", ".join(f"'{label}' {shape}" for label, shape in shapes.items())
+    msg = f"{owner}: {listed} must all have the same shape, one value per {quantity}."
+    raise ValueError(msg)
+
+
 def require_same_shape(owner: object, *fields: str, quantity: str = "point") -> None:
     """Require the named fields of *owner* to have exactly the same shape.
 
@@ -355,14 +381,7 @@ def require_same_shape(owner: object, *fields: str, quantity: str = "point") -> 
     if all(np.ndim(value) == 0 for _, value in present):
         return
     shapes = {name: np.shape(value) for name, value in present}
-    if len(set(shapes.values())) <= 1:
-        return
-    listed = ", ".join(f"'{name}' {shape}" for name, shape in shapes.items())
-    msg = (
-        f"{type(owner).__name__}: {listed} must all have the same shape, "
-        f"one value per {quantity}."
-    )
-    raise ValueError(msg)
+    require_equal_shapes(type(owner).__name__, shapes, quantity)
 
 
 def require_per_band(

--- a/src/phonometry/_plot/geometry/electroacoustics.py
+++ b/src/phonometry/_plot/geometry/electroacoustics.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 
+from ..._internal.validation import require_equal_shapes
 from ..common import (
     _C_EDGE,
     _C_MUTED,
@@ -150,9 +151,11 @@ def plot_piston_geometry(
     if angles is not None and directivity is not None:
         ang = np.asarray(angles, dtype=np.float64)
         d_lin = np.abs(np.asarray(directivity, dtype=np.float64))
-        if ang.shape != d_lin.shape:
-            msg = "'angles' and 'directivity' must match."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "plot_piston_geometry",
+            {"angles": ang.shape, "directivity": d_lin.shape},
+            "angle",
+        )
         peak = float(d_lin.max())
         if peak > 0.0:
             scale = 2.8 * a / peak

--- a/src/phonometry/_report/_insulation_fiche.py
+++ b/src/phonometry/_report/_insulation_fiche.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -237,9 +238,10 @@ def render_insulation_fiche(
         verbose columns instead of the two-column ``f | value`` form.
     :param language: ``"en"`` (default) or ``"es"``.
     :return: The written ``path`` as a :class:`str`.
-    :raises ValueError: If ``rating.quantity`` does not match ``is_impact`` or
+    :raises ValueError: If ``rating.quantity`` does not match ``is_impact``, or
         the rating is missing its per-band ``band_centers`` / ``measured`` /
-        ``shifted_reference`` arrays (a manually constructed rating).
+        ``shifted_reference`` arrays, or those disagree in shape with the
+        reported curve (all three, a manually constructed rating).
     :raises ImportError: If reportlab (or, for the figure, matplotlib) is not
         installed.
     """
@@ -276,13 +278,16 @@ def render_insulation_fiche(
     centers = np.asarray(rating.band_centers, dtype=np.float64)
     measured = np.asarray(rating.measured, dtype=np.float64)
     shifted = np.asarray(rating.shifted_reference, dtype=np.float64)
-    if not (curve.shape == centers.shape == measured.shape == shifted.shape):
-        msg = (
-            "The report needs matching per-band lengths: the rating's "
-            "'band_centers', 'measured' and 'shifted_reference' and the "
-            "result's per-band curve must all have the same length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        f"{type(result).__name__}.report",
+        {
+            curve_attr: curve.shape,
+            "rating.band_centers": centers.shape,
+            "rating.measured": measured.shape,
+            "rating.shifted_reference": shifted.shape,
+        },
+        "band",
+    )
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title_text = t(spec["title"], language)

--- a/src/phonometry/_report/iso10534.py
+++ b/src/phonometry/_report/iso10534.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -329,12 +330,16 @@ def render_iso10534_report(
     alpha = np.asarray(result.absorption, dtype=np.float64)
     reflection = np.asarray(result.reflection, dtype=np.complex128)
     z = np.asarray(result.normalized_impedance, dtype=np.complex128)
-    if not freqs.shape == alpha.shape == reflection.shape == z.shape:
-        msg = (
-            "render_iso10534_report() needs 'frequency', 'absorption', "
-            "'reflection' and 'normalized_impedance' of equal length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "ImpedanceTubeResult.report",
+        {
+            "frequency": freqs.shape,
+            "absorption": alpha.shape,
+            "reflection": reflection.shape,
+            "normalized_impedance": z.shape,
+        },
+        "frequency",
+    )
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Impedance-tube sound absorption and impedance", language)

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -322,7 +323,7 @@ def _left_table(
     :param verbose: Keep the octave evaluation columns.
     :param language: Label language.
     :return: The table flowable and its caption.
-    :raises ValueError: If the one-third-octave arrays differ in length.
+    :raises ValueError: If the one-third-octave arrays differ in shape.
     """
     alpha_s = result.third_octave_alpha_s
     bands = result.third_octave_bands
@@ -331,12 +332,14 @@ def _left_table(
         return table, t("Octave-band &#945;<sub>p</sub>", language)
     third_octave_bands = np.asarray(bands, dtype=np.float64)
     third_octave_alpha_s = np.asarray(alpha_s, dtype=np.float64)
-    if third_octave_bands.shape != third_octave_alpha_s.shape:
-        msg = (
-            "render_iso11654_report() needs 'third_octave_bands' and "
-            "'third_octave_alpha_s' of equal length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "AbsorptionRatingResult.report",
+        {
+            "third_octave_bands": third_octave_bands.shape,
+            "third_octave_alpha_s": third_octave_alpha_s.shape,
+        },
+        "one-third-octave band",
+    )
     table = _third_octave_table(
         third_octave_bands, third_octave_alpha_s, measured, language
     )
@@ -384,12 +387,15 @@ def render_iso11654_report(
     centers = np.asarray(result.band_centers, dtype=np.float64)
     measured = np.asarray(result.measured, dtype=np.float64)
     shifted = np.asarray(result.shifted_reference, dtype=np.float64)
-    if not centers.shape == measured.shape == shifted.shape:
-        msg = (
-            "render_iso11654_report() needs 'band_centers', 'measured' and "
-            "'shifted_reference' of equal length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "AbsorptionRatingResult.report",
+        {
+            "band_centers": centers.shape,
+            "measured": measured.shape,
+            "shifted_reference": shifted.shape,
+        },
+        "octave band",
+    )
     # Unfavourable deviation: measured practical coefficient below the curve.
     deviations = np.maximum(shifted - measured, 0.0)
 

--- a/src/phonometry/_report/iso16251.py
+++ b/src/phonometry/_report/iso16251.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -348,12 +349,11 @@ def render_iso16251_report(
 
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     delta_l = np.asarray(result.improvement, dtype=np.float64)
-    if freqs.shape != delta_l.shape:
-        msg = (
-            "render_iso16251_report() needs 'frequencies' and 'improvement' of "
-            "equal length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "FloorCoveringImprovementResult.report",
+        {"frequencies": freqs.shape, "improvement": delta_l.shape},
+        "band",
+    )
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Floor-covering impact sound improvement", language)

--- a/src/phonometry/_report/iso17497.py
+++ b/src/phonometry/_report/iso17497.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -295,18 +296,21 @@ def render_scattering_report(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     s = np.asarray(result.scattering, dtype=np.float64)
     a_s = np.asarray(result.random_incidence, dtype=np.float64)
-    if not freqs.shape == s.shape == a_s.shape:
-        msg = (
-            "render_scattering_report() needs 'frequencies', 'scattering' and "
-            "'random_incidence' of equal length."
+    require_equal_shapes(
+        "ScatteringResult.report",
+        {
+            "frequencies": freqs.shape,
+            "scattering": s.shape,
+            "random_incidence": a_s.shape,
+        },
+        "band",
+    )
+    if verbose:
+        require_equal_shapes(
+            "ScatteringResult.report(verbose=True)",
+            {"frequencies": freqs.shape, "specular": np.shape(result.specular)},
+            "band",
         )
-        raise ValueError(msg)
-    if verbose and np.asarray(result.specular, dtype=np.float64).shape != freqs.shape:
-        msg = (
-            "render_scattering_report(verbose=True) needs 'specular' of the "
-            "same length as 'frequencies'."
-        )
-        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Surface scattering measurement", language)
@@ -449,21 +453,17 @@ def render_diffusion_spectrum_report(
     # figure draws it whenever it is present, the table when verbose).
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     d = np.asarray(result.diffusion, dtype=np.float64)
-    if freqs.shape != d.shape:
-        msg = (
-            "render_diffusion_spectrum_report() needs 'frequencies' and "
-            "'diffusion' of equal length."
+    require_equal_shapes(
+        "DiffusionSpectrum.report",
+        {"frequencies": freqs.shape, "diffusion": d.shape},
+        "band",
+    )
+    if result.normalized is not None:
+        require_equal_shapes(
+            "DiffusionSpectrum.report",
+            {"frequencies": freqs.shape, "normalized": np.shape(result.normalized)},
+            "band",
         )
-        raise ValueError(msg)
-    if (
-        result.normalized is not None
-        and np.asarray(result.normalized, dtype=np.float64).shape != freqs.shape
-    ):
-        msg = (
-            "render_diffusion_spectrum_report() needs 'normalized' of the same "
-            "length as 'frequencies'."
-        )
-        raise ValueError(msg)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Surface diffusion measurement", language)
@@ -573,12 +573,11 @@ def render_diffusion_polar_report(
 
     angles = np.asarray(result.angles, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
-    if angles.shape != levels.shape:
-        msg = (
-            "render_diffusion_polar_report() needs 'angles' and 'levels' of "
-            "equal length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "DiffusionResult.report",
+        {"angles": angles.shape, "levels": levels.shape},
+        "receiver angle",
+    )
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Surface diffusion measurement", language)

--- a/src/phonometry/_report/iso354.py
+++ b/src/phonometry/_report/iso354.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -232,28 +233,32 @@ def render_iso354_report(
 
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     alpha_s = np.asarray(result.alpha_s, dtype=np.float64)
-    if freqs.shape != alpha_s.shape:
-        msg = (
-            "render_iso354_report() needs 'frequencies' and 'alpha_s' of equal length."
-        )
-        raise ValueError(msg)
-    # SoundAbsorptionMeasurement is a plain frozen dataclass, so a hand-built
-    # result can carry per-band arrays of differing lengths. The four columns
-    # only the verbose detail table reads are checked here too; the guard above
-    # covers 'alpha_s' alone.
+    require_equal_shapes(
+        "SoundAbsorptionMeasurement.report",
+        {"frequencies": freqs.shape, "alpha_s": alpha_s.shape},
+        "band",
+    )
+    # SoundAbsorptionMeasurement pins every per-band column to one length at
+    # construction, so both guards here catch only an instance whose fields
+    # were replaced past the frozen dataclass. The four columns that just the
+    # verbose detail table reads are checked below; the guard above covers
+    # 'alpha_s' alone.
     if verbose:
         t1 = np.asarray(result.t_empty, dtype=np.float64)
         t2 = np.asarray(result.t_specimen, dtype=np.float64)
         a1 = np.asarray(result.absorption_area_empty, dtype=np.float64)
         a2 = np.asarray(result.absorption_area_with_specimen, dtype=np.float64)
-        if not freqs.shape == t1.shape == t2.shape == a1.shape == a2.shape:
-            msg = (
-                "render_iso354_report(verbose=True) needs 't_empty', "
-                "'t_specimen', 'absorption_area_empty' and "
-                "'absorption_area_with_specimen' of the same length as "
-                "'frequencies'."
-            )
-            raise ValueError(msg)
+        require_equal_shapes(
+            "SoundAbsorptionMeasurement.report(verbose=True)",
+            {
+                "frequencies": freqs.shape,
+                "t_empty": t1.shape,
+                "t_specimen": t2.shape,
+                "absorption_area_empty": a1.shape,
+                "absorption_area_with_specimen": a2.shape,
+            },
+            "band",
+        )
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
     title = t("Sound absorption measurement", language)

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -395,7 +396,7 @@ def _validated_curves(
     """Band centres, measured and shifted curves, and the unfavourable deviations.
 
     :raises ValueError: If a curve is missing from the result or the three do
-        not share a length.
+        not share a shape.
     """
     centers = result.band_centers
     measured = result.measured
@@ -409,12 +410,15 @@ def _validated_curves(
     centers = np.asarray(centers, dtype=np.float64)
     measured = np.asarray(measured, dtype=np.float64)
     shifted = np.asarray(shifted, dtype=np.float64)
-    if not centers.shape == measured.shape == shifted.shape:
-        msg = (
-            "render_iso717_report() needs 'band_centers', 'measured' and "
-            "'shifted_reference' of equal length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        f"{type(result).__name__}.report",
+        {
+            "band_centers": centers.shape,
+            "measured": measured.shape,
+            "shifted_reference": shifted.shape,
+        },
+        "band",
+    )
 
     # Unfavourable deviation: reference above measurement (airborne) or
     # measurement above the reference (impact, the opposite sign).

--- a/src/phonometry/_report/iso9613.py
+++ b/src/phonometry/_report/iso9613.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
 from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
@@ -307,12 +308,11 @@ def _resolve_levels(
 
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     lw = np.atleast_1d(np.asarray(emission.sound_power_level, dtype=np.float64))
-    if lw.shape != freqs.shape:
-        msg = (
-            "source_emission.sound_power_level must have one value per frequency "
-            f"band (got {lw.size}, expected {freqs.size})."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "OutdoorAttenuation.report",
+        {"source_emission.sound_power_level": lw.shape, "frequencies": freqs.shape},
+        "band",
+    )
     receiver = _compose_receiver_level(
         lw,
         emission.directivity_index,

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -78,6 +78,7 @@ import numpy as np
 
 from ..._internal.validation import (
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -679,10 +680,17 @@ def vibration_reduction_index_from_flanking(
     s_i = _positive(area_i, "area_i")
     s_j = _positive(area_j, "area_j")
     a0 = _positive(reference_area, "reference_area")
-    sizes = {dn_f.size, r_i.size, r_j.size, a_i.size, a_j.size}
-    if len(sizes) != 1:
-        msg = "All per-band inputs must share the same length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "vibration_reduction_index_from_flanking",
+        {
+            "normalized_flanking_level_difference": dn_f.shape,
+            "reduction_index_i": r_i.shape,
+            "reduction_index_j": r_j.shape,
+            "absorption_length_i": a_i.shape,
+            "absorption_length_j": a_j.shape,
+        },
+        "band",
+    )
     k_ij = (
         dn_f
         - 0.5 * (r_i + r_j)

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -54,7 +54,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from .insulation import (
     impact_improvement_adaptation_term,
     weighted_impact_improvement,
@@ -153,9 +157,11 @@ def background_corrected_level(
     """
     lp = _finite(signal_and_background, "signal_and_background")
     lb = _finite(background, "background")
-    if lp.shape != lb.shape:
-        msg = "'signal_and_background' and 'background' must share their shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "background_corrected_level",
+        {"signal_and_background": lp.shape, "background": lb.shape},
+        "band",
+    )
     margin = lp - lb
     diff = 10.0 ** (lp / 10.0) - 10.0 ** (lb / 10.0)
     with np.errstate(invalid="ignore", divide="ignore"):
@@ -365,9 +371,11 @@ def impact_improvement(
     l1 = _finite(with_covering, "with_covering")
     freqs = _finite(frequencies, "frequencies")
     n_bands = freqs.shape[0]
-    if l0.shape != l1.shape:
-        msg = "'bare' and 'with_covering' must share their shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "impact_improvement",
+        {"bare": l0.shape, "with_covering": l1.shape},
+        "position and band",
+    )
     if l0.ndim not in (1, 2) or l0.shape[-1] != n_bands:
         msg = (
             "'bare'/'with_covering' must be (bands,) or (positions, bands) "
@@ -425,9 +433,11 @@ def improvement_octave_bands(
     """
     dl = _finite(improvement, "improvement")
     freqs = _finite(frequencies, "frequencies")
-    if dl.shape != freqs.shape:
-        msg = "'improvement' and 'frequencies' must share their shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "improvement_octave_bands",
+        {"improvement": dl.shape, "frequencies": freqs.shape},
+        "band",
+    )
     octave_freqs: list[float] = []
     octave_values: list[float] = []
     by_freq = {round(float(f), 3): float(d) for f, d in zip(freqs, dl, strict=True)}

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -104,6 +104,7 @@ import numpy as np
 
 from ..._internal.validation import (
     require_choice,
+    require_equal_shapes,
     require_finite_array,
     require_positive,
     require_ranks,
@@ -679,9 +680,11 @@ def standardized_maximum_impact_level(
     freqs: np.ndarray | None = None
     if frequency is not None:
         freqs = require_finite_array(frequency, "frequency")
-        if freqs.shape != li.shape:
-            msg = "'frequency' must match 'level'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "standardized_maximum_impact_level",
+            {"level": li.shape, "frequency": freqs.shape},
+            "band",
+        )
     correction = fast_reverberation_correction(t, reference_time=reference_time)
     volume_term = float(10.0 * np.log10(v / v0))
     return StandardizedMaximumImpactResult(

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -75,6 +75,7 @@ from ..._internal.levels_math import energy_mean
 from ..._internal.types import as_float_or_array
 from ..._internal.validation import (
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -1024,8 +1025,8 @@ def facade_insulation(
     :raises ValueError: If band counts differ, if ``method`` is unknown, if
         ``t2``/``t0``/``area``/``volume`` are not positive, if ``area`` is
         given without ``surface_level``, if ``surface_level`` and ``area`` are
-        given without ``volume``, if ``frequencies`` is given with a length
-        that differs from the band count, or if inputs are non-finite.
+        given without ``volume``, if ``frequencies`` is given with a shape
+        that differs from the band axis, or if inputs are non-finite.
         Supplying ``surface_level`` alone is not an error: ``r_prime`` simply
         stays ``None``.
     """
@@ -1063,9 +1064,11 @@ def facade_insulation(
     r_prime: np.ndarray | None = None
     if surface_level is not None and area is not None and absorption is not None:
         surf_bands = _as_band_levels(surface_level, "surface_level")
-        if surf_bands.shape != l2_bands.shape:
-            msg = "'surface_level' must share the band count of 'l2'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "facade_insulation",
+            {"surface_level": surf_bands.shape, "l2": l2_bands.shape},
+            "band",
+        )
         r_prime = (
             surf_bands
             - l2_bands
@@ -1076,12 +1079,12 @@ def facade_insulation(
     freqs = (
         np.asarray(frequencies, dtype=np.float64) if frequencies is not None else None
     )
-    if freqs is not None and freqs.shape != d_2m.shape:
-        msg = (
-            "'frequencies' must have one value per band; got "
-            f"{freqs.size} for {d_2m.size} bands."
+    if freqs is not None:
+        require_equal_shapes(
+            "facade_insulation",
+            {"l1_2m": l1_bands.shape, "frequencies": freqs.shape},
+            "band",
         )
-        raise ValueError(msg)
     return FacadeInsulationResult(
         d_2m=d_2m,
         d_2m_nt=d_2m_nt,

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -79,6 +79,7 @@ import numpy as np
 
 from ..._internal.validation import (
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -536,9 +537,11 @@ def surface_pressure_intensity_indicator(
     """
     p = np.asarray(lp, dtype=np.float64)
     i = np.asarray(l_in, dtype=np.float64)
-    if p.shape != i.shape:
-        msg = "'lp' and 'l_in' must share their shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "surface_pressure_intensity_indicator",
+        {"lp": p.shape, "l_in": i.shape},
+        "band",
+    )
     if not (np.all(np.isfinite(p)) and np.all(np.isfinite(i))):
         msg = "Levels must contain only finite values."
         raise ValueError(msg)
@@ -665,9 +668,11 @@ def intensity_sound_reduction(
     """
     lp1_bands = _as_band_levels(lp1, "lp1")
     l_in_bands = _as_band_levels(l_in, "l_in")
-    if lp1_bands.shape != l_in_bands.shape:
-        msg = "'lp1' and 'l_in' must share the same band count."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "intensity_sound_reduction",
+        {"lp1": lp1_bands.shape, "l_in": l_in_bands.shape},
+        "band",
+    )
     sm = _positive_area(measurement_area, "measurement_area")
     s = _positive_area(area, "area")
 
@@ -676,9 +681,11 @@ def intensity_sound_reduction(
     r_i_modified: np.ndarray | None = None
     if kc is not None:
         kc_bands = np.asarray(kc, dtype=np.float64)
-        if kc_bands.shape != r_i.shape:
-            msg = "'kc' must share the band count of the levels."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "intensity_sound_reduction",
+            {"lp1": lp1_bands.shape, "kc": kc_bands.shape},
+            "band",
+        )
         if not np.all(np.isfinite(kc_bands)):
             msg = "'kc' must contain only finite values."
             raise ValueError(msg)
@@ -748,9 +755,11 @@ def intensity_element_normalized_difference(
     """
     lp1_bands = _as_band_levels(lp1, "lp1")
     l_in_bands = _as_band_levels(l_in, "l_in")
-    if lp1_bands.shape != l_in_bands.shape:
-        msg = "'lp1' and 'l_in' must share the same band count."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "intensity_element_normalized_difference",
+        {"lp1": lp1_bands.shape, "l_in": l_in_bands.shape},
+        "band",
+    )
     sm = _positive_area(measurement_area, "measurement_area")
     if int(n) != n or n < 1:
         msg = "'n' must be a positive integer."

--- a/src/phonometry/building/measurement/lab_insulation.py
+++ b/src/phonometry/building/measurement/lab_insulation.py
@@ -54,7 +54,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ..._internal.warnings import PhonometryWarning
 from .insulation import (
     ImpactRatingResult,
@@ -427,9 +431,11 @@ def background_correction(
     """
     lsb = np.asarray(signal_and_background, dtype=np.float64)
     lb = np.asarray(background, dtype=np.float64)
-    if lsb.shape != lb.shape:
-        msg = "'signal_and_background' and 'background' must share their shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "background_correction",
+        {"signal_and_background": lsb.shape, "background": lb.shape},
+        "band",
+    )
     if not (np.all(np.isfinite(lsb)) and np.all(np.isfinite(lb))):
         msg = "Levels must contain only finite values."
         raise ValueError(msg)
@@ -493,9 +499,11 @@ def lab_airborne_insulation(
     """
     l1_bands = _as_band_levels(l1, "l1")
     l2_bands = _as_band_levels(l2, "l2")
-    if l1_bands.shape != l2_bands.shape:
-        msg = "'l1' and 'l2' must share the same band count."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "lab_airborne_insulation",
+        {"l1": l1_bands.shape, "l2": l2_bands.shape},
+        "band",
+    )
     if not np.isfinite(area) or area <= 0.0:
         msg = "'area' must be positive."
         raise ValueError(msg)

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -66,7 +66,11 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.levels_math import energy_sum
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -1185,10 +1189,16 @@ def _match_bands(
 
 
 def _validated_extended_input(
+    owner: str,
     values_by_band: Sequence[float] | np.ndarray,
     frequencies: Sequence[float] | np.ndarray | None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Validate the extended-range input; return (measured, freqs, core_idx)."""
+    """Validate the extended-range input; return (measured, freqs, core_idx).
+
+    *owner* is the entry point the caller typed, so that the message about
+    the two spectra names it rather than this validator, which two entry
+    points share.
+    """
     data = np.asarray(values_by_band, dtype=np.float64)
     if data.ndim != 1:
         raise ValueError(_VALUES_1D_MSG)
@@ -1205,9 +1215,11 @@ def _validated_extended_input(
         freqs = np.asarray(_FREQ_THIRD_OCTAVE, dtype=np.float64)
     else:
         freqs = np.asarray(frequencies, dtype=np.float64)
-        if freqs.shape != data.shape:
-            msg = "'frequencies' must have one value per band of 'values_by_band'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            owner,
+            {"values_by_band": data.shape, "frequencies": freqs.shape},
+            "band",
+        )
         if not np.all(np.isfinite(freqs)) or np.any(freqs <= 0.0):
             msg = "'frequencies' must contain positive values."
             raise ValueError(msg)
@@ -1253,7 +1265,9 @@ def weighted_rating_extended(
     :raises ValueError: If the input is not one-dimensional and finite, the
         band counts differ, or the core bands are missing.
     """
-    measured, freqs, core_idx = _validated_extended_input(values_by_band, frequencies)
+    measured, freqs, core_idx = _validated_extended_input(
+        "weighted_rating_extended", values_by_band, frequencies
+    )
     core_measured = measured[core_idx]
     ref = np.asarray(_REF_THIRD_OCTAVE, dtype=np.float64)
     step = 0.1 if one_decimal else 1.0
@@ -1325,7 +1339,9 @@ def weighted_impact_rating_extended(
     :raises ValueError: If the input is not one-dimensional and finite, the
         band counts differ, or the core bands are missing.
     """
-    measured, freqs, core_idx = _validated_extended_input(values_by_band, frequencies)
+    measured, freqs, core_idx = _validated_extended_input(
+        "weighted_impact_rating_extended", values_by_band, frequencies
+    )
     core_measured = measured[core_idx]
     ref = np.asarray(_REF_IMPACT_THIRD_OCTAVE, dtype=np.float64)
     step = 0.1 if one_decimal else 1.0

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -72,7 +72,11 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from .insulation import (
     ImpactRatingResult,
     WeightedRatingResult,
@@ -747,9 +751,11 @@ def survey_airborne_insulation(
     """
     l1_bands = _as_band_levels(l1, "l1")
     l2_bands = _as_band_levels(l2, "l2")
-    if l1_bands.shape != l2_bands.shape:
-        msg = "'l1' and 'l2' must share the same band count."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "survey_airborne_insulation",
+        {"l1": l1_bands.shape, "l2": l2_bands.shape},
+        "band",
+    )
     k = _validate_index(reverberation_index, int(l1_bands.size))
 
     d = l1_bands - l2_bands
@@ -841,9 +847,11 @@ def survey_facade_insulation(
     """
     out = _as_band_levels(l1_2m, "l1_2m")
     l2_bands = _as_band_levels(l2, "l2")
-    if out.shape != l2_bands.shape:
-        msg = "'l1_2m' and 'l2' must share the same band count."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "survey_facade_insulation",
+        {"l1_2m": out.shape, "l2": l2_bands.shape},
+        "band",
+    )
     k = _validate_index(reverberation_index, int(out.size))
 
     d_2m = out - l2_bands

--- a/src/phonometry/building/measurement/uncertainty.py
+++ b/src/phonometry/building/measurement/uncertainty.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
+from ..._internal.validation import require_equal_shapes
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -766,7 +768,7 @@ def single_number_uncertainty_uncorrelated(
     :param band_uncertainties: Per-band standard uncertainties ``u_i``, in dB.
     :param reference_differences: Per-band :math:`L_i - R_i`
         (reference-spectrum level minus measured band value), in dB.
-    :raises ValueError: Mismatched lengths, empty input, or negative ``u_i``.
+    :raises ValueError: Mismatched shapes, empty input, or negative ``u_i``.
     """
     u_arr = np.asarray(band_uncertainties, dtype=float)
     d_arr = np.asarray(reference_differences, dtype=float)
@@ -776,9 +778,14 @@ def single_number_uncertainty_uncorrelated(
     if u_arr.size == 0:
         msg = "At least one band is required."
         raise ValueError(msg)
-    if u_arr.shape != d_arr.shape:
-        msg = "band_uncertainties and reference_differences differ in length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "single_number_uncertainty_uncorrelated",
+        {
+            "band_uncertainties": u_arr.shape,
+            "reference_differences": d_arr.shape,
+        },
+        "band",
+    )
     if np.any(u_arr < 0):
         msg = "Band uncertainties must be non-negative."
         raise ValueError(msg)

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -109,6 +109,7 @@ import numpy as np
 
 from ..._internal.validation import (
     require_choice,
+    require_equal_shapes,
     require_finite_array,
     require_positive,
     require_ranks,
@@ -229,9 +230,11 @@ def normalized_ceiling_attenuation(
     """
     l1 = require_finite_array(level_source, "level_source")
     l2 = require_finite_array(level_receiving, "level_receiving")
-    if l1.shape != l2.shape:
-        msg = "'level_source' and 'level_receiving' must share their shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "normalized_ceiling_attenuation",
+        {"level_source": l1.shape, "level_receiving": l2.shape},
+        "band",
+    )
     area = require_finite_array(absorption_area, "absorption_area")
     if area.size == 1:
         area = np.full(l1.shape, float(area[0]))
@@ -558,12 +561,14 @@ def plenum_flanking_reduction_index(
     """
     rs = require_finite_array(reduction_index_source, "reduction_index_source")
     rr = require_finite_array(reduction_index_receiving, "reduction_index_receiving")
-    if rs.shape != rr.shape:
-        msg = (
-            "'reduction_index_source' and 'reduction_index_receiving' must "
-            "share their shape."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "plenum_flanking_reduction_index",
+        {
+            "reduction_index_source": rs.shape,
+            "reduction_index_receiving": rr.shape,
+        },
+        "band",
+    )
     lr = require_positive(ceiling_length, "ceiling_length")
     h = require_positive(plenum_height, "plenum_height")
     ls = (
@@ -578,9 +583,11 @@ def plenum_flanking_reduction_index(
     freqs: np.ndarray | None = None
     if frequency is not None:
         freqs = require_finite_array(frequency, "frequency")
-        if freqs.shape != rs.shape:
-            msg = "'frequency' must match the reduction indices."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "plenum_flanking_reduction_index",
+            {"reduction_index_source": rs.shape, "frequency": freqs.shape},
+            "band",
+        )
 
     tau_s = 10.0 ** (-rs / 10.0)
     tau_r = 10.0 ** (-rr / 10.0)
@@ -608,9 +615,15 @@ def plenum_flanking_reduction_index(
 
     ms = require_finite_array(attenuation_source, "attenuation_source")
     mr = require_finite_array(attenuation_receiving, "attenuation_receiving")
-    if ms.shape != rs.shape or mr.shape != rs.shape:
-        msg = "the attenuation coefficients must match the reduction indices."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "plenum_flanking_reduction_index",
+        {
+            "reduction_index_source": rs.shape,
+            "attenuation_source": ms.shape,
+            "attenuation_receiving": mr.shape,
+        },
+        "band",
+    )
     if np.any(ms <= 0.0) or np.any(mr <= 0.0):
         msg = "the attenuation coefficients must be positive."
         raise ValueError(msg)

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -103,6 +103,7 @@ from ..._internal.validation import (
     require_axis_count,
     require_choice,
     require_equal_counts,
+    require_equal_shapes,
     require_positive,
     require_positive_array,
     require_ranks,
@@ -589,12 +590,14 @@ def perimeter_absorption_coefficient(
     """
     fc = require_positive_array(critical_frequencies, "critical_frequencies")
     kij = np.atleast_1d(np.asarray(vibration_reduction_indices, dtype=np.float64))
-    if kij.shape != fc.shape:
-        msg = (
-            "'critical_frequencies' and 'vibration_reduction_indices' must "
-            "have the same length (one value per connected element)."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "perimeter_absorption_coefficient",
+        {
+            "critical_frequencies": fc.shape,
+            "vibration_reduction_indices": kij.shape,
+        },
+        "connected element",
+    )
     if not np.all(np.isfinite(kij)):
         msg = "'vibration_reduction_indices' must be finite."
         raise ValueError(msg)

--- a/src/phonometry/building/prediction/facade.py
+++ b/src/phonometry/building/prediction/facade.py
@@ -74,6 +74,7 @@ import numpy as np
 from ..._internal.validation import (
     require_axis_count,
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -163,17 +164,26 @@ class FacadeElement:
         return weight * 10.0 ** (-level / 10.0)
 
 
-def _band_count(elements: Sequence[FacadeElement]) -> int:
-    """Number of frequency bands implied by the elements (1 if all scalar)."""
-    sizes = set()
+def _band_count(elements: Sequence[FacadeElement], owner: str) -> int:
+    """Number of frequency bands implied by the elements (1 if all scalar).
+
+    *owner* is the entry point the caller typed, so that a façade whose
+    elements disagree is answered by name: which element carries which
+    spectrum, rather than the bare fact that two of them differ.
+    """
+    spectra: dict[str, np.ndarray] = {}
     for el in elements:
         kind = el._kind()  # exactly one of r / dn_e / insertion_loss
-        sizes.add(_as_array(getattr(el, kind), f"{el.name} ({kind})").size)
-    sizes.discard(1)
-    if len(sizes) > 1:
-        msg = "Elements have inconsistent band counts."
-        raise ValueError(msg)
-    return sizes.pop() if sizes else 1
+        label = f"{el.name} ({kind})"
+        level = _as_array(getattr(el, kind), label)
+        # A single value is broadcast over whatever the others carry
+        # (:meth:`FacadeElement.tau`), so it disagrees with nothing.
+        if level.size != 1:
+            spectra[label] = level
+    require_equal_shapes(
+        owner, {label: level.shape for label, level in spectra.items()}, "band"
+    )
+    return next(iter(spectra.values())).size if spectra else 1
 
 
 @dataclass(frozen=True)
@@ -396,7 +406,7 @@ _A_WEIGHT_OCTAVE = {
 
 
 def _apparent_reduction(
-    elements: Sequence[FacadeElement], total_area: float
+    elements: Sequence[FacadeElement], total_area: float, owner: str
 ) -> tuple[np.ndarray, dict[str, np.ndarray]]:
     r""":math:`R' = -10 \log_{10}(\sum \tau)` (F. 10 / Part 4 F. 3), plus ``Rp``."""
     if not elements:
@@ -409,7 +419,7 @@ def _apparent_reduction(
     if len(set(names)) != len(names):
         msg = "Façade element names must be unique (they key the per-element results)."
         raise ValueError(msg)
-    n = _band_count(elements)
+    n = _band_count(elements, owner)
     # Sum over the element list (not a name-keyed dict), so no element is ever
     # silently dropped, then key the per-element index by the unique names.
     taus = [el.tau(total_area, n) for el in elements]
@@ -462,7 +472,9 @@ def facade_sound_reduction(
     if v <= 0:
         msg = "'volume' must be positive."
         raise ValueError(msg)
-    r_prime, element_r = _apparent_reduction(elements, float(area))
+    r_prime, element_r = _apparent_reduction(
+        elements, float(area), "facade_sound_reduction"
+    )
     if frequencies is not None:
         require_equal_counts(
             "facade_sound_reduction",
@@ -522,7 +534,7 @@ def radiated_sound_power(
         the per-band data; enables the A-weighted single number.
     :return: A :class:`RadiatedPowerResult`.
     """
-    r_prime, _ = _apparent_reduction(elements, float(area))
+    r_prime, _ = _apparent_reduction(elements, float(area), "radiated_sound_power")
     if r_prime_cap is not None:
         r_prime = np.minimum(r_prime, float(r_prime_cap))
     lp = _as_array(lp_in, "lp_in")

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -84,7 +84,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -501,9 +505,11 @@ def db_hr_global_index(
         selected = values.copy()
     else:
         given = np.asarray(frequencies, dtype=np.float64)
-        if given.shape != values.shape:
-            msg = "'frequencies' must have one value per band of 'band_values'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "db_hr_global_index",
+            {"band_values": values.shape, "frequencies": given.shape},
+            "band",
+        )
         if not np.all(np.isfinite(given)) or np.any(given <= 0.0):
             msg = "'frequencies' must contain positive values."
             raise ValueError(msg)

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -74,6 +74,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_equal_shapes
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -380,9 +381,11 @@ def static_airflow_resistance(
     if u.ndim != 1 or dp.ndim != 1:
         msg = "'velocities' and 'pressure_drops' must be 1-D."
         raise ValueError(msg)
-    if u.shape != dp.shape:
-        msg = "'velocities' and 'pressure_drops' must have equal length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "static_airflow_resistance",
+        {"velocities": u.shape, "pressure_drops": dp.shape},
+        "measurement step",
+    )
     if u.size < _MIN_MEASUREMENT_STEPS:
         msg = "At least two measurement steps are required."
         raise ValueError(msg)

--- a/src/phonometry/materials/absorbers/layered.py
+++ b/src/phonometry/materials/absorbers/layered.py
@@ -471,8 +471,8 @@ def _termination_impedance(
     zl_arr = np.asarray(termination, dtype=np.complex128)
     if zl_arr.ndim > 0 and zl_arr.shape != f.shape:
         msg = (
-            "'termination' impedance array must be scalar or match the "
-            f"frequency vector length ({f.size}), got {zl_arr.size}."
+            "'termination' impedance array must be scalar or match the shape "
+            f"of 'frequency' {f.shape}; got shape {zl_arr.shape}."
         )
         raise ValueError(msg)
     if not np.all(np.abs(zl_arr) > 0.0):

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -59,7 +59,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -621,12 +625,15 @@ def measure_sound_absorption(
     freqs = np.asarray(frequencies, dtype=np.float64)
     t1 = np.asarray(t_empty, dtype=np.float64)
     t2 = np.asarray(t_specimen, dtype=np.float64)
-    if not (freqs.shape == t1.shape == t2.shape):
-        msg = (
-            "'frequencies', 't_empty' and 't_specimen' must share one shape; "
-            f"got {freqs.shape}, {t1.shape} and {t2.shape}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "measure_sound_absorption",
+        {
+            "frequencies": freqs.shape,
+            "t_empty": t1.shape,
+            "t_specimen": t2.shape,
+        },
+        "band",
+    )
     m_arr = np.broadcast_to(np.asarray(m, dtype=np.float64), freqs.shape).astype(
         np.float64, copy=True
     )

--- a/src/phonometry/materials/absorbers/uncertainty.py
+++ b/src/phonometry/materials/absorbers/uncertainty.py
@@ -47,7 +47,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -301,6 +305,8 @@ def _band_uncertainty(
     frequencies: np.ndarray,
     table: dict[float, tuple[float, float]],
     *,
+    owner: str,
+    values_name: str,
     quantity: str,
     condition: str,
     confidence: float,
@@ -308,13 +314,19 @@ def _band_uncertainty(
 ) -> AbsorptionUncertaintyResult:
     r"""Shared engine for the coefficient formulae
     :math:`\sigma_\mathrm{R} = m \alpha + n` (values == α).
+
+    :param owner: Name of the entry point the caller invoked, so that the
+        shape complaint names the function that was typed rather than this
+        engine, which the Clause 5 and Clause 6 coefficients share.
+    :param values_name: Parameter name the coefficient arrived under, so that
+        the complaint quotes the argument the caller passed: ``alpha`` for
+        Clause 5, ``alpha_p`` for Clause 6.
     """
-    if values.shape != frequencies.shape:
-        msg = (
-            f"'{quantity}' values and frequencies must have the same shape; "
-            f"got {values.shape} and {frequencies.shape}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        owner,
+        {values_name: values.shape, "frequencies": frequencies.shape},
+        "band",
+    )
     m, n = _table_constants(frequencies, table, band_kind)
     sigma_r = m * values + n
     u = sigma_r if condition == _REPRODUCIBILITY else _REPEATABILITY_FACTOR * sigma_r
@@ -355,6 +367,8 @@ def sound_absorption_coefficient_uncertainty(
         _finite_bands(alpha, "alpha"),
         _finite_bands(frequencies, "frequencies"),
         _TABLE1,
+        owner="sound_absorption_coefficient_uncertainty",
+        values_name="alpha",
         quantity="absorption_coefficient",
         condition=_condition(condition),
         confidence=confidence,
@@ -385,12 +399,11 @@ def equivalent_area_uncertainty(
     """
     a = _finite_bands(area, "area")
     f = _finite_bands(frequencies, "frequencies")
-    if a.shape != f.shape:
-        msg = (
-            f"'area' values and frequencies must have the same shape; "
-            f"got {a.shape} and {f.shape}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "equivalent_area_uncertainty",
+        {"area": a.shape, "frequencies": f.shape},
+        "band",
+    )
     m, n = _table_constants(f, _TABLE1, "one-third-octave")
     cond = _condition(condition)
     sigma_r = m * a + n * _EQUIV_AREA_REFERENCE_S
@@ -432,6 +445,8 @@ def practical_coefficient_uncertainty(
         _finite_bands(alpha_p, "alpha_p"),
         _finite_bands(frequencies, "frequencies"),
         _TABLE2,
+        owner="practical_coefficient_uncertainty",
+        values_name="alpha_p",
         quantity="practical_coefficient",
         condition=_condition(condition),
         confidence=confidence,

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ..._internal.validation import require_equal_shapes
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -468,23 +469,27 @@ def scattering_coefficient_spectrum(
     :param random_absorption: Random-incidence absorption ``alpha_s`` per band.
     :param truncate_negative: Clip negative ``s`` to 0 (Clause 8.3 default).
     :return: A :class:`ScatteringResult` with ``.plot()``.
-    :raises ValueError: if the three inputs differ in length, are empty, or any
-        ``alpha_s`` equals 1.
+    :raises ValueError: if the three inputs differ in shape, the band centres
+        are empty or not 1-D, or any ``alpha_s`` equals 1.
     """
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     spec = np.atleast_1d(np.asarray(specular_absorption, dtype=np.float64))
     rand = np.atleast_1d(np.asarray(random_absorption, dtype=np.float64))
-    if (
-        freq.ndim != 1
-        or freq.size == 0
-        or freq.shape != spec.shape
-        or freq.shape != rand.shape
-    ):
+    if freq.ndim != 1 or freq.size == 0:
         msg = (
-            "'frequencies', 'specular_absorption' and 'random_absorption' must "
-            "be non-empty, 1-D and equal-length."
+            "'frequencies' must be a non-empty 1-D sequence of band centres; "
+            f"got shape {freq.shape}."
         )
         raise ValueError(msg)
+    require_equal_shapes(
+        "scattering_coefficient_spectrum",
+        {
+            "frequencies": freq.shape,
+            "specular_absorption": spec.shape,
+            "random_absorption": rand.shape,
+        },
+        "band",
+    )
     s = scattering_coefficient(spec, rand, truncate_negative=truncate_negative)
     return ScatteringResult(
         frequencies=freq,

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_equal_counts
+from ..._internal.validation import require_equal_counts, require_equal_shapes
 from .reverberation_room_scattering import _positive_scalar
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -261,19 +261,26 @@ def diffusion_spectrum(
     :param normalized: Optional normalised diffusion coefficient ``d_n`` per
         band; ``None`` when the reference flat surface was not measured.
     :return: A :class:`DiffusionSpectrum` with ``.plot()`` and ``.report()``.
-    :raises ValueError: if the inputs differ in length, are empty or not 1-D.
+    :raises ValueError: if the inputs differ in shape, are empty or not 1-D.
     """
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     d = np.atleast_1d(np.asarray(diffusion, dtype=np.float64))
-    if freq.ndim != 1 or freq.size == 0 or freq.shape != d.shape:
-        msg = "'frequencies' and 'diffusion' must be non-empty, 1-D and equal-length."
+    if freq.ndim != 1 or freq.size == 0:
+        msg = "'frequencies' must be a non-empty 1-D sequence of band centres."
         raise ValueError(msg)
+    require_equal_shapes(
+        "diffusion_spectrum",
+        {"frequencies": freq.shape, "diffusion": d.shape},
+        "band",
+    )
     d_n: Real | None = None
     if normalized is not None:
         d_n = np.atleast_1d(np.asarray(normalized, dtype=np.float64))
-        if d_n.shape != freq.shape:
-            msg = "'normalized' must match 'frequencies' in length."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "diffusion_spectrum",
+            {"frequencies": freq.shape, "normalized": d_n.shape},
+            "band",
+        )
     return DiffusionSpectrum(
         frequencies=freq,
         diffusion=d,
@@ -303,9 +310,11 @@ def directional_diffusion(
     """
     ang = np.atleast_1d(np.asarray(angles, dtype=np.float64))
     lev = np.atleast_1d(np.asarray(levels, dtype=np.float64))
-    if ang.shape != lev.shape:
-        msg = "'angles' and 'levels' must have the same length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "directional_diffusion",
+        {"angles": ang.shape, "levels": lev.shape},
+        "receiver",
+    )
     d = float(directional_diffusion_coefficient(lev, area_weights=weights))
     return DiffusionResult(angles=ang, levels=lev, coefficient=d)
 

--- a/src/phonometry/materials/surfaces/road_absorption.py
+++ b/src/phonometry/materials/surfaces/road_absorption.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from ..._internal.validation import require_equal_shapes
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import (
     SignalInput,
@@ -607,13 +608,18 @@ def one_third_octave_absorption(
     :param clip_negative: Set negative band results to zero (default ``True``).
     :return: Tuple ``(band_centres, band_absorption)``; a band with no
         narrow-band samples yields ``nan``.
-    :raises ValueError: If ``frequency`` and ``absorption`` differ in length or
+    :raises ValueError: If ``frequency`` and ``absorption`` differ in shape or
         are empty.
     """
     freq = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
     alpha = np.atleast_1d(np.asarray(absorption, dtype=np.float64))
-    if freq.size == 0 or freq.shape != alpha.shape:
-        msg = "'frequency' and 'absorption' must be non-empty and equal-length."
+    require_equal_shapes(
+        "one_third_octave_absorption",
+        {"frequency": freq.shape, "absorption": alpha.shape},
+        "frequency",
+    )
+    if freq.size == 0:
+        msg = "'frequency' and 'absorption' must be non-empty."
         raise ValueError(msg)
     centres = np.array(
         [c for c in _ONE_THIRD_OCTAVE_CENTERS if f_min <= c <= f_max],
@@ -973,9 +979,14 @@ def spot_internal_loss_correction(
     """
     alpha_m = np.atleast_1d(np.asarray(measured_absorption, dtype=np.float64))
     alpha_s = np.atleast_1d(np.asarray(system_absorption, dtype=np.float64))
-    if alpha_m.shape != alpha_s.shape:
-        msg = "'measured_absorption' and 'system_absorption' must share a shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "spot_internal_loss_correction",
+        {
+            "measured_absorption": alpha_m.shape,
+            "system_absorption": alpha_s.shape,
+        },
+        "band",
+    )
     corrected = alpha_m - alpha_s
     if clip_negative:
         corrected = np.maximum(corrected, 0.0)

--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -507,7 +507,13 @@ def test_single_number_uncorrelated_dominant_band():
 
 
 def test_single_number_uncorrelated_length_mismatch():
-    with pytest.raises(ValueError, match="length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"single_number_uncertainty_uncorrelated: 'band_uncertainties' .*"
+            r"'reference_differences' .*same shape"
+        ),
+    ):
         single_number_uncertainty_uncorrelated([1.0, 2.0], [0.0])
 
 

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -253,6 +253,21 @@ def test_surface_and_area_without_volume_raises() -> None:
         )
 
 
+def test_surface_level_of_another_band_count_raises() -> None:
+    # R' subtracts 'l2' from 'surface_level' band by band, so the message
+    # names both curves and the shapes it just compared.
+    outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
+    with pytest.raises(ValueError, match=r"'surface_level'.*'l2'.*same shape"):
+        building.facade_insulation(
+            outdoor,
+            indoor,
+            rt,
+            area=10.0,
+            volume=62.5,
+            surface_level=_flat(4, 72.0),
+        )
+
+
 def test_surface_area_and_volume_returns_r_prime() -> None:
     # The complete set of R' inputs still yields a value.
     res = building.facade_insulation(
@@ -315,8 +330,21 @@ def test_frequencies_length_mismatch_raises() -> None:
     # 'frequencies' shorter than the band count must fail clearly here rather
     # than deferring a confusing matplotlib shape error to plot().
     outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
         building.facade_insulation(outdoor, indoor, rt, frequencies=[125.0, 250.0])
+
+
+def test_frequencies_with_an_extra_axis_raises() -> None:
+    """A `frequencies` of the right count but the wrong shape is named.
+
+    The counts agree here, so the old count-by-count message read "got 3 for
+    3 bands"; the shapes are what disagree, and they are what is reported.
+    """
+    outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
+    with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
+        building.facade_insulation(
+            outdoor, indoor, rt, frequencies=np.full((1, 3), 125.0)
+        )
 
 
 # --------------------------------------------------------------------------

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -257,6 +257,7 @@ def test_surface_level_of_another_band_count_raises() -> None:
     # R' subtracts 'l2' from 'surface_level' band by band, so the message
     # names both curves and the shapes it just compared.
     outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
+    four_bands = _flat(4, 72.0)
     with pytest.raises(ValueError, match=r"'surface_level'.*'l2'.*same shape"):
         building.facade_insulation(
             outdoor,
@@ -264,7 +265,7 @@ def test_surface_level_of_another_band_count_raises() -> None:
             rt,
             area=10.0,
             volume=62.5,
-            surface_level=_flat(4, 72.0),
+            surface_level=four_bands,
         )
 
 

--- a/tests/building/measurement/test_flanking_transmission.py
+++ b/tests/building/measurement/test_flanking_transmission.py
@@ -316,6 +316,27 @@ def test_indirect_kij_from_flanking_roundtrip() -> None:
     assert recovered[0] == pytest.approx(k_true)
 
 
+def test_indirect_kij_band_count_mismatch_names_every_input() -> None:
+    """The guard names each per-band argument, not just "the inputs"."""
+    with pytest.raises(
+        ValueError,
+        match=r"vibration_reduction_index_from_flanking: "
+        r"'normalized_flanking_level_difference'.*'reduction_index_i'.*"
+        r"'reduction_index_j'.*'absorption_length_i'.*'absorption_length_j'.*"
+        r"same shape, one value per band",
+    ):
+        building.vibration_reduction_index_from_flanking(
+            [50.0, 52.0, 54.0],
+            [45.0, 46.0],
+            [44.0, 45.0, 46.0],
+            2.8,
+            10.0,
+            12.0,
+            [1.5, 1.6, 1.7],
+            [1.4, 1.5, 1.6, 1.7],
+        )
+
+
 # ---------------------------------------------------------------------------
 # Validity criteria
 # ---------------------------------------------------------------------------

--- a/tests/building/measurement/test_floor_covering_improvement.py
+++ b/tests/building/measurement/test_floor_covering_improvement.py
@@ -142,7 +142,7 @@ def test_background_correction_boundary_at_6_subtracts() -> None:
 
 
 def test_background_correction_shape_mismatch() -> None:
-    with pytest.raises(ValueError, match="share their shape"):
+    with pytest.raises(ValueError, match=r"'signal_and_background'.*same shape"):
         building.background_corrected_level([80.0, 70.0], [50.0])
 
 
@@ -306,7 +306,7 @@ def test_impact_improvement_with_background_flags_limited() -> None:
 
 
 def test_impact_improvement_shape_mismatch() -> None:
-    with pytest.raises(ValueError, match="share their shape"):
+    with pytest.raises(ValueError, match=r"'with_covering'.*same shape"):
         building.impact_improvement([75.0, 75.0], [70.0], [500.0, 1000.0])
 
 

--- a/tests/building/measurement/test_heavy_impact.py
+++ b/tests/building/measurement/test_heavy_impact.py
@@ -421,6 +421,13 @@ def test_standardization_rejects_a_mismatched_reverberation_time() -> None:
         building.standardized_maximum_impact_level([70.0, 65.0], 50.0, [1.0, 2.0, 3.0])
 
 
+def test_standardization_rejects_a_mismatched_frequency_axis() -> None:
+    with pytest.raises(ValueError, match=r"'frequency'.*same shape"):
+        building.standardized_maximum_impact_level(
+            [70.0, 65.0, 60.0], 50.0, 0.5, frequency=[63.0, 125.0]
+        )
+
+
 def test_standardization_result_rejects_a_stretched_reverberation_time() -> None:
     """``reverberation_time`` is carried, not drawn, and not recomputed.
 

--- a/tests/building/measurement/test_insulation.py
+++ b/tests/building/measurement/test_insulation.py
@@ -478,6 +478,21 @@ def test_extended_requires_core_bands() -> None:
         building.weighted_rating_extended([40.0] * 18)
 
 
+def test_extended_mismatched_frequencies_name_the_entry_point() -> None:
+    """Both entry points share one validator; each names itself, not it."""
+    freqs = [100.0 * 2.0 ** (k / 3.0) for k in range(16)]
+    with pytest.raises(
+        ValueError,
+        match=r"weighted_rating_extended: 'values_by_band'.*'frequencies'.*same shape",
+    ):
+        building.weighted_rating_extended([40.0] * 18, freqs)
+    with pytest.raises(
+        ValueError,
+        match=r"weighted_impact_rating_extended: 'values_by_band'.*'frequencies'",
+    ):
+        building.weighted_impact_rating_extended([40.0] * 18, freqs)
+
+
 def test_one_decimal_rating_annex_b() -> None:
     """ISO 12999-1:2020 Annex B: the 0,1 dB shift yields Rw = 57,4 dB and the
     one-decimal sums Rw + C50-5000 = 56,4 / Rw + Ctr,50-5000 = 51,1 dB.

--- a/tests/building/measurement/test_intensity_insulation.py
+++ b/tests/building/measurement/test_intensity_insulation.py
@@ -189,7 +189,7 @@ def test_fpi_is_lp_minus_lin() -> None:
 
 
 def test_fpi_shape_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="share their shape"):
+    with pytest.raises(ValueError, match=r"'lp'.*'l_in'.*same shape"):
         building.surface_pressure_intensity_indicator([60.0, 58.0], [55.0])
 
 
@@ -264,14 +264,21 @@ def test_reduction_rejects_nonpositive_areas() -> None:
 
 
 def test_reduction_band_count_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(ValueError, match=r"'lp1'.*'l_in'.*same shape"):
         building.intensity_sound_reduction(
             [80.0, 80.0], [40.0], measurement_area=10.0, area=10.0
         )
 
 
+def test_element_normalized_band_count_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match=r"'lp1'.*'l_in'.*same shape"):
+        building.intensity_element_normalized_difference(
+            [80.0, 80.0], [40.0], measurement_area=10.0
+        )
+
+
 def test_kc_band_count_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(ValueError, match=r"'lp1'.*'kc'.*same shape"):
         building.intensity_sound_reduction(
             [80.0], [40.0], measurement_area=10.0, area=10.0, kc=[1.0, 2.0]
         )

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -250,8 +250,8 @@ def test_manual_impact_result_renders(tmp_path) -> None:
 
 
 def test_report_rejects_band_count_mismatch(tmp_path) -> None:
-    """A rating whose per-band arrays are shorter than the curve raises a clear
-    ValueError (not an uncaught IndexError).
+    """A rating whose per-band arrays are shorter than the curve raises a
+    ValueError naming each array and its shape (not an uncaught IndexError).
     """
     import dataclasses
 
@@ -265,5 +265,9 @@ def test_report_rejects_band_count_mismatch(tmp_path) -> None:
     )
     bad = dataclasses.replace(res, rating=short)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="matching per-band lengths"):
+    with pytest.raises(
+        ValueError,
+        match=r"LabAirborneInsulationResult\.report: .*'rating\.band_centers' "
+        r".* must all have the same shape, one value per band",
+    ):
         bad.report(out)

--- a/tests/building/measurement/test_lab_insulation.py
+++ b/tests/building/measurement/test_lab_insulation.py
@@ -230,7 +230,9 @@ def test_background_correction_feeds_r() -> None:
 def test_airborne_band_count_mismatch() -> None:
     l1, t2 = np.full(16, 80.0), np.full(16, 0.8)
     short_l2 = np.full(5, 30.0)
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(
+        ValueError, match=r"lab_airborne_insulation: 'l1' .*'l2' .*same shape"
+    ):
         building.lab_airborne_insulation(l1, short_l2, t2, area=10.0, volume=50.0)
 
 
@@ -276,7 +278,9 @@ def test_impact_bad_volume() -> None:
 
 
 def test_background_shape_mismatch() -> None:
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(
+        ValueError, match=r"background_correction: 'signal_and_background' .*same shape"
+    ):
         building.background_correction([60.0, 50.0], [50.0])
 
 

--- a/tests/building/measurement/test_survey_insulation.py
+++ b/tests/building/measurement/test_survey_insulation.py
@@ -95,6 +95,16 @@ def test_airborne_energy_averages_positions() -> None:
     np.testing.assert_allclose(multi.d, single.d)
 
 
+def test_airborne_room_levels_of_different_lengths_raise() -> None:
+    """The message names both rooms, since either one may be the wrong one."""
+    with pytest.raises(
+        ValueError, match=r"survey_airborne_insulation: 'l1' .*'l2' .*same shape"
+    ):
+        building.survey_airborne_insulation(
+            np.full(_OCTAVE, 80.0), np.full(3, 45.0), np.zeros(_OCTAVE)
+        )
+
+
 # ---------------------------------------------------------------------------
 # Impact (Formulas (8), (9), (10))
 # ---------------------------------------------------------------------------
@@ -126,6 +136,16 @@ def test_facade_d2m_family() -> None:
     assert res.d_2m_nt[0] == pytest.approx(37.0)  # D2m + k
     assert res.d_2m_n[0] == pytest.approx(35.0 + 2.0 + _norm(40.0))
     assert res.rating is not None
+
+
+def test_facade_outdoor_and_indoor_levels_of_different_lengths_raise() -> None:
+    """The outdoor and receiving-room levels are subtracted band by band."""
+    with pytest.raises(
+        ValueError, match=r"survey_facade_insulation: 'l1_2m' .*'l2' .*same shape"
+    ):
+        building.survey_facade_insulation(
+            np.full(_OCTAVE, 75.0), np.full(4, 40.0), np.zeros(_OCTAVE)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/building/prediction/test_ceiling_plenum.py
+++ b/tests/building/prediction/test_ceiling_plenum.py
@@ -472,6 +472,15 @@ def test_normalization_rejects_a_non_positive_absorption() -> None:
         building.normalized_ceiling_attenuation([90.0], [50.0], 0.0)
 
 
+def test_normalization_rejects_levels_over_different_bands() -> None:
+    """Dn,c is a band-by-band difference, so L1 and L2 must share their bands.
+
+    The message names both spectra and the shapes it compared.
+    """
+    with pytest.raises(ValueError, match=r"'level_source'.*'level_receiving'.*shape"):
+        building.normalized_ceiling_attenuation([90.0, 88.0, 86.0], [50.0, 49.0], 10.0)
+
+
 # ---------------------------------------------------------------------------
 # One-dimensional plenum model (Vigran Eqs. (9.13), (9.18) to (9.20))
 # ---------------------------------------------------------------------------
@@ -766,6 +775,55 @@ def test_plenum_model_rejects_a_non_positive_height() -> None:
     with pytest.raises(ValueError, match="plenum_height"):
         building.plenum_flanking_reduction_index(
             [30.0], [30.0], ceiling_length=4.75, plenum_height=0.0
+        )
+
+
+def test_plenum_model_rejects_ceilings_over_different_bands() -> None:
+    """RS and RR are added band by band, so they must run over the same ones."""
+    with pytest.raises(
+        ValueError,
+        match=r"'reduction_index_source'.*'reduction_index_receiving'.*shape",
+    ):
+        building.plenum_flanking_reduction_index(
+            [30.0, 35.0, 40.0],
+            [28.0, 33.0],
+            ceiling_length=4.75,
+            plenum_height=0.43,
+        )
+
+
+def test_plenum_model_rejects_frequencies_of_another_length() -> None:
+    """The band axis is carried into the result and plotted against Rcl."""
+    with pytest.raises(
+        ValueError, match=r"'reduction_index_source'.*'frequency'.*shape"
+    ):
+        building.plenum_flanking_reduction_index(
+            [30.0, 35.0, 40.0],
+            [28.0, 33.0, 38.0],
+            ceiling_length=4.75,
+            plenum_height=0.43,
+            frequency=[125.0, 250.0],
+        )
+
+
+def test_plenum_model_names_which_attenuation_coefficient_disagrees() -> None:
+    """mS and mR are checked one by one, not as an indivisible pair.
+
+    The message points at the odd one out, naming every coefficient and the
+    band axis they were measured against.
+    """
+    with pytest.raises(
+        ValueError,
+        match=r"'reduction_index_source'.*'attenuation_source'"
+        r".*'attenuation_receiving'.*shape",
+    ):
+        building.plenum_flanking_reduction_index(
+            [30.0, 35.0, 40.0],
+            [28.0, 33.0, 38.0],
+            ceiling_length=4.75,
+            plenum_height=0.43,
+            attenuation_source=[0.5, 0.5],
+            attenuation_receiving=[0.5, 0.5, 0.5],
         )
 
 

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -845,7 +845,14 @@ def test_radiation_factor_rejects_invalid_geometry(kwargs: dict, message: str) -
 
 def test_perimeter_absorption_rejects_mismatched_lengths() -> None:
     """Formula (C.4) needs one ``Kij`` per connected element."""
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"perimeter_absorption_coefficient: 'critical_frequencies' .*"
+            r"'vibration_reduction_indices' .*same shape, "
+            r"one value per connected element"
+        ),
+    ):
         building.perimeter_absorption_coefficient([100.0, 200.0], [6.0])
 
 

--- a/tests/building/prediction/test_facade.py
+++ b/tests/building/prediction/test_facade.py
@@ -374,13 +374,34 @@ def test_area_element_requires_positive_area() -> None:
         element.tau(10.0, 1)
 
 
-def test_inconsistent_band_counts_raise() -> None:
+def test_inconsistent_band_counts_name_each_element() -> None:
+    """The guard names the elements that disagree, not just "the elements"."""
     elements = [
         building.FacadeElement(name="a", area=5.0, r=[40.0, 41.0, 42.0]),
         building.FacadeElement(name="b", area=5.0, r=[30.0, 31.0]),
     ]
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(
+        ValueError,
+        match=r"facade_sound_reduction: 'a \(r\)'.*'b \(r\)'.*"
+        r"same shape, one value per band",
+    ):
         building.facade_sound_reduction(elements, area=10.0, volume=50.0)
+
+
+def test_inconsistent_band_counts_leave_the_scalar_element_out() -> None:
+    """A scalar broadcasts, so it is not one of the shapes in dispute."""
+    elements = [
+        building.FacadeElement(name="a", area=5.0, r=[40.0, 41.0, 42.0]),
+        building.FacadeElement(name="b", area=5.0, r=30.0),
+        building.FacadeElement(name="c", dn_e=[30.0, 31.0]),
+    ]
+    with pytest.raises(
+        ValueError,
+        match=r"radiated_sound_power: 'a \(r\)'.*'c \(dn_e\)'.*"
+        r"same shape, one value per band",
+    ) as err:
+        building.radiated_sound_power(elements, lp_in=70.0, area=10.0)
+    assert "'b (r)'" not in str(err.value)
 
 
 def test_scalar_broadcasts_to_band_count() -> None:

--- a/tests/building/regulation/test_spanish_building_code.py
+++ b/tests/building/regulation/test_spanish_building_code.py
@@ -679,7 +679,7 @@ def test_global_index_validation() -> None:
     two_dimensional = np.zeros((2, 18))
     with pytest.raises(ValueError, match="one-dimensional"):
         hr.db_hr_global_index(two_dimensional)
-    with pytest.raises(ValueError, match="one value per band"):
+    with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
         hr.db_hr_global_index(_R_PRIME, frequencies=[100.0, 125.0])
     with pytest.raises(ValueError, match="positive"):
         hr.db_hr_global_index(_R_PRIME, frequencies=[0.0, *hr.DB_HR_FREQUENCIES[1:]])

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -90,7 +90,9 @@ def test_attenuation_emission_length_mismatch_raises(tmp_path) -> None:
     result = _attenuation()
     bad = environment.SourceEmission(sound_power_level=np.full(4, 100.0))
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="one value per frequency"):
+    with pytest.raises(
+        ValueError, match=r"'source_emission\.sound_power_level'.*same shape"
+    ):
         result.report(out, source_emission=bad)
 
 

--- a/tests/materials/absorbers/test_absorption_uncertainty.py
+++ b/tests/materials/absorbers/test_absorption_uncertainty.py
@@ -164,9 +164,11 @@ def test_frequency_must_be_tabulated() -> None:
 
 
 def test_shape_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="same shape"):
+    with pytest.raises(ValueError, match=r"'alpha'.*must all have the same shape"):
         materials.sound_absorption_coefficient_uncertainty([0.5, 0.6], [1000])
-    with pytest.raises(ValueError, match="same shape"):
+    with pytest.raises(ValueError, match=r"'alpha_p'.*must all have the same shape"):
+        materials.practical_coefficient_uncertainty([0.5, 0.6], [1000])
+    with pytest.raises(ValueError, match=r"'area'.*must all have the same shape"):
         materials.equivalent_area_uncertainty([5.0, 6.0], [500])
 
 

--- a/tests/materials/absorbers/test_airflow_resistance.py
+++ b/tests/materials/absorbers/test_airflow_resistance.py
@@ -159,9 +159,9 @@ def test_static_velocity_above_limit_warns() -> None:
             lambda: static_airflow_resistance([1e-3], [12.0], 0.008),
             "At least two measurement steps",
         ),
-        (  # length
+        (  # shape
             lambda: static_airflow_resistance([1e-3, 2e-3], [12.0], 0.008),
-            "must have equal length",
+            r"'velocities'.*must all have the same shape",
         ),
         (  # neg u
             lambda: static_airflow_resistance([1e-3, -2e-3], [12.0, 24.0], 0.008),

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -139,14 +139,15 @@ def test_short_per_frequency_array_rejected(
     ``ImpedanceTubeResult`` is a frozen dataclass with no validation, so a
     caller can hand the renderer a result whose arrays disagree in length; the
     value table would then be silently cut short, in the plain four-column
-    branch and in the verbose ``|r|`` branch alike. The renderer names the
-    field it needs of equal length and leaves no PDF behind.
+    branch and in the verbose ``|r|`` branch alike. The renderer names every
+    per-frequency field beside the shape it was given, and leaves no PDF
+    behind.
     """
     result = _result()
     ragged = dataclasses.replace(result, **{field: getattr(result, field)[:-1]})
     out = tmp_path / "iso10534_ragged.pdf"
     metadata = _metadata()
-    with pytest.raises(ValueError, match=field):
+    with pytest.raises(ValueError, match=rf"'{field}'.*same shape"):
         ragged.report(str(out), metadata=metadata, verbose=verbose)
     assert not out.exists()
 

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -503,7 +503,10 @@ def test_measurement_air_attenuation_reduces_area() -> None:
 
 
 def test_measurement_shape_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="share one shape"):
+    with pytest.raises(
+        ValueError,
+        match=r"measure_sound_absorption: .*'t_empty' .* must all have the same shape",
+    ):
         materials.measure_sound_absorption(
             _FREQS, _T1[:-1], _T2, volume=200.0, area=10.8
         )

--- a/tests/materials/diffusers/test_iso17497_report.py
+++ b/tests/materials/diffusers/test_iso17497_report.py
@@ -240,7 +240,10 @@ def test_scattering_short_random_incidence_rejected(tmp_path) -> None:
     result = _scattering()
     short = replace(result, random_incidence=result.random_incidence[:-1])
     out = tmp_path / "scat_short.pdf"
-    with pytest.raises(ValueError, match="'random_incidence'"):
+    with pytest.raises(
+        ValueError,
+        match=r"ScatteringResult\.report: .*'random_incidence'.*same shape",
+    ):
         short.report(str(out))
     assert not out.exists()  # refused before the fiche is written
 
@@ -250,7 +253,10 @@ def test_scattering_verbose_short_specular_rejected(tmp_path) -> None:
     result = _scattering()
     short = replace(result, specular=result.specular[:-1])
     out = tmp_path / "scat_short_verbose.pdf"
-    with pytest.raises(ValueError, match="'specular'"):
+    with pytest.raises(
+        ValueError,
+        match=r"ScatteringResult\.report\(verbose=True\): .*'specular'.*same shape",
+    ):
         short.report(str(out), verbose=True)
     assert not out.exists()
 
@@ -312,7 +318,23 @@ def test_diffusion_short_normalized_rejected(tmp_path) -> None:
     result = _diffusion_spectrum()
     short = replace(result, normalized=result.normalized[:-1])
     out = tmp_path / "diff_short.pdf"
-    with pytest.raises(ValueError, match="'normalized'"):
+    with pytest.raises(
+        ValueError,
+        match=r"DiffusionSpectrum\.report: .*'normalized'.*same shape",
+    ):
+        short.report(str(out))
+    assert not out.exists()
+
+
+def test_diffusion_short_spectrum_rejected(tmp_path) -> None:
+    """A hand-built spectrum whose d is short would cut the fiche table."""
+    result = _diffusion_spectrum()
+    short = replace(result, diffusion=result.diffusion[:-1])
+    out = tmp_path / "diff_short_d.pdf"
+    with pytest.raises(
+        ValueError,
+        match=r"DiffusionSpectrum\.report: .*'diffusion'.*same shape",
+    ):
         short.report(str(out))
     assert not out.exists()
 
@@ -337,6 +359,19 @@ def test_polar_unknown_engine_rejected(tmp_path) -> None:
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
+
+
+def test_polar_short_levels_rejected(tmp_path) -> None:
+    """One level per receiver angle: a short column is refused before rendering."""
+    result = _polar()
+    short = replace(result, levels=result.levels[:-1])
+    out = tmp_path / "polar_short.pdf"
+    with pytest.raises(
+        ValueError,
+        match=r"DiffusionResult\.report: .*'levels'.*one value per receiver angle",
+    ):
+        short.report(str(out))
+    assert not out.exists()
 
 
 def test_polar_spanish_uses_comma_decimal(tmp_path) -> None:

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -579,20 +579,26 @@ def test_scattering_spectrum_recomputes_s_per_band() -> None:
     np.testing.assert_allclose(result.random_incidence, alpha_s)
 
 
-def test_scattering_spectrum_length_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="non-empty, 1-D and equal-length"):
+def test_scattering_spectrum_shape_mismatch_raises() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"scattering_coefficient_spectrum: 'frequencies' "
+            r".*'specular_absorption' .*same shape"
+        ),
+    ):
         scattering_coefficient_spectrum([250.0, 500.0], [0.2], [0.1])
 
 
 def test_scattering_spectrum_empty_raises() -> None:
-    with pytest.raises(ValueError, match="non-empty, 1-D and equal-length"):
+    with pytest.raises(ValueError, match="'frequencies' must be a non-empty 1-D"):
         scattering_coefficient_spectrum([], [], [])
 
 
 def test_scattering_spectrum_rejects_2d_input() -> None:
     # frequencies is documented 1-D; equal-shaped 2-D arrays must be rejected.
     two_d = [[250.0, 500.0], [1000.0, 2000.0]]
-    with pytest.raises(ValueError, match="non-empty, 1-D and equal-length"):
+    with pytest.raises(ValueError, match="'frequencies' must be a non-empty 1-D"):
         scattering_coefficient_spectrum(two_d, two_d, two_d)
 
 
@@ -630,7 +636,7 @@ def test_directional_diffusion_coefficient_matches_scalar() -> None:
 
 def test_directional_diffusion_length_mismatch_raises() -> None:
     with pytest.raises(
-        ValueError, match="'angles' and 'levels' must have the same length"
+        ValueError, match=r"directional_diffusion: .*'levels'.*same shape"
     ):
         directional_diffusion([-30.0, 0.0, 30.0], [70.0, 72.0])
 
@@ -664,12 +670,24 @@ def test_diffusion_spectrum_optional_fields_default_none() -> None:
 
 
 def test_diffusion_spectrum_length_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="non-empty, 1-D and equal-length"):
+    with pytest.raises(ValueError, match=r"diffusion_spectrum: .*'diffusion'.*shape"):
         diffusion_spectrum([250.0, 500.0], [0.3])
 
 
+def test_diffusion_spectrum_empty_raises() -> None:
+    with pytest.raises(ValueError, match="'frequencies' must be a non-empty 1-D"):
+        diffusion_spectrum([], [])
+
+
+def test_diffusion_spectrum_rejects_2d_input() -> None:
+    # frequencies is documented 1-D; equal-shaped 2-D arrays must be rejected.
+    two_d = [[250.0, 500.0], [1000.0, 2000.0]]
+    with pytest.raises(ValueError, match="'frequencies' must be a non-empty 1-D"):
+        diffusion_spectrum(two_d, two_d)
+
+
 def test_diffusion_spectrum_normalized_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="'normalized' must match"):
+    with pytest.raises(ValueError, match=r"diffusion_spectrum: .*'normalized'.*shape"):
         diffusion_spectrum([250.0, 500.0], [0.3, 0.5], normalized=[0.2])
 
 

--- a/tests/materials/surfaces/test_road_absorption.py
+++ b/tests/materials/surfaces/test_road_absorption.py
@@ -337,9 +337,12 @@ def test_one_third_octave_clipping() -> None:
 
 
 def test_one_third_octave_guards() -> None:
-    with pytest.raises(ValueError, match="must be non-empty and equal-length"):
+    with pytest.raises(
+        ValueError,
+        match=r"one_third_octave_absorption: 'frequency' .*'absorption' .*same shape",
+    ):
         one_third_octave_absorption([250.0, 500.0], [0.1])
-    with pytest.raises(ValueError, match="must be non-empty and equal-length"):
+    with pytest.raises(ValueError, match=r"'frequency' .*must be non-empty"):
         one_third_octave_absorption([], [])
 
 
@@ -489,7 +492,13 @@ def test_spot_guards() -> None:
         spot_tube_upper_frequency(0.0)
     with pytest.raises(ValueError, match="'f_min' must be less than 'f_max'"):
         spot_microphone_spacing_bounds(340.0, f_min=1800.0, f_max=220.0)
-    with pytest.raises(ValueError, match="must share a shape"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"spot_internal_loss_correction: 'measured_absorption' "
+            r".*'system_absorption' .*same shape"
+        ),
+    ):
         spot_internal_loss_correction([0.1, 0.2], [0.1])
 
 

--- a/tests/test_internal_validation.py
+++ b/tests/test_internal_validation.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 
 from phonometry._internal.validation import (
+    require_equal_shapes,
     require_ranks,
     require_same_length,
     require_same_shape,
@@ -188,3 +189,29 @@ def test_the_message_names_the_result_the_fields_and_the_counts() -> None:
     assert "'first' (16)" in message
     assert "'second' (17)" in message
     assert "one value per band" in message
+
+
+def test_equal_shapes_names_the_entry_point_and_every_shape() -> None:
+    """The loose-arguments form, for a function validating what it was passed.
+
+    There is no instance to read fields off, so the caller states the label and
+    the shape. The owner is the name the caller typed, not the private
+    validator it happened to reach.
+    """
+    with pytest.raises(ValueError, match="'y'") as caught:
+        require_equal_shapes("coherence", {"x": (3, 2), "y": (3, 4)}, "sample")
+    message = str(caught.value)
+    assert "coherence:" in message
+    assert "'x' (3, 2)" in message
+    assert "one value per sample" in message
+
+
+def test_equal_shapes_is_quiet_when_they_agree() -> None:
+    require_equal_shapes("coherence", {"x": (3, 2), "y": (3, 2)}, "sample")
+
+
+def test_equal_shapes_sees_what_a_count_cannot() -> None:
+    """Two grids of the same height agree on every count a length check reads."""
+    require_equal_shapes("f", {"a": (3,), "b": (3,)})
+    with pytest.raises(ValueError, match="'b'"):
+        require_equal_shapes("f", {"a": (3, 2), "b": (3, 4)})

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -207,7 +207,17 @@ def test_render_modules_only_type_check_domain_imports() -> None:
     for ``_plot/geometry/emission.py`` two dots are still ``_plot`` and it
     takes three. An import escapes when its level exceeds the module's own
     depth below the rendering root.
+
+    ``_internal`` is not domain code and is exempt. Counting dots is a proxy
+    for "reaches the domain", and it is the right proxy for every package but
+    this one: the eight modules under ``_internal`` import numpy, scipy and the
+    standard library and **nothing from this package at all**, so importing one
+    can no more drag a domain module into a rendering leaf than importing numpy
+    can. Without the exemption the shared guards would have to be imported
+    inside every function that validates an argument, which is a worse file for
+    a rule that was never about them.
     """
+    exempt = "_internal"
     checked = False
     for sub in ("_plot", "_report"):
         render_dir = SRC / sub
@@ -218,12 +228,15 @@ def test_render_modules_only_type_check_domain_imports() -> None:
             depth = len(path.relative_to(render_dir).parts)
             tree = ast.parse(path.read_text(encoding="utf-8"))
             for node in tree.body:  # module level only
-                if isinstance(node, ast.ImportFrom) and node.level > depth:
-                    pytest.fail(
-                        f"{path.relative_to(SRC)}:{node.lineno}: module-level "
-                        f"import of domain code '{'.' * node.level}"
-                        f"{node.module or ''}' (must live under TYPE_CHECKING)"
-                    )
+                if not isinstance(node, ast.ImportFrom) or node.level <= depth:
+                    continue
+                if (node.module or "").split(".")[0] == exempt:
+                    continue
+                pytest.fail(
+                    f"{path.relative_to(SRC)}:{node.lineno}: module-level "
+                    f"import of domain code '{'.' * node.level}"
+                    f"{node.module or ''}' (must live under TYPE_CHECKING)"
+                )
     if not checked:
         pytest.skip("neither _plot nor _report created yet")
 


### PR DESCRIPTION
Stacked on #619, which did the same for the checks that compared lengths.

A check that two arrays must have the same shape said only that they must. The shapes it had just measured went unmentioned, so a reader went back to print by hand what the exception had already computed:

```
before:  'signal_and_background' and 'background' must share their shape.
after:   background_correction: 'signal_and_background' (3, 8), 'background' (3, 6) must all have the same shape, one value per band.
```

These move onto `require_equal_shapes`, which is new here. The module already had a bound-to-an-instance form for shapes but no loose-arguments form, although it has both for lengths, so this is the missing half of a pair rather than a new idea: `require_equal_shapes` is to `require_same_shape` what `require_equal_counts` is to `require_same_length`. The bound one now delegates to it instead of building the same sentence a second time.

This pull request carries the shared helper and the building, materials and rendering trees. The rest of the packages follow in the one stacked on top, so that each stays inside the review limits.

## The architecture gate

A rendering leaf may not import domain code at module level, and the gate approximates "reaches the domain" by counting the dots an import climbs. That proxy is right for every package but one. The eight modules under `_internal` import numpy, scipy and the standard library, and nothing at all from this package, so importing one can no more drag a domain module into a rendering leaf than importing numpy can.

Without the exemption the shared guards would have had to be imported inside every function that validates an argument, in nine files, which is a worse tree for a rule that was never about them. The gate still fails on a real domain import; I checked by adding one and watching it go red before taking it out again.

## What is deliberately left alone

Seventeen comparable checks stay exactly as they are, and that is the part worth reading. A message is not improved by being made uniform. `require_per_band` is the clearest case: it accepts a scalar and broadcasts it over every band, deliberately refuses a one-element array because broadcasting that one would return an answer that looks perfectly ordinary, and says so in the message. Replacing it would gain two shapes it already printed and lose the clause that a scalar is admissible.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Improve shape validation errors throughout the building, materials, plotting, and reporting APIs by reporting the compared inputs and their shapes.

New Features:
- Add a shared validation helper that reports the compared argument names and shapes when shape agreement is required.

Bug Fixes:
- Improve shape-mismatch errors across building, materials, plotting, and reporting APIs so they identify all relevant inputs and their shapes.
- Ensure rendering and reporting paths reject mismatched multidimensional data before producing incomplete or misleading output.

Enhancements:
- Make instance-based shape validation delegate to the shared shape-comparison helper while preserving scalar broadcasting and specialized validation messages.
- Expand shape validation coverage across measurement, prediction, regulation, materials, plotting, and report generation code.
- Allow the architecture check to exempt internal utility imports that do not reach domain code.

Documentation:
- Update API reference descriptions to refer to mismatched shapes rather than lengths and clarify related validation conditions.

Tests:
- Add and update validation, reporting, architecture, and domain tests to verify descriptive shape-mismatch errors, multidimensional mismatches, scalar broadcasting, and early rendering failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for mismatched array shapes across measurement, prediction, reporting, and material-analysis workflows.
  * Inputs with matching element counts but incompatible dimensions are now correctly rejected.
  * Validation errors now identify affected inputs and expected shapes more clearly.
  * Added stricter checks for empty or non-one-dimensional frequency inputs where applicable.

* **Documentation**
  * Updated API references to accurately describe shape-based validation and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->