### PR TITLE
Say the shapes in the remaining packages

### DIFF
--- a/site/src/content/docs/reference/api/rooms/open-plan.md
+++ b/site/src/content/docs/reference/api/rooms/open-plan.md
@@ -71,7 +71,7 @@ the distraction distance `rD` (STI = 0.50) and privacy distance
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If fewer than four positions are given (Clause 5.2.2) or the three arrays differ in length. |
+| ValueError | If fewer than four positions are given (Clause 5.2.2) or the three arrays differ in shape. |
 
 ## OpenPlanResult
 

--- a/site/src/content/docs/reference/api/underwater/weighting.md
+++ b/site/src/content/docs/reference/api/underwater/weighting.md
@@ -254,7 +254,7 @@ dual-metric rule requires.
 | Name | Description |
 | :--- | :--- |
 | `frequency_hz` | Band centre frequencies, in Hz (1-D, positive). |
-| `band_sel` | Per-band single-event SEL, in dB re 1 µPa²·s (or dB re (20 µPa)²·s for an in-air group); same length. `-inf` is accepted for a band that carries no energy, which is what [`strike_sel_spectrum`](/phonometry/reference/api/underwater/pile-driving-noise/#strike_sel_spectrum) returns for bands narrower than its FFT bin spacing; such a band adds nothing to the energy sum. Both input arrays are copied, so the result never aliases the caller's data. |
+| `band_sel` | Per-band single-event SEL, in dB re 1 µPa²·s (or dB re (20 µPa)²·s for an in-air group); same shape. `-inf` is accepted for a band that carries no energy, which is what [`strike_sel_spectrum`](/phonometry/reference/api/underwater/pile-driving-noise/#strike_sel_spectrum) returns for bands narrower than its FFT bin spacing; such a band adds nothing to the energy sum. Both input arrays are copied, so the result never aliases the caller's data. |
 | `group` | Hearing-group code as used by `guidance`. |
 | `guidance` | `"nmfs-2024"` (default), `"nmfs-2018"` or `"southall-2019"`. |
 | `impulsive` | Compare against the impulsive criteria (the default, the case for pile driving and air guns). |

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -27,7 +27,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -467,12 +471,11 @@ def epnl_from_pnlt(
     dt_arr = (
         np.full(p.shape, float(dt_raw.reshape(-1)[0])) if dt_raw.size == 1 else dt_raw
     )
-    if (
-        dt_arr.shape != p.shape
-        or np.any(dt_arr <= 0.0)
-        or not np.all(np.isfinite(dt_arr))
-    ):
-        msg = "'dt' must be positive and match 'pnlt' in length."
+    require_equal_shapes(
+        "epnl_from_pnlt", {"pnlt": p.shape, "dt": dt_arr.shape}, "record"
+    )
+    if np.any(dt_arr <= 0.0) or not np.all(np.isfinite(dt_arr)):
+        msg = "'dt' must be positive and finite."
         raise ValueError(msg)
     if reference_time <= 0.0 or not np.isfinite(reference_time):
         msg = "'reference_time' must be a positive, finite number."
@@ -482,8 +485,11 @@ def epnl_from_pnlt(
     delta_b = 0.0
     if tone_corrections is not None:
         c = np.atleast_1d(np.asarray(tone_corrections, dtype=np.float64))
-        if c.shape != p.shape or not np.all(np.isfinite(c)):
-            msg = "'tone_corrections' must match 'pnlt' in length and be finite."
+        require_equal_shapes(
+            "epnl_from_pnlt", {"pnlt": p.shape, "tone_corrections": c.shape}, "record"
+        )
+        if not np.all(np.isfinite(c)):
+            msg = "'tone_corrections' must be finite."
             raise ValueError(msg)
         t_mid = np.cumsum(dt_arr) - 0.5 * dt_arr
         window = c[np.abs(t_mid - t_mid[km]) <= 1.0 + 1e-9]

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -57,6 +57,7 @@ import numpy as np
 
 from .._internal.validation import (
     require_choice,
+    require_equal_shapes,
     require_positive,
     require_positive_array,
     require_ranks,
@@ -607,8 +608,16 @@ def flight_condition_weights(
     """
     v = np.atleast_1d(np.asarray(airspeeds, dtype=np.float64))
     g = np.atleast_1d(np.asarray(path_angles, dtype=np.float64))
-    if v.ndim != 1 or v.shape != g.shape or v.size < 1:
-        msg = "'airspeeds' and 'path_angles' must be 1-D of equal, non-zero size."
+    require_equal_shapes(
+        "flight_condition_weights",
+        {"airspeeds": v.shape, "path_angles": g.shape},
+        "flight condition",
+    )
+    if v.ndim != 1 or v.size < 1:
+        msg = (
+            "'airspeeds' and 'path_angles' must be 1-D and non-empty; "
+            f"got shape {v.shape}."
+        )
         raise ValueError(msg)
     if not (np.all(np.isfinite(v)) and np.all(np.isfinite(g))):
         msg = "'airspeeds' and 'path_angles' must be finite."

--- a/src/phonometry/aircraft/rotorcraft_propagation.py
+++ b/src/phonometry/aircraft/rotorcraft_propagation.py
@@ -58,6 +58,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    require_equal_shapes,
     require_non_negative,
     require_positive,
     require_positive_array,
@@ -493,9 +494,11 @@ def mean_flow_resistivity(
     """
     d = require_positive_array(lengths, "lengths")
     sig = require_positive_array(resistivities, "resistivities")
-    if d.shape != sig.shape:
-        msg = "'lengths' and 'resistivities' must have equal shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "mean_flow_resistivity",
+        {"lengths": d.shape, "resistivities": sig.shape},
+        "segment",
+    )
     return float(10.0 ** (np.sum(d * np.log10(sig)) / np.sum(d)))
 
 

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    require_equal_shapes,
     require_positive,
     require_ranks,
     require_same_length,
@@ -653,8 +654,13 @@ def _resolve_polar(
         return None, None, polar_frequency, directivity.index_db
     p_ang = np.atleast_1d(np.asarray(polar[0], dtype=np.float64))
     p_db = np.atleast_1d(np.asarray(polar[1], dtype=np.float64))
-    if p_ang.ndim != 1 or p_ang.shape != p_db.shape:
-        msg = "'polar' angles and levels must be 1-D and equal length."
+    require_equal_shapes(
+        "loudspeaker_characteristics",
+        {"polar angles": p_ang.shape, "polar levels": p_db.shape},
+        "angle",
+    )
+    if p_ang.ndim != 1:
+        msg = f"'polar' angles and levels must be 1-D; got shape {p_ang.shape}."
         raise ValueError(msg)
     if not (np.all(np.isfinite(p_ang)) and np.all(np.isfinite(p_db))):
         msg = "'polar' angles and levels must be finite."

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -67,7 +67,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_positive, require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_shapes,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 from .loudspeaker import _as_curve, _threshold_crossing
 
 if TYPE_CHECKING:
@@ -652,8 +657,13 @@ def _resolve_polar(
         return None, None, index_db
     p_ang = np.atleast_1d(np.asarray(polar[0], dtype=np.float64))
     p_db = np.atleast_1d(np.asarray(polar[1], dtype=np.float64))
-    if p_ang.ndim != 1 or p_ang.shape != p_db.shape:
-        msg = "'polar' angles and levels must be 1-D and equal length."
+    require_equal_shapes(
+        "microphone_characteristics",
+        {"polar angles": p_ang.shape, "polar levels": p_db.shape},
+        "angle",
+    )
+    if p_ang.ndim != 1:
+        msg = f"'polar' angles and levels must be 1-D; got shape {p_ang.shape}."
         raise ValueError(msg)
     if p_ang.size < _MIN_CURVE_POINTS:
         msg = "'polar' needs at least two angle points."

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -71,6 +71,7 @@ from .._internal.utils import _typesignal
 from .._internal.validation import (
     require_axis_count,
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -854,12 +855,11 @@ def field_indicators(
             "field_indicators expects 1D (positions,) or 2D (positions, bands) arrays."
         )
         raise ValueError(msg)
-    if lp.shape != i_n.shape:
-        msg = (
-            f"'pressure_levels' and 'normal_intensity' must have the same "
-            f"shape, got {lp.shape} and {i_n.shape}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "field_indicators",
+        {"pressure_levels": lp.shape, "normal_intensity": i_n.shape},
+        "position",
+    )
     if lp.shape[0] < _MIN_VARIATION_OBSERVATIONS:
         msg = "At least two measurement positions are required."
         raise ValueError(msg)

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -100,7 +100,11 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 from .._internal.levels_math import energy_mean, weighted_energy_mean
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ._shared import SoundPowerWarning, _a_weighting_corrections, _check_grade
 from .intensity import dynamic_capability_index
 
@@ -1126,12 +1130,11 @@ def precision_field_indicators(
     """
     i_n = np.atleast_2d(np.asarray(segment_intensity, dtype=np.float64))
     lp = np.atleast_2d(np.asarray(segment_pressure_levels, dtype=np.float64))
-    if i_n.shape != lp.shape:
-        msg = (
-            "'segment_intensity' and 'segment_pressure_levels' must have the "
-            f"same shape, got {i_n.shape} and {lp.shape}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "precision_field_indicators",
+        {"segment_intensity": i_n.shape, "segment_pressure_levels": lp.shape},
+        "segment",
+    )
     n_seg = i_n.shape[0]
     if n_seg < _MIN_STDDEV_SAMPLES:
         msg = "At least two segments are required for the indicators."

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
 
 
 from .._internal.validation import (
+    require_equal_shapes,
     require_positive,
     require_ranks,
     require_same_length,
@@ -159,9 +160,11 @@ def mean_velocity_level(levels: ArrayLike, areas: ArrayLike | None = None) -> fl
         mean_energy = float(np.mean(energy))
     else:
         s = np.asarray(areas, dtype=np.float64)
-        if s.shape != lv.shape:
-            msg = "'areas' must match the shape of 'levels'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "mean_velocity_level",
+            {"levels": lv.shape, "areas": s.shape},
+            "position",
+        )
         mean_energy = float(np.sum(s * energy) / np.sum(s))
     return float(10.0 * np.log10(mean_energy))
 
@@ -436,9 +439,11 @@ def sound_power_from_vibration(
     freq = None
     if frequencies is not None:
         freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
-        if freq.shape != lv.shape:
-            msg = "'frequencies' must match the shape of 'velocity_level'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "sound_power_from_vibration",
+            {"velocity_level": lv.shape, "frequencies": freq.shape},
+            "band",
+        )
     return VibrationSoundPowerResult(
         velocity_level=lv,
         sound_power_level=np.asarray(lw, dtype=np.float64),

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -64,7 +64,11 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -314,12 +318,11 @@ def impulse_prominence(
     if orate.size == 0:
         msg = "at least one impulse is required."
         raise ValueError(msg)
-    if orate.shape != ld.shape:
-        msg = (
-            f"onset_rates and level_differences must have the same shape; "
-            f"got {orate.shape} and {ld.shape}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "impulse_prominence",
+        {"onset_rates": orate.shape, "level_differences": ld.shape},
+        "impulse",
+    )
     per_impulse = predicted_prominence(orate, ld)
     qualifies = orate > ONSET_RATE_LIMIT
     if not np.all(qualifies):
@@ -375,9 +378,11 @@ def rating_level(
     le = np.atleast_1d(np.asarray(laeq, dtype=np.float64))
     ki = np.atleast_1d(np.asarray(adjustment, dtype=np.float64))
     dt = np.atleast_1d(np.asarray(durations, dtype=np.float64))
-    if not le.shape == ki.shape == dt.shape:
-        msg = "laeq, adjustment and durations must have equal length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "rating_level",
+        {"laeq": le.shape, "adjustment": ki.shape, "durations": dt.shape},
+        "sub-interval",
+    )
     if le.size == 0:
         msg = "at least one sub-interval is required."
         raise ValueError(msg)

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -85,7 +85,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -431,12 +435,11 @@ def _validate_kt_spectrum(band_levels: np.ndarray, freqs: np.ndarray) -> None:
     if band_levels.ndim != 1 or freqs.ndim != 1:
         msg = "'levels' and 'frequencies' must be one-dimensional."
         raise ValueError(msg)
-    if band_levels.shape != freqs.shape:
-        msg = (
-            "'levels' and 'frequencies' must have the same length; got "
-            f"{band_levels.size} and {freqs.size}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "tonal_correction",
+        {"levels": band_levels.shape, "frequencies": freqs.shape},
+        "band",
+    )
     if band_levels.size < _MIN_KT_BANDS:
         msg = (
             "At least three one-third-octave bands are needed: the procedure "
@@ -775,12 +778,11 @@ def long_term_corrected_level(
         counts = np.ones_like(levels)
     else:
         counts = np.asarray(weights, dtype=np.float64).ravel()
-        if counts.shape != levels.shape:
-            msg = (
-                "'weights' must have one value per daily level; got "
-                f"{counts.size} for {levels.size} levels."
-            )
-            raise ValueError(msg)
+        require_equal_shapes(
+            "long_term_corrected_level",
+            {"daily_levels": levels.shape, "weights": counts.shape},
+            "daily level",
+        )
         if not np.all(np.isfinite(counts)) or np.any(counts <= 0.0):
             msg = "'weights' must contain positive, finite values."
             raise ValueError(msg)

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -55,6 +55,7 @@ import numpy as np
 
 from ..._internal.rays import march_rays
 from ..._internal.validation import (
+    require_equal_shapes,
     require_positive,
     require_ranks,
     require_same_length,
@@ -246,9 +247,11 @@ def _clean_profile(
     if z.ndim != 1 or z.size < _MIN_POLYLINE_NODES:
         msg = "the profile must have at least two height samples."
         raise ValueError(msg)
-    if c.shape != z.shape:
-        msg = "'sound_speeds' must match 'heights' in length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "EffectiveSoundSpeedProfile",
+        {"heights": z.shape, "sound_speeds": c.shape},
+        "profile node",
+    )
     if not (np.all(np.isfinite(z)) and np.all(np.isfinite(c))):
         msg = "the profile heights and speeds must be finite."
         raise ValueError(msg)

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -82,7 +82,9 @@ import numpy as np
 
 from ..._internal.validation import (
     require_axis_count,
+    require_axis_rank,
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -2033,12 +2035,12 @@ def roughness_to_frequency(
     """
     y = np.asarray(levels, dtype=np.float64)
     lam = np.asarray(wavelengths, dtype=np.float64) / 1000.0
-    if y.ndim != 1 or y.shape != lam.shape:
-        msg = (
-            "'levels' and 'wavelengths' must be one-dimensional and of the "
-            f"same length; got {y.shape} and {lam.shape}."
-        )
-        raise ValueError(msg)
+    require_axis_rank(y, "roughness_to_frequency", "levels", 1)
+    require_equal_shapes(
+        "roughness_to_frequency",
+        {"levels": y.shape, "wavelengths": lam.shape},
+        "wavelength",
+    )
     if np.any(lam <= 0.0):
         msg = "'wavelengths' must all be positive."
         raise ValueError(msg)

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -30,7 +30,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -53,7 +57,7 @@ _HANNING_ENBW_FACTOR = 1.5
 #: Low-frequency band where the critical band is fixed to 20-120 Hz.
 _LOW_FREQ_MIN, _LOW_FREQ_MAX = 20.0, 70.0
 _LOW_FREQ_BANDWIDTH = 100.0
-#: Minimum lines of a valid narrowband spectrum (the error message's ">= 3"):
+#: Minimum lines of a valid narrowband spectrum, named in the error message:
 #: the smallest size with more than one np.diff spacing to compare and
 #: adjacent lines about the candidate peak for the 9.5.2 screen.
 _MIN_SPECTRUM_LINES = 3
@@ -309,8 +313,19 @@ def _validate_narrowband(
     """Coerce and validate a uniformly-spaced narrowband spectrum."""
     lv = np.asarray(levels, dtype=np.float64)
     fr = np.asarray(frequencies, dtype=np.float64)
-    if lv.ndim != 1 or lv.shape != fr.shape or lv.size < _MIN_SPECTRUM_LINES:
-        msg = "'levels' and 'frequencies' must be 1-D and the same length (>= 3)."
+    require_equal_shapes(
+        "wind_turbine_tonality",
+        {"levels": lv.shape, "frequencies": fr.shape},
+        "line",
+    )
+    if lv.ndim != 1:
+        msg = f"'levels' and 'frequencies' must be 1-D; got shape {lv.shape}."
+        raise ValueError(msg)
+    if lv.size < _MIN_SPECTRUM_LINES:
+        msg = (
+            "'levels' and 'frequencies' must carry at least "
+            f"{_MIN_SPECTRUM_LINES} lines; got {lv.size}."
+        )
         raise ValueError(msg)
     if not (np.all(np.isfinite(lv)) and np.all(np.isfinite(fr))):
         msg = "'levels' and 'frequencies' must be finite."

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -69,6 +69,7 @@ import numpy as np
 
 from .._internal.validation import (
     require_choice,
+    require_equal_shapes,
     require_positive,
     require_ranks,
     require_same_length,
@@ -284,6 +285,7 @@ def _resolve_interior(
     frequencies: ArrayLike | None,
     model: str,
     name: str,
+    owner: str,
 ) -> tuple[
     NDArray[np.float64] | None,
     NDArray[np.float64],
@@ -298,6 +300,10 @@ def _resolve_interior(
     ``values`` (a panel ``R`` for :func:`enclosure_insertion_loss`, a target
     ``IL`` for :func:`enclosure_required_transmission_loss`), and returns
     ``(frequencies, values, correction C, room constant R_i, S_E, S_i)``.
+
+    *name* is the parameter the spectrum arrived under and *owner* the entry
+    point the caller typed, so a band count that disagrees is reported in the
+    caller's own vocabulary rather than in this helper's.
     """
     s_e = require_positive(external_area, "external_area")
     s_i = require_positive(internal_area, "internal_area")
@@ -316,9 +322,17 @@ def _resolve_interior(
 
     r_i = np.atleast_1d(np.asarray(room_constant(s_i, alpha), dtype=np.float64))
     r_i_b, v_b = np.broadcast_arrays(r_i, v)
-    if freqs is not None and freqs.shape != v_b.shape:
-        msg = f"'frequencies' must match the number of {name} / absorption bands."
-        raise ValueError(msg)
+    if freqs is not None:
+        # The band count is whatever the spectrum and the absorption broadcast
+        # to, so either of them can be the one that disagrees with the labels.
+        require_equal_shapes(
+            owner,
+            {
+                "frequencies": freqs.shape,
+                f"{name} / internal_absorption": v_b.shape,
+            },
+            "band",
+        )
     correction = 10.0 * np.log10(floor + s_e / r_i_b)
     return (
         freqs,
@@ -390,7 +404,8 @@ def enclosure_insertion_loss(
         internal_absorption,
         frequencies,
         model,
-        "panel_transmission_loss",
+        name="panel_transmission_loss",
+        owner="enclosure_insertion_loss",
     )
     return EnclosureResult(
         frequencies=freqs,
@@ -447,7 +462,8 @@ def enclosure_required_transmission_loss(
         internal_absorption,
         frequencies,
         model,
-        "insertion_loss",
+        name="insertion_loss",
+        owner="enclosure_required_transmission_loss",
     )
     return EnclosureResult(
         frequencies=freqs,

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -100,6 +100,7 @@ import numpy as np
 
 from ..._internal.validation import (
     require_equal_counts,
+    require_equal_shapes,
     require_ranks,
     require_same_length,
 )
@@ -1059,12 +1060,14 @@ def mean_audibility_uncertainty(
     if deltas.size == 0:
         msg = "'decisive_audibilities' must not be empty."
         raise ValueError(msg)
-    if deltas.shape != uncertainties.shape:
-        msg = (
-            "'decisive_audibilities' and 'extended_uncertainties' must share "
-            "their length."
-        )
-        raise ValueError(msg)
+    require_equal_shapes(
+        "mean_audibility_uncertainty",
+        {
+            "decisive_audibilities": deltas.shape,
+            "extended_uncertainties": uncertainties.shape,
+        },
+        "spectrum",
+    )
     if not (np.all(np.isfinite(deltas)) and np.all(np.isfinite(uncertainties))):
         msg = "Inputs must be finite."
         raise ValueError(msg)
@@ -1382,9 +1385,14 @@ def assess_tones(
     uncertainties: NDArray[np.float64] | None = None
     if extended_uncertainties is not None:
         uncertainties = np.asarray(extended_uncertainties, dtype=np.float64)
-        if uncertainties.shape != freqs.shape:
-            msg = "'extended_uncertainties' must match 'tone_frequencies' in length."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "assess_tones",
+            {
+                "tone_frequencies": freqs.shape,
+                "extended_uncertainties": uncertainties.shape,
+            },
+            "tone",
+        )
         if not np.all(np.isfinite(uncertainties)):
             msg = "'extended_uncertainties' must be finite."
             raise ValueError(msg)

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -71,7 +71,11 @@ import numpy as np
 from scipy import signal
 
 from .._internal.utils import _typesignal
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import (
     apply_calibration,
@@ -955,12 +959,17 @@ def _shaped_target_db(
         raise ValueError(msg)
     t_freq = np.asarray(target[0], dtype=np.float64)
     t_db = np.asarray(target[1], dtype=np.float64)
-    if t_freq.ndim != 1 or t_freq.size < 2 or t_db.shape != t_freq.shape:  # noqa: PLR2004
+    if t_freq.ndim != 1 or t_freq.size < 2:  # noqa: PLR2004
         msg = (
             "an array target must be a (frequencies_hz, magnitude_db) pair "
-            "of equal-length 1-D arrays with at least 2 points"
+            "of 1-D arrays with at least 2 points"
         )
         raise ValueError(msg)
+    require_equal_shapes(
+        "shaped_sweep_signal",
+        {"frequencies_hz": t_freq.shape, "magnitude_db": t_db.shape},
+        "frequency",
+    )
     if np.any(t_freq <= 0.0) or np.any(np.diff(t_freq) <= 0.0):
         msg = "target frequencies must be positive and increasing"
         raise ValueError(msg)

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -38,7 +38,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -425,8 +429,17 @@ def _criterion_curve_at(
     )
 
 
-def _align_levels(levels: ArrayLike, frequencies: ArrayLike | None) -> np.ndarray:
-    """Validate levels and align them to :data:`OCTAVE_BANDS`."""
+def _align_levels(
+    levels: ArrayLike, frequencies: ArrayLike | None, owner: str
+) -> np.ndarray:
+    """Validate levels and align them to :data:`OCTAVE_BANDS`.
+
+    :param levels: Octave-band sound pressure levels, in dB.
+    :param frequencies: Optional band centre frequencies matching ``levels``.
+    :param owner: Name of the entry point the caller typed, for the messages.
+    :return: The levels on the ten :data:`OCTAVE_BANDS`, absent bands NaN.
+    :raises ValueError: for malformed inputs or unknown band frequencies.
+    """
     lv = np.atleast_1d(np.asarray(levels, dtype=np.float64))
     if lv.ndim != 1:
         msg = "levels must be a 1-D vector of octave-band levels."
@@ -440,9 +453,7 @@ def _align_levels(levels: ArrayLike, frequencies: ArrayLike | None) -> np.ndarra
             raise ValueError(msg)
         return lv
     fr = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
-    if fr.shape != lv.shape:
-        msg = "levels and frequencies must have the same shape."
-        raise ValueError(msg)
+    require_equal_shapes(owner, {"levels": lv.shape, "frequencies": fr.shape}, "band")
     aligned = np.full(_N_BANDS, np.nan)
     for f, level in zip(fr, lv, strict=True):
         matches = np.isclose(OCTAVE_BANDS, f, rtol=0.03)
@@ -486,7 +497,7 @@ def noise_criterion(
     :return: An :class:`NCResult` with the designation and its ``.plot()``.
     :raises ValueError: for malformed inputs or unknown band frequencies.
     """
-    aligned = _align_levels(levels, frequencies)
+    aligned = _align_levels(levels, frequencies, "noise_criterion")
     valid = ~np.isnan(aligned)
     if not valid.any():
         msg = "no valid octave-band levels were supplied."
@@ -579,7 +590,7 @@ def room_criterion(levels: ArrayLike, frequencies: ArrayLike | None = None) -> R
     :return: An :class:`RCResult` with the rating, tag and its ``.plot()``.
     :raises ValueError: if the 500/1000/2000 Hz mid-frequency bands are absent.
     """
-    aligned = _align_levels(levels, frequencies)
+    aligned = _align_levels(levels, frequencies, "room_criterion")
     mid = aligned[5:8]  # 500, 1000, 2000 Hz.
     if np.isnan(mid).any():
         msg = (

--- a/src/phonometry/room/open_plan.py
+++ b/src/phonometry/room/open_plan.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import require_equal_shapes
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -249,15 +251,21 @@ def open_plan_metrics(
     :return: :class:`OpenPlanResult` with ``d2s``, ``lp_as_4m``, ``rd``
         and ``rp``.
     :raises ValueError: If fewer than four positions are given
-        (Clause 5.2.2) or the three arrays differ in length.
+        (Clause 5.2.2) or the three arrays differ in shape.
     """
     r = np.asarray(positions_m, dtype=np.float64)
     lp = np.asarray(spl_a_speech, dtype=np.float64)
     sti = np.asarray(sti_values, dtype=np.float64)
 
-    if not (r.shape == lp.shape == sti.shape):
-        msg = "positions_m, spl_a_speech and sti_values must have the same length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "open_plan_metrics",
+        {
+            "positions_m": r.shape,
+            "spl_a_speech": lp.shape,
+            "sti_values": sti.shape,
+        },
+        "position",
+    )
     if r.ndim != 1:
         msg = "Inputs must be one-dimensional."
         raise ValueError(msg)

--- a/src/phonometry/simulation/ntff.py
+++ b/src/phonometry/simulation/ntff.py
@@ -68,6 +68,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from scipy.special import hankel2
 
+from .._internal.validation import require_equal_shapes
+
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, NDArray
 
@@ -190,7 +192,15 @@ class ContourPhasors:
         if not np.isclose(self.frequency, reference.frequency):
             msg = "cannot subtract phasors at different frequencies"
             raise ValueError(msg)
-        if self.positions.shape != reference.positions.shape or not (
+        require_equal_shapes(
+            "ContourPhasors.subtract",
+            {
+                "positions": self.positions.shape,
+                "reference.positions": reference.positions.shape,
+            },
+            "sample",
+        )
+        if not (
             np.allclose(self.positions, reference.positions)
             and np.allclose(self.normals, reference.normals)
         ):

--- a/src/phonometry/speech/objective_intelligibility.py
+++ b/src/phonometry/speech/objective_intelligibility.py
@@ -44,7 +44,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ..io._resolve import apply_calibration, resolve_pair_fs
 
 if TYPE_CHECKING:
@@ -273,11 +277,7 @@ def _validate_pair(
     if x.ndim != 1 or y.ndim != 1:
         msg = "'clean' and 'degraded' must be 1-D signals."
         raise ValueError(msg)
-    if x.shape != y.shape:
-        msg = (
-            f"'clean' and 'degraded' must have equal length; got {x.size} and {y.size}."
-        )
-        raise ValueError(msg)
+    require_equal_shapes("stoi", {"clean": x.shape, "degraded": y.shape}, "sample")
     if x.size == 0:
         msg = "'clean' and 'degraded' must be non-empty."
         raise ValueError(msg)

--- a/src/phonometry/underwater/bioacoustics/weighting.py
+++ b/src/phonometry/underwater/bioacoustics/weighting.py
@@ -61,7 +61,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -821,7 +825,7 @@ def weighted_exposure(
 
     :param frequency_hz: Band centre frequencies, in Hz (1-D, positive).
     :param band_sel: Per-band single-event SEL, in dB re 1 µPa²·s (or
-        dB re (20 µPa)²·s for an in-air group); same length. ``-inf`` is
+        dB re (20 µPa)²·s for an in-air group); same shape. ``-inf`` is
         accepted for a band that carries no energy, which is what
         :func:`~phonometry.underwater.sources.pile_driving_noise.strike_sel_spectrum`
         returns for bands narrower than its FFT bin spacing; such a band adds
@@ -841,9 +845,9 @@ def weighted_exposure(
     """
     f = _positive_frequencies(frequency_hz)
     sel = np.array(band_sel, dtype=np.float64, copy=True, ndmin=1)
-    if sel.shape != f.shape:
-        msg = "'band_sel' must have the same length as 'frequency_hz'."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "weighted_exposure", {"frequency_hz": f.shape, "band_sel": sel.shape}, "band"
+    )
     # -inf is admitted as the level of a band that carries no energy (see
     # StrikeSelSpectrum.band_sel); it is the neutral element of the energy sum.
     if np.any(np.isnan(sel)) or np.any(sel == np.inf):

--- a/src/phonometry/underwater/propagation/numerical.py
+++ b/src/phonometry/underwater/propagation/numerical.py
@@ -58,6 +58,7 @@ import numpy as np
 
 from ..._internal.rays import DynamicRays, SlopingBoundary, march_rays
 from ..._internal.validation import (
+    require_equal_shapes,
     require_positive,
     require_ranks,
     require_same_length,
@@ -131,15 +132,27 @@ _MIN_PE_DEPTH_POINTS = 16
 def _clean_profile(
     depths: NDArray[np.float64] | list[float],
     sound_speeds: NDArray[np.float64] | list[float],
+    owner: str,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """One validated sound-speed profile out of the two node arrays.
+
+    :param depths: Depth nodes of the profile, in metres.
+    :param sound_speeds: Sound speed at each of those depths, in m/s.
+    :param owner: The solver the caller typed, for the error messages: the
+        four of them share this cleaner, and the name in the message should
+        be the one on the call that raised.
+    :return: The coerced ``(depths, sound_speeds)`` pair.
+    :raises ValueError: if the two do not describe one increasing profile
+        from the surface down.
+    """
     z = np.asarray(depths, dtype=np.float64)
     c = np.asarray(sound_speeds, dtype=np.float64)
     if z.ndim != 1 or z.size < _MIN_POLYLINE_NODES:
         msg = "'depths' must be a 1-D array of at least two points."
         raise ValueError(msg)
-    if c.shape != z.shape:
-        msg = "'sound_speeds' must match 'depths' in length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        owner, {"depths": z.shape, "sound_speeds": c.shape}, "profile node"
+    )
     if not (np.all(np.isfinite(z)) and np.all(np.isfinite(c))):
         msg = "'depths' and 'sound_speeds' must be finite."
         raise ValueError(msg)
@@ -161,6 +174,7 @@ def _clean_bathymetry(
     ]
     | None,
     z_prof: NDArray[np.float64],
+    owner: str,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
     """One validated depth(r) polyline out of the node pair, or ``None``.
 
@@ -170,6 +184,15 @@ def _clean_bathymetry(
     column at the source is stated rather than extrapolated, and it may not
     dive below the profile's last node, because the profile *is* the medium
     and a bottom below it would put water where no sound speed was given.
+
+    :param bathymetry: The ``(ranges_m, depths_m)`` node pair, or ``None``.
+    :param z_prof: Depth nodes of the sound-speed profile, whose last node is
+        the deepest water the medium is stated for.
+    :param owner: The solver the caller typed, for the error messages: both
+        of them share this cleaner.
+    :return: The coerced ``(ranges, depths)`` pair, or ``None``.
+    :raises ValueError: if the pair does not describe one increasing bottom
+        polyline from the source, inside the profile.
     """
     if bathymetry is None:
         return None
@@ -179,12 +202,14 @@ def _clean_bathymetry(
         raise ValueError(msg)
     br = np.asarray(pair[0], dtype=np.float64).ravel()
     bd = np.asarray(pair[1], dtype=np.float64).ravel()
-    if br.size < _MIN_POLYLINE_NODES or bd.shape != br.shape:
-        msg = (
-            "the two halves of 'bathymetry' must be 1-D"
-            " arrays of equal length, at least two points."
-        )
+    if br.size < _MIN_POLYLINE_NODES:
+        msg = "the two halves of 'bathymetry' must carry at least two points."
         raise ValueError(msg)
+    require_equal_shapes(
+        owner,
+        {"bathymetry ranges": br.shape, "bathymetry depths": bd.shape},
+        "node",
+    )
     if not (np.all(np.isfinite(br)) and np.all(np.isfinite(bd))):
         msg = "the bathymetry must be finite."
         raise ValueError(msg)
@@ -509,7 +534,7 @@ def normal_modes(
     """
     f = require_positive(frequency_hz, "frequency_hz")
     rho = require_positive(density, "density")
-    z_prof, c_prof = _clean_profile(depths, sound_speeds)
+    z_prof, c_prof = _clean_profile(depths, sound_speeds, "normal_modes")
     water_depth = float(z_prof[-1])
     zs = float(source_depth)
     zr = float(receiver_depth)
@@ -870,8 +895,8 @@ def ray_trace(
     :return: A :class:`RayTraceResult`.
     :raises ValueError: If the inputs are invalid.
     """
-    z_prof, c_prof = _clean_profile(depths, sound_speeds)
-    bathy = _clean_bathymetry(bathymetry, z_prof)
+    z_prof, c_prof = _clean_profile(depths, sound_speeds, "ray_trace")
+    bathy = _clean_bathymetry(bathymetry, z_prof, "ray_trace")
     water_depth = float(z_prof[-1])
     depth_at_source = water_depth if bathy is None else float(bathy[1][0])
     zs = float(source_depth)
@@ -3278,8 +3303,8 @@ def gaussian_beams(
     """
     f = require_positive(frequency_hz, "frequency_hz")
     fan = BeamFan() if fan is None else fan
-    z_prof, c_prof = _clean_profile(depths, sound_speeds)
-    bathy = _clean_bathymetry(bathymetry, z_prof)
+    z_prof, c_prof = _clean_profile(depths, sound_speeds, "gaussian_beams")
+    bathy = _clean_bathymetry(bathymetry, z_prof, "gaussian_beams")
     water_depth = float(z_prof[-1])
     depth_at_source = water_depth if bathy is None else float(bathy[1][0])
     zs = float(source_depth)
@@ -3641,7 +3666,7 @@ def parabolic_equation(
     from scipy.fft import dst, idst
 
     f = require_positive(frequency_hz, "frequency_hz")
-    z_prof, c_prof = _clean_profile(depths, sound_speeds)
+    z_prof, c_prof = _clean_profile(depths, sound_speeds, "parabolic_equation")
     water_depth = float(z_prof[-1])
     zs = float(source_depth)
     if not (0.0 < zs < water_depth):

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -46,7 +46,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_same_shape
+from .._internal.validation import require_equal_shapes, require_same_shape
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -439,9 +439,11 @@ def detection_range_from_curve(
     fom = _finite(figure_of_merit, "figure_of_merit")
     r = _finite_array(range_m, "range_m")
     pl = _finite_array(propagation_loss, "propagation_loss")
-    if r.shape != pl.shape:
-        msg = "'propagation_loss' must have the same length as 'range_m'."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "detection_range_from_curve",
+        {"range_m": r.shape, "propagation_loss": pl.shape},
+        "sample",
+    )
     if r.size < _MIN_CURVE_POINTS or np.any(np.diff(r) <= 0.0):
         msg = "'range_m' must be strictly increasing with at least two samples."
         raise ValueError(msg)

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -46,7 +46,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_equal_shapes, require_same_shape
+from .._internal.validation import (
+    require_axis_rank,
+    require_equal_shapes,
+    require_same_shape,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -439,6 +443,14 @@ def detection_range_from_curve(
     fom = _finite(figure_of_merit, "figure_of_merit")
     r = _finite_array(range_m, "range_m")
     pl = _finite_array(propagation_loss, "propagation_loss")
+    # Rank before shape: the coercion widens a scalar and never narrows a
+    # grid, so two equal two-dimensional inputs agree on their shape and reach
+    # the crossing search, where the interpolation of a bracketing pair ends in
+    # numpy's "only 0-dimensional arrays can be converted to Python scalars",
+    # which names neither the argument nor this function. A curve is 1-D, as
+    # the signature says.
+    for name, value in (("range_m", r), ("propagation_loss", pl)):
+        require_axis_rank(value, "detection_range_from_curve", name, 1)
     require_equal_shapes(
         "detection_range_from_curve",
         {"range_m": r.shape, "propagation_loss": pl.shape},

--- a/src/phonometry/underwater/sources/ambient_noise.py
+++ b/src/phonometry/underwater/sources/ambient_noise.py
@@ -33,6 +33,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    require_equal_shapes,
+    require_finite_array,
     require_non_negative,
     require_positive,
     require_positive_array,
@@ -218,10 +220,12 @@ def ocean_ambient_noise(
     energies = 10.0 ** (wind / 10.0) + 10.0 ** (thermal / 10.0)
     ship_arr: NDArray[np.float64] | None = None
     if shipping is not None:
-        ship_arr = np.asarray(shipping, dtype=np.float64)
-        if ship_arr.shape != f.shape or not np.all(np.isfinite(ship_arr)):
-            msg = "'shipping' must be finite and match 'frequency_hz' in length."
-            raise ValueError(msg)
+        ship_arr = require_finite_array(shipping, "shipping")
+        require_equal_shapes(
+            "ocean_ambient_noise",
+            {"frequency_hz": f.shape, "shipping": ship_arr.shape},
+            "frequency",
+        )
         energies = energies + 10.0 ** (ship_arr / 10.0)
     spectrum = 10.0 * np.log10(energies)
     return AmbientNoiseResult(

--- a/src/phonometry/underwater/sources/ship_radiated_noise.py
+++ b/src/phonometry/underwater/sources/ship_radiated_noise.py
@@ -28,7 +28,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_equal_shapes,
+    require_ranks,
+    require_same_length,
+)
 from ..acoustics import UNDERWATER_REFERENCE_PRESSURE, _positive
 
 if TYPE_CHECKING:
@@ -244,9 +248,11 @@ def monopole_source_level(
         raise ValueError(msg)
     if rnl_arr.size == 1 and freqs.size > 1:
         rnl_arr = np.full(freqs.shape, rnl_arr[0])
-    if rnl_arr.shape != freqs.shape:
-        msg = "'rnl' and 'frequency' must have the same length."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "monopole_source_level",
+        {"rnl": rnl_arr.shape, "frequency": freqs.shape},
+        "frequency",
+    )
     source_depth = _SOURCE_DEPTH_FRACTION * d
     delta_l = _surface_correction(freqs, source_depth, speed)
     return ShipSourceLevelResult(

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -61,7 +61,7 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy import signal as sig
 
-from ..._internal.validation import require_equal_counts
+from ..._internal.validation import require_equal_counts, require_equal_shapes
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -556,12 +556,14 @@ def weighted_acceleration(
     """
     accel = np.atleast_1d(np.asarray(band_accelerations, dtype=np.float64))
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
-    if accel.ndim != 1 or accel.size == 0 or accel.shape != freq.shape:
-        msg = (
-            "'band_accelerations' and 'frequencies' must be non-empty, 1-D and "
-            "equal-length."
-        )
+    if accel.ndim != 1 or accel.size == 0:
+        msg = "'band_accelerations' must be a non-empty 1-D array."
         raise ValueError(msg)
+    require_equal_shapes(
+        "weighted_acceleration",
+        {"band_accelerations": accel.shape, "frequencies": freq.shape},
+        "band",
+    )
     factors = weighting_factors(weighting, freq)
     weighted = factors * accel
     overall = float(np.sqrt(np.sum(weighted**2)))
@@ -787,9 +789,11 @@ def vibration_total_value(
         factors = np.ones_like(comp)
     else:
         factors = np.atleast_1d(np.asarray(k, dtype=np.float64))
-        if factors.shape != comp.shape:
-            msg = "'k' must have the same length as 'components'."
-            raise ValueError(msg)
+        require_equal_shapes(
+            "vibration_total_value",
+            {"components": comp.shape, "k": factors.shape},
+            "axis",
+        )
     return float(np.sqrt(np.sum((factors * comp) ** 2)))
 
 
@@ -878,11 +882,14 @@ def hav_daily_exposure(
     """
     ahv = np.atleast_1d(np.asarray(total_values, dtype=np.float64))
     t = np.atleast_1d(np.asarray(durations_s, dtype=np.float64))
-    if ahv.ndim != 1 or ahv.size == 0 or ahv.shape != t.shape:
-        msg = (
-            "'total_values' and 'durations_s' must be non-empty, 1-D and equal-length."
-        )
+    if ahv.ndim != 1 or ahv.size == 0:
+        msg = "'total_values' must be a non-empty 1-D array."
         raise ValueError(msg)
+    require_equal_shapes(
+        "hav_daily_exposure",
+        {"total_values": ahv.shape, "durations_s": t.shape},
+        "operation",
+    )
     if np.any(ahv < 0.0) or np.any(t < 0.0):
         msg = "'total_values' and 'durations_s' must be non-negative."
         raise ValueError(msg)
@@ -905,9 +912,14 @@ def energy_equivalent_acceleration(
     """
     a = np.atleast_1d(np.asarray(magnitudes, dtype=np.float64))
     t = np.atleast_1d(np.asarray(durations_s, dtype=np.float64))
-    if a.ndim != 1 or a.size == 0 or a.shape != t.shape:
-        msg = "'magnitudes' and 'durations_s' must be non-empty, 1-D and equal-length."
+    if a.ndim != 1 or a.size == 0:
+        msg = "'magnitudes' must be a non-empty 1-D array."
         raise ValueError(msg)
+    require_equal_shapes(
+        "energy_equivalent_acceleration",
+        {"magnitudes": a.shape, "durations_s": t.shape},
+        "period",
+    )
     if np.any(t < 0.0):
         msg = "'durations_s' must be non-negative."
         raise ValueError(msg)
@@ -1139,11 +1151,14 @@ def daily_vibration_exposure(
     """
     ahv = np.atleast_1d(np.asarray(total_values, dtype=np.float64))
     t = np.atleast_1d(np.asarray(durations_s, dtype=np.float64))
-    if ahv.ndim != 1 or ahv.size == 0 or ahv.shape != t.shape:
-        msg = (
-            "'total_values' and 'durations_s' must be non-empty, 1-D and equal-length."
-        )
+    if ahv.ndim != 1 or ahv.size == 0:
+        msg = "'total_values' must be a non-empty 1-D array."
         raise ValueError(msg)
+    require_equal_shapes(
+        "daily_vibration_exposure",
+        {"total_values": ahv.shape, "durations_s": t.shape},
+        "operation",
+    )
     if labels is None:
         labels = tuple(f"op {i + 1}" for i in range(ahv.size))
     else:

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -66,7 +66,12 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import numpy as np
 
 from ..._internal.types import as_float_or_array
-from ..._internal.validation import require_1d_signal, require_choice, require_positive
+from ..._internal.validation import (
+    require_1d_signal,
+    require_choice,
+    require_equal_shapes,
+    require_positive,
+)
 from ...hearing.threshold import SEXES as _SEXES
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -291,9 +296,15 @@ def daily_dose_multi(
     dz = np.asarray(doses, dtype=np.float64).ravel()
     td = np.asarray(exposure_times, dtype=np.float64).ravel()
     tm = np.asarray(measurement_times, dtype=np.float64).ravel()
-    if not dz.shape == td.shape == tm.shape:
-        msg = "doses, exposure_times and measurement_times must match."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "daily_dose_multi",
+        {
+            "doses": dz.shape,
+            "exposure_times": td.shape,
+            "measurement_times": tm.shape,
+        },
+        "exposure condition",
+    )
     if dz.size == 0:
         msg = "at least one condition is required."
         raise ValueError(msg)

--- a/src/phonometry/vibration/structural/mechanical_mobility.py
+++ b/src/phonometry/vibration/structural/mechanical_mobility.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
 
 
 from ..._internal.validation import (
+    require_equal_shapes,
     require_non_negative,
     require_positive,
     require_ranks,
@@ -396,9 +397,11 @@ def rigid_mass_calibration_check(
     tolerance = require_positive(tolerance, "tolerance")
     freq = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     measured = np.abs(np.atleast_1d(np.asarray(frf, dtype=np.complex128)))
-    if measured.shape != freq.shape:
-        msg = "'frf' and 'frequencies' must have the same shape."
-        raise ValueError(msg)
+    require_equal_shapes(
+        "rigid_mass_calibration_check",
+        {"frf": measured.shape, "frequencies": freq.shape},
+        "frequency",
+    )
     omega = _omega(freq)
     if quantity == "accelerance":
         expected = np.full_like(freq, 1.0 / mass)

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -227,6 +227,24 @@ def test_epnl_single_element_dt_treated_as_scalar() -> None:
     assert a == pytest.approx(b, rel=1e-12)
 
 
+def test_epnl_names_the_record_history_that_disagrees() -> None:
+    # A per-record dt or tone correction is matched record for record; the
+    # message names the offender rather than only that two things must agree.
+    p = np.array([90.0, 95.0, 90.0])
+    with pytest.raises(ValueError, match=r"'dt'.*same shape"):
+        epnl_from_pnlt(p, [0.5, 0.5])
+    with pytest.raises(ValueError, match=r"'tone_corrections'.*same shape"):
+        epnl_from_pnlt(p, 0.5, tone_corrections=[0.0, 0.0])
+
+
+def test_epnl_rejects_non_positive_and_non_finite_records() -> None:
+    p = np.array([90.0, 95.0, 90.0])
+    with pytest.raises(ValueError, match="'dt' must be positive"):
+        epnl_from_pnlt(p, np.full(3, -0.5))
+    with pytest.raises(ValueError, match="'tone_corrections' must be finite"):
+        epnl_from_pnlt(p, 0.5, tone_corrections=np.full(3, np.nan))
+
+
 def test_effective_perceived_noise_level_rejects_bad_shape() -> None:
     two_dimensional = np.zeros((5, 10))
     with pytest.raises(ValueError, match=r"'spectra' must have shape \(K, 24\)"):

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -1141,8 +1141,10 @@ def test_fc_weights_lookup_table_is_honoured() -> None:
 
 
 def test_fc_weights_validation() -> None:
-    with pytest.raises(ValueError, match="equal, non-zero size"):
+    with pytest.raises(ValueError, match=r"'path_angles'.*same shape"):
         flight_condition_weights([50.0, 60.0], [0.0], 55.0, 0.0)
+    with pytest.raises(ValueError, match=r"'airspeeds'.*non-empty"):
+        flight_condition_weights([[50.0, 60.0]], [[0.0, 1.0]], 55.0, 0.0)
     with pytest.raises(ValueError, match="finite"):
         flight_condition_weights([50.0, 60.0], [0.0, 0.0], np.nan, 0.0)
     with pytest.raises(ValueError, match="shape"):

--- a/tests/aircraft/test_rotorcraft_terrain.py
+++ b/tests/aircraft/test_rotorcraft_terrain.py
@@ -82,7 +82,7 @@ def test_mean_flow_resistivity_log_average() -> None:
     # Length weighting: 3:1 towards 1e6.
     got = aircraft.mean_flow_resistivity([1.0, 3.0], [1.0e4, 1.0e6])
     assert got == pytest.approx(10.0 ** (0.25 * 4.0 + 0.75 * 6.0))
-    with pytest.raises(ValueError, match="equal shape"):
+    with pytest.raises(ValueError, match=r"'resistivities'.*same shape"):
         aircraft.mean_flow_resistivity([1.0, 2.0], [1.0e5])
 
 

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -198,6 +198,29 @@ def test_mismatched_response_lengths_rejected() -> None:
         )
 
 
+def test_mismatched_polar_pair_rejected() -> None:
+    """A polar pattern whose two halves disagree names both and their shapes."""
+    f, spl = _flat_response()
+    ragged_polar = electroacoustics.LoudspeakerDirectivity(
+        polar=([0.0, 90.0, 180.0], [0.0, -3.0]), frequency=1000.0
+    )
+    with pytest.raises(ValueError, match="'polar angles'.*same shape"):
+        electroacoustics.loudspeaker_characteristics(
+            f, spl, _R, directivity=ragged_polar
+        )
+
+
+def test_two_dimensional_polar_rejected() -> None:
+    """A polar pattern of matching but two-dimensional halves is still refused."""
+    f, spl = _flat_response()
+    grid_polar = electroacoustics.LoudspeakerDirectivity(
+        polar=([[0.0, 90.0], [180.0, 270.0]], [[0.0, -3.0], [-6.0, -3.0]]),
+        frequency=1000.0,
+    )
+    with pytest.raises(ValueError, match="'polar' angles and levels must be 1-D"):
+        electroacoustics.loudspeaker_characteristics(f, spl, _R, directivity=grid_polar)
+
+
 def test_sensitivity_band_out_of_range_rejected() -> None:
     f, spl = _flat_response()
     with pytest.raises(ValueError, match="no on-axis response samples"):

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -366,6 +366,30 @@ def test_empty_polar_rejected() -> None:
         )
 
 
+def test_mismatched_polar_pair_rejected() -> None:
+    """A pattern with more angles than levels names both shapes."""
+    f, rel = _flat_response()
+    ragged_polar = electroacoustics.MicrophoneDirectivity(
+        polar=([0.0, 90.0, 180.0], [0.0, -3.0])
+    )
+    with pytest.raises(ValueError, match="'polar angles'.*same shape"):
+        electroacoustics.microphone_characteristics(
+            f, rel, _M_MV, directivity=ragged_polar
+        )
+
+
+def test_two_dimensional_polar_rejected() -> None:
+    """Angles and levels agreeing on a two-dimensional shape are still refused."""
+    f, rel = _flat_response()
+    grid_polar = electroacoustics.MicrophoneDirectivity(
+        polar=([[0.0, 90.0], [180.0, 270.0]], [[0.0, -3.0], [-6.0, -3.0]])
+    )
+    with pytest.raises(ValueError, match="'polar' angles and levels must be 1-D"):
+        electroacoustics.microphone_characteristics(
+            f, rel, _M_MV, directivity=grid_polar
+        )
+
+
 def test_nonfinite_stated_directivity_index_rejected_with_polar() -> None:
     """A non-finite stated DI is rejected whether or not a pattern is given."""
     f, rel = _flat_response()

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -302,7 +302,9 @@ def test_field_indicators_negative_partial_power() -> None:
 
 
 def test_field_indicators_validation() -> None:
-    with pytest.raises(ValueError, match="same shape"):
+    with pytest.raises(
+        ValueError, match=r"'pressure_levels'.*'normal_intensity'.*same shape"
+    ):
         emission.field_indicators([90.0, 91.0], [1e-3])
     with pytest.raises(ValueError, match="two measurement positions"):
         emission.field_indicators([90.0], [1e-3])

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -720,7 +720,10 @@ def test_field_indicators_shape_mismatch_raises() -> None:
     mismatched_levels = np.full((3, 1), 60.0)
     with pytest.raises(
         ValueError,
-        match="'segment_intensity' and 'segment_pressure_levels' must have",
+        match=(
+            r"precision_field_indicators: 'segment_intensity' "
+            r".*'segment_pressure_levels' .*same shape"
+        ),
     ):
         precision_field_indicators(intensity, mismatched_levels)
 

--- a/tests/emission/test_vibration_sound_power.py
+++ b/tests/emission/test_vibration_sound_power.py
@@ -64,7 +64,9 @@ def test_mean_velocity_level_area_weighted() -> None:
 
 
 def test_mean_velocity_level_area_shape_mismatch() -> None:
-    with pytest.raises(ValueError, match="areas"):
+    with pytest.raises(
+        ValueError, match=r"mean_velocity_level: 'levels' .*'areas' .*same shape"
+    ):
         emission.mean_velocity_level([60.0, 66.0], areas=[1.0])
 
 
@@ -142,7 +144,11 @@ def test_result_bundle_and_total() -> None:
 
 
 def test_result_frequencies_shape_mismatch() -> None:
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(
+        ValueError,
+        match=r"sound_power_from_vibration: 'velocity_level' .*"
+        r"'frequencies' .*same shape",
+    ):
         emission.sound_power_from_vibration(
             [70.0, 75.0, 72.0], 1.5, frequencies=[250.0, 500.0]
         )

--- a/tests/environment/assessment/test_impulse_prominence.py
+++ b/tests/environment/assessment/test_impulse_prominence.py
@@ -87,9 +87,15 @@ def test_invalid_inputs_raise() -> None:
         nt.predicted_prominence(100.0, -1.0)
     with pytest.raises(ValueError, match="at least one"):
         nt.impulse_prominence([], [])
-    with pytest.raises(ValueError, match="same shape"):
+    with pytest.raises(
+        ValueError,
+        match=r"impulse_prominence: 'onset_rates' .*'level_differences' .*same shape",
+    ):
         nt.impulse_prominence([1.0, 2.0], [1.0])
-    with pytest.raises(ValueError, match="equal length"):
+    with pytest.raises(
+        ValueError,
+        match=r"rating_level: 'laeq' .*'adjustment' .*'durations' .*same shape",
+    ):
         nt.rating_level([70.0, 60.0], [0.0], [30.0, 30.0], 60.0)
     with pytest.raises(ValueError, match="positive"):
         nt.rating_level([70.0], [0.0], [30.0], 0.0)

--- a/tests/environment/assessment/test_spain.py
+++ b/tests/environment/assessment/test_spain.py
@@ -588,7 +588,9 @@ def test_tonal_result_does_not_alias_the_caller_s_arrays() -> None:
 
 def test_tonal_correction_validation() -> None:
     """The Kt spectrum must be one-dimensional, aligned, finite and ascending."""
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError, match=r"tonal_correction: 'levels' .*'frequencies' .*same shape"
+    ):
         rd.tonal_correction([60.0, 60.0], [100.0, 125.0, 160.0])
     with pytest.raises(ValueError, match="At least three"):
         rd.tonal_correction([60.0, 60.0], [100.0, 125.0])
@@ -656,7 +658,7 @@ def test_long_term_level_validation() -> None:
         rd.long_term_corrected_level([])
     with pytest.raises(ValueError, match="finite"):
         rd.long_term_corrected_level([math.nan])
-    with pytest.raises(ValueError, match="one value per"):
+    with pytest.raises(ValueError, match=r"'daily_levels' .*'weights' .*same shape"):
         rd.long_term_corrected_level([50.0, 50.0], weights=[1.0])
     with pytest.raises(ValueError, match="positive"):
         rd.long_term_corrected_level([50.0], weights=[0.0])

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -181,6 +181,19 @@ def test_ground_effect_rejects_non_finite_impedance() -> None:
         environment.ground_effect(_BANDS, 1.0, 1.0, 20.0, impedance=0.0)
 
 
+def test_impedance_is_a_scalar_or_one_value_per_frequency() -> None:
+    # Two admissible forms, and the message names both: a scalar is deliberately
+    # broadcast over every frequency, an array must carry one value per band.
+    broadcast = environment.ground_effect(_BANDS, 1.0, 1.0, 20.0, impedance=10.0 + 5.0j)
+    assert broadcast.normalized_impedance.shape == _BANDS.shape
+    with pytest.raises(ValueError, match=r"'impedance' must be a scalar or match"):
+        environment.ground_effect(_BANDS, 1.0, 1.0, 20.0, impedance=_BANDS[:3] * 1j)
+    with pytest.raises(ValueError, match=r"'impedance' must be a scalar or match"):
+        environment.spherical_reflection_coefficient(
+            _BANDS, _BANDS[:3] * 1j, 1.0, 1.5, 50.0
+        )
+
+
 def test_unknown_ground_model_raises() -> None:
     with pytest.raises(ValueError, match="unknown ground model"):
         environment.ground_effect(

--- a/tests/environment/sources/test_cnossos_rail.py
+++ b/tests/environment/sources/test_cnossos_rail.py
@@ -873,8 +873,15 @@ def test_invalid_inputs() -> None:
         rolling_sound_power(roughness, roughness, 0)
     with pytest.raises(ValueError, match="non-negative number of m"):
         impact_roughness(roughness, -1.0)
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError,
+        match=r"roughness_to_frequency: 'levels' .*'wavelengths' .*same shape",
+    ):
         roughness_to_frequency([1.0, 2.0], [1.0], 50.0)
+    with pytest.raises(
+        ValueError, match=r"roughness_to_frequency: 'levels' must have one axis"
+    ):
+        roughness_to_frequency([[1.0, 2.0]], [1.0, 2.0], 50.0)
     with pytest.raises(ValueError, match="'wavelengths' must all be positive"):
         roughness_to_frequency([1.0, 2.0], [1.0, 0.0], 50.0)
     with pytest.raises(ValueError, match="'frequencies' must all be positive"):

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -122,8 +122,24 @@ def test_tonal_audibility_flat_spectrum_not_audible() -> None:
 
 
 def test_tonal_audibility_rejects_short_input() -> None:
-    with pytest.raises(ValueError, match="1-D and the same length"):
+    with pytest.raises(ValueError, match=r"'levels' and 'frequencies' must carry"):
         wind_turbine_tonality([1.0, 2.0], [10.0, 12.0])
+
+
+def test_tonal_audibility_rejects_two_dimensional_spectrum() -> None:
+    # Two spectra stacked into one array: shapes agree, the rank does not.
+    freqs = np.tile(np.arange(100.0, 108.0, 2.0), (2, 1))
+    with pytest.raises(ValueError, match=r"'levels' and 'frequencies' must be 1-D"):
+        wind_turbine_tonality(np.full_like(freqs, 30.0), freqs)
+
+
+def test_tonal_audibility_rejects_mismatched_spectrum() -> None:
+    # One level short of its own frequency axis: the message names both.
+    with pytest.raises(
+        ValueError,
+        match=r"wind_turbine_tonality: 'levels' .*'frequencies' .*same shape",
+    ):
+        wind_turbine_tonality([30.0, 31.0, 32.0], [100.0, 102.0, 104.0, 106.0])
 
 
 def test_tonal_audibility_rejects_non_monotonic_frequencies() -> None:

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -191,6 +191,27 @@ def test_validation() -> None:
         noise_control.enclosure_insertion_loss([20.0], 6.0, 5.0, 0.3, model="hansen")
 
 
+def test_frequency_labels_off_the_band_count_are_refused() -> None:
+    """The labels must run over the bands the enclosure was solved on.
+
+    The band count is whatever the supplied spectrum and the interior
+    absorption broadcast to, so the message names both: a scalar absorption
+    leaves the spectrum in charge, a per-band one can set the count on its own.
+    """
+    with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
+        noise_control.enclosure_insertion_loss(
+            [20.0, 30.0, 40.0], 6.0, 5.0, 0.3, frequencies=[125.0, 250.0, 500.0, 1000.0]
+        )
+    with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
+        noise_control.enclosure_insertion_loss(
+            [20.0], 6.0, 5.0, np.array([0.1, 0.2, 0.3]), frequencies=[125.0]
+        )
+    with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
+        noise_control.enclosure_required_transmission_loss(
+            [10.0, 20.0], 6.0, 5.0, 0.3, frequencies=[125.0, 250.0, 500.0]
+        )
+
+
 @pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
 def test_a_room_constant_off_the_band_axis_is_refused(trim: bool) -> None:
     """``R_i`` is the column a fiche prints without complaining.

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -393,7 +393,9 @@ def test_chain_shunt_accepts_a_constant_and_rejects_a_mismatch() -> None:
     # A constant impedance has no least value inside the grid.
     assert chain.elements[1].shorting_frequency is None
     empty = sl.SilencerChain(f)
-    with pytest.raises(ValueError, match="one value per analysis frequency"):
+    with pytest.raises(
+        ValueError, match=r"'branch_impedance' must be a scalar or hold one value"
+    ):
         empty.shunt(np.ones(7, dtype=np.complex128))
 
 

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -657,6 +657,23 @@ def test_assess_tones_rejects_length_mismatch() -> None:
         psychoacoustics.assess_tones([100.0, 200.0], [60.0], [50.0], 2.7)
 
 
+def test_assess_tones_rejects_uncertainty_mismatch() -> None:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"assess_tones: 'tone_frequencies' .*'extended_uncertainties' .* "
+            r"same shape, one value per tone"
+        ),
+    ):
+        psychoacoustics.assess_tones(
+            [100.0, 200.0],
+            [60.0, 61.0],
+            [50.0, 51.0],
+            2.7,
+            extended_uncertainties=[1.0],
+        )
+
+
 def test_assess_tones_rejects_empty() -> None:
     with pytest.raises(ValueError, match="At least one tone is required"):
         psychoacoustics.assess_tones([], [], [], 2.7)
@@ -777,7 +794,13 @@ def test_uncertainty_constants_and_validation() -> None:
         psychoacoustics.audibility_uncertainty([], [50.0], 137.3, 2.7)
     with pytest.raises(ValueError, match="finite"):
         psychoacoustics.audibility_uncertainty([60.0, np.nan], [50.0], 137.3, 2.7)
-    with pytest.raises(ValueError, match="share their length"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"mean_audibility_uncertainty: 'decisive_audibilities' .*"
+            r"'extended_uncertainties' .* same shape, one value per spectrum"
+        ),
+    ):
         psychoacoustics.mean_audibility_uncertainty([9.18, 6.04], [3.21])
 
 

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -230,7 +230,9 @@ def test_rc_requires_mid_frequency_bands() -> None:
 def test_invalid_inputs_raise() -> None:
     with pytest.raises(ValueError, match="octave-band values"):
         rn.noise_criterion([1.0, 2.0, 3.0])
-    with pytest.raises(ValueError, match="same shape"):
+    with pytest.raises(
+        ValueError, match=r"noise_criterion: 'levels'.*must all have the same shape"
+    ):
         rn.noise_criterion([1.0, 2.0], [63.0])
     with pytest.raises(ValueError, match="not one of"):
         rn.noise_criterion([50.0], [777.0])

--- a/tests/room/test_open_plan.py
+++ b/tests/room/test_open_plan.py
@@ -100,11 +100,14 @@ def test_too_few_positions_raises() -> None:
 
 
 def test_mismatched_lengths_raise() -> None:
-    """Position / level / STI arrays must have equal length."""
+    """Position / level / STI arrays must have equal shape."""
     r = np.array([2.0, 4.0, 8.0, 16.0])
     lp = 70.0 - 6.0 * np.log2(r)
     sti = np.array([0.6, 0.4, 0.2])  # one short
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError,
+        match=r"open_plan_metrics: .*'sti_values'.*must all have the same shape",
+    ):
         room.open_plan_metrics(r, lp, sti)
 
 

--- a/tests/room/test_shaped_sweep.py
+++ b/tests/room/test_shaped_sweep.py
@@ -182,8 +182,13 @@ def test_rejects_bad_inputs() -> None:
     with pytest.raises(ValueError, match="unknown named target"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target="blue")
     mismatched = (np.array([100.0, 200.0]), np.array([0.0]))
-    with pytest.raises(ValueError, match="equal-length"):
+    with pytest.raises(
+        ValueError, match=r"'frequencies_hz'.*'magnitude_db'.*same shape"
+    ):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=mismatched)
+    too_short = (np.array([100.0]), np.array([0.0]))
+    with pytest.raises(ValueError, match=r"array target.*at least 2 points"):
+        room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=too_short)
     decreasing = (np.array([200.0, 100.0]), np.array([0.0, 0.0]))
     with pytest.raises(ValueError, match="increasing"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=decreasing)

--- a/tests/simulation/test_fdtd_ntff.py
+++ b/tests/simulation/test_fdtd_ntff.py
@@ -539,12 +539,22 @@ def test_contour_phasors_subtract_mismatch() -> None:
     sim = FDTD2D(C0, 0.01, shape=(40, 50))
     p1 = sim.add_contour_probe(5, 10, 20, 25, frequencies=[F0, 2.0 * F0])
     p2 = sim.add_contour_probe(5, 11, 20, 25, frequencies=[F0])
+    p3 = sim.add_contour_probe(6, 11, 20, 25, frequencies=[F0])
     sim.run(4)
     base = p1.phasors(F0)
     harmonic = p1.phasors(2.0 * F0)
-    shifted = p2.phasors(F0)
+    longer = p2.phasors(F0)
+    shifted = p3.phasors(F0)
     with pytest.raises(ValueError, match="different frequencies"):
         base.subtract(harmonic)
+    with pytest.raises(
+        ValueError,
+        match=r"ContourPhasors\.subtract: 'positions' .*'reference\.positions' "
+        r".*same shape",
+    ):
+        base.subtract(longer)
+    # Same sample count, one cell along: only the coordinates disagree.
+    assert shifted.positions.shape == base.positions.shape
     with pytest.raises(ValueError, match="different contours"):
         base.subtract(shifted)
 

--- a/tests/speech/test_objective_intelligibility.py
+++ b/tests/speech/test_objective_intelligibility.py
@@ -122,7 +122,7 @@ def test_input_validation() -> None:
     with_nan[0] = np.nan
     empty = np.array([])
 
-    with pytest.raises(ValueError, match="equal length"):
+    with pytest.raises(ValueError, match=r"stoi: 'clean'.*'degraded'.*same shape"):
         speech.stoi(x, shorter, FS)
     with pytest.raises(ValueError, match="1-D"):
         speech.stoi(two_d, two_d, FS)

--- a/tests/test_device_geometry_plots.py
+++ b/tests/test_device_geometry_plots.py
@@ -289,6 +289,10 @@ def test_piston_geometry_with_and_without_lobe() -> None:
         pm.electroacoustics.plot_piston_geometry(0.0)
     with pytest.raises(ValueError, match="together"):
         pm.electroacoustics.plot_piston_geometry(0.1, angles=angles)
+    with pytest.raises(ValueError, match=r"'directivity'.*same shape"):
+        pm.electroacoustics.plot_piston_geometry(
+            0.1, angles=angles, directivity=np.ones(angles.size - 1)
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/underwater/bioacoustics/test_weighting.py
+++ b/tests/underwater/bioacoustics/test_weighting.py
@@ -485,7 +485,7 @@ def test_invalid_frequencies_raise(frequency: list[float]) -> None:
 
 
 def test_mismatched_band_spectrum_raises() -> None:
-    with pytest.raises(ValueError, match="band_sel"):
+    with pytest.raises(ValueError, match="band_sel.*same shape"):
         weighted_exposure([100.0, 200.0], [170.0], "LF")
 
 

--- a/tests/underwater/propagation/test_bathymetry.py
+++ b/tests/underwater/propagation/test_bathymetry.py
@@ -672,8 +672,10 @@ def test_invalid_bathymetry_is_rejected() -> None:
     good = {"source_depth": 60.0, "launch_angles_deg": [10.0], "max_range": 1000.0}
     with pytest.raises(ValueError, match="pair"):
         ray_trace([0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, 1000.0],))  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="equal length"):
+    with pytest.raises(ValueError, match=r"ray_trace: 'bathymetry ranges'.*same shape"):
         ray_trace([0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, 1000.0], [200.0]))
+    with pytest.raises(ValueError, match="at least two points"):
+        ray_trace([0.0, 200.0], [_C, _C], **good, bathymetry=([0.0], [200.0]))
     with pytest.raises(ValueError, match="strictly increasing"):
         ray_trace(
             [0.0, 200.0],

--- a/tests/underwater/propagation/test_numerical.py
+++ b/tests/underwater/propagation/test_numerical.py
@@ -582,6 +582,36 @@ def test_invalid_inputs_rejected() -> None:
         )
 
 
+def test_profile_mismatch_names_the_solver_that_was_called() -> None:
+    """A sound speed missing from the profile names the call that raised.
+
+    The solvers share one profile cleaner, so the message has to carry the
+    name the caller typed rather than the private validator's, and the two
+    halves it compared rather than a bare demand that they agree.
+    """
+    z = np.array([0.0, 50.0, 100.0])
+    c = np.array([1500.0, 1500.0])
+    calls = (
+        (
+            "normal_modes",
+            lambda: normal_modes(50.0, z, c, source_depth=25.0, receiver_depth=35.0),
+        ),
+        (
+            "ray_trace",
+            lambda: ray_trace(z, c, source_depth=25.0, launch_angles_deg=[10.0]),
+        ),
+        (
+            "parabolic_equation",
+            lambda: parabolic_equation(50.0, z, c, source_depth=25.0),
+        ),
+    )
+    for name, call in calls:
+        with pytest.raises(
+            ValueError, match=rf"{name}: 'depths'.*'sound_speeds'.*same shape"
+        ):
+            call()
+
+
 _PER_RANGE = "one value per range"
 _PER_DEPTH = "one value per depth"
 _PER_MODE = "one value per mode"

--- a/tests/underwater/sources/test_ambient_noise.py
+++ b/tests/underwater/sources/test_ambient_noise.py
@@ -104,8 +104,15 @@ def test_shipping_component_added_in_energy() -> None:
 
 
 def test_shipping_length_mismatch_rejected() -> None:
-    with pytest.raises(ValueError, match="shipping"):
+    with pytest.raises(ValueError, match="shipping.*same shape"):
         ocean_ambient_noise([100.0, 1000.0], wind_speed_knots=5.0, shipping=[80.0])
+
+
+def test_shipping_non_finite_rejected() -> None:
+    with pytest.raises(ValueError, match="shipping.*finite"):
+        ocean_ambient_noise(
+            [100.0, 1000.0], wind_speed_knots=5.0, shipping=[80.0, np.nan]
+        )
 
 
 def test_invalid_inputs_rejected() -> None:

--- a/tests/underwater/sources/test_ship_radiated_noise.py
+++ b/tests/underwater/sources/test_ship_radiated_noise.py
@@ -127,5 +127,8 @@ def test_result_plot_smoke() -> None:
 def test_rejects_shape_mismatch() -> None:
     levels_2_bands = np.array([1.0, 2.0])
     frequencies_3_bands = np.array([100.0, 200.0, 300.0])
-    with pytest.raises(ValueError, match="'rnl' and 'frequency'"):
+    with pytest.raises(
+        ValueError,
+        match=r"monopole_source_level: 'rnl'.*must all have the same shape",
+    ):
         underwater.monopole_source_level(levels_2_bands, frequencies_3_bands, 8.0)

--- a/tests/underwater/test_ainslie_worked_examples.py
+++ b/tests/underwater/test_ainslie_worked_examples.py
@@ -307,9 +307,9 @@ def test_detection_range_validates_its_arguments(
 
 
 def test_detection_range_from_curve_validates_its_arguments() -> None:
-    with pytest.raises(ValueError, match="propagation_loss"):
+    with pytest.raises(ValueError, match="propagation_loss.*same shape"):
         detection_range_from_curve(60.0, [1.0, 2.0], [10.0])
-    with pytest.raises(ValueError, match="range_m"):
+    with pytest.raises(ValueError, match="range_m.*strictly increasing"):
         detection_range_from_curve(60.0, [2.0, 1.0], [10.0, 20.0])
     with pytest.raises(ValueError, match="crossing"):
         detection_range_from_curve(60.0, [1.0, 2.0], [10.0, 20.0], crossing="middle")

--- a/tests/underwater/test_sonar_equation.py
+++ b/tests/underwater/test_sonar_equation.py
@@ -18,6 +18,7 @@ import pytest
 from phonometry.underwater.sonar_equation import (
     SonarEquationResult,
     active_sonar_equation,
+    detection_range_from_curve,
     passive_sonar_equation,
 )
 
@@ -239,3 +240,19 @@ def test_ainslie_active_orca_hearing_threshold_fom() -> None:
     # masking level with no array gain and no detection threshold.
     res = active_sonar_equation(198.2, 0.0, -29.0, 51.2)
     assert res.figure_of_merit == pytest.approx(59.0, abs=0.05)
+
+
+def test_a_detection_curve_of_two_axes_is_refused_by_name() -> None:
+    """A curve is one axis, and the crossing search cannot answer for a grid.
+
+    Two equal two-dimensional inputs agree on their shape, so only the rank
+    sees them. Without it the interpolation of the bracketing pair ended in
+    numpy's "only 0-dimensional arrays can be converted to Python scalars",
+    which names neither this function nor the argument that was wrong.
+    """
+    ranges = np.array([100.0, 200.0, 300.0, 400.0])
+    losses = np.array([40.0, 50.0, 60.0, 70.0])
+    assert detection_range_from_curve(55.0, ranges, losses) == pytest.approx(250.0)
+    grid_r, grid_pl = ranges.reshape(2, 2), losses.reshape(2, 2)
+    with pytest.raises(ValueError, match=r"'range_m' must have one axis"):
+        detection_range_from_curve(55.0, grid_r, grid_pl)

--- a/tests/vibration/human/test_human_vibration.py
+++ b/tests/vibration/human/test_human_vibration.py
@@ -247,7 +247,11 @@ def test_weighted_acceleration_single_band_equals_factor_times_level() -> None:
 
 
 def test_weighted_acceleration_length_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="equal-length"):
+    with pytest.raises(
+        ValueError,
+        match=r"weighted_acceleration: 'band_accelerations' .*'frequencies' "
+        r".*same shape",
+    ):
         hv.weighted_acceleration([1.0, 2.0], [8.0], "Wk")
 
 
@@ -500,7 +504,9 @@ def test_running_rms_rejects_empty_signal() -> None:
 def test_vibration_total_value_validates() -> None:
     with pytest.raises(ValueError, match="non-empty"):
         hv.vibration_total_value([])
-    with pytest.raises(ValueError, match="same length"):
+    with pytest.raises(
+        ValueError, match=r"vibration_total_value: 'components' .*'k' .*same shape"
+    ):
         hv.vibration_total_value([1.0, 2.0], k=[1.4])
 
 
@@ -515,14 +521,20 @@ def test_combine_partial_exposures_rejects_empty() -> None:
 
 
 def test_hav_daily_exposure_validates() -> None:
-    with pytest.raises(ValueError, match="equal-length"):
+    with pytest.raises(
+        ValueError, match=r"hav_daily_exposure: 'total_values' .*'durations_s' .*shape"
+    ):
         hv.hav_daily_exposure([2.0, 3.0], [3600.0])
     with pytest.raises(ValueError, match="non-negative"):
         hv.hav_daily_exposure([2.0, -3.0], [3600.0, 3600.0])
 
 
 def test_energy_equivalent_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError, match="equal-length"):
+    with pytest.raises(
+        ValueError,
+        match=r"energy_equivalent_acceleration: 'magnitudes' .*'durations_s' "
+        r".*same shape",
+    ):
         hv.energy_equivalent_acceleration([1.0, 2.0], [3600.0])
 
 
@@ -537,7 +549,11 @@ def test_hav_vwf_lifetime_rejects_nonpositive() -> None:
 
 
 def test_daily_vibration_exposure_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError, match="equal-length"):
+    with pytest.raises(
+        ValueError,
+        match=r"daily_vibration_exposure: 'total_values' .*'durations_s' "
+        r".*same shape",
+    ):
         hv.daily_vibration_exposure([2.0, 3.0], [3600.0], kind="hav")
 
 

--- a/tests/vibration/human/test_multiple_shock_vibration.py
+++ b/tests/vibration/human/test_multiple_shock_vibration.py
@@ -214,7 +214,10 @@ def test_invalid_inputs_raise() -> None:
         v.spinal_response([], 256.0)
     with pytest.raises(ValueError, match="positive"):
         v.daily_dose(50.0, 8.0, 0.0)
-    with pytest.raises(ValueError, match="must match"):
+    with pytest.raises(
+        ValueError,
+        match=r"daily_dose_multi: 'doses'.*must all have the same shape",
+    ):
         v.daily_dose_multi([1.0, 2.0], [1.0], [1.0, 2.0])
     with pytest.raises(ValueError, match="years must be"):
         v.injury_risk(1.0, start_age=20, years=0, days_per_year=120)

--- a/tests/vibration/structural/test_mechanical_mobility.py
+++ b/tests/vibration/structural/test_mechanical_mobility.py
@@ -203,7 +203,10 @@ def test_rigid_mass_calibration_validation() -> None:
         )
     with pytest.raises(ValueError, match="mass"):
         vibration.rigid_mass_calibration_check([0.1], [100.0], 0.0)
-    with pytest.raises(ValueError, match="same shape"):
+    with pytest.raises(
+        ValueError,
+        match=r"rigid_mass_calibration_check: 'frf'.*'frequencies'.*same shape",
+    ):
         vibration.rigid_mass_calibration_check([0.1, 0.1], [100.0], 10.0)
     with pytest.raises(ValueError, match="frequency"):
         vibration.rigid_mass_calibration_check([0.1], [0.0], 10.0)


### PR DESCRIPTION
Stacked on #620, which introduced the helper and did the building, materials and rendering trees.

The other half of the same change, for the packages that one left: aircraft, electroacoustics, emission, environment, noise control, psychoacoustics, room, simulation, speech, underwater and vibration. No new helper and no new rule, only the same comparisons moved onto the one below.

Two of these were not written as a comparison at all, but as `len({a.size, b.size, ...}) != 1`, which collapses several fields into a set and then cannot say which of them disagreed. They are expanded to name each field, which is the whole point of the exercise.

The split is by review limit rather than by meaning: together the two pull requests are a hundred and twenty files, which is past what the review tooling on this repository will read, and separately they are fifty-eight and sixty-two.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Adopt consistent, descriptive shape validation throughout the remaining phonometry packages.

Enhancements:
- Standardize array shape validation across the remaining domain packages with contextual, argument-specific error messages.
- Improve validation clarity by separating shape, dimensionality, size, finiteness, and positivity checks where needed, including shared solver and helper entry points.

Documentation:
- Update API documentation to describe matching array shapes rather than matching lengths.

Tests:
- Expand validation coverage for mismatched shapes, invalid dimensions, insufficient sizes, and non-finite values across the affected packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for array inputs across acoustic, environmental, room, underwater, and vibration calculations.
  - Mismatched array shapes now produce clearer, parameter-specific error messages.
  - Dimensionality, minimum-size, finiteness, and positivity errors are reported separately.
  - Added support and validation for scalar or per-frequency impedance values.

- **Documentation**
  - Updated API guidance to describe matching array shapes rather than matching lengths.
  - Expanded documentation for underwater numerical solver inputs and errors.

- **Tests**
  - Added regression coverage for shape, dimensionality, finite-value, and minimum-size validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->