### PR TITLE
Type the figure scripts, and teach the clip fingerprint the runtime view

### DIFF
--- a/scripts/animation_fingerprint.py
+++ b/scripts/animation_fingerprint.py
@@ -192,6 +192,43 @@ def _target_names(target: ast.expr) -> Iterator[str]:
             yield from _target_names(element)
 
 
+class _RuntimeView(ast.NodeTransformer):
+    """A tree with everything only a type checker reads taken out.
+
+    Annotations are evaluated lazily or not at all, and no drawing code
+    introspects them, so a parameter gaining ``: Axes`` cannot move a pixel.
+    Leaving them in would break the fingerprint twice over: their expressions
+    would enter the hash, and an unquoted annotation naming a package class
+    would hand the dependency walk an edge no frame ever crosses. Both the
+    walk and the hash therefore see this view, applied once at parse time.
+
+    A bare declaration (``x: int`` with no value) binds nothing at run time
+    and is dropped whole; an assigned one keeps its assignment and loses the
+    annotation.
+    """
+
+    def visit_arg(self, node: ast.arg) -> ast.arg:
+        node.annotation = None
+        return node
+
+    def _defun(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> ast.FunctionDef | ast.AsyncFunctionDef:
+        node.returns = None
+        self.generic_visit(node)
+        return node
+
+    visit_FunctionDef = _defun
+    visit_AsyncFunctionDef = _defun
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.stmt | None:
+        if node.value is None:
+            return None
+        return ast.copy_location(
+            ast.Assign(targets=[node.target], value=self.visit(node.value)), node
+        )
+
+
 class Sources:
     """Every module of the figures package, parsed once."""
 
@@ -207,9 +244,8 @@ class Sources:
             name = ".".join([_PKG_NAME, *parts])
             if path.name == "__init__.py":
                 self.packages.add(name)
-            parsed[name] = ast.parse(
-                path.read_text(encoding="utf-8"), filename=str(path)
-            )
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            parsed[name] = ast.fix_missing_locations(_RuntimeView().visit(tree))
         # Every module name has to be known before the imports are resolved:
         # ``from . import media`` reads as a module reference or as a symbol
         # depending on whether ``figures.media`` exists.
@@ -372,10 +408,33 @@ def _module_level(body: list[ast.stmt]) -> str:
         s for s in body if not (isinstance(s, ast.If) and _is_type_checking(s.test))
     ]
     imports = sorted(
-        _dump(s) for s in live if isinstance(s, (ast.Import, ast.ImportFrom))
+        _dump(s)
+        for s in live
+        if isinstance(s, (ast.Import, ast.ImportFrom)) and not _typing_only_import(s)
     )
     rest = [s for s in live if not isinstance(s, (ast.Import, ast.ImportFrom))]
     return "\x00".join([*imports, _dump(ast.Module(body=rest, type_ignores=[]))])
+
+
+def _typing_only_import(node: ast.stmt) -> bool:
+    """Is *node* an import that only a type checker reads?
+
+    ``from __future__ import annotations`` changes how annotations are
+    evaluated, and the annotations themselves are removed from the runtime
+    view before anything is hashed, so the switch controls nothing that can
+    reach a frame. ``from typing import TYPE_CHECKING`` binds the guard whose
+    whole block is already taken out above. Either statement appearing or
+    disappearing is an artefact of typing work, not of drawing work.
+
+    Only the exact single-name forms are dropped: ``from typing import
+    TYPE_CHECKING, cast`` binds ``cast``, which is a real runtime name, and
+    stays recorded whole.
+    """
+    if not isinstance(node, ast.ImportFrom):
+        return False
+    if node.module == "__future__":
+        return True
+    return node.module == "typing" and [a.name for a in node.names] == ["TYPE_CHECKING"]
 
 
 def _literals(sources: Sources, symbols: Iterable[Symbol]) -> set[str]:

--- a/scripts/animation_fingerprints.txt
+++ b/scripts/animation_fingerprints.txt
@@ -1,54 +1,42 @@
-# What each committed clip was drawn by, one line per clip.
-#
-# The clips are not regenerated in CI (an FDTD run plus four video encodes
-# each), so nothing else can tell that the code drawing a clip has moved since
-# the clip was written. Each hash covers the clip's builder, everything it
-# reaches inside scripts/figures (the shared clip tail, the theme, the
-# translation machinery) and the translation-table entries its own strings
-# select; it is taken over the syntax tree, so comments and docstrings do not
-# move it. See scripts/animation_fingerprint.py.
-#
-# Written by the renderer. To refresh one clip, re-render it:
-#     python scripts/generate_graphs.py --animations --anim <clip>
-anim_block_vs_exponential 88b44c7e0cf357b4
-anim_comb_filtering 165cd151946f3949
-anim_dynamic_stiffness_sweep 4cc1a8b0502eee00
-anim_elastic_coincidence f5ecee5bf83d8155
-anim_elastic_halfspace_waves 22799f774791a8f1
-anim_elastic_mode_conversion 8a25ebb30faa9ffe
-anim_elastic_plate_junction be0c6e4a02ad805e
-anim_elastic_radiation_efficiency 9152eedffcdfb79b
-anim_epnl_flyover 7839e13c516b145e
-anim_fdtd_absorption_placement 8aaf85ebea7e53d4
-anim_fdtd_aperture_slit 22212cc917bd3484
-anim_fdtd_barrier 7bd88c2d488631b7
-anim_fdtd_critical_angle 9a223cfcac2b9bc3
-anim_fdtd_diffusion c2d8a2e13b1df617
-anim_fdtd_dispersion b6ccec8385c45572
-anim_fdtd_duct_cut_on 31cda8df7f58fbce
-anim_fdtd_ducting 1c5af61f8726c4c2
-anim_fdtd_expansion_chamber 0fba9ec3ba338996
-anim_fdtd_ground_effect dfc47825f84f2a3f
-anim_fdtd_impedance_tube 77c0a8c825575385
-anim_fdtd_metadiffuser 40f5a2d50d86b002
-anim_fdtd_pillar_hall 00f5cd8c8ad6c57c
-anim_fdtd_refraction e61d114b236c567f
-anim_fdtd_room_modes 91e20a50b5125125
-anim_fdtd_side_branch 501f198a25ffe738
-anim_fdtd_slit_absorber b746f7570883104a
-anim_fdtd_transmission_tube 602773a6490ce001
-anim_feedback_howl 7c329e841244dae1
-anim_flanking_paths 0135542560c20d0c
-anim_image_source_buildup 1195ac895034ff8c
-anim_instantaneous_intensity 9efd142e203e3948
-anim_intensity_scan_power f92cdbd6923cc0e3
-anim_iso717_shift dfc6b4e2f1ed73ae
-anim_loudness_gating 30611925de10ef6b
-anim_modulation_transfer 07c66e9d7f8b8dc8
-anim_onset_detection 35e35a2252798a18
-anim_power_two_rooms 8fc5202d0729b026
-anim_schroeder 75f5af5fd64656ee
-anim_specific_loudness c6b9f9bb9be0f904
-anim_standing_wave_tube 7cbd1433851f90a9
-anim_sweep_deconvolution 370a7aa824357a25
-anim_time_weighting 3717abc2bba76b53
+anim_block_vs_exponential 5de65d81db2ec9a9
+anim_comb_filtering 50b66aa13024cba4
+anim_dynamic_stiffness_sweep bc3ce110ff0a0a3a
+anim_elastic_coincidence f9189d9d0bf86268
+anim_elastic_halfspace_waves c2bccbfdd85345e7
+anim_elastic_mode_conversion 18d05d866859644e
+anim_elastic_plate_junction f467f7e15241d1ba
+anim_elastic_radiation_efficiency 280739ce7ddcb896
+anim_epnl_flyover 8cc3e6686e1eebba
+anim_fdtd_absorption_placement a2ccab7d9fefb99b
+anim_fdtd_aperture_slit bcf19ad089083b72
+anim_fdtd_barrier f82a38ff18f9c609
+anim_fdtd_critical_angle b67d743741fabc30
+anim_fdtd_diffusion 496c25f167cc7913
+anim_fdtd_dispersion e8cce1a92b071f87
+anim_fdtd_duct_cut_on c8228ac4b02ce85b
+anim_fdtd_ducting 4c6daaa0c03304b7
+anim_fdtd_expansion_chamber 365032d3b23cc653
+anim_fdtd_ground_effect e1ed1fd5930aa92c
+anim_fdtd_impedance_tube 2cc853001a691290
+anim_fdtd_metadiffuser c564f82d9ebcd475
+anim_fdtd_pillar_hall 93a4765be97d4c76
+anim_fdtd_refraction e8140d09967a2567
+anim_fdtd_room_modes 762de507bcf3305a
+anim_fdtd_side_branch d2c02fb069eebaba
+anim_fdtd_slit_absorber b36c6f7e40895036
+anim_fdtd_transmission_tube fe121005645c3ce6
+anim_feedback_howl 8f8bb94eefcb02fc
+anim_flanking_paths 88ac6e7725f313b8
+anim_image_source_buildup 1942b2b6eca702f3
+anim_instantaneous_intensity 858797bb289b09e2
+anim_intensity_scan_power d62c5c696280cee2
+anim_iso717_shift 753f72869bef5751
+anim_loudness_gating aed15c7167072500
+anim_modulation_transfer b166fb69e9473e06
+anim_onset_detection 0d3ac1fcb77f8411
+anim_power_two_rooms 02c0ccb7832d4883
+anim_schroeder 006cb03444b9c1d7
+anim_specific_loudness cb66aac7c7236fb7
+anim_standing_wave_tube 735fffae44c184ab
+anim_sweep_deconvolution 55d49146cf40d9f4
+anim_time_weighting 50691816c391b048

--- a/scripts/conformance/domains/absorbers.py
+++ b/scripts/conformance/domains/absorbers.py
@@ -18,7 +18,7 @@ vanishes.
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import reference_data as ref
@@ -26,6 +26,13 @@ import reference_data as ref
 import phonometry as ph
 
 from ..registry import Outcome, numeric, register
+
+if TYPE_CHECKING:
+    from phonometry.materials import (
+        BiotWavesResult,
+        PoroelasticLayer,
+        PorousMediumResult,
+    )
 
 _POROUS = "Porous & multilayer absorbers (Mechel / Bies / Cox & D'Antonio)"
 
@@ -342,14 +349,14 @@ _AA_TABLE_6_1_RHO1 = 130.0
 _AA_TABLE_6_1_SHEAR = 220.0e4 * (1.0 + 0.1j)
 
 
-def _aa_glass_wool_medium(frequency: np.ndarray) -> Any:
+def _aa_glass_wool_medium(frequency: np.ndarray) -> PorousMediumResult:
     """The rigid-frame JCA equivalent fluid of the Table 6.1 glass wool."""
     return ph.materials.johnson_champoux_allard(
         frequency, _AA_TABLE_6_1_SIGMA, **_AA_TABLE_6_1
     )
 
 
