### PR TITLE
Say the types in half the test suite

### DIFF
--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -106,7 +106,7 @@ TABLE2 = {
 
 
 @pytest.mark.parametrize(("situation", "col"), [("A", 0), ("B", 1), ("C", 2)])
-def test_table2_airborne_every_band(situation, col):
+def test_table2_airborne_every_band(situation: str, col: int) -> None:
     result = band_uncertainty("airborne", situation)
     assert list(result.frequencies) == FREQ_FULL
     for f, u in zip(result.frequencies, result.uncertainties, strict=True):
@@ -141,7 +141,7 @@ TABLE4 = {
 
 
 @pytest.mark.parametrize(("situation", "col"), [("B", 0), ("C", 1)])
-def test_table4_impact_every_band(situation, col):
+def test_table4_impact_every_band(situation: str, col: int) -> None:
     result = band_uncertainty("impact", situation)
     assert list(result.frequencies) == FREQ_IMPACT
     assert 500 not in result.frequencies  # 2020 edition drops 500 Hz
@@ -149,7 +149,7 @@ def test_table4_impact_every_band(situation, col):
         assert u == pytest.approx(TABLE4[int(f)][col]), f"{situation} @ {f} Hz"
 
 
-def test_impact_has_no_situation_a():
+def test_impact_has_no_situation_a() -> None:
     with pytest.raises(ValueError, match="not tabulated"):
         band_uncertainty("impact", "A")
 
@@ -182,7 +182,7 @@ TABLE6_A = [
 ]
 
 
-def test_table6_reduction_every_band():
+def test_table6_reduction_every_band() -> None:
     result = band_uncertainty("impact_reduction", "A")
     assert list(result.frequencies) == FREQ_FULL
     for u, expected in zip(result.uncertainties, TABLE6_A, strict=True):
@@ -190,7 +190,7 @@ def test_table6_reduction_every_band():
 
 
 @pytest.mark.parametrize("situation", ["B", "C"])
-def test_reduction_only_situation_a(situation):
+def test_reduction_only_situation_a(situation: str) -> None:
     with pytest.raises(ValueError, match="not tabulated"):
         band_uncertainty("impact_reduction", situation)
 
@@ -223,7 +223,7 @@ TABLED1 = [
 ]
 
 
-def test_tabled1_sigma_r95_bands():
+def test_tabled1_sigma_r95_bands() -> None:
     result = band_uncertainty("airborne", "A", upper_limit=True)
     assert result.upper_limit is True
     assert list(result.frequencies) == FREQ_FULL
@@ -231,7 +231,7 @@ def test_tabled1_sigma_r95_bands():
         assert u == pytest.approx(expected)
 
 
-def test_sigma_r95_only_airborne():
+def test_sigma_r95_only_airborne() -> None:
     with pytest.raises(ValueError, match="σR95"):
         band_uncertainty("impact", "B", upper_limit=True)
 
@@ -239,7 +239,7 @@ def test_sigma_r95_only_airborne():
 # --------------------------------------------------------------------------- #
 # Table 1 — maximum repeatability standard deviation (Clause 5.8).
 # --------------------------------------------------------------------------- #
-def test_table1_maximum_repeatability():
+def test_table1_maximum_repeatability() -> None:
     result = maximum_repeatability_standard_deviation()
     expected = [
         4.0,
@@ -287,11 +287,13 @@ TABLE3 = {
 
 @pytest.mark.parametrize(("quantity", "values"), list(TABLE3.items()))
 @pytest.mark.parametrize(("situation", "idx"), [("A", 0), ("B", 1), ("C", 2)])
-def test_table3_single_number(quantity, values, situation, idx):
+def test_table3_single_number(
+    quantity: str, values: tuple[float, float, float], situation: str, idx: int
+) -> None:
     assert single_number_uncertainty(quantity, situation) == pytest.approx(values[idx])
 
 
-def test_airborne_aliases_share_row():
+def test_airborne_aliases_share_row() -> None:
     for alias in ("R_w", "Rprime_w", "Dn_w", "DnT_w"):
         assert single_number_uncertainty(alias, "A") == pytest.approx(1.2)
         assert single_number_uncertainty(alias, "B") == pytest.approx(0.9)
@@ -304,12 +306,14 @@ def test_airborne_aliases_share_row():
     ("quantity", "expected"),
     [("ln_w", (1.5, 1.0, 0.5)), ("ln_w+ci", (1.5, 1.0, 0.6))],
 )
-def test_table5_impact_single_number(quantity, expected):
+def test_table5_impact_single_number(
+    quantity: str, expected: tuple[float, float, float]
+) -> None:
     for situation, e in zip("ABC", expected, strict=True):
         assert single_number_uncertainty(quantity, situation) == pytest.approx(e)
 
 
-def test_impact_single_number_aliases():
+def test_impact_single_number_aliases() -> None:
     for alias in ("Lprime_n_w", "LnT_w"):
         assert single_number_uncertainty(alias, "C") == pytest.approx(0.5)
 
@@ -317,12 +321,12 @@ def test_impact_single_number_aliases():
 # --------------------------------------------------------------------------- #
 # Table 7 — reduction single-number ΔLw (situation A only).
 # --------------------------------------------------------------------------- #
-def test_table7_delta_lw():
+def test_table7_delta_lw() -> None:
     assert single_number_uncertainty("delta_lw", "A") == pytest.approx(1.1)
 
 
 @pytest.mark.parametrize("situation", ["B", "C"])
-def test_delta_lw_only_situation_a(situation):
+def test_delta_lw_only_situation_a(situation: str) -> None:
     with pytest.raises(ValueError, match="not tabulated"):
         single_number_uncertainty("delta_lw", situation)
 
@@ -344,18 +348,18 @@ TABLED2 = {
 
 
 @pytest.mark.parametrize(("quantity", "expected"), list(TABLED2.items()))
-def test_tabled2_sigma_r95_single_number(quantity, expected):
+def test_tabled2_sigma_r95_single_number(quantity: str, expected: float) -> None:
     assert single_number_uncertainty(quantity, "A", upper_limit=True) == pytest.approx(
         expected
     )
 
 
-def test_sigma_r95_single_number_requires_situation_a():
+def test_sigma_r95_single_number_requires_situation_a() -> None:
     with pytest.raises(ValueError, match="situation A only"):
         single_number_uncertainty("r_w", "B", upper_limit=True)
 
 
-def test_sigma_r95_single_number_impact_absent():
+def test_sigma_r95_single_number_impact_absent() -> None:
     with pytest.raises(ValueError, match="No σR95"):
         single_number_uncertainty("ln_w", "A", upper_limit=True)
 
@@ -374,7 +378,7 @@ def test_sigma_r95_single_number_impact_absent():
         (0.999, 3.29),
     ],
 )
-def test_table8_two_sided(confidence, k):
+def test_table8_two_sided(confidence: float, k: float) -> None:
     assert insulation_coverage_factor(confidence, one_sided=False) == pytest.approx(k)
 
 
@@ -389,16 +393,16 @@ def test_table8_two_sided(confidence, k):
         (0.9995, 3.29),
     ],
 )
-def test_table8_one_sided(confidence, k):
+def test_table8_one_sided(confidence: float, k: float) -> None:
     assert insulation_coverage_factor(confidence, one_sided=True) == pytest.approx(k)
 
 
-def test_coverage_factor_unknown_confidence():
+def test_coverage_factor_unknown_confidence() -> None:
     with pytest.raises(ValueError, match="not tabulated"):
         insulation_coverage_factor(0.925)
 
 
-def test_coverage_factors_table_is_public():
+def test_coverage_factors_table_is_public() -> None:
     import phonometry
     from phonometry.building.measurement.uncertainty import COVERAGE_FACTORS
 
@@ -408,7 +412,7 @@ def test_coverage_factors_table_is_public():
     assert COVERAGE_FACTORS[(0.95, True)] == pytest.approx(1.65)
 
 
-def test_coverage_factors_table_is_read_only():
+def test_coverage_factors_table_is_read_only() -> None:
     from phonometry.building.measurement.uncertainty import COVERAGE_FACTORS
 
     with pytest.raises(TypeError):
@@ -418,26 +422,26 @@ def test_coverage_factors_table_is_read_only():
 # --------------------------------------------------------------------------- #
 # Expansion U = k·u (Formula 2) and the k >= 1 minimum.
 # --------------------------------------------------------------------------- #
-def test_expanded_uncertainty_two_sided():
+def test_expanded_uncertainty_two_sided() -> None:
     # Rw situation A, u = 1.2 dB, 95 % two-sided -> k = 1.96.
     assert insulation_expanded_uncertainty(1.2, coverage=0.95) == pytest.approx(
         1.96 * 1.2
     )
 
 
-def test_expanded_uncertainty_one_sided():
+def test_expanded_uncertainty_one_sided() -> None:
     # Conformity check at 95 % one-sided -> k = 1.65.
     assert insulation_expanded_uncertainty(
         1.2, coverage=0.95, one_sided=True
     ) == pytest.approx(1.65 * 1.2)
 
 
-def test_coverage_minimum_k_is_one():
+def test_coverage_minimum_k_is_one() -> None:
     # 68 % two-sided is exactly k = 1; U == u.
     assert insulation_expanded_uncertainty(0.9, coverage=0.68) == pytest.approx(0.9)
 
 
-def test_expanded_uncertainty_rejects_negative():
+def test_expanded_uncertainty_rejects_negative() -> None:
     with pytest.raises(ValueError, match="Standard uncertainty u must be non-negative"):
         insulation_expanded_uncertainty(-0.1)
 
@@ -445,7 +449,7 @@ def test_expanded_uncertainty_rejects_negative():
 # --------------------------------------------------------------------------- #
 # UncertainValue convenience (value ± U) — the reporting form Y = y ± U.
 # --------------------------------------------------------------------------- #
-def test_uncertain_value_two_sided_interval():
+def test_uncertain_value_two_sided_interval() -> None:
     # Standard's example: R = (35.1 ± 1.2) dB at k = 1 (two-sided 68 %).
     uv = uncertain_value(35.1, "r_w", "A", coverage=0.68)
     assert isinstance(uv, UncertainValue)
@@ -456,7 +460,7 @@ def test_uncertain_value_two_sided_interval():
     assert uv.upper == pytest.approx(36.3)
 
 
-def test_uncertain_value_one_sided_for_conformity():
+def test_uncertain_value_one_sided_for_conformity() -> None:
     # Annex A.3: in-situ R'w, u = 0.9 dB, 84 % one-sided -> k = 1 -> U = 0.9.
     uv = uncertain_value(52.0, "rprime_w", "B", coverage=0.84, one_sided=True)
     assert uv.standard_uncertainty == pytest.approx(0.9)
@@ -467,18 +471,18 @@ def test_uncertain_value_one_sided_for_conformity():
 # --------------------------------------------------------------------------- #
 # Combination rules — Annexes A/B/C with hand-computed oracles.
 # --------------------------------------------------------------------------- #
-def test_combine_uncertainties_quadrature():
+def test_combine_uncertainties_quadrature() -> None:
     assert combine_uncertainties(3.0, 4.0) == pytest.approx(5.0)
 
 
-def test_prediction_input_uncertainty_annex_a_example():
+def test_prediction_input_uncertainty_annex_a_example() -> None:
     # Annex A: sigma_R = 1.2, sigma_product = 1.0, n = 1 -> u_input = sqrt(3.44) ~ 1.9.
     u_input = prediction_input_uncertainty(1.2, 1.0, 1)
     assert u_input == pytest.approx(math.sqrt(3.44))
     assert round(u_input, 1) == 1.9
 
 
-def test_predicted_uncertainty_annex_a_example():
+def test_predicted_uncertainty_annex_a_example() -> None:
     # Annex A: u_calc = u_input (single element), u_reality = 0.8 -> u_pred ~ 2.0.
     u_input = prediction_input_uncertainty(1.2, 1.0, 1)
     u_pred = combine_uncertainties(u_input, 0.8)
@@ -486,27 +490,27 @@ def test_predicted_uncertainty_annex_a_example():
     assert round(u_pred, 1) == 2.0
 
 
-def test_reduce_by_independent_measurements():
+def test_reduce_by_independent_measurements() -> None:
     # Formula A.7: u = 0.9 / sqrt(m).
     assert reduce_by_independent_measurements(0.9, 4) == pytest.approx(0.45)
     assert reduce_by_independent_measurements(0.9, 1) == pytest.approx(0.9)
 
 
-def test_single_number_uncorrelated_equal_weights():
+def test_single_number_uncorrelated_equal_weights() -> None:
     # Two bands with equal (L_i - R_i) => equal weights 0.5; u_i = 2.0 each.
     # u = sqrt((0.5*2)^2 + (0.5*2)^2) = sqrt(2).
     u = single_number_uncertainty_uncorrelated([2.0, 2.0], [0.0, 0.0])
     assert u == pytest.approx(math.sqrt(2.0))
 
 
-def test_single_number_uncorrelated_dominant_band():
+def test_single_number_uncorrelated_dominant_band() -> None:
     # One band dominates the reference energy (much smaller L-R gap) -> its weight
     # -> 1, so the combined uncertainty approaches that band's u.
     u = single_number_uncertainty_uncorrelated([1.0, 5.0], [0.0, -100.0])
     assert u == pytest.approx(1.0, abs=1e-6)
 
 
