### PR TITLE
Clear the small debts the guard censuses recorded

### DIFF
--- a/site/src/content/docs/es/vibration/human/multiple-shock-vibration.mdx
+++ b/site/src/content/docs/es/vibration/human/multiple-shock-vibration.mdx
@@ -247,8 +247,8 @@ print(peaks.size, round(float(peaks.max()), 1), round(float(shares.max()), 1))
 # 28 30.3 98.6
 
 fig, (ax_t, ax_p) = plt.subplots(2, 1, sharex=True, figsize=(11, 7.6))
-ax_t.plot(time, seat, lw=0.9, color="#9e9e9e", label="$a_\mathrm{z}(t)$")
-ax_t.plot(time, response, lw=1.5, color="#1f77b4", label="$A_\mathrm{z}(t)$")
+ax_t.plot(time, seat, lw=0.9, color="#9e9e9e", label=r"$a_\mathrm{z}(t)$")
+ax_t.plot(time, response, lw=1.5, color="#1f77b4", label=r"$A_\mathrm{z}(t)$")
 ax_p.plot(time, response, lw=1.2, color="#1f77b4")
 ax_p.axhline(peaks.max() / 3.0, ls="--", color="#2ca02c")
 ax_t.legend(loc="upper left")

--- a/site/src/content/docs/reference/api/aeroacoustics/airport-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/airport-noise.md
@@ -126,7 +126,7 @@ event_level(
     *,
     reference_speed: float = 82.31104,
     mounting: str = 'wing',
-    metric: str = 'exposure',
+    metric: EventMetric = 'exposure',
     atmosphere: AerodromeAtmosphere = ...,
     segments: FlightSegmentState = ...,
 ) -> FlyoverResult
@@ -192,7 +192,7 @@ One entry per segment, so every field an `N`-point path fills has length
 ```python
 FlyoverResult(
     level: float,
-    metric: str,
+    metric: EventMetric,
     segment_levels: NDArray[np.float64],
     observer: NDArray[np.float64],
 )
@@ -293,7 +293,7 @@ noise_contour(
     y: NDArray[np.float64] | list[float],
     reference_speed: float = 82.31104,
     mounting: str = 'wing',
-    metric: str = 'exposure',
+    metric: EventMetric = 'exposure',
     atmosphere: AerodromeAtmosphere = ...,
     segments: FlightSegmentState = ...,
 ) -> NoiseContourResult
@@ -363,7 +363,7 @@ NoiseContourResult(
     x: NDArray[np.float64],
     y: NDArray[np.float64],
     level: NDArray[np.float64],
-    metric: str,
+    metric: EventMetric,
 )
 ```
 

--- a/site/src/content/docs/reference/api/aeroacoustics/anp-fleet.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/anp-fleet.md
@@ -79,7 +79,7 @@ AnpAircraft.event_level(
     operation: str,
     *,
     stage_length: int = 1,
-    metric: str = 'exposure',
+    metric: EventMetric = 'exposure',
     temperature: float = 15.0,
     pressure: float = 101.325,
 ) -> FlyoverResult
@@ -96,7 +96,7 @@ AnpAircraft.noise_contour(
     x: NDArray[np.float64] | list[float],
     y: NDArray[np.float64] | list[float],
     stage_length: int = 1,
-    metric: str = 'exposure',
+    metric: EventMetric = 'exposure',
     temperature: float = 15.0,
     pressure: float = 101.325,
 ) -> NoiseContourResult
@@ -171,7 +171,7 @@ AnpDatabase.event_level(
     operation: str,
     *,
     stage_length: int = 1,
-    metric: str = 'exposure',
+    metric: EventMetric = 'exposure',
     temperature: float = 15.0,
     pressure: float = 101.325,
 ) -> FlyoverResult
@@ -206,7 +206,7 @@ AnpDatabase.noise_contour(
     x: NDArray[np.float64] | list[float],
     y: NDArray[np.float64] | list[float],
     stage_length: int = 1,
-    metric: str = 'exposure',
+    metric: EventMetric = 'exposure',
     temperature: float = 15.0,
     pressure: float = 101.325,
 ) -> NoiseContourResult

--- a/site/src/content/docs/reference/api/building/ratings.md
+++ b/site/src/content/docs/reference/api/building/ratings.md
@@ -224,7 +224,7 @@ ImpactRatingResult(
     band_centers: np.ndarray | None = None,
     measured: np.ndarray | None = None,
     shifted_reference: np.ndarray | None = None,
-    quantity: str = 'impact',
+    quantity: Literal['impact'] = 'impact',
 )
 ```
 
@@ -509,7 +509,7 @@ WeightedRatingResult(
     band_centers: np.ndarray | None = None,
     measured: np.ndarray | None = None,
     shifted_reference: np.ndarray | None = None,
-    quantity: str = 'airborne',
+    quantity: RatingQuantity = 'airborne',
 )
 ```
 

--- a/site/src/content/docs/reference/api/building/ratings.md
+++ b/site/src/content/docs/reference/api/building/ratings.md
@@ -509,7 +509,7 @@ WeightedRatingResult(
     band_centers: np.ndarray | None = None,
     measured: np.ndarray | None = None,
     shifted_reference: np.ndarray | None = None,
-    quantity: RatingQuantity = 'airborne',
+    quantity: Literal['airborne'] = 'airborne',
 )
 ```
 
@@ -526,7 +526,7 @@ Single-number weighted rating and adaptation terms (ISO 717-1).
 | `band_centers` | Band centre frequencies of the measured curve, in Hz. Defaults to `None` for backward-compatible construction. |
 | `measured` | The measured band quantities used for the rating (after the one-decimal reduction of Clause 4.4), in dB. Defaults to `None`. |
 | `shifted_reference` | Table 3 reference curve after the final shift, in dB. Defaults to `None`. |
-| `quantity` | `"airborne"` (ISO 717-1, sound reduction index) or `"impact"` (ISO 717-2), selecting the labels of the ISO 717 Annex C report. Defaults to `"airborne"`. |
+| `quantity` | Always `"airborne"`: this class carries the ISO 717-1 airborne rating, and the renderers dispatch on this tag when handed the union with [`ImpactRatingResult`](/phonometry/reference/api/building/ratings/#impactratingresult), which carries `"impact"`. The field used to admit both values and promise that `"impact"` would select the impact labels; it never could, since the impact labels read `ci` off the result and this class does not have one, so the promise ended in the renderer's `AttributeError`. |
 
 ### WeightedRatingResult.plot()
 

--- a/site/src/content/docs/reference/api/noise_control/hvac.md
+++ b/site/src/content/docs/reference/api/noise_control/hvac.md
@@ -606,7 +606,7 @@ in dB re 1e-12 W (VDI 2081-1), for airflow speed `U` in a duct of area
 HvacSpectrumResult(
     frequencies: np.ndarray,
     values: np.ndarray,
-    quantity: str,
+    quantity: HvacQuantity,
     label: str,
 )
 ```