-def _aa_glass_wool_waves(frequency: np.ndarray) -> Any:
+def _aa_glass_wool_waves(frequency: np.ndarray) -> BiotWavesResult:
     return ph.materials.biot_waves(
         _aa_glass_wool_medium(frequency),
         porosity=_AA_TABLE_6_1["porosity"],
@@ -359,7 +366,9 @@ def _aa_glass_wool_waves(frequency: np.ndarray) -> Any:
     )
 
 
-def _aa_glass_wool_layer(medium: Any, thickness: float, scale: float = 1.0) -> Any:
+def _aa_glass_wool_layer(
+    medium: PorousMediumResult, thickness: float, scale: float = 1.0
+) -> PoroelasticLayer:
     """The same material as a poroelastic layer, optionally frozen stiff."""
     return ph.materials.PoroelasticLayer(
         thickness,

--- a/scripts/conformance/domains/aircraft.py
+++ b/scripts/conformance/domains/aircraft.py
@@ -17,13 +17,16 @@ diffraction.
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 import phonometry as ph
 
 from ..registry import _ROOT, Outcome, numeric, register
+
+if TYPE_CHECKING:
+    from phonometry.aircraft import RotorcraftHemisphere
 
 _AIRCRAFT = "Aircraft noise (ICAO Annex 16 / IEC 61265)"
 
@@ -355,7 +358,9 @@ def _chk_doc32_chain() -> Outcome:
     return numeric(55.87, got, 0.1, unit="dB(A)", places=3)
 
 
-def _uniform_hemisphere(level: float, bands: list[float] | None = None) -> Any:
+def _uniform_hemisphere(
+    level: float, bands: list[float] | None = None
+) -> RotorcraftHemisphere:
     """A synthetic hemisphere with one uniform level on the standard 10° grid."""
     freqs = np.asarray(bands if bands is not None else [50.0], dtype=np.float64)
     az = np.arange(-90.0, 91.0, 10.0)

--- a/scripts/conformance/domains/assessment.py
+++ b/scripts/conformance/domains/assessment.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import reference_data as ref
@@ -27,6 +27,10 @@ from scipy import signal as sg
 import phonometry as ph
 
 from ..registry import Outcome, numeric, register
+
+if TYPE_CHECKING:
+    from phonometry.environment import ImpulseOnset
+    from phonometry.metrology import UncertaintyResult
 
 _NTA = "Impulsive-sound prominence (NT ACOU 112)"
 
@@ -50,7 +54,7 @@ def _chk_impulse_adjustment() -> Outcome:
 _ISO1996_3 = "Impulsive-sound prominence (ISO/PAS 1996-3)"
 
 
-def _iso1996_3_ramp_onset() -> Any:
+def _iso1996_3_ramp_onset() -> ImpulseOnset:
     """Detected onset of a 30 dB LpAF ramp over 0.30 s (dt = 20 ms)."""
     from phonometry.environment.assessment.impulsive_sound import detect_onsets
 
@@ -161,7 +165,7 @@ def _chk_gum_welch() -> Outcome:
     return numeric(ref.GUM_WELCH_VEFF, result.effective_dof, 1e-6, places=3)
 
 
-def _gum_h1_result() -> Any:
+def _gum_h1_result() -> UncertaintyResult:
     quantities = [
         ph.metrology.Quantity(v, unc, dof=dof) for v, unc, dof in ref.GUM_H1_INPUTS
     ]

--- a/scripts/conformance/domains/building.py
+++ b/scripts/conformance/domains/building.py
@@ -21,7 +21,7 @@ published ASTM E1414 laboratory reports.
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import reference_data as ref
@@ -31,6 +31,11 @@ import phonometry as ph
 
 from ..registry import Outcome, numeric, register
 from .levels import _FS
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+    from phonometry.building import InSituElementResult
 
 _A60 = 6.0 * math.log(10.0)
 
@@ -1192,7 +1197,9 @@ def _chk_iso9611_mean_velocity() -> Outcome:
 
 
 # --- Detailed per-band building prediction (ISO 12354-1/-2:2017) ---
-def _iso12354_detailed_situ() -> tuple[Any, dict[str, Any], np.ndarray]:
+def _iso12354_detailed_situ() -> tuple[
+    np.ndarray, dict[str, InSituElementResult], np.ndarray
+]:
     """The Annex L / Annex G building evaluated in situ, per band."""
     import iso12354_building as bld
 
@@ -1217,7 +1224,7 @@ def _chk_iso12354_annex_l_elements() -> Outcome:
     # absorption length as 10 lg of its ratio to the printed value.
     _bands, situ, _delta = _iso12354_detailed_situ()
 
-    def _ratio_db(computed: Any, printed: Any) -> float:
+    def _ratio_db(computed: ArrayLike, printed: ArrayLike) -> float:
         return float(
             np.max(np.abs(10.0 * np.log10(np.asarray(computed) / np.asarray(printed))))
         )

--- a/scripts/conformance/domains/cnossos_rail.py
+++ b/scripts/conformance/domains/cnossos_rail.py
@@ -14,7 +14,7 @@ validate against different tables.
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import reference_data as ref
@@ -23,10 +23,13 @@ import phonometry as ph
 
 from ..registry import Outcome, numeric, register
 
+if TYPE_CHECKING:
+    from phonometry.environment import RailwayEmissionResult
+
 _CNOSSOS_RAIL = "CNOSSOS-EU railway source (Directive 2002/49/EC Annex II)"
 
 
-def _cnossos_rail_case(case: dict[str, str]) -> Any:
+def _cnossos_rail_case(case: dict[str, str]) -> RailwayEmissionResult:
     """One committed workbook case through the shipped model.
 
     The Commission's source-module test set was computed with the 2015

--- a/scripts/conformance/domains/speech.py
+++ b/scripts/conformance/domains/speech.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import reference_data as ref
@@ -29,6 +29,9 @@ from phonometry.speech.sti import _sti_from_mtf
 
 from ..registry import _DELTA_PLACES, Outcome, _fmt, numeric, register
 from .levels import _FS
+
+if TYPE_CHECKING:
+    from phonometry.signals import InverseFilterResult
 
 _NUM_STI_BANDS = 7
 _NUM_MOD_FREQS = 14
@@ -338,7 +341,7 @@ def _chk_golay_recovery() -> Outcome:
     )
 
 
-def _sysmeas_inverse() -> Any:
+def _sysmeas_inverse() -> InverseFilterResult:
     b, a = sg.butter(2, [100.0, 8000.0], btype="bandpass", fs=float(_FS))
     imp = np.zeros(1024)
     imp[0] = 1.0

--- a/scripts/conformance/domains/swept_sine.py
+++ b/scripts/conformance/domains/swept_sine.py
@@ -15,7 +15,7 @@ closed forms.
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy import signal as sg
@@ -24,13 +24,16 @@ import phonometry as ph
 
 from ..registry import Outcome, numeric, register
 
+if TYPE_CHECKING:
+    from phonometry.electroacoustics import SweptSineDistortionResult
+
 _SWEPT_SINE = "Swept-sine distortion & phase utilities (Farina / Novak)"
 
 #: Chebyshev oracle for y = x + a2 x^2 + a3 x^3 driven by a unit sweep.
 _SS_A2, _SS_A3 = 0.1, 0.2
 
 
-def _swept_sine_polynomial() -> Any:
+def _swept_sine_polynomial() -> SweptSineDistortionResult:
     fs, f1, f2, seconds = 48000, 20.0, 6000.0, 2.0
     x = ph.electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)
     y = x + _SS_A2 * x**2 + _SS_A3 * x**3
@@ -39,7 +42,7 @@ def _swept_sine_polynomial() -> Any:
     )
 
 
-def _ss_response_at(res: Any, order: int, freq: float) -> complex:
+def _ss_response_at(res: SweptSineDistortionResult, order: int, freq: float) -> complex:
     idx = int(np.argmin(np.abs(res.frequencies - freq)))
     return complex(res.harmonic_responses[order - 1][idx])
 

--- a/scripts/fdtd_gpu.py
+++ b/scripts/fdtd_gpu.py
@@ -30,10 +30,14 @@ the equation-by-equation mapping.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from types import ModuleType
 
 Field2D = NDArray[np.float64]
 #: Backend array: ``numpy.ndarray`` or ``cupy.ndarray`` depending on ``xp``.
@@ -127,7 +131,7 @@ def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
 
 
 def _resolve_sponge(
-    sponge_width: Any, sponge_reflection: float, ny: int, nx: int
+    sponge_width: int, sponge_reflection: float, ny: int, nx: int
 ) -> tuple[int, float]:
     """Validate the sponge configuration exactly as the library does."""
     width = _integer("sponge_width", sponge_width)
@@ -162,7 +166,7 @@ def _resolve_damping(
     return damping_map
 
 
-def _resolve_sponge_sides(sponge_sides: Any) -> tuple[str, ...]:
+def _resolve_sponge_sides(sponge_sides: str | Iterable[str] | None) -> tuple[str, ...]:
     """Normalise the sponge-side spec into a validated tuple of side names."""
     if sponge_sides is None:
         sides: tuple[str, ...] = _SIDES
@@ -259,7 +263,7 @@ class _ImpedanceEdge:
 
     def __init__(
         self,
-        xp: Any,
+        xp: ModuleType,
         side: str,
         impedance: Field2D,
         rho_edge: Field2D,
@@ -327,11 +331,11 @@ class GpuFDTD2D:
         c: float | Field2D,
         dx: float,
         *,
-        xp: Any = np,
+        xp: ModuleType = np,
         rho: float | Field2D = 1.2,
         cfl: float = 0.6,
         sponge_width: int = 0,
-        sponge_sides: Any = None,
+        sponge_sides: str | Iterable[str] | None = None,
         sponge_reflection: float = 1e-4,
         damping: float | NDArray[np.float64] = 0.0,
         shape: tuple[int, int] | None = None,

--- a/scripts/fdtd_gpu_remote.py
+++ b/scripts/fdtd_gpu_remote.py
@@ -60,6 +60,8 @@ import fdtd_gpu
 import job_runner
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from numpy.typing import NDArray
 
 _REPO_ROOT = _SCRIPTS.parent
@@ -166,7 +168,7 @@ def build_job(
     rho: float | NDArray[np.float64] = 1.2,
     cfl: float = 0.6,
     sponge_width: int = 0,
-    sponge_sides: Any = None,
+    sponge_sides: str | Iterable[str] | None = None,
     sponge_reflection: float = 1e-4,
     damping: float | NDArray[np.float64] = 0.0,
     edge_impedance: dict[str, float | NDArray[np.float64]] | None = None,

--- a/scripts/figures/aircraft.py
+++ b/scripts/figures/aircraft.py
@@ -7,10 +7,13 @@ contours, and the rotorcraft ground effect, flyover and terrain screening of
 ICAO Doc 32. Everything here is embedded by a page under ``aircraft/``.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+if TYPE_CHECKING:
+    from phonometry.aircraft import RotorcraftHemisphere
 
 from phonometry._plot.common import (
     format_frequency_axis,
@@ -982,7 +985,7 @@ def generate_anp_contour(output_dir: str) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def _synthetic_hemisphere(masked: bool = False) -> "Any":
+def _synthetic_hemisphere(masked: bool = False) -> "RotorcraftHemisphere":
     """A helicopter-like hemisphere on the Doc 32 grid, for the figures.
 
     The library implements the method and ships no hemisphere database, so

--- a/scripts/figures/building.py
+++ b/scripts/figures/building.py
@@ -449,7 +449,7 @@ def generate_facade_prediction(output_dir: str) -> None:
     info = [
         (
             rf"$R^{{\prime}}_\mathrm{{tr,s,w}}$ = {result.r_tr_s_w} dB"
-            rf"   ($C_\mathrm{{tr}}$ = {_fmt_minus(result.c_tr)})"
+            rf"   ($C_\mathrm{{tr}}$ = {_fmt_minus(result.c_tr)})"  # type: ignore[arg-type]  # octave layout: Ctr always computed
         ),
         rf"$D_\mathrm{{2m,nT,w}}$ = {result.d_2m_nt_w} dB",
         "air inlet limits the low bands",
@@ -1333,8 +1333,8 @@ def generate_extended_insulation_rating(output_dir: str) -> None:
             f"({_fmt_minus(ext.c, 'g')};{_fmt_minus(ext.ctr, 'g')})"
         ),
         (
-            f"$C_{{50-5000}}$ = {_fmt_minus(ext.c_50_5000, 'g')},  "
-            rf"$C_{{\mathrm{{tr}},50-5000}}$ = {_fmt_minus(ext.ctr_50_5000, 'g')}"
+            f"$C_{{50-5000}}$ = {_fmt_minus(ext.c_50_5000, 'g')},  "  # type: ignore[arg-type]  # 50-5000 Hz input: term always computed
+            rf"$C_{{\mathrm{{tr}},50-5000}}$ = {_fmt_minus(ext.ctr_50_5000, 'g')}"  # type: ignore[arg-type]  # 50-5000 Hz input: term always computed
         ),
         "rating on the core bands, terms on the full range",
     ]

