### PR TITLE
Make every Any name its replacement, and the rule keep it so

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,15 @@ select = [
     "PERF",                 # a loop whose whole body is one `append` is a
                             # comprehension, unless saying so costs more lines
                             # than it saves
+    "ANN401",               # an `Any` earns its keep or names its replacement.
+                            # A forwarding `*args`/`**kwargs` is exempt below:
+                            # matplotlib's keyword surface is an open set and
+                            # promising it closed would be the lie this rule
+                            # exists to catch. Everything else carries the type
+                            # the code actually handles, `object` when it never
+                            # looks inside, or a reasoned noqa when openness is
+                            # the point; every site was read one by one before
+                            # this went on
 ]
 ignore = [
     # TC006 quotes the first argument of `typing.cast`, which that function
@@ -217,6 +226,12 @@ ignore = [
     "D203",  # a blank line before a class docstring; D211 is the house shape
     "D213",  # the summary on the second line; D212 is the house shape
 ]
+[tool.ruff.lint.flake8-annotations]
+# The seam ANN401 needs to stay honest: a star-argument that only forwards is
+# allowed to be `Any`, because the set of keywords matplotlib and friends
+# accept is open and no TypedDict can close it truthfully.
+allow-star-arg-any = true
+
 [tool.ruff.lint.per-file-ignores]
 # `matplotlib.use("Agg")` has to run between `import matplotlib` and the first
 # `import matplotlib.pyplot`, and the scripts put the repository on `sys.path`

--- a/site/src/content/docs/reference/api/electroacoustics/piston.md
+++ b/site/src/content/docs/reference/api/electroacoustics/piston.md
@@ -203,7 +203,7 @@ plottable bundle around it.
 
 ```python
 PistonDirectivity.plot(
-    ax: Axes | None = None,
+    ax: PolarAxes | None = None,
     *,
     language: str = 'en',
     **kwargs: Any,

--- a/site/src/content/docs/reference/api/environment/cnossos-rail.md
+++ b/site/src/content/docs/reference/api/environment/cnossos-rail.md
@@ -251,7 +251,7 @@ Which text of the vertical directivity (2.3.16) to evaluate.
 horizontal_directivity(
     phi: float,
     *,
-    frequencies: Any = (50.0, 63.0, 80.0, 100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0),
+    frequencies: ArrayLike = (50.0, 63.0, 80.0, 100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0),
 ) -> NDArray[np.float64]
 ```
 
@@ -284,7 +284,10 @@ here to every source, as the Commission's reference module does.
 ## impact_roughness
 
 ```python
-impact_roughness(single: Any, joint_density: float) -> NDArray[np.float64]
+impact_roughness(
+    single: ArrayLike,
+    joint_density: float,
+) -> NDArray[np.float64]
 ```
 
 Impact roughness `L_R,IMPACT,i` of (2.3.12), in dB.
@@ -324,7 +327,7 @@ Directive prescribes for jointed track.
 ## octave_bands_from_third_octaves
 
 ```python
-octave_bands_from_third_octaves(levels: Any) -> NDArray[np.float64]
+octave_bands_from_third_octaves(levels: ArrayLike) -> NDArray[np.float64]
 ```
 
 Energy-sum a 24-band 1/3-octave spectrum into the eight octave bands.
@@ -584,8 +587,8 @@ REFERENCE_JOINT_DENSITY = 0.01
 
 ```python
 rolling_sound_power(
-    roughness: Any,
-    transfer: Any,
+    roughness: ArrayLike,
+    transfer: ArrayLike,
     axles: float,
 ) -> NDArray[np.float64]
 ```
@@ -653,11 +656,11 @@ than from the [`cnossos_rail`](/phonometry/reference/api/environment/cnossos-rai
 
 ```python
 roughness_to_frequency(
-    levels: Any,
-    wavelengths: Any,
+    levels: ArrayLike,
+    wavelengths: ArrayLike,
     speed: float,
     *,
-    frequencies: Any = (50.0, 63.0, 80.0, 100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0),
+    frequencies: ArrayLike = (50.0, 63.0, 80.0, 100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0),
     interpolation: RoughnessInterpolation = ...,
 ) -> NDArray[np.float64]
 ```
@@ -734,9 +737,9 @@ for freight wagons only.
 
 ```python
 total_effective_roughness(
-    rail: Any,
-    wheel: Any,
-    filter_: Any,
+    rail: ArrayLike,
+    wheel: ArrayLike,
+    filter_: ArrayLike,
 ) -> NDArray[np.float64]
 ```
 
@@ -978,7 +981,7 @@ Digit 1 of the vehicle descriptor, Table [2.3.a].
 vertical_directivity(
     psi: float,
     *,
-    frequencies: Any = (50.0, 63.0, 80.0, 100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0),
+    frequencies: ArrayLike = (50.0, 63.0, 80.0, 100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0, 800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0, 6300.0, 8000.0, 10000.0),
     height: int = 1,
     aerodynamic: bool = False,
     edition: DirectivityEdition = ...,

--- a/site/src/content/docs/reference/api/materials/design.md
+++ b/site/src/content/docs/reference/api/materials/design.md
@@ -242,7 +242,7 @@ predicted_diffusion_spectrum(
     frequencies: ArrayLike,
     *,
     depths: ArrayLike,
-    reflection_of: Any | None = None,
+    reflection_of: None = None,
     angles: ArrayLike = (-90, -85, -80, -75, -70, -65, -60, -55, -50, -45, -40, -35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90),
     source_angle: float = 0.0,
     periods: int = 1,

--- a/site/src/content/docs/reference/api/power/sound-power.md
+++ b/site/src/content/docs/reference/api/power/sound-power.md
@@ -177,12 +177,12 @@ returned as an `(N, 3)` array of Cartesian `(x, y, z)` in metres.
 ```python
 plot_microphone_positions(
     positions: ArrayLike,
-    ax: Any | None = None,
+    ax: Axes3D | None = None,
     *,
     radius: float | None = None,
     language: str = 'en',
     **kwargs: Any,
-) -> Any
+) -> Axes3D
 ```
 
 Draw a microphone position array on its measurement surface, in 3-D.

--- a/site/src/content/docs/reference/api/rooms/impulse-response.md
+++ b/site/src/content/docs/reference/api/rooms/impulse-response.md
@@ -370,7 +370,7 @@ autocorrelation is a near-perfect periodic delta
 
 ```python
 plot_excitation(
-    signal: np.ndarray | Any,
+    signal: ArrayLike,
     fs: int,
     *,
     kind: str = 'sweep',

--- a/site/src/content/docs/reference/api/signals/inversion.md
+++ b/site/src/content/docs/reference/api/signals/inversion.md
@@ -143,7 +143,7 @@ Number of samples in the inverse filter.
 
 ```python
 regularized_inverse_filter(
-    response: Signal | list[float] | np.ndarray | Any,
+    response: Signal | list[float] | np.ndarray | ImpulseResponseResult,
     fs: float | None = None,
     *,
     f_range: tuple[float, float],

--- a/site/src/content/docs/reference/api/signals/inversion.md
+++ b/site/src/content/docs/reference/api/signals/inversion.md
@@ -143,7 +143,7 @@ Number of samples in the inverse filter.
 
 ```python
 regularized_inverse_filter(
-    response: SignalInput,
+    response: SignalInput | TimedResponse,
     fs: float | None = None,
     *,
     f_range: tuple[float, float],

--- a/site/src/content/docs/reference/api/signals/inversion.md
+++ b/site/src/content/docs/reference/api/signals/inversion.md
@@ -143,7 +143,7 @@ Number of samples in the inverse filter.
 
 ```python
 regularized_inverse_filter(
-    response: Signal | list[float] | np.ndarray | ImpulseResponseResult,
+    response: SignalInput,
     fs: float | None = None,
     *,
     f_range: tuple[float, float],

--- a/src/phonometry/_i18n.py
+++ b/src/phonometry/_i18n.py
@@ -17,7 +17,10 @@ lazily and is a no-op for English, so English plots are byte-for-byte unchanged.
 from __future__ import annotations
 
 import re
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
 #: Supported rendering languages. English is the default everywhere.
 Language = Literal["en", "es"]
@@ -108,7 +111,7 @@ def decimal_comma(value: str, language: str = "en") -> str:
     return value.replace(".", ",") if language == "es" else value
 
 
-def localize_axes(ax: Any, language: str = "en") -> None:
+def localize_axes(ax: Axes, language: str = "en") -> None:
     """Localise the tick-label decimal separator of ``ax`` for the language.
 
     For Spanish, both axes' major tick labels are reformatted so decimals use a
@@ -129,7 +132,7 @@ def localize_axes(ax: Any, language: str = "en") -> None:
         than the ``1`` and ``1,5`` a bare ``{x:g}`` would produce.
         """
 
-        def __call__(self, x: float, pos: Any = None) -> str:
+        def __call__(self, x: float, pos: int | None = None) -> str:
             return super().__call__(x, pos).replace(".", ",")
 
     for axis in (ax.xaxis, ax.yaxis):

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -1055,7 +1055,7 @@ _MAX_NAMED_PATHS = 6
 
 
 def _plot_path_shares(
-    result: Any,
+    result: DetailedAirborneResult | DetailedImpactResult,
     total: np.ndarray,
     *,
     total_label: str,

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -30,6 +30,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from types import ModuleType
 
     from matplotlib.axes import Axes
     from matplotlib.container import BarContainer
@@ -39,6 +40,13 @@ if TYPE_CHECKING:
         ImpactRatingResult,
         WeightedRatingResult,
     )
+    from ..emission.sound_power import SoundPowerResult
+    from ..emission.sound_power_anechoic import PrecisionSoundPowerResult
+    from ..emission.sound_power_intensity import (
+        PrecisionIntensityResult,
+        SoundPowerIntensityResult,
+    )
+    from ..emission.sound_power_reverberation import ReverberationSoundPowerResult
     from ..room.acoustics import RoomAcousticsResult
 
 _INSTALL_HINT = (
@@ -558,7 +566,7 @@ def _t(text: str, language: str = "en") -> str:
     return _STRINGS.get(text, text) if language == "es" else text
 
 
-def _import_pyplot() -> Any:
+def _import_pyplot() -> ModuleType:
     """Import :mod:`matplotlib.pyplot` lazily with an actionable error."""
     try:
         import matplotlib.pyplot as plt
@@ -1050,13 +1058,18 @@ def _draw_decay_times(
 # ---------------------------------------------------------------------------
 
 
-def _sound_power_designation(result: Any) -> str:
+def _sound_power_designation(
+    result: SoundPowerResult
+    | PrecisionSoundPowerResult
+    | ReverberationSoundPowerResult
+    | SoundPowerIntensityResult
+    | PrecisionIntensityResult,
+) -> str:
     """The standard designation matching a sound-power result's method.
 
     Distinguishes the reverberation-room (ISO 3741) and intensity (ISO 9614)
-    determinations by their result types; the enveloping-surface pressure
-    methods (:class:`~phonometry.emission.sound_power.SoundPowerResult` and any other
-    duck-typed result) fall back to ISO 3744/3746.
+    determinations by their result types; every other result type falls back
+    to the enveloping-surface pressure methods' ISO 3744/3746.
     """
     from ..emission.sound_power_intensity import SoundPowerIntensityResult
     from ..emission.sound_power_reverberation import ReverberationSoundPowerResult

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -1067,10 +1067,14 @@ def _sound_power_designation(
 ) -> str:
     """The standard designation matching a sound-power result's method.
 
-    Distinguishes the reverberation-room (ISO 3741) and intensity (ISO 9614)
-    determinations by their result types; every other result type falls back
-    to the enveloping-surface pressure methods' ISO 3744/3746.
+    Distinguishes the reverberation-room (ISO 3741), intensity (ISO 9614)
+    and precision anechoic (ISO 3745) determinations by their result types;
+    every other result type falls back to the enveloping-surface pressure
+    methods' ISO 3744/3746. The precision branch is the youngest: until the
+    designation helper knew the type, an ISO 3745 grade-1 determination was
+    captioned with the engineering and survey standards it exists to outrank.
     """
+    from ..emission.sound_power_anechoic import PrecisionSoundPowerResult
     from ..emission.sound_power_intensity import SoundPowerIntensityResult
     from ..emission.sound_power_reverberation import ReverberationSoundPowerResult
 
@@ -1078,6 +1082,8 @@ def _sound_power_designation(
         return "ISO 3741"
     if isinstance(result, SoundPowerIntensityResult):
         return "ISO 9614"
+    if isinstance(result, PrecisionSoundPowerResult):
+        return "ISO 3745"
     return "ISO 3744/3746"
 
 

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import numpy as np
 
@@ -24,6 +24,7 @@ from .common import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.projections.polar import PolarAxes
 
     from ..electroacoustics.distortion import HarmonicDistortionResult
     from ..electroacoustics.frequency_response import FrequencyResponseResult
@@ -498,7 +499,7 @@ def plot_piston_impedance(
     return ax
 
 
-def _sign_theta_labels(ax: Any) -> None:
+def _sign_theta_labels(ax: PolarAxes) -> None:
     """Sign the polar angle ticks with the typographic minus U+2212.
 
     Matplotlib's polar ``ThetaFormatter`` builds its degree labels with a plain
@@ -511,7 +512,7 @@ def _sign_theta_labels(ax: Any) -> None:
 
     from .._i18n import fmt_minus
 
-    def _degrees(value: float, _pos: Any = None) -> str:
+    def _degrees(value: float, _pos: int | None = None) -> str:
         return f"{fmt_minus(round(float(np.degrees(value))), 'd')}°"
 
     ax.xaxis.set_major_formatter(FuncFormatter(_degrees))
@@ -519,7 +520,7 @@ def _sign_theta_labels(ax: Any) -> None:
 
 def plot_piston_directivity(
     result: PistonDirectivity,
-    ax: Any | None = None,
+    ax: PolarAxes | None = None,
     *,
     language: str = "en",
     **kwargs: Any,
@@ -584,8 +585,7 @@ def plot_piston_directivity(
             fontsize="small",
         )
     localize_axes(ax, language)
-    axes: Axes = ax
-    return axes
+    return ax
 
 
 # ---------------------------------------------------------------------------
@@ -707,7 +707,7 @@ def _draw_loudspeaker_thd(
 
 def _draw_datasheet_polar(
     result: LoudspeakerCharacteristics | MicrophoneCharacteristics,
-    ax: Any,
+    ax: PolarAxes,
     *,
     language: str = "en",
 ) -> None:
@@ -835,11 +835,11 @@ def _draw_microphone_distortion(
     ax.legend(loc="upper left", fontsize="small")
 
 
-def _new_polar_axes() -> Any:
+def _new_polar_axes() -> PolarAxes:
     """Create a single fresh polar figure + axes and return the axes."""
     plt = _import_pyplot()
     _fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
-    return ax
+    return cast("PolarAxes", ax)
 
 
 #: The loudspeaker ``.plot()`` quantities: the panel drawer, whether the panel
@@ -862,7 +862,7 @@ _MICROPHONE_QUANTITIES: dict[str, tuple[Any, bool, str | None]] = {
 
 
 def _plot_one_quantity(
-    result: Any,
+    result: LoudspeakerCharacteristics | MicrophoneCharacteristics,
     quantity: str,
     table: dict[str, tuple[Any, bool, str | None]],
     ax: Axes | None,

--- a/src/phonometry/_plot/emission.py
+++ b/src/phonometry/_plot/emission.py
@@ -32,7 +32,11 @@ if TYPE_CHECKING:
         IntensityInstrumentComplianceResult,
     )
     from ..emission.sound_power import SoundPowerResult
-    from ..emission.sound_power_intensity import SoundPowerIntensityResult
+    from ..emission.sound_power_anechoic import PrecisionSoundPowerResult
+    from ..emission.sound_power_intensity import (
+        PrecisionIntensityResult,
+        SoundPowerIntensityResult,
+    )
     from ..emission.sound_power_reverberation import ReverberationSoundPowerResult
     from ..emission.vibration_sound_power import VibrationSoundPowerResult
 
@@ -96,9 +100,10 @@ def _t(text: str, language: str = "en", **fmt: Any) -> str:
 def plot_sound_power(
     result: (
         SoundPowerResult
+        | PrecisionSoundPowerResult
         | ReverberationSoundPowerResult
         | SoundPowerIntensityResult
-        | Any
+        | PrecisionIntensityResult
     ),
     ax: Axes | None = None,
     language: str = "en",
@@ -117,9 +122,7 @@ def plot_sound_power(
     non-positive (``negative_band`` / ``not_applicable_band``) are hatched and
     greyed as unusable.
 
-    :param result: A sound-power result object exposing
-        ``sound_power_level``, ``sound_power_level_a`` and (optionally)
-        ``frequencies`` and ``negative_band``.
+    :param result: One of the five sound-power results named above.
     :param ax: Existing axes, or ``None`` to create a figure.
     :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the band :meth:`~matplotlib.axes.Axes.bar`.

--- a/src/phonometry/_plot/geometry/_draft.py
+++ b/src/phonometry/_plot/geometry/_draft.py
@@ -33,6 +33,7 @@ from ..common import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.patches import Rectangle
 
 #: Axis labels shared by the plan-view and 3-D renderers.
 _AXIS_X = "x [m]"
@@ -216,7 +217,7 @@ def _material_rect(
     height: float,
     kind: str,
     **kwargs: Any,
-) -> Any:
+) -> Rectangle:
     """A material cross-section rectangle in the house style; returns it."""
     from matplotlib.patches import Rectangle
 

--- a/src/phonometry/_plot/geometry/building.py
+++ b/src/phonometry/_plot/geometry/building.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from ...building.prediction.aperture_transmission import (
         ApertureTransmissionResult,
     )
-    from ...building.prediction.facade import FacadeElement
+    from ...building.prediction.facade import FacadeElement, FacadePredictionResult
     from ...building.prediction.panel_transmission import SoundReductionResult
 
 #: Spanish translations of the fixed strings rendered here, keyed by their
@@ -289,14 +289,14 @@ def plot_facade_elements(
 
 
 def plot_facade_result_geometry(
-    result: Any,
+    result: FacadePredictionResult,
     ax: Axes | None = None,
     *,
     language: str = "en",
     **kwargs: Any,
 ) -> Axes:
     """Facade elevation for a prediction that retained its ``elements``."""
-    if getattr(result, "elements", None) is None:
+    if result.elements is None:
         msg = (
             "This result does not retain its elements; call "
             "plot_facade_elements(elements) with the original sequence."

--- a/src/phonometry/_plot/geometry/emission.py
+++ b/src/phonometry/_plot/geometry/emission.py
@@ -44,6 +44,8 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.typing import ColorType
+    from mpl_toolkits.mplot3d.axes3d import Axes3D
     from numpy.typing import ArrayLike
 
     from ...emission.intensity import IntensityResult
@@ -81,7 +83,7 @@ def _t(text: str, language: str = "en") -> str:
 # ---------------------------------------------------------------------------
 # Microphone position arrays (ISO 3744/3745/3746), 3-D.
 # ---------------------------------------------------------------------------
-def _recede_3d_scaffolding(ax: Any, foreground: str) -> None:
+def _recede_3d_scaffolding(ax: Axes3D, foreground: str) -> None:
     """Clear the 3-D panes and dim the grid so the surface is the subject.
 
     Matplotlib's 3-D panes keep their light default under the dark style, and
@@ -108,7 +110,9 @@ def _recede_3d_scaffolding(ax: Any, foreground: str) -> None:
             )
 
 
-def _number_points(ax: Any, pts: np.ndarray, colours: Any) -> None:
+def _number_points(
+    ax: Axes3D, pts: np.ndarray, colours: str | Sequence[ColorType]
+) -> None:
     """Number each point with a chip in that point's own colour.
 
     The number is a chip in its own point's colour, so it carries the series
@@ -145,12 +149,12 @@ def _number_points(ax: Any, pts: np.ndarray, colours: Any) -> None:
 
 def plot_microphone_positions(
     positions: ArrayLike,
-    ax: Any | None = None,
+    ax: Axes3D | None = None,
     *,
     radius: float | None = None,
     language: str = "en",
     **kwargs: Any,
-) -> Any:
+) -> Axes3D:
     """Draw a microphone position array on its measurement surface, in 3-D.
 
     Numbered microphone points with a wireframe of the hemisphere (or full

--- a/src/phonometry/_plot/geometry/materials.py
+++ b/src/phonometry/_plot/geometry/materials.py
@@ -43,17 +43,26 @@ from ._draft import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.patches import Rectangle
     from numpy.typing import ArrayLike
 
     from ...materials.absorbers.four_microphone import TransferMatrix
     from ...materials.absorbers.impedance_tube import ImpedanceTubeResult
-    from ...materials.absorbers.layered import Layer, LayeredAbsorberResult
+    from ...materials.absorbers.layered import (
+        Layer,
+        LayeredAbsorberResult,
+        MicroperforatedPlateLayer,
+        PerforatedPlateLayer,
+    )
     from ...materials.absorbers.slow_sound import (
         HelmholtzResonator,
         SlitResonatorAbsorberResult,
     )
     from ...materials.diffusers.design import DiffuserPolarResponse
-    from ...materials.diffusers.metadiffuser import MetadiffuserResult
+    from ...materials.diffusers.metadiffuser import (
+        MetadiffuserResult,
+        MetadiffuserWell,
+    )
     from ...materials.surfaces.road_absorption import InsituAbsorptionResult
 
 #: Spanish translations of the fixed strings rendered here, keyed by their
@@ -106,7 +115,7 @@ def _t(text: str, language: str = "en") -> str:
 _MEMBRANE_DRAW_FRACTION = 0.012
 
 
-def _layer_kind_and_thickness(layer: Any, total: float) -> tuple[str, float, str]:
+def _layer_kind_and_thickness(layer: Layer, total: float) -> tuple[str, float, str]:
     """Map a layer dataclass to (style kind, drawn thickness, label key).
 
     Dispatch is by the classes themselves, imported lazily so this rendering
@@ -148,7 +157,11 @@ def _stack_total_depth(layers: Sequence[Any]) -> float:
 
 
 def _draw_plate_holes(
-    ax: Axes, layer: Any, x: float, thickness: float, height: float
+    ax: Axes,
+    layer: MicroperforatedPlateLayer | PerforatedPlateLayer,
+    x: float,
+    thickness: float,
+    height: float,
 ) -> None:
     """Carve the hole pattern of a (micro)perforated plate, to scale.
 
@@ -197,6 +210,11 @@ def plot_absorber_stack(
     :param kwargs: Forwarded to the front-layer rectangle.
     :return: The axes.
     """
+    from ...materials.absorbers.layered import (
+        MicroperforatedPlateLayer,
+        PerforatedPlateLayer,
+    )
+
     _check_language(language)
     stack = list(layers) if isinstance(layers, Sequence) else [layers]
     if not stack:
@@ -217,7 +235,10 @@ def plot_absorber_stack(
         kind, drawn, label_key = dispatched
         extra = dict(kwargs) if index == 0 else {}
         _material_rect(ax, x, 0.0, drawn, height, kind, **extra)
-        if kind == "plate":
+        # The isinstance is the "plate" test: `_layer_kind_and_thickness`
+        # styles exactly these two classes "plate", and matching the classes
+        # (not the style string) hands the hole drawer a narrowed layer.
+        if isinstance(layer, (MicroperforatedPlateLayer, PerforatedPlateLayer)):
             _draw_plate_holes(ax, layer, x, drawn, height)
         label = _t(label_key, language)
         physical = float(getattr(layer, "thickness", 0.0))
@@ -267,7 +288,7 @@ def _draw_resonator(
     ax: Axes,
     x_mouth: float,
     y_mouth: float,
-    resonator: Any,
+    resonator: HelmholtzResonator,
     *,
     wall: float,
 ) -> tuple[float, float]:
@@ -626,7 +647,7 @@ def _tube_bore(
     shape: str | None,
     diameter_known: bool,
     **kwargs: Any,
-) -> Any:
+) -> Rectangle:
     """Tube walls + bore + cross-section emblem; returns the primary patch.
 
     The bore spans ``y in [0, bore]``; walls are drawn just outside it. The
@@ -995,7 +1016,11 @@ def plot_slit_absorber_result_geometry(
 
 
 def _draw_metadiffuser_well(
-    ax: Axes, well: Any, x_slit: float, depth: float, kwargs: dict[str, Any]
+    ax: Axes,
+    well: MetadiffuserWell,
+    x_slit: float,
+    depth: float,
+    kwargs: dict[str, Any],
 ) -> None:
     """One slit with its sideways resonator shelves, panel coordinates."""
     h = float(well.slit_height)

--- a/src/phonometry/_plot/geometry/noise_control.py
+++ b/src/phonometry/_plot/geometry/noise_control.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from matplotlib.axes import Axes
+    from matplotlib.patches import Rectangle
 
     from ...noise_control.silencers import (
         ReactiveSilencerResult,
@@ -125,7 +126,7 @@ def _duct_walls(ax: Axes, x0: float, x1: float, d: float, wall: float) -> None:
         _material_rect(ax, x0, y, x1 - x0, wall, "plate", linewidth=0.5)
 
 
-def _draw_duct(ax: Axes, x0: float, x1: float, d: float, **kwargs: Any) -> Any:
+def _draw_duct(ax: Axes, x0: float, x1: float, d: float, **kwargs: Any) -> Rectangle:
     """A straight duct run: bore centred on y = 0, walls just outside."""
     from matplotlib.patches import Rectangle
 

--- a/src/phonometry/_plot/materials.py
+++ b/src/phonometry/_plot/materials.py
@@ -24,6 +24,7 @@ from .common import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..materials.absorbers.airflow_resistance import StaticAirflowResult
     from ..materials.absorbers.biot import BiotWavesResult
@@ -123,7 +124,7 @@ def _t(text: str, language: str = "en") -> str:
     return _STRINGS.get(text, text) if language == "es" else text
 
 
-def _localize_band_axes(ax: Any, language: str) -> None:
+def _localize_band_axes(ax: Axes, language: str) -> None:
     """Comma-localise the numeric y-axis of a categorical band plot.
 
     :func:`~phonometry._i18n.localize_axes` reformats only the automatic numeric
@@ -1044,7 +1045,7 @@ def plot_diffuser_polar_response(
 
 def plot_transfer_matrix(
     matrix: TransferMatrix,
-    frequency: Any,
+    frequency: ArrayLike,
     characteristic_impedance: float,
     ax: Axes | None = None,
     language: str = "en",

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -31,12 +31,13 @@ from .common import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..room.acoustics import DecayCurve, RoomAcousticsResult
     from ..room.crowd_noise import CrowdNoiseResult
     from ..room.enclosed_space_absorption import ReverberationResult
     from ..room.image_source import ImageSourceResult
-    from ..room.impulse_response import ImpulseResponseResult
+    from ..room.impulse_response import ImpulseResponseResult, ShapedSweepResult
     from ..room.modes import RoomModesResult
     from ..room.noise_criteria import NCResult, RCResult
     from ..room.open_plan import OpenPlanResult
@@ -150,7 +151,7 @@ def _t(text: str, language: str = "en") -> str:
     return _STRINGS.get(text, text) if language == "es" else text
 
 
-def _localize_band_axes(ax: Any, language: str) -> None:
+def _localize_band_axes(ax: Axes, language: str) -> None:
     """Comma-localise the numeric y-axis of a categorical band plot.
 
     :func:`~phonometry._i18n.localize_axes` reformats only the automatic numeric
@@ -675,7 +676,7 @@ def plot_open_plan(
 
 
 def plot_excitation(
-    signal: np.ndarray | Any,
+    signal: ArrayLike,
     fs: int,
     *,
     kind: str = "sweep",
@@ -955,7 +956,10 @@ def plot_steady_field(
 
 
 def plot_shaped_sweep(
-    result: Any, ax: Axes | None = None, language: str = "en", **kwargs: Any
+    result: ShapedSweepResult,
+    ax: Axes | None = None,
+    language: str = "en",
+    **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Shaped-sweep waveform and its Welch spectrum against the target.
 

--- a/src/phonometry/_plot/signals.py
+++ b/src/phonometry/_plot/signals.py
@@ -9,6 +9,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.typing import ColorType
 
     from ..signals.cepstrum import (
         CepstrumResult,
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
         TimeDelayResult,
     )
     from ..signals.envelope import EnvelopeResult, EnvelopeSpectrumResult
+    from ..signals.inversion import InverseFilterResult
     from ..signals.miso import MISOCoherenceResult
     from ..signals.multitaper import MultitaperSpectralDensityResult
     from ..signals.phase import PhaseDecompositionResult
@@ -214,7 +216,7 @@ def _plot_density_with_band(
     language: str,
     kwargs: dict[str, Any],
     *,
-    band_color: Any,
+    band_color: ColorType | None,
     band_alpha: float | None,
     band_label: str,
     line_label: str,
@@ -1460,7 +1462,11 @@ def plot_envelope_spectrum(
 
 #: Y-axis labels of the stationarity plot, keyed by the segment statistic.
 def plot_inverse_filter(
-    result: Any, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
+    result: InverseFilterResult,
+    ax: Axes | None = None,
+    *,
+    language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Measured, inverse and equalized magnitudes of a regularized inversion.
 

--- a/src/phonometry/_plot/simulation.py
+++ b/src/phonometry/_plot/simulation.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 
-    from ..simulation.elastic_fdtd import ElasticFDTDResult
+    from ..simulation.elastic_fdtd import ElasticFDTDResult, ElasticSource
     from ..simulation.fdtd import FDTDResult
 
 _TIME_LABEL = "Time [ms]"
@@ -273,7 +273,7 @@ def plot_fdtd_snapshot(
 
 
 def _elastic_source_position(
-    source: Any,
+    source: ElasticSource,
     dx: float,
 ) -> tuple[float, float]:
     """Physical position of an elastic source marker."""

--- a/src/phonometry/_plot/underwater.py
+++ b/src/phonometry/_plot/underwater.py
@@ -23,6 +23,7 @@ from .common import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike
 
     from ..underwater.bioacoustics.audiograms import AudiogramResult
     from ..underwater.bioacoustics.weighting import (
@@ -704,7 +705,7 @@ def plot_ray_trace(
 
 def _draw_bathymetry(
     ax: Axes,
-    result: Any,
+    result: RayTraceResult | GaussianBeamResult,
     r_max: float,
     language: str,
     *,
@@ -939,7 +940,7 @@ def plot_gaussian_beams(
     return ax
 
 
-def _plottable(levels: Any) -> np.ndarray:
+def _plottable(levels: ArrayLike) -> np.ndarray:
     """Levels with non-finite entries as ``nan``, which matplotlib skips.
 
     Band levels carry ``-inf`` where a band holds no energy at all; drawing

--- a/src/phonometry/_plot/vibration.py
+++ b/src/phonometry/_plot/vibration.py
@@ -31,7 +31,10 @@ _OP_COLORS = (_C_PRIMARY, _C_TERTIARY, _C_QUATERNARY, _C_PRIMARY_LIGHT, _C_MUTED
 _A8_COLOR = _C_EDGE
 
 if TYPE_CHECKING:
+    from typing import Protocol
+
     from matplotlib.axes import Axes
+    from numpy.typing import ArrayLike, NDArray
 
     from ..vibration.human.exposure import (
         DailyVibrationExposure,
@@ -50,6 +53,21 @@ if TYPE_CHECKING:
     )
     from ..vibration.structural.radiation_efficiency import RadiationEfficiencyResult
     from ..vibration.structural.transfer_stiffness import TransferStiffnessResult
+
+    class _SpectrumLike(Protocol):
+        """A measured spectrum: anything exposing the two plotted vectors.
+
+        :class:`~phonometry.signals.envelope.EnvelopeSpectrumResult` is the
+        expected case, but the fault-line overlay only reads these two
+        array-likes, so the contract is stated structurally.
+        """
+
+        @property
+        def frequencies(self) -> ArrayLike: ...
+
+        @property
+        def amplitude(self) -> ArrayLike: ...
+
 
 #: Shared frequency-axis label of the vibration renderers.
 _FREQ_LABEL = "Frequency [Hz]"
@@ -683,8 +701,8 @@ _FAMILY_COLORS: dict[str, str] = {
 
 def _draw_measured_spectrum(
     ax: Axes,
-    frequencies: Any,
-    amplitude: Any,
+    frequencies: NDArray[np.float64] | None,
+    amplitude: NDArray[np.float64] | None,
     f_max: float,
     language: str,
     kwargs: dict[str, Any],
@@ -870,7 +888,7 @@ def plot_fault_frequencies(
     ax: Axes | None = None,
     *,
     language: str = "en",
-    spectrum: Any | None = None,
+    spectrum: _SpectrumLike | None = None,
     max_frequency: float | None = None,
     annotate: bool = True,
     **kwargs: Any,

--- a/src/phonometry/_report/_frf_fiche.py
+++ b/src/phonometry/_report/_frf_fiche.py
@@ -44,6 +44,8 @@ from ._layout import (
 if TYPE_CHECKING:
     import numpy as np
 
+    from ..vibration.structural.mechanical_mobility import MobilityResult
+    from ..vibration.structural.transfer_stiffness import TransferStiffnessResult
     from .metadata import ReportMetadata
 
 
@@ -89,7 +91,7 @@ def frf_metadata_pairs(
 
 
 def render_frf_fiche(
-    result: Any,
+    result: MobilityResult | TransferStiffnessResult,
     path: str,
     *,
     title: str,

--- a/src/phonometry/_report/_insulation_fiche.py
+++ b/src/phonometry/_report/_insulation_fiche.py
@@ -45,6 +45,9 @@ from ._layout import (
 from .iso717 import _Y_TOP_AIRBORNE, _Y_TOP_IMPACT, _metadata_pairs
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from reportlab.platypus import Table
+
     from ..building.measurement.insulation import (
         ImpactRatingResult,
         WeightedRatingResult,
@@ -61,7 +64,7 @@ Column = tuple[str, np.ndarray, int]
 #: the multi-column verbose table) or ``None`` (the two-column ``f | value``
 #: form, whose widths are fixed here).
 ColumnsBuilder = Callable[
-    [str, np.ndarray, bool, str], tuple[Sequence[Column], str, Any]
+    [str, np.ndarray, bool, str], tuple[Sequence[Column], str, list[float] | None]
 ]
 
 
@@ -117,8 +120,8 @@ def band_value_table(
     centers: np.ndarray,
     columns: Sequence[Column],
     language: str,
-    col_widths: Any = None,
-) -> Any:
+    col_widths: list[float] | None = None,
+) -> Table:
     """Build the left-hand per-band table.
 
     A single column following the frequency column is the recommended-form
@@ -133,6 +136,7 @@ def band_value_table(
 
     head_style = band_table_header_style()
 
+    widths: list[float] | None
     if len(columns) == 1:
         header = [
             fiche_paragraph(t("Frequency f [Hz]", language), head_style),
@@ -203,7 +207,7 @@ def iso717_columns_builder(
 
 
 def render_insulation_fiche(
-    result: Any,
+    result: object,
     rating: WeightedRatingResult | ImpactRatingResult,
     path: str,
     *,
@@ -314,7 +318,7 @@ def render_insulation_fiche(
     value_table = band_value_table(centers, columns, language, col_widths)
     left_cell = [fiche_paragraph(caption, caption_style), value_table]
 
-    def _plot(ax: Any = None, language: str = language) -> Any:
+    def _plot(ax: Axes | None = None, language: str = language) -> Axes:
         axes = rating.plot(ax=ax, language=language)
         axes.set_ylabel(t(spec["ylabel"], language))
         return axes

--- a/src/phonometry/_report/_layout.py
+++ b/src/phonometry/_report/_layout.py
@@ -32,6 +32,12 @@ from ._i18n import format_number, t
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from numpy.typing import ArrayLike
+    from reportlab.graphics.shapes import Drawing
+    from reportlab.lib.colors import Color
+    from reportlab.lib.styles import ParagraphStyle, StyleSheet1
+    from reportlab.platypus import Flowable, Paragraph, Table
+
     from .metadata import ReportMetadata
 
 #: Installation hints for the three soft dependencies of the report.
@@ -86,7 +92,7 @@ _BAND_RATIO_TOLERANCE = 0.03
 _MIN_RESPONSE_SPAN = 2.0 ** (1.0 / 3.0)
 
 
-def fiche_paragraph(text: str, style: Any, **kwargs: Any) -> Any:
+def fiche_paragraph(text: str, style: ParagraphStyle, **kwargs: Any) -> Paragraph:
     """Build a reportlab ``Paragraph`` whose sub/superscripts cannot collide.
 
     Every fiche paragraph is created through this factory (the renderers
@@ -120,7 +126,7 @@ def escaped_pairs(
     ]
 
 
-def measurement_basis_style() -> Any:
+def measurement_basis_style() -> ParagraphStyle:
     """The muted footnote style for the measurement-basis strip under a fiche.
 
     The stacked-layout fiches (programme loudness, room acoustics ...) close
@@ -192,7 +198,7 @@ def render_figure_drawing(
     figsize: tuple[float, float] | None = None,
     subplot_kw: dict[str, Any] | None = None,
     language: str = "en",
-) -> Any:
+) -> Drawing:
     """Draw a result's plot as a scaled, vector reportlab ``Drawing``.
 
     ``plot_fn`` is the result's own ``plot`` method; it is called with a fresh
@@ -320,7 +326,7 @@ def render_figure_drawing(
     return drawing
 
 
-def grid_table(pairs: list[tuple[str, str]]) -> Any:
+def grid_table(pairs: list[tuple[str, str]]) -> Table:
     """Lay an ordered list of (label, value) pairs into a two-column grid.
 
     Each grid row holds up to two label/value pairs (four table cells:
@@ -382,7 +388,7 @@ def grid_table(pairs: list[tuple[str, str]]) -> Any:
     return table
 
 
-def band_table_header_style() -> Any:
+def band_table_header_style() -> ParagraphStyle:
     """The white-on-accent header-cell paragraph style of the band tables.
 
     Shared by the one-third-octave value tables of the sound-insulation
@@ -401,7 +407,7 @@ def band_table_header_style() -> Any:
     )
 
 
-def response_decades(frequencies: Any, where: str) -> float:
+def response_decades(frequencies: ArrayLike, where: str) -> float:
     """The decades a response curve spans, refusing a span too narrow to draw.
 
     The IEC 60268 fiches keep their response panel to the IEC 60263 scale by
@@ -434,7 +440,9 @@ def response_decades(frequencies: Any, where: str) -> float:
     return float(np.log10(high / low))
 
 
-def _require_column_widths(data: list[list[Any]], col_widths: Any, where: str) -> None:
+def _require_column_widths(
+    data: list[list[Any]], col_widths: list[float] | None, where: str
+) -> None:
     """Require a width list to have one entry per column of *data*.
 
     reportlab does not refuse a list of the wrong length: it takes the column
@@ -466,7 +474,7 @@ def _require_column_widths(data: list[list[Any]], col_widths: Any, where: str) -
         raise ValueError(msg)
 
 
-def _octave_grouping(band_centres: Any) -> int | None:
+def _octave_grouping(band_centres: ArrayLike | None) -> int | None:
     """Rows per octave in *band_centres*, or ``None`` when they are not bands.
 
     The thin rules of the accredited reports group a table by octave, so they
@@ -495,12 +503,12 @@ def _octave_grouping(band_centres: Any) -> int | None:
 
 def band_table(
     rows: list[list[Any]],
-    col_widths: list[Any],
+    col_widths: list[float] | None,
     n_data: int,
     extra_styles: list[Any] | None = None,
     *,
-    band_centres: Any,
-) -> Any:
+    band_centres: ArrayLike | None,
+) -> Table:
     """Assemble a band table with the accredited styling.
 
     Applies the shared look of the sound-insulation fiches: the accent header
@@ -559,7 +567,9 @@ def band_table(
     return table
 
 
-def document_styles(accent: Any) -> tuple[Any, Any, Any, Any]:
+def document_styles(
+    accent: Color,
+) -> tuple[StyleSheet1, ParagraphStyle, ParagraphStyle, ParagraphStyle]:
     """Return ``(stylesheet, title_style, basis_style, caption_style)``.
 
     The title (accent, 16 pt), the standard-basis line (muted, 9.5 pt) and the
@@ -598,12 +608,12 @@ def document_styles(accent: Any) -> tuple[Any, Any, Any, Any]:
 
 
 def two_panel_body(
-    left_cell: Any,
-    plot_drawing: Any,
+    left_cell: Flowable | list[Flowable],
+    plot_drawing: Drawing,
     *,
     left_width_mm: float = 56.0,
     plot_width_mm: float = 118.0,
-) -> Any:
+) -> Table:
     """Assemble the two-panel body: a left cell beside the result's plot.
 
     Every fiche puts a table or metrics list on the left and the result's own
@@ -634,7 +644,9 @@ def two_panel_body(
     return body
 
 
-def metrics_table(rows: list[tuple[str, str]], *, col_widths: Any = None) -> Any:
+def metrics_table(
+    rows: list[tuple[str, str]], *, col_widths: list[float] | None = None
+) -> Table:
     """A compact two-column ``metric | value`` table for a non-band fiche.
 
     The band fiches put a frequency table on the left; the single-metric fiches
@@ -691,9 +703,9 @@ def metrics_table(rows: list[tuple[str, str]], *, col_widths: Any = None) -> Any
 def compliance_table(
     rows: list[tuple[str, str, str, str]],
     *,
-    col_widths: Any = None,
+    col_widths: list[float] | None = None,
     language: str = "en",
-) -> Any:
+) -> Table:
     """A full-width 4-column ``metric | measured | target/limit | result`` table.
 
     The stacked-layout fiches (programme loudness, aircraft noise ...) check a
@@ -857,7 +869,7 @@ def exceedance_markup(exceeded: bool | None, language: str = "en") -> str:
     )
 
 
-def stacked_table(data: list[list[Any]], col_widths: list[Any]) -> Any:
+def stacked_table(data: list[list[Any]], col_widths: list[float]) -> Table:
     """A full-width table with the accredited styling (accent header, zebra rows).
 
     Shared by the exposure fiches: the accent header row, zebra body rows and a
@@ -893,10 +905,10 @@ def stacked_table(data: list[list[Any]], col_widths: list[Any]) -> Any:
 
 def result_box(
     statement: str,
-    styles: Any,
-    accent: Any,
+    styles: StyleSheet1,
+    accent: Color,
     extended: list[str] | None = None,
-) -> Any:
+) -> Table:
     """The boxed single-number result, with optional extended terms alongside.
 
     Called only after the renderer has imported reportlab.
@@ -945,7 +957,7 @@ def result_box(
 
 
 def verdict_flow(
-    text: str, passed: bool, styles: Any, language: str = "en"
+    text: str, passed: bool, styles: StyleSheet1, language: str = "en"
 ) -> list[Any]:
     """The PASS/FAIL verdict paragraph for a precomputed comparison.
 

--- a/src/phonometry/_report/_noise_control_fiche.py
+++ b/src/phonometry/_report/_noise_control_fiche.py
@@ -48,6 +48,11 @@ from ._layout import (
 from ._sound_power_fiche import band_labels, d1, metadata_pairs, power_value_table
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
+    from ..noise_control.enclosures import EnclosureResult
+    from ..noise_control.hvac import HvacSpectrumResult
+    from ..noise_control.silencers import ReactiveSilencerResult
     from .metadata import ReportMetadata
 
 __all__ = [
@@ -123,13 +128,13 @@ def performance_verdict(
 
 
 def render_noise_control_fiche(
-    result: Any,
+    result: EnclosureResult | ReactiveSilencerResult | HvacSpectrumResult,
     path: str,
     *,
     title: str,
     basis: str,
     caption: str,
-    value_table: Any,
+    value_table: Table,
     statement: str,
     extended: list[str],
     basis_strips: list[str],

--- a/src/phonometry/_report/_sound_power_fiche.py
+++ b/src/phonometry/_report/_sound_power_fiche.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 
@@ -47,7 +47,30 @@ from ._layout import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from numpy.typing import ArrayLike
+    from reportlab.platypus import Table
+
     from .metadata import ReportMetadata
+
+    class SoundPowerLike(Protocol):
+        """A determined sound-power result, stated structurally.
+
+        The shared helpers read exactly these three members: the per-band
+        ``sound_power_level``, its A-weighted total and the band centres that
+        label the table rows. Every sound-power result class (ISO 3744/3745,
+        ISO 3741, ISO 9614 and its precision variant, ISO/TS 7849) carries
+        them; the render layer never imports those domain classes at runtime.
+        """
+
+        @property
+        def frequencies(self) -> np.ndarray | None: ...
+
+        @property
+        def sound_power_level(self) -> np.ndarray: ...
+
+        @property
+        def sound_power_level_a(self) -> float: ...
+
 
 #: Reference sound power for the sound power level, 1 pW = 10^-12 W.
 POWER_REFERENCE = "1 pW"
@@ -143,7 +166,7 @@ def range_str(values: np.ndarray, language: str = "en", decimals: int = 1) -> st
     )
 
 
-def energy_sum(levels: Any) -> float:
+def energy_sum(levels: ArrayLike) -> float:
     """Energy sum of a per-band level array, ``10 lg(sum 10^(L/10))`` dB.
 
     Non-finite bands are skipped: a band the method could not determine
@@ -157,12 +180,12 @@ def energy_sum(levels: Any) -> float:
     return float(10.0 * np.log10(np.sum(10.0 ** (finite / 10.0))))
 
 
-def total_power_level(result: Any) -> float:
+def total_power_level(result: SoundPowerLike) -> float:
     """Energy sum of the band sound-power levels, ``10 lg(sum 10^(LW/10))`` dB."""
     return energy_sum(result.sound_power_level)
 
 
-def headline_level(result: Any, level_a: float | None = None) -> float:
+def headline_level(result: SoundPowerLike, level_a: float | None = None) -> float:
     """The single number the verdict compares: ``LWA`` if defined, else total ``LW``.
 
     ``level_a`` overrides the result's own A-weighted total, for a fiche whose
@@ -196,7 +219,7 @@ def headline_level(result: Any, level_a: float | None = None) -> float:
 
 
 def power_statement(
-    result: Any, language: str = "en", *, level_a: float | None = None
+    result: SoundPowerLike, language: str = "en", *, level_a: float | None = None
 ) -> tuple[str, list[str]]:
     """The boxed sound-power result and its base extended terms.
 
@@ -235,7 +258,7 @@ def power_statement(
 
 
 def power_verdict(
-    result: Any,
+    result: SoundPowerLike,
     requirement: float,
     language: str = "en",
     *,
@@ -297,7 +320,7 @@ def level_limit_verdict(
     return text, passed
 
 
-def fraction_caption(result: Any, language: str = "en") -> str:
+def fraction_caption(result: SoundPowerLike, language: str = "en") -> str:
     """The caption declaring the analysis band set above the table."""
     freqs = getattr(result, "frequencies", None)
     n = np.asarray(result.sound_power_level, dtype=np.float64).size
@@ -314,7 +337,7 @@ def power_value_table(
     rows_data: Sequence[Sequence[Any]],
     widths: Sequence[float],
     fraction: int,
-) -> Any:
+) -> Table:
     """Build the full-width per-band table with the accredited sound-power style.
 
     ``header`` holds the (markup) column headings and ``rows_data`` the band
@@ -394,11 +417,15 @@ class FicheCopy:
 
 
 def render_sound_power_fiche(
-    result: Any,
+    # The skeleton itself reads only ``plot``, but the airborne fiches lean on
+    # the fallback verdict below, which reads the SoundPowerLike levels, while
+    # the structure-borne fiches (EN 15657, EN 12354-5) pass plot-only results
+    # with a pre-computed verdict. No one protocol covers both contracts.
+    result: Any,  # noqa: ANN401
     path: str,
     *,
     copy: FicheCopy,
-    value_table: Any,
+    value_table: Table,
     metadata: ReportMetadata | None,
     language: str,
     verdict: tuple[str, bool] | None = None,

--- a/src/phonometry/_report/ansi_s12_2.py
+++ b/src/phonometry/_report/ansi_s12_2.py
@@ -66,6 +66,11 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.platypus import Table
+
     from ..room.noise_criteria import NCResult, RCResult
     from .metadata import ReportMetadata
 
@@ -73,7 +78,7 @@ if TYPE_CHECKING:
 _TITLE = "Room noise rating"
 
 
-def _thead_style() -> Any:
+def _thead_style() -> ParagraphStyle:
     """The shared white-on-accent table-header paragraph style (7.4 pt)."""
     from reportlab.lib import colors
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -133,8 +138,8 @@ def _level_cell(level: float, language: str, decimals: int = 1) -> str:
 
 def _value_table(
     columns: list[tuple[str, list[str]]],
-    col_widths: list[Any],
-) -> Any:
+    col_widths: list[float],
+) -> Table:
     """Assemble the left-hand octave-band table with the accredited styling.
 
     ``columns`` is an ordered list of ``(header_markup, cell_strings)`` pairs;
@@ -211,11 +216,11 @@ def _base_columns(levels: np.ndarray, language: str) -> list[tuple[str, list[str
 
 def _assemble_left(
     columns: list[tuple[str, list[str]]],
-    col_widths: list[Any],
+    col_widths: list[float],
     widths: tuple[float, float],
-    caption_style: Any,
+    caption_style: ParagraphStyle,
     language: str,
-) -> tuple[list[Any], list[Any]]:
+) -> tuple[list[Any], list[float]]:
     """Wrap the caption and value table into a two-panel left cell."""
     from ._layout import fiche_paragraph
 
@@ -228,8 +233,8 @@ def _assemble_left(
 
 
 def _nc_left_cell(
-    result: NCResult, verbose: bool, caption_style: Any, language: str
-) -> tuple[list[Any], list[Any]]:
+    result: NCResult, verbose: bool, caption_style: ParagraphStyle, language: str
+) -> tuple[list[Any], list[float]]:
     """The NC fiche left cell (caption + table) and its two-panel column widths."""
     from reportlab.lib.units import mm
 
@@ -250,8 +255,8 @@ def _nc_left_cell(
 
 
 def _rc_left_cell(
-    result: RCResult, verbose: bool, caption_style: Any, language: str
-) -> tuple[list[Any], list[Any]]:
+    result: RCResult, verbose: bool, caption_style: ParagraphStyle, language: str
+) -> tuple[list[Any], list[float]]:
     """The RC fiche left cell (caption + table) and its two-panel column widths."""
     from reportlab.lib.units import mm
 
@@ -439,13 +444,15 @@ def _verdict(
     return text, passed
 
 
-def _render_room_noise(
-    result: NCResult | RCResult,
+def _render_room_noise[R: NCResult | RCResult](
+    result: R,
     path: str,
     *,
     basis_template: str,
-    left_builder: Any,
-    statement_builder: Any,
+    left_builder: Callable[
+        [R, bool, ParagraphStyle, str], tuple[list[Any], list[float]]
+    ],
+    statement_builder: Callable[[R, str], tuple[str, list[str]]],
     symbol: str,
     metadata: ReportMetadata | None,
     verbose: bool,

--- a/src/phonometry/_report/duct_path.py
+++ b/src/phonometry/_report/duct_path.py
@@ -57,6 +57,7 @@ from ._sound_power_fiche import metadata_pairs
 
 if TYPE_CHECKING:
     from ..noise_control.duct_path import DuctPathResult
+    from ..room.noise_criteria import NCResult, RCResult
     from .metadata import ReportMetadata
 
 #: Rows whose values are a level rather than a correction, shaded to separate
@@ -269,7 +270,7 @@ def _sheet_table(
     return table, len(rows)
 
 
-def _rating_designation(rating: Any) -> str:
+def _rating_designation(rating: NCResult | RCResult) -> str:
     """The room-criterion designation, at the display rounding of a fiche.
 
     The rating objects print their designation with ``:g``, which is right for

--- a/src/phonometry/_report/en12354_5.py
+++ b/src/phonometry/_report/en12354_5.py
@@ -41,7 +41,7 @@ guarded with an actionable :class:`ImportError`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -57,6 +57,8 @@ from ._sound_power_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..building.prediction.installed_structure_borne import InstalledSourceResult
     from .metadata import ReportMetadata
 
@@ -74,7 +76,7 @@ def _basis(language: str = "en") -> str:
     )
 
 
-def _caption(result: Any, language: str = "en") -> str:
+def _caption(result: InstalledSourceResult, language: str = "en") -> str:
     """The caption declaring the analysis band set above the table."""
     freqs = getattr(result, "frequencies", None)
     total = np.atleast_1d(np.asarray(result.total_level, dtype=np.float64))
@@ -99,7 +101,9 @@ def _column_widths(n_columns: int) -> list[float]:
     return [_CONTENT_WIDTH_MM / n_columns] * n_columns
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(
+    result: InstalledSourceResult, verbose: bool, language: str = "en"
+) -> Table:
     """Build the full-width per-band multi-path table.
 
     Columns are ``f | L_Ws,inst | L_n,s,1 ... L_n,s,P | L_n,s`` (the installed
@@ -134,7 +138,9 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
+def _statement(
+    result: InstalledSourceResult, language: str = "en"
+) -> tuple[str, list[str]]:
     """The boxed total ``L_n,s`` and its extended terms."""
     overall = float(result.overall_level)
     statement = t(

--- a/src/phonometry/_report/en15657.py
+++ b/src/phonometry/_report/en15657.py
@@ -39,7 +39,7 @@ guarded with an actionable :class:`ImportError`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -55,6 +55,8 @@ from ._sound_power_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..building.measurement.structure_borne_power import StructureBornePowerResult
     from .metadata import ReportMetadata
 
@@ -69,7 +71,7 @@ def _basis(language: str = "en") -> str:
     )
 
 
-def _caption(result: Any, language: str = "en") -> str:
+def _caption(result: StructureBornePowerResult, language: str = "en") -> str:
     """The caption declaring the analysis band set above the table."""
     freqs = getattr(result, "frequencies", None)
     n = np.asarray(result.power_level, dtype=np.float64).size
@@ -88,7 +90,9 @@ def _eta_cell(value: float, language: str = "en") -> str:
     return format_number(float(value), language, decimals=4)
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(
+    result: StructureBornePowerResult, verbose: bool, language: str = "en"
+) -> Table:
     """Build the full-width per-band table (nominal frequency, Lv, L_Ws).
 
     The default table is the ``f | Lv | L_Ws`` form; ``verbose`` inserts the
@@ -130,7 +134,9 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
+def _statement(
+    result: StructureBornePowerResult, language: str = "en"
+) -> tuple[str, list[str]]:
     """The boxed total ``L_Ws`` and its extended plate terms."""
     total = float(result.total_level)
     statement = t(

--- a/src/phonometry/_report/enclosure.py
+++ b/src/phonometry/_report/enclosure.py
@@ -32,7 +32,7 @@ matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -47,6 +47,8 @@ from ._noise_control_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..noise_control.enclosures import EnclosureResult
     from .metadata import ReportMetadata
 
@@ -75,7 +77,7 @@ def _prediction_statement(language: str = "en") -> str:
     )
 
 
-def _caption(result: Any, language: str = "en") -> str:
+def _caption(result: EnclosureResult, language: str = "en") -> str:
     """The caption declaring the analysis band set above the table."""
     freqs = getattr(result, "frequencies", None)
     n = np.asarray(result.insertion_loss, dtype=np.float64).size
@@ -87,7 +89,7 @@ def _caption(result: Any, language: str = "en") -> str:
     return t("One-third-octave-band insertion loss", language)
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(result: EnclosureResult, verbose: bool, language: str = "en") -> Table:
     """Build the per-band table (nominal frequency, R, C, IL; verbose adds R_i).
 
     Called only after the renderer has imported reportlab.
@@ -134,7 +136,9 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[float, str, list[str]]:
+def _statement(
+    result: EnclosureResult, language: str = "en"
+) -> tuple[float, str, list[str]]:
     """The boxed mean insertion loss and its extended enclosure terms."""
     mean_il = mean_finite(result.insertion_loss)
     mean_r = mean_finite(result.panel_transmission_loss)

--- a/src/phonometry/_report/human_vibration.py
+++ b/src/phonometry/_report/human_vibration.py
@@ -71,7 +71,9 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
-    from ..vibration.human.exposure import DailyVibrationExposure
+    from reportlab.platypus import Table
+
+    from ..vibration.human.exposure import DailyVibrationExposure, ExposureAssessment
     from .metadata import ReportMetadata
 
 #: Number of decimal places the fiche displays vibration magnitudes at. Two
@@ -164,7 +166,7 @@ def _metadata_pairs(
 
 def _operations_table(
     result: DailyVibrationExposure, verbose: bool = False, language: str = "en"
-) -> Any:
+) -> Table:
     """The per-operation exposure-analysis table (ISO 5349-1/-2 Eqs. (2)/(3)).
 
     One row per operation (label, the vibration total value, the daily exposure
@@ -284,7 +286,7 @@ def _assessment_rows(
     ]
 
 
-def _assessment_table(result: DailyVibrationExposure, language: str = "en") -> Any:
+def _assessment_table(result: DailyVibrationExposure, language: str = "en") -> Table:
     """The Directive 2002/44/EC assessment table (exceeded / not exceeded)."""
     from reportlab.lib.units import mm
 
@@ -321,7 +323,7 @@ _ZONE_LABELS: dict[str, str] = {
 }
 
 
-def _displayed_zone(assessment: Any) -> str:
+def _displayed_zone(assessment: ExposureAssessment) -> str:
     """The exposure zone evaluated on the value rounded as displayed.
 
     The assessment rows and the verdict compare ``A(8)`` rounded exactly as

--- a/src/phonometry/_report/hvac.py
+++ b/src/phonometry/_report/hvac.py
@@ -33,7 +33,7 @@ matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -48,6 +48,8 @@ from ._noise_control_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..noise_control.hvac import HvacSpectrumResult
     from .metadata import ReportMetadata
 
@@ -59,7 +61,7 @@ _POWER_REFERENCE = "1 pW"
 _THIRD_OCTAVE_FRACTION = 3
 
 
-def _is_power(result: Any) -> bool:
+def _is_power(result: HvacSpectrumResult) -> bool:
     """Return ``True`` for a regenerated sound power spectrum, else attenuation."""
     return getattr(result, "quantity", "") == "sound_power_level"
 
@@ -104,7 +106,7 @@ def _a_weighted_total(
     return _overall_level(weighted)
 
 
-def _basis(result: Any, language: str = "en") -> str:
+def _basis(result: HvacSpectrumResult, language: str = "en") -> str:
     """The prediction-basis line naming the quantity and the Bies chapter."""
     if _is_power(result):
         return t(
@@ -122,7 +124,7 @@ def _basis(result: Any, language: str = "en") -> str:
     )
 
 
-def _prediction_statement(result: Any, language: str = "en") -> str:
+def _prediction_statement(result: HvacSpectrumResult, language: str = "en") -> str:
     """The prediction statement printed under the boxed figure."""
     if _is_power(result):
         return t(
@@ -141,7 +143,7 @@ def _prediction_statement(result: Any, language: str = "en") -> str:
     )
 
 
-def _element_label(result: Any, language: str = "en") -> str:
+def _element_label(result: HvacSpectrumResult, language: str = "en") -> str:
     """The element label, with its descriptive words translated.
 
     The result carries a short English label built from the element kind and
@@ -163,7 +165,7 @@ def _element_label(result: Any, language: str = "en") -> str:
     return f"{t(head, language)} ({', '.join(parts)})"
 
 
-def _caption(result: Any, language: str = "en") -> str:
+def _caption(result: HvacSpectrumResult, language: str = "en") -> str:
     """The caption declaring the analysis band set above the table."""
     n = np.asarray(result.values, dtype=np.float64).size
     _, fraction = band_labels(getattr(result, "frequencies", None), n)
@@ -188,8 +190,11 @@ def _caption(result: Any, language: str = "en") -> str:
 
 
 def _value_table(
-    result: Any, verbose: bool, corrections: np.ndarray | None, language: str = "en"
-) -> Any:
+    result: HvacSpectrumResult,
+    verbose: bool,
+    corrections: np.ndarray | None,
+    language: str = "en",
+) -> Table:
     """Build the per-band table (nominal frequency and the reported quantity).
 
     A verbose regenerated-noise table adds the A-weighting correction and the
@@ -228,7 +233,9 @@ def _value_table(
 
 
 def _statement(
-    result: Any, corrections: np.ndarray | None, language: str = "en"
+    result: HvacSpectrumResult,
+    corrections: np.ndarray | None,
+    language: str = "en",
 ) -> tuple[float, bool, str, list[str]]:
     """The boxed headline figure, its pass direction and the extended terms.
 
@@ -279,7 +286,9 @@ def _statement(
 
 
 def _basis_strip(
-    result: Any, corrections: np.ndarray | None, language: str = "en"
+    result: HvacSpectrumResult,
+    corrections: np.ndarray | None,
+    language: str = "en",
 ) -> list[str]:
     """The method-basis strip(s) for the reported quantity."""
     if _is_power(result):

--- a/src/phonometry/_report/iec60268_4.py
+++ b/src/phonometry/_report/iec60268_4.py
@@ -34,7 +34,7 @@ reportlab, matplotlib and svglib are soft dependencies imported lazily
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ._i18n import format_number, t
 from ._layout import (
@@ -62,6 +62,9 @@ from .iec60268_5 import (
 )
 
 if TYPE_CHECKING:
+    from matplotlib.projections.polar import PolarAxes
+    from reportlab.graphics.shapes import Drawing
+
     from ..electroacoustics.microphone import MicrophoneCharacteristics
     from .metadata import ReportMetadata
 
@@ -181,7 +184,7 @@ def _rated_rows(
 # --------------------------------------------------------------------------- #
 def _response_drawing(
     result: MicrophoneCharacteristics, target_width: float, language: str = "en"
-) -> Any:
+) -> Drawing:
     """Free-field response with the tolerance band and effective-range markers.
 
     Drawn by the shared :func:`phonometry._plot.electroacoustics` panel renderer
@@ -209,7 +212,7 @@ def _response_drawing(
 
 def _secondary_drawing(
     result: MicrophoneCharacteristics, target_width: float, language: str = "en"
-) -> Any | None:
+) -> Drawing | None:
     """Directional-pattern, noise-spectrum and distortion panels for the data.
 
     The panels are drawn by the shared
@@ -241,9 +244,12 @@ def _secondary_drawing(
     FigureCanvasAgg(fig)
     idx = 1
     if has_polar:
+        # `add_subplot` is typed as returning a plain Axes; the polar
+        # projection makes it a PolarAxes at runtime, which the stubs
+        # cannot express.
         _draw_datasheet_polar(
             result,
-            fig.add_subplot(1, panels, idx, projection="polar"),
+            cast("PolarAxes", fig.add_subplot(1, panels, idx, projection="polar")),
             language=language,
         )
         idx += 1

--- a/src/phonometry/_report/iec60268_5.py
+++ b/src/phonometry/_report/iec60268_5.py
@@ -33,7 +33,7 @@ import html
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from ._i18n import format_number, t
 from ._layout import (
@@ -54,6 +54,11 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from matplotlib.projections.polar import PolarAxes
+    from reportlab.graphics.shapes import Drawing
+
     from ..electroacoustics.loudspeaker import LoudspeakerCharacteristics
     from .metadata import ReportMetadata
 
@@ -192,7 +197,9 @@ def _rated_rows(
 # --------------------------------------------------------------------------- #
 # IEC 60263 characteristic graphs
 # --------------------------------------------------------------------------- #
-def _drawing_from_figure(fig: Any, target_width: float, language: str = "en") -> Any:
+def _drawing_from_figure(
+    fig: Figure, target_width: float, language: str = "en"
+) -> Drawing:
     """Convert a matplotlib figure to a scaled, vector reportlab ``Drawing``.
 
     Mirrors :func:`phonometry._report._layout.render_figure_drawing` (SVG with
@@ -234,7 +241,7 @@ def _drawing_from_figure(fig: Any, target_width: float, language: str = "en") ->
 
 def _response_drawing(
     result: LoudspeakerCharacteristics, target_width: float, language: str = "en"
-) -> Any:
+) -> Drawing:
     """On-axis response with the tolerance band and effective-range markers.
 
     Drawn by the shared :func:`phonometry._plot.electroacoustics` panel renderer
@@ -262,7 +269,7 @@ def _response_drawing(
 
 def _secondary_drawing(
     result: LoudspeakerCharacteristics, target_width: float, language: str = "en"
-) -> Any | None:
+) -> Drawing | None:
     """Impedance, THD and polar-directivity panels for the data supplied.
 
     The panels are drawn by the shared
@@ -299,9 +306,12 @@ def _secondary_drawing(
         _thin_freq_ticklabels(ax)
         idx += 1
     if has_polar:
+        # `add_subplot` is typed as returning a plain Axes; the polar
+        # projection makes it a PolarAxes at runtime, which the stubs
+        # cannot express.
         _draw_datasheet_polar(
             result,
-            fig.add_subplot(1, panels, idx, projection="polar"),
+            cast("PolarAxes", fig.add_subplot(1, panels, idx, projection="polar")),
             language=language,
         )
         idx += 1
@@ -309,7 +319,7 @@ def _secondary_drawing(
     return _drawing_from_figure(fig, target_width, language)
 
 
-def _thin_freq_ticklabels(ax: Any, keep_every: int = 2) -> None:
+def _thin_freq_ticklabels(ax: Axes, keep_every: int = 2) -> None:
     """Blank alternate labelled frequency ticks on a narrow report panel.
 
     The shared ``.plot()`` panel drawers label every nominal octave centre

--- a/src/phonometry/_report/iso10052.py
+++ b/src/phonometry/_report/iso10052.py
@@ -32,7 +32,7 @@ matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -126,7 +126,7 @@ _AIRBORNE_QUANTITIES: dict[str, tuple[str, str, dict[str, str]]] = {
 
 
 def _render_survey(
-    result: Any,
+    result: SurveyAirborneResult | SurveyFacadeResult | SurveyImpactResult,
     rating: WeightedRatingResult | ImpactRatingResult,
     path: str,
     *,

--- a/src/phonometry/_report/iso10534.py
+++ b/src/phonometry/_report/iso10534.py
@@ -55,10 +55,13 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
+from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.platypus import Table
+
     from ..materials.absorbers.impedance_tube import ImpedanceTubeResult
-    from .metadata import ReportMetadata
 
 #: Printable label for each accepted ``ReportMetadata.tube_shape`` value.
 _SHAPE_LABELS = {
@@ -88,21 +91,18 @@ def _metadata_pairs(
     millimetres. Only fields that are set are returned, so empty rows never
     appear.
     """
-
-    def _md(name: str) -> Any:
-        return getattr(metadata, name) if metadata is not None else None
-
-    client = _md("client")
-    manufacturer = _md("manufacturer")
-    specimen = _md("specimen")
-    tube_diameter = _md("tube_diameter")
-    mic_spacing = _md("mic_spacing")
-    tube_shape = _md("tube_shape")
-    mounting = _md("mounting")
-    test_room = _md("test_room")
-    test_date = _md("test_date")
-    temperature = _md("temperature")
-    pressure = _md("pressure")
+    md = metadata if metadata is not None else ReportMetadata()
+    client = md.client
+    manufacturer = md.manufacturer
+    specimen = md.specimen
+    tube_diameter = md.tube_diameter
+    mic_spacing = md.mic_spacing
+    tube_shape = md.tube_shape
+    mounting = md.mounting
+    test_room = md.test_room
+    test_date = md.test_date
+    temperature = md.temperature
+    pressure = md.pressure
 
     freqs = np.asarray(result.frequency, dtype=np.float64)
     freq_range = None
@@ -159,7 +159,7 @@ def _metadata_pairs(
 
 def _value_table(
     result: ImpedanceTubeResult, verbose: bool, language: str = "en"
-) -> Any:
+) -> Table:
     """Build the per-frequency value table (~102 mm wide).
 
     The default table lists ``f | alpha | Re z | Im z`` (the normal-incidence
@@ -263,9 +263,9 @@ def _caption(verbose: bool, language: str = "en") -> str:
 def _body(
     result: ImpedanceTubeResult,
     verbose: bool,
-    caption_style: Any,
+    caption_style: ParagraphStyle,
     language: str = "en",
-) -> Any:
+) -> Table:
     """The two-panel body: the per-frequency table beside the ``alpha(f)`` curve.
 
     Called only after the renderer has imported reportlab.

--- a/src/phonometry/_report/iso10848.py
+++ b/src/phonometry/_report/iso10848.py
@@ -64,6 +64,10 @@ from ._layout import (
 from .iso717 import _metadata_pairs
 
 if TYPE_CHECKING:
+    from reportlab.lib.colors import Color
+    from reportlab.lib.styles import StyleSheet1
+    from reportlab.platypus import Table
+
     from ..building.measurement.flanking_transmission import (
         FlankingImpactLevelResult,
         FlankingLevelDifferenceResult,
@@ -315,7 +319,7 @@ def _kij_value_table(
     in_mean: np.ndarray,
     verbose: bool,
     language: str,
-) -> Any:
+) -> Table:
     """Build the per-band ``Kij`` table.
 
     Bands bracketed for poor modal overlap are printed with their value in
@@ -357,10 +361,10 @@ def _kij_result_box(
     bracketed: np.ndarray | None,
     in_mean: np.ndarray,
     band_range: tuple[float, float],
-    styles: Any,
-    accent: Any,
+    styles: StyleSheet1,
+    accent: Color,
     language: str,
-) -> Any:
+) -> Table:
     """Build the boxed single-number ``Kij`` result with its extended terms."""
     low, high = band_range
     averaged = int(np.count_nonzero(in_mean))

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -59,6 +59,10 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.lib.colors import Color
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.platypus import Table
+
     from ..materials.absorbers.rating import AbsorptionRatingResult
     from .metadata import ReportMetadata
 
@@ -71,7 +75,7 @@ def _d2(value: float, language: str = "en") -> str:
     return format_number(value, language, decimals=2)
 
 
-def _thead_style() -> Any:
+def _thead_style() -> ParagraphStyle:
     """The shared accent table-header paragraph style (white, centred, 7.2 pt)."""
     from reportlab.lib import colors
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -87,7 +91,7 @@ def _thead_style() -> Any:
     )
 
 
-def _base_table_style(accent: Any, light: Any, n_data: int) -> list[Any]:
+def _base_table_style(accent: Color, light: Color, n_data: int) -> list[Any]:
     """The accredited-table command list shared by every left-panel table.
 
     Accent header row with a rule below it, zebra striping over the ``n_data``
@@ -151,7 +155,7 @@ def _value_table(
     deviations: np.ndarray,
     verbose: bool,
     language: str = "en",
-) -> Any:
+) -> Table:
     """Build the left-hand octave-band absorption table (accredited or evaluation).
 
     Called only after :func:`render_iso11654_report` has imported reportlab.
@@ -216,7 +220,7 @@ def _third_octave_table(
     alpha_s: np.ndarray,
     measured: np.ndarray,
     language: str = "en",
-) -> Any:
+) -> Table:
     """Build the combined one-third-octave ``f | alpha_s | alpha_p`` table.
 
     The accredited ISO 354 convention (Fellert, Mueller-BBM, Peutz): every

--- a/src/phonometry/_report/iso12354.py
+++ b/src/phonometry/_report/iso12354.py
@@ -60,6 +60,10 @@ from ._layout import (
 from .iso717 import _metadata_pairs
 
 if TYPE_CHECKING:
+    from ..building.measurement.insulation import (
+        ImpactRatingResult,
+        WeightedRatingResult,
+    )
     from ..building.prediction.detailed_model import (
         DetailedAirborneResult,
         DetailedImpactResult,
@@ -137,7 +141,13 @@ def _prediction_verdict(
 
 def _render_prediction_fiche(
     *,
-    result: Any,
+    result: (
+        AirbornePredictionResult
+        | ImpactPredictionResult
+        | DetailedAirborneResult
+        | DetailedImpactResult
+        | FacadePredictionResult
+    ),
     path: str,
     title_key: str,
     basis_key: str,
@@ -382,7 +392,9 @@ _DETAILED_STATEMENT = (
 
 
 def _detailed_path_rows(
-    result: Any, verbose: bool, language: str
+    result: DetailedAirborneResult | DetailedImpactResult,
+    verbose: bool,
+    language: str,
 ) -> list[tuple[str, str]]:
     """Per-path rows of a detailed-model fiche: energy share, largest first.
 
@@ -408,7 +420,9 @@ def _detailed_path_rows(
     return rows
 
 
-def _detailed_rating(result: Any) -> Any:
+def _detailed_rating(
+    result: DetailedAirborneResult | DetailedImpactResult,
+) -> WeightedRatingResult | ImpactRatingResult:
     """Return the result's ISO 717 rating, refusing an unrated spectrum."""
     if result.rating is None:
         msg = (

--- a/src/phonometry/_report/iso15186.py
+++ b/src/phonometry/_report/iso15186.py
@@ -123,7 +123,7 @@ def _qualification_columns(
     return columns
 
 
-def _even_widths(n_columns: int) -> Any:
+def _even_widths(n_columns: int) -> list[float]:
     """Even column widths spanning the compact left cell, in points."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/iso16251.py
+++ b/src/phonometry/_report/iso16251.py
@@ -63,12 +63,16 @@ from ._layout import (
     two_panel_body,
     verdict_flow,
 )
+from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from reportlab.lib.styles import ParagraphStyle, StyleSheet1
+    from reportlab.platypus import Table
+
     from ..building.measurement.floor_covering_improvement import (
         FloorCoveringImprovementResult,
     )
-    from .metadata import ReportMetadata
 
 
 def _metadata_pairs(
@@ -83,13 +87,10 @@ def _metadata_pairs(
     climate ...) come from the :class:`ReportMetadata` when one is supplied.
     Only fields that are set are returned, so empty rows never appear.
     """
-
-    def _md(name: str) -> Any:
-        return getattr(metadata, name) if metadata is not None else None
-
-    mass_per_area = _md("mass_per_area")
-    temperature = _md("temperature")
-    pressure = _md("pressure")
+    md = metadata if metadata is not None else ReportMetadata()
+    mass_per_area = md.mass_per_area
+    temperature = md.temperature
+    pressure = md.pressure
 
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     freq_range = None
@@ -100,17 +101,17 @@ def _metadata_pairs(
 
     range_label = t("Frequency range [Hz]", language)
     specs: list[tuple[str, str | None]] = [
-        (t("Client", language), _md("client")),
-        (t("Manufacturer", language), _md("manufacturer")),
-        (t("Floor covering", language), _md("specimen")),
-        (t("Mounting", language), _md("mounting")),
+        (t("Client", language), md.client),
+        (t("Manufacturer", language), md.manufacturer),
+        (t("Floor covering", language), md.specimen),
+        (t("Mounting", language), md.mounting),
         (
             t("Mass per unit area [kg/m<super>2</super>]", language),
             fmt_meta(mass_per_area, language) if mass_per_area is not None else None,
         ),
         (range_label, freq_range),
-        (t("Test facility", language), _md("test_room")),
-        (t("Date of test", language), _md("test_date")),
+        (t("Test facility", language), md.test_room),
+        (t("Date of test", language), md.test_date),
         (
             t("Temperature [&#176;C]", language),
             fmt_meta(temperature, language) if temperature is not None else None,
@@ -163,7 +164,7 @@ def _value_table(
     result: FloorCoveringImprovementResult,
     ln_r: np.ndarray | None,
     language: str = "en",
-) -> Any:
+) -> Table:
     """Build the per-band ``f | delta-L`` table.
 
     A band at the 1,3 dB limit of measurement is reported as ``> delta-L``
@@ -258,9 +259,9 @@ def _box_statement(result: FloorCoveringImprovementResult, language: str = "en")
 def _body(
     result: FloorCoveringImprovementResult,
     verbose: bool,
-    caption_style: Any,
+    caption_style: ParagraphStyle,
     language: str = "en",
-) -> Any:
+) -> Table:
     """The two-panel body: the per-band table beside the ``delta-L(f)`` curve.
 
     Called only after the renderer has imported reportlab.
@@ -283,7 +284,7 @@ def _body(
         _value_table(result, ln_r, language),
     ]
 
-    def _plot(ax: Any = None, language: str = language) -> Any:
+    def _plot(ax: Axes | None = None, language: str = language) -> Axes:
         return result.plot(ax=ax, language=language)
 
     left_width, plot_width = (66.0, 108.0) if ln_r is not None else (56.0, 118.0)
@@ -298,7 +299,7 @@ def _body(
 def _verdict_row(
     result: FloorCoveringImprovementResult,
     requirement: float,
-    styles: Any,
+    styles: StyleSheet1,
     language: str,
 ) -> list[Any]:
     """The requirement verdict: a higher weighted improvement passes."""

--- a/src/phonometry/_report/iso17497.py
+++ b/src/phonometry/_report/iso17497.py
@@ -62,14 +62,17 @@ from ._layout import (
     result_box,
     two_panel_body,
 )
+from .metadata import ReportMetadata
 
 if TYPE_CHECKING:
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.platypus import Table
+
     from ..materials.diffusers.reverberation_room_scattering import ScatteringResult
     from ..materials.diffusers.scattering_diffusion import (
         DiffusionResult,
         DiffusionSpectrum,
     )
-    from .metadata import ReportMetadata
 
 #: Header of the band centre-frequency column of every ISO 17497 table.
 _FREQUENCY_COLUMN = "f [Hz]"
@@ -108,21 +111,18 @@ def _common_metadata_pairs(
     reused across a Part 1 and a Part 2 campaign never leaks them into the
     diffusion sheet).
     """
-
-    def _md(name: str) -> Any:
-        return getattr(metadata, name) if metadata is not None else None
-
-    area = _md("area") if include_room_fields else None
-    room_volume = _md("room_volume") if include_room_fields else None
-    temperature = _md("temperature")
-    humidity = _md("relative_humidity")
-    pressure = _md("pressure")
+    md = metadata if metadata is not None else ReportMetadata()
+    area = md.area if include_room_fields else None
+    room_volume = md.room_volume if include_room_fields else None
+    temperature = md.temperature
+    humidity = md.relative_humidity
+    pressure = md.pressure
 
     freq_label = t("Frequency range [Hz]", language)
     specs: list[tuple[str, str | None]] = [
-        (t("Client", language), _md("client")),
-        (t("Manufacturer", language), _md("manufacturer")),
-        (t("Description", language), _md("specimen")),
+        (t("Client", language), md.client),
+        (t("Manufacturer", language), md.manufacturer),
+        (t("Description", language), md.specimen),
         (
             t("Sample area S [m<super>2</super>]", language),
             fmt_meta(area, language) if area is not None else None,
@@ -132,9 +132,9 @@ def _common_metadata_pairs(
             fmt_meta(room_volume, language) if room_volume is not None else None,
         ),
         (freq_label, freq_range),
-        (t("Mounting", language), _md("mounting")),
-        (t("Test room", language), _md("test_room")),
-        (t("Date of test", language), _md("test_date")),
+        (t("Mounting", language), md.mounting),
+        (t("Test room", language), md.test_room),
+        (t("Date of test", language), md.test_date),
         (
             t("Temperature [&#176;C]", language),
             fmt_meta(temperature, language) if temperature is not None else None,
@@ -185,8 +185,8 @@ def _header_flow(
     title: str,
     basis: str,
     header_pairs: list[tuple[str, str]],
-    title_style: Any,
-    basis_style: Any,
+    title_style: ParagraphStyle,
+    basis_style: ParagraphStyle,
 ) -> list[Any]:
     """The shared title/basis/metadata-grid opening of an ISO 17497 fiche."""
     from reportlab.platypus import Spacer
@@ -209,7 +209,7 @@ def _header_flow(
 # ---------------------------------------------------------------------------
 def _scattering_table(
     result: ScatteringResult, verbose: bool, language: str = "en"
-) -> Any:
+) -> Table:
     """Build the per-band ``f | alpha_s | s`` table (``alpha_spec`` if verbose)."""
     from reportlab.lib.units import mm
 
@@ -377,7 +377,7 @@ def render_scattering_report(
 # ---------------------------------------------------------------------------
 def _diffusion_table(
     result: DiffusionSpectrum, show_normalized: bool, language: str = "en"
-) -> Any:
+) -> Table:
     """Build the per-band ``f | d`` table (adds ``d_n`` when requested)."""
     from reportlab.lib.units import mm
 
@@ -518,7 +518,7 @@ def render_diffusion_spectrum_report(
 # ---------------------------------------------------------------------------
 # ISO 17497-2: single-source polar response.
 # ---------------------------------------------------------------------------
-def _polar_table(result: DiffusionResult, language: str = "en") -> Any:
+def _polar_table(result: DiffusionResult, language: str = "en") -> Table:
     """Build the corrected ``angle | reflected level`` polar-response table."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/iso1996_impulse.py
+++ b/src/phonometry/_report/iso1996_impulse.py
@@ -65,6 +65,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..environment.assessment.impulsive_sound import ImpulseProminenceResult
     from .metadata import ReportMetadata
 
@@ -171,7 +173,7 @@ def _metadata_pairs(
     return [(label, value) for label, value in specs if value]
 
 
-def _per_impulse_table(result: ImpulseProminenceResult, language: str = "en") -> Any:
+def _per_impulse_table(result: ImpulseProminenceResult, language: str = "en") -> Table:
     """The full-width per-impulse table (onset rate, level difference, P).
 
     One row per candidate impulse: the onset rate (dB/s), the level difference

--- a/src/phonometry/_report/iso1996_tone.py
+++ b/src/phonometry/_report/iso1996_tone.py
@@ -66,6 +66,9 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from reportlab.platypus import Table
+
     from ..psychoacoustics.quality.tone_audibility import ToneAudibilityResult
     from .metadata import ReportMetadata
 
@@ -147,7 +150,7 @@ def _type_label(group_size: int | None, language: str = "en") -> str:
 
 def _key_quantity_table(
     result: ToneAudibilityResult, verbose: bool = False, language: str = "en"
-) -> Any:
+) -> Table:
     """The full-width per-tone key-quantity table (ISO/PAS 20065 Table E.2 style).
 
     One row per detected tone: frequency ``f_T``, entry type (single tone or a
@@ -361,7 +364,9 @@ def render_tone_audibility_report(
 
     # Full-width, landscape level-versus-frequency analysis plot: the tone
     # levels above their critical-band masking noise (a self-scaling dB axis).
-    def _levels_plot(ax: Any = None, language: str = "en", **kwargs: Any) -> Any:
+    def _levels_plot(
+        ax: Axes | None = None, language: str = "en", **kwargs: Any
+    ) -> Axes:
         from .._plot.psychoacoustics import plot_tone_audibility_levels
 
         return plot_tone_audibility_levels(result, ax=ax, language=language, **kwargs)

--- a/src/phonometry/_report/iso1999.py
+++ b/src/phonometry/_report/iso1999.py
@@ -58,6 +58,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..hearing.noise_induced_hearing_loss import HtlanResult, NiptsResult
     from .metadata import ReportMetadata
 
@@ -177,7 +179,7 @@ def _nipts_metadata_pairs(
 
 def _nipts_table(
     result: NiptsResult, verbose: bool = False, language: str = "en"
-) -> Any:
+) -> Table:
     """The per-audiometric-frequency NIPTS table (median and fractile value)."""
     from reportlab.lib.units import mm
 
@@ -360,7 +362,7 @@ def render_nipts_report(
 # --------------------------------------------------------------------------- #
 def _htlan_table(
     result: HtlanResult, verbose: bool = False, language: str = "en"
-) -> Any:
+) -> Table:
     """The per-audiometric-frequency HTLAN table (age, noise and combined)."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/iso2631_5.py
+++ b/src/phonometry/_report/iso2631_5.py
@@ -62,6 +62,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Paragraph, Table
+
     from ..vibration.human.multiple_shock import MultipleShockResult
     from .metadata import ReportMetadata
 
@@ -181,7 +183,7 @@ def _unit_ms2() -> str:
     return "m/s<sup>2</sup>"
 
 
-def _analysis_table(result: MultipleShockResult, language: str = "en") -> Any:
+def _analysis_table(result: MultipleShockResult, language: str = "en") -> Table:
     """The dose-and-stress analysis table (Clause 5 dose and Annex C stress).
 
     One row per quantity (quantity, symbol, value with unit, clause reference):
@@ -260,7 +262,7 @@ def _analysis_table(result: MultipleShockResult, language: str = "en") -> Any:
     return table
 
 
-def _classification_table(result: MultipleShockResult, language: str = "en") -> Any:
+def _classification_table(result: MultipleShockResult, language: str = "en") -> Table:
     """The Annex C risk-classification table against the Table C.2 levels.
 
     Four rows partition the stress variable ``R`` by the Table C.2 risk levels
@@ -352,7 +354,7 @@ def _statement(result: MultipleShockResult, language: str = "en") -> str:
     )
 
 
-def _zone_row(result: MultipleShockResult, language: str = "en") -> Any:
+def _zone_row(result: MultipleShockResult, language: str = "en") -> Paragraph:
     """The classification zone row stating the Annex C risk band for ``R``."""
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 

--- a/src/phonometry/_report/iso3382.py
+++ b/src/phonometry/_report/iso3382.py
@@ -62,6 +62,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..room.acoustics import RoomAcousticsResult
     from .metadata import ReportMetadata
 
@@ -173,7 +175,7 @@ def _metadata_pairs(
     return escaped_pairs(specs)
 
 
-def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Any:
+def _parameter_table(result: RoomAcousticsResult, language: str = "en") -> Table:
     """Build the full-width per-band parameter table.
 
     Rows are the analysis bands (or a single ``Broadband`` row); the columns are

--- a/src/phonometry/_report/iso354.py
+++ b/src/phonometry/_report/iso354.py
@@ -57,6 +57,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..materials.absorbers.sound_absorption import SoundAbsorptionMeasurement
     from .metadata import ReportMetadata
 
@@ -131,7 +133,7 @@ def _metadata_pairs(
     ]
 
 
-def _alpha_table(freqs: np.ndarray, alpha_s: np.ndarray, language: str = "en") -> Any:
+def _alpha_table(freqs: np.ndarray, alpha_s: np.ndarray, language: str = "en") -> Table:
     """Build the compact two-column ``f | alpha_s`` table (accredited default)."""
     from reportlab.lib.units import mm
 
@@ -148,7 +150,7 @@ def _alpha_table(freqs: np.ndarray, alpha_s: np.ndarray, language: str = "en") -
     return band_table(rows, [28 * mm, 28 * mm], len(freqs), band_centres=freqs)
 
 
-def _detail_table(result: SoundAbsorptionMeasurement, language: str = "en") -> Any:
+def _detail_table(result: SoundAbsorptionMeasurement, language: str = "en") -> Table:
     """Build the verbose table ``f | T1 | T2 | A1 | A2 | alpha_s`` (~102 mm wide)."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/iso3741.py
+++ b/src/phonometry/_report/iso3741.py
@@ -42,7 +42,7 @@ guarded with an actionable :class:`ImportError`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -58,6 +58,8 @@ from ._sound_power_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..emission.sound_power_reverberation import ReverberationSoundPowerResult
     from .metadata import ReportMetadata
 
@@ -69,12 +71,12 @@ _COL_LP = "L<sub>p</sub> [dB]"
 _COL_LW = "L<sub>W</sub> [dB]"
 
 
-def _is_comparison(result: Any) -> bool:
+def _is_comparison(result: ReverberationSoundPowerResult) -> bool:
     """Return ``True`` for a comparison-method result, ``False`` for direct."""
     return getattr(result, "method", "direct") == "comparison"
 
 
-def _basis(result: Any, language: str = "en") -> str:
+def _basis(result: ReverberationSoundPowerResult, language: str = "en") -> str:
     """The standard-basis line naming the reverberation-room method and grade."""
     grade = t("precision method, accuracy grade 1", language)
     if _is_comparison(result):
@@ -92,7 +94,9 @@ def _basis(result: Any, language: str = "en") -> str:
     ).format(grade=grade)
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(
+    result: ReverberationSoundPowerResult, verbose: bool, language: str = "en"
+) -> Table:
     """Build the full-width per-band table (nominal frequency, Lp, LW).
 
     The default table is the ``f | Lp | LW`` form; ``verbose`` adds the
@@ -156,7 +160,9 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
+def _statement(
+    result: ReverberationSoundPowerResult, language: str = "en"
+) -> tuple[str, list[str]]:
     """The boxed sound-power result and its extended terms.
 
     Delegates the ``LWA``/``LW`` box to the shared
@@ -178,7 +184,9 @@ def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
     return statement, extended
 
 
-def _corrections_strip(result: Any, language: str = "en") -> str:
+def _corrections_strip(
+    result: ReverberationSoundPowerResult, language: str = "en"
+) -> str:
     """The applied-corrections line for the basis strip (Eq. 20 or Eq. 21)."""
     c2 = format_number(float(result.c2), language, decimals=2)
     c = format_number(float(result.speed_of_sound), language, decimals=1)

--- a/src/phonometry/_report/iso3744.py
+++ b/src/phonometry/_report/iso3744.py
@@ -43,7 +43,7 @@ extra, matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -60,6 +60,10 @@ from ._sound_power_fiche import (
 )
 
 if TYPE_CHECKING:
+    from typing import TypeIs
+
+    from reportlab.platypus import Table
+
     from ..emission.sound_power import SoundPowerResult
     from ..emission.sound_power_anechoic import PrecisionSoundPowerResult
     from .metadata import ReportMetadata
@@ -72,19 +76,25 @@ _COL_LP = "L<sub>p</sub> [dB]"
 _COL_LW = "L<sub>W</sub> [dB]"
 
 
-def _is_precision(result: Any) -> bool:
+def _is_precision(
+    result: SoundPowerResult | PrecisionSoundPowerResult,
+) -> TypeIs[PrecisionSoundPowerResult]:
     """Return ``True`` for an ISO 3745 precision result, ``False`` for ISO 3744.
 
     The precision result carries the meteorological corrections ``c1``/``c2``/
     ``c3`` (and no environmental ``K2``); the surface-pressure result carries
     the per-band ``environmental_correction`` (``K2``) and a ``grade``. The
-    duck-typed check keeps this module free of a module-level import of the
-    domain classes (the render layer imports them only under TYPE_CHECKING).
+    duck-typed check keeps this module free of a runtime import of the domain
+    classes (the render layer imports them only under TYPE_CHECKING), and the
+    :class:`~typing.TypeIs` narrows each caller's branch to the method whose
+    fields it reads.
     """
     return hasattr(result, "c1") and hasattr(result, "c2") and hasattr(result, "c3")
 
 
-def _method(result: Any, language: str = "en") -> tuple[str, str]:
+def _method(
+    result: SoundPowerResult | PrecisionSoundPowerResult, language: str = "en"
+) -> tuple[str, str]:
     """Return ``(standard, grade_phrase)`` for the applied determination method.
 
     ISO 3744:2010 is the engineering method (accuracy grade 2), ISO 3746:2010
@@ -99,7 +109,9 @@ def _method(result: Any, language: str = "en") -> tuple[str, str]:
     return "ISO 3744:2010", t("engineering method, accuracy grade 2", language)
 
 
-def _basis(result: Any, language: str = "en") -> str:
+def _basis(
+    result: SoundPowerResult | PrecisionSoundPowerResult, language: str = "en"
+) -> str:
     """The standard-basis line naming the method, the surface and the grade."""
     standard, grade_phrase = _method(result, language)
     if _is_precision(result):
@@ -116,7 +128,11 @@ def _basis(result: Any, language: str = "en") -> str:
     ).format(standard=standard, grade=grade_phrase)
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(
+    result: SoundPowerResult | PrecisionSoundPowerResult,
+    verbose: bool,
+    language: str = "en",
+) -> Table:
     """Build the full-width per-band table (nominal frequency, Lp, LW).
 
     ``verbose`` adds the energy-averaged level ``Lp'`` and, for the ISO 3744/
@@ -132,8 +148,7 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
     n = lw.size
     labels, fraction = band_labels(getattr(result, "frequencies", None), n)
 
-    precision = _is_precision(result)
-    if verbose and not precision:
+    if verbose and not _is_precision(result):
         k1 = np.asarray(result.background_correction, dtype=np.float64)
         k2 = np.asarray(result.environmental_correction, dtype=np.float64)
         header = [
@@ -156,7 +171,7 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
             ]
             for i in range(n)
         ]
-    elif verbose and precision:
+    elif verbose:
         header = [
             t(_COL_FREQUENCY, language),
             "L'<sub>p</sub> [dB]",
@@ -187,7 +202,9 @@ def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
+def _statement(
+    result: SoundPowerResult | PrecisionSoundPowerResult, language: str = "en"
+) -> tuple[str, list[str]]:
     """The boxed sound-power result and its extended terms.
 
     Delegates the ``LWA``/``LW`` box to the shared
@@ -211,7 +228,9 @@ def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
     return statement, extended
 
 
-def _corrections_strip(result: Any, language: str = "en") -> str:
+def _corrections_strip(
+    result: SoundPowerResult | PrecisionSoundPowerResult, language: str = "en"
+) -> str:
     """The applied-corrections line for the basis strip (K1/K2 or C1/C2/C3)."""
     if _is_precision(result):
         return t(
@@ -244,7 +263,9 @@ def _corrections_strip(result: Any, language: str = "en") -> str:
     )
 
 
-def _a_weighting_strip(result: Any, language: str = "en") -> str:
+def _a_weighting_strip(
+    result: SoundPowerResult | PrecisionSoundPowerResult, language: str = "en"
+) -> str:
     """The A-weighting citation line, keyed to the method that combined LWA.
 
     The surface-pressure result combines the band levels with the ISO 3744:2010

--- a/src/phonometry/_report/iso4871.py
+++ b/src/phonometry/_report/iso4871.py
@@ -52,6 +52,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..emission.declaration import NoiseEmissionDeclaration
     from .metadata import ReportMetadata
 
@@ -224,7 +226,7 @@ def _emission_declared_cell(value: int | None, language: str = "en") -> str:
 
 def _declaration_table(
     declaration: NoiseEmissionDeclaration, language: str = "en"
-) -> Any:
+) -> Table:
     """Reproduce the ISO 4871 Annex B declaration table (identification + values)."""
     from reportlab.lib import colors
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet

--- a/src/phonometry/_report/iso532.py
+++ b/src/phonometry/_report/iso532.py
@@ -54,6 +54,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
     from ..psychoacoustics.loudness.zwicker import ZwickerLoudness
     from .metadata import ReportMetadata
 
@@ -268,7 +270,9 @@ def render_iso532_report(
         # Clause 7 f): a time-varying loudness report states "the loudness
         # time function in sones". Full-width landscape N(t) trace with the
         # N5/N10 percentile levels marked.
-        def _time_plot(ax: Any = None, language: str = "en", **kwargs: Any) -> Any:
+        def _time_plot(
+            ax: Axes | None = None, language: str = "en", **kwargs: Any
+        ) -> Axes:
             from .._plot.psychoacoustics import plot_zwicker_loudness_time
 
             return plot_zwicker_loudness_time(

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -59,6 +59,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..building.measurement.insulation import (
         ImpactRatingResult,
         WeightedRatingResult,
@@ -260,7 +262,7 @@ def _value_table(
     value_header: str,
     verbose: bool,
     language: str = "en",
-) -> Any:
+) -> Table:
     """Build the left-hand one-third-octave table (accredited or Annex C).
 
     Called only after :func:`render_iso717_report` has imported reportlab.

--- a/src/phonometry/_report/iso7849.py
+++ b/src/phonometry/_report/iso7849.py
@@ -44,7 +44,7 @@ matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -60,6 +60,8 @@ from ._sound_power_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..emission.vibration_sound_power import VibrationSoundPowerResult
     from .metadata import ReportMetadata
 
@@ -69,13 +71,13 @@ if TYPE_CHECKING:
 _UNITY_TOLERANCE = 1e-9
 
 
-def _is_survey(result: Any) -> bool:
+def _is_survey(result: VibrationSoundPowerResult) -> bool:
     """Return ``True`` for the survey method (every band uses ``epsilon = 1``)."""
     eps = np.asarray(result.radiation_factor, dtype=np.float64)
     return bool(np.all(np.abs(eps - 1.0) < _UNITY_TOLERANCE))
 
 
-def _basis(result: Any, language: str = "en") -> str:
+def _basis(result: VibrationSoundPowerResult, language: str = "en") -> str:
     """The standard-basis line naming the vibration method and its part."""
     if _is_survey(result):
         return t(
@@ -92,7 +94,9 @@ def _basis(result: Any, language: str = "en") -> str:
     )
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(
+    result: VibrationSoundPowerResult, verbose: bool, language: str = "en"
+) -> Table:
     """Build the full-width per-band table (nominal frequency, Lv, LW).
 
     The default table is the ``f | Lv | LW`` form; ``verbose`` inserts the
@@ -141,7 +145,9 @@ def _eps_cell(value: float, language: str = "en") -> str:
     return format_number(float(value), language, decimals=3)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
+def _statement(
+    result: VibrationSoundPowerResult, language: str = "en"
+) -> tuple[str, list[str]]:
     """The boxed sound-power result and its extended terms.
 
     Delegates the ``LWA``/``LW`` box to the shared
@@ -185,7 +191,7 @@ def _relation_strip(language: str = "en") -> str:
     ).format(imp=imp)
 
 
-def _factor_strip(result: Any, language: str = "en") -> str:
+def _factor_strip(result: VibrationSoundPowerResult, language: str = "en") -> str:
     """The radiation-factor / A-weighting line for the basis strip."""
     if _is_survey(result):
         factor = t(

--- a/src/phonometry/_report/iso9612.py
+++ b/src/phonometry/_report/iso9612.py
@@ -68,6 +68,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..hearing.occupational_exposure import ExposureResult
     from .metadata import ReportMetadata
 
@@ -163,7 +165,7 @@ def _esc(value: str | None) -> str | None:
 
 def _task_table(
     result: ExposureResult, verbose: bool = False, language: str = "en"
-) -> Any:
+) -> Table:
     """The Clause 15 b/d work-analysis table of a task-based result.
 
     One row per task (label, mean duration ``T_m``, sample count ``I``, the
@@ -246,7 +248,7 @@ def _task_table(
     return table
 
 
-def _sampling_table(result: ExposureResult, language: str = "en") -> Any:
+def _sampling_table(result: ExposureResult, language: str = "en") -> Table:
     """The sampling summary of a job-based/full-day result (Formula (C.9) budget)."""
     from reportlab.lib.units import mm
 
@@ -339,7 +341,7 @@ def _assessment_rows(
     return rows
 
 
-def _assessment_table(result: ExposureResult, language: str = "en") -> Any:
+def _assessment_table(result: ExposureResult, language: str = "en") -> Table:
     """The Directive 2003/10/EC assessment table (exceeded / not exceeded)."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/iso9613.py
+++ b/src/phonometry/_report/iso9613.py
@@ -58,6 +58,7 @@ from ._layout import (
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+    from reportlab.platypus import Table
 
     from ..environment.propagation.ground_barriers import BarrierInsertionLoss
     from ..environment.propagation.outdoor_propagation import (
@@ -183,7 +184,7 @@ def _attenuation_table(
     levels: _AttenuationLevels | None,
     verbose: bool,
     language: str,
-) -> Any:
+) -> Table:
     """The full-width per-band attenuation table (ISO 9613-2:1996, clause 7).
 
     One row per octave band: the divergence, atmospheric, ground and barrier
@@ -500,7 +501,7 @@ def _barrier_metadata_pairs(
     return [(label, value) for label, value in specs if value]
 
 
-def _barrier_table(result: BarrierInsertionLoss, verbose: bool, language: str) -> Any:
+def _barrier_table(result: BarrierInsertionLoss, verbose: bool, language: str) -> Table:
     """The per-band barrier insertion-loss table (``IL`` and, verbose, ``N``)."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/iso9614.py
+++ b/src/phonometry/_report/iso9614.py
@@ -60,7 +60,7 @@ lazily; each is guarded with an actionable :class:`ImportError`.
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -80,6 +80,8 @@ from ._sound_power_fiche import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from reportlab.platypus import Table
 
     from ..emission.sound_power_intensity import (
         PrecisionCriteria,
@@ -140,7 +142,7 @@ _SPLIT_ABOVE = 8
 _PRECISION_FIGSIZE = (9.2, 2.5)
 
 
-def _basis(result: Any, language: str = "en") -> str:
+def _basis(result: SoundPowerIntensityResult, language: str = "en") -> str:
     """The standard-basis line naming the scanning method and its grade."""
     grade = _GRADE_PHRASE.get(
         getattr(result, "grade", "engineering"), _GRADE_PHRASE["engineering"]
@@ -153,7 +155,9 @@ def _basis(result: Any, language: str = "en") -> str:
     ).format(grade=t(grade, language))
 
 
-def _value_table(result: Any, verbose: bool, language: str = "en") -> Any:
+def _value_table(
+    result: SoundPowerIntensityResult, verbose: bool, language: str = "en"
+) -> Table:
     """Build the full-width per-band table (nominal frequency, LW, indicators).
 
     The default table is the recommended ``f | LW`` form; ``verbose`` adds the
@@ -210,7 +214,9 @@ def _grade_cell(grade: np.ndarray | None, i: int) -> str:
     return _GRADE_CELL.get(str(grade[i]), _ABSENT)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
+def _statement(
+    result: SoundPowerIntensityResult, language: str = "en"
+) -> tuple[str, list[str]]:
     """The boxed sound-power result and its extended terms.
 
     Delegates the ``LWA``/``LW`` box to the shared
@@ -236,7 +242,7 @@ def _statement(result: Any, language: str = "en") -> tuple[str, list[str]]:
     return statement, extended
 
 
-def _indicator_strip(result: Any, language: str = "en") -> str:
+def _indicator_strip(result: SoundPowerIntensityResult, language: str = "en") -> str:
     """The partial-power / field-indicator line for the basis strip."""
     grade = getattr(result, "grade", "engineering")
     return t(
@@ -255,7 +261,7 @@ def _indicator_strip(result: Any, language: str = "en") -> str:
     )
 
 
-def _criteria_strip(result: Any, language: str = "en") -> str:
+def _criteria_strip(result: SoundPowerIntensityResult, language: str = "en") -> str:
     """The Annex B qualification / A-weighting line for the basis strip."""
     text = t(
         "A band reaches engineering grade when L<sub>d</sub> &gt; F<sub>pI</sub>"
@@ -357,7 +363,7 @@ def _precision_basis(language: str = "en") -> str:
     ).format(grade=t(_PRECISION_GRADE_PHRASE, language))
 
 
-def _band_uncertainty(result: Any) -> np.ndarray:
+def _band_uncertainty(result: PrecisionIntensityResult) -> np.ndarray:
     """Per-band expanded uncertainty ``U = 2 sigma_R0`` (Table 1), in dB.
 
     ISO 9614-3:2002 clause 4.3 states the expanded uncertainty for a coverage
@@ -438,12 +444,12 @@ def _qualified_cell(
 
 
 def _precision_value_table(
-    result: Any,
+    result: PrecisionIntensityResult,
     indicators: PrecisionFieldIndicators | None,
     criteria: PrecisionCriteria | None,
     verbose: bool,
     language: str = "en",
-) -> Any:
+) -> Table:
     """Build the per-band table of the precision fiche.
 
     The default columns are the ones clause 10 f) asks for: the band level
@@ -519,7 +525,7 @@ def _precision_value_table(
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _precision_caption(result: Any, language: str = "en") -> str:
+def _precision_caption(result: PrecisionIntensityResult, language: str = "en") -> str:
     """The band-set caption, extended with the frequency range determined.
 
     ISO 9614-3:2002 clause 4.3 covers the one-third-octave bands from 50 Hz to
@@ -538,7 +544,9 @@ def _precision_caption(result: Any, language: str = "en") -> str:
     )
 
 
-def _precision_omitted(result: Any, criteria: PrecisionCriteria | None) -> np.ndarray:
+def _precision_omitted(
+    result: PrecisionIntensityResult, criteria: PrecisionCriteria | None
+) -> np.ndarray:
     """The bands the A-weighted determination leaves out, per band.
 
     Two rules put a band here, and the sheet has to distinguish them: the
@@ -553,7 +561,7 @@ def _precision_omitted(result: Any, criteria: PrecisionCriteria | None) -> np.nd
     return omitted
 
 
-def _precision_level_a(result: Any, omitted: np.ndarray) -> float:
+def _precision_level_a(result: PrecisionIntensityResult, omitted: np.ndarray) -> float:
     """The A-weighted level the fiche boxes: the qualified bands only.
 
     The result object sums every applicable band, because it is computed
@@ -575,7 +583,7 @@ def _precision_level_a(result: Any, omitted: np.ndarray) -> float:
 
 
 def _precision_statement(
-    result: Any, level_a: float, language: str = "en"
+    result: PrecisionIntensityResult, level_a: float, language: str = "en"
 ) -> tuple[str, list[str]]:
     """The boxed precision result and its extended terms.
 
@@ -625,7 +633,7 @@ def _precision_statement(
     return statement, extended
 
 
-def _normalization_offset(result: Any) -> float:
+def _normalization_offset(result: PrecisionIntensityResult) -> float:
     """The applied meteorological normalization ``LW - LW0``, in dB (Eq. 10).
 
     The term depends only on the test atmosphere, so it is the same in every
@@ -648,7 +656,7 @@ def _dynamic_capability(
 
 
 def _precision_model_strip(
-    result: Any,
+    result: PrecisionIntensityResult,
     indicators: PrecisionFieldIndicators | None,
     residual_index: float | Sequence[float] | np.ndarray | None,
     language: str = "en",
@@ -723,7 +731,10 @@ def _failed_criteria(criteria: PrecisionCriteria | None, i: int) -> list[int]:
 
 
 def _omission_reason(
-    result: Any, criteria: PrecisionCriteria | None, i: int, language: str = "en"
+    result: PrecisionIntensityResult,
+    criteria: PrecisionCriteria | None,
+    i: int,
+    language: str = "en",
 ) -> str:
     """Why a band is out of the A-weighted determination: clause 9.2, or which criteria."""
     if bool(np.asarray(result.not_applicable_band, dtype=bool)[i]):
@@ -741,7 +752,7 @@ def _omission_reason(
 
 
 def _omitted_band_list(
-    result: Any,
+    result: PrecisionIntensityResult,
     criteria: PrecisionCriteria | None,
     omitted: np.ndarray,
     language: str = "en",
@@ -757,7 +768,7 @@ def _omitted_band_list(
 
 
 def _precision_criteria_strip(
-    result: Any,
+    result: PrecisionIntensityResult,
     criteria: PrecisionCriteria | None,
     omitted: np.ndarray,
     language: str = "en",

--- a/src/phonometry/_report/rd1367.py
+++ b/src/phonometry/_report/rd1367.py
@@ -76,6 +76,10 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from reportlab.lib.styles import ParagraphStyle
+    from reportlab.platypus import Table
+
     from ..environment.assessment.spain import (
         ActivityAssessment,
         PeriodAssessment,
@@ -143,7 +147,7 @@ def _metadata_pairs(
 
 def _phase_table(
     result: ActivityAssessment, verbose: bool = False, language: str = "en"
-) -> Any:
+) -> Table:
     """The full-width *fases de ruido* table.
 
     One row per noise phase of every assessed period: the phase label, its
@@ -221,7 +225,10 @@ def _criterion_cell(
 
 
 def _result_row(
-    period: PeriodAssessment, label_style: Any, value_style: Any, language: str
+    period: PeriodAssessment,
+    label_style: ParagraphStyle,
+    value_style: ParagraphStyle,
+    language: str,
 ) -> list[Any]:
     """The six cells of one period row of the Article 25.1 b results table.
 
@@ -265,7 +272,7 @@ def _result_row(
     ]
 
 
-def _results_table(result: ActivityAssessment, language: str = "en") -> Any:
+def _results_table(result: ActivityAssessment, language: str = "en") -> Table:
     """The per-period results table against the Article 25.1 b criteria.
 
     One row per assessed period, each cell showing the assessed index against
@@ -427,7 +434,9 @@ def render_activity_report(
     flow.append(_results_table(result, language))
     flow.append(Spacer(1, 6))
 
-    def _assessment_plot(ax: Any = None, language: str = "en", **kwargs: Any) -> Any:
+    def _assessment_plot(
+        ax: Axes | None = None, language: str = "en", **kwargs: Any
+    ) -> Axes:
         from .._plot.environment import plot_activity_assessment
 
         return plot_activity_assessment(result, ax=ax, language=language, **kwargs)

--- a/src/phonometry/_report/reverberation.py
+++ b/src/phonometry/_report/reverberation.py
@@ -62,6 +62,9 @@ from ._layout import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from reportlab.lib.styles import ParagraphStyle, StyleSheet1
+    from reportlab.platypus import Table
+
     from ..room.enclosed_space_absorption import ReverberationResult
     from ..room.reverberation_prediction import ReverberationModelResult
     from .metadata import ReportMetadata
@@ -122,7 +125,7 @@ def _mid_or_first(freqs: np.ndarray, values: np.ndarray) -> tuple[float, bool]:
 
 def _octave_table(
     header_cells: list[Any], rows: list[list[Any]], col_widths: list[Any]
-) -> Any:
+) -> Table:
     """Assemble an octave-band table with the accredited accent/zebra styling.
 
     Octave-band tables have one row per octave, so (unlike the one-third-octave
@@ -154,7 +157,7 @@ def _octave_table(
     return table
 
 
-def _band_header_style() -> Any:
+def _band_header_style() -> ParagraphStyle:
     """White-on-accent header-cell paragraph style for the octave tables."""
     from reportlab.lib import colors
     from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -169,7 +172,7 @@ def _band_header_style() -> Any:
     )
 
 
-def _target_line(requirement: float, styles: Any, language: str) -> list[Any]:
+def _target_line(requirement: float, styles: StyleSheet1, language: str) -> list[Any]:
     """A muted reference line for a supplied target reverberation time.
 
     A room reverberation time is a target range, not a strictly
@@ -251,7 +254,7 @@ def _header_grid(
 # ---------------------------------------------------------------------------
 
 
-def _models_table(result: ReverberationModelResult, language: str) -> Any:
+def _models_table(result: ReverberationModelResult, language: str) -> Table:
     """Build the per-band table with one reverberation-time column per model."""
     from reportlab.lib.units import mm
 
@@ -410,7 +413,7 @@ def render_reverberation_models_report(
 # ---------------------------------------------------------------------------
 
 
-def _enclosed_table(result: ReverberationResult, language: str) -> Any:
+def _enclosed_table(result: ReverberationResult, language: str) -> Table:
     """Build the per-band ``f | A | T`` table of the enclosed-space fiche."""
     from reportlab.lib.units import mm
 

--- a/src/phonometry/_report/sii.py
+++ b/src/phonometry/_report/sii.py
@@ -53,6 +53,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..speech.sii import SIIResult
     from .metadata import ReportMetadata
 
@@ -98,7 +100,7 @@ def _metadata_pairs(
     ]
 
 
-def _band_table(result: SIIResult, verbose: bool, language: str = "en") -> Any:
+def _band_table(result: SIIResult, verbose: bool, language: str = "en") -> Table:
     """Build the left-hand per-band audibility table of the procedure.
 
     The default table carries the equivalent speech spectrum level ``Ei'``, the

--- a/src/phonometry/_report/silencer.py
+++ b/src/phonometry/_report/silencer.py
@@ -32,7 +32,7 @@ matplotlib in ``phonometry[plot]``); each is guarded with an actionable
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -47,6 +47,8 @@ from ._noise_control_fiche import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..noise_control.silencers import ReactiveSilencerResult
     from .metadata import ReportMetadata
 
@@ -75,7 +77,7 @@ def _prediction_statement(language: str = "en") -> str:
     )
 
 
-def _caption(result: Any, language: str = "en") -> str:
+def _caption(result: ReactiveSilencerResult, language: str = "en") -> str:
     """The caption declaring the analysis band set above the table."""
     freqs = getattr(result, "frequencies", None)
     n = np.asarray(result.transmission_loss, dtype=np.float64).size
@@ -87,7 +89,7 @@ def _caption(result: Any, language: str = "en") -> str:
     return t("One-third-octave-band transmission loss", language)
 
 
-def _value_table(result: Any, language: str = "en") -> Any:
+def _value_table(result: ReactiveSilencerResult, language: str = "en") -> Table:
     """Build the per-band table (nominal frequency, TL, and IL when computed).
 
     Called only after the renderer has imported reportlab.
@@ -111,7 +113,7 @@ def _value_table(result: Any, language: str = "en") -> Any:
     return power_value_table(header, rows_data, widths, fraction)
 
 
-def _resonance_term(result: Any, language: str = "en") -> str | None:
+def _resonance_term(result: ReactiveSilencerResult, language: str = "en") -> str | None:
     """The extended term naming the resonance frequencies, or ``None``."""
     resonances = getattr(result, "resonances", None)
     if resonances is None:
@@ -124,7 +126,9 @@ def _resonance_term(result: Any, language: str = "en") -> str | None:
     return t("Resonance frequencies: {values} Hz", language).format(values=listed)
 
 
-def _statement(result: Any, language: str = "en") -> tuple[float, str, list[str]]:
+def _statement(
+    result: ReactiveSilencerResult, language: str = "en"
+) -> tuple[float, str, list[str]]:
     """The boxed mean transmission loss and its extended silencer terms."""
     tl = np.asarray(result.transmission_loss, dtype=np.float64)
     mean_tl = mean_finite(tl)

--- a/src/phonometry/_report/sti.py
+++ b/src/phonometry/_report/sti.py
@@ -49,6 +49,8 @@ from ._layout import (
 )
 
 if TYPE_CHECKING:
+    from reportlab.platypus import Table
+
     from ..speech.sti import STIResult
     from .metadata import ReportMetadata
 
@@ -98,7 +100,7 @@ def _metadata_pairs(
     ]
 
 
-def _band_table(result: STIResult, language: str = "en") -> Any:
+def _band_table(result: STIResult, language: str = "en") -> Table:
     """Build the left-hand per-octave-band modulation-transfer-index table.
 
     Called only after :func:`render_sti_report` has imported reportlab.

--- a/src/phonometry/building/prediction/detailed_model.py
+++ b/src/phonometry/building/prediction/detailed_model.py
@@ -1507,7 +1507,9 @@ def _path_matrix(paths: Sequence[BandPath], n_bands: int) -> np.ndarray:
     )
 
 
-def _require_paths_and_bands(result: Any, total: str) -> None:
+def _require_paths_and_bands(
+    result: DetailedAirborneResult | DetailedImpactResult, total: str
+) -> None:
     """Reject a decomposition whose paths and bands do not line up.
 
     Shared by the airborne and the impact result, which decompose different

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -86,6 +86,7 @@ from .._internal.validation import require_positive, require_ranks, require_same
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.projections.polar import PolarAxes
     from numpy.typing import ArrayLike, NDArray
 
 #: First zero of the Bessel function ``J1``; the first directivity null of the
@@ -236,7 +237,7 @@ class PistonDirectivity:
         )
 
     def plot(
-        self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
+        self, ax: PolarAxes | None = None, *, language: str = "en", **kwargs: Any
     ) -> Axes:
         """Plot the far-field directivity (beam) pattern on a polar axes.
 

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -452,7 +452,11 @@ def background_noise_correction(
 
 
 def _require_room_pair(
-    first: Any, second: Any, first_name: str, second_name: str, equation: str
+    first: float | np.ndarray | None,
+    second: float | None,
+    first_name: str,
+    second_name: str,
+    equation: str,
 ) -> None:
     """Reject a half-specified room pair for the ``K2`` absorption area.
 

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -822,9 +822,9 @@ class RegulationLimits:
         return {period: self[period] for period in RD1367_EVALUATION_PERIODS}
 
 
-def _limits(
-    table: Mapping[Any, tuple[float, float, float]],
-    key: Any,
+def _limits[K](
+    table: Mapping[K, tuple[float, float, float]],
+    key: K,
     *,
     index: str,
     reference: str,

--- a/src/phonometry/environment/sources/cnossos_rail.py
+++ b/src/phonometry/environment/sources/cnossos_rail.py
@@ -91,7 +91,7 @@ from ..._internal.validation import (
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from numpy.typing import NDArray
+    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "AERODYNAMIC_REFERENCE_SPEED",
@@ -1737,7 +1737,7 @@ def _speed(value: float, name: str = "speed") -> float:
     return v
 
 
-def _spectrum(values: Any, name: str, size: int = 24) -> NDArray[np.float64]:
+def _spectrum(values: ArrayLike, name: str, size: int = 24) -> NDArray[np.float64]:
     array = np.asarray(values, dtype=np.float64)
     if array.shape != (size,):
         msg = (
@@ -2008,11 +2008,11 @@ def bridge_transfer(bridge: BridgeType | str) -> NDArray[np.float64]:
 
 
 def roughness_to_frequency(
-    levels: Any,
-    wavelengths: Any,
+    levels: ArrayLike,
+    wavelengths: ArrayLike,
     speed: float,
     *,
-    frequencies: Any = RAILWAY_THIRD_OCTAVE_BANDS,
+    frequencies: ArrayLike = RAILWAY_THIRD_OCTAVE_BANDS,
     interpolation: RoughnessInterpolation = RoughnessInterpolation.PROPORTIONAL,
 ) -> NDArray[np.float64]:
     r"""Resample a roughness spectrum from wavelength onto frequency.
@@ -2060,7 +2060,7 @@ def roughness_to_frequency(
 
 
 def total_effective_roughness(
-    rail: Any, wheel: Any, filter_: Any
+    rail: ArrayLike, wheel: ArrayLike, filter_: ArrayLike
 ) -> NDArray[np.float64]:
     r"""Total effective roughness ``L_R,TOT,i`` of (2.3.7), in dB.
 
@@ -2080,7 +2080,7 @@ def total_effective_roughness(
     )
 
 
-def impact_roughness(single: Any, joint_density: float) -> NDArray[np.float64]:
+def impact_roughness(single: ArrayLike, joint_density: float) -> NDArray[np.float64]:
     r"""Impact roughness ``L_R,IMPACT,i`` of (2.3.12), in dB.
 
     :math:`L_{\mathrm{R,IMPACT},i} = L_{\mathrm{R,IMPACT-SINGLE},i} + 10
@@ -2108,7 +2108,7 @@ def impact_roughness(single: Any, joint_density: float) -> NDArray[np.float64]:
 
 
 def rolling_sound_power(
-    roughness: Any, transfer: Any, axles: float
+    roughness: ArrayLike, transfer: ArrayLike, axles: float
 ) -> NDArray[np.float64]:
     r"""One rolling-noise component of (2.3.8) to (2.3.10), in dB.
 
@@ -2183,7 +2183,7 @@ def curve_squeal_excess(
 
 
 def horizontal_directivity(
-    phi: float, *, frequencies: Any = RAILWAY_THIRD_OCTAVE_BANDS
+    phi: float, *, frequencies: ArrayLike = RAILWAY_THIRD_OCTAVE_BANDS
 ) -> NDArray[np.float64]:
     r"""Horizontal directivity ``dL_W,dir,hor,i`` of (2.3.15), in dB.
 
@@ -2210,7 +2210,7 @@ def horizontal_directivity(
 def vertical_directivity(
     psi: float,
     *,
-    frequencies: Any = RAILWAY_THIRD_OCTAVE_BANDS,
+    frequencies: ArrayLike = RAILWAY_THIRD_OCTAVE_BANDS,
     height: int = 1,
     aerodynamic: bool = False,
     edition: DirectivityEdition = DirectivityEdition.CURRENT,
@@ -2253,7 +2253,7 @@ def vertical_directivity(
     return np.asarray(np.where(angle > 0.0, shape, 0.0), dtype=np.float64)
 
 
-def octave_bands_from_third_octaves(levels: Any) -> NDArray[np.float64]:
+def octave_bands_from_third_octaves(levels: ArrayLike) -> NDArray[np.float64]:
     """Energy-sum a 24-band 1/3-octave spectrum into the eight octave bands.
 
     Annex II 2.3.2 requires the directional sound power to be derived in 1/3

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -573,7 +573,7 @@ _WEIGHTING_TRANSCRIPTIONS = frozenset(
 )
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> object:
     """Serve the transcriptions this module used to carry from their module."""
     if name in _WEIGHTING_TRANSCRIPTIONS:
         from . import weighting_compliance

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -509,9 +509,11 @@ class TimeWeightedEnvelope:
     mode: str
     calibrated: bool
 
-    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """Return the envelope as an array (optionally recast)."""
-        return np.asarray(self.mean_square, dtype=dtype)
+        return np.asarray(self.mean_square, dtype=dtype, copy=copy)
 
     def __len__(self) -> int:
         """Length of the leading axis: channels when 2-D, samples for one channel."""

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -63,6 +63,7 @@ from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import DTypeLike
 
 #: Rejection message shared by the three entry points that take ``fs``.
 _FS_POSITIVE = "Sample rate 'fs' must be positive."
@@ -508,7 +509,7 @@ class TimeWeightedEnvelope:
     mode: str
     calibrated: bool
 
-    def __array__(self, dtype: Any = None) -> np.ndarray:
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
         """Return the envelope as an array (optionally recast)."""
         return np.asarray(self.mean_square, dtype=dtype)
 
@@ -516,7 +517,7 @@ class TimeWeightedEnvelope:
         """Length of the leading axis: channels when 2-D, samples for one channel."""
         return int(self.mean_square.shape[0])
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
         """Index the mean square; the result is bare values, not another envelope."""
         return self.mean_square[key]
 

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -517,7 +517,7 @@ class TimeWeightedEnvelope:
         """Length of the leading axis: channels when 2-D, samples for one channel."""
         return int(self.mean_square.shape[0])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
         """Index the mean square; the result is bare values, not another envelope."""
         return self.mean_square[key]
 

--- a/src/phonometry/io/_backends.py
+++ b/src/phonometry/io/_backends.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -52,6 +52,8 @@ from ._signal import Signal, SignalOrigin
 from ._wav import AudioFileInfo, read_wav, wav_info
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from ._chunks import WavChunks
 
 
@@ -141,7 +143,7 @@ def _sniff(path: str | Path) -> str | None:
     raise ValueError(msg)
 
 
-def _import_soundfile(format_name: str) -> Any:
+def _import_soundfile(format_name: str) -> ModuleType:
     """Import python-soundfile or explain which extra provides it."""
     try:
         import soundfile
@@ -151,7 +153,9 @@ def _import_soundfile(format_name: str) -> Any:
             f"phonometry ships as the [audio] extra. {_AUDIO_EXTRA_HINT}"
         )
         raise ImportError(msg) from exc
-    return soundfile
+    # soundfile ships no py.typed, so mypy sees the import as Any; the
+    # returned object is nonetheless the module itself.
+    return soundfile  # type: ignore[no-any-return]
 
 
 def _warn_lossy(format_name: str, path: str | Path) -> None:

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -141,9 +141,11 @@ class Signal:
         """The array the object stands for: 1-D mono, 2-D multichannel."""
         return self.data[0] if self.data.shape[0] == 1 else self.data
 
-    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """Return the samples as an array (optionally recast)."""
-        return np.asarray(self._view, dtype=dtype)
+        return np.asarray(self._view, dtype=dtype, copy=copy)
 
     def __len__(self) -> int:
         return int(self._view.shape[0])

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from matplotlib.axes import Axes
-    from numpy.typing import NDArray
+    from numpy.typing import DTypeLike, NDArray
 
     from ._chunks import BroadcastMetadata
 
@@ -141,14 +141,14 @@ class Signal:
         """The array the object stands for: 1-D mono, 2-D multichannel."""
         return self.data[0] if self.data.shape[0] == 1 else self.data
 
-    def __array__(self, dtype: Any = None) -> np.ndarray:
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
         """Return the samples as an array (optionally recast)."""
         return np.asarray(self._view, dtype=dtype)
 
     def __len__(self) -> int:
         return int(self._view.shape[0])
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
         return self._view[key]
 
     @property

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -148,7 +148,7 @@ class Signal:
     def __len__(self) -> int:
         return int(self._view.shape[0])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
         return self._view[key]
 
     @property

--- a/src/phonometry/materials/diffusers/design.py
+++ b/src/phonometry/materials/diffusers/design.py
@@ -492,7 +492,7 @@ def predicted_diffusion_spectrum(
     frequencies: ArrayLike,
     *,
     depths: ArrayLike,
-    reflection_of: Any | None = None,
+    reflection_of: None = None,
     angles: ArrayLike = DEFAULT_POLAR_ANGLES,
     source_angle: float = 0.0,
     periods: int = 1,

--- a/src/phonometry/materials/diffusers/metadiffuser.py
+++ b/src/phonometry/materials/diffusers/metadiffuser.py
@@ -145,7 +145,7 @@ class MetadiffuserResult:
 
 
 def _check_panel(
-    wells: Any, depth: float, period: float
+    wells: Sequence[MetadiffuserWell | None], depth: float, period: float
 ) -> tuple[MetadiffuserWell | None, ...]:
     """Validate the well sequence against the panel depth and period."""
     require_positive(depth, "depth")

--- a/src/phonometry/noise_control/_criterion.py
+++ b/src/phonometry/noise_control/_criterion.py
@@ -15,14 +15,14 @@ Private module: nothing here is part of the public API.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import numpy as np
 
 from .._internal.validation import require_choice
 
 if TYPE_CHECKING:
-    from numpy.typing import NDArray
+    from numpy.typing import ArrayLike, NDArray
 
     from ..room.noise_criteria import NCResult, RCResult
 
@@ -50,8 +50,20 @@ def validate_target(criterion: str, target: float | None) -> tuple[str, float | 
     return family, value
 
 
+class PerBandValues(Protocol):
+    """Anything carrying a per-band ``values`` array.
+
+    Structural stand-in for the spectrum results a workflow forwards whole,
+    such as :class:`~phonometry.noise_control.hvac.HvacSpectrumResult`.
+    """
+
+    @property
+    def values(self) -> ArrayLike:
+        """The per-band quantity."""
+
+
 def as_band_spectrum(
-    value: Any, n: int, name: str, *, default: float = 0.0
+    value: ArrayLike | PerBandValues | None, n: int, name: str, *, default: float = 0.0
 ) -> NDArray[np.float64]:
     """Coerce a scalar, array or spectrum result to a finite ``n``-band array.
 

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -265,7 +265,7 @@ class FluctuationStrengthResult:
         )
 
 
-def _bandpass_envelope_filter(fs: float) -> Any:
+def _bandpass_envelope_filter(fs: float) -> NDArray[np.float64]:
     """H(fmod): band-pass on the envelope (Osses 2016 §2.1.3/3.1, re-fitted).
 
     A ``_LP_ORDER``-order low-pass and a ``_HP_ORDER``-order high-pass in cascade
@@ -316,7 +316,7 @@ _INV_GRID_HZ = np.linspace(20.0, 20000.0, 20000)
 _INV_GRID_BARK = _hz_to_bark(_INV_GRID_HZ)
 
 
-def _bark_center_hz(z: NDArray[np.float64] | float) -> Any:
+def _bark_center_hz(z: NDArray[np.float64] | float) -> NDArray[np.float64] | np.float64:
     """Approximate inverse of :func:`_hz_to_bark` for a band centre (Hz).
 
     Accepts a scalar or an array of critical-band rates and returns the matching
@@ -378,7 +378,7 @@ def _band_envelopes(
 
 
 def _modulation_depth(
-    band_env: NDArray[np.float64], env_sos: Any
+    band_env: NDArray[np.float64], env_sos: NDArray[np.float64]
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Generalised modulation depth m* per band (Osses 2016 §2.1.3).
 

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -89,6 +89,7 @@ class ImpulseResponseWarning(PhonometryWarning):
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import DTypeLike
 
     from ..io._signal import Signal
 
@@ -167,7 +168,7 @@ class ImpulseResponseResult:
     fs: int | None
     method: str
 
-    def __array__(self, dtype: Any = None) -> np.ndarray:
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
         """Return the impulse response as an array (optionally recast)."""
         return np.asarray(self.ir, dtype=dtype)
 
@@ -175,7 +176,7 @@ class ImpulseResponseResult:
         """Number of impulse-response samples (the length of ``ir``'s last axis)."""
         return int(self.ir.shape[-1])
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
         """Forward indexing to ``ir``: ``result[key]`` yields ``ir[key]``."""
         return self.ir[key]
 
@@ -896,7 +897,7 @@ class ShapedSweepResult:
             self, "frequencies", "magnitude", "group_delay", axis="frequency bin"
         )
 
-    def __array__(self, dtype: Any = None) -> np.ndarray:
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
         """Return the sweep samples as an array (optionally recast)."""
         return np.asarray(self.signal, dtype=dtype)
 
@@ -904,7 +905,7 @@ class ShapedSweepResult:
         """Number of sweep samples (the length of ``signal``'s last axis)."""
         return int(self.signal.shape[-1])
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
         """Forward indexing to ``signal``: ``result[key]`` yields ``signal[key]``."""
         return self.signal[key]
 

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -168,9 +168,11 @@ class ImpulseResponseResult:
     fs: int | None
     method: str
 
-    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """Return the impulse response as an array (optionally recast)."""
-        return np.asarray(self.ir, dtype=dtype)
+        return np.asarray(self.ir, dtype=dtype, copy=copy)
 
     def __len__(self) -> int:
         """Number of impulse-response samples (the length of ``ir``'s last axis)."""
@@ -897,9 +899,11 @@ class ShapedSweepResult:
             self, "frequencies", "magnitude", "group_delay", axis="frequency bin"
         )
 
-    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """Return the sweep samples as an array (optionally recast)."""
-        return np.asarray(self.signal, dtype=dtype)
+        return np.asarray(self.signal, dtype=dtype, copy=copy)
 
     def __len__(self) -> int:
         """Number of sweep samples (the length of ``signal``'s last axis)."""

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -176,7 +176,7 @@ class ImpulseResponseResult:
         """Number of impulse-response samples (the length of ``ir``'s last axis)."""
         return int(self.ir.shape[-1])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
         """Forward indexing to ``ir``: ``result[key]`` yields ``ir[key]``."""
         return self.ir[key]
 
@@ -905,7 +905,7 @@ class ShapedSweepResult:
         """Number of sweep samples (the length of ``signal``'s last axis)."""
         return int(self.signal.shape[-1])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401 - mirrors ndarray indexing, whose key union numpy does not export
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
         """Forward indexing to ``signal``: ``result[key]`` yields ``signal[key]``."""
         return self.signal[key]
 

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -79,7 +79,9 @@ class TimedResponse(Protocol):
     @property
     def fs(self) -> float | None: ...
 
-    def __array__(self) -> np.ndarray: ...
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray: ...
 
 
 @dataclass(frozen=True)
@@ -183,9 +185,11 @@ class InverseFilterResult:
             axis="frequency",
         )
 
-    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
+    def __array__(
+        self, dtype: DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """Return the inverse-filter samples as an array."""
-        return np.asarray(self.inverse, dtype=dtype)
+        return np.asarray(self.inverse, dtype=dtype, copy=copy)
 
     def __len__(self) -> int:
         """Number of inverse-filter samples, the ``n_fft`` of the design."""

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -47,12 +47,14 @@ import numpy as np
 
 from .._internal.utils import _typesignal
 from .._internal.validation import require_ranks, require_same_length
-from ..io._resolve import apply_calibration
+from ..io._resolve import SignalInput, apply_calibration
 from ..io._resolve import resolve_fs as _resolve_signal_fs
 from ..io._signal import Signal
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from numpy.typing import DTypeLike
+
 
 __all__ = [
     "InverseFilterResult",
@@ -164,7 +166,7 @@ class InverseFilterResult:
             axis="frequency",
         )
 
-    def __array__(self, dtype: Any = None) -> np.ndarray:
+    def __array__(self, dtype: DTypeLike | None = None) -> np.ndarray:
         """Return the inverse-filter samples as an array."""
         return np.asarray(self.inverse, dtype=dtype)
 
@@ -251,7 +253,9 @@ def _regularization_profile(
     return np.asarray(np.exp(log_eps))
 
 
-def _validated_response(response: Any) -> np.ndarray:
+def _validated_response(
+    response: SignalInput,
+) -> np.ndarray:
     """Validate the measured impulse response array."""
     h = _typesignal(np.asarray(response, dtype=np.float64))
     if h.ndim != 1:
@@ -281,7 +285,10 @@ def _validated_band(f_range: tuple[float, float], fs: float) -> tuple[float, flo
     return f1, f2
 
 
-def _resolve_fs(response: Any, fs: float | None) -> float:
+def _resolve_fs(
+    response: SignalInput,
+    fs: float | None,
+) -> float:
     """Take ``fs`` from the argument or from a result carrying one.
 
     A :class:`phonometry.io.Signal` goes through the library-wide resolver,
@@ -307,7 +314,7 @@ def _resolve_fs(response: Any, fs: float | None) -> float:
 
 
 def regularized_inverse_filter(
-    response: Signal | list[float] | np.ndarray | Any,
+    response: SignalInput,
     fs: float | None = None,
     *,
     f_range: tuple[float, float],

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -41,7 +41,7 @@ out-of-band the filter gain never exceeds the
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 
@@ -63,6 +63,23 @@ __all__ = [
 
 #: Fewest samples a measured impulse response must have to be inverted.
 _MIN_RESPONSE_SAMPLES = 2
+
+
+class TimedResponse(Protocol):
+    """A measured response that knows its own sample rate.
+
+    The structural face of the sweep/MLS/Golay result objects: an array view
+    of the impulse response plus the rate it was sampled at. Structural on
+    purpose, because naming :class:`phonometry.room.ImpulseResponseResult`
+    here would put a toolbox-to-domain edge in the import graph that the
+    architecture forbids; any object with these two members is accepted, and
+    that class is one of them.
+    """
+
+    @property
+    def fs(self) -> float | None: ...
+
+    def __array__(self) -> np.ndarray: ...
 
 
 @dataclass(frozen=True)
@@ -254,7 +271,7 @@ def _regularization_profile(
 
 
 def _validated_response(
-    response: SignalInput,
+    response: SignalInput | TimedResponse,
 ) -> np.ndarray:
     """Validate the measured impulse response array."""
     h = _typesignal(np.asarray(response, dtype=np.float64))
@@ -267,7 +284,13 @@ def _validated_response(
     if not np.all(np.isfinite(h)):
         msg = "'response' must be finite."
         raise ValueError(msg)
-    return apply_calibration(response, h)
+    if isinstance(response, Signal):
+        return apply_calibration(response, h)
+    # The calibration contract is Signal-scoped; every other accepted form,
+    # the plain arrays and the timed result objects, takes the same
+    # pass-through apply_calibration would give it, said here so the wider
+    # parameter type checks.
+    return h
 
 
 def _validated_band(f_range: tuple[float, float], fs: float) -> tuple[float, float]:
@@ -286,7 +309,7 @@ def _validated_band(f_range: tuple[float, float], fs: float) -> tuple[float, flo
 
 
 def _resolve_fs(
-    response: SignalInput,
+    response: SignalInput | TimedResponse,
     fs: float | None,
 ) -> float:
     """Take ``fs`` from the argument or from a result carrying one.
@@ -314,7 +337,7 @@ def _resolve_fs(
 
 
 def regularized_inverse_filter(
-    response: SignalInput,
+    response: SignalInput | TimedResponse,
     fs: float | None = None,
     *,
     f_range: tuple[float, float],

--- a/tests/filters/test_performance.py
+++ b/tests/filters/test_performance.py
@@ -2,6 +2,7 @@
 """Tests that the filter-bank design work is reused rather than repeated."""
 
 import time
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -15,11 +16,11 @@ from phonometry.filters import core
 class _DesignCounter:
     """Wraps ``_design_sos_filter`` and counts how often it is invoked."""
 
-    def __init__(self, inner: Any) -> None:
+    def __init__(self, inner: Callable[..., list[np.ndarray]]) -> None:
         self._inner = inner
         self.calls = 0
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+    def __call__(self, *args: Any, **kwargs: Any) -> list[np.ndarray]:
         self.calls += 1
         return self._inner(*args, **kwargs)
 

--- a/tests/signal_contract.py
+++ b/tests/signal_contract.py
@@ -17,7 +17,7 @@ from typing import Any
 import numpy as np
 
 
-def assert_same(a: Any, b: Any, path: str = "") -> None:
+def assert_same(a: Any, b: Any, path: str = "") -> None:  # noqa: ANN401 - deep-compares results of any shape: dataclasses, dicts, sequences, arrays, scalars
     """Assert two results are identical, walking result objects field by field.
 
     :param a: The result of the call under test.

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
 
 from phonometry.simulation.fdtd import FDTD2D
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 _SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
 if _SCRIPTS not in sys.path:
@@ -37,7 +40,7 @@ import fdtd_gpu_remote
 import job_runner
 
 
-def _cupy_or_none() -> Any:
+def _cupy_or_none() -> ModuleType | None:
     """CuPy with a working CUDA device, else None."""
     try:
         import cupy
@@ -52,7 +55,7 @@ def _cupy_or_none() -> Any:
 _CUPY = _cupy_or_none()
 
 
-def _remote_or_none() -> Any:
+def _remote_or_none() -> fdtd_gpu_remote.RemoteConfig | None:
     """The configured GPU host when it answers, else None.
 
     A CUDA card is not the only way to reach one. ``fdtd_gpu_remote`` already
@@ -194,7 +197,7 @@ def _assert_parity(
 @pytest.mark.parametrize(("xp", "tol"), BACKENDS)
 @pytest.mark.parametrize("direction", list(_WAVES))
 def test_plane_wave_directions_match_library(
-    xp: Any, tol: float, direction: str
+    xp: ModuleType, tol: float, direction: str
 ) -> None:
     """A plane packet in each travel direction reproduces the library."""
     wave = _WAVES[direction]
@@ -214,7 +217,7 @@ def test_plane_wave_directions_match_library(
 
 @pytest.mark.parametrize(("xp", "tol"), BACKENDS)
 @pytest.mark.parametrize("scenario", list(_scenarios()))
-def test_scenarios_match_library(xp: Any, tol: float, scenario: str) -> None:
+def test_scenarios_match_library(xp: ModuleType, tol: float, scenario: str) -> None:
     """Each engine feature (and their combination) reproduces the library."""
     kwargs = _scenarios()[scenario]
     wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
@@ -460,7 +463,11 @@ def test_submit_falls_back_to_local_numpy_run(
     )
     monkeypatch.setattr(fdtd_gpu_remote, "remote_available", lambda config: True)
 
-    def _boom(job: dict[str, Any], config: Any, timeout: float = 0.0) -> dict[str, Any]:
+    def _boom(
+        job: dict[str, Any],
+        config: fdtd_gpu_remote.RemoteConfig,
+        timeout: float = 0.0,
+    ) -> dict[str, Any]:
         msg = "docker run failed"
         raise fdtd_gpu_remote.RemoteRunError(msg)
 

--- a/tests/test_figure_field_labels.py
+++ b/tests/test_figure_field_labels.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import math
 import pathlib
 import sys
-from typing import Any
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -36,16 +36,23 @@ if _SCRIPTS not in sys.path:
 
 from figures.fields._core import _fit_text_below, _fit_text_x, _layout_box
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from matplotlib.text import Text
+
 GAP = 8.0
 
 
 @pytest.fixture(autouse=True)
-def _close_figures() -> Any:
+def _close_figures() -> Iterator[None]:
     yield
     plt.close("all")
 
 
-def _panel() -> tuple[Any, Any]:
+def _panel() -> tuple[Figure, Axes]:
     """A plain 10 x 10 data panel, drawn at a fixed size and resolution."""
     fig, ax = plt.subplots(figsize=(6.0, 4.0), dpi=100)
     ax.set_xlim(0.0, 10.0)
@@ -53,7 +60,7 @@ def _panel() -> tuple[Any, Any]:
     return fig, ax
 
 
-def _x_span(ax: Any, artist: Any) -> tuple[float, float]:
+def _x_span(ax: Axes, artist: Text) -> tuple[float, float]:
     """The artist's rendered box, in x data units of *ax*."""
     box = _layout_box(artist)
     inv = ax.transData.inverted()
@@ -63,7 +70,7 @@ def _x_span(ax: Any, artist: Any) -> tuple[float, float]:
 
 def _slide_below(
     rotation: float,
-) -> tuple[Any, Any, Any, Any, float, tuple[float, float]]:
+) -> tuple[Figure, Axes, Text, Text, float, tuple[float, float]]:
     """Run ``_fit_text_below`` on a label tilted *rotation* degrees.
 
     The label is anchored on top of the one it has to clear, so the pass


### PR DESCRIPTION
Every `Any` in an annotation now either names the type the code actually handles or carries a written reason, and the rule that keeps it that way is part of the lint gate.

The policy half first, since it decides what the rest means. ANN401 is enabled with one seam: a forwarding `*args`/`**kwargs` may stay `Any`, because the keyword surface of matplotlib and friends is an open set and promising it closed with a TypedDict would be the very lie the rule exists to catch. That seam removes 516 findings that were never defects. The 393 that remain across src, tests and scripts were each read and answered on a ladder: the real type where the code pins one, `object` where the function never looks inside the value, and a reasoned `noqa` in the six places where openness is the point, four of which are one `__getitem__` mirroring ndarray indexing, whose key union numpy does not export.

Some replacements did more than satisfy the rule. The sound-power fiche types its five result classes through a structural `Protocol` rather than a union of names; the ISO 3744 discriminator became a `TypeIs`, so its branch narrows by itself; two `getattr`-driven metadata helpers whose fields no single type could describe were rewritten to direct typed access, and mypy now checks field names that used to be strings; and pinning the rating quantity to the single value it can carry let mypy prove two renderer casts redundant, closing the gap a review had already shown could end in an `AttributeError`.

One union asked for a type the layering forbids. The inversion helpers in `signals` had been annotated with `room`'s impulse-response result, which put a toolbox-to-domain edge in the import graph that the architecture suite rightly refused, and alongside it a duplicated `isinstance` dispatch that `apply_calibration` already performs inside. Both are gone: the body is back to main's, and the parameter carries `SignalInput`, the alias the calibration contract already defines one whitelisted edge away. mypy stays green across the tree, which also settles that no caller ever passed the domain object the union speculated about.

Stacked on the pull request below it, which types the figure and conformance scripts and teaches the clip-freshness fingerprint the runtime view those annotations need.

## Summary by Sourcery

Enforce meaningful annotation types throughout the project by replacing non-forwarding Any usage with accurate contracts while preserving explicitly open interfaces.

Bug Fixes:
- Correct sound-power report designations so precision ISO 3745 results are identified correctly.
- Prevent redundant plotting casts and eliminate a potential invalid result handling path in signal inversion.

Enhancements:
- Enable Ruff ANN401 enforcement while allowing genuinely open forwarding star arguments, replacing broad Any annotations with concrete, structural, or object types across source, tests, scripts, and API documentation.
- Strengthen plotting and report interfaces with domain-specific result, array, axes, module, and ReportLab types, including structural protocols for cross-layer contracts.
- Replace dynamic metadata access with typed field access and improve type narrowing for sound-power method dispatch and signal inputs.
- Update NumPy array protocol implementations to support typed dtype and copy arguments.

Build:
- Add Ruff configuration for the ANN401 star-argument exception.

Documentation:
- Update generated API reference signatures to reflect the more precise public annotations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for timed response objects in regularized inverse filtering.
  * Expanded sound-power plotting support for precision measurement results.
  * Added optional copy control when converting signal and response objects to arrays.

* **Documentation**
  * Clarified API types for array-like inputs, plotting axes, and supported analysis results.
  * Documented more precise inputs for rail-noise, room-response, materials, and signal-processing features.

* **Improvements**
  * Improved type consistency across plotting, reporting, filtering, and analysis interfaces.
  * Existing runtime behavior and generated reports remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->