--- a/site/src/content/docs/reference/api/rooms/noise-criteria.md
+++ b/site/src/content/docs/reference/api/rooms/noise-criteria.md
@@ -68,8 +68,8 @@ NCResult(
     levels: np.ndarray,
     sil: float = nan,
     tangency_rating: float = nan,
-    method: str = 'tangency',
-    out_of_range: str | None = None,
+    method: NCMethod = 'tangency',
+    out_of_range: NCOutOfRange | None = None,
 )
 ```
 

--- a/site/src/content/docs/vibration/human/multiple-shock-vibration.mdx
+++ b/site/src/content/docs/vibration/human/multiple-shock-vibration.mdx
@@ -234,8 +234,8 @@ print(peaks.size, round(float(peaks.max()), 1), round(float(shares.max()), 1))
 # 28 30.3 98.6
 
 fig, (ax_t, ax_p) = plt.subplots(2, 1, sharex=True, figsize=(11, 7.6))
-ax_t.plot(time, seat, lw=0.9, color="#9e9e9e", label="$a_\mathrm{z}(t)$")
-ax_t.plot(time, response, lw=1.5, color="#1f77b4", label="$A_\mathrm{z}(t)$")
+ax_t.plot(time, seat, lw=0.9, color="#9e9e9e", label=r"$a_\mathrm{z}(t)$")
+ax_t.plot(time, response, lw=1.5, color="#1f77b4", label=r"$A_\mathrm{z}(t)$")
 ax_p.plot(time, response, lw=1.2, color="#1f77b4")
 ax_p.axhline(peaks.max() / 3.0, ls="--", color="#2ca02c")
 ax_t.legend(loc="upper left")

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -76,6 +76,25 @@ def require_choice(value: str, name: str, options: tuple[str, ...]) -> str:
     return value
 
 
+def check_engine(engine: str) -> None:
+    """Require *engine* to name the one report engine there is.
+
+    The counterpart of :func:`phonometry._i18n.check_language` for the
+    ``engine`` parameter every ``report`` entry point takes. A single-choice
+    check reads oddly until the choice is seen for what it is: ``"reportlab"``
+    is the only engine today, and the parameter is the seam a second engine
+    would arrive through. Gating it here keeps every entry point rejecting the
+    same way, with one message to update when that day comes.
+
+    :param engine: The requested report engine.
+    :raises ValueError: for any value other than ``"reportlab"``.
+    """
+    if engine == "reportlab":
+        return
+    msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
+    raise ValueError(msg)
+
+
 def require_positive_array(x: ArrayLike, name: str) -> np.ndarray:
     """Coerce *x* to a 1-D float64 array of strictly positive, finite values.
 

--- a/src/phonometry/_plot/geometry/materials.py
+++ b/src/phonometry/_plot/geometry/materials.py
@@ -109,23 +109,36 @@ _MEMBRANE_DRAW_FRACTION = 0.012
 def _layer_kind_and_thickness(layer: Any, total: float) -> tuple[str, float, str]:
     """Map a layer dataclass to (style kind, drawn thickness, label key).
 
-    Dispatch is by class name so this rendering leaf never imports the domain
-    dataclasses at runtime.
+    Dispatch is by the classes themselves, imported lazily so this rendering
+    leaf still pays nothing for the domain at import time. It used to compare
+    class names, which a rename silently breaks and no refactoring tool can
+    follow; matching the class also lets a subclass draw like its base
+    instead of falling through to the refusal below. The more derived plate
+    and porous kinds are tested before their plainer siblings so that order
+    keeps meaning something if one ever subclasses the other.
     """
-    name = type(layer).__name__
-    if name == "AirLayer":
+    from ...materials.absorbers.layered import (
+        AirLayer,
+        MembraneLayer,
+        MicroperforatedPlateLayer,
+        PerforatedPlateLayer,
+        PoroelasticLayer,
+        PorousLayer,
+    )
+
+    if isinstance(layer, AirLayer):
         return "air", float(layer.thickness), "Air"
-    if name == "PorousLayer":
-        return "porous", float(layer.thickness), "Porous"
-    if name == "PoroelasticLayer":
+    if isinstance(layer, PoroelasticLayer):
         return "porous", float(layer.thickness), "Poroelastic"
-    if name == "PerforatedPlateLayer":
-        return "plate", float(layer.thickness), "Perforated plate"
-    if name == "MicroperforatedPlateLayer":
+    if isinstance(layer, PorousLayer):
+        return "porous", float(layer.thickness), "Porous"
+    if isinstance(layer, MicroperforatedPlateLayer):
         return "plate", float(layer.thickness), "Microperforated plate"
-    if name == "MembraneLayer":
+    if isinstance(layer, PerforatedPlateLayer):
+        return "plate", float(layer.thickness), "Perforated plate"
+    if isinstance(layer, MembraneLayer):
         return "membrane", _MEMBRANE_DRAW_FRACTION * total, "Membrane"
-    msg = f"Unsupported layer type: {name!r}."
+    msg = f"Unsupported layer type: {type(layer).__name__!r}."
     raise TypeError(msg)
 
 

--- a/src/phonometry/_report/_insulation_fiche.py
+++ b/src/phonometry/_report/_insulation_fiche.py
@@ -20,7 +20,7 @@ reportlab, matplotlib and svglib are soft dependencies imported lazily
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -75,7 +75,8 @@ def single_number_statement(
     reports the fiche mirrors).
     """
     if rating.quantity == "impact":
-        impact = cast("ImpactRatingResult", rating)
+        # The tag proves the class: only ImpactRatingResult carries "impact".
+        impact = rating
         return (
             f"{rating_symbol} (C<sub>I</sub>) = "
             f"<b>{impact.rating} ({impact.ci:+d}) dB</b>"

--- a/src/phonometry/_report/_insulation_fiche.py
+++ b/src/phonometry/_report/_insulation_fiche.py
@@ -80,7 +80,7 @@ def single_number_statement(
             f"{rating_symbol} (C<sub>I</sub>) = "
             f"<b>{impact.rating} ({impact.ci:+d}) dB</b>"
         )
-    airborne = cast("WeightedRatingResult", rating)
+    airborne = rating
     return (
         f"{rating_symbol} (C; C<sub>tr</sub>) = "
         f"<b>{airborne.rating} ({airborne.c:+d}; {airborne.ctr:+d}) dB</b>"

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -144,7 +144,7 @@ def _labels(
         statement = f"{sym} (C<sub>I</sub>) = <b>{impact.rating} ({impact.ci:d}) dB</b>"
         value_header = _band_symbol_markup(symbol) if symbol else "L<sub>n</sub>"
     else:
-        airborne = cast("WeightedRatingResult", result)
+        airborne = result
         title = t("Airborne sound insulation rating", language)
         rating_part = "ISO 717-1"
         sym = _symbol_markup(symbol if symbol is not None else "Rw")

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import html
 import math
 import re
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -137,7 +137,8 @@ def _labels(
     the style of the standard's own examples (e.g. ``41 (0; -5) dB``).
     """
     if result.quantity == "impact":
-        impact = cast("ImpactRatingResult", result)
+        # The tag proves the class: only ImpactRatingResult carries "impact".
+        impact = result
         title = t("Impact sound insulation rating", language)
         rating_part = "ISO 717-2"
         sym = _symbol_markup(symbol if symbol is not None else "Ln,w")

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -33,7 +33,7 @@ Doc 29 5th ed. Vol 3 Part 1 reference workbook.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 import numpy as np
 
@@ -647,6 +647,18 @@ class FlightSegmentState:
 #: shared instance, as the bundle is frozen).
 _AIRBORNE = FlightSegmentState()
 
+#: The single-event level reported: "exposure" (SEL) or "maximum" (LAmax).
+EventMetric = Literal["exposure", "maximum"]
+
+
+def _checked_metric(metric: str) -> EventMetric:
+    """Normalise and validate the requested event-level metric."""
+    key = metric.strip().lower()
+    if key not in ("exposure", "maximum"):
+        msg = "'metric' must be 'exposure' or 'maximum'."
+        raise ValueError(msg)
+    return cast("EventMetric", key)
+
 
 @dataclass(frozen=True)
 class FlyoverResult:
@@ -660,7 +672,7 @@ class FlyoverResult:
     """
 
     level: float
-    metric: str
+    metric: EventMetric
     segment_levels: NDArray[np.float64]
     observer: NDArray[np.float64]
 
@@ -1300,7 +1312,7 @@ def event_level(
     *,
     reference_speed: float = _VREF_MS,
     mounting: str = "wing",
-    metric: str = "exposure",
+    metric: EventMetric = "exposure",
     atmosphere: AerodromeAtmosphere = _STANDARD_ATMOSPHERE,
     segments: FlightSegmentState = _AIRBORNE,
 ) -> FlyoverResult:
@@ -1338,10 +1350,7 @@ def event_level(
     if obs.shape != (3,) or not np.all(np.isfinite(obs)):
         msg = "'observer' must be a finite (x, y, z) point."
         raise ValueError(msg)
-    key = metric.strip().lower()
-    if key not in ("exposure", "maximum"):
-        msg = "'metric' must be 'exposure' or 'maximum'."
-        raise ValueError(msg)
+    key = _checked_metric(metric)
     gr = _validate_ground_roll(segments.ground_roll, pts.shape[0])
     lr = _validate_ground_roll(segments.landing_roll, pts.shape[0])
     bk = _validate_bank(segments.bank, pts.shape[0])
@@ -1367,7 +1376,7 @@ class NoiseContourResult:
     x: NDArray[np.float64]
     y: NDArray[np.float64]
     level: NDArray[np.float64]
-    metric: str
+    metric: EventMetric
 
     def __post_init__(self) -> None:
         """Reject a contour whose level grid does not match the axes beside it.
@@ -1410,7 +1419,7 @@ def noise_contour(
     y: NDArray[np.float64] | list[float],
     reference_speed: float = _VREF_MS,
     mounting: str = "wing",
-    metric: str = "exposure",
+    metric: EventMetric = "exposure",
     atmosphere: AerodromeAtmosphere = _STANDARD_ATMOSPHERE,
     segments: FlightSegmentState = _AIRBORNE,
 ) -> NoiseContourResult:
@@ -1442,10 +1451,7 @@ def noise_contour(
         raise ValueError(msg)
     # Validate and clean the shared inputs once, not per grid point.
     pts = _validate_path(path)
-    key = metric.strip().lower()
-    if key not in ("exposure", "maximum"):
-        msg = "'metric' must be 'exposure' or 'maximum'."
-        raise ValueError(msg)
+    key = _checked_metric(metric)
     gr = _validate_ground_roll(segments.ground_roll, pts.shape[0])
     lr = _validate_ground_roll(segments.landing_roll, pts.shape[0])
     bk = _validate_bank(segments.bank, pts.shape[0])

--- a/src/phonometry/aircraft/anp_fleet.py
+++ b/src/phonometry/aircraft/anp_fleet.py
@@ -49,6 +49,7 @@ from .._internal.validation import (
 )
 from .airport_noise import (
     AerodromeAtmosphere,
+    EventMetric,
     FlightSegmentState,
     FlyoverResult,
     NoiseContourResult,
@@ -337,7 +338,7 @@ class AnpAircraft:
         operation: str,
         *,
         stage_length: int = 1,
-        metric: str = "exposure",
+        metric: EventMetric = "exposure",
         temperature: float = 15.0,
         pressure: float = 101.325,
     ) -> FlyoverResult:
@@ -359,7 +360,7 @@ class AnpAircraft:
         x: NDArray[np.float64] | list[float],
         y: NDArray[np.float64] | list[float],
         stage_length: int = 1,
-        metric: str = "exposure",
+        metric: EventMetric = "exposure",
         temperature: float = 15.0,
         pressure: float = 101.325,
     ) -> NoiseContourResult:
@@ -598,7 +599,7 @@ class AnpDatabase:
         operation: str,
         *,
         stage_length: int = 1,
-        metric: str = "exposure",
+        metric: EventMetric = "exposure",
         temperature: float = 15.0,
         pressure: float = 101.325,
     ) -> FlyoverResult:
@@ -642,7 +643,7 @@ class AnpDatabase:
         x: NDArray[np.float64] | list[float],
         y: NDArray[np.float64] | list[float],
         stage_length: int = 1,
-        metric: str = "exposure",
+        metric: EventMetric = "exposure",
         temperature: float = 15.0,
         pressure: float = 101.325,
     ) -> NoiseContourResult:

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -617,9 +618,7 @@ class EPNLResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.annex16_epnl import render_annex16_epnl_report
 
         return render_annex16_epnl_report(

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -57,7 +57,12 @@ if TYPE_CHECKING:
 from .._internal.peaks import inter_sample_peak
 from .._internal.types import as_float_or_array
 from .._internal.utils import _typesignal
-from .._internal.validation import require_positive, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 _EMPTY_SIGNAL = "Input signal 'x' cannot be empty."
 
@@ -850,9 +855,7 @@ class ProgramLoudnessResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.broadcast import render_program_loudness_report
 
         return render_program_loudness_report(

--- a/src/phonometry/building/measurement/flanking_transmission.py
+++ b/src/phonometry/building/measurement/flanking_transmission.py
@@ -77,11 +77,13 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_counts,
     require_equal_shapes,
     require_ranks,
     require_same_length,
 )
+from ...filters.frequencies import _OCTAVE_SPACING_MIN_RATIO
 from .insulation import (
     ImpactRatingResult,
     WeightedRatingResult,
@@ -107,9 +109,7 @@ def _validate_report_request(engine: str, language: str) -> None:
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
 
 
 #: Reference equivalent sound absorption area ``A0`` for the normalized
@@ -154,8 +154,11 @@ _OCTAVE_CENTRES = (31.5, 63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000
 
 #: Median consecutive-centre-frequency ratio above which a band set is classed
 #: as octave-spaced (nominal step 2) rather than one-third-octave-spaced
-#: (step 2^(1/3) ≈ 1.26); the threshold sits between the two nominal steps.
-_OCTAVE_STEP_THRESHOLD = 1.6
+#: (step 2^(1/3) ≈ 1.26). One discriminant for the whole library: the value is
+#: the geometric midpoint of the two IEC 61260 nominal steps, defined next to
+#: the band machinery it tells apart. This module used to keep its own 1.6
+#: beside the 1.5 in ``filters.frequencies`` for the same question.
+_OCTAVE_STEP_THRESHOLD = _OCTAVE_SPACING_MIN_RATIO
 
 
 def _as_1d(values: float | Sequence[float] | np.ndarray, name: str) -> np.ndarray:

--- a/src/phonometry/building/measurement/floor_covering_improvement.py
+++ b/src/phonometry/building/measurement/floor_covering_improvement.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -288,9 +289,7 @@ class FloorCoveringImprovementResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso16251 import render_iso16251_report
 
         return render_iso16251_report(

--- a/src/phonometry/building/measurement/insulation.py
+++ b/src/phonometry/building/measurement/insulation.py
@@ -74,6 +74,7 @@ import numpy as np
 from ..._internal.levels_math import energy_mean
 from ..._internal.types import as_float_or_array
 from ..._internal.validation import (
+    check_engine,
     require_equal_counts,
     require_equal_shapes,
     require_ranks,
@@ -540,9 +541,9 @@ class FacadeInsulationResult:
 #: The field quantities each result kind can report, mapping the ``quantity``
 #: argument of ``report()`` to the attribute holding the per-band curve and
 #: the per-band chain columns ``verbose=True`` needs.
-_FIELD_QUANTITIES: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
-    "AirborneInsulationResult": (("dnt", "r_prime"), ("l1", "l2", "t2")),
-    "ImpactInsulationResult": (("l_n_t", "l_n"), ("li", "t2")),
+_FIELD_QUANTITIES: dict[type, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    AirborneInsulationResult: (("dnt", "r_prime"), ("l1", "l2", "t2")),
+    ImpactInsulationResult: (("l_n_t", "l_n"), ("li", "t2")),
 }
 
 
@@ -568,11 +569,8 @@ def _render_iso16283(
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
-    kind = type(result).__name__
-    quantities, chain_attrs = _FIELD_QUANTITIES[kind]
+    check_engine(engine)
+    quantities, chain_attrs = _FIELD_QUANTITIES[type(result)]
     if quantity not in quantities:
         expected = " or ".join(repr(q) for q in quantities)
         msg = f"Unknown field quantity {quantity!r}; expected {expected}."
@@ -603,7 +601,7 @@ def _render_iso16283(
                 "impact_insulation() so they are populated."
             )
             raise ValueError(msg)
-    if kind == "ImpactInsulationResult":
+    if isinstance(result, ImpactInsulationResult):
         rating: WeightedRatingResult | ImpactRatingResult = weighted_impact_rating(
             curve
         )
@@ -649,9 +647,7 @@ def _render_iso16283_facade(
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
     if quantity not in _FACADE_FIELD_QUANTITIES:
         expected = " or ".join(repr(q) for q in _FACADE_FIELD_QUANTITIES)
         msg = f"Unknown facade quantity {quantity!r}; expected {expected}."

--- a/src/phonometry/building/measurement/intensity_insulation.py
+++ b/src/phonometry/building/measurement/intensity_insulation.py
@@ -78,6 +78,7 @@ from typing import TYPE_CHECKING, Any, overload
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_counts,
     require_equal_shapes,
     require_ranks,
@@ -137,9 +138,7 @@ def _validate_intensity_report(
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
     if rating is None:
         msg = (
             f"The {label} report needs the ISO 717-1 single-number rating; it "

--- a/src/phonometry/building/measurement/lab_insulation.py
+++ b/src/phonometry/building/measurement/lab_insulation.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -338,9 +339,7 @@ def _render_iso10140(
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
     rating = result.rating
     if rating is None:
         msg = (

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -336,10 +336,6 @@ _CI_50_2500_FREQS: tuple[float, ...] = _FREQ_50_5000[:18]
 _VALUES_1D_MSG = "'values_by_band' must be one-dimensional."
 _VALUES_FINITE_MSG = "'values_by_band' must contain only finite values."
 
-#: Which ISO 717 part's Annex C report labels the rating selects: "airborne"
-#: (ISO 717-1, sound reduction) or "impact" (ISO 717-2, impact sound level).
-RatingQuantity = Literal["airborne", "impact"]
-
 
 @dataclass(frozen=True)
 class WeightedRatingResult:
@@ -361,9 +357,13 @@ class WeightedRatingResult:
         ``None``.
     :ivar shifted_reference: Table 3 reference curve after the final shift,
         in dB. Defaults to ``None``.
-    :ivar quantity: ``"airborne"`` (ISO 717-1, sound reduction index) or
-        ``"impact"`` (ISO 717-2), selecting the labels of the ISO 717
-        Annex C report. Defaults to ``"airborne"``.
+    :ivar quantity: Always ``"airborne"``: this class carries the ISO 717-1
+        airborne rating, and the renderers dispatch on this tag when handed
+        the union with :class:`ImpactRatingResult`, which carries
+        ``"impact"``. The field used to admit both values and promise that
+        ``"impact"`` would select the impact labels; it never could, since
+        the impact labels read ``ci`` off the result and this class does not
+        have one, so the promise ended in the renderer's ``AttributeError``.
     """
 
     rating: int
@@ -373,7 +373,7 @@ class WeightedRatingResult:
     band_centers: np.ndarray | None = None
     measured: np.ndarray | None = None
     shifted_reference: np.ndarray | None = None
-    quantity: RatingQuantity = "airborne"
+    quantity: Literal["airborne"] = "airborne"
 
     def __post_init__(self) -> None:
         """Reject a rating whose three band curves do not line up.

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -61,12 +61,13 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
 from ..._internal.levels_math import energy_sum
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -335,6 +336,10 @@ _CI_50_2500_FREQS: tuple[float, ...] = _FREQ_50_5000[:18]
 _VALUES_1D_MSG = "'values_by_band' must be one-dimensional."
 _VALUES_FINITE_MSG = "'values_by_band' must contain only finite values."
 
+#: Which ISO 717 part's Annex C report labels the rating selects: "airborne"
+#: (ISO 717-1, sound reduction) or "impact" (ISO 717-2, impact sound level).
+RatingQuantity = Literal["airborne", "impact"]
+
 
 @dataclass(frozen=True)
 class WeightedRatingResult:
@@ -368,7 +373,7 @@ class WeightedRatingResult:
     band_centers: np.ndarray | None = None
     measured: np.ndarray | None = None
     shifted_reference: np.ndarray | None = None
-    quantity: str = "airborne"
+    quantity: RatingQuantity = "airborne"
 
     def __post_init__(self) -> None:
         """Reject a rating whose three band curves do not line up.
@@ -492,7 +497,7 @@ class ImpactRatingResult:
     band_centers: np.ndarray | None = None
     measured: np.ndarray | None = None
     shifted_reference: np.ndarray | None = None
-    quantity: str = "impact"
+    quantity: Literal["impact"] = "impact"
 
     def __post_init__(self) -> None:
         """Reject a rating whose three band curves do not line up.
@@ -605,9 +610,7 @@ def _render_iso717(
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
     if (
         result.band_centers is None
         or result.measured is None

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -84,6 +84,7 @@ if TYPE_CHECKING:
 
 
 from ..._internal.validation import (
+    check_engine,
     require_per_band,
     require_positive,
     require_ranks,
@@ -317,9 +318,7 @@ class StructureBornePowerResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.en15657 import render_structure_borne_power_report
 
         return render_structure_borne_power_report(

--- a/src/phonometry/building/measurement/survey_insulation.py
+++ b/src/phonometry/building/measurement/survey_insulation.py
@@ -73,6 +73,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -103,9 +104,7 @@ def _validate_report_request(engine: str, language: str) -> None:
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
 
 
 #: Refusal raised by every survey-result ``plot()`` when the measured band set

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -100,6 +100,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_axis_count,
     require_choice,
     require_equal_counts,
@@ -250,9 +251,7 @@ def _check_report_request(engine: str, language: str) -> None:
     from ..._i18n import check_language
 
     check_language(language)
-    if engine != "reportlab":
-        msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-        raise ValueError(msg)
+    check_engine(engine)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/phonometry/building/prediction/installed_structure_borne.py
+++ b/src/phonometry/building/prediction/installed_structure_borne.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
 
 
 from ..._internal.validation import (
+    check_engine,
     require_choice,
     require_non_negative,
     require_positive,
@@ -1097,9 +1098,7 @@ class InstalledSourceResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.en12354_5 import render_installed_structure_borne_report
 
         return render_installed_structure_borne_report(

--- a/src/phonometry/building/prediction/simplified_model.py
+++ b/src/phonometry/building/prediction/simplified_model.py
@@ -60,6 +60,8 @@ from dataclasses import dataclass
 from math import isfinite, log10
 from typing import TYPE_CHECKING, Any, Literal
 
+from ..._internal.validation import check_engine
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
@@ -255,9 +257,7 @@ class AirbornePredictionResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso12354 import render_iso12354_airborne_report
 
         return render_iso12354_airborne_report(
@@ -346,9 +346,7 @@ class ImpactPredictionResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso12354 import render_iso12354_impact_report
 
         return render_iso12354_impact_report(

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_positive,
     require_ranks,
@@ -497,9 +498,7 @@ class LoudspeakerCharacteristics:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         del verbose  # uniform signature; the fiche has a single layout
         from .._report.iec60268_5 import render_iec60268_5_report
 

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_positive,
     require_ranks,
@@ -554,9 +555,7 @@ class MicrophoneCharacteristics:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         del verbose  # uniform signature; the fiche has a single layout
         from .._report.iec60268_4 import render_iec60268_4_report
 

--- a/src/phonometry/emission/declaration.py
+++ b/src/phonometry/emission/declaration.py
@@ -41,6 +41,8 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
+from .._internal.validation import check_engine
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -323,9 +325,7 @@ class NoiseEmissionDeclaration:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso4871 import render_iso4871_report
 
         return render_iso4871_report(

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_equal_counts,
     require_ranks,
     require_same_length,
@@ -553,9 +554,7 @@ class IntensityInstrumentComplianceResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iec61043 import render_iec61043_report
 
         return render_iec61043_report(

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -55,7 +55,7 @@ import numpy as np
 
 from .._internal.levels_math import energy_mean, energy_sum
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 from ._shared import (
     _S0,
     Grade,
@@ -331,9 +331,7 @@ class SoundPowerResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso3744 import render_sound_power_report
 
         return render_sound_power_report(

--- a/src/phonometry/emission/sound_power_anechoic.py
+++ b/src/phonometry/emission/sound_power_anechoic.py
@@ -47,7 +47,7 @@ import numpy as np
 
 from .._internal.levels_math import energy_mean, energy_sum, weighted_energy_mean
 from .._internal.types import as_float_or_array
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 from ._shared import _S0, SoundPowerWarning, _a_weighting_corrections
 
 if TYPE_CHECKING:
@@ -405,9 +405,7 @@ class PrecisionSoundPowerResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso3744 import render_sound_power_report
 
         return render_sound_power_report(

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
 
 from .._internal.levels_math import energy_mean, weighted_energy_mean
 from .._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -339,9 +340,7 @@ class SoundPowerIntensityResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso9614 import render_intensity_power_report
 
         return render_intensity_power_report(
@@ -1070,9 +1069,7 @@ class PrecisionIntensityResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         n_bands = int(np.asarray(self.sound_power_level).size)
         _check_report_bands(indicators, criteria, residual_index, n_bands)
 

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 from .._internal.levels_math import energy_mean, energy_sum
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 from ._shared import (
     SoundPowerWarning,
     _a_weighting_corrections,
@@ -225,9 +225,7 @@ class ReverberationSoundPowerResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso3741 import render_reverberation_power_report
 
         return render_reverberation_power_report(

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
 
 
 from .._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_positive,
     require_ranks,
@@ -405,9 +406,7 @@ class VibrationSoundPowerResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso7849 import render_vibration_power_report
 
         return render_vibration_power_report(

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -65,6 +65,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -218,9 +219,7 @@ class ImpulseProminenceResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso1996_impulse import render_impulse_prominence_report
 
         return render_impulse_prominence_report(

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -105,7 +105,11 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy.special import fresnel, wofz
 
-from ..._internal.validation import require_positive, require_positive_array
+from ..._internal.validation import (
+    check_engine,
+    require_positive,
+    require_positive_array,
+)
 from ...materials.absorbers.porous import delany_bazley, miki
 
 if TYPE_CHECKING:
@@ -709,9 +713,7 @@ class BarrierInsertionLoss:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso9613 import render_barrier_insertion_loss_report
 
         return render_barrier_insertion_loss_report(

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -48,7 +48,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import check_engine, require_ranks, require_same_length
 from .air_absorption import air_attenuation
 
 if TYPE_CHECKING:
@@ -392,9 +392,7 @@ class OutdoorAttenuation:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso9613 import render_outdoor_attenuation_report
 
         return render_outdoor_attenuation_report(

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -296,9 +297,7 @@ class WindTurbineTonalityResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iec61400 import render_wind_turbine_tonality_report
 
         return render_wind_turbine_tonality_report(

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import signal
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -516,9 +516,7 @@ class FilterComplianceResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iec61260 import render_iec61260_report
 
         return render_iec61260_report(

--- a/src/phonometry/filters/frequencies.py
+++ b/src/phonometry/filters/frequencies.py
@@ -16,7 +16,12 @@ _ANNEX_E3_MSD_THRESHOLD = 5.0
 
 # Adjacent mid-band centre ratio separating the two IEC 61260 band structures:
 # octave spacing (2) above it, one-third-octave spacing (2**(1/3) ~ 1.26) below.
-_OCTAVE_SPACING_MIN_RATIO = 1.5
+# The value is the geometric midpoint of those two nominal steps, equidistant
+# from both in ratio space, so a grid must err by more than half a third-octave
+# step before it is classed with the wrong structure. One constant, shared with
+# the ISO 10848 octave grouping in building.measurement.flanking_transmission:
+# the library used to hold 1.5 here and 1.6 there for the same discriminant.
+_OCTAVE_SPACING_MIN_RATIO = 2.0 ** (2.0 / 3.0)
 
 # One kilohertz in hertz: the boundary at which a nominal-frequency label
 # switches to the abbreviated "k" form, and the Hz-to-kHz divisor.

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 from .._internal.warnings import PhonometryWarning
 from .threshold import age_threshold
 
@@ -261,9 +261,7 @@ class NiptsResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso1999 import render_nipts_report
 
         return render_nipts_report(
@@ -384,9 +382,7 @@ class HtlanResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso1999 import render_htlan_report
 
         return render_htlan_report(

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from .._internal.levels_math import energy_mean
+from .._internal.validation import check_engine
 from .._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -432,9 +433,7 @@ class ExposureResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso9612 import render_iso9612_report
 
         return render_iso9612_report(

--- a/src/phonometry/io/_chunks.py
+++ b/src/phonometry/io/_chunks.py
@@ -64,7 +64,7 @@ import os
 import struct
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from typing import BinaryIO
@@ -396,11 +396,16 @@ class Ds64Chunk:
     sample_count: int
 
 
+#: The container the RIFF prelude declares: classic 32-bit "WAV" (``RIFF``
+#: fourcc), or the 64-bit "RF64" (EBU Tech 3306) / "BW64" (ITU-R BS.2088).
+WavContainer = Literal["WAV", "RF64", "BW64"]
+
+
 @dataclass(frozen=True)
 class WavChunks:
     """Everything the walker gathered from one pass over the headers."""
 
-    container: str
+    container: WavContainer
     fmt: FormatChunk
     data_offset: int
     data_size: int
@@ -590,14 +595,18 @@ def _parse_fact(payload: bytes, path: str | Path) -> int:
     return int(fact_frames)
 
 
-def _read_wave_header(fh: BinaryIO, path: str | Path) -> str:
+def _read_wave_header(fh: BinaryIO, path: str | Path) -> WavContainer:
     """Check the 12-byte RIFF prelude and name the container it declares."""
     header = fh.read(_RIFF_PRELUDE_BYTES)
     if len(header) < _RIFF_PRELUDE_BYTES or header[8:12] != _WAVE_FORM_TYPE:
         msg = f"{path}: not a WAVE file"
         raise ValueError(msg)
     fourcc = header[:4]
-    containers = {b"RIFF": "WAV", b"RF64": "RF64", b"BW64": "BW64"}
+    containers: dict[bytes, WavContainer] = {
+        b"RIFF": "WAV",
+        b"RF64": "RF64",
+        b"BW64": "BW64",
+    }
     if fourcc not in containers:
         msg = (
             f"{path}: unknown container fourcc {fourcc!r} (expected RIFF, RF64 or BW64)"
@@ -647,7 +656,7 @@ def _read_chunk_payload(
 
 
 def _true_data_size(
-    size: int, container: str, ds64: Ds64Chunk | None, path: str | Path
+    size: int, container: WavContainer, ds64: Ds64Chunk | None, path: str | Path
 ) -> int:
     """Resolve the ``data`` size, through ``ds64`` for the RF64 sentinel."""
     if size != _RF64_SIZE_SENTINEL or container == "WAV":

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -74,7 +74,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_equal_shapes
+from ..._internal.validation import check_engine, require_equal_shapes
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -229,9 +229,7 @@ class StaticAirflowResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso9053 import render_static_airflow_report
 
         return render_static_airflow_report(

--- a/src/phonometry/materials/absorbers/impedance_tube.py
+++ b/src/phonometry/materials/absorbers/impedance_tube.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from ..._internal.validation import check_engine
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -577,9 +578,7 @@ class ImpedanceTubeResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso10534 import render_iso10534_report
 
         return render_iso10534_report(

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_axis_count,
     require_equal_counts,
     require_ranks,
@@ -408,9 +409,7 @@ class AbsorptionRatingResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso11654 import render_iso11654_report
 
         return render_iso11654_report(

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -60,6 +60,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -553,9 +554,7 @@ class SoundAbsorptionMeasurement:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso354 import render_iso354_report
 
         return render_iso354_report(

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_equal_shapes
+from ..._internal.validation import check_engine, require_equal_shapes
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -440,9 +440,7 @@ class ScatteringResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso17497 import render_scattering_report
 
         return render_scattering_report(

--- a/src/phonometry/materials/diffusers/scattering_diffusion.py
+++ b/src/phonometry/materials/diffusers/scattering_diffusion.py
@@ -32,7 +32,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_equal_counts, require_equal_shapes
+from ..._internal.validation import (
+    check_engine,
+    require_equal_counts,
+    require_equal_shapes,
+)
 from .reverberation_room_scattering import _positive_scalar
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -136,9 +140,7 @@ class DiffusionResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso17497 import render_diffusion_polar_report
 
         return render_diffusion_polar_report(
@@ -229,9 +231,7 @@ class DiffusionSpectrum:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso17497 import render_diffusion_spectrum_report
 
         return render_diffusion_spectrum_report(

--- a/src/phonometry/materials/resilient/dynamic_stiffness.py
+++ b/src/phonometry/materials/resilient/dynamic_stiffness.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
 
 
 from ..._internal.types import as_float_or_array
-from ..._internal.validation import require_positive
+from ..._internal.validation import check_engine, require_positive
 from ..._internal.warnings import PhonometryWarning
 
 # ---------------------------------------------------------------------------
@@ -348,9 +348,7 @@ class DynamicStiffnessResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso9052 import render_dynamic_stiffness_report
 
         return render_dynamic_stiffness_report(

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -54,6 +54,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_axis_count,
     require_equal_counts,
     require_ranks,
@@ -423,9 +424,7 @@ class DuctPathResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.duct_path import render_duct_path_report
 
         return render_duct_path_report(

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_choice,
     require_equal_shapes,
     require_positive,
@@ -213,9 +214,7 @@ class EnclosureResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.enclosure import render_enclosure_report
 
         return render_enclosure_report(

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -74,11 +74,12 @@ end-to-end fan-to-room calculation.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_choice,
     require_positive,
     require_ranks,
@@ -437,6 +438,11 @@ def _octave_slots(
     return f, idx
 
 
+#: What an HVAC spectrum holds: "attenuation" (insertion loss/attenuation, dB)
+#: or "sound_power_level" (regenerated noise, dB re 1e-12 W).
+HvacQuantity = Literal["attenuation", "sound_power_level"]
+
+
 @dataclass(frozen=True)
 class HvacSpectrumResult:
     """A per-frequency HVAC quantity (attenuation or regenerated power level).
@@ -451,7 +457,7 @@ class HvacSpectrumResult:
 
     frequencies: np.ndarray
     values: np.ndarray
-    quantity: str
+    quantity: HvacQuantity
     label: str
 
     def __post_init__(self) -> None:
@@ -544,9 +550,7 @@ class HvacSpectrumResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.hvac import render_hvac_report
 
         return render_hvac_report(

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -115,6 +115,7 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import (
+    check_engine,
     require_non_negative,
     require_positive,
     require_ranks,
@@ -593,9 +594,7 @@ class ReactiveSilencerResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.silencer import render_reactive_silencer_report
 
         return render_reactive_silencer_report(

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -36,6 +36,7 @@ from scipy import signal
 
 from ..._internal.utils import _typesignal
 from ..._internal.validation import (
+    check_engine,
     require_positive,
     require_ranks,
     require_same_length,
@@ -245,9 +246,7 @@ class ZwickerLoudness:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso532 import render_iso532_report
 
         return render_iso532_report(

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -99,6 +99,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_counts,
     require_equal_shapes,
     require_ranks,
@@ -1285,9 +1286,7 @@ class ToneAudibilityResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso1996_tone import render_tone_audibility_report
 
         return render_tone_audibility_report(

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -44,7 +44,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.utils import _typesignal
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 from ..filters.core import OctaveFilterBank
 from ..io._resolve import apply_calibration, resolve_fs
 
@@ -282,9 +282,7 @@ class RoomAcousticsResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso3382 import render_iso3382_report
 
         return render_iso3382_report(

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import (
+    check_engine,
     require_fraction,
     require_positive,
     require_ranks,
@@ -321,9 +322,7 @@ class ReverberationResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.reverberation import render_enclosed_space_report
 
         return render_enclosed_space_report(

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -34,11 +34,12 @@ from __future__ import annotations
 import math
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -117,6 +118,13 @@ _RC_RUMBLE_LIMIT_DB = 5.0
 _RC_HISS_LIMIT_DB = 3.0
 
 
+#: How the NC designation was settled: the clause 5.2.2 NC-(SIL) curve, or
+#: the clause 5.2.3 tangency method.
+NCMethod = Literal["SIL", "tangency"]
+#: Which side of the NC-15 to NC-70 family an unratable spectrum left it on.
+NCOutOfRange = Literal["above", "below"]
+
+
 @dataclass(frozen=True)
 class NCResult:
     """Result of a Noise Criteria (NC) rating (ANSI/ASA S12.2-2019, 5.2).
@@ -153,8 +161,8 @@ class NCResult:
     levels: np.ndarray
     sil: float = float("nan")
     tangency_rating: float = float("nan")
-    method: str = "tangency"
-    out_of_range: str | None = None
+    method: NCMethod = "tangency"
+    out_of_range: NCOutOfRange | None = None
 
     def __post_init__(self) -> None:
         """Reject a rating whose spectrum and band axis disagree.
@@ -238,9 +246,7 @@ class NCResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.ansi_s12_2 import render_nc_report
 
         return render_nc_report(
@@ -360,9 +366,7 @@ class RCResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.ansi_s12_2 import render_rc_report
 
         return render_rc_report(
@@ -519,8 +523,8 @@ def noise_criterion(
         rating: float,
         governing_frequency: float,
         tangency_rating: float,
-        method: str,
-        out_of_range: str | None,
+        method: NCMethod,
+        out_of_range: NCOutOfRange | None,
     ) -> NCResult:
         return NCResult(
             rating=rating,

--- a/src/phonometry/room/open_plan.py
+++ b/src/phonometry/room/open_plan.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from .._internal.validation import require_equal_shapes
+from .._internal.validation import check_engine, require_equal_shapes
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -186,9 +186,7 @@ class OpenPlanResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.iso3382_3 import render_iso3382_3_report
 
         return render_iso3382_3_report(

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -77,6 +77,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import (
+    check_engine,
     require_non_negative,
     require_positive,
     require_ranks,
@@ -690,9 +691,7 @@ class ReverberationModelResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.reverberation import render_reverberation_models_report
 
         return render_reverberation_models_report(

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.validation import (
+    check_engine,
     require_axis_count,
     require_equal_counts,
     require_ranks,
@@ -833,9 +834,7 @@ class SIIResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.sii import render_sii_report
 
         return render_sii_report(

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 from scipy import signal
 
 from .._internal.utils import _typesignal
-from .._internal.validation import require_ranks, require_same_length
+from .._internal.validation import check_engine, require_ranks, require_same_length
 from .._internal.warnings import PhonometryWarning
 from ..filters.core import OctaveFilterBank
 from ..filters.frequencies import nominal_frequencies
@@ -194,9 +194,7 @@ class STIResult:
         from .._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from .._report.sti import render_sti_report
 
         return render_sti_report(

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -61,7 +61,11 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from scipy import signal as sig
 
-from ..._internal.validation import require_equal_counts, require_equal_shapes
+from ..._internal.validation import (
+    check_engine,
+    require_equal_counts,
+    require_equal_shapes,
+)
 from ..._internal.warnings import PhonometryWarning
 from ...io._resolve import SignalInput, resolve_fs, resolve_samples
 
@@ -1109,9 +1113,7 @@ class DailyVibrationExposure:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.human_vibration import render_human_vibration_report
 
         return render_human_vibration_report(

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -67,6 +67,7 @@ import numpy as np
 
 from ..._internal.types import as_float_or_array
 from ..._internal.validation import (
+    check_engine,
     require_1d_signal,
     require_choice,
     require_equal_shapes,
@@ -533,9 +534,7 @@ class MultipleShockResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso2631_5 import render_iso2631_5_report
 
         return render_iso2631_5_report(

--- a/src/phonometry/vibration/structural/mechanical_mobility.py
+++ b/src/phonometry/vibration/structural/mechanical_mobility.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
 
 
 from ..._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_non_negative,
     require_positive,
@@ -572,9 +573,7 @@ class MobilityResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso7626 import render_mobility_report
 
         return render_mobility_report(

--- a/src/phonometry/vibration/structural/transfer_stiffness.py
+++ b/src/phonometry/vibration/structural/transfer_stiffness.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 
 
 from ..._internal.validation import (
+    check_engine,
     require_non_negative,
     require_positive,
     require_ranks,
@@ -445,9 +446,7 @@ class TransferStiffnessResult:
         from ..._i18n import check_language
 
         check_language(language)
-        if engine != "reportlab":
-            msg = f"Unknown report engine {engine!r}; only 'reportlab' is supported."
-            raise ValueError(msg)
+        check_engine(engine)
         from ..._report.iso10846 import render_transfer_stiffness_report
 
         return render_transfer_stiffness_report(

--- a/tests/test_internal_validation.py
+++ b/tests/test_internal_validation.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 
 from phonometry._internal.validation import (
+    check_engine,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -215,3 +216,18 @@ def test_equal_shapes_sees_what_a_count_cannot() -> None:
     require_equal_shapes("f", {"a": (3,), "b": (3,)})
     with pytest.raises(ValueError, match="'b'"):
         require_equal_shapes("f", {"a": (3, 2), "b": (3, 4)})
+
+
+def test_the_one_engine_there_is_passes_in_silence() -> None:
+    check_engine("reportlab")
+
+
+def test_an_unknown_engine_is_refused_by_name() -> None:
+    """The single-choice gate every ``report`` entry point shares.
+
+    ``"reportlab"`` is the only engine today; the parameter is the seam a
+    second one would arrive through, and this one message is what every entry
+    point rejects with until then.
+    """
+    with pytest.raises(ValueError, match="Unknown report engine 'weasyprint'"):
+        check_engine("weasyprint")


### PR DESCRIPTION
Five small debts the guard-work censuses recorded and left for later, cleared together. Each was re-measured against current main before being touched, since the censuses predate the last three merges; all five were still live.

**One discriminant for the two band structures.** `filters.frequencies` classed a grid as octave-spaced above a ratio of 1.5 and `flanking_transmission` above 1.6, two private constants for the same question. There is now one, defined beside the band machinery it tells apart, and its value is grounded rather than round: `2**(2/3)`, the geometric midpoint of the two IEC 61260 nominal steps, equidistant from both in ratio space. Verified against the full nominal series on both sides: the widest third-octave step is 1.28 and the narrowest octave step 1.98, so no real grid changes class.

**Classes instead of their names.** Seven dispatches compared `type(x).__name__` against a string, which a rename silently breaks and no refactoring tool can follow. The layer renderer now matches the classes themselves, imported lazily so the rendering leaf still pays nothing for the domain at import time, with derived kinds tested before their plainer siblings; the ISO 16283 field-report table is keyed by the class. The seventh site was hiding behind a shared local and turned up as an undefined-name error the moment the variable feeding it was removed, which is precisely the failure mode string dispatch protects from view.

**One engine guard instead of fifty-nine.** Every `.report()` entry point carried the same three-line rejection of unknown engines verbatim. They now call `check_engine` in the shared validation module, importable from everywhere at module level, raising the exact message the fifty-nine copies raised so no test bound to it moves. The one wrapper that says more than the helper, grouping engine and language for three methods, stays and delegates.

**Literal types for the enumerated string fields.** The rating quantity, the event metric, the NC method and its out-of-range side, the HVAC quantity and the WAV container tag each carried `str` where the code accepts a closed set. Each set was enumerated from the producing or validating code rather than guessed, and one census entry was refused on those grounds: the read-info container is an open set, since the soundfile backend stores whatever format it met, so it stays `str` and the Literal went to the header parser whose set really is closed. The two-value rating literal also lets mypy discriminate a union two renderers were casting by hand; both casts came out as provably redundant.

**Raw strings in the snippets that carry backslashes.** The checker's ten SyntaxWarnings turned out to be four occurrences of the same two legend labels writing `\mathrm` in a non-raw string, on one page and its Spanish twin. Both editions now use raw strings; the plain mirror never carried the snippet, which was verified rather than assumed. The snippet gate now runs warning-clean with warnings promoted to errors.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a centralized validation function `check_engine` in `_internal/validation.py` to enforce supported report engines.</li>
<li>Refactored `_layer_kind_and_thickness` in `_plot/geometry/materials.py` to use `isinstance` checks with lazily imported classes instead of string-based class name comparisons.</li>
<li>Standardized event-level metric validation in `aircraft/airport_noise.py` by introducing an `EventMetric` type and a helper function `_checked_metric`.</li>
<li>Updated type annotations and validation logic across multiple aircraft and reporting modules to improve consistency and maintainability.</li>
</ul></div>

## Summary by Sourcery

Strengthen validation, type contracts, and dispatch logic across reporting and band-processing APIs while removing documentation warnings.

Bug Fixes:
- Eliminate documentation snippet SyntaxWarnings caused by backslash escapes in Matplotlib labels.
- Prevent report engine validation from diverging across report entry points by centralizing the existing supported-engine check.
- Make layer rendering and ISO 16283 reporting robust to class renames by dispatching on types rather than class-name strings.

Enhancements:
- Unify octave and one-third-octave band classification around a single IEC-based spacing threshold.
- Replace open-ended string annotations with precise Literal types for closed-set result and parameter values, enabling safer type narrowing and clearer API contracts.
- Consolidate event-metric validation and expose its supported values through shared typing.

Documentation:
- Update API reference signatures to document enumerated metric, rating, HVAC, NC, and WAV container types.

Tests:
- Add coverage for centralized report-engine validation, including accepted and rejected engines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer API type definitions for noise metrics, rating quantities, HVAC quantities, room noise criteria, and WAV containers.
  * Report generation now consistently validates supported rendering engines and provides standardized errors for unsupported options.
* **Bug Fixes**
  * Improved acoustic layer handling, including support for derived layer types.
  * Refined octave and one-third-octave band classification.
  * Corrected acceleration notation rendering in vibration examples in English and Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->