--- a/scripts/figures/devices.py
+++ b/scripts/figures/devices.py
@@ -9,11 +9,12 @@ under ``devices/``.
 """
 
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import Normalize
+from numpy.typing import NDArray
 from scipy import signal as scipy_signal
 
 from phonometry._plot.common import format_frequency_axis, theme_fill, theme_line
@@ -32,6 +33,13 @@ from .theme import (
     measure_weighting_response,
     save_figure,
 )
+
+if TYPE_CHECKING:
+    from phonometry.electroacoustics import (
+        LoudspeakerCharacteristics,
+        MicrophoneCharacteristics,
+    )
+    from phonometry.noise_control import EnclosureResult, RoomToRoomResult
 
 # A negative reading a library plot assembled with ``format()``: the ASCII
 # hyphen before a digit, in a position no word or bracket claims. Restated to
@@ -484,7 +492,7 @@ def generate_piston_directivity(output_dir: str) -> None:
     plt.close()
 
 
-def _loudspeaker_datasheet_example() -> Any:
+def _loudspeaker_datasheet_example() -> "LoudspeakerCharacteristics":
     """The IEC 60268-5 loudspeaker result shared by the section-7 .plot() figures."""
     from phonometry import electroacoustics
 
@@ -515,7 +523,7 @@ def _loudspeaker_datasheet_example() -> Any:
     )
 
 
-def _microphone_datasheet_example() -> Any:
+def _microphone_datasheet_example() -> "MicrophoneCharacteristics":
     """The IEC 60268-4 microphone result shared by the section-8 .plot() figures."""
     from phonometry import electroacoustics
 
@@ -3514,7 +3522,7 @@ def generate_enclosure_required_tl(output_dir: str) -> None:
     bare_floor = 2.5 * 3.5 - 1.5 * 2.5
     alpha = room.mean_absorption([(radiating, wool), (bare_floor + machine, concrete)])
 
-    def _required(model: str) -> Any:
+    def _required(model: str) -> "EnclosureResult":
         return noise_control.enclosure_required_transmission_loss(
             lp1 - nc45,
             radiating,
@@ -3708,7 +3716,7 @@ def generate_room_to_room_partitions(output_dir: str) -> None:
     plt.close()
 
 
-def _norton_plant_room_chain() -> Any:
+def _norton_plant_room_chain() -> "RoomToRoomResult":
     """Norton problem 4.18: a blower in a plant room, into the operator room.
 
     Every number is the one printed in the problem statement, so the figure
@@ -4028,10 +4036,12 @@ def generate_intermodulation_tests(output_dir: str) -> None:
     t = np.arange(n) / fs
     a2, a3 = 0.05, 0.02  # one weak non-linearity for all three
 
-    def through(x: Any) -> Any:
+    def through(x: NDArray[np.float64]) -> NDArray[np.float64]:
         return x + a2 * x**2 + a3 * x**3
 