-def test_single_number_uncorrelated_length_mismatch():
+def test_single_number_uncorrelated_length_mismatch() -> None:
     with pytest.raises(
         ValueError,
         match=(
@@ -520,13 +524,13 @@ def test_single_number_uncorrelated_length_mismatch():
 # --------------------------------------------------------------------------- #
 # Conformity with a requirement (Formulae 4/5).
 # --------------------------------------------------------------------------- #
-def test_satisfies_lower_requirement():
+def test_satisfies_lower_requirement() -> None:
     # R'w = 54, U = 1.5 -> 52.5 > 52 required: pass.
     assert satisfies_lower_requirement(54.0, 1.5, 52.0) is True
     assert satisfies_lower_requirement(53.0, 1.5, 52.0) is False
 
 
-def test_satisfies_upper_requirement():
+def test_satisfies_upper_requirement() -> None:
     # L'n,w = 50, U = 1.0 -> 51 < 53 required: pass.
     assert satisfies_upper_requirement(50.0, 1.0, 53.0) is True
     assert satisfies_upper_requirement(52.5, 1.0, 53.0) is False
@@ -535,22 +539,22 @@ def test_satisfies_upper_requirement():
 # --------------------------------------------------------------------------- #
 # Validation of unknown quantities / situations.
 # --------------------------------------------------------------------------- #
-def test_unknown_quantity():
+def test_unknown_quantity() -> None:
     with pytest.raises(ValueError, match="Unknown single-number quantity"):
         single_number_uncertainty("nonsense", "A")
 
 
-def test_unknown_measurand():
+def test_unknown_measurand() -> None:
     with pytest.raises(ValueError, match="Unknown measurand"):
         band_uncertainty("magic", "A")  # type: ignore[arg-type]
 
 
-def test_unknown_situation_single_number():
+def test_unknown_situation_single_number() -> None:
     with pytest.raises(ValueError, match="Unknown situation"):
         single_number_uncertainty("r_w", "Z")  # type: ignore[arg-type]
 
 
-def test_band_uncertainty_to_arrays_roundtrip():
+def test_band_uncertainty_to_arrays_roundtrip() -> None:
     result = band_uncertainty("airborne", "A")
     freqs, u = result.to_arrays()
     assert isinstance(freqs, np.ndarray)
@@ -559,12 +563,12 @@ def test_band_uncertainty_to_arrays_roundtrip():
     assert u[0] == pytest.approx(6.8)
 
 
-def test_prediction_input_rejects_bad_n():
+def test_prediction_input_rejects_bad_n() -> None:
     with pytest.raises(ValueError, match="n must be a positive integer"):
         prediction_input_uncertainty(1.2, 1.0, 0)
 
 
-def test_the_bare_names_are_gone():
+def test_the_bare_names_are_gone() -> None:
     # The bare names shadowed the GUM pair at the package root. They were
     # deprecated in 3.1 and removed in 4.0; only the insulation_* names remain.
     import phonometry.building.measurement.uncertainty as bu

--- a/tests/building/measurement/test_facade_field_report.py
+++ b/tests/building/measurement/test_facade_field_report.py
@@ -13,6 +13,8 @@ rating, the standard-basis line and the mandatory field-method statement.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -21,6 +23,9 @@ pytest.importorskip("reportlab")
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: ISO 717-1 Annex C Table C.1 measured curve; rated 30 (-2; -3) dB.
 _ANNEX_C_R = np.array(
@@ -86,7 +91,7 @@ def test_dnt_reduces_to_d2m_at_reference_time() -> None:
     np.testing.assert_allclose(result.d_2m, _ANNEX_C_R)
 
 
-def test_dnt_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
+def test_dnt_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path: Path) -> None:
     """The D2m,nT fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3)."""
     out = tmp_path / "d2mnt.pdf"
     _facade_dnt().report(str(out))
@@ -99,7 +104,7 @@ def test_dnt_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     assert "D2m,nT" in text
 
 
-def test_r_prime_fiche(tmp_path) -> None:
+def test_r_prime_fiche(tmp_path: Path) -> None:
     """``quantity='r_prime'`` reports the apparent sound reduction index R'45."""
     result = _facade_r_prime()
     assert result.r_prime is not None
@@ -114,7 +119,7 @@ def test_r_prime_fiche(tmp_path) -> None:
     assert "30 (-2; -3) dB" in text
 
 
-def test_r_prime_road_traffic_fiche_labelled_rtrs(tmp_path) -> None:
+def test_r_prime_road_traffic_fiche_labelled_rtrs(tmp_path: Path) -> None:
     """A road-traffic result is labelled R'tr,s (Clause 3.13), never R'45."""
     # A = 0,16 x 62,5 / 1 = 10 = S, so 10 lg(S/A) = 0 and R'tr,s = L1,s - L2 - 3.
     surf = _ANNEX_C_R + 3.0
@@ -140,7 +145,7 @@ def test_r_prime_road_traffic_fiche_labelled_rtrs(tmp_path) -> None:
     assert "30 (-2; -3) dB" in text
 
 
-def test_d_2m_n_fiche(tmp_path) -> None:
+def test_d_2m_n_fiche(tmp_path: Path) -> None:
     """``quantity='d_2m_n'`` reports the normalized facade level difference."""
     result = _facade_dnt()
     assert result.d_2m_n is not None
@@ -150,7 +155,7 @@ def test_d_2m_n_fiche(tmp_path) -> None:
     assert "Normalized facade level difference" in _extract_text(str(out))
 
 
-def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
+def test_full_metadata_and_verbose_render_one_page(tmp_path: Path) -> None:
     """A fully populated verbose facade fiche is one page and passes its target."""
     metadata = ReportMetadata(
         specimen="Dwelling facade, loudspeaker method",
@@ -173,14 +178,14 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     assert "Unfav. dev." in text
 
 
-def test_requirement_verdict_fail(tmp_path) -> None:
+def test_requirement_verdict_fail(tmp_path: Path) -> None:
     """A facade level difference below the requirement fails."""
     out = tmp_path / "fail.pdf"
     _facade_dnt().report(str(out), metadata=ReportMetadata(requirement=45.0))
     assert "FAIL" in _extract_text(str(out))
 
 
-def test_spanish_fiche(tmp_path) -> None:
+def test_spanish_fiche(tmp_path: Path) -> None:
     """``language='es'`` renders the Spanish facade fiche with comma decimals."""
     import re
 
@@ -197,7 +202,7 @@ def test_spanish_fiche(tmp_path) -> None:
     assert re.search(r"\d+,\d", text)
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _facade_dnt()
     out = str(tmp_path / "x.pdf")
@@ -205,7 +210,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_quantity_rejected(tmp_path) -> None:
+def test_unknown_quantity_rejected(tmp_path: Path) -> None:
     """An unknown facade quantity raises ``ValueError``."""
     result = _facade_dnt()
     out = str(tmp_path / "x.pdf")
@@ -213,7 +218,7 @@ def test_unknown_quantity_rejected(tmp_path) -> None:
         result.report(out, quantity="dnt")
 
 
-def test_missing_quantity_rejected(tmp_path) -> None:
+def test_missing_quantity_rejected(tmp_path: Path) -> None:
     """Requesting d_2m_n / r_prime without their inputs raises ``ValueError``."""
     bare = building.facade_insulation(_ANNEX_C_R + 40.0, np.full(16, 40.0), _T_AT_T0)
     out = str(tmp_path / "x.pdf")
@@ -223,7 +228,7 @@ def test_missing_quantity_rejected(tmp_path) -> None:
         bare.report(out, quantity="r_prime")
 
 
-def test_non_core_band_count_rejected(tmp_path) -> None:
+def test_non_core_band_count_rejected(tmp_path: Path) -> None:
     """The facade field fiche needs the 16 core one-third-octave bands."""
     result = building.facade_insulation(
         np.full(21, 70.0), np.full(21, 30.0), np.full(21, 0.5)

--- a/tests/building/measurement/test_flanking_transmission_report.py
+++ b/tests/building/measurement/test_flanking_transmission_report.py
@@ -12,6 +12,8 @@ report tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -20,6 +22,9 @@ pytest.importorskip("reportlab")
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: The ISO 10848 mandatory one-third-octave range (100 Hz to 5000 Hz, 18 bands).
 _FREQS = [
@@ -118,7 +123,7 @@ def _lnf_result() -> building.FlankingImpactLevelResult:
 # --------------------------------------------------------------------------- #
 # Vibration reduction index Kij (ISO 10848-1)
 # --------------------------------------------------------------------------- #
-def test_kij_fiche_renders_single_number_and_basis(tmp_path) -> None:
+def test_kij_fiche_renders_single_number_and_basis(tmp_path: Path) -> None:
     """The Kij fiche boxes the Annex A mean and names ISO 10848-1."""
     result = _kij_result()
     out = tmp_path / "kij.pdf"
@@ -134,7 +139,7 @@ def test_kij_fiche_renders_single_number_and_basis(tmp_path) -> None:
     assert "excluded from the single number" in text
 
 
-def test_kij_fiche_verbose_adds_membership_column(tmp_path) -> None:
+def test_kij_fiche_verbose_adds_membership_column(tmp_path: Path) -> None:
     """``verbose=True`` adds the single-number-membership column."""
     out = tmp_path / "kij_verbose.pdf"
     _kij_result().report(str(out), verbose=True)
@@ -165,7 +170,9 @@ def test_kij_mean_membership_excludes_out_of_range_bands() -> None:
     assert bool(in_mean[list(_FREQS).index(250)])
 
 
-def test_kij_fiche_distinguishes_all_bracketed_from_out_of_range(tmp_path) -> None:
+def test_kij_fiche_distinguishes_all_bracketed_from_out_of_range(
+    tmp_path: Path,
+) -> None:
     """An empty mean states why: every in-range band bracketed (M < 0,25)."""
     result = building.vibration_reduction_index(
         _DV,
@@ -187,7 +194,7 @@ def test_kij_fiche_distinguishes_all_bracketed_from_out_of_range(tmp_path) -> No
     assert "todas las bandas del intervalo entre corchetes" in text_es
 
 
-def test_kij_fiche_states_no_bands_in_annex_a_range(tmp_path) -> None:
+def test_kij_fiche_states_no_bands_in_annex_a_range(tmp_path: Path) -> None:
     """A spectrum entirely outside the Annex A range keeps the range message."""
     high_freqs = [1600.0, 2000.0, 2500.0]
     result = building.vibration_reduction_index(
@@ -209,7 +216,7 @@ def test_kij_fiche_states_no_bands_in_annex_a_range(tmp_path) -> None:
     assert "no hay bandas en el intervalo del anexo A" in text_es
 
 
-def test_kij_fiche_without_frequencies_rejected(tmp_path) -> None:
+def test_kij_fiche_without_frequencies_rejected(tmp_path: Path) -> None:
     """A Kij result with no band frequencies cannot be reported."""
     result = building.vibration_reduction_index([5.0, 6.0, 7.0], 2.0, 4.0, 4.0)
     out = str(tmp_path / "x.pdf")
@@ -217,7 +224,7 @@ def test_kij_fiche_without_frequencies_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_kij_fiche_spanish(tmp_path) -> None:
+def test_kij_fiche_spanish(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish Kij fiche with comma decimals."""
     import re
 
@@ -232,7 +239,7 @@ def test_kij_fiche_spanish(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Normalized flanking level difference Dn,f (ISO 10848-2, airborne)
 # --------------------------------------------------------------------------- #
-def test_dnf_fiche_rating_and_basis(tmp_path) -> None:
+def test_dnf_fiche_rating_and_basis(tmp_path: Path) -> None:
     """The Dn,f fiche boxes the ISO 717-1 rating and names ISO 10848-2."""
     result = _dnf_result()
     rating = result.rating
@@ -247,7 +254,7 @@ def test_dnf_fiche_rating_and_basis(tmp_path) -> None:
     assert "ISO 717-1:2020" in text
 
 
-def test_dnf_fiche_verbose_and_verdict(tmp_path) -> None:
+def test_dnf_fiche_verbose_and_verdict(tmp_path: Path) -> None:
     """Verbose annexes the ISO 717 evaluation; the requirement passes."""
     out = tmp_path / "dnf_verbose.pdf"
     _dnf_result().report(
@@ -259,7 +266,7 @@ def test_dnf_fiche_verbose_and_verdict(tmp_path) -> None:
     assert "Unfav. dev." in text
 
 
-def test_dnf_fiche_part_selects_basis_designation(tmp_path) -> None:
+def test_dnf_fiche_part_selects_basis_designation(tmp_path: Path) -> None:
     """``part`` selects the governing ISO 10848 part named in the basis line."""
     result = _dnf_result()
     for part, designation in ((3, "ISO 10848-3:2006"), (4, "ISO 10848-4:2010")):
@@ -271,7 +278,7 @@ def test_dnf_fiche_part_selects_basis_designation(tmp_path) -> None:
         assert "ISO 10848-2:2006" not in text
 
 
-def test_dnf_fiche_unknown_part_rejected(tmp_path) -> None:
+def test_dnf_fiche_unknown_part_rejected(tmp_path: Path) -> None:
     """A part outside 2/3/4 is rejected."""
     out = str(tmp_path / "x.pdf")
     dnf, lnf = _dnf_result(), _lnf_result()
@@ -281,7 +288,7 @@ def test_dnf_fiche_unknown_part_rejected(tmp_path) -> None:
         lnf.report(out, part=5)
 
 
-def test_dnf_fiche_without_rating_rejected(tmp_path) -> None:
+def test_dnf_fiche_without_rating_rejected(tmp_path: Path) -> None:
     """A band count that yields no ISO 717 rating cannot be reported."""
     result = building.normalized_flanking_level_difference(
         [80.0] * 7, [40.0] * 7, [10.0] * 7
@@ -294,7 +301,7 @@ def test_dnf_fiche_without_rating_rejected(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Normalized flanking impact level Ln,f (ISO 10848-2, tapping machine)
 # --------------------------------------------------------------------------- #
-def test_lnf_fiche_rating_and_basis(tmp_path) -> None:
+def test_lnf_fiche_rating_and_basis(tmp_path: Path) -> None:
     """The Ln,f fiche boxes the ISO 717-2 rating and names ISO 10848-2."""
     result = _lnf_result()
     rating = result.rating
@@ -309,7 +316,7 @@ def test_lnf_fiche_rating_and_basis(tmp_path) -> None:
     assert "PASS" in text  # Ln,f,w = 49 dB <= 55 dB
 
 
-def test_lnf_fiche_part_selects_basis_designation(tmp_path) -> None:
+def test_lnf_fiche_part_selects_basis_designation(tmp_path: Path) -> None:
     """``part=4`` names ISO 10848-4:2010 on the Ln,f basis line."""
     out = tmp_path / "lnf_part4.pdf"
     _lnf_result().report(str(out), part=4)
@@ -319,7 +326,7 @@ def test_lnf_fiche_part_selects_basis_designation(tmp_path) -> None:
     assert "ISO 10848-2:2006" not in text
 
 
-def test_lnf_fiche_spanish(tmp_path) -> None:
+def test_lnf_fiche_spanish(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish Ln,f fiche."""
     out = tmp_path / "lnf_es.pdf"
     _lnf_result().report(str(out), language="es")
@@ -332,7 +339,7 @@ def test_lnf_fiche_spanish(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Rendering contract
 # --------------------------------------------------------------------------- #
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError`` on every fiche."""
     out = str(tmp_path / "x.pdf")
     kij, dnf, lnf = _kij_result(), _dnf_result(), _lnf_result()

--- a/tests/building/measurement/test_intensity_insulation.py
+++ b/tests/building/measurement/test_intensity_insulation.py
@@ -12,7 +12,9 @@ import reference_data as ref
 from phonometry import building
 
 
-def _levels_for_target_ri(ri, lp1, sm, s):
+def _levels_for_target_ri(
+    ri: list[float], lp1: float, sm: float, s: float
+) -> np.ndarray:
     """Receiving-side LIn that make Formula (7) return exactly ``ri``."""
     ri = np.asarray(ri, dtype=np.float64)
     return lp1 - 6.0 - 10.0 * np.log10(sm / s) - ri

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -17,6 +17,8 @@ report tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -35,6 +37,9 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 #: Receiving-room reverberation time and volume that make the equivalent
 #: absorption area A = 0,16 V / T equal to 10 m2 in every band, so both the
 #: airborne 10 lg(S/A) (with S = 10 m2) and the impact 10 lg(A/A0) (with
@@ -43,7 +48,7 @@ _T_UNITY = np.full(16, 0.5)
 _V_UNITY = 31.25
 
 
-def _airborne_result(**kwargs) -> building.LabAirborneInsulationResult:
+def _airborne_result(**kwargs: float) -> building.LabAirborneInsulationResult:
     """A lab airborne result whose R equals the ISO 717-1 Annex C curve."""
     l1 = np.full(16, 90.0)
     l2 = l1 - np.asarray(_AIRBORNE_R, dtype=np.float64)
@@ -51,7 +56,7 @@ def _airborne_result(**kwargs) -> building.LabAirborneInsulationResult:
     return building.lab_airborne_insulation(l1, l2, _T_UNITY, **params)
 
 
-def _impact_result(**kwargs) -> building.LabImpactInsulationResult:
+def _impact_result(**kwargs: float) -> building.LabImpactInsulationResult:
     """A lab impact result whose Ln equals the ISO 717-2 Annex C curve."""
     li = np.asarray(_IMPACT_LN, dtype=np.float64)
     params = {"volume": _V_UNITY, **kwargs}
@@ -72,7 +77,7 @@ def test_r_equals_level_difference_at_unity_absorption() -> None:
     assert np.allclose(result.absorption, 10.0)
 
 
-def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
+def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path: Path) -> None:
     """The R fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3) dB."""
     out = tmp_path / "r.pdf"
     _airborne_result().report(str(out))
@@ -94,7 +99,7 @@ def test_ln_equals_impact_level_at_reference_absorption() -> None:
     assert np.allclose(result.absorption, 10.0)
 
 
-def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path) -> None:
+def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path: Path) -> None:
     """The Ln fiche's rating is the published ISO 717-2 Annex C 79 (-11) dB."""
     out = tmp_path / "ln.pdf"
     _impact_result().report(str(out))
@@ -109,7 +114,7 @@ def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path) -> None:
     assert "tapping machine" in " ".join(text.split())
 
 
-def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
+def test_full_metadata_and_verbose_render_one_page(tmp_path: Path) -> None:
     """A fully populated lab fiche with the absorption column is one page."""
     metadata = ReportMetadata(
         specimen="100 mm autoclaved aerated concrete block wall",
@@ -143,7 +148,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     assert "precision method" in text
 
 
-def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
+def test_requirement_verdicts_pass_and_fail(tmp_path: Path) -> None:
     """Airborne passes at/above the requirement; impact at/below it."""
     airborne = _airborne_result()  # Rw = 30 dB
     failing = tmp_path / "fail.pdf"
@@ -156,7 +161,7 @@ def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
     assert "PASS" in _extract_text(str(passing))
 
 
-def test_octave_band_fiche_renders(tmp_path) -> None:
+def test_octave_band_fiche_renders(tmp_path: Path) -> None:
     """A five-octave-band laboratory result also yields a one-page fiche."""
     l1 = np.full(5, 90.0)
     r = np.array([30.0, 40.0, 48.0, 52.0, 55.0])
@@ -170,7 +175,7 @@ def test_octave_band_fiche_renders(tmp_path) -> None:
     assert "Octave-band" in _extract_text(str(out))
 
 
-def test_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish lab fiche with comma decimals."""
     import re
 
@@ -187,7 +192,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
     assert re.search(r"\d+,\d", text)  # comma decimal separator
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     airborne = _airborne_result()
@@ -198,7 +203,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         impact.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     airborne = _airborne_result()
@@ -209,7 +214,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         impact.report(out, language="fr")
 
 
-def test_missing_rating_rejected(tmp_path) -> None:
+def test_missing_rating_rejected(tmp_path: Path) -> None:
     """A result without the ISO 717 rating (non-core band count) is rejected."""
     l1 = np.full(8, 90.0)
     result = building.lab_airborne_insulation(
@@ -221,7 +226,7 @@ def test_missing_rating_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_rating_without_per_band_data_rejected(tmp_path) -> None:
+def test_rating_without_per_band_data_rejected(tmp_path: Path) -> None:
     """A manually built rating lacking the per-band arrays is rejected."""
     # A backward-compatibly constructed rating (band_centers / measured /
     # shifted_reference default to None) would otherwise crash the table.
@@ -238,7 +243,7 @@ def test_rating_without_per_band_data_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_manual_impact_result_renders(tmp_path) -> None:
+def test_manual_impact_result_renders(tmp_path: Path) -> None:
     """A manually built lab impact result reports its Ln fiche."""
     result = _impact_result()
     bare = building.LabImpactInsulationResult(
@@ -249,7 +254,7 @@ def test_manual_impact_result_renders(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_report_rejects_band_count_mismatch(tmp_path) -> None:
+def test_report_rejects_band_count_mismatch(tmp_path: Path) -> None:
     """A rating whose per-band arrays are shorter than the curve raises a
     ValueError naming each array and its shape (not an uncaught IndexError).
     """

--- a/tests/building/measurement/test_iso15186_element_report.py
+++ b/tests/building/measurement/test_iso15186_element_report.py
@@ -16,6 +16,8 @@ values, like the sibling report tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 import reference_data as ref
@@ -29,10 +31,15 @@ from phonometry.building.measurement.intensity_insulation import (
     IntensityElementNormalizedResult,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 _A0 = 10.0
 
 
-def _levels_for_target_dine(dine, lp1, sm, n):
+def _levels_for_target_dine(
+    dine: list[float] | np.ndarray, lp1: float, sm: float, n: int
+) -> np.ndarray:
     """Receiving-side LIn that make the corrected Formula (8) return ``dine``."""
     return (
         lp1
@@ -74,7 +81,7 @@ def test_dine_equals_annex_c_curve() -> None:
     np.testing.assert_allclose(result.d_i_n_e, ref.ISO717_1_ANNEX_C_R, atol=1e-9)
 
 
-def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
+def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path: Path) -> None:
     """The DI,n,e fiche's rating is the published 30 (-2; -3) dB."""
     out = tmp_path / "dine.pdf"
     _element_result().report(str(out))
@@ -90,7 +97,7 @@ def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     assert "20.4" in text  # the 100 Hz band value
 
 
-def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
+def test_full_metadata_and_verbose_render_one_page(tmp_path: Path) -> None:
     """A fully populated verbose fiche is one page and shows the evaluation."""
     metadata = ReportMetadata(
         specimen="Trickle ventilator in a 100 mm masonry wall",
@@ -117,7 +124,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     assert "ISO 717 evaluation" in text  # the verbose caption
 
 
-def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
+def test_requirement_verdicts_pass_and_fail(tmp_path: Path) -> None:
     """Element insulation passes at or above the requirement."""
     result = _element_result()  # DI,n,e,w = 30 dB
     failing = tmp_path / "fail.pdf"
@@ -129,7 +136,7 @@ def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
     assert "PASS" in _extract_text(str(passing))
 
 
-def test_octave_band_fiche_renders(tmp_path) -> None:
+def test_octave_band_fiche_renders(tmp_path: Path) -> None:
     """A five-octave-band element result also yields a one-page fiche."""
     result = _octave_result()
     assert result.rating is not None
@@ -139,7 +146,7 @@ def test_octave_band_fiche_renders(tmp_path) -> None:
     assert "Octave-band" in _extract_text(str(out))
 
 
-def test_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish fiche with comma decimals."""
     import re
 
@@ -156,7 +163,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
     assert re.search(r"\d+,\d", text)  # comma decimal separator
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = _element_result()
@@ -164,7 +171,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     result = _element_result()
@@ -172,7 +179,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         result.report(out, language="fr")
 
 
-def test_missing_rating_rejected(tmp_path) -> None:
+def test_missing_rating_rejected(tmp_path: Path) -> None:
     """A result without the ISO 717 rating (non-core band count) is rejected."""
     l_in = _levels_for_target_dine(np.full(8, 40.0), 85.0, 12.0, 1)
     result = building.intensity_element_normalized_difference(
@@ -184,7 +191,7 @@ def test_missing_rating_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_non_iso_band_count_rejected(tmp_path) -> None:
+def test_non_iso_band_count_rejected(tmp_path: Path) -> None:
     """A manually built 8-band result with matching rating arrays is rejected.
 
     The public API promises only the 16 one-third-octave or 5 octave bands
@@ -208,7 +215,7 @@ def test_non_iso_band_count_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_rating_without_per_band_data_rejected(tmp_path) -> None:
+def test_rating_without_per_band_data_rejected(tmp_path: Path) -> None:
     """A manually built rating lacking the per-band arrays is rejected."""
     bare_rating = building.WeightedRatingResult(
         rating=30, c=-2, ctr=-3, unfavourable_sum=0.0

--- a/tests/building/measurement/test_iso15186_report.py
+++ b/tests/building/measurement/test_iso15186_report.py
@@ -16,6 +16,8 @@ report tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 import reference_data as ref
@@ -28,6 +30,9 @@ from phonometry import ReportMetadata, building
 from phonometry.building.measurement.intensity_insulation import (
     IntensityReductionResult,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _RATING_FREQS = np.array(
     [
@@ -52,7 +57,9 @@ _RATING_FREQS = np.array(
 )
 
 
-def _levels_for_target_ri(ri, lp1, sm, s):
+def _levels_for_target_ri(
+    ri: list[float] | np.ndarray, lp1: float, sm: float, s: float
+) -> np.ndarray:
     """Receiving-side LIn that make Formula (7) return exactly ``ri``."""
     return lp1 - 6.0 - 10.0 * np.log10(sm / s) - np.asarray(ri, dtype=np.float64)
 
@@ -82,7 +89,7 @@ def test_ri_equals_annex_c_curve() -> None:
     np.testing.assert_allclose(result.r_i, ref.ISO15186_1_REF_RI, atol=1e-9)
 
 
-def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
+def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path: Path) -> None:
     """The RI fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3) dB."""
     out = tmp_path / "ri.pdf"
     _intensity_result().report(str(out))
@@ -98,7 +105,7 @@ def test_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     assert "20.4" in text  # the 100 Hz band value
 
 
-def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
+def test_full_metadata_and_verbose_render_one_page(tmp_path: Path) -> None:
     """A fully populated fiche with the RI,M column is one page."""
     metadata = ReportMetadata(
         specimen="100 mm autoclaved aerated concrete block wall",
@@ -130,7 +137,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     assert "Kc-modified" in text  # the verbose column caption
 
 
-def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
+def test_requirement_verdicts_pass_and_fail(tmp_path: Path) -> None:
     """Intensity insulation passes at or above the requirement."""
     result = _intensity_result()  # RI,w = 30 dB
     failing = tmp_path / "fail.pdf"
@@ -153,7 +160,7 @@ def _octave_result(*, with_kc: bool = False) -> IntensityReductionResult:
     )
 
 
-def test_octave_band_fiche_renders(tmp_path) -> None:
+def test_octave_band_fiche_renders(tmp_path: Path) -> None:
     """A five-octave-band intensity result also yields a one-page fiche."""
     result = _octave_result()
     assert result.rating is not None
@@ -163,7 +170,7 @@ def test_octave_band_fiche_renders(tmp_path) -> None:
     assert "Octave-band" in _extract_text(str(out))
 
 
-def test_octave_band_verbose_declares_band_resolution(tmp_path) -> None:
+def test_octave_band_verbose_declares_band_resolution(tmp_path: Path) -> None:
     """The verbose RI,M caption still declares the octave-band resolution."""
     out = tmp_path / "octave_verbose.pdf"
     _octave_result(with_kc=True).report(str(out), verbose=True)
@@ -173,7 +180,7 @@ def test_octave_band_verbose_declares_band_resolution(tmp_path) -> None:
     assert "Kc-modified" in text  # the RI,M column is present
 
 
-def test_one_third_octave_verbose_declares_band_resolution(tmp_path) -> None:
+def test_one_third_octave_verbose_declares_band_resolution(tmp_path: Path) -> None:
     """The verbose RI,M caption declares the one-third-octave resolution."""
     out = tmp_path / "verbose_res.pdf"
     _intensity_result(with_kc=True).report(str(out), verbose=True)
@@ -183,7 +190,7 @@ def test_one_third_octave_verbose_declares_band_resolution(tmp_path) -> None:
     assert "Kc-modified" in text
 
 
-def test_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish fiche with comma decimals."""
     import re
 
@@ -201,7 +208,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
     assert re.search(r"\d+,\d", text)  # comma decimal separator
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = _intensity_result()
@@ -209,7 +216,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     result = _intensity_result()
@@ -217,7 +224,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         result.report(out, language="fr")
 
 
-def test_missing_rating_rejected(tmp_path) -> None:
+def test_missing_rating_rejected(tmp_path: Path) -> None:
     """A result without the ISO 717 rating (non-core band count) is rejected."""
     l_in = _levels_for_target_ri(np.full(8, 40.0), 85.0, 12.0, 10.0)
     result = building.intensity_sound_reduction(
@@ -229,7 +236,7 @@ def test_missing_rating_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_verbose_without_kc_renders_plain_table(tmp_path) -> None:
+def test_verbose_without_kc_renders_plain_table(tmp_path: Path) -> None:
     """``verbose=True`` with no RI,M falls back to the two-column table."""
     out = tmp_path / "plain.pdf"
     _intensity_result(with_kc=False).report(str(out), verbose=True)
@@ -239,7 +246,7 @@ def test_verbose_without_kc_renders_plain_table(tmp_path) -> None:
     assert "Kc-modified" not in text
 
 
-def test_non_iso_band_count_rejected(tmp_path) -> None:
+def test_non_iso_band_count_rejected(tmp_path: Path) -> None:
     """A manually built 8-band result with matching rating arrays is rejected.
 
     The public API promises only the 16 one-third-octave or 5 octave bands
@@ -265,7 +272,7 @@ def test_non_iso_band_count_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_rating_without_per_band_data_rejected(tmp_path) -> None:
+def test_rating_without_per_band_data_rejected(tmp_path: Path) -> None:
     """A manually built rating lacking the per-band arrays is rejected."""
     bare_rating = building.WeightedRatingResult(
         rating=30, c=-2, ctr=-3, unfavourable_sum=0.0
@@ -281,7 +288,7 @@ def test_rating_without_per_band_data_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_clause8_areas_stated_in_statement(tmp_path) -> None:
+def test_clause8_areas_stated_in_statement(tmp_path: Path) -> None:
     """The statement carries S and Sm when the result holds them (Clause 8 g)."""
     out = tmp_path / "areas.pdf"
     _intensity_result().report(str(out))
@@ -291,7 +298,7 @@ def test_clause8_areas_stated_in_statement(tmp_path) -> None:
     assert "Clause 8" in text
 
 
-def test_clause8_fpi_and_residual_columns(tmp_path) -> None:
+def test_clause8_fpi_and_residual_columns(tmp_path: Path) -> None:
     """Supplied FpI and dpI0 spectra are annexed as table columns (Clause 8 i)."""
     result = _intensity_result()
     fpi = np.full(16, 4.0)
@@ -310,7 +317,7 @@ def test_clause8_fpi_and_residual_columns(tmp_path) -> None:
     assert_one_page(str(out2))
 
 
-def test_clause8_fpi_wrong_band_count_rejected(tmp_path) -> None:
+def test_clause8_fpi_wrong_band_count_rejected(tmp_path: Path) -> None:
     """An FpI spectrum not matching the reported bands is rejected."""
     result = _intensity_result()
     out = str(tmp_path / "x.pdf")

--- a/tests/building/measurement/test_iso16251_report.py
+++ b/tests/building/measurement/test_iso16251_report.py
@@ -19,6 +19,8 @@ and CI,delta = -11 - 0 = -11 dB.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -27,6 +29,9 @@ import numpy as np
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _FREQS = np.array(
     [
@@ -54,12 +59,12 @@ _DELTA_L = np.array(
 )
 
 
-def _result():
+def _result() -> building.FloorCoveringImprovementResult:
     bare = np.full(16, 78.0)
     return building.impact_improvement(bare, bare - _DELTA_L, _FREQS)
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: float | str) -> ReportMetadata:
     base = {
         "specimen": "Textile floor covering (carpet), 6 mm pile",
         "client": "Acoustic Test Client Ltd.",
@@ -88,34 +93,34 @@ def _text(path: str) -> str:
     )
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "iso16251.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_report_with_metadata_one_page(tmp_path) -> None:
+def test_report_with_metadata_one_page(tmp_path: Path) -> None:
     out = tmp_path / "iso16251_meta.pdf"
     _result().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(out, language="xx")
 
 
-def test_displayed_values_match_oracle(tmp_path) -> None:
+def test_displayed_values_match_oracle(tmp_path: Path) -> None:
     """The fiche prints the weighted improvement, band labels and delta-L."""
     out = tmp_path / "iso16251.pdf"
     _result().report(str(out), metadata=_metadata())
@@ -130,7 +135,7 @@ def test_displayed_values_match_oracle(tmp_path) -> None:
     assert "100 to 3150" in text  # measured frequency range
 
 
-def test_verbose_shows_reference_floor_column_one_page(tmp_path) -> None:
+def test_verbose_shows_reference_floor_column_one_page(tmp_path: Path) -> None:
     """verbose=True adds the reference-floor L_n,r column and stays one page."""
     out = tmp_path / "iso16251_verbose.pdf"
     _result().report(str(out), metadata=_metadata(), verbose=True)
@@ -141,14 +146,14 @@ def test_verbose_shows_reference_floor_column_one_page(tmp_path) -> None:
     assert "55.5" in text
 
 
-def test_requirement_pass_verdict(tmp_path) -> None:
+def test_requirement_pass_verdict(tmp_path: Path) -> None:
     """A higher weighted improvement passes the requirement."""
     out = tmp_path / "iso16251_pass.pdf"
     _result().report(str(out), metadata=_metadata(requirement=17.0))
     assert "PASS" in _text(str(out))
 
 
-def test_requirement_boundary_verdict(tmp_path) -> None:
+def test_requirement_boundary_verdict(tmp_path: Path) -> None:
     """At equality (requirement == delta_lw) the verdict passes (>= rule)."""
     out = tmp_path / "iso16251_boundary.pdf"
     result = _result()
@@ -159,14 +164,14 @@ def test_requirement_boundary_verdict(tmp_path) -> None:
     assert "FAIL" not in text
 
 
-def test_requirement_fail_verdict(tmp_path) -> None:
+def test_requirement_fail_verdict(tmp_path: Path) -> None:
     """A weighted improvement below the requirement fails."""
     out = tmp_path / "iso16251_fail.pdf"
     _result().report(str(out), metadata=_metadata(requirement=25.0))
     assert "FAIL" in _text(str(out))
 
 
-def test_limited_band_uses_literal_greater_than(tmp_path) -> None:
+def test_limited_band_uses_literal_greater_than(tmp_path: Path) -> None:
     """A band at the 1,3 dB limit renders a literal '>' marker, not '&gt;'."""
     bare = np.full(16, 50.0)
     covering = np.full(16, 49.0)
@@ -183,7 +188,7 @@ def test_limited_band_uses_literal_greater_than(tmp_path) -> None:
     assert "≥" in text  # the >= prefix on the boxed delta-Lw
 
 
-def test_unlimited_result_not_qualified_as_lower_bound(tmp_path) -> None:
+def test_unlimited_result_not_qualified_as_lower_bound(tmp_path: Path) -> None:
     """A result with no background-limited band prints a plain delta-Lw."""
     out = tmp_path / "iso16251_plain.pdf"
     _result().report(str(out))
@@ -192,7 +197,7 @@ def test_unlimited_result_not_qualified_as_lower_bound(tmp_path) -> None:
     assert "≥" not in text
 
 
-def test_manual_result_without_ci_delta_omits_adaptation_term(tmp_path) -> None:
+def test_manual_result_without_ci_delta_omits_adaptation_term(tmp_path: Path) -> None:
     """A hand-built result lacking CI,delta must not print a fabricated (+0)."""
     from phonometry.building.measurement.floor_covering_improvement import (
         FloorCoveringImprovementResult,
@@ -213,13 +218,13 @@ def test_manual_result_without_ci_delta_omits_adaptation_term(tmp_path) -> None:
     assert "15 dB" in text
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     out = tmp_path / "iso16251_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Carpet <A> & <B> "edge"'))
     assert_one_page(str(out))
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     """Without metadata the header still shows the measured frequency range."""
     out = tmp_path / "iso16251_bare.pdf"
     _result().report(str(out))
@@ -227,14 +232,14 @@ def test_no_metadata_still_renders(tmp_path) -> None:
     assert "100 to 3150" in _text(str(out))
 
 
-def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_fiche_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "iso16251_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))
     assert "15,0" in _text(str(out))  # Spanish decimal comma
 
 
-def test_characterisation_headline_without_rating_bands(tmp_path) -> None:
+def test_characterisation_headline_without_rating_bands(tmp_path: Path) -> None:
     """A spectrum without the 16 rating bands boxes a characterisation, no number."""
     result = building.impact_improvement(
         [1.0, 2.0, 3.0], [0.0, 0.0, 0.0], [500.0, 1000.0, 2000.0]

--- a/tests/building/measurement/test_iso16283_report.py
+++ b/tests/building/measurement/test_iso16283_report.py
@@ -14,6 +14,8 @@ the mandatory field-method statement, like the sibling report tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -32,13 +34,16 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 #: A receiving-room reverberation time equal to T0 = 0,5 s in every band:
 #: the standardized quantities then equal the raw ones exactly
 #: (10 lg(T/T0) = 0), making the fiche's rating hand-computable.
 _T_AT_T0 = np.full(16, 0.5)
 
 
-def _airborne_result(**kwargs) -> building.AirborneInsulationResult:
+def _airborne_result(**kwargs: float) -> building.AirborneInsulationResult:
     """A field airborne result whose ``DnT`` equals the ISO 717-1 Annex C curve."""
     l1 = np.full(16, 90.0)
     l2 = l1 - np.asarray(_AIRBORNE_R, dtype=np.float64)
@@ -67,7 +72,7 @@ def test_dnt_reverberation_correction_hand_computed() -> None:
     assert np.allclose(result.dnt, result.d + 10.0 * np.log10(2.0))
 
 
-def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
+def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path: Path) -> None:
     """The DnT fiche's rating is the published ISO 717-1 Annex C 30 (-2; -3) dB.
 
     ``DnT = D`` here by construction, so the fiche must print the exact
@@ -84,7 +89,7 @@ def test_airborne_fiche_rating_pinned_to_iso717_1_annex_c(tmp_path) -> None:
     assert "engineering method" in text
 
 
-def test_r_prime_fiche_hand_computed(tmp_path) -> None:
+def test_r_prime_fiche_hand_computed(tmp_path: Path) -> None:
     """R' = D + 10 lg(S T / (0,16 V)) (Formulae (4)/(5)) drives the R' fiche.
 
     With S = 10 m2, V = 50 m3 and T = 0,5 s the absorption area is
@@ -108,7 +113,7 @@ def test_impact_lnt_equals_li_at_reference_time() -> None:
     assert np.allclose(result.l_n_t, _IMPACT_LN)
 
 
-def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path) -> None:
+def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path: Path) -> None:
     """The L'nT fiche's rating is the published ISO 717-2 Annex C 79 (-11) dB."""
     result = building.impact_insulation(_IMPACT_LN, _T_AT_T0, volume=31.25)
     out = tmp_path / "lnt.pdf"
@@ -123,7 +128,7 @@ def test_impact_fiche_rating_pinned_to_iso717_2_annex_c(tmp_path) -> None:
     assert "tapping machine" in " ".join(text.split())
 
 
-def test_impact_l_n_fiche_hand_computed(tmp_path) -> None:
+def test_impact_l_n_fiche_hand_computed(tmp_path: Path) -> None:
     """L'n = Li + 10 lg(A/A0) with A = 0,16 V/T (Formulae (2)/(6)).
 
     V = 31,25 m3 and T = 0,5 s give A = 10 m2 = A0, so L'n = Li and the
@@ -140,7 +145,7 @@ def test_impact_l_n_fiche_hand_computed(tmp_path) -> None:
     assert "Normalized impact sound pressure level" in text
 
 
-def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
+def test_full_metadata_and_verbose_render_one_page(tmp_path: Path) -> None:
     """A fully populated field fiche with the measurement chain is one page."""
     result = _airborne_result(area=12.5, volume=30.4)
     metadata = ReportMetadata(
@@ -165,7 +170,7 @@ def test_full_metadata_and_verbose_render_one_page(tmp_path) -> None:
     assert "PASS" in text  # DnT,w = 30 dB >= 25 dB
 
 
-def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
+def test_requirement_verdicts_pass_and_fail(tmp_path: Path) -> None:
     """Airborne passes at/above the requirement; impact at/below it."""
     airborne = _airborne_result()  # DnT,w = 30 dB
     failing = tmp_path / "fail.pdf"
@@ -178,7 +183,7 @@ def test_requirement_verdicts_pass_and_fail(tmp_path) -> None:
     assert "PASS" in _extract_text(str(passing))
 
 
-def test_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish field fiche with comma decimals."""
     import re
 
@@ -197,7 +202,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
     assert re.search(r"\d+,\d", text)  # comma decimal separator
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _airborne_result()
     out = str(tmp_path / "x.pdf")
@@ -205,7 +210,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_quantity_rejected(tmp_path) -> None:
+def test_unknown_quantity_rejected(tmp_path: Path) -> None:
     """An unknown field quantity raises ``ValueError``."""
     airborne = _airborne_result()
     out = str(tmp_path / "x.pdf")
@@ -216,7 +221,7 @@ def test_unknown_quantity_rejected(tmp_path) -> None:
         impact.report(out, quantity="dnt")
 
 
-def test_missing_r_prime_rejected(tmp_path) -> None:
+def test_missing_r_prime_rejected(tmp_path: Path) -> None:
     """Requesting the R' fiche without area/volume raises ``ValueError``."""
     result = _airborne_result()
     out = str(tmp_path / "x.pdf")
@@ -224,7 +229,7 @@ def test_missing_r_prime_rejected(tmp_path) -> None:
         result.report(out, quantity="r_prime")
 
 
-def test_non_core_band_count_rejected(tmp_path) -> None:
+def test_non_core_band_count_rejected(tmp_path: Path) -> None:
     """The field fiche needs the 16 core one-third-octave bands."""
     result = building.airborne_insulation(
         np.full(5, 90.0), np.full(5, 50.0), np.full(5, 0.5)
@@ -234,7 +239,7 @@ def test_non_core_band_count_rejected(tmp_path) -> None:
         result.report(out)
 
 
-def test_verbose_needs_measurement_chain(tmp_path) -> None:
+def test_verbose_needs_measurement_chain(tmp_path: Path) -> None:
     """``verbose=True`` on a manually built result (no chain) is rejected."""
     curve = np.asarray(_AIRBORNE_R, dtype=np.float64)
     bare = building.AirborneInsulationResult(d=curve, dnt=curve, r_prime=None)
@@ -247,7 +252,7 @@ def test_verbose_needs_measurement_chain(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_manual_impact_result_renders_without_chain(tmp_path) -> None:
+def test_manual_impact_result_renders_without_chain(tmp_path: Path) -> None:
     """A backward-compatibly built impact result reports its L'nT fiche."""
     curve = np.asarray(_IMPACT_LN, dtype=np.float64)
     bare = building.ImpactInsulationResult(l_n_t=curve, l_n=None)

--- a/tests/building/measurement/test_iso717_report.py
+++ b/tests/building/measurement/test_iso717_report.py
@@ -11,6 +11,8 @@ layout content is never inspected.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -29,8 +31,11 @@ from report_assertions import assert_one_page, assert_pdf
 
 from phonometry import ReportMetadata, building
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def test_airborne_report_writes_pdf(tmp_path) -> None:
+
+def test_airborne_report_writes_pdf(tmp_path: Path) -> None:
     """An ISO 717-1 airborne rating renders a PDF fiche."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = tmp_path / "airborne.pdf"
@@ -39,7 +44,7 @@ def test_airborne_report_writes_pdf(tmp_path) -> None:
     assert_pdf(str(out))
 
 
-def test_impact_report_writes_pdf(tmp_path) -> None:
+def test_impact_report_writes_pdf(tmp_path: Path) -> None:
     """An ISO 717-2 impact rating renders a PDF fiche."""
     result = building.weighted_impact_rating(_IMPACT_LN)
     assert result.quantity == "impact"
@@ -49,7 +54,7 @@ def test_impact_report_writes_pdf(tmp_path) -> None:
     assert_pdf(str(out))
 
 
-def test_panel_result_report_convenience(tmp_path) -> None:
+def test_panel_result_report_convenience(tmp_path: Path) -> None:
     """``SoundReductionResult.report()`` rates ``R(f)`` and writes its fiche."""
     freqs = [
         100,
@@ -77,7 +82,7 @@ def test_panel_result_report_convenience(tmp_path) -> None:
     assert_pdf(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = str(tmp_path / "x.pdf")
@@ -85,7 +90,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_missing_band_data_rejected(tmp_path) -> None:
+def test_missing_band_data_rejected(tmp_path: Path) -> None:
     """A rating built without the per-band curves cannot be reported."""
     bare = building.WeightedRatingResult(rating=52, c=-1, ctr=-4, unfavourable_sum=30.0)
     assert bare.band_centers is None
@@ -94,7 +99,7 @@ def test_missing_band_data_rejected(tmp_path) -> None:
         bare.report(out)
 
 
-def test_airborne_fiche_reproduces_iso717_1_annex_c1(tmp_path) -> None:
+def test_airborne_fiche_reproduces_iso717_1_annex_c1(tmp_path: Path) -> None:
     """The airborne fiche reproduces the ISO 717-1:2020 Annex C Table C.1 example.
 
     The values printed in the standard's worked example are exactly the ones the
@@ -118,7 +123,7 @@ def test_airborne_fiche_reproduces_iso717_1_annex_c1(tmp_path) -> None:
     assert_pdf(str(result.report(str(tmp_path / "airborne_c1.pdf"))))
 
 
-def test_impact_fiche_reproduces_iso717_2_annex_c1(tmp_path) -> None:
+def test_impact_fiche_reproduces_iso717_2_annex_c1(tmp_path: Path) -> None:
     """The impact fiche reproduces the ISO 717-2 Annex C Table C.1 example.
 
     Ln,w = 79 dB, CI = -11 dB, unfavourable-deviation sum 28,0 dB (see the note
@@ -133,7 +138,7 @@ def test_impact_fiche_reproduces_iso717_2_annex_c1(tmp_path) -> None:
     assert_pdf(str(result.report(str(tmp_path / "impact_c1.pdf"))))
 
 
-def _full_metadata(**overrides) -> ReportMetadata:
+def _full_metadata(**overrides: float) -> ReportMetadata:
     """A fully populated :class:`ReportMetadata` for the accredited fiche."""
     base = {
         "specimen": "200 mm reinforced-concrete wall",
@@ -174,7 +179,7 @@ def test_metadata_rejects_out_of_range_humidity() -> None:
         ReportMetadata(relative_humidity=150.0)
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     result = building.weighted_rating(_AIRBORNE_R)
     md = ReportMetadata(
@@ -190,7 +195,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_full_metadata_renders_one_page(tmp_path) -> None:
+def test_full_metadata_renders_one_page(tmp_path: Path) -> None:
     """A full ReportMetadata renders a one-page accredited fiche."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = tmp_path / "airborne_meta.pdf"
@@ -198,7 +203,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_verbose_renders_annex_c_table(tmp_path) -> None:
+def test_verbose_renders_annex_c_table(tmp_path: Path) -> None:
     """``verbose=True`` renders the Annex C evaluation table one-pager."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = tmp_path / "airborne_verbose.pdf"
@@ -206,7 +211,7 @@ def test_verbose_renders_annex_c_table(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
+def test_requirement_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS and a FAIL requirement both render a one-page fiche."""
     result = building.weighted_rating(_AIRBORNE_R)  # Rw = 30 dB
     passing = tmp_path / "pass.pdf"
@@ -217,7 +222,7 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     assert_one_page(str(failing))
 
 
-def test_impact_requirement_verdict_renders(tmp_path) -> None:
+def test_impact_requirement_verdict_renders(tmp_path: Path) -> None:
     """An impact fiche with a requirement (lower is better) renders."""
     result = building.weighted_impact_rating(_IMPACT_LN)
     out = tmp_path / "impact_meta.pdf"
@@ -246,7 +251,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_airborne_fiche_pins_displayed_rating(tmp_path) -> None:
+def test_airborne_fiche_pins_displayed_rating(tmp_path: Path) -> None:
     """The fiche prints exactly the Annex C Table C.1 numbers.
 
     Independent oracle: ISO 717-1:2020 Annex C states Rw (C; Ctr) =
@@ -263,7 +268,7 @@ def test_airborne_fiche_pins_displayed_rating(tmp_path) -> None:
     assert "31.8" in text  # Annex C unfavourable-deviation sum
 
 
-def test_octave_band_fiche_declares_octave_bands(tmp_path) -> None:
+def test_octave_band_fiche_declares_octave_bands(tmp_path: Path) -> None:
     """A 5-band octave rating is captioned as octave bands (ISO 717-2 4.4).
 
     Clause 4.4 requires stating whether the rating came from one-third-octave
@@ -280,7 +285,7 @@ def test_octave_band_fiche_declares_octave_bands(tmp_path) -> None:
     assert "One-third-octave" not in text
 
 
-def test_symbol_labels_field_quantity(tmp_path) -> None:
+def test_symbol_labels_field_quantity(tmp_path: Path) -> None:
     """``symbol="DnT,w"`` relabels the boxed result, table and verdict.
 
     A field measurement rated to a standardized level difference must not be
@@ -296,7 +301,7 @@ def test_symbol_labels_field_quantity(tmp_path) -> None:
     assert "Rw" not in text
 
 
-def test_invalid_symbol_rejected(tmp_path) -> None:
+def test_invalid_symbol_rejected(tmp_path: Path) -> None:
     """A malformed quantity symbol raises ``ValueError``."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = str(tmp_path / "bad.pdf")
@@ -304,7 +309,7 @@ def test_invalid_symbol_rejected(tmp_path) -> None:
         result.report(out, symbol="not a symbol")
 
 
-def test_metadata_area_is_not_display_rounded(tmp_path) -> None:
+def test_metadata_area_is_not_display_rounded(tmp_path: Path) -> None:
     """A supplied area of 1.23 m^2 is reprinted verbatim, not reduced to 1.2."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = tmp_path / "area.pdf"
@@ -314,7 +319,7 @@ def test_metadata_area_is_not_display_rounded(tmp_path) -> None:
     assert "1.2 " not in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -328,7 +333,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = building.weighted_rating(_AIRBORNE_R)
     with pytest.raises(ValueError, match="language"):

--- a/tests/building/measurement/test_structure_borne_power_report.py
+++ b/tests/building/measurement/test_structure_borne_power_report.py
@@ -16,11 +16,16 @@ the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _FREQS = np.array([125, 250, 500, 1000, 2000, 4000], dtype=float)
 # Spatial mean plate velocity level Lv (dB re 1e-9 m/s) per octave band.
@@ -38,7 +43,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _result():
+def _result() -> building.StructureBornePowerResult:
     return building.reception_plate_power(
         _LV, _FREQS, mass_per_area=_MASS, area=_AREA, reverberation_time=_TS
     )
@@ -71,7 +76,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.total_level == pytest.approx(_oracle_total(), abs=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the total L_Ws and a couple of band L_Ws values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -105,7 +110,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "Plate-specific level" in text
 
 
-def test_verbose_adds_loss_factor_column(tmp_path) -> None:
+def test_verbose_adds_loss_factor_column(tmp_path: Path) -> None:
     """verbose=True adds the plate loss factor eta column."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -120,7 +125,7 @@ def test_verbose_adds_loss_factor_column(tmp_path) -> None:
     assert f"{eta[3]:.4f}" in text
 
 
-def test_third_octave_labels_and_caption(tmp_path) -> None:
+def test_third_octave_labels_and_caption(tmp_path: Path) -> None:
     """A one-third-octave set is labelled by nominal centres and captioned."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -143,7 +148,9 @@ def test_third_octave_labels_and_caption(tmp_path) -> None:
     ("limit", "verdict"),
     [(100.0, "PASS"), (40.0, "FAIL")],
 )
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -156,7 +163,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
     assert "declared limit" in text
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, environment and identity fields."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -181,7 +188,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     assert "Acoustics lab" in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the structure-borne vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -197,7 +204,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert f"{_oracle_total():.1f}".replace(".", ",") in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -205,7 +212,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/building/measurement/test_survey_insulation_report.py
+++ b/tests/building/measurement/test_survey_insulation_report.py
@@ -14,6 +14,8 @@ survey-method statement.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -22,6 +24,9 @@ pytest.importorskip("reportlab")
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: Five octave bands (125 Hz to 2000 Hz), the ISO 10052 survey range.
 _OCTAVE = 5
@@ -63,7 +68,7 @@ def _facade() -> building.survey_facade_insulation:  # type: ignore[valid-type]
 # --------------------------------------------------------------------------- #
 # Airborne DnT / R' (ISO 10052, ISO 717-1)
 # --------------------------------------------------------------------------- #
-def test_airborne_fiche_rating_and_basis(tmp_path) -> None:
+def test_airborne_fiche_rating_and_basis(tmp_path: Path) -> None:
     """The DnT fiche boxes the ISO 717-1 rating and names ISO 10052."""
     result = _airborne()
     rating = result.rating
@@ -79,7 +84,7 @@ def test_airborne_fiche_rating_and_basis(tmp_path) -> None:
     assert "33.0" in text  # the 125 Hz DnT band value (D + k with k = 0)
 
 
-def test_airborne_r_prime_quantity(tmp_path) -> None:
+def test_airborne_r_prime_quantity(tmp_path: Path) -> None:
     """``quantity='r_prime'`` reports the apparent sound reduction index R'."""
     result = _airborne()
     assert result.r_prime_rating is not None
@@ -90,7 +95,7 @@ def test_airborne_r_prime_quantity(tmp_path) -> None:
     assert "Apparent sound reduction index" in text
 
 
-def test_airborne_one_third_octave_caption(tmp_path) -> None:
+def test_airborne_one_third_octave_caption(tmp_path: Path) -> None:
     """A 16-band one-third-octave survey report captions its own band set.
 
     The survey method also accepts the ISO 717 one-third-octave set (16 bands,
@@ -114,7 +119,7 @@ def test_airborne_one_third_octave_caption(tmp_path) -> None:
     assert "octave bands)" not in text.replace("one-third-octave bands", "")
 
 
-def test_airborne_verbose_and_verdict_pass(tmp_path) -> None:
+def test_airborne_verbose_and_verdict_pass(tmp_path: Path) -> None:
     """Verbose annexes the ISO 717 evaluation; a level difference passes above."""
     out = tmp_path / "verbose.pdf"
     _airborne().report(
@@ -126,14 +131,14 @@ def test_airborne_verbose_and_verdict_pass(tmp_path) -> None:
     assert "Unfav. dev." in text
 
 
-def test_airborne_verdict_fail(tmp_path) -> None:
+def test_airborne_verdict_fail(tmp_path: Path) -> None:
     """A level difference below the requirement fails (higher is better)."""
     out = tmp_path / "fail.pdf"
     _airborne().report(str(out), metadata=ReportMetadata(requirement=60.0))
     assert "FAIL" in _extract_text(str(out))
 
 
-def test_airborne_spanish(tmp_path) -> None:
+def test_airborne_spanish(tmp_path: Path) -> None:
     """``language='es'`` renders the Spanish survey fiche with comma decimals."""
     import re
 
@@ -154,7 +159,7 @@ def test_airborne_spanish(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Impact L'nT (ISO 10052, ISO 717-2)
 # --------------------------------------------------------------------------- #
-def test_impact_fiche_rating_and_basis(tmp_path) -> None:
+def test_impact_fiche_rating_and_basis(tmp_path: Path) -> None:
     """The L'nT fiche boxes the ISO 717-2 rating and names the tapping machine."""
     result = _impact()
     rating = result.rating
@@ -170,7 +175,7 @@ def test_impact_fiche_rating_and_basis(tmp_path) -> None:
     assert "PASS" in text  # L'nT,w = 58 dB <= 62 dB (a lower level is better)
 
 
-def test_impact_verdict_fail(tmp_path) -> None:
+def test_impact_verdict_fail(tmp_path: Path) -> None:
     """An impact level above the requirement fails (lower is better)."""
     out = tmp_path / "fail.pdf"
     _impact().report(str(out), metadata=ReportMetadata(requirement=50.0))
@@ -180,7 +185,7 @@ def test_impact_verdict_fail(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Facade D2m,nT (ISO 10052, ISO 717-1)
 # --------------------------------------------------------------------------- #
-def test_facade_fiche_rating_and_basis(tmp_path) -> None:
+def test_facade_fiche_rating_and_basis(tmp_path: Path) -> None:
     """The D2m,nT fiche boxes the ISO 717-1 rating and names ISO 10052."""
     result = _facade()
     rating = result.rating
@@ -195,7 +200,7 @@ def test_facade_fiche_rating_and_basis(tmp_path) -> None:
     assert "PASS" in text  # D2m,nT,w >= 33 dB
 
 
-def test_facade_spanish(tmp_path) -> None:
+def test_facade_spanish(tmp_path: Path) -> None:
     """``language='es'`` renders the Spanish survey facade fiche."""
     out = tmp_path / "es.pdf"
     _facade().report(str(out), language="es")
@@ -206,7 +211,7 @@ def test_facade_spanish(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Rendering contract
 # --------------------------------------------------------------------------- #
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError`` on every survey fiche."""
     out = str(tmp_path / "x.pdf")
     airborne, impact, facade = _airborne(), _impact(), _facade()
@@ -218,7 +223,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         facade.report(out, engine="weasyprint")
 
 
-def test_unknown_airborne_quantity_rejected(tmp_path) -> None:
+def test_unknown_airborne_quantity_rejected(tmp_path: Path) -> None:
     """An unknown airborne quantity raises ``ValueError``."""
     airborne = _airborne()
     out = str(tmp_path / "x.pdf")
@@ -226,7 +231,7 @@ def test_unknown_airborne_quantity_rejected(tmp_path) -> None:
         airborne.report(out, quantity="dn")
 
 
-def test_missing_r_prime_rating_rejected(tmp_path) -> None:
+def test_missing_r_prime_rating_rejected(tmp_path: Path) -> None:
     """Requesting R' without area/volume (no R' rating) raises ``ValueError``."""
     result = building.survey_airborne_insulation(
         np.full(_OCTAVE, 80.0), np.full(_OCTAVE, 45.0), _K0
@@ -236,7 +241,7 @@ def test_missing_r_prime_rating_rejected(tmp_path) -> None:
         result.report(out, quantity="r_prime")
 
 
-def test_missing_rating_off_band_count_rejected(tmp_path) -> None:
+def test_missing_rating_off_band_count_rejected(tmp_path: Path) -> None:
     """A band count that yields no ISO 717 rating cannot be reported."""
     airborne = building.survey_airborne_insulation(
         np.full(4, 80.0), np.full(4, 45.0), np.zeros(4)

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -259,7 +259,7 @@ def test_velocity_level_difference_is_floored_at_zero() -> None:
 # Table L.1 - the airborne chain
 # --------------------------------------------------------------------------
 @pytest.fixture(scope="module")
-def airborne(situ: dict, delta_l: np.ndarray):
+def airborne(situ: dict, delta_l: np.ndarray) -> building.DetailedAirborneResult:
     """The Annex L airborne prediction, assembled from the fixture."""
     return building.detailed_airborne_prediction(
         BANDS,
@@ -270,7 +270,9 @@ def airborne(situ: dict, delta_l: np.ndarray):
     )
 
 
-def test_table_l1_every_transmission_path(airborne) -> None:
+def test_table_l1_every_transmission_path(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Table L.1, all thirteen direct and flanking sound reduction indices."""
     for path in airborne.paths:
         assert path.values == pytest.approx(
@@ -278,7 +280,9 @@ def test_table_l1_every_transmission_path(airborne) -> None:
         ), path.label
 
 
-def test_table_l1_apparent_index_and_rating(airborne) -> None:
+def test_table_l1_apparent_index_and_rating(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Table L.1, the total ``R'`` per band and its ISO 717-1 rating.
 
     Table L.1 prints ``Rw = 57,8`` and the statement line ``R'w = 57,9``: both
@@ -291,7 +295,9 @@ def test_table_l1_apparent_index_and_rating(airborne) -> None:
     assert airborne.rating.rating == ref.ISO12354_ANNEX_L1_R_PRIME_W
 
 
-def test_path_fractions_sum_to_one_and_name_a_dominant_path(airborne) -> None:
+def test_path_fractions_sum_to_one_and_name_a_dominant_path(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Every band's path shares partition the transmitted energy."""
     assert airborne.fractions.sum(axis=0) == pytest.approx(1.0)
     assert len(airborne.dominant) == BANDS.size
@@ -304,7 +310,7 @@ def test_path_fractions_sum_to_one_and_name_a_dominant_path(airborne) -> None:
 # Tables G.1 / G.4 - the impact chain
 # --------------------------------------------------------------------------
 @pytest.fixture(scope="module")
-def impact(situ: dict, delta_l: np.ndarray):
+def impact(situ: dict, delta_l: np.ndarray) -> building.DetailedImpactResult:
     """The Annex G impact prediction, assembled from the same fixture."""
     return building.detailed_impact_prediction(
         BANDS,
@@ -315,14 +321,18 @@ def impact(situ: dict, delta_l: np.ndarray):
     )
 
 
-def test_table_g4_direct_and_flanking_impact_levels(impact) -> None:
+def test_table_g4_direct_and_flanking_impact_levels(
+    impact: building.DetailedImpactResult,
+) -> None:
     """Table G.4, ``Ln,Dd`` (Formula 11) and ``Ln,Df`` (Formula 12)."""
     by_label = {p.label: p.values for p in impact.paths}
     assert by_label["Dd"] == pytest.approx(ref.ISO12354_ANNEX_G4_LN_DD, abs=TOL)
     assert by_label["Df1"] == pytest.approx(ref.ISO12354_ANNEX_G4_LN_DF, abs=TOL)
 
 
-def test_table_g1_direct_path_over_the_whole_range(impact) -> None:
+def test_table_g1_direct_path_over_the_whole_range(
+    impact: building.DetailedImpactResult,
+) -> None:
     """Table G.1, the direct column ``Ln,Dd`` over all 21 bands.
 
     The Table G.1 / G.4 disagreement recorded in docs/ERRATA.md affects only
@@ -335,7 +345,9 @@ def test_table_g1_direct_path_over_the_whole_range(impact) -> None:
 
 
 @pytest.mark.parametrize("label", ["Df1", "Df2", "Df3", "Df4"])
-def test_table_g1_flanking_paths_from_100_hz(impact, label: str) -> None:
+def test_table_g1_flanking_paths_from_100_hz(
+    impact: building.DetailedImpactResult, label: str
+) -> None:
     """Table G.1, per-element flanking impact levels, 100 Hz to 5 kHz.
 
     The 50 Hz, 63 Hz and 80 Hz cells of the four flanking columns of Table G.1
@@ -351,7 +363,7 @@ def test_table_g1_flanking_paths_from_100_hz(impact, label: str) -> None:
     )
 
 
-def test_table_g1_total_and_rating(impact) -> None:
+def test_table_g1_total_and_rating(impact: building.DetailedImpactResult) -> None:
     """Table G.1, the total ``L'n`` per band and ``L'n,w (CI)`` per ISO 717-2.
 
     The 50 Hz to 80 Hz flanking cells of Table G.1 feed its own total, so the
@@ -375,7 +387,9 @@ def test_table_g1_total_and_rating(impact) -> None:
 # --------------------------------------------------------------------------
 # Tables L.10 / G.10 - the simplified model on the same building
 # --------------------------------------------------------------------------
-def test_simplified_model_agrees_with_the_detailed_model(airborne) -> None:
+def test_simplified_model_agrees_with_the_detailed_model(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Tables L.10 and L.1: the two models rate the same building alike.
 
     The simplified single-number model of Clause 4.4 gives ``R'w = 57,0 dB``
@@ -881,7 +895,9 @@ def test_band_count_mismatch_is_reported(situ: dict) -> None:
 # .plot() coverage
 # --------------------------------------------------------------------------
 @pytest.mark.parametrize("language", ["en", "es"])
-def test_detailed_airborne_plot_draws_bars_and_the_total(airborne, language) -> None:
+def test_detailed_airborne_plot_draws_bars_and_the_total(
+    airborne: building.DetailedAirborneResult, language: str
+) -> None:
     """The airborne renderer stacks one bar per path and overlays ``R'``."""
     plt = pytest.importorskip("matplotlib.pyplot")
     ax = airborne.plot(language=language)
@@ -894,7 +910,9 @@ def test_detailed_airborne_plot_draws_bars_and_the_total(airborne, language) -> 
 
 
 @pytest.mark.parametrize("language", ["en", "es"])
-def test_detailed_impact_plot_draws_bars_and_the_total(impact, language) -> None:
+def test_detailed_impact_plot_draws_bars_and_the_total(
+    impact: building.DetailedImpactResult, language: str
+) -> None:
     """The impact renderer is the same figure with ``L'n`` overlaid."""
     plt = pytest.importorskip("matplotlib.pyplot")
     ax = impact.plot(language=language)
@@ -906,7 +924,7 @@ def test_detailed_impact_plot_draws_bars_and_the_total(impact, language) -> None
 
 
 @pytest.mark.parametrize("language", ["en", "es"])
-def test_in_situ_element_plot_draws_both_spectra(situ: dict, language) -> None:
+def test_in_situ_element_plot_draws_both_spectra(situ: dict, language: str) -> None:
     """The element renderer draws ``Rsitu`` and ``Ln,situ``."""
     plt = pytest.importorskip("matplotlib.pyplot")
     ax = situ["floor"].plot(language=language)
@@ -915,14 +933,18 @@ def test_in_situ_element_plot_draws_both_spectra(situ: dict, language) -> None:
     plt.close(ax.get_figure())
 
 
-def test_plot_rejects_an_unknown_language(airborne) -> None:
+def test_plot_rejects_an_unknown_language(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Only the languages the renderers translate are accepted."""
     pytest.importorskip("matplotlib.pyplot")
     with pytest.raises(ValueError, match="Unknown language"):
         airborne.plot(language="fr")
 
 
-def test_plot_pools_the_paths_beyond_the_named_set(airborne) -> None:
+def test_plot_pools_the_paths_beyond_the_named_set(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """With thirteen paths the renderer names six and pools the rest."""
     plt = pytest.importorskip("matplotlib.pyplot")
     ax = airborne.plot()
@@ -936,7 +958,9 @@ def test_plot_pools_the_paths_beyond_the_named_set(airborne) -> None:
 # --------------------------------------------------------------------------
 # Paths and bands that do not line up
 # --------------------------------------------------------------------------
-def test_a_share_column_short_of_a_path_is_refused(airborne) -> None:
+def test_a_share_column_short_of_a_path_is_refused(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """The share column is printed beside the path rows and sums to 100 %.
 
     A ``fractions`` array short of a path row leaves a sheet listing fewer
@@ -949,7 +973,9 @@ def test_a_share_column_short_of_a_path_is_refused(airborne) -> None:
         dataclasses.replace(airborne, fractions=airborne.fractions[:-1])
 
 
-def test_a_share_column_short_of_a_band_is_refused(airborne) -> None:
+def test_a_share_column_short_of_a_band_is_refused(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """``fractions`` is paths by bands: axis 1 is the one that carries bands."""
     import dataclasses
 
@@ -957,7 +983,9 @@ def test_a_share_column_short_of_a_band_is_refused(airborne) -> None:
         dataclasses.replace(airborne, fractions=airborne.fractions[:, :-1])
 
 
-def test_a_path_row_off_the_band_axis_is_refused(airborne) -> None:
+def test_a_path_row_off_the_band_axis_is_refused(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Every path row runs over the same bands as the frequency axis."""
     import dataclasses
 
@@ -967,7 +995,9 @@ def test_a_path_row_off_the_band_axis_is_refused(airborne) -> None:
         dataclasses.replace(airborne, paths=(short, *airborne.paths[1:]))
 
 
-def test_a_share_column_with_an_extra_axis_is_refused(airborne) -> None:
+def test_a_share_column_with_an_extra_axis_is_refused(
+    airborne: building.DetailedAirborneResult,
+) -> None:
     """Counting the axes is not enough on its own: their number is pinned too.
 
     A ``fractions`` of shape ``(paths, bands, 2)`` has the right number of
@@ -983,7 +1013,9 @@ def test_a_share_column_with_an_extra_axis_is_refused(airborne) -> None:
         dataclasses.replace(airborne, fractions=three_dimensional)
 
 
-def test_a_path_without_a_share_row_is_refused_on_the_impact_result(impact) -> None:
+def test_a_path_without_a_share_row_is_refused_on_the_impact_result(
+    impact: building.DetailedImpactResult,
+) -> None:
     """The impact result decomposes its own quantity over the same two axes.
 
     It shares the check with the airborne result, so nothing above would go
@@ -999,7 +1031,9 @@ def test_a_path_without_a_share_row_is_refused_on_the_impact_result(impact) -> N
         dataclasses.replace(impact, paths=(*impact.paths, extra))
 
 
-def test_an_impact_total_off_the_band_axis_is_refused(impact) -> None:
+def test_an_impact_total_off_the_band_axis_is_refused(
+    impact: building.DetailedImpactResult,
+) -> None:
     """``L'n`` runs over the frequencies the same paths were summed over.
 
     One band too long, the total is drawn against the frequency axis, and

--- a/tests/building/prediction/test_detailed_model_report.py
+++ b/tests/building/prediction/test_detailed_model_report.py
@@ -12,6 +12,8 @@ wording and the detailed model's own accuracy statement.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import iso12354_building as bld
 import numpy as np
 import pytest
@@ -27,6 +29,12 @@ from phonometry._report.iso12354 import (
     render_iso12354_detailed_impact_report,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from matplotlib.legend import Legend
+
 _BANDS = np.asarray(ref.ISO12354_ANNEX_L_BANDS, dtype=np.float64)
 
 
@@ -39,7 +47,7 @@ def _situ() -> tuple[dict, np.ndarray]:
     return situ, delta
 
 
-def _annex_l_airborne():
+def _annex_l_airborne() -> building.DetailedAirborneResult:
     """The Annex L detailed airborne prediction (R'w = 57 dB)."""
     situ, delta = _situ()
     return building.detailed_airborne_prediction(
@@ -51,7 +59,7 @@ def _annex_l_airborne():
     )
 
 
-def _annex_g_impact():
+def _annex_g_impact() -> building.DetailedImpactResult:
     """The Annex G detailed impact prediction (L'n,w = 41 dB)."""
     situ, delta = _situ()
     return building.detailed_impact_prediction(
@@ -72,7 +80,7 @@ def _extract_text(path: str) -> str:
     )
 
 
-def test_detailed_airborne_fiche_boxes_the_annex_l_rating(tmp_path) -> None:
+def test_detailed_airborne_fiche_boxes_the_annex_l_rating(tmp_path: Path) -> None:
     """The detailed airborne fiche boxes R'w = 57 dB and names Clause 4.2."""
     out = tmp_path / "air.pdf"
     assert _annex_l_airborne().report(str(out)) == str(out)
@@ -92,7 +100,7 @@ def test_detailed_airborne_fiche_boxes_the_annex_l_rating(tmp_path) -> None:
     assert "2d" in text
 
 
-def test_detailed_impact_fiche_boxes_the_annex_g_rating(tmp_path) -> None:
+def test_detailed_impact_fiche_boxes_the_annex_g_rating(tmp_path: Path) -> None:
     """The detailed impact fiche boxes L'n,w = 41 dB and verdicts a limit."""
     out = tmp_path / "imp.pdf"
     result = _annex_g_impact()
@@ -116,7 +124,7 @@ def test_detailed_impact_fiche_boxes_the_annex_g_rating(tmp_path) -> None:
     assert "Df1" in text
 
 
-def test_spanish_detailed_fiche_renders(tmp_path) -> None:
+def test_spanish_detailed_fiche_renders(tmp_path: Path) -> None:
     """The fiches translate to Spanish like every other report."""
     out = tmp_path / "air_es.pdf"
     _annex_l_airborne().report(str(out), language="es")
@@ -132,7 +140,7 @@ def test_spanish_detailed_fiche_renders(tmp_path) -> None:
     assert "not a measurement" not in text
 
 
-def test_detailed_fiche_rejects_an_unrated_spectrum(tmp_path) -> None:
+def test_detailed_fiche_rejects_an_unrated_spectrum(tmp_path: Path) -> None:
     """Without the ISO 717 band range there is no single number to box."""
     partial = building.detailed_airborne_prediction(
         _BANDS[:5], direct_index=np.full(5, 55.0)
@@ -143,7 +151,7 @@ def test_detailed_fiche_rejects_an_unrated_spectrum(tmp_path) -> None:
         partial.report(out)
 
 
-def test_detailed_fiche_rejects_an_unknown_engine(tmp_path) -> None:
+def test_detailed_fiche_rejects_an_unknown_engine(tmp_path: Path) -> None:
     """Only the reportlab back end exists."""
     result = _annex_g_impact()
     out = str(tmp_path / "x.pdf")
@@ -163,7 +171,13 @@ def test_detailed_fiche_rejects_an_unknown_engine(tmp_path) -> None:
     ids=["airborne", "impact"],
 )
 def test_the_fiche_legend_keeps_the_curve_it_rates(
-    tmp_path, monkeypatch, build, render, rated
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    build: Callable[
+        [], building.DetailedAirborneResult | building.DetailedImpactResult
+    ],
+    render: Callable[..., str],
+    rated: str,
 ) -> None:
     """The rated curve is drawn on a twin axis and must survive the rebuild.
 
@@ -177,7 +191,7 @@ def test_the_fiche_legend_keeps_the_curve_it_rates(
     legends: list[list[str]] = []
     original = Axes.legend
 
-    def record(self, *args, **kwargs):
+    def record(self: Axes, *args: object, **kwargs: object) -> Legend:
         drawn = original(self, *args, **kwargs)
         legends.append([text.get_text() for text in drawn.get_texts()])
         return drawn

--- a/tests/building/prediction/test_installed_structure_borne_report.py
+++ b/tests/building/prediction/test_installed_structure_borne_report.py
@@ -16,11 +16,16 @@ engines/languages) complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, building
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _S0 = 10.0
 
@@ -43,7 +48,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _paths():
+def _paths() -> list[dict[str, np.ndarray | float]]:
     return [
         {
             "adjustment_term": _DSA,
@@ -58,7 +63,7 @@ def _paths():
     ]
 
 
-def _result():
+def _result() -> building.InstalledSourceResult:
     return building.installed_source_prediction(
         _LWSC, _DC, _paths(), frequencies=_BANDS
     )
@@ -104,7 +109,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.overall_level == pytest.approx(_oracle_overall(), abs=1e-9)
 
 
-def test_report_reads_as_prediction(tmp_path) -> None:
+def test_report_reads_as_prediction(tmp_path: Path) -> None:
     """The sheet is explicitly a prediction, never a measurement."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -123,7 +128,7 @@ def test_report_reads_as_prediction(tmp_path) -> None:
     assert "tested specimen" not in text.replace("not to a tested specimen", "")
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The verbose fiche prints the overall, total and per-path band values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -150,7 +155,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "Transmission paths: 2" in text
 
 
-def test_nonverbose_hides_path_columns(tmp_path) -> None:
+def test_nonverbose_hides_path_columns(tmp_path: Path) -> None:
     """verbose=False keeps only the installed power and the combined total."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -168,7 +173,9 @@ def test_nonverbose_hides_path_columns(tmp_path) -> None:
     ("limit", "verdict"),
     [(45.0, "PASS"), (30.0, "FAIL")],
 )
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -181,7 +188,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
     assert "declared limit" in text
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, receiving room and identity."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -204,7 +211,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     assert "Building acoustics office" in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the prediction vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -220,7 +227,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert f"{_oracle_overall():.1f}".replace(".", ",") in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -228,7 +235,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
@@ -236,7 +243,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         res.report(out, language="xx")
 
 
-def test_scalar_source_level_fiche_renders(tmp_path) -> None:
+def test_scalar_source_level_fiche_renders(tmp_path: Path) -> None:
     """A single-number L_Ws,c with per-band paths renders (regression).
 
     The table prints L_Ws,inst per band, so a scalar source level used to

--- a/tests/building/prediction/test_simplified_model_report.py
+++ b/tests/building/prediction/test_simplified_model_report.py
@@ -26,6 +26,8 @@ from phonometry import ReportMetadata, building
 from phonometry._i18n import fmt_minus
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from phonometry.building.prediction.facade import (
         FacadePredictionResult,
     )
@@ -95,7 +97,7 @@ def _extract_text(path: str) -> str:
     )
 
 
-def test_airborne_prediction_rating_pinned_to_annex_h3(tmp_path) -> None:
+def test_airborne_prediction_rating_pinned_to_annex_h3(tmp_path: Path) -> None:
     """The airborne fiche boxes the Annex H.3 predicted R'w = 52 dB."""
     out = tmp_path / "air.pdf"
     # report() returns the written path (part of the public contract).
@@ -117,7 +119,7 @@ def test_airborne_prediction_rating_pinned_to_annex_h3(tmp_path) -> None:
     assert "73" in text  # intwall-Ff Rij,w
 
 
-def test_impact_prediction_rating_pinned_to_annex_e3(tmp_path) -> None:
+def test_impact_prediction_rating_pinned_to_annex_e3(tmp_path: Path) -> None:
     """The impact fiche boxes the Annex E.3 predicted L'n,w = 45 dB."""
     out = tmp_path / "imp.pdf"
     assert _annex_e3_impact().report(str(out)) == str(out)
@@ -134,7 +136,7 @@ def test_impact_prediction_rating_pinned_to_annex_e3(tmp_path) -> None:
     assert "Formula (21)" in text
 
 
-def test_airborne_verbose_adds_energy_share(tmp_path) -> None:
+def test_airborne_verbose_adds_energy_share(tmp_path: Path) -> None:
     """``verbose=True`` annexes each path's share of the transmitted energy."""
     plain = tmp_path / "plain.pdf"
     _annex_h3_airborne().report(str(plain))
@@ -147,7 +149,7 @@ def test_airborne_verbose_adds_energy_share(tmp_path) -> None:
     assert "energy share" in text  # the verbose caption
 
 
-def test_airborne_requirement_verdict(tmp_path) -> None:
+def test_airborne_requirement_verdict(tmp_path: Path) -> None:
     """Airborne insulation passes at or above the requirement."""
     result = _annex_h3_airborne()  # R'w = 52 dB
     passing = tmp_path / "pass.pdf"
@@ -159,7 +161,7 @@ def test_airborne_requirement_verdict(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_impact_requirement_verdict_lower_is_better(tmp_path) -> None:
+def test_impact_requirement_verdict_lower_is_better(tmp_path: Path) -> None:
     """Impact level passes at or below the requirement (lower is better)."""
     result = _annex_e3_impact()  # L'n,w = 45 dB
     passing = tmp_path / "pass.pdf"
@@ -171,7 +173,7 @@ def test_impact_requirement_verdict_lower_is_better(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """A populated metadata header prints on the fiche."""
     metadata = ReportMetadata(
         specimen="Separating wall Rs,w = 57 dB",
@@ -191,7 +193,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     assert "Phonometry Reference Laboratory" in text
 
 
-def test_lightweight_fiche_without_metadata(tmp_path) -> None:
+def test_lightweight_fiche_without_metadata(tmp_path: Path) -> None:
     """A fiche with no metadata is still a valid one-page prediction report."""
     out = tmp_path / "bare.pdf"
     _annex_e3_impact().report(str(out))
@@ -199,7 +201,7 @@ def test_lightweight_fiche_without_metadata(tmp_path) -> None:
     assert "prediction" in _extract_text(str(out))
 
 
-def test_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish fiche with comma decimals."""
     import re
 
@@ -218,7 +220,7 @@ def test_spanish_fiche_renders_translated(tmp_path) -> None:
     assert re.search(r"\d+,\d", text)  # comma decimal separator
 
 
-def test_impact_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_impact_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """The impact fiche also renders in Spanish."""
     out = tmp_path / "es_imp.pdf"
     _annex_e3_impact().report(str(out), language="es")
@@ -228,7 +230,7 @@ def test_impact_spanish_fiche_renders_translated(tmp_path) -> None:
     assert "rmula (21)" in text  # "fórmula (21)"
 
 
-def test_facade_prediction_rating_pinned_to_annex_f(tmp_path) -> None:
+def test_facade_prediction_rating_pinned_to_annex_f(tmp_path: Path) -> None:
     """The facade fiche boxes the Annex F predicted D2m,nT,w = 33 dB."""
     out = tmp_path / "facade.pdf"
     assert _annex_f_facade().report(str(out)) == str(out)
@@ -255,7 +257,7 @@ def test_facade_prediction_rating_pinned_to_annex_f(tmp_path) -> None:
     assert "37" in text  # window Rp,w
 
 
-def test_facade_verbose_adds_energy_share(tmp_path) -> None:
+def test_facade_verbose_adds_energy_share(tmp_path: Path) -> None:
     """``verbose=True`` annexes each element's share of the transmitted energy."""
     plain = tmp_path / "plain.pdf"
     _annex_f_facade().report(str(plain))
@@ -268,7 +270,7 @@ def test_facade_verbose_adds_energy_share(tmp_path) -> None:
     assert "energy share" in text  # the verbose caption
 
 
-def test_facade_requirement_verdict(tmp_path) -> None:
+def test_facade_requirement_verdict(tmp_path: Path) -> None:
     """Facade insulation passes at or above the requirement."""
     result = _annex_f_facade()  # D2m,nT,w = 33 dB
     passing = tmp_path / "pass.pdf"
@@ -280,7 +282,7 @@ def test_facade_requirement_verdict(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_facade_lightweight_fiche_without_metadata(tmp_path) -> None:
+def test_facade_lightweight_fiche_without_metadata(tmp_path: Path) -> None:
     """A facade fiche with no metadata is still a valid one-page prediction."""
     out = tmp_path / "bare.pdf"
     _annex_f_facade().report(str(out))
@@ -288,7 +290,7 @@ def test_facade_lightweight_fiche_without_metadata(tmp_path) -> None:
     assert "prediction" in _extract_text(str(out))
 
 
-def test_facade_spanish_fiche_renders_translated(tmp_path) -> None:
+def test_facade_spanish_fiche_renders_translated(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish facade fiche."""
     out = tmp_path / "es.pdf"
     _annex_f_facade().report(
@@ -305,7 +307,7 @@ def test_facade_spanish_fiche_renders_translated(tmp_path) -> None:
     assert "fachada" in text  # "facade"
 
 
-def test_facade_report_requires_single_number_ratings(tmp_path) -> None:
+def test_facade_report_requires_single_number_ratings(tmp_path: Path) -> None:
     """A facade result without the ISO 717-1 ratings cannot be reported."""
     # Three bands: not the 5 octave / 16 one-third-octave set, so no rating.
     result = building.facade_sound_reduction(
@@ -318,7 +320,7 @@ def test_facade_report_requires_single_number_ratings(tmp_path) -> None:
         result.report(out)
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = _annex_h3_airborne()
@@ -326,7 +328,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     result = _annex_e3_impact()

--- a/tests/building/test_building_plots.py
+++ b/tests/building/test_building_plots.py
@@ -10,6 +10,8 @@ centre frequencies, a rigid rather than resilient tie) have to be exercised.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -19,6 +21,12 @@ import numpy as np
 import pytest
 
 import phonometry as ph
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from matplotlib.axes import Axes
+    from matplotlib.lines import Line2D
 
 # ISO 717-2:2020 Table D.4, the octave-band field measurement.
 _TABLE_D4 = (65.3, 64.5, 58.0, 55.8)
@@ -44,12 +52,12 @@ _ALA_DNC = (
 
 
 @pytest.fixture(autouse=True)
-def _close_figures():
+def _close_figures() -> Iterator[None]:
     yield
     plt.close("all")
 
 
-def _line_by_label(ax, needle: str):
+def _line_by_label(ax: Axes, needle: str) -> Line2D:
     """The first line whose label contains *needle*."""
     for line in ax.lines:
         if needle in line.get_label():
@@ -200,7 +208,7 @@ def test_ceiling_attenuation_plot_forwards_kwargs() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _plenum(**kwargs):
+def _plenum(**kwargs: list[float]) -> ph.building.PlenumFlankingResult:
     ceiling = [17.0, 21.0, 25.0, 29.0, 32.0]
     return ph.building.plenum_flanking_reduction_index(
         ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, **kwargs
@@ -248,7 +256,7 @@ def test_plenum_plot_forwards_kwargs() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _coupling(**kwargs):
+def _coupling(**kwargs: str) -> ph.building.WallTieCouplingResult:
     freq = np.logspace(np.log10(50.0), np.log10(4000.0), 24)
     return ph.building.wall_tie_coupling_loss_factor(
         freq, 150.0, 170.0, 1.0e5, 1.2e5, ties_per_area=2.5, **kwargs
@@ -300,7 +308,7 @@ def test_wall_tie_plot_forwards_kwargs() -> None:
         lambda: _coupling(tie="butterfly"),
     ],
 )
-def test_plot_rejects_an_unknown_language(factory) -> None:
+def test_plot_rejects_an_unknown_language(factory: Callable[[], object]) -> None:
     result = factory()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="fr")

--- a/tests/building/test_building_plots.py
+++ b/tests/building/test_building_plots.py
@@ -10,7 +10,7 @@ centre frequencies, a rigid rather than resilient tie) have to be exercised.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import matplotlib as mpl
 
@@ -292,6 +292,17 @@ def test_wall_tie_plot_forwards_kwargs() -> None:
     assert any(ln.get_linewidth() == 3.0 for ln in ax.lines)
 
 
+class _Plottable(Protocol):
+    """What the language-validation test actually uses: the shared plot seam.
+
+    ``object`` would claim the test never looks inside the result, and calling
+    ``plot`` is the whole test; a union of the six concrete types would repeat
+    the parametrize list. The protocol says exactly as much as the test needs.
+    """
+
+    def plot(self, *, language: str = ...) -> Axes: ...
+
+
 # ---------------------------------------------------------------------------
 # Language validation
 # ---------------------------------------------------------------------------
@@ -308,7 +319,7 @@ def test_wall_tie_plot_forwards_kwargs() -> None:
         lambda: _coupling(tie="butterfly"),
     ],
 )
-def test_plot_rejects_an_unknown_language(factory: Callable[[], object]) -> None:
+def test_plot_rejects_an_unknown_language(factory: Callable[[], _Plottable]) -> None:
     result = factory()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="fr")

--- a/tests/emission/test_iso3741_report.py
+++ b/tests/emission/test_iso3741_report.py
@@ -22,6 +22,8 @@ languages) complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
@@ -31,6 +33,11 @@ from phonometry.emission import (
     sound_power_comparison,
     sound_power_reverberation,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from phonometry.emission import ReverberationSoundPowerResult
 
 # Standard octave-band A-weighting corrections Ck (dB), IEC 61672 / ISO 3744
 # Annex E Table E.2 (reused by ISO 3741 Annex F), at the example band centres.
@@ -62,7 +69,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _result():
+def _result() -> ReverberationSoundPowerResult:
     """The direct-method determination whose LW and LWA are hand-derivable."""
     return sound_power_reverberation(
         _LP,
@@ -110,7 +117,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.sound_power_level_a == pytest.approx(_oracle_lwa(), abs=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the hand-derived LWA and a couple of band LW values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -142,7 +149,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "Annex F" in text
 
 
-def test_third_octave_labels_and_grouping(tmp_path) -> None:
+def test_third_octave_labels_and_grouping(tmp_path: Path) -> None:
     """A one-third-octave set is labelled by nominal centres and captioned."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -167,7 +174,7 @@ def test_third_octave_labels_and_grouping(tmp_path) -> None:
 # --- verbose (reverberation-specific columns) ---------------------------------
 
 
-def test_verbose_adds_absorption_and_waterhouse_columns(tmp_path) -> None:
+def test_verbose_adds_absorption_and_waterhouse_columns(tmp_path: Path) -> None:
     """verbose=True adds the K1, absorption area A and Waterhouse Cw columns."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -186,7 +193,7 @@ def test_verbose_adds_absorption_and_waterhouse_columns(tmp_path) -> None:
 # --- comparison method --------------------------------------------------------
 
 
-def test_comparison_method_reports_eq21(tmp_path) -> None:
+def test_comparison_method_reports_eq21(tmp_path: Path) -> None:
     """The comparison-method fiche cites Eq. 21 and the reference sound source."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -221,7 +228,9 @@ def test_comparison_method_reports_eq21(tmp_path) -> None:
     ("limit", "verdict"),
     [(110.0, "PASS"), (80.0, "FAIL")],
 )
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -237,7 +246,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
 # --- metadata header ----------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, environment and identity fields."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -265,7 +274,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the sound-power vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -285,7 +294,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -293,7 +302,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/emission/test_iso3744_report.py
+++ b/tests/emission/test_iso3744_report.py
@@ -18,6 +18,7 @@ facts (one page, rejected engines/languages) complete the rendering contract.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -25,6 +26,11 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import sound_power_anechoic, sound_power_pressure
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from phonometry.emission import SoundPowerResult
 
 # ISO 3744:2010 Annex E, Table E.2 octave-band A-weighting corrections Ck (dB).
 _CK_OCTAVE = {
@@ -50,7 +56,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _uniform_result(radius: float = 2.0):
+def _uniform_result(radius: float = 2.0) -> SoundPowerResult:
     """A hemisphere determination with a uniform free-field surface spectrum.
 
     Ten identical position spectra (so the energy average equals ``_SURFACE_LP``
@@ -93,7 +99,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.sound_power_level_a == pytest.approx(_oracle_lwa(), abs=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the hand-derived LWA and a couple of band LW values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -122,7 +128,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "Octave-band sound power levels" in text
 
 
-def test_third_octave_labels_and_grouping(tmp_path) -> None:
+def test_third_octave_labels_and_grouping(tmp_path: Path) -> None:
     """A one-third-octave set is labelled by nominal centres and captioned."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -147,7 +153,7 @@ def test_third_octave_labels_and_grouping(tmp_path) -> None:
 # --- verbose (K1/K2 columns) --------------------------------------------------
 
 
-def test_verbose_adds_correction_columns(tmp_path) -> None:
+def test_verbose_adds_correction_columns(tmp_path: Path) -> None:
     """verbose=True adds the mean level and the K1/K2 correction columns."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -170,7 +176,9 @@ def test_verbose_adds_correction_columns(tmp_path) -> None:
     ("limit", "verdict"),
     [(120.0, "PASS"), (80.0, "FAIL")],
 )
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -186,7 +194,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
 # --- metadata header ----------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, environment and identity fields."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -214,7 +222,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- ISO 3745 precision result ------------------------------------------------
 
 
-def test_precision_report_names_iso3745(tmp_path) -> None:
+def test_precision_report_names_iso3745(tmp_path: Path) -> None:
     """A precision result renders the ISO 3745 basis and the C1/C2/C3 strip."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -243,7 +251,7 @@ def test_precision_report_names_iso3745(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the sound-power vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -263,7 +271,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "x.pdf")
@@ -271,7 +279,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/emission/test_iso4871_report.py
+++ b/tests/emission/test_iso4871_report.py
@@ -16,12 +16,16 @@ from __future__ import annotations
 
 import math
 import pickle
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, emission
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _annex_b_modes() -> tuple[
@@ -45,7 +49,7 @@ def _annex_b_modes() -> tuple[
     return mode1, mode2
 
 
-def _annex_b_declaration(**kwargs) -> emission.NoiseEmissionDeclaration:
+def _annex_b_declaration(**kwargs: str) -> emission.NoiseEmissionDeclaration:
     return emission.NoiseEmissionDeclaration(
         _annex_b_modes(),
         machine="Type 990, Model 11-TC",
@@ -240,7 +244,7 @@ def test_declare_requires_finite_lwa() -> None:
 # --- rendering ---------------------------------------------------------------
 
 
-def test_dual_number_report_renders_one_page(tmp_path) -> None:
+def test_dual_number_report_renders_one_page(tmp_path: Path) -> None:
     """A dual-number declaration renders a valid one-page fiche."""
     pytest.importorskip("reportlab")
     decl = _annex_b_declaration(noise_test_code="ISO 3746 test code")
@@ -254,7 +258,7 @@ def test_dual_number_report_renders_one_page(tmp_path) -> None:
     assert "ISO 3744" in text
 
 
-def test_single_number_report_renders_one_page(tmp_path) -> None:
+def test_single_number_report_renders_one_page(tmp_path: Path) -> None:
     """A single-number declaration renders its L_WAd table."""
     pytest.importorskip("reportlab")
     decl = _annex_b_declaration(form="single-number")
@@ -264,7 +268,7 @@ def test_single_number_report_renders_one_page(tmp_path) -> None:
     assert "DECLARED SINGLE-NUMBER" in _extract_text(str(out))
 
 
-def test_dual_number_report_follows_annex_b2_layout(tmp_path) -> None:
+def test_dual_number_report_follows_annex_b2_layout(tmp_path: Path) -> None:
     """The dual-number table states only L and K (Annex B.2): no derived
     L_WAd row, whose mix of separately rounded addends and a once-rounded sum
     is not part of the dual layout.
@@ -279,7 +283,7 @@ def test_dual_number_report_follows_annex_b2_layout(tmp_path) -> None:
     assert "Declared A-weighted sound power level" not in text
 
 
-def test_dual_number_verification_row_uses_rounded_sum(tmp_path) -> None:
+def test_dual_number_verification_row_uses_rounded_sum(tmp_path: Path) -> None:
     """A dual-number fiche verifies against L_WA + K_WA of the separately
     rounded declared values (93 + 2 = 95 for 93,4/2,4), not round(95,8) = 96.
     """
@@ -306,7 +310,7 @@ def test_dual_number_verification_row_uses_rounded_sum(tmp_path) -> None:
     assert "PASS" in text2
 
 
-def test_verification_verdict_renders_both_ways(tmp_path) -> None:
+def test_verification_verdict_renders_both_ways(tmp_path: Path) -> None:
     """A passing and a failing verification both render in the verdict table."""
     pytest.importorskip("reportlab")
     mode1 = emission.OperatingModeDeclaration(
@@ -325,7 +329,7 @@ def test_verification_verdict_renders_both_ways(tmp_path) -> None:
     assert "FAIL" in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders a one-page Spanish fiche."""
     pytest.importorskip("reportlab")
     decl = _annex_b_declaration()
@@ -337,7 +341,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert "DOBLE NÚMERO" in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     pytest.importorskip("reportlab")
     decl = _annex_b_declaration()
@@ -346,7 +350,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         decl.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     decl = _annex_b_declaration()
     with pytest.raises(ValueError, match="language"):
@@ -356,7 +360,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # More modes than the sheet has width for
 # --------------------------------------------------------------------------
-def test_more_modes_than_the_sheet_can_print_are_refused(tmp_path) -> None:
+def test_more_modes_than_the_sheet_can_print_are_refused(tmp_path: Path) -> None:
     """The mode columns divide the page width, with nothing bounding them.
 
     A declaration is free to carry as many operating modes as the machine
@@ -375,7 +379,7 @@ def test_more_modes_than_the_sheet_can_print_are_refused(tmp_path) -> None:
         declaration.report(str(out))
 
 
-def test_six_modes_still_print(tmp_path) -> None:
+def test_six_modes_still_print(tmp_path: Path) -> None:
     """Six is the widest that still holds a three-digit level per column."""
     modes = tuple(
         emission.OperatingModeDeclaration(f"Mode {i}", 88.0, 2.0) for i in range(6)

--- a/tests/emission/test_iso7849_report.py
+++ b/tests/emission/test_iso7849_report.py
@@ -18,12 +18,17 @@ contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
-from phonometry.emission import sound_power_from_vibration
+from phonometry.emission import VibrationSoundPowerResult, sound_power_from_vibration
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Standard octave-band A-weighting corrections Ck (dB), IEC 61672 / ISO 3744
 # Annex E Table E.2, at the example band centres.
@@ -49,14 +54,14 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _engineering_result():
+def _engineering_result() -> VibrationSoundPowerResult:
     """A Part 2 (engineering) determination with a measured radiation factor."""
     return sound_power_from_vibration(
         _LV, area=_AREA, radiation_factor=_EPS, frequencies=_FREQS
     )
 
 
-def _survey_result():
+def _survey_result() -> VibrationSoundPowerResult:
     """A Part 1 (survey) determination with the fixed radiation factor eps = 1."""
     return sound_power_from_vibration(_LV, area=_AREA, frequencies=_FREQS)
 
@@ -83,7 +88,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.sound_power_level_a == pytest.approx(_oracle_lwa(_EPS), abs=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the hand-derived LWA and a couple of band LW values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -116,7 +121,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "1.60" in text
 
 
-def test_survey_part1_basis_and_method(tmp_path) -> None:
+def test_survey_part1_basis_and_method(tmp_path: Path) -> None:
     """The survey method (eps = 1) names Part 1 and the upper-limit method."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -134,7 +139,7 @@ def test_survey_part1_basis_and_method(tmp_path) -> None:
     assert f"{lw[2]:.1f}" in text
 
 
-def test_broadband_result_has_no_a_weighted_claim(tmp_path) -> None:
+def test_broadband_result_has_no_a_weighted_claim(tmp_path: Path) -> None:
     """A broadband result (no frequencies) cannot be A-weighted, so no LWA."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -156,7 +161,7 @@ def test_broadband_result_has_no_a_weighted_claim(tmp_path) -> None:
     assert "declared limit" in text
 
 
-def test_third_octave_labels_and_grouping(tmp_path) -> None:
+def test_third_octave_labels_and_grouping(tmp_path: Path) -> None:
     """A one-third-octave set is labelled by nominal centres and captioned."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -176,7 +181,7 @@ def test_third_octave_labels_and_grouping(tmp_path) -> None:
 # --- verbose (radiation-factor column) ----------------------------------------
 
 
-def test_verbose_adds_radiation_factor_column(tmp_path) -> None:
+def test_verbose_adds_radiation_factor_column(tmp_path: Path) -> None:
     """verbose=True adds the radiation factor epsilon column."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -197,7 +202,9 @@ def test_verbose_adds_radiation_factor_column(tmp_path) -> None:
     ("limit", "verdict"),
     [(95.0, "PASS"), (80.0, "FAIL")],
 )
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -214,7 +221,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
 # --- metadata header ----------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, environment and identity fields."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -242,7 +249,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the sound-power vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -262,7 +269,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _engineering_result()
     out = str(tmp_path / "x.pdf")
@@ -270,7 +277,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _engineering_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/emission/test_iso9614_3_report.py
+++ b/tests/emission/test_iso9614_3_report.py
@@ -23,17 +23,25 @@ engines, languages and band counts) complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.emission import (
+    PrecisionCriteria,
+    PrecisionFieldIndicators,
+    PrecisionIntensityResult,
     SoundPowerWarning,
     precision_field_indicators,
     precision_qualification,
     sound_power_intensity_precision,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Standard one-third-octave A-weighting corrections Ck (dB), IEC 61672 /
 # ISO 3744 Annex E Table E.1, at the example band centres.
@@ -120,7 +128,9 @@ def _row(label: str, *cells: str) -> str:
     return " ".join((label, *cells))
 
 
-def _determination(intensity: np.ndarray = _INTENSITY, freqs: np.ndarray = _FREQS):
+def _determination(
+    intensity: np.ndarray = _INTENSITY, freqs: np.ndarray = _FREQS
+) -> PrecisionIntensityResult:
     """A uniform-field precision determination, so LW and LW0 are derivable."""
     scan = np.tile(intensity, (_N_SEG, 1))
     return sound_power_intensity_precision(
@@ -132,7 +142,9 @@ def _determination(intensity: np.ndarray = _INTENSITY, freqs: np.ndarray = _FREQ
     )
 
 
-def _qualification(margin: np.ndarray, freqs: np.ndarray = _FREQS):
+def _qualification(
+    margin: np.ndarray, freqs: np.ndarray = _FREQS
+) -> tuple[PrecisionFieldIndicators, PrecisionCriteria]:
     """Annex B indicators and Annex C criteria for the uniform-field scan.
 
     ``margin`` is the per-band amount by which the segment pressure levels
@@ -191,7 +203,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.sound_power_level_a == pytest.approx(_oracle_lwa(), abs=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the hand-derived LWA, band LW, LW0 and Table 1 U."""
     res = _determination()
     out = tmp_path / "iso9614_3.pdf"
@@ -229,7 +241,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert f"Measurement surface S = {_SURFACE:.2f} m2" in text
 
 
-def test_uncertainty_column_follows_table_1(tmp_path) -> None:
+def test_uncertainty_column_follows_table_1(tmp_path: Path) -> None:
     """Every band prints U = 2*sigma_R0 from its ISO 9614-3 Table 1 row."""
     # Six consecutive one-third-octave bands crossing all three Table 1 tiers:
     # 160 Hz -> 2*2,0 = 4,0 dB; 200 to 315 Hz -> 2*1,5 = 3,0 dB; 400 and
@@ -255,7 +267,7 @@ def test_uncertainty_column_follows_table_1(tmp_path) -> None:
     assert "Table 1 standard deviation of reproducibility" in text
 
 
-def test_octave_bands_have_no_tabulated_uncertainty(tmp_path) -> None:
+def test_octave_bands_have_no_tabulated_uncertainty(tmp_path: Path) -> None:
     """Table 1 tabulates one-third-octave bands; an octave set prints an em dash."""
     freqs = np.array([250, 500, 1000, 2000], dtype=float)
     intensity = _INTENSITY[:4]
@@ -275,7 +287,7 @@ def test_octave_bands_have_no_tabulated_uncertainty(tmp_path) -> None:
 # --- Annex B tabulation (verbose) ---------------------------------------------
 
 
-def test_verbose_tabulates_annex_b_indicators(tmp_path) -> None:
+def test_verbose_tabulates_annex_b_indicators(tmp_path: Path) -> None:
     """verbose=True tabulates the four Annex B indicators and the qualification."""
     res = _determination()
     indicators, criteria = _qualification(np.full(_FREQS.size, 2.0))
@@ -310,7 +322,7 @@ def test_verbose_tabulates_annex_b_indicators(tmp_path) -> None:
         )
 
 
-def test_qualification_cell_separates_the_rejected_band(tmp_path) -> None:
+def test_qualification_cell_separates_the_rejected_band(tmp_path: Path) -> None:
     """The verbose cell reads no for the band Annex C rejects, yes for the rest."""
     res = _determination()
     indicators, criteria = _qualification(np.array([8.0, 2.0, 2.0, 2.0, 2.0]))
@@ -355,7 +367,7 @@ def test_qualification_cell_separates_the_rejected_band(tmp_path) -> None:
 # --- clause 10 f) 2) omission -------------------------------------------------
 
 
-def test_failing_band_is_omitted_and_named(tmp_path) -> None:
+def test_failing_band_is_omitted_and_named(tmp_path: Path) -> None:
     """A band failing criterion 2 leaves LWA and is named with its criterion."""
     res = _determination()
     # A 200 Hz pressure-intensity indicator of 8 dB exceeds the probe's
@@ -388,7 +400,7 @@ def test_failing_band_is_omitted_and_named(tmp_path) -> None:
     assert f"δpI0 = {_RESIDUAL_INDEX:.1f} dB" in text
 
 
-def test_not_applicable_band_named_with_clause_9_2(tmp_path) -> None:
+def test_not_applicable_band_named_with_clause_9_2(tmp_path: Path) -> None:
     """A net-negative band prints an em dash and is named under clause 9.2."""
     scan = np.tile(_INTENSITY, (_N_SEG, 1)).copy()
     # Drive the 250 Hz band net-negative (more energy flowing in than out).
@@ -411,7 +423,7 @@ def test_not_applicable_band_named_with_clause_9_2(tmp_path) -> None:
     assert f"{_oracle_lw()[2]:.1f}" in text
 
 
-def test_without_criteria_the_fiche_says_so(tmp_path) -> None:
+def test_without_criteria_the_fiche_says_so(tmp_path: Path) -> None:
     """No Annex C qualification: the result's own LWA, and the strip says why."""
     res = _determination()
     out = tmp_path / "unqualified.pdf"
@@ -421,7 +433,7 @@ def test_without_criteria_the_fiche_says_so(tmp_path) -> None:
     assert f"Sound power level LWA = {_oracle_lwa():.1f} dB(A) re 1 pW" in text
 
 
-def test_clause_9_2_band_is_named_without_any_qualification(tmp_path) -> None:
+def test_clause_9_2_band_is_named_without_any_qualification(tmp_path: Path) -> None:
     """A not-applicable band is named even when no Annex C data was supplied.
 
     The omission statement is the standard's, not the qualification's: a band
@@ -445,7 +457,7 @@ def test_clause_9_2_band_is_named_without_any_qualification(tmp_path) -> None:
     assert "Bands omitted from LWA: 250 Hz (clause 9.2)" in text
 
 
-def test_qualified_set_states_that_nothing_is_omitted(tmp_path) -> None:
+def test_qualified_set_states_that_nothing_is_omitted(tmp_path: Path) -> None:
     """Every band qualifying is stated too, not left to silence."""
     res = _determination()
     indicators, criteria = _qualification(np.full(_FREQS.size, 2.0))
@@ -458,7 +470,7 @@ def test_qualified_set_states_that_nothing_is_omitted(tmp_path) -> None:
 # --- the wide (one-third-octave) band set -------------------------------------
 
 
-def test_wide_band_set_is_paired_onto_one_page(tmp_path) -> None:
+def test_wide_band_set_is_paired_onto_one_page(tmp_path: Path) -> None:
     """Sixteen one-third-octave bands print in two column groups, on one page."""
     freqs = np.array(list(_CK_THIRD), dtype=float)
     intensity = np.full(freqs.size, 2.0e-5)
@@ -478,7 +490,9 @@ def test_wide_band_set_is_paired_onto_one_page(tmp_path) -> None:
 
 
 @pytest.mark.parametrize(("limit", "verdict"), [(120.0, "PASS"), (60.0, "FAIL")])
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     res = _determination()
     out = tmp_path / f"verdict_{limit}.pdf"
@@ -488,7 +502,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
     assert "declared limit" in text
 
 
-def test_verdict_follows_the_boxed_level(tmp_path) -> None:
+def test_verdict_follows_the_boxed_level(tmp_path: Path) -> None:
     """The verdict compares the qualified-band LWA the fiche boxes, not the raw one."""
     res = _determination()
     indicators, criteria = _qualification(np.array([8.0, 2.0, 2.0, 2.0, 2.0]))
@@ -513,7 +527,7 @@ def test_verdict_follows_the_boxed_level(tmp_path) -> None:
 # --- metadata header ----------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, environment and identity fields."""
     res = _determination()
     metadata = ReportMetadata(
@@ -544,7 +558,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
+def test_spanish_fiche_translates_every_fixed_string(tmp_path: Path) -> None:
     """No English template survives into the Spanish precision fiche.
 
     ``_i18n.t`` falls back to the English text when a key is missing, so a typo
@@ -597,7 +611,7 @@ def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_incomplete_qualification_is_stated_as_such(tmp_path) -> None:
+def test_incomplete_qualification_is_stated_as_such(tmp_path: Path) -> None:
     """Criteria that could not be closed are not the same as criteria withheld.
 
     ``precision_qualification`` leaves ``qualified`` unset when criterion 1 or
@@ -619,7 +633,7 @@ def test_incomplete_qualification_is_stated_as_such(tmp_path) -> None:
     assert "The Annex C qualification was not supplied" not in text
 
 
-def test_criterion_5_is_not_reported_as_a_failure(tmp_path) -> None:
+def test_criterion_5_is_not_reported_as_a_failure(tmp_path: Path) -> None:
     """A band satisfying criterion 4 is never named against criterion 5.
 
     Clause 10 f) 2) rejects a band on criteria 1 to 4, or on criteria 1 to 3
@@ -653,7 +667,7 @@ def test_criterion_5_is_not_reported_as_a_failure(tmp_path) -> None:
     assert "criteria 2, 5" not in text
 
 
-def test_frequencies_none_falls_back_to_the_band_total(tmp_path) -> None:
+def test_frequencies_none_falls_back_to_the_band_total(tmp_path: Path) -> None:
     """Without band frequencies there is no A-weighting, and the box says so."""
     scan = np.tile(_INTENSITY, (_N_SEG, 1))
     res = sound_power_intensity_precision(
@@ -672,7 +686,7 @@ def test_frequencies_none_falls_back_to_the_band_total(tmp_path) -> None:
     assert "dB(A)" not in text
 
 
-def test_odd_band_count_pairs_with_a_blank_row(tmp_path) -> None:
+def test_odd_band_count_pairs_with_a_blank_row(tmp_path: Path) -> None:
     """An odd wide band set pairs cleanly, the last right-hand row left empty."""
     freqs = np.array(list(_CK_THIRD)[:9], dtype=float)
     intensity = np.full(freqs.size, 2.0e-5)
@@ -695,7 +709,7 @@ def test_odd_band_count_pairs_with_a_blank_row(tmp_path) -> None:
         )
 
 
-def test_per_band_residual_index_is_ranged_in_the_strip(tmp_path) -> None:
+def test_per_band_residual_index_is_ranged_in_the_strip(tmp_path: Path) -> None:
     """A residual index measured band by band is stated as its range."""
     res = _determination()
     residual = np.array([12.0, 13.0, 14.0, 15.0, 16.0])
@@ -706,21 +720,21 @@ def test_per_band_residual_index_is_ranged_in_the_strip(tmp_path) -> None:
     assert "dynamic capability Ld = 2.0 to 6.0 dB" in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _determination()
     with pytest.raises(ValueError, match="engine"):
         res.report(str(tmp_path / "x.pdf"), engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _determination()
     with pytest.raises(ValueError, match="language"):
         res.report(str(tmp_path / "bad.pdf"), language="xx")
 
 
-def test_indicators_over_other_bands_rejected(tmp_path) -> None:
+def test_indicators_over_other_bands_rejected(tmp_path: Path) -> None:
     """Indicators measured over a different band set are refused, not printed."""
     res = _determination()
     other, _criteria = _qualification(np.full(3, 2.0), _FREQS[:3])
@@ -728,7 +742,7 @@ def test_indicators_over_other_bands_rejected(tmp_path) -> None:
         res.report(str(tmp_path / "mismatch.pdf"), indicators=other)
 
 
-def test_criteria_over_other_bands_rejected(tmp_path) -> None:
+def test_criteria_over_other_bands_rejected(tmp_path: Path) -> None:
     """Criteria evaluated over a different band set are refused too."""
     res = _determination()
     _indicators, other = _qualification(np.full(3, 2.0), _FREQS[:3])
@@ -736,7 +750,7 @@ def test_criteria_over_other_bands_rejected(tmp_path) -> None:
         res.report(str(tmp_path / "mismatch.pdf"), criteria=other)
 
 
-def test_residual_index_over_other_bands_rejected(tmp_path) -> None:
+def test_residual_index_over_other_bands_rejected(tmp_path: Path) -> None:
     """A per-band residual index must span the determination's bands."""
     res = _determination()
     with pytest.raises(ValueError, match="residual_index"):

--- a/tests/emission/test_iso9614_report.py
+++ b/tests/emission/test_iso9614_report.py
@@ -18,12 +18,21 @@ the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
-from phonometry.emission import SoundPowerWarning, sound_power_intensity
+from phonometry.emission import (
+    SoundPowerIntensityResult,
+    SoundPowerWarning,
+    sound_power_intensity,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Standard octave-band A-weighting corrections Ck (dB), IEC 61672 / ISO 3744
 # Annex E Table E.2, at the example band centres.
@@ -45,7 +54,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _uniform_result(grade: str = "engineering"):
+def _uniform_result(grade: str = "engineering") -> SoundPowerIntensityResult:
     """A uniform-field determination, so LW and LWA are hand-derivable.
 
     The six segments share one intensity spectrum and the two sweeps coincide
@@ -87,7 +96,7 @@ def test_hand_oracle_matches_library() -> None:
     assert res.sound_power_level_a == pytest.approx(_oracle_lwa(), abs=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the hand-derived LWA and a couple of band LW values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -118,7 +127,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "3.00" in text
 
 
-def test_third_octave_labels_and_grouping(tmp_path) -> None:
+def test_third_octave_labels_and_grouping(tmp_path: Path) -> None:
     """A one-third-octave set is labelled by nominal centres and captioned."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -140,7 +149,7 @@ def test_third_octave_labels_and_grouping(tmp_path) -> None:
 # --- verbose (field-indicator columns) ----------------------------------------
 
 
-def test_verbose_adds_indicator_columns(tmp_path) -> None:
+def test_verbose_adds_indicator_columns(tmp_path: Path) -> None:
     """verbose=True adds the FpI / F+/- indicators and the per-band grade."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -158,7 +167,7 @@ def test_verbose_adds_indicator_columns(tmp_path) -> None:
 # --- clause 10.6 b omission surfaced in the basis strip ------------------------
 
 
-def test_omitted_bands_listed_in_basis_strip(tmp_path) -> None:
+def test_omitted_bands_listed_in_basis_strip(tmp_path: Path) -> None:
     """A band omitted from LWA per clause 10.6 b is named in the basis strip."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -194,7 +203,9 @@ def test_omitted_bands_listed_in_basis_strip(tmp_path) -> None:
     ("limit", "verdict"),
     [(120.0, "PASS"), (80.0, "FAIL")],
 )
-def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_limit(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared limit yields a PASS/FAIL verdict (lower is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -210,7 +221,7 @@ def test_verdict_against_declared_limit(tmp_path, limit: float, verdict: str) ->
 # --- negative (net-inflow) band -----------------------------------------------
 
 
-def test_negative_band_reported_as_dash(tmp_path) -> None:
+def test_negative_band_reported_as_dash(tmp_path: Path) -> None:
     """A net-negative band is not determinable and prints an em dash, not a level."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -233,7 +244,7 @@ def test_negative_band_reported_as_dash(tmp_path) -> None:
 # --- metadata header ----------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the source, environment and identity fields."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -261,7 +272,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the sound-power vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -281,7 +292,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "x.pdf")
@@ -289,7 +300,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -31,7 +31,14 @@ def _c2(theta: float, ps: float) -> float:
     return -10.0 * np.log10(ps / _PS0) + 15.0 * np.log10((273.15 + theta) / _THETA1)
 
 
-def _bracket(t60, volume, surface, freq, theta, ps):
+def _bracket(
+    t60: np.ndarray,
+    volume: float,
+    surface: float,
+    freq: np.ndarray,
+    theta: float,
+    ps: float,
+) -> np.ndarray:
     """Independent re-implementation of the Eq. (20) bracket, for inversion."""
     c = 20.05 * np.sqrt(273.0 + theta)
     a = (55.26 / c) * (volume / np.asarray(t60, dtype=float))

--- a/tests/materials/absorbers/test_airflow_resistance.py
+++ b/tests/materials/absorbers/test_airflow_resistance.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -45,6 +46,9 @@ from phonometry.materials.absorbers.airflow_resistance import (
     static_airflow_resistance,
     thermal_boundary_layer_thickness,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # --- 3.1-3.4: quantity chain and units --------------------------------------
 
@@ -103,7 +107,7 @@ def test_specific_resistance_requires_exactly_one_route() -> None:
         ),
     ],
 )
-def test_invalid_inputs_raise(call, message: str) -> None:  # type: ignore[no-untyped-def]
+def test_invalid_inputs_raise(call: Callable[[], object], message: str) -> None:
     with pytest.raises(ValueError, match=message):
         call()
 
@@ -173,7 +177,7 @@ def test_static_velocity_above_limit_warns() -> None:
         ),
     ],
 )
-def test_static_invalid_inputs_raise(call, message: str) -> None:  # type: ignore[no-untyped-def]
+def test_static_invalid_inputs_raise(call: Callable[[], object], message: str) -> None:
     with pytest.raises(ValueError, match=message):
         call()
 

--- a/tests/materials/absorbers/test_biot.py
+++ b/tests/materials/absorbers/test_biot.py
@@ -103,7 +103,7 @@ def _glass_wool_medium(frequency: np.ndarray) -> materials.PorousMediumResult:
     )
 
 
-def _glass_wool_waves(frequency: np.ndarray):
+def _glass_wool_waves(frequency: np.ndarray) -> materials.BiotWavesResult:
     return materials.biot_waves(
         _glass_wool_medium(frequency),
         porosity=TABLE_6_1_POROSITY,
@@ -520,7 +520,7 @@ def test_transfer_matrix_composes() -> None:
 
 
 def _reference_field(
-    waves, x3: float, k_t: float, amplitudes: np.ndarray
+    waves: materials.BiotWavesResult, x3: float, k_t: float, amplitudes: np.ndarray
 ) -> np.ndarray:
     """``[v1s, v3s, v3f, s33s, s13s, s33f]`` rebuilt from the potentials.
 
@@ -552,7 +552,7 @@ def _reference_field(
     k13, k23, k33 = (np.sqrt(d**2 - k_t**2) for d in (d1, d2, d3))
     a1p, a1m, a2p, a2m, a3p, a3m = amplitudes
 
-    def potential(ap, am, kx):
+    def potential(ap: complex, am: complex, kx: complex) -> tuple[complex, complex]:
         value = ap * np.cos(kx * x3) - 1j * am * np.sin(kx * x3)
         slope = -kx * (ap * np.sin(kx * x3) + 1j * am * np.cos(kx * x3))
         return value, slope

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import dataclasses
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -41,12 +42,17 @@ from phonometry.materials import (
     two_microphone_impedance,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from phonometry.materials import ImpedanceTubeResult
+
 _TEMPERATURE_K = 293.15  # 20 degC
 _DIAMETER, _SPACING, _X1 = 0.100, 0.050, 0.100
 _FREQS = np.array([400, 500, 630, 800, 1000, 1250, 1600], dtype=float)
 
 
-def _result():
+def _result() -> ImpedanceTubeResult:
     c0 = float(speed_of_sound_iso(_TEMPERATURE_K))
     rho = float(air_density_iso(_TEMPERATURE_K, 101.0))
     rc = characteristic_impedance(rho, c0)
@@ -71,7 +77,7 @@ def _result():
     )
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: object) -> ReportMetadata:
     base = {
         "specimen": "Resistive facing over an 86 mm rigidly-backed air cavity",
         "client": "Acoustic Test Client Ltd.",
@@ -100,27 +106,27 @@ def _text(path: str) -> str:
     )
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "iso10534.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_report_with_metadata_one_page(tmp_path) -> None:
+def test_report_with_metadata_one_page(tmp_path: Path) -> None:
     out = tmp_path / "iso10534_meta.pdf"
     _result().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
@@ -132,7 +138,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
     "field", ["frequency", "absorption", "reflection", "normalized_impedance"]
 )
 def test_short_per_frequency_array_rejected(
-    field: str, verbose: bool, tmp_path
+    field: str, verbose: bool, tmp_path: Path
 ) -> None:
     """One short per-frequency array raises before the fiche is written.
 
@@ -152,7 +158,7 @@ def test_short_per_frequency_array_rejected(
     assert not out.exists()
 
 
-def test_displayed_absorption_matches_oracle(tmp_path) -> None:
+def test_displayed_absorption_matches_oracle(tmp_path: Path) -> None:
     """The fiche prints the closed-form alpha, band labels and geometry."""
     out = tmp_path / "iso10534.pdf"
     _result().report(str(out), metadata=_metadata())
@@ -168,7 +174,7 @@ def test_displayed_absorption_matches_oracle(tmp_path) -> None:
     assert re.search(r"Microphone spacing s\s*\[mm\]:\s*50\b", text)  # s = 50 mm
 
 
-def test_verbose_shows_reflection_column_one_page(tmp_path) -> None:
+def test_verbose_shows_reflection_column_one_page(tmp_path: Path) -> None:
     """verbose=True adds the |r| column and stays one page."""
     out = tmp_path / "iso10534_verbose.pdf"
     _result().report(str(out), metadata=_metadata(), verbose=True)
@@ -177,13 +183,13 @@ def test_verbose_shows_reflection_column_one_page(tmp_path) -> None:
     assert "0.45" in text  # |r|(500 Hz) = 1/sqrt(5)
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     out = tmp_path / "iso10534_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Panel <A> & <B> "edge"'))
     assert_one_page(str(out))
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     """Without metadata the header still shows the measured frequency range."""
     out = tmp_path / "iso10534_bare.pdf"
     _result().report(str(out))
@@ -191,7 +197,7 @@ def test_no_metadata_still_renders(tmp_path) -> None:
     assert "400 to 1600" in _text(str(out))
 
 
-def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_fiche_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "iso10534_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))
@@ -216,7 +222,7 @@ def test_metadata_rejects_invalid_geometry(field: str, value: float) -> None:
 # A table longer than the single page a fiche is
 # --------------------------------------------------------------------------
 @pytest.mark.parametrize("points", [38, 60], ids=["runs-on", "layout-error"])
-def test_a_table_longer_than_the_page_is_refused(tmp_path, points: int) -> None:
+def test_a_table_longer_than_the_page_is_refused(tmp_path: Path, points: int) -> None:
     """A fiche is one page, and nothing used to check that it came to one.
 
     Up to about forty rows the sheet quietly ran on, leaving page 1 with the

--- a/tests/materials/absorbers/test_iso11654_report.py
+++ b/tests/materials/absorbers/test_iso11654_report.py
@@ -10,6 +10,8 @@ and the requirement verdict renders. Pixel or layout content is never inspected.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -44,6 +46,9 @@ from phonometry.materials import (
     weighted_absorption_from_third_octave,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 # Fifteen one-third-octave alpha_s (200 Hz to 5000 Hz) whose octave means are
 # the Annex A.2 practical coefficients (0.35, 1.00, 0.65, 0.60, 0.55).
 _THIRD_OCTAVE_ALPHA_S = (
@@ -65,7 +70,7 @@ _THIRD_OCTAVE_ALPHA_S = (
 )
 
 
-def test_absorption_report_writes_pdf(tmp_path) -> None:
+def test_absorption_report_writes_pdf(tmp_path: Path) -> None:
     """A weighted absorption rating renders a PDF fiche."""
     result = weighted_absorption(_A1_ALPHA_P)
     out = tmp_path / "absorption.pdf"
@@ -74,7 +79,7 @@ def test_absorption_report_writes_pdf(tmp_path) -> None:
     assert_pdf(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = weighted_absorption(_A1_ALPHA_P)
     out = str(tmp_path / "x.pdf")
@@ -82,7 +87,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_fiche_reproduces_iso11654_annex_a1(tmp_path) -> None:
+def test_fiche_reproduces_iso11654_annex_a1(tmp_path: Path) -> None:
     """The fiche renders the ISO 11654 Annex A.1 example: alpha_w = 0.60, class C."""
     result = weighted_absorption(_A1_ALPHA_P)
     assert result.alpha_w == pytest.approx(_A1_ALPHA_W)
@@ -91,7 +96,7 @@ def test_fiche_reproduces_iso11654_annex_a1(tmp_path) -> None:
     assert_one_page(str(result.report(str(tmp_path / "a1.pdf"))))
 
 
-def test_fiche_reproduces_iso11654_annex_a2(tmp_path) -> None:
+def test_fiche_reproduces_iso11654_annex_a2(tmp_path: Path) -> None:
     """The fiche renders the Annex A.2 example: alpha_w = 0.60(M) shape indicator."""
     result = weighted_absorption(_A2_ALPHA_P)
     assert result.alpha_w == pytest.approx(_A2_ALPHA_W)
@@ -99,7 +104,7 @@ def test_fiche_reproduces_iso11654_annex_a2(tmp_path) -> None:
     assert_one_page(str(result.report(str(tmp_path / "a2.pdf"))))
 
 
-def test_third_octave_fiche_renders_and_round_trips(tmp_path) -> None:
+def test_third_octave_fiche_renders_and_round_trips(tmp_path: Path) -> None:
     """A rating built from one-third-octave alpha_s renders the full-table fiche.
 
     The retained alpha_s round-trips on the result, and the accredited
@@ -132,7 +137,7 @@ def test_third_octave_fiche_renders_and_round_trips(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_third_octave_fiche_with_metadata(tmp_path) -> None:
+def test_third_octave_fiche_with_metadata(tmp_path: Path) -> None:
     """The one-third-octave fiche renders one page with a full metadata header."""
     result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
     out = tmp_path / "third_octave_meta.pdf"
@@ -175,7 +180,7 @@ def test_third_octave_arrays_must_hold_three_bands_per_octave(bands: int) -> Non
         )
 
 
-def test_statement_writes_shape_indicator_without_space(tmp_path) -> None:
+def test_statement_writes_shape_indicator_without_space(tmp_path: Path) -> None:
     """The boxed rating is written ``0.60(M)``, the ISO 11654 5.3 style.
 
     The clause 5.3 example prints the shape indicator immediately after the
@@ -197,7 +202,7 @@ def test_statement_writes_shape_indicator_without_space(tmp_path) -> None:
     assert "5.3 NOTE" in text  # shape-indicator recommendation footnote
 
 
-def test_plain_rating_without_alpha_s_still_renders(tmp_path) -> None:
+def test_plain_rating_without_alpha_s_still_renders(tmp_path: Path) -> None:
     """A plain weighted_absorption result (alpha_s None) falls back and renders."""
     result = weighted_absorption(_A2_ALPHA_P)
     assert result.third_octave_alpha_s is None
@@ -206,7 +211,7 @@ def test_plain_rating_without_alpha_s_still_renders(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_verbose_renders_evaluation_table(tmp_path) -> None:
+def test_verbose_renders_evaluation_table(tmp_path: Path) -> None:
     """``verbose=True`` renders the ISO 11654 evaluation-column one-pager."""
     result = weighted_absorption(_A2_ALPHA_P)
     out = tmp_path / "verbose.pdf"
@@ -214,7 +219,7 @@ def test_verbose_renders_evaluation_table(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def _full_metadata(**overrides) -> ReportMetadata:
+def _full_metadata(**overrides: object) -> ReportMetadata:
     base = {
         "specimen": "50 mm porous absorber over a 100 mm air gap",
         "client": "Acoustic Test Client Ltd.",
@@ -235,7 +240,7 @@ def _full_metadata(**overrides) -> ReportMetadata:
     return ReportMetadata(**base)
 
 
-def test_full_metadata_renders_one_page(tmp_path) -> None:
+def test_full_metadata_renders_one_page(tmp_path: Path) -> None:
     """A full ReportMetadata renders a one-page accredited absorption fiche."""
     result = weighted_absorption(_A2_ALPHA_P)
     out = tmp_path / "meta.pdf"
@@ -243,7 +248,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
+def test_requirement_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS and a FAIL alpha_w requirement both render a one-page fiche."""
     result = weighted_absorption(_A1_ALPHA_P)  # alpha_w = 0.60
     passing = tmp_path / "pass.pdf"
@@ -254,7 +259,7 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     assert_one_page(str(failing))
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     result = weighted_absorption(_A1_ALPHA_P)
     md = ReportMetadata(
@@ -277,7 +282,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -295,7 +300,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
     with pytest.raises(ValueError, match="language"):

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -13,6 +13,7 @@ Pixel or layout content is never inspected.
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -23,6 +24,11 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.materials import measure_sound_absorption
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from phonometry.materials import SoundAbsorptionMeasurement
 
 # The committed clean-room example (V = 200 m3, S = 10.8 m2, 20 degC -> c = 343,
 # m = 0); alpha_s(500 Hz) = 0.33 and alpha_s(1000 Hz) = 0.61 by Eq. (8)/(9).
@@ -95,7 +101,7 @@ _T2 = np.array(
 )
 
 
-def _result():
+def _result() -> SoundAbsorptionMeasurement:
     return measure_sound_absorption(
         _FREQS,
         _T1,
@@ -107,7 +113,7 @@ def _result():
     )
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: object) -> ReportMetadata:
     base = {
         "specimen": "50 mm porous absorber over a 100 mm air gap",
         "client": "Acoustic Test Client Ltd.",
@@ -133,34 +139,34 @@ def _text(path: str) -> str:
     )
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "iso354.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_report_with_metadata_one_page(tmp_path) -> None:
+def test_report_with_metadata_one_page(tmp_path: Path) -> None:
     out = tmp_path / "iso354_meta.pdf"
     _result().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(out, language="xx")
 
 
-def test_displayed_alpha_s_matches_oracle(tmp_path) -> None:
+def test_displayed_alpha_s_matches_oracle(tmp_path: Path) -> None:
     """The fiche prints the closed-form alpha_s and the band labels."""
     out = tmp_path / "iso354.pdf"
     _result().report(str(out), metadata=_metadata())
@@ -172,7 +178,7 @@ def test_displayed_alpha_s_matches_oracle(tmp_path) -> None:
     assert "343" in text  # speed of sound c (Eq. (6))
 
 
-def test_verbose_shows_areas_and_times_one_page(tmp_path) -> None:
+def test_verbose_shows_areas_and_times_one_page(tmp_path: Path) -> None:
     """verbose=True adds the T1/T2/A1/A2 columns and stays one page."""
     out = tmp_path / "iso354_verbose.pdf"
     _result().report(str(out), metadata=_metadata(), verbose=True)
@@ -205,13 +211,13 @@ def test_a_short_band_column_is_refused(field: str) -> None:
         replace(result, **{field: one_short})
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     out = tmp_path / "iso354_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Panel <A> & <B> "edge"'))
     assert_one_page(str(out))
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     """Without metadata the body still shows the result's physical conditions."""
     out = tmp_path / "iso354_bare.pdf"
     _result().report(str(out))
@@ -219,7 +225,7 @@ def test_no_metadata_still_renders(tmp_path) -> None:
     assert "343" in _text(str(out))  # speed of sound from the result
 
 
-def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_fiche_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "iso354_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))

--- a/tests/materials/absorbers/test_iso9053_report.py
+++ b/tests/materials/absorbers/test_iso9053_report.py
@@ -15,6 +15,7 @@ is never inspected.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -27,6 +28,9 @@ from phonometry import (
     ReportMetadata,
     materials,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # The committed clean-room example: a 50 mm porous absorber in a 100 mm diameter
 # cell (A = pi*0.05^2 m2), stepped to 12 mm/s (below the 15 mm/s clause-7.5
@@ -45,13 +49,13 @@ _R = _RS / _AREA  # ~2062645 Pa*s/m^3
 _SIGMA = _RS / _THICKNESS  # 324000 Pa*s/m^2
 
 
-def _result():
+def _result() -> materials.StaticAirflowResult:
     u = np.array([0.5, 1.0, 2.0, 4.0, 8.0, 12.0]) * 1e-3
     dp = _A_COEFF * u + _B_COEFF * u**2
     return materials.static_airflow_resistance(u, dp, area=_AREA, thickness=_THICKNESS)
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: object) -> ReportMetadata:
     base = {
         "specimen": "50 mm porous absorber (open-cell)",
         "client": "Acoustic Test Client Ltd.",
@@ -82,14 +86,14 @@ def _text(path: str) -> str:
     return _raw_text(path).replace("\n", " ")
 
 
-def test_writes_one_page_pdf(tmp_path) -> None:
+def test_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "airflow.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_displayed_values_match_oracle(tmp_path) -> None:
+def test_displayed_values_match_oracle(tmp_path: Path) -> None:
     """The fiche prints R_s (boxed), R, sigma and the evaluation velocity.
 
     The oracle is derived from the standard's clause 7.5 procedure, independent
@@ -113,7 +117,7 @@ def test_displayed_values_match_oracle(tmp_path) -> None:
     assert "Acoustic Test Client Ltd." in text  # metadata
 
 
-def test_metadata_and_fit_rows_appear(tmp_path) -> None:
+def test_metadata_and_fit_rows_appear(tmp_path: Path) -> None:
     """The specimen thickness and the through-origin fit coefficients appear."""
     out = tmp_path / "airflow.pdf"
     _result().report(str(out), metadata=_metadata())
@@ -125,14 +129,14 @@ def test_metadata_and_fit_rows_appear(tmp_path) -> None:
     assert "400000" in text  # quadratic coefficient b
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     out = tmp_path / "airflow_bare.pdf"
     _result().report(str(out))
     assert_one_page(str(out))
     assert "ISO 9053-1:2018" in _text(str(out))  # standard-basis line
 
 
-def test_no_thickness_omits_resistivity(tmp_path) -> None:
+def test_no_thickness_omits_resistivity(tmp_path: Path) -> None:
     """Without a thickness the fiche prints no airflow-resistivity row/term."""
     u = np.array([0.5, 1.0, 2.0, 4.0, 8.0, 12.0]) * 1e-3
     dp = _A_COEFF * u + _B_COEFF * u**2
@@ -143,27 +147,27 @@ def test_no_thickness_omits_resistivity(tmp_path) -> None:
     assert "Airflow resistivity" not in _text(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(out, language="xx")
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     out = tmp_path / "airflow_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Foam <A> & <B> "edge"'))
     assert_one_page(str(out))
 
 
-def test_spanish_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "airflow_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))

--- a/tests/materials/diffusers/test_iso17497_report.py
+++ b/tests/materials/diffusers/test_iso17497_report.py
@@ -13,6 +13,8 @@ decimal comma. Pixel or layout content is never inspected.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -26,6 +28,9 @@ from phonometry import (
     ReportMetadata,
     materials,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # The committed clean-room example: V = 200 m3, S = 10 m2, 20 degC (c = 343.2),
 # m = 0, symmetrical base plate (T1 = T3). See scripts/generate_reports.py.
@@ -77,7 +82,7 @@ _T1 = np.array(
 _ANGLES = np.arange(-90.0, 90.5, 10.0)
 
 
-def _scattering():
+def _scattering() -> materials.ScatteringResult:
     volume, area, c = 200.0, 10.0, 343.2
     t2 = _T1 * 0.90
     t4 = t2 * (1.0 - np.linspace(0.02, 0.28, _FREQS.size))
@@ -93,14 +98,16 @@ def _scattering():
 _SOURCES = np.array([0.0, 30.0, -30.0, 60.0, -60.0])
 
 
-def _polar_energy(angles, width, peak, specular=0.0):
+def _polar_energy(
+    angles: np.ndarray, width: float, peak: float, specular: float = 0.0
+) -> np.ndarray:
     return (
         10.0 * np.log10(1.0 + peak * np.exp(-(((angles - specular) / width) ** 2)))
         + 60.0
     )
 
 
-def _diffusion_spectrum():
+def _diffusion_spectrum() -> materials.DiffusionSpectrum:
     """The committed random-incidence spectrum: source-averaged per band (8.4)."""
     widths = np.linspace(15.0, 70.0, _FREQS.size)
     peaks = np.linspace(30.0, 3.0, _FREQS.size)
@@ -126,7 +133,7 @@ def _diffusion_spectrum():
     return materials.diffusion_spectrum(_FREQS, d, normalized=d_n)
 
 
-def _polar():
+def _polar() -> materials.DiffusionResult:
     band = int(np.argmin(np.abs(_FREQS - 1000.0)))
     widths = np.linspace(15.0, 70.0, _FREQS.size)
     peaks = np.linspace(30.0, 3.0, _FREQS.size)
@@ -135,7 +142,7 @@ def _polar():
     )
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: object) -> ReportMetadata:
     base = {
         "specimen": "Quadratic-residue diffuser (N = 7)",
         "client": "Acoustic Test Client Ltd.",
@@ -166,14 +173,14 @@ def _text(path: str) -> str:
 
 
 # --- ISO 17497-1 scattering ------------------------------------------------
-def test_scattering_writes_one_page_pdf(tmp_path) -> None:
+def test_scattering_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "scat.pdf"
     returned = _scattering().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_scattering_displayed_values_match_oracle(tmp_path) -> None:
+def test_scattering_displayed_values_match_oracle(tmp_path: Path) -> None:
     """The fiche prints the closed-form s (Eq. (5)) and the band labels."""
     out = tmp_path / "scat.pdf"
     _scattering().report(str(out), metadata=_metadata())
@@ -188,28 +195,28 @@ def test_scattering_displayed_values_match_oracle(tmp_path) -> None:
     assert "Room volume" in text
 
 
-def test_scattering_verbose_shows_alpha_spec_one_page(tmp_path) -> None:
+def test_scattering_verbose_shows_alpha_spec_one_page(tmp_path: Path) -> None:
     out = tmp_path / "scat_v.pdf"
     _scattering().report(str(out), metadata=_metadata(), verbose=True)
     assert_one_page(str(out))
     assert "0.13" in _text(str(out))  # alpha_spec(500 Hz) = 0.131 -> 0.13
 
 
-def test_scattering_unknown_engine_rejected(tmp_path) -> None:
+def test_scattering_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _scattering()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_scattering_unknown_language_rejected(tmp_path) -> None:
+def test_scattering_unknown_language_rejected(tmp_path: Path) -> None:
     result = _scattering()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(out, language="xx")
 
 
-def test_scattering_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_scattering_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     out = tmp_path / "scat_xml.pdf"
     _scattering().report(
         str(out), metadata=_metadata(specimen='Panel <A> & <B> "edge"')
@@ -217,21 +224,21 @@ def test_scattering_metadata_xml_specials_do_not_break(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_scattering_no_metadata_still_renders(tmp_path) -> None:
+def test_scattering_no_metadata_still_renders(tmp_path: Path) -> None:
     out = tmp_path / "scat_bare.pdf"
     _scattering().report(str(out))
     assert_one_page(str(out))
     assert "100 to 5000" in _text(str(out))  # measured frequency range
 
 
-def test_scattering_spanish_uses_comma_decimal(tmp_path) -> None:
+def test_scattering_spanish_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "scat_es.pdf"
     _scattering().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))
     assert "0,45" in _text(str(out))  # Spanish decimal comma
 
 
-def test_scattering_short_random_incidence_rejected(tmp_path) -> None:
+def test_scattering_short_random_incidence_rejected(tmp_path: Path) -> None:
     """ScatteringResult is a frozen dataclass, so the fiche checks the lengths.
 
     A caller can hand-build one whose per-band arrays disagree; the alpha_s
@@ -248,7 +255,7 @@ def test_scattering_short_random_incidence_rejected(tmp_path) -> None:
     assert not out.exists()  # refused before the fiche is written
 
 
-def test_scattering_verbose_short_specular_rejected(tmp_path) -> None:
+def test_scattering_verbose_short_specular_rejected(tmp_path: Path) -> None:
     """The alpha_spec column is only tabulated when verbose, and so is its length."""
     result = _scattering()
     short = replace(result, specular=result.specular[:-1])
@@ -262,13 +269,13 @@ def test_scattering_verbose_short_specular_rejected(tmp_path) -> None:
 
 
 # --- ISO 17497-2 diffusion spectrum ---------------------------------------
-def test_diffusion_writes_one_page_pdf(tmp_path) -> None:
+def test_diffusion_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "diff.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_diffusion_displayed_values_match_oracle(tmp_path) -> None:
+def test_diffusion_displayed_values_match_oracle(tmp_path: Path) -> None:
     """The fiche prints the per-band random-incidence d (Clause 8.4)."""
     out = tmp_path / "diff.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata())
@@ -279,7 +286,7 @@ def test_diffusion_displayed_values_match_oracle(tmp_path) -> None:
     assert "4000" in text
 
 
-def test_diffusion_omits_room_fields(tmp_path) -> None:
+def test_diffusion_omits_room_fields(tmp_path: Path) -> None:
     """The free-field diffusion fiche must not show sample area / room volume."""
     out = tmp_path / "diff.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata())
@@ -288,28 +295,28 @@ def test_diffusion_omits_room_fields(tmp_path) -> None:
     assert "Room volume" not in text
 
 
-def test_diffusion_verbose_shows_normalized_one_page(tmp_path) -> None:
+def test_diffusion_verbose_shows_normalized_one_page(tmp_path: Path) -> None:
     out = tmp_path / "diff_v.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata(), verbose=True)
     assert_one_page(str(out))
     assert "0.35" in _text(str(out))  # d_n(500 Hz) = 0.347 -> 0.35
 
 
-def test_diffusion_unknown_engine_rejected(tmp_path) -> None:
+def test_diffusion_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _diffusion_spectrum()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_diffusion_spanish_uses_comma_decimal(tmp_path) -> None:
+def test_diffusion_spanish_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "diff_es.pdf"
     _diffusion_spectrum().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))
     assert "0,81" in _text(str(out))
 
 
-def test_diffusion_short_normalized_rejected(tmp_path) -> None:
+def test_diffusion_short_normalized_rejected(tmp_path: Path) -> None:
     """The normalised spectrum is optional, but a present one has to be full length.
 
     The figure draws d_n whenever it is there, so the length is checked for any
@@ -326,7 +333,7 @@ def test_diffusion_short_normalized_rejected(tmp_path) -> None:
     assert not out.exists()
 
 
-def test_diffusion_short_spectrum_rejected(tmp_path) -> None:
+def test_diffusion_short_spectrum_rejected(tmp_path: Path) -> None:
     """A hand-built spectrum whose d is short would cut the fiche table."""
     result = _diffusion_spectrum()
     short = replace(result, diffusion=result.diffusion[:-1])
@@ -340,13 +347,13 @@ def test_diffusion_short_spectrum_rejected(tmp_path) -> None:
 
 
 # --- ISO 17497-2 polar response -------------------------------------------
-def test_polar_writes_one_page_pdf(tmp_path) -> None:
+def test_polar_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "polar.pdf"
     _polar().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_polar_displays_coefficient_and_angles(tmp_path) -> None:
+def test_polar_displays_coefficient_and_angles(tmp_path: Path) -> None:
     out = tmp_path / "polar.pdf"
     _polar().report(str(out), metadata=_metadata())
     text = _text(str(out))
@@ -354,14 +361,14 @@ def test_polar_displays_coefficient_and_angles(tmp_path) -> None:
     assert "90.0" in text  # receiver angle label
 
 
-def test_polar_unknown_engine_rejected(tmp_path) -> None:
+def test_polar_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _polar()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_polar_short_levels_rejected(tmp_path) -> None:
+def test_polar_short_levels_rejected(tmp_path: Path) -> None:
     """One level per receiver angle: a short column is refused before rendering."""
     result = _polar()
     short = replace(result, levels=result.levels[:-1])
@@ -374,7 +381,7 @@ def test_polar_short_levels_rejected(tmp_path) -> None:
     assert not out.exists()
 
 
-def test_polar_spanish_uses_comma_decimal(tmp_path) -> None:
+def test_polar_spanish_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "polar_es.pdf"
     _polar().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))

--- a/tests/materials/resilient/test_iso9052_report.py
+++ b/tests/materials/resilient/test_iso9052_report.py
@@ -20,12 +20,17 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from typing import TYPE_CHECKING
+
 from report_assertions import assert_one_page
 
 from phonometry import (
     ReportMetadata,
     materials,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # The committed clean-room example: the standard 8 kg load plate over the
 # 0.04 m2 specimen (m't = 200 kg/m2, Clauses 5-6), a measured resonance of
@@ -40,7 +45,7 @@ _POROSITY = 0.9
 _RESISTIVITY = 50.0
 
 
-def _result():
+def _result() -> materials.DynamicStiffnessResult:
     return materials.floating_floor_resonance(
         resonant_frequency=_FR,
         total_mass_per_area=_MT,
@@ -51,8 +56,8 @@ def _result():
     )
 
 
-def _metadata(**overrides) -> ReportMetadata:
-    base = {
+def _metadata(**overrides: object) -> ReportMetadata:
+    base: dict[str, object] = {
         "specimen": "20 mm mineral-wool resilient layer",
         "client": "Acoustic Test Client Ltd.",
         "manufacturer": "Acoustics Works Inc.",
@@ -68,7 +73,7 @@ def _metadata(**overrides) -> ReportMetadata:
         "report_id": "PHN-2026-29052",
     }
     base.update(overrides)
-    return ReportMetadata(**base)
+    return ReportMetadata(**base)  # type: ignore[arg-type]
 
 
 def _raw_text(path: str) -> str:
@@ -87,14 +92,14 @@ def _text(path: str) -> str:
 _PRIME = "′"
 
 
-def test_writes_one_page_pdf(tmp_path) -> None:
+def test_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "dyn.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_displayed_values_match_oracle(tmp_path) -> None:
+def test_displayed_values_match_oracle(tmp_path: Path) -> None:
     """The fiche prints s't (Formula 4), s'a, s', fr and f0, and the metadata.
 
     The oracle is derived from the standard's formulae, independent of the
@@ -126,7 +131,7 @@ def test_displayed_values_match_oracle(tmp_path) -> None:
     assert "Acoustic Test Client Ltd." in text  # metadata
 
 
-def test_metadata_fields_appear(tmp_path) -> None:
+def test_metadata_fields_appear(tmp_path: Path) -> None:
     """The mass per area m't and the loaded thickness d appear in the header."""
     out = tmp_path / "dyn.pdf"
     _result().report(str(out), metadata=_metadata())
@@ -137,14 +142,14 @@ def test_metadata_fields_appear(tmp_path) -> None:
     assert re.search(rf"m{_PRIME} \[kg/m2\]\s+110\b", raw)  # supported-floor mass
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     out = tmp_path / "dyn_bare.pdf"
     _result().report(str(out))
     assert_one_page(str(out))
     assert "EN 29052-1" in _text(str(out))  # standard-basis line
 
 
-def test_high_resistivity_omits_gas_term(tmp_path) -> None:
+def test_high_resistivity_omits_gas_term(tmp_path: Path) -> None:
     """For r >= 100 kPa.s/m2 the installed s' equals s't and no s'a row shows."""
     out = tmp_path / "dyn_hi.pdf"
     result = materials.floating_floor_resonance(
@@ -157,27 +162,27 @@ def test_high_resistivity_omits_gas_term(tmp_path) -> None:
     assert "Enclosed-gas stiffness" not in _text(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(out, language="xx")
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     out = tmp_path / "dyn_xml.pdf"
     _result().report(str(out), metadata=_metadata(specimen='Layer <A> & <B> "edge"'))
     assert_one_page(str(out))
 
 
-def test_spanish_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_uses_comma_decimal(tmp_path: Path) -> None:
     out = tmp_path / "dyn_es.pdf"
     _result().report(str(out), metadata=_metadata(), language="es")
     assert_one_page(str(out))

--- a/tests/materials/test_geometry_plots.py
+++ b/tests/materials/test_geometry_plots.py
@@ -16,15 +16,22 @@ import pytest
 matplotlib = pytest.importorskip("matplotlib")
 matplotlib.use("Agg")
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 
 from phonometry import materials as m
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from matplotlib.axes import Axes
 
 FREQ = np.linspace(200.0, 2000.0, 32)
 
 
 @pytest.fixture(autouse=True)
-def _close_figures():
+def _close_figures() -> Iterator[None]:
     yield
     plt.close("all")
 
@@ -50,7 +57,7 @@ def _layers() -> list:
 # ---------------------------------------------------------------------------
 # Smoke: every renderer returns an equal-aspect Axes.
 # ---------------------------------------------------------------------------
-def _geometry_axes():
+def _geometry_axes() -> Iterator[Axes]:
     yield m.plot_absorber_stack(_layers())
     yield _resonator().plot()
     yield m.plot_slit_absorber_geometry(
@@ -265,7 +272,7 @@ def test_absorber_stack_validation() -> None:
 # ---------------------------------------------------------------------------
 # Spanish labels reach the artists.
 # ---------------------------------------------------------------------------
-def _texts(ax) -> str:
+def _texts(ax: Axes) -> str:
     return " ".join(t.get_text() for t in ax.texts) + " " + ax.get_title()
 
 

--- a/tests/materials/test_materials_plot_i18n.py
+++ b/tests/materials/test_materials_plot_i18n.py
@@ -10,6 +10,7 @@ clear :class:`ValueError`.
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -50,6 +51,9 @@ from phonometry.materials.surfaces.road_absorption import (
     InsituAbsorptionResult,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 _C0 = 343.0
 _RHO0 = 1.205
 _RC = _RHO0 * _C0
@@ -67,11 +71,11 @@ def _texts(ax_or_axes: object) -> str:
     return "\n".join(parts)
 
 
-def _weighted():
+def _weighted() -> materials.AbsorptionRatingResult:
     return weighted_absorption([0.35, 0.50, 0.65, 0.60, 0.55])
 
 
-def _measurement():
+def _measurement() -> materials.SoundAbsorptionMeasurement:
     freqs = np.array([250.0, 500.0, 1000.0, 2000.0, 4000.0])
     t1 = np.array([7.8, 7.4, 6.9, 5.8, 4.6])
     t2 = np.array([6.5, 4.2, 2.85, 2.5, 2.7])
@@ -80,28 +84,28 @@ def _measurement():
     )
 
 
-def _scattering():
+def _scattering() -> materials.ScatteringResult:
     return scattering_coefficient_spectrum(
         [250.0, 500.0, 1000.0], [0.2, 0.3, 0.5], [0.1, 0.1, 0.1]
     )
 
 
-def _diffusion():
+def _diffusion() -> materials.DiffusionResult:
     return directional_diffusion([-30.0, 0.0, 30.0], [70.0, 72.0, 69.0])
 
 
-def _insitu():
+def _insitu() -> InsituAbsorptionResult:
     return InsituAbsorptionResult(
         frequencies=np.array([250.0, 500.0, 1000.0, 2000.0]),
         absorption=np.array([0.2, 0.4, 0.6, 0.5]),
     )
 
 
-def _dynamic_stiffness():
+def _dynamic_stiffness() -> materials.DynamicStiffnessResult:
     return floating_floor_resonance(25.0, 200.0, 100.0)
 
 
-def _impedance_tube():
+def _impedance_tube() -> ImpedanceTubeResult:
     f = np.array([500.0, 1000.0, 1500.0])
     reflection = np.array([0.4 - 0.3j, 0.3 - 0.2j, 0.2 - 0.1j])
     absorption = 1.0 - np.abs(reflection) ** 2
@@ -115,26 +119,26 @@ def _impedance_tube():
     )
 
 
-def _static_airflow():
+def _static_airflow() -> materials.StaticAirflowResult:
     u = np.array([1.0e-3, 2.0e-3, 4.0e-3])
     dp = 12000.0 * u
     return static_airflow_resistance(u, dp, 0.008)
 
 
-def _uncertainty():
+def _uncertainty() -> materials.AbsorptionUncertaintyResult:
     freqs = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
     alpha = [0.15, 0.35, 0.55, 0.70, 0.80, 0.85]
     return materials.sound_absorption_coefficient_uncertainty(alpha, freqs)
 
 
-def _porous_medium():
+def _porous_medium() -> materials.PorousMediumResult:
     f = np.geomspace(100.0, 5000.0, 24)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         return delany_bazley(f, 20000.0, air_density=_RHO0, speed_of_sound=_C0)
 
 
-def _layered():
+def _layered() -> materials.LayeredAbsorberResult:
     f = np.geomspace(100.0, 5000.0, 24)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -142,7 +146,7 @@ def _layered():
         return layered_absorber(f, [PorousLayer(0.05, med)])
 
 
-def _diffuse():
+def _diffuse() -> materials.DiffuseFieldAbsorptionResult:
     f = np.geomspace(100.0, 5000.0, 24)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -174,7 +178,7 @@ _CASES = [
 @pytest.mark.parametrize(
     ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
 )
-def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
+def test_plot_spanish_labels(name: str, build: Callable[[], Any], spanish: str) -> None:
     result = build()
     ax = result.plot(language="es")
     assert spanish in _texts(ax)
@@ -184,7 +188,9 @@ def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
 @pytest.mark.parametrize(
     ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
 )
-def test_plot_rejects_unknown_language(name: str, build, spanish: str) -> None:
+def test_plot_rejects_unknown_language(
+    name: str, build: Callable[[], Any], spanish: str
+) -> None:
     result = build()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")

--- a/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
@@ -24,6 +24,7 @@ within ~1.5 phon.  Annex C.1 is therefore the tone oracle used.
 """
 
 import dataclasses
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -32,6 +33,10 @@ from phonometry import psychoacoustics
 from phonometry.psychoacoustics.loudness.moore_glasberg_time import _ALPHA_AL, _ALPHA_RL
 
 FS = 32000.0  # the Annex B/C sampling rate; keeps reference tones on FFT bins
+
+#: The memoised steady-tone analyser the ``mg_tone`` fixture returns; ``...``
+#: because ``Callable`` cannot spell its keyword-only ``field``/``presentation``.
+MgTone = Callable[..., psychoacoustics.MooreGlasbergTimeVaryingLoudness]
 
 
 def _tone(frequency: float, level_db: float, duration: float = 1.3) -> np.ndarray:
@@ -42,7 +47,7 @@ def _tone(frequency: float, level_db: float, duration: float = 1.3) -> np.ndarra
 
 
 @pytest.fixture(scope="module")
-def mg_tone():
+def mg_tone() -> MgTone:
     """Memoised steady-tone loudness, shared across the Annex C.1 checks.
 
     Several parametrised suites analyse the *same* (frequency, level, field,
@@ -79,7 +84,7 @@ def mg_tone():
 # --------------------------------------------------------------------------
 
 
-def test_anchor_1khz_40db_is_one_sone(mg_tone) -> None:
+def test_anchor_1khz_40db_is_one_sone(mg_tone: MgTone) -> None:
     """A 1 kHz tone at 40 dB SPL, binaural, free field -> 1.000 sone / 40 phon."""
     res = mg_tone(1000.0, 40.0)
     assert res.n_max == pytest.approx(1.0, abs=0.02)
@@ -125,7 +130,9 @@ _C1_1KHZ = [
 
 
 @pytest.mark.parametrize(("level_db", "sone", "phon"), _C1_1KHZ)
-def test_annex_c1_1khz_tone(mg_tone, level_db: float, sone: float, phon: float) -> None:
+def test_annex_c1_1khz_tone(
+    mg_tone: MgTone, level_db: float, sone: float, phon: float
+) -> None:
     """1 kHz tone 10-80 dB reaches the Annex C.1 peak long-term loudness."""
     res = mg_tone(1000.0, level_db)
     # Loudness level (phon) is the linear-in-perception comparison; within the
@@ -155,7 +162,7 @@ _C1_OTHER = [
     ("frequency", "level_db", "field", "presentation", "phon"), _C1_OTHER
 )
 def test_annex_c1_other_tones(
-    mg_tone,
+    mg_tone: MgTone,
     frequency: float,
     level_db: float,
     field: str,
@@ -185,7 +192,7 @@ _C1_SONE = [
     ("frequency", "field", "presentation", "level_db", "sone"), _C1_SONE
 )
 def test_annex_c1_sone_values(
-    mg_tone,
+    mg_tone: MgTone,
     frequency: float,
     field: str,
     presentation: str,
@@ -491,7 +498,7 @@ def test_invalid_inputs_raise() -> None:
         psychoacoustics.loudness_moore_glasberg_time(with_nan, FS)
 
 
-def test_level_curve_off_the_frame_axis_is_refused(mg_tone) -> None:
+def test_level_curve_off_the_frame_axis_is_refused(mg_tone: MgTone) -> None:
     """A phon curve that has lost a frame is refused at construction.
 
     Neither loudness-level curve is drawn by the chart (it plots the two sone

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -351,7 +351,7 @@ def test_annex_b4_tone_pulses(case: str, num: int, level: float) -> None:
 
 
 @requires_iso_data
-def test_n5_n10_use_full_rate_series(monkeypatch) -> None:
+def test_n5_n10_use_full_rate_series(monkeypatch: pytest.MonkeyPatch) -> None:
     """N5/N10 must come from the full-rate 2000 Hz weighted-loudness series,
     not the 4x-decimated 500 Hz output trace. Decimation keeps only one of
     four phases, spreading N5 by up to ~3 % across the phases (Annex B

--- a/tests/psychoacoustics/quality/test_tonality_ecma.py
+++ b/tests/psychoacoustics/quality/test_tonality_ecma.py
@@ -174,7 +174,9 @@ def test_user_band_excluding_tone_lowers_tonality() -> None:
     assert restricted.tonality < 0.2
 
 
-def test_loudness_and_tonality_share_the_tonal_split(monkeypatch) -> None:
+def test_loudness_and_tonality_share_the_tonal_split(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Loudness and tonality must report the same underlying N'_tonal(l, z).
 
     Clause 8.1.1 builds the loudness on the Clause 6.2 outputs, so the two
@@ -192,7 +194,9 @@ def test_loudness_and_tonality_share_the_tonal_split(monkeypatch) -> None:
     recorded = []
     orig = L._tonal_noise_split
 
-    def spy(x, field):
+    def spy(
+        x: np.ndarray, field: str
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, int, int]:
         out = orig(x, field)
         recorded.append(out[0].copy())  # N'_tonal(l, z)
         return out

--- a/tests/psychoacoustics/test_iso1996_tone_report.py
+++ b/tests/psychoacoustics/test_iso1996_tone_report.py
@@ -18,13 +18,18 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from typing import TYPE_CHECKING
+
 import reference_data as ref
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, environment, psychoacoustics
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def _result():
+
+def _result() -> psychoacoustics.ToneAudibilityResult:
     """The ISO/PAS 20065 Annex E spectrum-1 detection (three tones + FG)."""
     return psychoacoustics.analyze_spectrum(
         ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, ref.ISO20065_LINE_SPACING
@@ -37,7 +42,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     """A detected-tone result renders a one-page PDF fiche."""
     result = _result()
     out = tmp_path / "tone.pdf"
@@ -46,7 +51,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
@@ -54,7 +59,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
@@ -62,7 +67,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         result.report(out, language="xx")
 
 
-def test_report_states_audibility_adjustment_and_frequency(tmp_path) -> None:
+def test_report_states_audibility_adjustment_and_frequency(tmp_path: Path) -> None:
     """The fiche states ΔL_ta, the derived K and the decisive tone frequency.
 
     The decisive audibility is the FG entry near the 137.3 Hz critical band; its
@@ -89,7 +94,7 @@ def test_report_states_audibility_adjustment_and_frequency(tmp_path) -> None:
     assert "single spectrum" in text
 
 
-def test_metadata_appears_and_one_page(tmp_path) -> None:
+def test_metadata_appears_and_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders one page and prints its fields."""
     md = ReportMetadata(
         specimen="Combustion engine, steady operation",
@@ -112,7 +117,7 @@ def test_metadata_appears_and_one_page(tmp_path) -> None:
     assert "ISO 1996-2" in text
 
 
-def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
+def test_requirement_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS and a FAIL audibility limit both render one page."""
     result = _result()
     delta = result.decisive_audibility
@@ -126,7 +131,7 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing)).replace("\n", " ")
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
@@ -142,7 +147,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -161,7 +166,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_absent_tone_reports_zero_adjustment(tmp_path) -> None:
+def test_absent_tone_reports_zero_adjustment(tmp_path: Path) -> None:
     """A weakly-audible decisive tone still renders and states its adjustment.
 
     A synthetic near-threshold tone keeps K low; the prominence note and boxed

--- a/tests/psychoacoustics/test_iso532_report.py
+++ b/tests/psychoacoustics/test_iso532_report.py
@@ -17,9 +17,14 @@ import pytest
 
 pytest.importorskip("reportlab")
 
+from typing import TYPE_CHECKING
+
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, psychoacoustics
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # A shaped 28-band one-third-octave spectrum (25 Hz..12.5 kHz), descending.
 _LEVELS = np.array(
@@ -57,11 +62,11 @@ _LEVELS = np.array(
 )
 
 
-def _result():
+def _result() -> psychoacoustics.ZwickerLoudness:
     return psychoacoustics.loudness_zwicker_from_spectrum(_LEVELS, field="free")
 
 
-def test_loudness_report_writes_pdf(tmp_path) -> None:
+def test_loudness_report_writes_pdf(tmp_path: Path) -> None:
     """A stationary Zwicker loudness result renders a one-page PDF fiche."""
     result = _result()
     assert result.loudness > 0.0
@@ -75,7 +80,7 @@ def test_loudness_report_writes_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
@@ -83,7 +88,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_full_metadata_renders_one_page(tmp_path) -> None:
+def test_full_metadata_renders_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders a one-page loudness fiche."""
     md = ReportMetadata(
         specimen="Household appliance, steady operating noise",
@@ -101,7 +106,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
+def test_requirement_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS and a FAIL maximum-loudness requirement both render one page."""
     result = _result()
     n = result.loudness
@@ -113,7 +118,7 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     assert_one_page(str(failing))
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
@@ -135,7 +140,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_stationary_fiche_states_method_and_field(tmp_path) -> None:
+def test_stationary_fiche_states_method_and_field(tmp_path: Path) -> None:
     """The fiche states the method and sound field (ISO 532-1 clause 7 c/d).
 
     Clause 7 requires a loudness report to state the method used (stationary,
@@ -152,7 +157,7 @@ def test_stationary_fiche_states_method_and_field(tmp_path) -> None:
     assert expected in text
 
 
-def test_time_varying_fiche_reports_nmax_percentiles_and_nt(tmp_path) -> None:
+def test_time_varying_fiche_reports_nmax_percentiles_and_nt(tmp_path: Path) -> None:
     """A time-varying fiche renders Nmax, N5/N10 and the N(t) trace.
 
     Clause 7 f) makes the loudness time function in sones mandatory for
@@ -183,7 +188,7 @@ def test_time_varying_fiche_reports_nmax_percentiles_and_nt(tmp_path) -> None:
     assert "Total loudness N [sone]" not in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -201,7 +206,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     with pytest.raises(ValueError, match="language"):

--- a/tests/psychoacoustics/test_psychoacoustics_plot_i18n.py
+++ b/tests/psychoacoustics/test_psychoacoustics_plot_i18n.py
@@ -9,7 +9,7 @@ import pytest
 from phonometry import psychoacoustics
 
 
-def _result():
+def _result() -> psychoacoustics.ZwickerLoudness:
     fs = 48000
     t = np.arange(int(fs * 0.3)) / fs
     x = np.sqrt(2.0) * 0.02 * np.sin(2.0 * np.pi * 1000.0 * t)

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -30,6 +30,8 @@ something the file does not.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from signal_contract import assert_same
@@ -49,6 +51,9 @@ from phonometry.psychoacoustics import (
     tonality_ecma,
     tone_to_noise_ratio,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 48000
 CAL = 4.0
@@ -103,12 +108,16 @@ ALL_IDS = LEVELLED_IDS + RATIO_IDS
 
 
 @pytest.mark.parametrize(("func", "kwargs"), ALL, ids=ALL_IDS)
-def test_an_uncalibrated_signal_computes_the_bare_array_result(func, kwargs) -> None:
+def test_an_uncalibrated_signal_computes_the_bare_array_result(
+    func: Callable[..., object], kwargs: dict[str, bool]
+) -> None:
     assert_same(func(Signal(_TONE, FS), **kwargs), func(_TONE, FS, **kwargs))
 
 
 @pytest.mark.parametrize(("func", "kwargs"), ALL, ids=ALL_IDS)
-def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> None:
+def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
+    func: Callable[..., object], kwargs: dict[str, bool]
+) -> None:
     sig = Signal(_TONE, FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
         func(sig, FS + 1, **kwargs)
@@ -117,7 +126,9 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> No
 
 
 @pytest.mark.parametrize(("func", "kwargs"), ALL, ids=ALL_IDS)
-def test_a_bare_array_still_requires_fs(func, kwargs) -> None:
+def test_a_bare_array_still_requires_fs(
+    func: Callable[..., object], kwargs: dict[str, bool]
+) -> None:
     with pytest.raises(ValueError, match="fs is required"):
         func(_TONE, **kwargs)
 
@@ -128,7 +139,9 @@ def test_a_bare_array_still_requires_fs(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), LEVELLED, ids=LEVELLED_IDS)
-def test_a_calibrated_signal_is_analysed_in_pascals(func, kwargs) -> None:
+def test_a_calibrated_signal_is_analysed_in_pascals(
+    func: Callable[..., object], kwargs: dict[str, bool]
+) -> None:
     """And the answer moves with the factor, because the model is not a ratio."""
     record = _MODULATED if func is roughness_ecma else _TONE
     calibrated = func(Signal(record, FS, calibration_factor=CAL), **kwargs)
@@ -142,7 +155,9 @@ def test_a_calibrated_signal_is_analysed_in_pascals(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), RATIOS, ids=RATIO_IDS)
-def test_a_tone_ratio_does_not_move_with_the_factor(func, kwargs) -> None:
+def test_a_tone_ratio_does_not_move_with_the_factor(
+    func: Callable[..., object], kwargs: dict[str, bool]
+) -> None:
     """The factor is applied and then cancels, which is not the same as ignored."""
     calibrated = func(Signal(_TONE, FS, calibration_factor=CAL), **kwargs)
     assert_same(calibrated, func(CAL * _TONE, FS, **kwargs))
@@ -182,7 +197,9 @@ OWN_FACTOR_IDS = [f.__name__ for f, _ in OWN_FACTOR]
 
 
 @pytest.mark.parametrize(("func", "kwargs"), OWN_FACTOR, ids=OWN_FACTOR_IDS)
-def test_an_explicit_factor_wins_over_the_objects(func, kwargs) -> None:
+def test_an_explicit_factor_wins_over_the_objects(
+    func: Callable[..., object], kwargs: dict[str, bool]
+) -> None:
     """The opposite precedence to the rate's, and deliberately so.
 
     A caller who passes a factor knows something the file does not: a
@@ -245,7 +262,9 @@ def test_a_bare_array_with_no_factor_is_still_read_as_pascals() -> None:
     [fluctuation_strength, fluctuation_strength_ecma],
     ids=["fluctuation_strength", "fluctuation_strength_ecma"],
 )
-def test_the_fluctuation_models_take_the_signal_too(func) -> None:
+def test_the_fluctuation_models_take_the_signal_too(
+    func: Callable[..., object],
+) -> None:
     """They are analysed in 2 s frames, so they get their own longer record."""
     record = _tone(seconds=2.0)
     assert_same(func(Signal(record, FS)), func(record, FS))

--- a/tests/room/test_enclosed_space_absorption_report.py
+++ b/tests/room/test_enclosed_space_absorption_report.py
@@ -23,9 +23,14 @@ pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
+from typing import TYPE_CHECKING
+
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, room
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _VOLUME = 50.0
 _SURFACES = [
@@ -48,7 +53,7 @@ def _result() -> room.ReverberationResult:
     )
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: float) -> ReportMetadata:
     base = {
         "specimen": "Meeting room, furnished",
         "client": "Acoustic Test Client Ltd.",
@@ -74,40 +79,40 @@ def _text(path: str) -> str:
     )
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "enclosed.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_report_with_metadata_one_page(tmp_path) -> None:
+def test_report_with_metadata_one_page(tmp_path: Path) -> None:
     out = tmp_path / "enclosed_meta.pdf"
     _result().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     out = tmp_path / "enclosed_bare.pdf"
     _result().report(str(out), metadata=None)
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     res = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     res = _result()
     out = str(tmp_path / "bad.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         res.report(out, language="xx")
 
 
-def test_band_labels_and_area_and_time_render(tmp_path) -> None:
+def test_band_labels_and_area_and_time_render(tmp_path: Path) -> None:
     """Nominal band labels and the closed-form A and T (2 decimals) render."""
     res = _result()
     out = tmp_path / "values.pdf"
@@ -120,7 +125,7 @@ def test_band_labels_and_area_and_time_render(tmp_path) -> None:
     assert f"{res.reverberation_time[3]:.2f}" in text
 
 
-def test_mid_frequency_descriptor_renders(tmp_path) -> None:
+def test_mid_frequency_descriptor_renders(tmp_path: Path) -> None:
     """The boxed mid-frequency reverberation time appears in the text."""
     res = _result()
     out = tmp_path / "mid.pdf"
@@ -130,7 +135,7 @@ def test_mid_frequency_descriptor_renders(tmp_path) -> None:
     assert f"{t_mid:.2f}" in text
 
 
-def test_characterisation_has_no_pass_fail_verdict(tmp_path) -> None:
+def test_characterisation_has_no_pass_fail_verdict(tmp_path: Path) -> None:
     """The fiche never invents a PASS/FAIL verdict, even with a target."""
     out = tmp_path / "noverdict.pdf"
     _result().report(str(out), metadata=_metadata(requirement=0.6))
@@ -140,7 +145,7 @@ def test_characterisation_has_no_pass_fail_verdict(tmp_path) -> None:
     assert "Target reverberation time" in text
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
         specimen="room <A> & <B>",
@@ -154,7 +159,7 @@ def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_fiche_uses_comma_decimal(tmp_path: Path) -> None:
     import re
 
     out = tmp_path / "enclosed_es.pdf"

--- a/tests/room/test_iso3382_3_report.py
+++ b/tests/room/test_iso3382_3_report.py
@@ -39,6 +39,8 @@ from phonometry import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from phonometry.room import OpenPlanResult
 
 
@@ -65,7 +67,7 @@ def _extract_text(path: str) -> str:
     )
 
 
-def _full_metadata(**overrides) -> ReportMetadata:
+def _full_metadata(**overrides: float) -> ReportMetadata:
     base = {
         "specimen": "Furnished, unoccupied, background noise present",
         "client": "Acoustic Test Client Ltd.",
@@ -102,7 +104,7 @@ def test_synthetic_line_matches_closed_form() -> None:
 # --------------------------------------------------------------------------
 # Structural rendering
 # --------------------------------------------------------------------------
-def test_report_writes_pdf(tmp_path) -> None:
+def test_report_writes_pdf(tmp_path: Path) -> None:
     """An open-plan result renders a PDF fiche and returns its path."""
     out = tmp_path / "openplan.pdf"
     returned = _result().report(str(out))
@@ -110,21 +112,21 @@ def test_report_writes_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_report_with_full_metadata_one_page(tmp_path) -> None:
+def test_report_with_full_metadata_one_page(tmp_path: Path) -> None:
     """A full ReportMetadata renders a one-page accredited open-plan fiche."""
     out = tmp_path / "openplan_meta.pdf"
     _result().report(str(out), metadata=_full_metadata())
     assert_one_page(str(out))
 
 
-def test_report_bare_without_metadata(tmp_path) -> None:
+def test_report_bare_without_metadata(tmp_path: Path) -> None:
     """metadata=None renders a bare characterisation fiche (no header)."""
     out = tmp_path / "bare.pdf"
     _result().report(str(out), metadata=None)
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -132,7 +134,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
@@ -143,7 +145,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # Displayed values (the oracle appears in the rendered text)
 # --------------------------------------------------------------------------
-def test_single_number_quantities_render(tmp_path) -> None:
+def test_single_number_quantities_render(tmp_path: Path) -> None:
     """The four single-number quantities appear in the rendered text."""
     out = tmp_path / "values.pdf"
     _result().report(str(out), metadata=_full_metadata())
@@ -158,7 +160,7 @@ def test_single_number_quantities_render(tmp_path) -> None:
     assert "Distraction distance" in text
 
 
-def test_verdict_renders_both_ways(tmp_path) -> None:
+def test_verdict_renders_both_ways(tmp_path: Path) -> None:
     """A target D2,S renders a PASS when met and a FAIL when not.
 
     The requirement is the minimum acceptable D2,S: the oracle 7.0 dB passes a
@@ -174,7 +176,7 @@ def test_verdict_renders_both_ways(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_report_without_requirement_has_no_verdict(tmp_path) -> None:
+def test_report_without_requirement_has_no_verdict(tmp_path: Path) -> None:
     """With no target the characterisation fiche omits the verdict row."""
     out = tmp_path / "noverdict.pdf"
     _result().report(str(out), metadata=_full_metadata())
@@ -186,7 +188,7 @@ def test_report_without_requirement_has_no_verdict(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # Robustness and localisation
 # --------------------------------------------------------------------------
-def test_degenerate_result_renders_without_plot(tmp_path) -> None:
+def test_degenerate_result_renders_without_plot(tmp_path: Path) -> None:
     """A result with no positions in 2-16 m (NaN D2,S) still renders one page.
 
     The spatial-decay regression is undefined, so its plot cannot be drawn; the
@@ -202,7 +204,7 @@ def test_degenerate_result_renders_without_plot(tmp_path) -> None:
     assert "—" in _extract_text(str(out))  # em-dash empty-cell symbol
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
@@ -218,7 +220,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders a one-page Spanish fiche with comma decimals."""
     import re
 

--- a/tests/room/test_iso3382_report.py
+++ b/tests/room/test_iso3382_report.py
@@ -20,6 +20,8 @@ columns and fix the mid-frequency descriptor T_mid = (T30@500 + T30@1000)/2.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -30,6 +32,9 @@ import numpy as np
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, room
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pathlib import Path
 
 _FS = 48000
 #: 6*ln(10): energy-decay-rate constant so exp(-A60*t/T) falls 60 dB in T s.
@@ -64,7 +69,7 @@ def _extract_text(path: str) -> str:
     )
 
 
-def _full_metadata(**overrides) -> ReportMetadata:
+def _full_metadata(**overrides: float) -> ReportMetadata:
     base = {
         "specimen": "Small auditorium, unoccupied, fully furnished",
         "client": "Acoustic Test Client Ltd.",
@@ -104,7 +109,7 @@ def test_synthetic_decay_matches_closed_form() -> None:
 # --------------------------------------------------------------------------
 # Structural rendering
 # --------------------------------------------------------------------------
-def test_report_writes_pdf(tmp_path) -> None:
+def test_report_writes_pdf(tmp_path: Path) -> None:
     """A room-acoustics result renders a PDF fiche and returns its path."""
     out = tmp_path / "room.pdf"
     returned = _result().report(str(out))
@@ -112,21 +117,21 @@ def test_report_writes_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_report_with_full_metadata_one_page(tmp_path) -> None:
+def test_report_with_full_metadata_one_page(tmp_path: Path) -> None:
     """A full ReportMetadata renders a one-page accredited room fiche."""
     out = tmp_path / "room_meta.pdf"
     _result().report(str(out), metadata=_full_metadata())
     assert_one_page(str(out))
 
 
-def test_report_bare_without_metadata(tmp_path) -> None:
+def test_report_bare_without_metadata(tmp_path: Path) -> None:
     """metadata=None renders a bare characterisation fiche (no header)."""
     out = tmp_path / "bare.pdf"
     _result().report(str(out), metadata=None)
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -134,7 +139,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
@@ -145,7 +150,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # Displayed values (the oracle appears in the rendered text)
 # --------------------------------------------------------------------------
-def test_band_labels_and_reverberation_times_render(tmp_path) -> None:
+def test_band_labels_and_reverberation_times_render(tmp_path: Path) -> None:
     """Nominal band labels and the closed-form T30/EDT appear in the PDF."""
     out = tmp_path / "values.pdf"
     _result().report(str(out), metadata=_full_metadata())
@@ -161,7 +166,7 @@ def test_band_labels_and_reverberation_times_render(tmp_path) -> None:
     assert "C80" in text
 
 
-def test_mid_frequency_descriptor_and_verdict(tmp_path) -> None:
+def test_mid_frequency_descriptor_and_verdict(tmp_path: Path) -> None:
     """The boxed T_mid = 1.15 s and a PASS/FAIL verdict both render."""
     passing = tmp_path / "pass.pdf"
     failing = tmp_path / "fail.pdf"
@@ -176,7 +181,7 @@ def test_mid_frequency_descriptor_and_verdict(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_report_without_requirement_has_no_verdict(tmp_path) -> None:
+def test_report_without_requirement_has_no_verdict(tmp_path: Path) -> None:
     """With no target RT the characterisation fiche omits the verdict row."""
     out = tmp_path / "noverdict.pdf"
     _result().report(str(out), metadata=_full_metadata())
@@ -216,7 +221,7 @@ def _synthetic_result(
 # --------------------------------------------------------------------------
 # Band-set variants
 # --------------------------------------------------------------------------
-def test_third_octave_report_renders(tmp_path) -> None:
+def test_third_octave_report_renders(tmp_path: Path) -> None:
     """A one-third-octave analysis renders and labels T_mid honestly.
 
     With one-third-octave data only the 500 Hz and 1 kHz one-third-octave
@@ -232,7 +237,7 @@ def test_third_octave_report_renders(tmp_path) -> None:
     assert "500-1000 Hz" not in text
 
 
-def test_band_range_without_mid_octaves_names_the_band(tmp_path) -> None:
+def test_band_range_without_mid_octaves_names_the_band(tmp_path: Path) -> None:
     """A range missing the mid bands boxes the first finite T30 band by name."""
     res = room.room_parameters(_synthetic_ir(), _FS, limits=(2000.0, 4000.0))
     assert res.frequency is not None
@@ -245,7 +250,7 @@ def test_band_range_without_mid_octaves_names_the_band(tmp_path) -> None:
     assert "T_mid" not in text
 
 
-def test_edt_label_follows_edts_own_band_coverage(tmp_path) -> None:
+def test_edt_label_follows_edts_own_band_coverage(tmp_path: Path) -> None:
     """EDT_mid vs EDT is chosen from EDT's own bands, not T30's.
 
     Here T30 is finite in both mid octaves (T_mid = 1.15 s) but the 500 Hz
@@ -263,7 +268,7 @@ def test_edt_label_follows_edts_own_band_coverage(tmp_path) -> None:
     assert "EDT (1000 Hz) = 1.00 s" in text
 
 
-def test_verdict_uses_display_rounded_values(tmp_path) -> None:
+def test_verdict_uses_display_rounded_values(tmp_path: Path) -> None:
     """T_mid = 1.1502 s prints as 1.15 s and must PASS a 1.15 s target."""
     freq = np.array([500.0, 1000.0])
     res = _synthetic_result(freq, t30=np.array([1.2004, 1.1]), edt=np.array([1.2, 1.1]))
@@ -275,7 +280,7 @@ def test_verdict_uses_display_rounded_values(tmp_path) -> None:
     assert "FAIL" not in text
 
 
-def test_single_band_is_not_labeled_broadband(tmp_path) -> None:
+def test_single_band_is_not_labeled_broadband(tmp_path: Path) -> None:
     """A narrow single-band selection is a single band, not broadband.
 
     Selecting a single octave band leaves one frequency entry (not ``None``),
@@ -292,7 +297,7 @@ def test_single_band_is_not_labeled_broadband(tmp_path) -> None:
     assert "Broadband" not in text
 
 
-def test_octave_report_many_bands_renders(tmp_path) -> None:
+def test_octave_report_many_bands_renders(tmp_path: Path) -> None:
     """A wide octave analysis (>6 bands) renders one page as an octave set.
 
     The one-third-octave triplet grouping is gated on the band structure, so a
@@ -308,7 +313,7 @@ def test_octave_report_many_bands_renders(tmp_path) -> None:
     assert "Octave-band parameters" in _extract_text(str(out))
 
 
-def test_broadband_report_renders(tmp_path) -> None:
+def test_broadband_report_renders(tmp_path: Path) -> None:
     """A broadband (single-band) analysis renders a one-page fiche."""
     res = room.room_parameters(_synthetic_ir(), _FS, limits=None)
     assert res.frequency is None
@@ -318,7 +323,7 @@ def test_broadband_report_renders(tmp_path) -> None:
     assert "Broadband" in _extract_text(str(out))
 
 
-def test_broadband_makes_no_mid_frequency_claim(tmp_path) -> None:
+def test_broadband_makes_no_mid_frequency_claim(tmp_path: Path) -> None:
     """A broadband result must NOT box a false "500-1000 Hz" T_mid.
 
     With no frequency bands there is no 500/1000 Hz averaging, so the boxed
@@ -340,7 +345,7 @@ def test_broadband_makes_no_mid_frequency_claim(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # Robustness and localisation
 # --------------------------------------------------------------------------
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
@@ -356,7 +361,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -380,7 +385,9 @@ def test_room_volume_must_be_positive() -> None:
 
 @pytest.mark.parametrize("field", ["source_positions", "receiver_positions"])
 @pytest.mark.parametrize("bad", [0, -1, 2.5, True])
-def test_position_counts_must_be_positive_integers(field, bad) -> None:
+def test_position_counts_must_be_positive_integers(
+    field: str, bad: int | float
+) -> None:
     """A position count must be a positive integer (bools and floats rejected)."""
     with pytest.raises(ValueError, match=field):
         ReportMetadata(**{field: bad})

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -16,12 +16,23 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 import reference_data as ref
 
 from phonometry import room
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable
+
+    #: The models called as ``model(volume, [(surface, alpha), ...])``.
+    _SurfaceModel = Callable[[float, list[tuple[float, float]]], np.ndarray | float]
+    #: The models called as ``model(dimensions, per_axis_alphas)``.
+    _AxialModel = Callable[
+        [tuple[float, float, float], tuple[float, float, float]], np.ndarray | float
+    ]
 
 # A shoebox 8 x 5 x 3 m: V = 120 m3, S = 2(40 + 24 + 15) = 158 m2.
 DIMS = (8.0, 5.0, 3.0)
@@ -286,7 +297,7 @@ def test_empty_surfaces_raise() -> None:
 )
 @pytest.mark.parametrize("bad", [-0.1, math.nan, math.inf])
 def test_negative_and_non_finite_alpha_rejected_by_surface_models(
-    model, bad: float
+    model: _SurfaceModel, bad: float
 ) -> None:
     """Negative and non-finite coefficients are rejected by every model."""
     with pytest.raises(ValueError, match="absorption coefficients must be"):
@@ -299,7 +310,7 @@ def test_negative_and_non_finite_alpha_rejected_by_surface_models(
 )
 @pytest.mark.parametrize("bad", [-0.1, math.nan, math.inf])
 def test_negative_and_non_finite_alpha_rejected_by_axial_models(
-    model, bad: float
+    model: _AxialModel, bad: float
 ) -> None:
     with pytest.raises(ValueError, match="absorption coefficients must be"):
         model(DIMS, (bad, 0.2, 0.2))
@@ -313,7 +324,9 @@ def test_negative_and_non_finite_alpha_rejected_by_axial_models(
         room.millington_sette_reverberation_time,
     ],
 )
-def test_alpha_above_unit_error_bound_rejected_by_surface_models(model) -> None:
+def test_alpha_above_unit_error_bound_rejected_by_surface_models(
+    model: _SurfaceModel,
+) -> None:
     """A coefficient above 2 is flagged as a probable percent-vs-fraction slip.
 
     (The axial models reject 20.0 too, but through their stricter below-1

--- a/tests/room/test_reverberation_prediction_report.py
+++ b/tests/room/test_reverberation_prediction_report.py
@@ -16,6 +16,8 @@ oracle is re-derived here through the public API rather than hardcoded.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -26,6 +28,9 @@ import numpy as np
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, room
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pathlib import Path
 
 _MODELS = ("Sabine", "Eyring", "Millington-Sette", "Fitzroy", "Arau-Puchades")
 # A shoebox 8 x 5 x 3 m (V = 120 m3, S = 158 m2) with an anisotropic
@@ -42,7 +47,7 @@ def _result() -> room.ReverberationModelResult:
     )
 
 
-def _metadata(**overrides) -> ReportMetadata:
+def _metadata(**overrides: float) -> ReportMetadata:
     base = {
         "specimen": "Classroom, one wall lined with a broadband absorber",
         "client": "Acoustic Test Client Ltd.",
@@ -67,40 +72,40 @@ def _text(path: str) -> str:
     )
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     out = tmp_path / "reverb.pdf"
     returned = _result().report(str(out))
     assert returned == str(out)
     assert_one_page(str(out))
 
 
-def test_report_with_metadata_one_page(tmp_path) -> None:
+def test_report_with_metadata_one_page(tmp_path: Path) -> None:
     out = tmp_path / "reverb_meta.pdf"
     _result().report(str(out), metadata=_metadata())
     assert_one_page(str(out))
 
 
-def test_no_metadata_still_renders(tmp_path) -> None:
+def test_no_metadata_still_renders(tmp_path: Path) -> None:
     out = tmp_path / "reverb_bare.pdf"
     _result().report(str(out), metadata=None)
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     res = _result()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     res = _result()
     out = str(tmp_path / "bad.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         res.report(out, language="xx")
 
 
-def test_all_model_names_render(tmp_path) -> None:
+def test_all_model_names_render(tmp_path: Path) -> None:
     """The five model column headers appear in the rendered fiche text."""
     out = tmp_path / "models.pdf"
     _result().report(str(out), metadata=_metadata())
@@ -109,7 +114,7 @@ def test_all_model_names_render(tmp_path) -> None:
         assert name in text
 
 
-def test_band_labels_and_per_model_values_render(tmp_path) -> None:
+def test_band_labels_and_per_model_values_render(tmp_path: Path) -> None:
     """Nominal band labels and closed-form per-model T (2 decimals) render."""
     res = _result()
     out = tmp_path / "values.pdf"
@@ -124,7 +129,7 @@ def test_band_labels_and_per_model_values_render(tmp_path) -> None:
     assert sabine_500 in text
 
 
-def test_mid_frequency_prediction_descriptor_renders(tmp_path) -> None:
+def test_mid_frequency_prediction_descriptor_renders(tmp_path: Path) -> None:
     """The boxed Arau-Puchades mid-frequency prediction appears in the text."""
     res = _result()
     out = tmp_path / "mid.pdf"
@@ -137,7 +142,7 @@ def test_mid_frequency_prediction_descriptor_renders(tmp_path) -> None:
     assert "Arau-Puchades" in text
 
 
-def test_prediction_has_no_pass_fail_verdict(tmp_path) -> None:
+def test_prediction_has_no_pass_fail_verdict(tmp_path: Path) -> None:
     """A prediction never invents a PASS/FAIL verdict, even with a target."""
     out = tmp_path / "noverdict.pdf"
     _result().report(str(out), metadata=_metadata(requirement=0.8))
@@ -148,7 +153,7 @@ def test_prediction_has_no_pass_fail_verdict(tmp_path) -> None:
     assert "Target reverberation time" in text
 
 
-def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
+def test_metadata_xml_specials_do_not_break(tmp_path: Path) -> None:
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
         specimen="hall <A> & foyer",
@@ -161,7 +166,7 @@ def test_metadata_xml_specials_do_not_break(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_fiche_uses_comma_decimal(tmp_path) -> None:
+def test_spanish_fiche_uses_comma_decimal(tmp_path: Path) -> None:
     import re
 
     out = tmp_path / "reverb_es.pdf"

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -21,6 +21,8 @@ RC-35(R)).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -32,6 +34,10 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.room import noise_criteria as rn
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable
+    from pathlib import Path
 
 
 def _nc_result() -> rn.NCResult:
@@ -58,7 +64,7 @@ def _extract_text(path: str) -> str:
     )
 
 
-def _full_metadata(**overrides) -> ReportMetadata:
+def _full_metadata(**overrides: float) -> ReportMetadata:
     base = {
         "specimen": "Open-plan office, air handling at nominal flow",
         "client": "Acoustic Test Client Ltd.",
@@ -96,7 +102,7 @@ def test_example_spectra_match_standard() -> None:
 # --------------------------------------------------------------------------
 # Structural rendering
 # --------------------------------------------------------------------------
-def test_nc_report_writes_pdf(tmp_path) -> None:
+def test_nc_report_writes_pdf(tmp_path: Path) -> None:
     """An NC result renders a PDF fiche and returns its path."""
     out = tmp_path / "nc.pdf"
     returned = _nc_result().report(str(out))
@@ -104,7 +110,7 @@ def test_nc_report_writes_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_rc_report_writes_pdf(tmp_path) -> None:
+def test_rc_report_writes_pdf(tmp_path: Path) -> None:
     """An RC result renders a PDF fiche and returns its path."""
     out = tmp_path / "rc.pdf"
     returned = _rc_result().report(str(out))
@@ -112,7 +118,7 @@ def test_rc_report_writes_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_reports_with_full_metadata_one_page(tmp_path) -> None:
+def test_reports_with_full_metadata_one_page(tmp_path: Path) -> None:
     """A full ReportMetadata renders a one-page fiche for both ratings."""
     _nc_result().report(str(tmp_path / "nc_meta.pdf"), metadata=_full_metadata())
     _rc_result().report(str(tmp_path / "rc_meta.pdf"), metadata=_full_metadata())
@@ -120,7 +126,7 @@ def test_reports_with_full_metadata_one_page(tmp_path) -> None:
     assert_one_page(str(tmp_path / "rc_meta.pdf"))
 
 
-def test_reports_bare_without_metadata(tmp_path) -> None:
+def test_reports_bare_without_metadata(tmp_path: Path) -> None:
     """metadata=None renders a bare assessment fiche (no header)."""
     _nc_result().report(str(tmp_path / "nc_bare.pdf"), metadata=None)
     _rc_result().report(str(tmp_path / "rc_bare.pdf"), metadata=None)
@@ -128,7 +134,7 @@ def test_reports_bare_without_metadata(tmp_path) -> None:
     assert_one_page(str(tmp_path / "rc_bare.pdf"))
 
 
-def test_verbose_reports_one_page(tmp_path) -> None:
+def test_verbose_reports_one_page(tmp_path: Path) -> None:
     """verbose=True (NC contour / RC reference + deviation) still fits one page."""
     _nc_result().report(
         str(tmp_path / "nc_v.pdf"), metadata=_full_metadata(), verbose=True
@@ -141,7 +147,9 @@ def test_verbose_reports_one_page(tmp_path) -> None:
 
 
 @pytest.mark.parametrize("factory", [_nc_result, _rc_result])
-def test_unknown_engine_rejected(tmp_path, factory) -> None:
+def test_unknown_engine_rejected(
+    tmp_path: Path, factory: Callable[[], rn.NCResult | rn.RCResult]
+) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = factory()
@@ -150,7 +158,9 @@ def test_unknown_engine_rejected(tmp_path, factory) -> None:
 
 
 @pytest.mark.parametrize("factory", [_nc_result, _rc_result])
-def test_unknown_language_rejected(tmp_path, factory) -> None:
+def test_unknown_language_rejected(
+    tmp_path: Path, factory: Callable[[], rn.NCResult | rn.RCResult]
+) -> None:
     """An unknown fiche language raises ``ValueError``."""
     out = str(tmp_path / "bad.pdf")
     result = factory()
@@ -161,7 +171,7 @@ def test_unknown_language_rejected(tmp_path, factory) -> None:
 # --------------------------------------------------------------------------
 # Displayed values (the oracle appears in the rendered text)
 # --------------------------------------------------------------------------
-def test_nc_rating_and_levels_render(tmp_path) -> None:
+def test_nc_rating_and_levels_render(tmp_path: Path) -> None:
     """The NC-40 rating, governing band and a couple band levels appear."""
     out = tmp_path / "nc_values.pdf"
     _nc_result().report(str(out), metadata=_full_metadata())
@@ -173,7 +183,7 @@ def test_nc_rating_and_levels_render(tmp_path) -> None:
     assert "79.0" in text  # 16 Hz level (depressed contour)
 
 
-def test_rc_rating_and_levels_render(tmp_path) -> None:
+def test_rc_rating_and_levels_render(tmp_path: Path) -> None:
     """The RC-35(R) rating, the mid-frequency average and a level appear."""
     out = tmp_path / "rc_values.pdf"
     _rc_result().report(str(out), metadata=_full_metadata())
@@ -183,7 +193,7 @@ def test_rc_rating_and_levels_render(tmp_path) -> None:
     assert "53.0" in text  # 250 Hz rumble level (45 + 8)
 
 
-def test_nc_verbose_shows_contour_column(tmp_path) -> None:
+def test_nc_verbose_shows_contour_column(tmp_path: Path) -> None:
     """The verbose NC table adds the per-band NC contour column."""
     out = tmp_path / "nc_contour.pdf"
     _nc_result().report(str(out), metadata=_full_metadata(), verbose=True)
@@ -193,7 +203,7 @@ def test_nc_verbose_shows_contour_column(tmp_path) -> None:
     assert "40.0" in text
 
 
-def test_verdict_both_ways(tmp_path) -> None:
+def test_verdict_both_ways(tmp_path: Path) -> None:
     """A target rating renders PASS at or above the rating and FAIL below it."""
     passing = tmp_path / "pass.pdf"
     failing = tmp_path / "fail.pdf"
@@ -203,7 +213,7 @@ def test_verdict_both_ways(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_verdict_uses_display_rounded_values(tmp_path) -> None:
+def test_verdict_uses_display_rounded_values(tmp_path: Path) -> None:
     """A rating that displays as the target must PASS at the boundary.
 
     The fiche prints the NC rating to one decimal, so the verdict compares
@@ -223,7 +233,7 @@ def test_verdict_uses_display_rounded_values(tmp_path) -> None:
     assert "FAIL" not in text
 
 
-def test_nc_sil_designation_renders(tmp_path) -> None:
+def test_nc_sil_designation_renders(tmp_path: Path) -> None:
     """A SIL-designated spectrum (clause 5.2.2) boxes NC-(SIL), no band."""
     result = rn.noise_criterion(rn.nc_curve(40.0))
     assert result.method == "SIL"
@@ -235,7 +245,7 @@ def test_nc_sil_designation_renders(tmp_path) -> None:
     assert "Governing band" not in text
 
 
-def test_nc_out_of_range_above_renders(tmp_path) -> None:
+def test_nc_out_of_range_above_renders(tmp_path: Path) -> None:
     """A spectrum above NC-70 renders >NC-70 and fails any in-family target."""
     import numpy as np
 
@@ -249,7 +259,7 @@ def test_nc_out_of_range_above_renders(tmp_path) -> None:
     assert "FAIL" in text
 
 
-def test_nc_out_of_range_below_renders(tmp_path) -> None:
+def test_nc_out_of_range_below_renders(tmp_path: Path) -> None:
     """A spectrum below NC-15 renders <NC-15 and passes any in-family target."""
     import numpy as np
 
@@ -262,7 +272,7 @@ def test_nc_out_of_range_below_renders(tmp_path) -> None:
     assert "PASS" in text
 
 
-def test_rc_out_of_family_note_renders(tmp_path) -> None:
+def test_rc_out_of_family_note_renders(tmp_path: Path) -> None:
     """An RC rating outside RC-25 to RC-50 renders the extrapolation note."""
     result = rn.room_criterion(rn.rc_curve(55.0))
     assert result.out_of_family
@@ -271,7 +281,7 @@ def test_rc_out_of_family_note_renders(tmp_path) -> None:
     assert "Outside the tabulated RC-25 to RC-50 family" in _extract_text(str(out))
 
 
-def test_report_without_requirement_has_no_verdict(tmp_path) -> None:
+def test_report_without_requirement_has_no_verdict(tmp_path: Path) -> None:
     """With no target rating the assessment fiche omits the verdict row."""
     out = tmp_path / "noverdict.pdf"
     _rc_result().report(str(out), metadata=_full_metadata())
@@ -283,7 +293,7 @@ def test_report_without_requirement_has_no_verdict(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # Robustness and localisation
 # --------------------------------------------------------------------------
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
@@ -299,7 +309,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_reports_render_translated(tmp_path) -> None:
+def test_spanish_reports_render_translated(tmp_path: Path) -> None:
     """language="es" renders one-page Spanish fiches with comma decimals."""
     import re
 
@@ -322,7 +332,7 @@ def test_spanish_reports_render_translated(tmp_path) -> None:
     assert "retumbe" in rc_text  # rumble spectral quality
 
 
-def test_subset_spectrum_renders_missing_bands(tmp_path) -> None:
+def test_subset_spectrum_renders_missing_bands(tmp_path: Path) -> None:
     """A subset of octave bands renders, showing an em dash for absent bands."""
     freqs = [500.0, 1000.0, 2000.0, 4000.0, 8000.0]
     levels = [40.0, 35.0, 30.0, 27.0, 22.0]

--- a/tests/room/test_room_plot_i18n.py
+++ b/tests/room/test_room_plot_i18n.py
@@ -10,6 +10,7 @@ clear :class:`ValueError`.
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -24,15 +25,36 @@ from phonometry import room
 from phonometry._plot.room import plot_excitation
 from phonometry.room import enclosed_space_absorption as esa
 from phonometry.room import noise_criteria as rn
-from phonometry.room.crowd_noise import crowd_noise
-from phonometry.room.image_source import image_source_rir
+from phonometry.room.crowd_noise import CrowdNoiseResult, crowd_noise
+from phonometry.room.image_source import ImageSourceResult, image_source_rir
 from phonometry.room.impulse_response import ImpulseResponseResult
-from phonometry.room.modes import room_modes
-from phonometry.room.open_plan import open_plan_metrics
+from phonometry.room.modes import RoomModesResult, room_modes
+from phonometry.room.open_plan import OpenPlanResult, open_plan_metrics
 from phonometry.room.reverberation_prediction import (
+    ReverberationModelResult,
     reverberation_time_models,
 )
-from phonometry.room.steady_field import steady_state_field
+from phonometry.room.steady_field import SteadyFieldResult, steady_state_field
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable
+
+#: What the builders below return: every room result with a ``.plot()`` renderer.
+_RoomResult = (
+    CrowdNoiseResult
+    | ImageSourceResult
+    | ImpulseResponseResult
+    | OpenPlanResult
+    | ReverberationModelResult
+    | RoomModesResult
+    | SteadyFieldResult
+    | esa.ReverberationResult
+    | rn.NCResult
+    | rn.RCResult
+    | room.DecayCurve
+    | room.RoomAcousticsResult
+    | room.ShapedSweepResult
+)
 
 FS = 48000
 
@@ -56,25 +78,25 @@ def _texts(ax_or_axes: object) -> str:
     return "\n".join(parts)
 
 
-def _room_acoustics():
+def _room_acoustics() -> room.RoomAcousticsResult:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         return room.room_parameters(_decaying_ir(), FS, limits=None)
 
 
-def _decay_curve():
+def _decay_curve() -> room.DecayCurve:
     return room.decay_curve(_decaying_ir(), FS)
 
 
-def _nc():
+def _nc() -> rn.NCResult:
     return rn.noise_criterion(rn.nc_curve(40.0))
 
 
-def _rc():
+def _rc() -> rn.RCResult:
     return rn.room_criterion(rn.rc_curve(35.0))
 
 
-def _enclosed():
+def _enclosed() -> esa.ReverberationResult:
     return esa.enclosed_space_reverberation(
         [(20.0, [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70])],
         50.0,
@@ -82,43 +104,43 @@ def _enclosed():
     )
 
 
-def _models():
+def _models() -> ReverberationModelResult:
     return reverberation_time_models(
         (8.0, 5.0, 3.0), (0.2, 0.15, 0.3), frequencies=[125.0, 250.0]
     )
 
 
-def _open_plan():
+def _open_plan() -> OpenPlanResult:
     r = np.array([2.0, 4.0, 8.0, 16.0])
     lp = 70.0 - 6.0 * np.log2(r)
     sti = 0.6 - 0.02 * r
     return open_plan_metrics(r, lp, sti)
 
 
-def _impulse_response():
+def _impulse_response() -> ImpulseResponseResult:
     return ImpulseResponseResult(ir=_decaying_ir(), fs=FS, method="spectral")
 
 
-def _shaped_sweep():
+def _shaped_sweep() -> room.ShapedSweepResult:
 
     return room.shaped_sweep_signal(FS, 100.0, 5000.0, 0.4, target="pink")
 
 
-def _image_source():
+def _image_source() -> ImageSourceResult:
     return image_source_rir(
         (5.0, 4.0, 3.0), (1.2, 1.1, 1.3), (3.5, 2.6, 1.7), 0.15, fs=16000, max_order=8
     )
 
 
-def _steady_field():
+def _steady_field() -> SteadyFieldResult:
     return steady_state_field(90.0, 100.0, 0.2)
 
 
-def _room_modes():
+def _room_modes() -> RoomModesResult:
     return room_modes((7.0, 5.0, 3.0), max_frequency=120.0, reverberation_time=0.8)
 
 
-def _crowd_noise():
+def _crowd_noise() -> CrowdNoiseResult:
     return crowd_noise([20.0, 190.0])
 
 
@@ -143,7 +165,9 @@ _CASES = [
 @pytest.mark.parametrize(
     ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
 )
-def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
+def test_plot_spanish_labels(
+    name: str, build: Callable[[], _RoomResult], spanish: str
+) -> None:
     result = build()
     ax = result.plot(language="es")
     assert spanish in _texts(ax)
@@ -153,7 +177,9 @@ def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
 @pytest.mark.parametrize(
     ("name", "build", "spanish"), _CASES, ids=[c[0] for c in _CASES]
 )
-def test_plot_rejects_unknown_language(name: str, build, spanish: str) -> None:
+def test_plot_rejects_unknown_language(
+    name: str, build: Callable[[], _RoomResult], spanish: str
+) -> None:
     result = build()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")

--- a/tests/room/test_room_signal_overloads.py
+++ b/tests/room/test_room_signal_overloads.py
@@ -21,6 +21,7 @@ overload heads say so and the refusal names the reason.
 from __future__ import annotations
 
 from dataclasses import fields
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -36,6 +37,16 @@ from phonometry.room import (
     mls_signal,
     room_parameters,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Callable
+
+    from phonometry.room import DecayCurve, ImpulseResponseResult, RoomAcousticsResult
+
+    #: The two measurements that read time off the record (rate mandatory).
+    _TimedMeasurement = Callable[..., DecayCurve | RoomAcousticsResult]
+    #: The three deconvolutions, where the rate is only a label.
+    _Deconvolution = Callable[..., ImpulseResponseResult]
 
 FS = 8000
 CAL = 3.0
@@ -63,12 +74,16 @@ TIMED_IDS = [f.__name__ for f, _ in TIMED]
 
 
 @pytest.mark.parametrize(("func", "kwargs"), TIMED, ids=TIMED_IDS)
-def test_an_uncalibrated_signal_computes_the_bare_array_result(func, kwargs) -> None:
+def test_an_uncalibrated_signal_computes_the_bare_array_result(
+    func: _TimedMeasurement, kwargs: dict[str, tuple[float, float]]
+) -> None:
     assert_same(func(Signal(_IR, FS), **kwargs), func(_IR, FS, **kwargs))
 
 
 @pytest.mark.parametrize(("func", "kwargs"), TIMED, ids=TIMED_IDS)
-def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> None:
+def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
+    func: _TimedMeasurement, kwargs: dict[str, tuple[float, float]]
+) -> None:
     sig = Signal(_IR, FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
         func(sig, FS + 1, **kwargs)
@@ -77,13 +92,17 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> No
 
 
 @pytest.mark.parametrize(("func", "kwargs"), TIMED, ids=TIMED_IDS)
-def test_a_bare_array_still_requires_fs(func, kwargs) -> None:
+def test_a_bare_array_still_requires_fs(
+    func: _TimedMeasurement, kwargs: dict[str, tuple[float, float]]
+) -> None:
     with pytest.raises(ValueError, match="fs is required"):
         func(_IR, **kwargs)
 
 
 @pytest.mark.parametrize(("func", "kwargs"), TIMED, ids=TIMED_IDS)
-def test_a_calibrated_signal_is_scaled_and_then_cancels(func, kwargs) -> None:
+def test_a_calibrated_signal_is_scaled_and_then_cancels(
+    func: _TimedMeasurement, kwargs: dict[str, tuple[float, float]]
+) -> None:
     """The factor is applied and then cancels, which is not the same as ignored.
 
     Against the pre-scaled array the equality is exact: the samples really
@@ -137,7 +156,11 @@ DECONVOLUTION_IDS = [f.__name__ for f, _, _ in DECONVOLUTIONS]
 @pytest.mark.parametrize(
     ("func", "records", "kwargs"), DECONVOLUTIONS, ids=DECONVOLUTION_IDS
 )
-def test_a_deconvolution_keeps_its_rate_optional(func, records, kwargs) -> None:
+def test_a_deconvolution_keeps_its_rate_optional(
+    func: _Deconvolution,
+    records: tuple[np.ndarray, np.ndarray],
+    kwargs: dict[str, str | tuple[np.ndarray, np.ndarray]],
+) -> None:
     """The rate labels the axis; without one the recovery is still defined."""
     first, second = records
     result = func(first, second, **kwargs)
@@ -147,7 +170,11 @@ def test_a_deconvolution_keeps_its_rate_optional(func, records, kwargs) -> None:
 @pytest.mark.parametrize(
     ("func", "records", "kwargs"), DECONVOLUTIONS, ids=DECONVOLUTION_IDS
 )
-def test_a_deconvolution_takes_the_label_from_the_signal(func, records, kwargs) -> None:
+def test_a_deconvolution_takes_the_label_from_the_signal(
+    func: _Deconvolution,
+    records: tuple[np.ndarray, np.ndarray],
+    kwargs: dict[str, str | tuple[np.ndarray, np.ndarray]],
+) -> None:
     first, second = records
     assert_same(
         func(Signal(first, FS), second, **kwargs),
@@ -158,7 +185,11 @@ def test_a_deconvolution_takes_the_label_from_the_signal(func, records, kwargs) 
 @pytest.mark.parametrize(
     ("func", "records", "kwargs"), DECONVOLUTIONS, ids=DECONVOLUTION_IDS
 )
-def test_a_deconvolution_refuses_a_conflicting_rate(func, records, kwargs) -> None:
+def test_a_deconvolution_refuses_a_conflicting_rate(
+    func: _Deconvolution,
+    records: tuple[np.ndarray, np.ndarray],
+    kwargs: dict[str, str | tuple[np.ndarray, np.ndarray]],
+) -> None:
     first, second = records
     sig = Signal(first, FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
@@ -168,7 +199,11 @@ def test_a_deconvolution_refuses_a_conflicting_rate(func, records, kwargs) -> No
 @pytest.mark.parametrize(
     ("func", "records", "kwargs"), DECONVOLUTIONS, ids=DECONVOLUTION_IDS
 )
-def test_a_calibrated_recording_deconvolves_in_pascals(func, records, kwargs) -> None:
+def test_a_calibrated_recording_deconvolves_in_pascals(
+    func: _Deconvolution,
+    records: tuple[np.ndarray, np.ndarray],
+    kwargs: dict[str, str | tuple[np.ndarray, np.ndarray]],
+) -> None:
     first, second = records
     assert_same(
         func(Signal(first, FS, calibration_factor=CAL), second, **kwargs),

--- a/tests/room/test_shaped_sweep.py
+++ b/tests/room/test_shaped_sweep.py
@@ -19,6 +19,7 @@ Validation strategy (closed-form, not self-consistency):
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -26,10 +27,15 @@ from scipy import signal
 
 from phonometry import room
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 FS = 48000
 
 
-def _welch_deviation_db(res: room.ShapedSweepResult, target_db_fn) -> float:
+def _welch_deviation_db(
+    res: room.ShapedSweepResult, target_db_fn: Callable[[np.ndarray], np.ndarray]
+) -> float:
     """Worst |Welch - target| deviation in dB over the band interior."""
     x = np.asarray(res)
     nperseg = 8192


### PR DESCRIPTION
The library, its scripts and its gates are fully annotated; the test suite was the last corner where a parameter arrived nameless. This half covers the building, materials, room, emission and psychoacoustics trees.

The types were read, not guessed. pytest's plumbing carries pytest's own types, a parametrize argument is typed from the values really in its list, and a fixture or helper from what its body builds, checked against the library signature it calls. Annotations cannot change what a test does, and the full suite agrees: the same 9402 tests pass before and after, run over the combined stack.

The second half, and the lint rule that keeps the whole suite this way, stack on top.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added type hints to test functions across the test suite to improve code quality and maintainability.</li>
<li>Standardized function signatures by adding explicit return types (e.g., -> None) and parameter types.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive static type annotations across building, emission, materials, psychoacoustics, and room test suites.
  * Improved typing for temporary paths, fixtures, helpers, callbacks, numerical arrays, and test results.
  * Expanded validation coverage with an explicit unsupported-language test.
  * Test behavior, assertions, rendering, and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->