-    def spectrum(sig: Any) -> tuple[Any, Any]:
+    def spectrum(
+        sig: NDArray[np.float64],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         win = np.hanning(len(sig))
         mag = np.abs(np.fft.rfft(sig * win)) * 2.0 / np.sum(win)
         f = np.fft.rfftfreq(len(sig), d=1.0 / fs)
@@ -4287,7 +4297,7 @@ def generate_microphone_noise_weightings(output_dir: str) -> None:
     a_w = np.interp(noise_f, fa, wa_curve)
     w468 = np.asarray(electroacoustics.itu_r_468_weighting(noise_f), dtype=float)
 
-    def total(bands: Any, weight: Any) -> float:
+    def total(bands: NDArray[np.float64], weight: NDArray[np.float64]) -> float:
         return float(10.0 * np.log10(np.sum(10.0 ** ((bands + weight) / 10.0))))
 
     _fig, (ax_top, ax_bot) = plt.subplots(

--- a/scripts/figures/environment.py
+++ b/scripts/figures/environment.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy.typing import NDArray
 
 from phonometry._plot.common import format_frequency_axis, theme_fill
 
@@ -2003,7 +2004,7 @@ def generate_cnossos_road_gradient(output_dir: str) -> None:
 
     weights = np.asarray(environment.CNOSSOS_A_WEIGHTING)
 
-    def a_weighted(bands: Any) -> float:
+    def a_weighted(bands: NDArray[np.float64]) -> float:
         return float(
             10.0 * np.log10(np.sum(10.0 ** ((np.asarray(bands) + weights) / 10.0)))
         )
@@ -2105,7 +2106,7 @@ def generate_cnossos_rail_components(output_dir: str) -> None:
 
     stock, track = _cnossos_rail_scene()
 
-    def total(bands: Any) -> float:
+    def total(bands: NDArray[np.float64]) -> float:
         return float(10.0 * np.log10(np.sum(10.0 ** (np.asarray(bands) / 10.0))))
 
     _fig, (left, right) = plt.subplots(1, 2, figsize=(13, 5.4))

--- a/scripts/figures/fields/_core.py
+++ b/scripts/figures/fields/_core.py
@@ -8,17 +8,30 @@ loudspeaker drawn on the clips that drive a bore, and the measure-then-slide
 pass that keeps an annotation inside its panel in either language.
 """
 
+from __future__ import annotations
+
 import sys
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from ..theme import COLOR_FG
 
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from matplotlib.text import Text
+    from matplotlib.transforms import Bbox
+    from numpy.typing import NDArray
+
+    from phonometry.simulation.fdtd import FDTD2D
+
 
 def _fdtd_cw_capture(
-    sim: Any, frequency: float, every: int, n_frames: int, decimate: int = 2
-) -> tuple[Any, Any, Any, Any]:
+    sim: FDTD2D, frequency: float, every: int, n_frames: int, decimate: int = 2
+) -> tuple[
+    NDArray[np.float32], NDArray[np.float32], NDArray[np.float64], NDArray[np.float64]
+]:
     """Drive a CW simulation and capture instantaneous + running-RMS frames.
 
     The running mean square uses a two-period time constant, so the RMS map
@@ -28,8 +41,8 @@ def _fdtd_cw_capture(
     """
     beta = float(np.exp(-sim.dt * frequency / 2.0))
     ms = np.zeros_like(sim.p)
-    ps: list[Any] = []
-    rs: list[Any] = []
+    ps: list[NDArray[np.float32]] = []
+    rs: list[NDArray[np.float32]] = []
     ts: list[float] = []
     for _ in range(every * n_frames):
         sim.step()
@@ -41,7 +54,9 @@ def _fdtd_cw_capture(
     return np.stack(ps), np.stack(rs), np.asarray(ts), np.sqrt(ms)
 
 
-def _rms_to_db(rms_frames: Any, *, floor: float = -40.0) -> Any:
+def _rms_to_db(
+    rms_frames: NDArray[np.float32], *, floor: float = -40.0
+) -> NDArray[np.float32]:
     """RMS frame stack -> dB re the final frame's maximum, clipped at floor."""
     ref = float(rms_frames[-1].max())
     with np.errstate(divide="ignore"):
@@ -87,7 +102,9 @@ _GAIN_STEPS = (
 )
 
 
-def _weak_field_gain(weak: Any, vmax: float, *, quantile: float = 0.999) -> float:
+def _weak_field_gain(
+    weak: NDArray[np.float32], vmax: float, *, quantile: float = 0.999
+) -> float:
     """Rounded display gain that lifts a weak field onto a readable colour.
 
     ``weak`` is the quiet region of the field (any shape), ``vmax`` the
@@ -116,7 +133,7 @@ def _gain_note(region: str, gain: float) -> str:
     return f"{region} drawn ×{gain:g} (+{20.0 * np.log10(gain):.0f} dB)"
 
 
-def _layout_box(artist: Any) -> Any:
+def _layout_box(artist: Text) -> Bbox:
     """The rendered box of a label: its background patch, or its glyphs.
 
     For a label with a background patch -- a pill -- this is the patch's own
@@ -138,7 +155,7 @@ def _layout_box(artist: Any) -> Any:
     return artist.get_window_extent()
 
 
-def _settle(fig: Any) -> None:
+def _settle(fig: Figure) -> None:
     """Draw *fig* until its constrained layout stops moving under it.
 
     The first draw of a constrained-layout figure is the one that decides
@@ -151,7 +168,7 @@ def _settle(fig: Any) -> None:
     fig.canvas.draw()
 
 
-def _text_width_x(fig: Any, ax: Any, artist: Any) -> float:
+def _text_width_x(fig: Figure, ax: Axes, artist: Text) -> float:
     """The rendered width of *artist*, in x data units of *ax*."""
     _settle(fig)
     box = _layout_box(artist)
@@ -161,7 +178,7 @@ def _text_width_x(fig: Any, ax: Any, artist: Any) -> float:
 
 
 def _fit_text_below(
-    fig: Any, ax: Any, artist: Any, other: Any, *, gap: float = 8.0
+    fig: Figure, ax: Axes, artist: Text, other: Text, *, gap: float = 8.0
 ) -> float:
     """Slide *artist* back along its own baseline until it clears *other*.
 
@@ -207,7 +224,13 @@ def _fit_text_below(
 
 
 def _fit_text_x(
-    fig: Any, ax: Any, artist: Any, x_lo: float, x_hi: float, *, margin: float = 0.0
+    fig: Figure,
+    ax: Axes,
+    artist: Text,
+    x_lo: float,
+    x_hi: float,
+    *,
+    margin: float = 0.0,
 ) -> float:
     """Slide *artist* along x until its rendered box sits inside the panel.
 
@@ -249,7 +272,7 @@ def _fit_text_x(
 
 
 def _anim_speaker(
-    ax: Any,
+    ax: Axes,
     x0: float,
     y_mid: float,
     bore: float,

--- a/scripts/figures/fields/absorption_placement.py
+++ b/scripts/figures/fields/absorption_placement.py
@@ -32,6 +32,7 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..media import (
     _ANIM_PILL_BOX,
@@ -119,7 +120,9 @@ def _ap_linings() -> tuple[float, float, float, float]:
     return zeta_a, zeta_b, _ap_alpha_stat(zeta_a), a_b
 
 
-def _ap_fit_t60(t: Any, level: Any, lo: float, hi: float) -> float:
+def _ap_fit_t60(
+    t: NDArray[np.float64], level: NDArray[np.float64], lo: float, hi: float
+) -> float:
     """T60 extrapolated from a straight fit of the decay between two levels,
     the T20/T30 practice of the measurement guides.
     """
@@ -288,7 +291,7 @@ def animate_fdtd_absorption_placement(output_dir: str) -> None:
         rms_axes.append(ax_r)
         for row, ax in enumerate((ax_p, ax_r)):
             ax.grid(False)
-            kwargs = (
+            kwargs: dict[str, Any] = (
                 {"cmap": CMAP_FIELD, "vmin": -vmax, "vmax": vmax}
                 if row == 0
                 else {"cmap": "magma", "vmin": -_AP_RMS_SPAN, "vmax": 0.0}
@@ -494,7 +497,7 @@ def animate_fdtd_absorption_placement(output_dir: str) -> None:
         fontsize=9.5,
         color=COLOR_FG,
     )
-    fig.get_layout_engine().set(rect=(0.0, 0.03, 1.0, 0.965))
+    fig.get_layout_engine().set(rect=(0.0, 0.03, 1.0, 0.965))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     fig.text(
         0.5,
         0.005,

--- a/scripts/figures/fields/aperture.py
+++ b/scripts/figures/fields/aperture.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..media import (
     _ANIM_FPS,
@@ -328,14 +329,14 @@ def animate_fdtd_aperture_slit(output_dir: str) -> None:
 
     reveal = int(0.5 * p_all.shape[1])
 
-    def shadow_gained(col: int, k: int) -> Any:
+    def shadow_gained(col: int, k: int) -> NDArray[np.float32]:
         """Frame *k* of panel *col* with the shadow side amplified.
 
         The gain is applied frame by frame: the field stack is memoised and
         shared by the four language/theme variants, so it must not be
         rescaled in place.
         """
-        frame = p_all[col][k]
+        frame: NDArray[np.float32] = p_all[col][k]
         if gains[col] <= 1.0:
             return frame
         out = frame.copy()

--- a/scripts/figures/fields/barrier.py
+++ b/scripts/figures/fields/barrier.py
@@ -362,11 +362,14 @@ def animate_fdtd_barrier(output_dir: str) -> None:
         # separates them.
         t_txt.set_text(T(f"$t$ = {times[-1] * 1000.0:4.1f} ms"))
         _settle(fig)
+        # The ignores: ``get_fontsize`` is typed ``float | str`` for the
+        # named sizes ("small"), which this title, set from rcParams,
+        # never carries.
         while (
             sup.get_window_extent().x0 - t_txt.get_window_extent().x1 < 0.6 * fig.dpi
-            and sup.get_fontsize() > 9.0
+            and sup.get_fontsize() > 9.0  # type: ignore[operator]
         ):
-            sup.set_fontsize(sup.get_fontsize() - 0.25)
+            sup.set_fontsize(sup.get_fontsize() - 0.25)  # type: ignore[operator]
         t_txt.set_text("")
 
     def update(k: int) -> tuple[Any, ...]:

--- a/scripts/figures/fields/dispersion.py
+++ b/scripts/figures/fields/dispersion.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..media import _ANIM_PILL_BOX, _anim_figure, _render_clip, _translate_str
 from ..theme import (
@@ -59,7 +60,9 @@ _DISP_HOLD = round(2.0 * _DISP_FPS)
 _DISP_REVEAL = 1.5e-3
 
 
-def _disp_group_speed(cells: Any, courant: float) -> Any:
+def _disp_group_speed(
+    cells: float | NDArray[np.float64], courant: float
+) -> np.float64 | NDArray[np.float64]:
     """Exact discrete group speed / c on the grid axis.
 
     Differentiating ``sin(omega dt / 2) = S sin(k dx / 2)`` at fixed grid
@@ -72,7 +75,9 @@ def _disp_group_speed(cells: Any, courant: float) -> Any:
     return np.cos(theta) / np.sqrt(np.clip(1.0 - arg**2, 1e-12, None))
 
 
-def _disp_phase_speed(cells: Any, courant: float) -> Any:
+def _disp_phase_speed(
+    cells: float | NDArray[np.float64], courant: float
+) -> np.float64 | NDArray[np.float64]:
     """Exact discrete phase speed / c on the grid axis, in cells per
     wavelength: ``arcsin(S sin theta) / (S theta)``. This is the error the
     guide's ``(1 - S^2)(k dx)^2 / 24`` approximates.
@@ -82,7 +87,9 @@ def _disp_phase_speed(cells: Any, courant: float) -> Any:
     return np.arcsin(arg) / theta / courant
 
 
-def _disp_packet_group_speed(profile: Any, dx: float, courant: float) -> float:
+def _disp_packet_group_speed(
+    profile: NDArray[np.float64], dx: float, courant: float
+) -> float:
     """Group speed of a whole packet / c, weighted by its own spectrum.
 
     Each wavenumber carries its energy at its own ``v_g``, so the energy
@@ -356,7 +363,7 @@ def animate_fdtd_dispersion(output_dir: str) -> None:
         color=COLOR_FG,
         alpha=0.85,
     )
-    fig.get_layout_engine().set(rect=(0.0, 0.045, 1.0, 0.94))
+    fig.get_layout_engine().set(rect=(0.0, 0.045, 1.0, 0.94))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
 
     def update(k: int) -> tuple[Any, ...]:
         j = min(k, times.size - 1)

--- a/scripts/figures/fields/duct_modes.py
+++ b/scripts/figures/fields/duct_modes.py
@@ -193,7 +193,7 @@ def animate_fdtd_duct_cut_on(output_dir: str) -> None:
     fig = _anim_figure()
     # Reserve the bottom strip for the two-line footer: fig.text does not
     # claim space from the constrained layout on its own.
-    fig.get_layout_engine().set(rect=(0.0, 0.075, 1.0, 0.925))
+    fig.get_layout_engine().set(rect=(0.0, 0.075, 1.0, 0.925))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     fig.suptitle(
         T("Duct cut-on: is one pressure enough? (2D FDTD)"),
     )

--- a/scripts/figures/fields/ducting.py
+++ b/scripts/figures/fields/ducting.py
@@ -1,8 +1,10 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 """The SOFAR channel: sound trapped by an ocean sound-speed minimum."""
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -17,11 +19,14 @@ from ..theme import (
     FIELD_STROKE,
 )
 
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
 _DUCT_AXIS = 400.0  # channel-axis depth [m]
 _DUCT_SRC_DEPTHS = (400.0, 150.0)  # on the axis / near the surface
 
 
-def _duct_profile(z: Any) -> Any:
+def _duct_profile(z: NDArray[np.floating[Any]]) -> NDArray[np.float64]:
     """Munk-style sound-speed profile with an exaggerated gradient.
 
     The canonical SOFAR shape (Munk 1974): a minimum at the channel axis,

--- a/scripts/figures/fields/elastic.py
+++ b/scripts/figures/fields/elastic.py
@@ -201,7 +201,7 @@ def animate_elastic_plate_junction(output_dir: str) -> None:
     # fixed 16:9 canvas, so every point of vertical padding costs 2.3 of
     # panel width: the layout pads and the title pads run tight to give
     # back part of the side bands the aspect ratio forces.
-    fig.get_layout_engine().set(h_pad=0.022, w_pad=0.015, hspace=0.0, wspace=0.0)
+    fig.get_layout_engine().set(h_pad=0.022, w_pad=0.015, hspace=0.0, wspace=0.0)  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     fig.suptitle(
         T("Bending waves at an L-junction (elastic 2D FDTD)"),
     )
@@ -605,7 +605,7 @@ def animate_elastic_coincidence(output_dir: str) -> None:
     # no room of its own from the layout), the pads run tight, and the
     # display window is cropped on the right below so the panels use the
     # height instead.
-    fig.get_layout_engine().set(
+    fig.get_layout_engine().set(  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
         rect=(0.0, 0.065, 1.0, 0.935), h_pad=0.015, w_pad=0.015, hspace=0.0, wspace=0.0
     )
     # Display-only crop: the run, the capture and the under-plate

--- a/scripts/figures/fields/expansion_chamber.py
+++ b/scripts/figures/fields/expansion_chamber.py
@@ -1,8 +1,10 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 """The expansion chamber: a reactive muffler passing and stopping."""
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -15,6 +17,9 @@ from ..media import (
 )
 from ..theme import CMAP_FIELD, COLOR_FG, COLOR_GRID, COLOR_PRIMARY
 from ._core import _anim_speaker
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
 _CHAMBER_L = 0.30  # chamber length of the TL example
 _CHAMBER_M = 4.0  # expansion area ratio
@@ -270,7 +275,7 @@ def animate_fdtd_expansion_chamber(output_dir: str) -> None:
 
 
 def _anim_chamber_hardware(
-    ax: Any,
+    ax: Axes,
     length: float,
     height: float,
     pipe_y: tuple[float, float],

--- a/scripts/figures/fields/ground_effect.py
+++ b/scripts/figures/fields/ground_effect.py
@@ -1,8 +1,10 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 """The ground effect: the direct wave and its ground bounce interfering."""
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -20,6 +22,9 @@ from ..theme import (
     FIELD_STROKE,
 )
 from ._core import _rms_to_db
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 _GROUND_FREQ = 400.0
 _GROUND_H = 1.5
@@ -111,7 +116,9 @@ def _ground_effect_fields(
 
     # Two-path image-source model on the same arc (2D line source: 1/sqrt(r)
     # spreading), and the predicted nulls where r2 - r1 = (m + 1/2) lambda.
-    def paths(th: Any) -> tuple[Any, Any]:
+    def paths(
+        th: NDArray[np.float64],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         x, y = (
             _GROUND_ARC_R * np.cos(np.radians(th)),
             _GROUND_ARC_R * np.sin(np.radians(th)),

--- a/scripts/figures/fields/halfspace.py
+++ b/scripts/figures/fields/halfspace.py
@@ -205,7 +205,7 @@ def animate_elastic_halfspace_waves(output_dir: str) -> None:
     # Reserve the bottom strip for the two figure-level captions: fig.text
     # does not claim space from the constrained layout on its own, and
     # without this the material line lands on the lower axis label.
-    fig.get_layout_engine().set(rect=(0.0, 0.055, 1.0, 0.945))
+    fig.get_layout_engine().set(rect=(0.0, 0.055, 1.0, 0.945))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     # Short on purpose: the Spanish of a longer title overran the canvas at
     # both ends. What the boundary has to do with it is in the panel titles.
     fig.suptitle(T("Lamb's problem: P, S and the surface wave (elastic 2D FDTD)"))

--- a/scripts/figures/fields/metadiffuser.py
+++ b/scripts/figures/fields/metadiffuser.py
@@ -7,8 +7,10 @@ Table-1 geometry, so they share its pitch, period count and design
 frequency.
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -21,6 +23,9 @@ from ..theme import (
     FIELD_INK,
     FIELD_STROKE,
 )
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 @lru_cache(maxsize=1)
@@ -106,7 +111,7 @@ _META_PITCH, _META_PERIODS = 0.07, 2
 _META_F0 = 2000.0
 
 
-def _metadiffuser_panel_mask(rho: Any) -> None:
+def _metadiffuser_panel_mask(rho: NDArray[np.float64]) -> None:
     """Carve the Table-1 metadiffuser (two periods) into a dense slab.
 
     The slab spans the panel depth L = 2 cm plus a 3 mm back wall under
@@ -160,7 +165,7 @@ def _meta_qrd_wells() -> list[tuple[float, float, float]]:
     return wells
 
 
-def _meta_rho(kind: str) -> Any:
+def _meta_rho(kind: str) -> NDArray[np.float64]:
     """Density map of one run: ``flat``, ``qrd``, ``meta`` or ``ref``."""
     dx, ny, nx = _META_DX, _META_NY, _META_NX
     y1 = _META_FACE
@@ -188,7 +193,7 @@ def _meta_rho(kind: str) -> Any:
     return rho
 
 
-def _meta_taper() -> Any:
+def _meta_taper() -> NDArray[np.float64]:
     """Lateral cosine taper of the incident packet (free-field edges).
 
     The wavefront is flat over the panels and dies smoothly well before

--- a/scripts/figures/fields/mode_conversion.py
+++ b/scripts/figures/fields/mode_conversion.py
@@ -275,7 +275,7 @@ def animate_elastic_mode_conversion(output_dir: str) -> None:
     fig = _anim_figure()
     # Reserve the bottom strip for the figure-level caption and clock:
     # fig.text does not claim space from the constrained layout on its own.
-    fig.get_layout_engine().set(rect=(0.0, 0.055, 1.0, 0.945))
+    fig.get_layout_engine().set(rect=(0.0, 0.055, 1.0, 0.945))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     fig.suptitle(
         T("Mode conversion: water on steel, three incidences (elastic 2D FDTD)")
     )

--- a/scripts/figures/fields/pillar_hall.py
+++ b/scripts/figures/fields/pillar_hall.py
@@ -6,15 +6,20 @@ is this one, and the override is computed from this clip's own mesh, stride
 and trimmed warm-up.
 """
 
+from __future__ import annotations
+
 import os
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 from ..media import _ANIM_DPI, _ANIM_HOLD, _render_clip, _translate_str
 from ..theme import _FILENAME_SUFFIX, CMAP_FIELD, COLOR_FG, COLOR_GRID
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 def _poster_ss_for(webm: str) -> float | None:
@@ -121,7 +126,7 @@ def _pillar_layout() -> list[tuple[float, float, float]]:
     return out
 
 
-def _pillar_mask() -> Any:
+def _pillar_mask() -> NDArray[np.bool_]:
     """Rasterise the columns into the rigid-cell mask of the banner run."""
     xs = (np.arange(_PILLAR_NX) + 0.5) * _PILLAR_DX
     ys = (np.arange(_PILLAR_NY) + 0.5) * _PILLAR_DX

--- a/scripts/figures/fields/radiation_efficiency.py
+++ b/scripts/figures/fields/radiation_efficiency.py
@@ -6,8 +6,10 @@ plate, but driven by a force on the plate itself rather than by an airborne
 wave, so what the air above it does is *radiation* and not transmission.
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -24,6 +26,9 @@ from .elastic import (
     _EL_RHO0,
     _elastic_plate_bp_m2,
 )
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 # Grid. The plate, its mesh and its numerical-dispersion compensation are
 # the coincidence clip's, imported rather than restated: same 10 mm steel,
@@ -92,7 +97,7 @@ def _re_bending_wavenumber(frequency: float) -> float:
     return float((m2 * (2.0 * np.pi * frequency) ** 2 / bp) ** 0.25)
 
 
-def _re_decay_length(rms_by_row: Any, r0: int, dx: float) -> float:
+def _re_decay_length(rms_by_row: NDArray[np.float64], r0: int, dx: float) -> float:
     """e-folding height of the pressure envelope above the plate [m].
 
     A log-linear fit of the row-wise RMS between 1 and 4 cm above the
@@ -288,7 +293,7 @@ def animate_elastic_radiation_efficiency(output_dir: str) -> None:
     fig = _anim_figure()
     # Reserve the bottom strip for the two figure-level captions and the
     # clock: fig.text does not claim space from the constrained layout.
-    fig.get_layout_engine().set(rect=(0.0, 0.055, 1.0, 0.945))
+    fig.get_layout_engine().set(rect=(0.0, 0.055, 1.0, 0.945))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     # Short on purpose: the Spanish of the longer title overran the canvas
     # at both ends. The solver and the plate moved to the footer.
     fig.suptitle(

--- a/scripts/figures/fields/seabed.py
+++ b/scripts/figures/fields/seabed.py
@@ -13,8 +13,10 @@ lower axis where the *measured* energy flux through the seabed fills in
 behind the contact point and lands on the closed form.
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -28,6 +30,9 @@ from ..theme import (
     COLOR_PRIMARY,
     COLOR_SECONDARY,
 )
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 _SB_C1, _SB_RHO1 = 1500.0, 1000.0  # water: the guide's own pair
 #: The two sediments. Sand is the guide's water-over-sand example, whose
@@ -80,7 +85,7 @@ def _sb_geometry() -> tuple[int, int, int, int, int]:
     return n_vis, n_rows, rows_water, ix_src, iy_src
 
 
-def _sb_front_angle(times: Any) -> Any:
+def _sb_front_angle(times: NDArray[np.float64]) -> NDArray[np.float64]:
     """Grazing angle at which the direct front meets the seabed [deg].
 
     The front is a circle of radius ``c1 (t - t0)`` about a source sitting
@@ -502,7 +507,7 @@ def animate_fdtd_critical_angle(output_dir: str) -> None:
         color=COLOR_FG,
         alpha=0.85,
     )
-    fig.get_layout_engine().set(rect=(0.0, 0.035, 1.0, 0.95))
+    fig.get_layout_engine().set(rect=(0.0, 0.035, 1.0, 0.95))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
 
     def update(k: int) -> tuple[Any, ...]:
         j = min(k, times.size - 1)

--- a/scripts/figures/fields/side_branch.py
+++ b/scripts/figures/fields/side_branch.py
@@ -426,7 +426,7 @@ def animate_fdtd_side_branch(output_dir: str) -> None:
         fontsize=9.5,
         color=COLOR_FG,
     )
-    fig.get_layout_engine().set(rect=(0.0, 0.03, 1.0, 0.965))
+    fig.get_layout_engine().set(rect=(0.0, 0.03, 1.0, 0.965))  # type: ignore[union-attr, call-arg]  # _anim_figure: constrained engine, never None
     fig.text(
         0.5,
         0.005,

--- a/scripts/figures/fields/slit_absorber.py
+++ b/scripts/figures/fields/slit_absorber.py
@@ -1,8 +1,10 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 """The slit absorber: a critically coupled panel swallowing the wave."""
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -16,6 +18,11 @@ from ..media import (
 from ..theme import CMAP_FIELD, COLOR_FG, COLOR_GRID, COLOR_PRIMARY
 from ._core import _anim_speaker, _fit_text_x
 
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+    from phonometry.materials import CriticalCouplingResult
+
 _SLIT_ABS_F0 = 300.0  # critical-coupling design frequency
 _SLIT_ABS_TUBE = 0.60  # air column before the panel face
 _SLIT_ABS_PERIOD = 5.0e-2  # panel period d = the tube bore
@@ -24,7 +31,7 @@ _SLIT_ABS_DETUNE = 1.7  # wide-slit factor of the alpha figure
 
 
 @lru_cache(maxsize=1)
-def _slit_absorber_design() -> Any:
+def _slit_absorber_design() -> CriticalCouplingResult:
     """The 300 Hz critical-coupling design of the slow-sound figures."""
     from phonometry import materials
 
@@ -505,7 +512,7 @@ def animate_fdtd_slit_absorber(output_dir: str) -> None:
 
 
 def _anim_slit_tube_walls(
-    ax: Any, length: float, bore: float, *, speaker: bool = True
+    ax: Axes, length: float, bore: float, *, speaker: bool = True
 ) -> None:
     """Tube walls and drive loudspeaker for the slit-absorber clip (the
     shared ``_anim_tube_hardware`` labels its termination as a plug, but

--- a/scripts/figures/fields/tubes.py
+++ b/scripts/figures/fields/tubes.py
@@ -7,8 +7,10 @@ their sample, mesh and carrier. The standing-wave clip is the schematic view
 of the same ISO 10534-2 apparatus.
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -32,6 +34,9 @@ from ..theme import (
 )
 from ._core import _anim_speaker
 
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
 #: Virtual-tube sample: the equivalent fluid of the solver cross-checks
 #: (slower, denser, lossy; k = (omega - j sigma)/c at the real rho c).
 _VTUBE_C2, _VTUBE_RHO2, _VTUBE_SIGMA = 0.6 * 343.0, 3.6, 600.0
@@ -40,7 +45,7 @@ _VTUBE_F = 850.0  # CW inside the 100 mm plane range
 
 
 def _anim_tube_hardware(
-    ax: Any,
+    ax: Axes,
     length: float,
     *,
     bore: float = 0.1,

--- a/scripts/figures/i18n.py
+++ b/scripts/figures/i18n.py
@@ -11,12 +11,17 @@ The table is the module -- it is data, not code, and it is kept here so a
 translation fix never means touching a figure.
 """
 
+from __future__ import annotations
+
 import os
 import re
 import sys
-from typing import Any
+from typing import TYPE_CHECKING
 
 from . import _publish
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
 
 # The miss recorder sits at the top of ``scripts/``, next to the checker that
 # reads what it writes; the figures package is a subdirectory of the same
@@ -5605,7 +5610,7 @@ def _decimal_comma(s: str) -> str:
 _LEADING_SIGN_RE = re.compile(r"^(\s*)-")
 
 
-def _fmt_minus(value: Any, spec: str = "") -> str:
+def _fmt_minus(value: float, spec: str = "") -> str:
     """Format *value* for a label, with the minus sign the figures are set in.
 
     ``format`` writes a negative number with an ASCII hyphen, so a reading
@@ -5667,7 +5672,7 @@ def lookup(s: str) -> str:
     return s
 
 
-def _audit_english(fig: Any) -> None:
+def _audit_english(fig: Figure) -> None:
     """Report what the tables cannot translate, on the English pass.
 
     The English figure is correct by construction, so this walk exists only
@@ -5704,7 +5709,7 @@ def _audit_english(fig: Any) -> None:
             lookup(artist.get_text())
 
 
-def _translate_figure(fig: Any) -> None:
+def _translate_figure(fig: Figure) -> None:
     """Rewrite every Text artist of *fig* into the active language."""
     import re as _re
 

--- a/scripts/figures/materials.py
+++ b/scripts/figures/materials.py
@@ -8,6 +8,8 @@ alike) that scatter rather than absorb. Everything here is embedded by a page
 under ``materials/``.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
@@ -35,6 +37,9 @@ from .theme import (
 )
 
 if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from phonometry.materials import CriticalCouplingResult, HelmholtzResonator
     from phonometry.materials.absorbers.layered import Layer
 
 
@@ -3498,7 +3503,7 @@ def generate_standing_wave_envelope(output_dir: str) -> None:
     k = 2.0 * np.pi * freq / c0
     x = np.linspace(0.0, 1.0, 2400)
 
-    def level(magnitude: Any, phi: float) -> Any:
+    def level(magnitude: float, phi: float) -> NDArray[np.float64]:
         """Envelope in decibels, which is what the analyser shows."""
         env2 = 1.0 + magnitude**2 + 2.0 * magnitude * np.cos(2 * k * x - phi)
         return 10.0 * np.log10(np.maximum(env2, 1e-6))
@@ -3989,7 +3994,7 @@ def generate_sheet_transfer_impedance(output_dir: str) -> None:
     plt.close()
 
 
-def _slit_design(target: float = 300.0) -> Any:
+def _slit_design(target: float = 300.0) -> CriticalCouplingResult:
     """The guide's 300 Hz critical-coupling design, solved once."""
     from phonometry import materials
 
@@ -4204,7 +4209,9 @@ def generate_graded_slit_absorber(output_dir: str) -> None:
     uniform = [single.resonator] * 4
 
     _fig, ax = plt.subplots(figsize=(10.5, 6.2))
-    curves = (
+    curves: tuple[
+        tuple[str, HelmholtzResonator | list[HelmholtzResonator], float, str, str], ...
+    ] = (
         (
             "one cell, $L$ = 30 mm",
             single.resonator,

--- a/scripts/figures/media.py
+++ b/scripts/figures/media.py
@@ -11,10 +11,11 @@ variants as WebM, extracts the deferred-loading poster still and adds the
 English GIF for the GitHub docs.
 """
 
+from __future__ import annotations
+
 import os
 import sys
-from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import matplotlib.pyplot as plt
 
@@ -26,6 +27,12 @@ from .i18n import (
     lookup,
 )
 from .theme import _FILENAME_SUFFIX
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from matplotlib.animation import FuncAnimation
+    from matplotlib.figure import Figure
 
 # ====================================================================# Animations (Tier 1 pilot)
 # ---------------------------------------------------------------------------
@@ -134,13 +141,13 @@ def _anim_path(output_dir: str, stem: str, ext: str) -> str:
     return os.path.join(output_dir, f"{stem}{_LANG_SUFFIX}{_FILENAME_SUFFIX}.{ext}")  # noqa: PTH118
 
 
-def _anim_figure() -> Any:
+def _anim_figure() -> Figure:
     """A fixed-size themed figure for a clip (constant canvas across frames)."""
     return plt.figure(figsize=_ANIM_FIGSIZE, dpi=_ANIM_DPI, layout="constrained")
 
 
 def _render_clip(
-    fig: Any,
+    fig: Figure,
     update: Callable[[int], tuple[Any, ...]],
     output_dir: str,
     stem: str,
@@ -322,8 +329,8 @@ ssh -o BatchMode=yes -- {q_target} "rm -f {q_dir}/$rid"
 
 
 def _save_animation(
-    anim: Any,
-    fig: Any,
+    anim: FuncAnimation,
+    fig: Figure,
     output_dir: str,
     stem: str,
     make_gif: bool = True,

--- a/scripts/figures/schematics.py
+++ b/scripts/figures/schematics.py
@@ -9,8 +9,10 @@ clips that use them, ahead of the wave-field clips of :mod:`figures.fields`,
 which borrow the same vocabulary to annotate a simulated field.
 """
 
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -38,6 +40,15 @@ from .theme import (
     COLOR_TERTIARY,
     FIELD_STROKE,
 )
+
+if TYPE_CHECKING:
+    from matplotlib.artist import Artist
+    from matplotlib.axes import Axes
+    from matplotlib.collections import FillBetweenPolyCollection
+    from matplotlib.figure import Figure
+    from matplotlib.patches import Arc, FancyArrowPatch, Rectangle
+    from matplotlib.typing import ColorType
+    from numpy.typing import NDArray
 
 
 def _halo(linewidth: float = 2.4) -> list[Any]:
@@ -72,7 +83,7 @@ def _pending_ink(color: str) -> tuple[float, float, float]:
     return (0.35 * r + 0.65, 0.35 * g + 0.65, 0.35 * b + 0.65)
 
 
-def _half_width(fig: Any, ax: Any, artist: Any) -> float:
+def _half_width(fig: Figure, ax: Axes, artist: Artist) -> float:
     """Half the rendered width of *artist*, in x data units of *ax*.
 
     Several clips centre a readout on a moving glyph, or anchor an annotation
@@ -89,13 +100,13 @@ def _half_width(fig: Any, ax: Any, artist: Any) -> float:
     return float(abs(x1 - x0)) / 2.0
 
 
-def _grid_axes(ax: Any) -> None:
+def _grid_axes(ax: Axes) -> None:
     """Apply the standard documentation grid to a data axes."""
     ax.grid(True, color=COLOR_GRID, linestyle="--", alpha=0.5)
 
 
 def _schematic_axes(
-    ax: Any,
+    ax: Axes,
     xlim: tuple[float, float],
     ylim: tuple[float, float],
     *,
@@ -114,7 +125,7 @@ def _schematic_axes(
 
 
 def _draw_mic(
-    ax: Any,
+    ax: Axes,
     x: float,
     y: float,
     *,
@@ -169,7 +180,7 @@ def _draw_mic(
 
 
 def _draw_speaker(
-    ax: Any, x: float, y: float, *, size: float = 1.0, direction: int = 1
+    ax: Axes, x: float, y: float, *, size: float = 1.0, direction: int = 1
 ) -> None:
     """A loudspeaker symbol: cabinet plus cone, radiating toward
     ``direction`` (+1 = +x, -1 = -x). ``(x, y)`` is the cone mouth centre.
@@ -202,7 +213,7 @@ def _draw_speaker(
 
 
 def _make_wavefronts(
-    ax: Any,
+    ax: Axes,
     x: float,
     y: float,
     color: str,
@@ -211,7 +222,7 @@ def _make_wavefronts(
     theta1: float = 0.0,
     theta2: float = 360.0,
     lw: float = 1.6,
-) -> list[Any]:
+) -> list[Arc]:
     """``n`` expanding wavefront arcs centred on ``(x, y)``, initially hidden.
 
     Drive them with :func:`_set_wavefronts`; ``theta1``/``theta2`` restrict
@@ -231,13 +242,13 @@ def _make_wavefronts(
 
 
 def _set_wavefronts(
-    arcs: list[Any],
+    arcs: list[Arc],
     radii: list[float],
     rmax: float,
     *,
     alpha: float = 0.9,
-    color: Any = None,
-) -> list[Any]:
+    color: ColorType | None = None,
+) -> list[Arc]:
     """Resize each wavefront arc; fronts fade toward ``rmax`` and hide beyond.
 
     ``radii`` pairs with ``arcs``; non-positive radii hide the arc. Returns
@@ -256,7 +267,7 @@ def _set_wavefronts(
     return arcs
 
 
-def _polyline_point(pts: Any, frac: float) -> tuple[float, float]:
+def _polyline_point(pts: NDArray[np.float64], frac: float) -> tuple[float, float]:
     """The point a fraction ``frac`` of the arc length along a polyline.
 
     ``pts`` is an ``(N, 2)`` array of vertices; ``frac`` is clipped to
@@ -276,7 +287,7 @@ def _polyline_point(pts: Any, frac: float) -> tuple[float, float]:
 
 
 def _make_gauge(
-    ax: Any,
+    ax: Axes,
     cx: float,
     cy: float,
     r: float,
@@ -381,7 +392,7 @@ def _set_gauge(gauge: dict[str, Any], frac: float, text: str) -> tuple[Any, Any]
 
 
 def _flow_box(
-    ax: Any, cx: float, cy: float, w: float, h: float, title: str
+    ax: Axes, cx: float, cy: float, w: float, h: float, title: str
 ) -> dict[str, Any]:
     """A processing-pipeline box, dimmed until :func:`_light_box` lights it."""
     from matplotlib.colors import to_rgba
@@ -444,7 +455,7 @@ def _dim_box(box: dict[str, Any]) -> None:
     box["value"].set_text("")
 
 
-def _make_arrow(ax: Any, color: str, scale: float = 14.0) -> Any:
+def _make_arrow(ax: Axes, color: str, scale: float = 14.0) -> FancyArrowPatch:
     """An updatable arrow patch; reposition it with ``set_positions``."""
     from matplotlib.patches import FancyArrowPatch
 
@@ -462,7 +473,7 @@ def _make_arrow(ax: Any, color: str, scale: float = 14.0) -> Any:
     return arrow
 
 
-def _draw_resistor(ax: Any, x0: float, x1: float, y: float) -> None:
+def _draw_resistor(ax: Axes, x0: float, x1: float, y: float) -> None:
     """A zigzag resistor symbol on a horizontal wire from *x0* to *x1*."""
     n = 6
     xs = np.linspace(x0, x1, 2 * n + 1)
@@ -555,7 +566,7 @@ def animate_time_weighting_ballistics(output_dir: str) -> None:
         xytext=(0.6, 7.3),
         arrowprops={"arrowstyle": "-|>", "color": COLOR_FG, "lw": 1.2},
     )
-    wire = {"color": COLOR_FG, "lw": 1.4}
+    wire: dict[str, Any] = {"color": COLOR_FG, "lw": 1.4}
     ax_s.plot([0.6, 1.3], [5.6, 5.6], **wire)
     ax_s.add_patch(
         FancyBboxPatch(
@@ -1273,7 +1284,7 @@ def animate_schroeder(output_dir: str) -> None:
     sweep_max = float(t_raw[-1])  # start the front at the very end of p²
     fill_alpha = 0.5 if _FILENAME_SUFFIX else 0.35
     ax_e.plot(t_raw[ds], raw_db[ds], color="gray", alpha=0.4, lw=0.6)
-    e_fill = {"art": None}
+    e_fill: dict[str, FillBetweenPolyCollection | None] = {"art": None}
     front_e = ax_e.axvline(sweep_max, color=COLOR_FG, lw=1.3, alpha=0.55)
     # Sits well below the upper-right legend (a higher anchor ran under it).
     front_txt = ax_e.text(
@@ -2252,7 +2263,7 @@ def animate_specific_loudness(output_dir: str) -> None:
     ax.set_xlabel(T("Critical-band rate $z$ [Bark]"))
     ax.set_ylabel(T(r"Specific loudness $N^{\prime}$ [sone/Bark]"), fontsize=9)
     (line,) = ax.plot([], [], color=COLOR_PRIMARY, lw=2.2)
-    fill = {"art": None}
+    fill: dict[str, FillBetweenPolyCollection | None] = {"art": None}
     ax.axvline(8.5, color=COLOR_FG, lw=0.9, ls=":", alpha=0.6)
     ax.text(
         8.75,
@@ -2501,7 +2512,7 @@ def animate_power_two_rooms(output_dir: str) -> None:
     cr = (1.7, 1.3)
     _draw_speaker(ax_r, cr[0] - 0.05, cr[1], size=0.85)
     # bouncing ray trails (specular folding inside the rectangle)
-    rays = [
+    rays: list[dict[str, Any]] = [
         {
             "v": (2.9, 1.9),
             "trail": ax_r.plot([], [], color=COLOR_TERTIARY, lw=1.1, alpha=0.75)[0],
@@ -2911,9 +2922,9 @@ def animate_dynamic_stiffness_sweep(output_dir: str) -> None:
     f_lo, f_hi = 8.0, 60.0
     freqs = np.linspace(f_lo, f_hi, 800)
 
-    def response(f: np.ndarray | float) -> Any:
+    def response(f: np.ndarray | float) -> NDArray[np.complex128]:
         ratio = np.asarray(f, dtype=float) / f_r
-        return 1.0 / (1.0 - ratio**2 + 1j * eta * ratio)
+        return 1.0 / (1.0 - ratio**2 + 1j * eta * ratio)  # type: ignore[return-value]  # numpy stubs miss the 1j promotion to complex128
 
     mag = np.abs(response(freqs))
     phase = np.degrees(np.angle(response(freqs)))
@@ -3297,7 +3308,7 @@ def animate_modulation_transfer(output_dir: str) -> None:
             "alpha": 0.8,
         },
     )
-    floor_fill = {"art": None}
+    floor_fill: dict[str, FillBetweenPolyCollection | None] = {"art": None}
     peak_line = ax_e.axhline(0.0, color=COLOR_SECONDARY, lw=1.0, ls=":")
     dip_line = ax_e.axhline(0.0, color=COLOR_SECONDARY, lw=1.0, ls=":")
     depth = _make_arrow(ax_e, COLOR_SECONDARY, scale=9.0)
@@ -3447,7 +3458,7 @@ _GATE_RELATIVE = -10.0  # Formula (5), the integrated relative gate
 _LRA_RELATIVE = -20.0  # EBU Tech 3342, the deeper loudness-range gate
 
 
-def _energy_mean_lufs(values: Any) -> float:
+def _energy_mean_lufs(values: NDArray[np.float64]) -> float:
     """Energy (not arithmetic) mean of block loudness values, in LUFS."""
     return float(10.0 * np.log10(np.mean(10.0 ** (np.asarray(values) / 10.0))))
 
@@ -3605,7 +3616,7 @@ def animate_loudness_gating(output_dir: str) -> None:
         visible=False,
         bbox=_label_bbox,
     )
-    lra_band = {"art": None}
+    lra_band: dict[str, Rectangle | None] = {"art": None}
     ax_t.legend(loc="lower right", fontsize=7.5, framealpha=0.9)
 
     # --- top right: the distribution the second pass is computed from ----
@@ -3917,7 +3928,7 @@ def animate_epnl_flyover(output_dir: str) -> None:
         ms=2.4,
         label=T(r"$\mathrm{PNLT} = \mathrm{PNL} + C$"),
     )
-    gap = {"art": None, "win": None}
+    gap: dict[str, FillBetweenPolyCollection | None] = {"art": None, "win": None}
     thr_line = ax_h.axhline(
         threshold, color=COLOR_SECONDARY, lw=1.2, ls=":", visible=False
     )
@@ -3971,7 +3982,7 @@ def animate_epnl_flyover(output_dir: str) -> None:
     win_at = int(0.86 * sweep)  # the 10 dB-down window opens
     epnl_at = int(0.96 * sweep)  # the duration correction and the EPNL
 
-    def plane_shape(x: float, y: float) -> Any:
+    def plane_shape(x: float, y: float) -> NDArray[np.float64]:
         s_x, s_y = 0.42, 0.30
         return np.array(
             [
@@ -4335,7 +4346,7 @@ def animate_image_source_buildup(output_dir: str) -> None:
         reached = plan_t <= now
         pts = plan_xy[reached]
         lit.set_offsets(pts if pts.size else np.empty((0, 2)))
-        lit.set_facecolors([palette[o] for o in d["plan_order"][reached]])
+        lit.set_facecolors([palette[o] for o in d["plan_order"][reached]])  # type: ignore[attr-defined]  # runtime alias of set_facecolor, absent from the stubs
         rays.set_segments(
             [
                 [(float(x), float(y)), (float(_IS_RECEIVER[0]), float(_IS_RECEIVER[1]))]
@@ -4347,7 +4358,7 @@ def animate_image_source_buildup(output_dir: str) -> None:
         n = int(arrived.sum())
         xy = np.column_stack([t_ms[arrived], level[arrived]])
         dots.set_offsets(xy if n else np.empty((0, 2)))
-        dots.set_facecolors([palette[o] for o in order[arrived]])
+        dots.set_facecolors([palette[o] for o in order[arrived]])  # type: ignore[attr-defined]  # runtime alias of set_facecolor, absent from the stubs
         stems.set_segments([[(float(a), -26.0), (float(a), float(b))] for a, b in xy])
 
         shown = grid_t <= now
@@ -4527,7 +4538,7 @@ def animate_iso717_shift(output_dir: str) -> None:
         zorder=3,
         label=T("reference curve, as shifted"),
     )
-    shade = {"art": None}
+    shade: dict[str, FillBetweenPolyCollection | None] = {"art": None}
     (read_dot,) = ax_s.plot(
         [], [], color=COLOR_TERTIARY, marker="o", ms=11.0, ls="none", zorder=5
     )
@@ -4934,7 +4945,7 @@ def animate_block_vs_exponential(output_dir: str) -> None:
     ax_a.set_xlabel(T("Burst start within the block [ms]"), fontsize=8.5)
     ax_a.set_ylabel(T("Reading [dB]"), fontsize=8.5)
     ax_a.tick_params(labelsize=8)
-    corridor = {"art": None}
+    corridor: dict[str, Rectangle | None] = {"art": None}
     (exp_trace,) = ax_a.plot([], [], color=COLOR_PRIMARY, lw=2.4)
     (blk_trace,) = ax_a.plot([], [], color=COLOR_TERTIARY, lw=2.4)
     (now_dot,) = ax_a.plot(

--- a/scripts/figures/signals.py
+++ b/scripts/figures/signals.py
@@ -11,7 +11,9 @@ have modules of their own (:mod:`figures.spectral_estimation`,
 the checks made around the measurement are in :mod:`figures.metrology`.
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
@@ -37,6 +39,9 @@ from .theme import (
     measure_weighting_response,
     save_figure,
 )
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
 
 def generate_filter_type_comparison(output_dir: str) -> None:
@@ -423,10 +428,10 @@ def generate_decomposition_plot(output_dir: str) -> None:
 
 
 def _draw_weighting_curves(
-    ax: Any,
+    ax: Axes,
     fs: int,
     curves: tuple[tuple[str, str, str, str, float], ...],
-    inset: Any = None,
+    inset: Axes | None = None,
 ) -> None:
     """Draw ``(code, label, colour, linestyle, linewidth)`` curves measured at *fs*.
 

--- a/scripts/figures/simulation.py
+++ b/scripts/figures/simulation.py
@@ -8,8 +8,10 @@ checked against. The clips these belong with live in :mod:`figures.fields`.
 Everything here is embedded by a page under ``simulation/``.
 """
 
+from __future__ import annotations
+
 from functools import cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,6 +33,9 @@ from .theme import (
     LABEL_FREQ_HZ,
     save_figure,
 )
+
+if TYPE_CHECKING:
+    from phonometry.simulation import ElasticFDTDResult
 
 
 def generate_metadiffuser_ntff_polar(output_dir: str) -> None:
@@ -248,7 +253,7 @@ def generate_elastic_halfspace_waves(output_dir: str) -> None:
 
 
 @cache
-def _scholte_interface_result() -> Any:
+def _scholte_interface_result() -> ElasticFDTDResult:
     """Water over a soft seabed, explosive shot near the contact (cached).
 
     Language/theme independent: the van Vossen (2002) benchmark media

--- a/scripts/figures/theme.py
+++ b/scripts/figures/theme.py
@@ -12,9 +12,10 @@ the figures apply to their axes, plus :func:`measure_weighting_response`, the
 measurement the weighting figures are drawn from and the tests guard.
 """
 
+from __future__ import annotations
+
 import os
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -24,6 +25,11 @@ from phonometry._plot.common import _register_field_dark_cmap
 
 from . import _publish
 from .i18n import _LANG_SUFFIX, _translate_figure, audit_figure
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from matplotlib.axes import Axes
 
 # Constants for professional styling
 LABEL_FREQ_HZ = "Frequency [Hz]"
@@ -298,7 +304,7 @@ def save_figure(output_dir: str, filename: str, **kwargs: Any) -> None:
 
 
 def apply_axis_styling(
-    ax: Any,
+    ax: Axes,
     title: str,
     xlim: tuple[float, float] | None = None,
     ylim: tuple[float, float] | None = None,
@@ -335,7 +341,7 @@ def apply_axis_styling(
 
 
 def plot_psd(
-    ax: Any,
+    ax: Axes,
     x: np.ndarray,
     fs: int,
     label: str = "Raw Signal PSD",
@@ -367,7 +373,7 @@ def plot_psd(
 
 
 def measure_weighting_response(
-    fs: int, curve: str, freqs: "np.ndarray | None" = None
+    fs: int, curve: str, freqs: np.ndarray | None = None
 ) -> tuple[np.ndarray, np.ndarray]:
     """Measure a weighting curve the way the docs figure plots it: impulse
     response through the real filter path, evaluated with ``freqz`` (DTFT
@@ -426,7 +432,7 @@ _THIRD_OCTAVE_16 = [
 
 
 def _band_index_axis(
-    ax: Any, freqs: Sequence[float] | np.ndarray, fontsize: int = 8
+    ax: Axes, freqs: Sequence[float] | np.ndarray, fontsize: int = 8
 ) -> np.ndarray:
     """Rotated nominal band labels on an index axis (band-data figures)."""
     x = np.arange(len(freqs))

--- a/scripts/figures/underwater.py
+++ b/scripts/figures/underwater.py
@@ -1979,7 +1979,7 @@ def generate_marine_mammal_assessment(output_dir: str) -> None:
         res.plot(ax=ax, language=_LANG)
         ax.set_title(
             f"{group}: cumulative {res.cumulative_sel:.1f} dB, "
-            f"margin {_fmt_minus(res.sel_margin, '+.1f')} dB",
+            f"margin {_fmt_minus(res.sel_margin, '+.1f')} dB",  # type: ignore[arg-type]  # NMFS 2024 impulsive: SEL threshold always set
             pad=12,
         )
     plt.tight_layout()

--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -38,7 +38,7 @@ import shutil
 import sys
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, get_overloads
+from typing import TYPE_CHECKING, get_overloads
 
 from api_taxonomy import (
     OBJECT_MODULE_OVERRIDES,
@@ -49,6 +49,7 @@ from api_taxonomy import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from types import ModuleType
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -588,7 +589,7 @@ def _attribute_docstrings(module: ModuleType) -> dict[str, str]:
 
 def format_signature(
     name: str,
-    obj: Any,
+    obj: Callable[..., object],
     *,
     drop_first: bool = False,
     omit_return: bool = False,
@@ -619,7 +620,7 @@ def format_signature(
 
 def _format_one_signature(
     name: str,
-    obj: Any,
+    obj: Callable[..., object],
     *,
     drop_first: bool = False,
     omit_return: bool = False,
@@ -702,7 +703,7 @@ def _class_methods(
         raw = inspect.getattr_static(cls, attr_name)
         qualified = f"{name}.{attr_name}"
         kind: str
-        func: object
+        func: Callable[..., object] | None
         if isinstance(raw, staticmethod):
             kind, func = "staticmethod", raw.__func__
         elif isinstance(raw, classmethod):
@@ -715,7 +716,7 @@ def _class_methods(
             continue  # class attributes, enum members: documented via :ivar:
         doc = inspect.getdoc(func) or ""
         signature: str | None = None
-        if kind != "property":
+        if kind != "property" and func is not None:
             try:
                 signature = format_signature(
                     qualified, func, drop_first=kind != "staticmethod"
@@ -905,7 +906,11 @@ def _build_page(
 
 
 def _try_signature(
-    name: str, obj: Any, issues: list[str], *, omit_return: bool = False
+    name: str,
+    obj: Callable[..., object],
+    issues: list[str],
+    *,
+    omit_return: bool = False,
 ) -> str | None:
     try:
         return format_signature(name, obj, omit_return=omit_return)

--- a/scripts/job_runner.py
+++ b/scripts/job_runner.py
@@ -44,13 +44,17 @@ from __future__ import annotations
 import json
 import sys
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import fdtd_gpu
 import numpy as np
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from types import ModuleType
 
-def _pick_backend() -> tuple[Any, str]:
+
+def _pick_backend() -> tuple[ModuleType, str]:
     """Return (array module, name): CuPy with a usable GPU, else NumPy."""
     try:
         import cupy
@@ -62,7 +66,7 @@ def _pick_backend() -> tuple[Any, str]:
     return cupy, "cupy"
 
 
-def _build_engine(job: Any, xp: Any) -> fdtd_gpu.GpuFDTD2D:
+def _build_engine(job: Mapping[str, Any], xp: ModuleType) -> fdtd_gpu.GpuFDTD2D:
     """Instantiate the engine from the job archive on backend *xp*."""
     damping = job["damping"]
     edge_impedance: dict[str, Any] = {
@@ -119,7 +123,7 @@ def _sample_frame(
     return np.asarray(frame)
 
 
-def run_job(job: Any) -> dict[str, Any]:
+def run_job(job: Mapping[str, Any]) -> dict[str, Any]:
     """Run one job dict/archive and return the result payload."""
     xp, backend = _pick_backend()
     sim = _build_engine(job, xp)

--- a/scripts/mirror_glossary.py
+++ b/scripts/mirror_glossary.py
@@ -77,7 +77,7 @@ def _load() -> list[dict[str, Any]]:
     return data
 
 
-def _localized(value: Any) -> str:
+def _localized(value: str | dict[str, str] | None) -> str:
     """A field that is either shared by both languages or given per language."""
     if value is None:
         return ""

--- a/scripts/reports/environment.py
+++ b/scripts/reports/environment.py
@@ -10,8 +10,6 @@ and the RD 1367/2007 assessment of an activity against the limits binding it.
 
 from __future__ import annotations
 
-from typing import Any
-
 import numpy as np
 
 import phonometry as ph
@@ -206,7 +204,11 @@ class _WithSourceEmission:
     keeping the generator loop unchanged.
     """
 
-    def __init__(self, result: Any, emission: ph.environment.SourceEmission) -> None:
+    def __init__(
+        self,
+        result: ph.environment.OutdoorAttenuation,
+        emission: ph.environment.SourceEmission,
+    ) -> None:
         self._result = result
         self._emission = emission
 

--- a/tests/test_animation_fingerprint.py
+++ b/tests/test_animation_fingerprint.py
@@ -224,6 +224,27 @@ def test_a_change_that_reaches_a_clip_moves_its_fingerprint(
         # or changing a Spanish string must not mark every clip stale.
         ("i18n", '"otra figura cualquiera"', '"una figura distinta"'),
         ("i18n", r'r"cosa \1 no relacionada"', r'r"otra cosa \1"'),
+        # Annotations, in every position they take: a type checker reads them
+        # and a frame never does, so typing a clip's helpers must not cost a
+        # re-render. This is the hash's runtime view, not an accident of the
+        # dump: parameters and returns are stripped, an annotated assignment
+        # hashes as the plain one, and the imports that exist only to spell
+        # the annotations go with them.
+        (
+            "schematics",
+            "def _shared_label(ax):",
+            "def _shared_label(ax: object) -> None:",
+        ),
+        ("media", "_ANIM_FPS = 20", "_ANIM_FPS: int = 20"),
+        (
+            "schematics",
+            "from .media import _render_clip, _translate_str",
+            "from __future__ import annotations\n\n"
+            "from typing import TYPE_CHECKING\n"
+            "from .media import _render_clip, _translate_str\n"
+            "if TYPE_CHECKING:\n"
+            "    from matplotlib.axes import Axes",
+        ),
     ],
 )
 def test_a_change_that_cannot_reach_a_clip_leaves_it_alone(


### PR DESCRIPTION
The figure and conformance scripts climb the same ladder the library is about to: the real type where the code pins one, `object` where a function never looks inside, and in these files not one reasoned `noqa` was needed. Figure scripts overwhelmingly meant `Axes`, `Figure`, a result class or `NDArray`, imported under `TYPE_CHECKING`.

## The clip fingerprints

Typing the figure scripts collided with the animation freshness gate, and the collision was worth having. The gate hashes the AST of the code each committed clip was drawn by, precisely so that prose cannot cost a re-render; annotations were the case its runtime view did not yet cover, and an annotation-only edit marked all forty-two clips stale at once. The fingerprint now normalises the tree at parse time: annotations, `TYPE_CHECKING` blocks and typing-only imports are invisible to both the hash and the dependency walk, because none of them can reach a frame.

That honesty cut both ways. Comparing main against this branch under the new view showed thirteen clips still moving, and they were right to move: the typing pass had smuggled in runtime rewrites, a narrowing helper called from ten files and a restructured font-size loop among them, behaviour-preserving on paper but exactly the kind of claim the gate exists not to take on faith. Those rewrites are undone, mechanically verified symbol by symbol until the figure package is runtime-identical to main, with the annotations kept and mypy satisfied by inert `type: ignore` comments that never enter the AST.

The manifest is then resealed under the new algorithm, which is legitimate for a reason that can be checked rather than believed: the stamps were valid against main, and the branch is provably runtime-identical to it, so the clips are still drawn by this code. The gate was proven both ways afterwards, red on a real constant change inside one clip's closure, naming exactly that clip, and green on an annotation edit; both cases are now pinned in the fingerprint's own test suite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced a `_RuntimeView` AST transformer to strip type annotations and type-only imports from parsed modules, ensuring they do not affect animation fingerprints.</li>
<li>Updated `Sources` class to apply `_RuntimeView` during module parsing, preventing type-checking artifacts from influencing the hash.</li>
<li>Added `_typing_only_import` helper to identify and exclude `from __future__ import annotations` and `from typing import TYPE_CHECKING` from the fingerprinting process.</li>
<li>Updated `_module_level` to filter out typing-only imports when generating module-level fingerprints.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Animation fingerprints now remain stable when source changes only involve type annotations or type-checking-only imports.
  * Updated animation fingerprint values to reflect the revised fingerprinting behavior.

* **Refactor**
  * Improved type clarity across conformance, simulation, plotting, reporting, and job-processing tools by replacing broad annotations with more precise types.
  * Runtime behavior and generated outputs remain unchanged.

* **Tests**
  * Added regression coverage confirming annotation-only changes do not alter animation fingerprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->