### PR TITLE
Finish the suite's annotations, and let the gate hold them

### DIFF
--- a/.github/scripts/comment_pr.py
+++ b/.github/scripts/comment_pr.py
@@ -10,7 +10,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
-def parse_test_results(test_dir):
+def parse_test_results(test_dir: str) -> tuple[str, int, int]:
     summary = []
     total_tests = 0
     total_failures = 0
@@ -82,7 +82,7 @@ def parse_test_results(test_dir):
     return "\n".join(summary), total_tests, total_failures
 
 
-def read_conformance_report():
+def read_conformance_report() -> str:
     """Return the conformance-report Markdown, or a fallback notice."""
     report = Path("conformance_report.md")
     if report.exists():
@@ -93,7 +93,7 @@ def read_conformance_report():
     )
 
 
-def main():
+def main() -> None:
     repo = os.environ.get("GITHUB_REPOSITORY")
     run_id = os.environ.get("GITHUB_RUN_ID")
     test_dir = "test-results"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,12 @@ select = [
     "PERF",                 # a loop whose whole body is one `append` is a
                             # comprehension, unless saying so costs more lines
                             # than it saves
+    "ANN0", "ANN2",         # every parameter and return says its type. The
+                            # suite was the last unannotated corner, and its
+                            # fixtures were the point: a parametrize argument
+                            # is typed from the values really in its list, a
+                            # helper from what its body builds, and pytest's
+                            # own plumbing from pytest's own types
     "ANN401",               # an `Any` earns its keep or names its replacement.
                             # A forwarding `*args`/`**kwargs` is exempt below:
                             # matplotlib's keyword surface is an open set and

--- a/tests/aircraft/test_epnl_report.py
+++ b/tests/aircraft/test_epnl_report.py
@@ -12,6 +12,8 @@ flyover keeps the fiche test independent.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -24,8 +26,11 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, aircraft
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
-def _flyover():
+
+def _flyover() -> aircraft.EPNLResult:
     """A deterministic synthetic flyover EPNLResult (Gaussian temporal peak)."""
     k, dt = 24, 0.5
     idx = np.arange(k)
@@ -38,7 +43,7 @@ def _flyover():
     return aircraft.effective_perceived_noise_level(spectra, dt)
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     """A computed flyover renders a one-page certification fiche."""
     result = _flyover()
     assert np.isfinite(result.epnl)
@@ -48,7 +53,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _flyover()  # constructed outside pytest.raises (Sonar S5778)
     out = str(tmp_path / "x.pdf")
@@ -56,7 +61,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_passing_requirement_renders(tmp_path) -> None:
+def test_passing_requirement_renders(tmp_path: Path) -> None:
     """A certification limit at or above the EPNL renders a passing fiche."""
     result = _flyover()
     limit = float(result.epnl) + 3.0
@@ -65,7 +70,7 @@ def test_passing_requirement_renders(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_failing_requirement_renders(tmp_path) -> None:
+def test_failing_requirement_renders(tmp_path: Path) -> None:
     """A certification limit below the EPNL renders a failing fiche."""
     result = _flyover()
     limit = float(result.epnl) - 3.0
@@ -74,7 +79,7 @@ def test_failing_requirement_renders(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_full_metadata_renders_one_page(tmp_path) -> None:
+def test_full_metadata_renders_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders a one-page fiche."""
     md = ReportMetadata(
         specimen="Example twin-turbofan transport",
@@ -93,7 +98,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_no_metadata_prediction_fiche(tmp_path) -> None:
+def test_no_metadata_prediction_fiche(tmp_path: Path) -> None:
     """With ``metadata=None`` a prediction fiche renders (no verdict row)."""
     out = tmp_path / "prediction.pdf"
     _flyover().report(str(out))
@@ -107,7 +112,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_verdict_follows_one_decimal_epnl_at_the_limit(tmp_path) -> None:
+def test_verdict_follows_one_decimal_epnl_at_the_limit(tmp_path: Path) -> None:
     """The verdict compares the EPNL determined to one decimal place.
 
     Annex 16 determines the EPNL "to one decimal place": an unrounded
@@ -135,7 +140,7 @@ def test_verdict_follows_one_decimal_epnl_at_the_limit(tmp_path) -> None:
     assert "FAIL" in text2
 
 
-def test_reference_conditions_cite_part_ii(tmp_path) -> None:
+def test_reference_conditions_cite_part_ii(tmp_path: Path) -> None:
     """The reference-conditions strip states the Part II 3.6.1.5 conditions."""
     out = tmp_path / "refcond.pdf"
     _flyover().report(str(out))
@@ -145,7 +150,7 @@ def test_reference_conditions_cite_part_ii(tmp_path) -> None:
     assert "Part II, 3.6.1.5" in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -158,7 +163,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _flyover()
     with pytest.raises(ValueError, match="language"):

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -17,6 +17,7 @@ synthetic signal keeps the fiche test independent.
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -27,7 +28,10 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry._report.broadcast import _verdict
-from phonometry.broadcast import program_loudness
+from phonometry.broadcast import ProgramLoudnessResult, program_loudness
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 FS = 48000
 
@@ -48,7 +52,7 @@ def _steps(segments: tuple[tuple[float, float], ...]) -> np.ndarray:
     return _stereo(np.concatenate([_sine(lvl, dur) for lvl, dur in segments]))
 
 
-def _case1_result():
+def _case1_result() -> ProgramLoudnessResult:
     """Tech 3342 Case 1 shaped steps, trimmed 0.4 dB onto the -23.0 target.
 
     The -20.4/-30.4 dBFS stereo steps keep the Case 1 loudness range near
@@ -58,7 +62,7 @@ def _case1_result():
     return program_loudness(_steps(((-20.4, 20.0), (-30.4, 20.0))), FS)
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     """A measured programme renders a one-page compliance fiche."""
     result = _case1_result()
     assert np.isfinite(result.integrated)
@@ -68,7 +72,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _case1_result()
     out = str(tmp_path / "x.pdf")
@@ -76,7 +80,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_full_metadata_renders_one_page(tmp_path) -> None:
+def test_full_metadata_renders_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders a one-page fiche."""
     md = ReportMetadata(
         specimen="Reference tone sequence",
@@ -95,7 +99,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_compliant_programme_passes(tmp_path) -> None:
+def test_compliant_programme_passes(tmp_path: Path) -> None:
     """The trimmed signal is compliant (I within -23.0 +/-0.2 LU, TP <= -1 dBTP)."""
     result = _case1_result()
     assert abs(result.integrated - (-23.0)) <= 0.2
@@ -106,7 +110,7 @@ def test_compliant_programme_passes(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_non_compliant_true_peak_fails(tmp_path) -> None:
+def test_non_compliant_true_peak_fails(tmp_path: Path) -> None:
     """A 0 dBFS tone exceeds the -1 dBTP true-peak ceiling and fails."""
     result = program_loudness(_stereo(_sine(0.0, 10.0)), FS)
     assert result.true_peak > -1.0
@@ -117,7 +121,7 @@ def test_non_compliant_true_peak_fails(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_informational_rows_do_not_change_verdict(tmp_path) -> None:
+def test_informational_rows_do_not_change_verdict(tmp_path: Path) -> None:
     """LRA and the momentary/short-term maxima never affect the PASS verdict."""
     result = _case1_result()
     _text, passed = _verdict(result, -23.0)
@@ -155,7 +159,7 @@ def test_default_tolerance_is_qc_02_lu() -> None:
     assert passed2 is True
 
 
-def test_live_tolerance_applies_item_h_1_lu(tmp_path) -> None:
+def test_live_tolerance_applies_item_h_1_lu(tmp_path: Path) -> None:
     """``tolerance="live"`` applies the +-1.0 LU rule of R 128 item h)."""
     result = dataclasses.replace(_case1_result(), integrated=-23.8)
     _t1, qc_passed = _verdict(result, -23.0, "qc")
@@ -173,7 +177,7 @@ def test_live_tolerance_applies_item_h_1_lu(tmp_path) -> None:
     assert "live programmes" in text
 
 
-def test_unknown_tolerance_rejected(tmp_path) -> None:
+def test_unknown_tolerance_rejected(tmp_path: Path) -> None:
     """An unknown tolerance rule raises ``ValueError``."""
     result = _case1_result()
     out = str(tmp_path / "bad.pdf")
@@ -196,7 +200,7 @@ def test_verdict_follows_displayed_rounding_at_boundary() -> None:
         assert passed is expected, integrated
 
 
-def test_fiche_pins_displayed_numbers(tmp_path) -> None:
+def test_fiche_pins_displayed_numbers(tmp_path: Path) -> None:
     """The rendered fiche shows the QC tolerance, its R 128 item and the
     0.1 LU rounded measured loudness.
     """
@@ -214,7 +218,7 @@ def test_fiche_pins_displayed_numbers(tmp_path) -> None:
     assert "Quality Control (EBU R 128 item i)." in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -227,7 +231,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _case1_result()
     with pytest.raises(ValueError, match="language"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 import os
 
+import pytest
+
 # Select a non-interactive matplotlib backend for the headless test suite.
 # The library no longer forces a backend (see issue #52), so the test harness
 # must opt into Agg itself; otherwise matplotlib picks a GUI backend (e.g.
@@ -9,7 +11,7 @@ import os
 os.environ.setdefault("MPLBACKEND", "Agg")
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     """Configure environment variables for the test session.
     We disable Numba JIT to allow coverage tools to trace inside the kernels.
     """
@@ -46,7 +48,9 @@ _FRONTLOADED_MODULES = (
 )
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
     """Move the known-heavy modules to the front of the dispatch order.
 
     The sort is stable, so relative order inside every module (and among all
@@ -66,7 +70,7 @@ def pytest_collection_modifyitems(config, items):
     items.sort(key=lambda item: rank[item.nodeid.split("::", 1)[0]])
 
 
-def pytest_report_header(config):
+def pytest_report_header(config: pytest.Config) -> list[str]:
     """Report which copy of every heavy oracle set this run will read.
 
     The suites in ``tests/oracle_data.DATASETS`` prefer a full local copy of

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 
@@ -20,6 +21,9 @@ import pytest
 import reference_data as ref
 
 from phonometry import electroacoustics
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 48000
 N = 48000  # 1 s -> 1 Hz bin resolution, every test tone lands on a bin.
@@ -411,7 +415,7 @@ def test_harmonic_result_rejects_amplitude_axis_of_another_length() -> None:
         lambda s, fs: electroacoustics.sinad(s, fs),
     ],
 )
-def test_rejects_non_finite_signal(func) -> None:  # type: ignore[no-untyped-def]
+def test_rejects_non_finite_signal(func: Callable[[np.ndarray, int], object]) -> None:
     bad = np.array([np.nan] * 100)
     with pytest.raises(ValueError, match="'signal' must be finite"):
         func(bad, FS)

--- a/tests/electroacoustics/test_electroacoustics_signal_overloads.py
+++ b/tests/electroacoustics/test_electroacoustics_signal_overloads.py
@@ -23,6 +23,8 @@ is therefore the opposite of every other one here.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from signal_contract import assert_same
@@ -46,6 +48,9 @@ from phonometry.electroacoustics import (
     weighted_thd,
 )
 from phonometry.io import Signal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 48000
 CAL = 3.0
@@ -104,7 +109,7 @@ PAIR_IDS = [f.__name__ for f, _ in PAIRS]
     ("func", "record", "kwargs"), SOLO + FULL_SCALE, ids=SOLO_IDS + FULL_SCALE_IDS
 )
 def test_an_uncalibrated_signal_computes_the_bare_array_result(
-    func, record, kwargs
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
 ) -> None:
     assert_same(func(Signal(record, FS), **kwargs), func(record, FS, **kwargs))
 
@@ -113,7 +118,7 @@ def test_an_uncalibrated_signal_computes_the_bare_array_result(
     ("func", "record", "kwargs"), SOLO + FULL_SCALE, ids=SOLO_IDS + FULL_SCALE_IDS
 )
 def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
-    func, record, kwargs
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
 ) -> None:
     sig = Signal(record, FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
@@ -125,7 +130,9 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
 @pytest.mark.parametrize(
     ("func", "record", "kwargs"), SOLO + FULL_SCALE, ids=SOLO_IDS + FULL_SCALE_IDS
 )
-def test_a_bare_array_still_requires_fs(func, record, kwargs) -> None:
+def test_a_bare_array_still_requires_fs(
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
+) -> None:
     with pytest.raises(ValueError, match="fs is required"):
         func(record, **kwargs)
 
@@ -133,7 +140,9 @@ def test_a_bare_array_still_requires_fs(func, record, kwargs) -> None:
 @pytest.mark.parametrize(
     ("func", "record", "kwargs"), SOLO + FULL_SCALE, ids=SOLO_IDS + FULL_SCALE_IDS
 )
-def test_a_multichannel_signal_is_refused_by_name(func, record, kwargs) -> None:
+def test_a_multichannel_signal_is_refused_by_name(
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
+) -> None:
     """These metrics are defined on one record, and say so."""
     block = Signal(np.stack([record, record]), FS)
     with pytest.raises(ValueError, match="one-dimensional"):
@@ -146,7 +155,9 @@ def test_a_multichannel_signal_is_refused_by_name(func, record, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "record", "kwargs"), SOLO, ids=SOLO_IDS)
-def test_a_calibrated_signal_is_analysed_in_pascals(func, record, kwargs) -> None:
+def test_a_calibrated_signal_is_analysed_in_pascals(
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
+) -> None:
     assert_same(
         func(Signal(record, FS, calibration_factor=CAL), **kwargs),
         func(CAL * record, FS, **kwargs),
@@ -154,7 +165,9 @@ def test_a_calibrated_signal_is_analysed_in_pascals(func, record, kwargs) -> Non
 
 
 @pytest.mark.parametrize(("func", "record", "kwargs"), FULL_SCALE, ids=FULL_SCALE_IDS)
-def test_a_full_scale_quantity_never_sees_the_calibration(func, record, kwargs) -> None:
+def test_a_full_scale_quantity_never_sees_the_calibration(
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
+) -> None:
     """The exemption, asserted from both sides.
 
     The calibrated call must equal the *bare* one, and must differ from the
@@ -173,7 +186,9 @@ def test_a_full_scale_quantity_never_sees_the_calibration(func, record, kwargs) 
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_a_pair_takes_the_rate_from_either_side(func, kwargs) -> None:
+def test_a_pair_takes_the_rate_from_either_side(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x, y = _HARMONIC, _MODULATION
     reference = func(x, y, FS, **kwargs)
     assert_same(func(Signal(x, FS), y, **kwargs), reference)
@@ -182,20 +197,26 @@ def test_a_pair_takes_the_rate_from_either_side(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_two_signals_at_different_rates_are_refused(func, kwargs) -> None:
+def test_two_signals_at_different_rates_are_refused(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     first, second = Signal(_HARMONIC, FS), Signal(_MODULATION, FS // 2)
     with pytest.raises(ValueError, match="recorded at different rates"):
         func(first, second, **kwargs)
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_a_pair_of_bare_arrays_still_requires_fs(func, kwargs) -> None:
+def test_a_pair_of_bare_arrays_still_requires_fs(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     with pytest.raises(ValueError, match="fs is required"):
         func(_HARMONIC, _MODULATION, **kwargs)
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_a_calibrated_pair_is_analysed_in_pascals(func, kwargs) -> None:
+def test_a_calibrated_pair_is_analysed_in_pascals(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     """Two different factors, because a shared one cancels from both of these.
 
     The transfer function is a ratio of the two records and the coherence is

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -21,12 +21,16 @@ rejected engines/languages.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, electroacoustics
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _R = 8.0
 _L0 = 90.0
@@ -251,7 +255,7 @@ def test_distortion_from_swept_sine_result() -> None:
 # --- rendering ---------------------------------------------------------------
 
 
-def _example_result():
+def _example_result() -> electroacoustics.LoudspeakerCharacteristics:
     f, spl = _flat_response()
     angles = np.radians(np.linspace(0.0, 90.0, 40))
     pist = electroacoustics.radiating_piston(
@@ -279,7 +283,7 @@ def _example_result():
     )
 
 
-def test_report_renders_one_page_with_rated_table(tmp_path) -> None:
+def test_report_renders_one_page_with_rated_table(tmp_path: Path) -> None:
     """The fiche renders a valid one-page PDF listing the rated characteristics."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -305,7 +309,7 @@ def test_report_renders_one_page_with_rated_table(tmp_path) -> None:
     assert "PASS" in text
 
 
-def test_report_without_optional_panels(tmp_path) -> None:
+def test_report_without_optional_panels(tmp_path: Path) -> None:
     """A response-only result (no impedance/THD/polar) still renders."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -318,7 +322,7 @@ def test_report_without_optional_panels(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders a one-page Spanish fiche."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -378,7 +382,7 @@ def test_plot_rejects_unknown_quantity_and_missing_data() -> None:
         bare.plot(quantity="impedance")
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "x.pdf")
@@ -386,7 +390,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "bad.pdf")
@@ -397,7 +401,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
 # --------------------------------------------------------------------------
 # A response the panel cannot be drawn over
 # --------------------------------------------------------------------------
-def test_a_response_span_too_narrow_to_draw_is_refused(tmp_path) -> None:
+def test_a_response_span_too_narrow_to_draw_is_refused(tmp_path: Path) -> None:
     """The fiche scales its panel by the decades the curve spans.
 
     Two points a hair apart pass every other check on the curve and send that

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -26,12 +26,16 @@ rejected engines/languages.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, electroacoustics
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _M_MV = 12.5
 _TOL = 3.0
@@ -421,7 +425,7 @@ def test_no_noise_input_gives_no_noise_rows() -> None:
 # --- rendering -------------------------------------------------------------------
 
 
-def _example_result():
+def _example_result() -> electroacoustics.MicrophoneCharacteristics:
     f, rel = _flat_response()
     angles = np.linspace(0.0, 179.0, 359)
     pattern = 20.0 * np.log10((1.0 + np.cos(np.radians(angles))) / 2.0)
@@ -450,7 +454,7 @@ def _example_result():
     )
 
 
-def test_report_renders_one_page_with_rated_table(tmp_path) -> None:
+def test_report_renders_one_page_with_rated_table(tmp_path: Path) -> None:
     """The fiche renders a valid one-page PDF listing the rated characteristics."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -476,7 +480,7 @@ def test_report_renders_one_page_with_rated_table(tmp_path) -> None:
     assert "PASS" in text
 
 
-def test_report_without_optional_panels(tmp_path) -> None:
+def test_report_without_optional_panels(tmp_path: Path) -> None:
     """A response-only result (no polar/noise/distortion) still renders."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -489,7 +493,7 @@ def test_report_without_optional_panels(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders a one-page Spanish fiche."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -546,7 +550,7 @@ def test_plot_rejects_unknown_quantity_and_missing_data() -> None:
         bare.plot(quantity="directivity")
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "x.pdf")
@@ -554,7 +558,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/environment/assessment/test_impulse_prominence_report.py
+++ b/tests/environment/assessment/test_impulse_prominence_report.py
@@ -15,6 +15,7 @@ governing prominence and adjustment are derived from Formula 1 and Formula 2.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -24,6 +25,9 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.environment.assessment import impulsive_sound as nt
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # The documented three-impulse pile-driving set: (onset rate dB/s, level
 # difference dB). All three qualify (onset rate > 10 dB/s); the first governs.
@@ -36,7 +40,7 @@ _P_GOVERNING = 3.0 * math.log10(1200.0) + 2.0 * math.log10(32.0)  # 12.2478...
 _KI_GOVERNING = 1.8 * (_P_GOVERNING - 5.0)  # 13.046...
 
 
-def _result():
+def _result() -> nt.ImpulseProminenceResult:
     """The documented three-impulse pile-driving prominence result."""
     return nt.impulse_prominence(_ONSET_RATES, _LEVEL_DIFFERENCES)
 
@@ -47,7 +51,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     """An impulse set renders a one-page PDF fiche."""
     result = _result()
     out = tmp_path / "impulse.pdf"
@@ -56,7 +60,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
@@ -64,7 +68,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
@@ -72,7 +76,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         result.report(out, language="xx")
 
 
-def test_report_states_prominence_and_adjustment(tmp_path) -> None:
+def test_report_states_prominence_and_adjustment(tmp_path: Path) -> None:
     """The fiche states the governing P, the derived KI and the formula basis.
 
     The governing prominence is the first (highest-P) impulse; its LAeq
@@ -93,7 +97,7 @@ def test_report_states_prominence_and_adjustment(tmp_path) -> None:
     assert "Formula 2" in text
 
 
-def test_metadata_appears_and_one_page(tmp_path) -> None:
+def test_metadata_appears_and_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders one page and prints its fields."""
     md = ReportMetadata(
         specimen="Pile-driving site, intermittent hammering",
@@ -118,7 +122,7 @@ def test_metadata_appears_and_one_page(tmp_path) -> None:
     assert "30 min" in text
 
 
-def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
+def test_requirement_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS and a FAIL prominence limit both render one page."""
     result = _result()
     p = result.prominence
@@ -132,7 +136,7 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing)).replace("\n", " ")
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) is escaped, rendered and not dropped.
 
     The specials must survive reportlab's XML parser (which would otherwise
@@ -159,7 +163,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert "R&D-112" in text  # footer report number
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -176,7 +180,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_verdict_compares_unrounded_prominence(tmp_path) -> None:
+def test_verdict_compares_unrounded_prominence(tmp_path: Path) -> None:
     """A prominence just above the requirement FAILs, not rounded to a PASS.
 
     The governing prominence 12.2478 rounds to 12.25 for display; a requirement
@@ -194,7 +198,7 @@ def test_verdict_compares_unrounded_prominence(tmp_path) -> None:
     assert "PASS" not in text
 
 
-def test_verdict_passes_at_the_requirement(tmp_path) -> None:
+def test_verdict_passes_at_the_requirement(tmp_path: Path) -> None:
     """A governing prominence at the requirement passes (``<=``)."""
     result = _result()
     out = tmp_path / "atlimit.pdf"
@@ -203,7 +207,7 @@ def test_verdict_passes_at_the_requirement(tmp_path) -> None:
     assert "PASS" in _extract_text(str(out)).replace("\n", " ")
 
 
-def test_oversized_impulse_set_stays_one_page(tmp_path) -> None:
+def test_oversized_impulse_set_stays_one_page(tmp_path: Path) -> None:
     """A large valid impulse set caps the table and stays exactly one page.
 
     Forty qualifying impulses exceed the table row cap; the fiche must keep the
@@ -268,7 +272,7 @@ def test_row_cap_force_includes_a_low_prominence_governing_impulse() -> None:
     assert governing in shown  # forced in despite its low prominence
 
 
-def test_non_prominent_impulse_reports_zero_adjustment(tmp_path) -> None:
+def test_non_prominent_impulse_reports_zero_adjustment(tmp_path: Path) -> None:
     """A qualifying but weak impulse (P <= 5) renders with a zero adjustment.
 
     A qualifying onset (rate above 10 dB/s) with a low prominence keeps KI at
@@ -286,7 +290,7 @@ def test_non_prominent_impulse_reports_zero_adjustment(tmp_path) -> None:
     assert "K = 0" in text or "0 dB" in text
 
 
-def test_non_qualifying_set_justifies_on_the_onset_gate(tmp_path) -> None:
+def test_non_qualifying_set_justifies_on_the_onset_gate(tmp_path: Path) -> None:
     """With no qualifying onset the note cites the onset gate, not P <= 5.
 
     Both gates can withhold the adjustment. Here every onset rate is at or
@@ -308,7 +312,7 @@ def test_non_qualifying_set_justifies_on_the_onset_gate(tmp_path) -> None:
     assert "No prominent impulse is present" not in text
 
 
-def test_assessment_period_reflects_the_analysed_interval(tmp_path) -> None:
+def test_assessment_period_reflects_the_analysed_interval(tmp_path: Path) -> None:
     """The header prints the analysed interval, defaulting to the 30 min default."""
     default_out = tmp_path / "default.pdf"
     _result().report(str(default_out))

--- a/tests/environment/assessment/test_impulsive_sound.py
+++ b/tests/environment/assessment/test_impulsive_sound.py
@@ -52,8 +52,13 @@ DT = 0.02  # 20 ms, within the 10-25 ms range of Clause 4.
 
 
 def _ramp(
-    level_start: float, level_difference: float, rise: float, *, pre=0.2, post=0.3
-):
+    level_start: float,
+    level_difference: float,
+    rise: float,
+    *,
+    pre: float = 0.2,
+    post: float = 0.3,
+) -> np.ndarray:
     """A flat-ramp-flat ``LpAF`` history sampled at :data:`DT`.
 
     The onset spans exactly ``rise`` seconds so its onset rate is

--- a/tests/environment/assessment/test_rd1367_report.py
+++ b/tests/environment/assessment/test_rd1367_report.py
@@ -18,6 +18,8 @@ against a 55 dB limit, so a new activity does not comply.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 pytest.importorskip("reportlab")
@@ -26,6 +28,9 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.environment.assessment import spain as rd
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _measurements() -> dict[str, list[rd.NoisePhase]]:
@@ -59,7 +64,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     """An activity assessment renders a one-page PDF fiche."""
     out = tmp_path / "acta.pdf"
     returned = _result().report(str(out))
@@ -67,7 +72,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
@@ -75,7 +80,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         result.report(out, language="xx")
 
 
-def test_fiche_defaults_to_spanish(tmp_path) -> None:
+def test_fiche_defaults_to_spanish(tmp_path: Path) -> None:
     """The fiche renders in Spanish by default, the language of the regulation.
 
     Its limit row is carried on the result in English, the library's API
@@ -97,7 +102,7 @@ def test_fiche_defaults_to_spanish(tmp_path) -> None:
     assert "Noise phase" not in text
 
 
-def test_english_fiche_renders_one_page(tmp_path) -> None:
+def test_english_fiche_renders_one_page(tmp_path: Path) -> None:
     """``language="en"`` renders the same fiche in English on one page."""
     out = tmp_path / "acta_en.pdf"
     _result().report(str(out), language="en")
@@ -108,7 +113,7 @@ def test_english_fiche_renders_one_page(tmp_path) -> None:
     assert "Day" in text
 
 
-def test_report_states_the_phase_and_period_numbers(tmp_path) -> None:
+def test_report_states_the_phase_and_period_numbers(tmp_path: Path) -> None:
     """The fiche prints the corrections, the phase levels and the period result.
 
     Ejemplo 3.1 gives LKeq,Ti of 59 dB and 54 dB from LAeq,Ti of 50 dB and
@@ -133,7 +138,7 @@ def test_report_states_the_phase_and_period_numbers(tmp_path) -> None:
 
 
 def test_verdict_fails_for_a_new_activity_and_passes_for_an_existing_one(
-    tmp_path,
+    tmp_path: Path,
 ) -> None:
     """Manual Ejemplo 3.3: the same activity fails as new and passes as existing.
 
@@ -158,7 +163,7 @@ def test_verdict_fails_for_a_new_activity_and_passes_for_an_existing_one(
     assert "Article 25.2" in existing_text
 
 
-def test_spanish_verdict_labels(tmp_path) -> None:
+def test_spanish_verdict_labels(tmp_path: Path) -> None:
     """The Spanish fiche renders the verdict as CUMPLE / NO CUMPLE."""
     out = tmp_path / "verdict_es.pdf"
     _result().report(str(out))
@@ -167,7 +172,7 @@ def test_spanish_verdict_labels(tmp_path) -> None:
     assert "supera" in text
 
 
-def test_metadata_appears_and_stays_one_page(tmp_path) -> None:
+def test_metadata_appears_and_stays_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders one page and prints its fields."""
     md = ReportMetadata(
         specimen="Taller mecanico, horario 9 h a 21 h",
@@ -189,7 +194,9 @@ def test_metadata_appears_and_stays_one_page(tmp_path) -> None:
     assert "EXP-2026-000123" in text
 
 
-def test_report_escapes_xml_specials_in_metadata_and_phase_labels(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata_and_phase_labels(
+    tmp_path: Path,
+) -> None:
     """XML specials (& < >) in metadata and phase labels survive reportlab.
 
     The phase label is free text that reaches the table as a paragraph, so it
@@ -218,7 +225,7 @@ def test_report_escapes_xml_specials_in_metadata_and_phase_labels(tmp_path) -> N
     assert "R&D-1367" in text
 
 
-def test_three_period_fiche_stays_one_page(tmp_path) -> None:
+def test_three_period_fiche_stays_one_page(tmp_path: Path) -> None:
     """A fiche carrying all three evaluation periods still fits one page.
 
     The phase table grows with the number of noise phases, so the assessment
@@ -245,7 +252,7 @@ def test_three_period_fiche_stays_one_page(tmp_path) -> None:
             assert_one_page(str(out))
 
 
-def test_adjacent_premises_limit_row_renders(tmp_path) -> None:
+def test_adjacent_premises_limit_row_renders(tmp_path: Path) -> None:
     """A fiche assessed against the Table B2 adjacent-premises row renders.
 
     Its limit row description names the premises and the room type, which the

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -14,6 +14,8 @@ measurement" wording and the verdict direction, like the sibling report tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -23,6 +25,9 @@ from report_assertions import assert_one_page
 
 import phonometry as ph
 from phonometry import ReportMetadata, environment
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _BANDS = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
 
@@ -58,7 +63,7 @@ def _extract_text(path: str) -> str:
 # --------------------------------------------------------------------------- #
 # Attenuation prediction fiche
 # --------------------------------------------------------------------------- #
-def test_attenuation_with_emission_boxes_receiver_level(tmp_path) -> None:
+def test_attenuation_with_emission_boxes_receiver_level(tmp_path: Path) -> None:
     """With a source emission the fiche boxes the A-weighted downwind level."""
     out = tmp_path / "atten.pdf"
     assert _attenuation().report(str(out), source_emission=_emission()) == str(out)
@@ -73,7 +78,7 @@ def test_attenuation_with_emission_boxes_receiver_level(tmp_path) -> None:
     assert "47.2" in text  # LfT(DW) at 63 Hz = 100 - a_total
 
 
-def test_attenuation_without_emission_boxes_total_range(tmp_path) -> None:
+def test_attenuation_without_emission_boxes_total_range(tmp_path: Path) -> None:
     """Without a source emission the fiche boxes the total-attenuation range."""
     out = tmp_path / "bare.pdf"
     _attenuation().report(str(out))
@@ -85,7 +90,7 @@ def test_attenuation_without_emission_boxes_total_range(tmp_path) -> None:
     assert "LAT(DW)" not in text  # no receiver level without a source emission
 
 
-def test_attenuation_emission_length_mismatch_raises(tmp_path) -> None:
+def test_attenuation_emission_length_mismatch_raises(tmp_path: Path) -> None:
     """A source power that does not match the band count is rejected."""
     result = _attenuation()
     bad = environment.SourceEmission(sound_power_level=np.full(4, 100.0))
@@ -96,7 +101,7 @@ def test_attenuation_emission_length_mismatch_raises(tmp_path) -> None:
         result.report(out, source_emission=bad)
 
 
-def test_attenuation_verbose_adds_a_weighted_band(tmp_path) -> None:
+def test_attenuation_verbose_adds_a_weighted_band(tmp_path: Path) -> None:
     """``verbose=True`` adds the A-weighted band-level column."""
     result = _attenuation()
     emission = _emission()
@@ -109,7 +114,7 @@ def test_attenuation_verbose_adds_a_weighted_band(tmp_path) -> None:
     assert "dB(A)" in _extract_text(str(verbose))  # the L_A column header
 
 
-def test_attenuation_requirement_lower_is_better(tmp_path) -> None:
+def test_attenuation_requirement_lower_is_better(tmp_path: Path) -> None:
     """The downwind level passes at or below the declared limit level."""
     result = _attenuation()  # LAT(DW) = 46.5 dB with the flat 100 dB source
     emission = _emission()
@@ -130,7 +135,7 @@ def test_attenuation_requirement_lower_is_better(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_attenuation_metadata_header_and_distance(tmp_path) -> None:
+def test_attenuation_metadata_header_and_distance(tmp_path: Path) -> None:
     """A populated metadata header and the recovered distance print."""
     metadata = ReportMetadata(
         specimen="Industrial fan plant",
@@ -148,7 +153,7 @@ def test_attenuation_metadata_header_and_distance(tmp_path) -> None:
     assert "200" in text  # distance d recovered from Adiv
 
 
-def test_attenuation_spanish_fiche(tmp_path) -> None:
+def test_attenuation_spanish_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish attenuation fiche."""
     import re
 
@@ -170,7 +175,7 @@ def test_attenuation_spanish_fiche(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Barrier insertion-loss prediction fiche
 # --------------------------------------------------------------------------- #
-def test_barrier_report_structure_and_numbers(tmp_path) -> None:
+def test_barrier_report_structure_and_numbers(tmp_path: Path) -> None:
     """The barrier fiche boxes the mean insertion loss and cites the model."""
     out = tmp_path / "bar.pdf"
     assert _barrier().report(str(out)) == str(out)
@@ -186,7 +191,7 @@ def test_barrier_report_structure_and_numbers(tmp_path) -> None:
     assert "21.0" in text  # IL at 8 kHz from the table
 
 
-def test_barrier_verbose_adds_fresnel_number(tmp_path) -> None:
+def test_barrier_verbose_adds_fresnel_number(tmp_path: Path) -> None:
     """``verbose=True`` adds the Fresnel-number column."""
     plain = tmp_path / "plain.pdf"
     _barrier().report(str(plain))
@@ -197,7 +202,7 @@ def test_barrier_verbose_adds_fresnel_number(tmp_path) -> None:
     assert "7.05" in _extract_text(str(verbose))  # N at 8 kHz
 
 
-def test_barrier_requirement_higher_is_better(tmp_path) -> None:
+def test_barrier_requirement_higher_is_better(tmp_path: Path) -> None:
     """The insertion loss passes at or above the required minimum."""
     result = _barrier()  # mean IL = 12.9 dB
     passing = tmp_path / "pass.pdf"
@@ -209,7 +214,7 @@ def test_barrier_requirement_higher_is_better(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing))
 
 
-def test_barrier_kurze_anderson_model_cited(tmp_path) -> None:
+def test_barrier_kurze_anderson_model_cited(tmp_path: Path) -> None:
     """The Kurze-Anderson method is named in the basis line."""
     out = tmp_path / "ka.pdf"
     _barrier(method="kurze_anderson").report(str(out))
@@ -217,7 +222,7 @@ def test_barrier_kurze_anderson_model_cited(tmp_path) -> None:
     assert "Kurze-Anderson" in _extract_text(str(out))
 
 
-def test_barrier_lightweight_without_metadata(tmp_path) -> None:
+def test_barrier_lightweight_without_metadata(tmp_path: Path) -> None:
     """A barrier fiche with no metadata is still a valid one-page prediction."""
     out = tmp_path / "bare.pdf"
     _barrier().report(str(out))
@@ -225,7 +230,7 @@ def test_barrier_lightweight_without_metadata(tmp_path) -> None:
     assert "prediction" in _extract_text(str(out))
 
 
-def test_barrier_spanish_fiche(tmp_path) -> None:
+def test_barrier_spanish_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders the Spanish barrier fiche."""
     out = tmp_path / "es.pdf"
     _barrier().report(str(out), language="es")
@@ -238,7 +243,7 @@ def test_barrier_spanish_fiche(tmp_path) -> None:
 # --------------------------------------------------------------------------- #
 # Shared validation
 # --------------------------------------------------------------------------- #
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError`` for both fiches."""
     attenuation = _attenuation()
     out_a = str(tmp_path / "a.pdf")
@@ -250,7 +255,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         barrier.report(out_b, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` for both fiches."""
     attenuation = _attenuation()
     out_a = str(tmp_path / "a.pdf")

--- a/tests/environment/sources/test_cnossos_road.py
+++ b/tests/environment/sources/test_cnossos_road.py
@@ -45,6 +45,7 @@ from phonometry.environment.sources.cnossos_road import (
     ROAD_REFERENCE_SPEED,
     JunctionType,
     RoadEmissionCoefficients,
+    RoadEmissionResult,
     RoadSurface,
     RoadSurfaceCoefficients,
     RoadTraffic,
@@ -71,7 +72,7 @@ def _workbook_cases() -> list[dict[str, str]]:
     return ref.cnossos_road_workbook_cases()
 
 
-def _run_case(case: dict[str, str]):
+def _run_case(case: dict[str, str]) -> RoadEmissionResult:
     surfaces = _surfaces_2015()
     traffic = [
         RoadTraffic(

--- a/tests/environment/sources/test_wind_turbine_tonality_report.py
+++ b/tests/environment/sources/test_wind_turbine_tonality_report.py
@@ -13,6 +13,8 @@ same hand-derived synthetic tone so its numbers are documented.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -22,8 +24,12 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.environment.sources.wind_turbine import (
+    WindTurbineTonalityResult,
     wind_turbine_tonality,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _synthetic_tone() -> tuple[np.ndarray, np.ndarray]:
@@ -38,7 +44,7 @@ def _synthetic_tone() -> tuple[np.ndarray, np.ndarray]:
     return levels, freqs
 
 
-def _result():
+def _result() -> WindTurbineTonalityResult:
     levels, freqs = _synthetic_tone()
     return wind_turbine_tonality(levels, freqs)
 
@@ -49,7 +55,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_report_writes_one_page_pdf(tmp_path) -> None:
+def test_report_writes_one_page_pdf(tmp_path: Path) -> None:
     """An audible-tone result renders a one-page PDF fiche."""
     result = _result()
     out = tmp_path / "wt.pdf"
@@ -58,7 +64,7 @@ def test_report_writes_one_page_pdf(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
@@ -66,7 +72,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
@@ -74,7 +80,7 @@ def test_unknown_language_rejected(tmp_path) -> None:
         result.report(out, language="xx")
 
 
-def test_report_states_audibility_frequency_and_decision(tmp_path) -> None:
+def test_report_states_audibility_frequency_and_decision(tmp_path: Path) -> None:
     """The fiche states ΔL_a, the tone frequency and the audibility decision."""
     result = _result()
     out = tmp_path / "wt.pdf"
@@ -89,7 +95,7 @@ def test_report_states_audibility_frequency_and_decision(tmp_path) -> None:
     assert "IEC 61400-11" in text
 
 
-def test_metadata_appears_and_one_page(tmp_path) -> None:
+def test_metadata_appears_and_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders one page and prints its fields."""
     md = ReportMetadata(
         specimen="Horizontal-axis wind turbine, gearbox tone",
@@ -112,7 +118,7 @@ def test_metadata_appears_and_one_page(tmp_path) -> None:
     assert "IEC 61400-11" in text
 
 
-def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
+def test_requirement_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS and a FAIL tonal-audibility limit both render one page."""
     result = _result()
     delta = result.tonal_audibility
@@ -126,7 +132,7 @@ def test_requirement_pass_and_fail_both_render(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(failing)).replace("\n", " ")
 
 
-def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
+def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:
     """Metadata with XML specials (& < >) renders without crashing reportlab."""
     md = ReportMetadata(
         client="Ac & Co <Ltd>",
@@ -142,7 +148,7 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -159,7 +165,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert re.search(r"\d,\d", text) is not None  # comma decimal separator
 
 
-def test_decision_matches_displayed_audibility_at_boundary(tmp_path) -> None:
+def test_decision_matches_displayed_audibility_at_boundary(tmp_path: Path) -> None:
     """The audibility decision reads the displayed rounded ΔL_a, not the raw flag.
 
     A raw tonal audibility of 0.03 dB is audible (> 0), but it rounds to the
@@ -178,7 +184,7 @@ def test_decision_matches_displayed_audibility_at_boundary(tmp_path) -> None:
     assert "0.0 dB" in text
 
 
-def test_no_identified_tone_reports_exclusion(tmp_path) -> None:
+def test_no_identified_tone_reports_exclusion(tmp_path: Path) -> None:
     """A spectrum with no classified tone renders and states the exclusion.
 
     A broad 33 dB bump on a 30 dB floor produces no tone line (subclause 9.5.4),

--- a/tests/filters/test_design.py
+++ b/tests/filters/test_design.py
@@ -1,6 +1,7 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 """Tests for filter design helpers and response plotting utilities."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import matplotlib.pyplot as plt
@@ -113,7 +114,7 @@ def test_bessel_minus3db_at_band_edges(fraction: float) -> None:
         )
 
 
-def test_showfilter_saves_shows_and_noops(tmp_path) -> None:
+def test_showfilter_saves_shows_and_noops(tmp_path: Path) -> None:
     """Verify _showfilter handles save, show, and no-output branches."""
     fs = 8000
     sos = [np.array([[1, 0, 0, 1, 0, 0]])]
@@ -155,7 +156,7 @@ def test_all_filter_architectures_design() -> None:
         assert len(sos[0]) > 0
 
 
-def test_design_sos_with_internal_plot(tmp_path) -> None:
+def test_design_sos_with_internal_plot(tmp_path: Path) -> None:
     """Verify _design_sos_filter forwards plot output to _showfilter."""
     plot_path = tmp_path / "test_design_plot.png"
 

--- a/tests/filters/test_iec61260_report.py
+++ b/tests/filters/test_iec61260_report.py
@@ -13,6 +13,7 @@ verification itself is validated against the standard's Table 1 elsewhere
 from __future__ import annotations
 
 import pickle
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -21,6 +22,9 @@ pytest.importorskip("reportlab")
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, filters
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _class1_bank() -> filters.OctaveFilterBank:
@@ -49,7 +53,7 @@ def test_filter_class_compliance_carries_bank_data() -> None:
     pickle.loads(pickle.dumps(result))
 
 
-def test_class1_bank_reports_complies(tmp_path) -> None:
+def test_class1_bank_reports_complies(tmp_path: Path) -> None:
     """A class-1 bank renders a valid one-page COMPLIES fiche."""
     result = filters.filter_class_compliance(_class1_bank())
     assert result.overall_class == 1
@@ -59,7 +63,7 @@ def test_class1_bank_reports_complies(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_1995_edition_reports_class0(tmp_path) -> None:
+def test_1995_edition_reports_class0(tmp_path: Path) -> None:
     """The 1995 edition keeps class 0; a high-order bank renders a Class 0 fiche."""
     bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[250, 4000])
     result = filters.filter_class_compliance(bank, edition="1995")
@@ -76,7 +80,7 @@ def test_1995_edition_reports_class0(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_full_metadata_renders_one_page(tmp_path) -> None:
+def test_full_metadata_renders_one_page(tmp_path: Path) -> None:
     """A populated ReportMetadata renders a one-page filter-compliance fiche."""
     result = filters.filter_class_compliance(_class1_bank())
     md = ReportMetadata(
@@ -96,7 +100,7 @@ def test_full_metadata_renders_one_page(tmp_path) -> None:
     assert_one_page(str(out))
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = filters.filter_class_compliance(
         _class1_bank()
@@ -106,7 +110,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         result.report(out, engine="weasyprint")
 
 
-def test_required_class_pass_and_fail_both_render(tmp_path) -> None:
+def test_required_class_pass_and_fail_both_render(tmp_path: Path) -> None:
     """A PASS (class 1 meets required 1) and a FAIL (meets no class) both render."""
     result = filters.filter_class_compliance(_class1_bank())
     assert result.overall_class == 1
@@ -123,7 +127,7 @@ def test_required_class_pass_and_fail_both_render(tmp_path) -> None:
     assert_one_page(str(failing))
 
 
-def test_required_class_missing_from_edition_rejected(tmp_path) -> None:
+def test_required_class_missing_from_edition_rejected(tmp_path: Path) -> None:
     """Class 0 against a 2014-edition result raises: the class does not exist.
 
     IEC 61260-1:2014 defines only classes 1 and 2; a required class 0 verdict
@@ -137,7 +141,7 @@ def test_required_class_missing_from_edition_rejected(tmp_path) -> None:
         result.report(out, metadata=meta)
 
 
-def test_fiche_labels_bands_with_nominal_frequencies(tmp_path) -> None:
+def test_fiche_labels_bands_with_nominal_frequencies(tmp_path: Path) -> None:
     """The per-band table uses the nominal mid-band frequencies.
 
     Both editions identify the filters by their nominal frequencies
@@ -154,7 +158,7 @@ def test_fiche_labels_bands_with_nominal_frequencies(tmp_path) -> None:
     assert "3981" not in text
 
 
-def test_range_limited_verdict_prints_qualifying_note(tmp_path) -> None:
+def test_range_limited_verdict_prints_qualifying_note(tmp_path: Path) -> None:
     """A range-limited COMPLIES is qualified on the fiche.
 
     The multirate verification cannot exercise the stop-band mask beyond each
@@ -173,7 +177,7 @@ def test_range_limited_verdict_prints_qualifying_note(tmp_path) -> None:
     assert "not demonstrated" in text
 
 
-def test_non_compliant_bank_renders(tmp_path) -> None:
+def test_non_compliant_bank_renders(tmp_path: Path) -> None:
     """A low-order bank that meets no class renders its non-compliance fiche."""
     bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=1, limits=[500, 2000])
     result = filters.filter_class_compliance(bank)
@@ -214,7 +218,7 @@ def _extract_text(path: str) -> str:
     return "\n".join(page.extract_text() for page in PdfReader(path).pages)
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re
 
@@ -229,7 +233,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert "margen" in text
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = filters.filter_class_compliance(_class1_bank())
     with pytest.raises(ValueError, match="language"):

--- a/tests/filters/test_nominal_frequencies.py
+++ b/tests/filters/test_nominal_frequencies.py
@@ -16,17 +16,17 @@ from phonometry.filters.frequencies import (
 # --- _iec_e3_round ---
 
 
-def test_iec_e3_round_msd_1_to_4():
+def test_iec_e3_round_msd_1_to_4() -> None:
     assert _iec_e3_round(1234.5) == pytest.approx(1230.0)
     assert _iec_e3_round(456.7) == pytest.approx(457.0)
 
 
-def test_iec_e3_round_msd_5_to_9():
+def test_iec_e3_round_msd_5_to_9() -> None:
     assert _iec_e3_round(5678.0) == pytest.approx(5700.0)
     assert _iec_e3_round(99.1) == pytest.approx(99.0)
 
 
-def test_iec_e3_round_nonpositive():
+def test_iec_e3_round_nonpositive() -> None:
     assert _iec_e3_round(0) == 0
     assert _iec_e3_round(-1) == -1
 
@@ -34,29 +34,29 @@ def test_iec_e3_round_nonpositive():
 # --- _nominal_freq_for_band ---
 
 
-def test_nominal_freq_fraction1():
+def test_nominal_freq_fraction1() -> None:
     assert _nominal_freq_for_band(15.849, 1) == pytest.approx(16.0)
     assert _nominal_freq_for_band(997.2, 1) == pytest.approx(1000.0)
 
 
-def test_nominal_freq_fraction3():
+def test_nominal_freq_fraction3() -> None:
     assert _nominal_freq_for_band(12.589, 3) == pytest.approx(12.5)
     assert _nominal_freq_for_band(1995.3, 3) == pytest.approx(2000.0)
 
 
-def test_nominal_freq_other_fraction():
+def test_nominal_freq_other_fraction() -> None:
     assert _nominal_freq_for_band(706.0, 2) == pytest.approx(710.0)
 
 
 # --- _format_nominal_freq ---
 
 
-def test_format_below_1k():
+def test_format_below_1k() -> None:
     assert _format_nominal_freq(31.5) == "31.5"
     assert _format_nominal_freq(500.0) == "500"
 
 
-def test_format_1k_and_above():
+def test_format_1k_and_above() -> None:
     assert _format_nominal_freq(1000.0) == "1k"
     assert _format_nominal_freq(16000.0) == "16k"
     assert _format_nominal_freq(1250.0) == "1.25k"
@@ -65,7 +65,7 @@ def test_format_1k_and_above():
 # --- nominal_frequencies — 4-tuple ---
 
 
-def test_getansifrequencies_returns_labels():
+def test_getansifrequencies_returns_labels() -> None:
     freq, _, _, labels = nominal_frequencies(fraction=3)
     assert isinstance(labels, list)
     assert all(isinstance(label, str) for label in labels)
@@ -74,7 +74,7 @@ def test_getansifrequencies_returns_labels():
     assert "31.5" in labels
 
 
-def test_getansifrequencies_fraction1_labels():
+def test_getansifrequencies_fraction1_labels() -> None:
     freq, _, _, labels = nominal_frequencies(fraction=1)
     assert "1k" in labels
     assert len(labels) == len(freq)
@@ -83,7 +83,7 @@ def test_getansifrequencies_fraction1_labels():
 # --- OctaveFilterBank.nominal_freq attribute ---
 
 
-def test_filterbank_nominal_freq_attribute():
+def test_filterbank_nominal_freq_attribute() -> None:
     fb = filters.OctaveFilterBank(fs=48000, fraction=1)
     assert hasattr(fb, "nominal_freq")
     assert isinstance(fb.nominal_freq, list)
@@ -95,7 +95,7 @@ def test_filterbank_nominal_freq_attribute():
 # --- filter(nominal=False) — default exact floats ---
 
 
-def test_filter_nominal_false_returns_floats():
+def test_filter_nominal_false_returns_floats() -> None:
     fb = filters.OctaveFilterBank(fs=48000, fraction=3)
     x = np.zeros(4800)
     _, freq = fb.filter(x, nominal=False)
@@ -105,7 +105,7 @@ def test_filter_nominal_false_returns_floats():
 # --- filter(nominal=True) — nominal string labels ---
 
 
-def test_filter_nominal_true_returns_strings():
+def test_filter_nominal_true_returns_strings() -> None:
     fb = filters.OctaveFilterBank(fs=48000, fraction=3)
     x = np.zeros(4800)
     _, freq = fb.filter(x, nominal=True)
@@ -113,7 +113,7 @@ def test_filter_nominal_true_returns_strings():
     assert "1k" in freq
 
 
-def test_filter_nominal_true_with_sigbands():
+def test_filter_nominal_true_with_sigbands() -> None:
     fb = filters.OctaveFilterBank(fs=48000, fraction=1)
     x = np.zeros(4800)
     _, freq, xb = fb.filter(x, sigbands=True, nominal=True)
@@ -124,14 +124,14 @@ def test_filter_nominal_true_with_sigbands():
 # --- octave_filter(nominal=True) ---
 
 
-def test_octavefilter_nominal_true():
+def test_octavefilter_nominal_true() -> None:
     x = np.zeros(4800)
     _, freq = filters.octave_filter(x, fs=48000, fraction=3, nominal=True)
     assert all(isinstance(f, str) for f in freq)
     assert "1k" in freq
 
 
-def test_octavefilter_nominal_false_default():
+def test_octavefilter_nominal_false_default() -> None:
     x = np.zeros(4800)
     _, freq = filters.octave_filter(x, fs=48000, fraction=3)
     assert all(isinstance(f, float) for f in freq)

--- a/tests/filters/test_signal_overloads.py
+++ b/tests/filters/test_signal_overloads.py
@@ -16,6 +16,8 @@ accident.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -33,6 +35,9 @@ from phonometry.filters import (
     weighting_filter,
 )
 from phonometry.io import Signal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 48000
 CAL = 2.0
@@ -63,7 +68,9 @@ def test_the_signals_rate_is_used_when_none_is_given() -> None:
         (parametric_eq, {"sections": EQSection("peaking", 1000.0, 3.0, 1.0)}),
     ],
 )
-def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> None:
+def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
+    func: Callable[..., object], kwargs: dict[str, float | EQSection]
+) -> None:
     sig = Signal(_tone(), FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
         func(sig, FS + 1, **kwargs)
@@ -82,7 +89,9 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> No
         (parametric_eq, {"sections": EQSection("peaking", 1000.0, 3.0, 1.0)}),
     ],
 )
-def test_a_bare_array_still_requires_fs(func, kwargs) -> None:
+def test_a_bare_array_still_requires_fs(
+    func: Callable[..., object], kwargs: dict[str, float | EQSection]
+) -> None:
     x = _tone()
     with pytest.raises(ValueError, match="fs is required"):
         func(x, **kwargs)
@@ -317,7 +326,11 @@ def test_the_spectrogram_returns_pascal_levels_for_a_calibrated_signal() -> None
         (lambda: TimeWeighting(FS), "process", "time weighting"),
     ],
 )
-def test_the_pre_designed_objects_refuse_a_foreign_rate(build, call, what) -> None:
+def test_the_pre_designed_objects_refuse_a_foreign_rate(
+    build: Callable[[], OctaveFilterBank | WeightingFilter | TimeWeighting],
+    call: str,
+    what: str,
+) -> None:
     obj = build()
     method = getattr(obj, call)
     foreign = Signal(_tone(), FS // 2)

--- a/tests/filters/test_stateful_octave_filter_bank.py
+++ b/tests/filters/test_stateful_octave_filter_bank.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.parametrize("block_size", [8, 256, 1024])
-def test_block_processing_matches_full_signal(block_size: int):
+def test_block_processing_matches_full_signal(block_size: int) -> None:
     from phonometry import filters
 
     """
@@ -57,7 +57,7 @@ def test_block_processing_matches_full_signal(block_size: int):
     )
 
 
-def test_resample_and_stateful():
+def test_resample_and_stateful() -> None:
     from phonometry.filters.core import (
         BlockProcessing,
         FilterDesign,
@@ -74,7 +74,7 @@ def test_resample_and_stateful():
         )
 
 
-def test_stateful_steady_ic_initialization():
+def test_stateful_steady_ic_initialization() -> None:
     from phonometry.filters.core import (
         BlockProcessing,
         FilterDesign,
@@ -112,7 +112,7 @@ def test_stateful_steady_ic_initialization():
         assert zi.shape[2] == 2
 
 
-def test_stateful_multichannel():
+def test_stateful_multichannel() -> None:
     """Test that stateful processing works with multichannel (e.g. stereo) input."""
     from phonometry.filters.core import (
         BlockProcessing,
@@ -146,7 +146,7 @@ def test_stateful_multichannel():
     assert spl2.shape[0] == n_channels
 
 
-def test_detrend_stateful_warning():
+def test_detrend_stateful_warning() -> None:
     from phonometry.filters.core import (
         BlockProcessing,
         FilterDesign,

--- a/tests/filters/test_stateful_weighting_filter.py
+++ b/tests/filters/test_stateful_weighting_filter.py
@@ -6,7 +6,7 @@ import pytest
 @pytest.mark.parametrize("filter_type", ["A", "C", "Z"])
 def test_weighting_filter_block_processing_matches_full_signal(
     block_size: int, filter_type: str
-):
+) -> None:
     from phonometry import filters
 
     """
@@ -47,7 +47,7 @@ def test_weighting_filter_block_processing_matches_full_signal(
     )
 
 
-def test_weighting_filter_steady_ic_initialization():
+def test_weighting_filter_steady_ic_initialization() -> None:
     from phonometry import filters
 
     # Create a stateful weighting filter with steady_ic=True
@@ -64,7 +64,7 @@ def test_weighting_filter_steady_ic_initialization():
     assert wf.zi.shape == (n_sections, 2)
 
 
-def test_weighting_filter_steady_ic_initialization_multichannel():
+def test_weighting_filter_steady_ic_initialization_multichannel() -> None:
     from phonometry import filters
 
     wf = filters.WeightingFilter(fs=48000, stateful=True, steady_ic=True)
@@ -77,7 +77,7 @@ def test_weighting_filter_steady_ic_initialization_multichannel():
     assert wf.zi.shape == (n_sections, 2, 2)
 
 
-def test_weighting_filter_multichannel_to_mono_transition():
+def test_weighting_filter_multichannel_to_mono_transition() -> None:
     from phonometry import filters
 
     """zi must reinit when input switches from multichannel to 1D."""
@@ -97,7 +97,7 @@ def test_weighting_filter_multichannel_to_mono_transition():
     assert y.shape == x_mono.shape
 
 
-def test_weighting_filter_multichannel():
+def test_weighting_filter_multichannel() -> None:
     from phonometry import filters
 
     """Stateful block-wise multichannel weighting must match full-signal processing."""
@@ -124,7 +124,7 @@ def test_weighting_filter_multichannel():
     np.testing.assert_allclose(stateful_out, ref_out, rtol=1e-10, atol=1e-12)
 
 
-def test_stateful_weighting_invalid_fs_raises():
+def test_stateful_weighting_invalid_fs_raises() -> None:
     """Non-positive sample rates must be rejected at construction."""
     from phonometry import filters
 
@@ -134,7 +134,7 @@ def test_stateful_weighting_invalid_fs_raises():
         filters.WeightingFilter(fs=-48000, stateful=True)
 
 
-def test_stateful_weighting_high_accuracy_raises():
+def test_stateful_weighting_high_accuracy_raises() -> None:
     """high_accuracy resampling is incompatible with block processing."""
     from phonometry import filters
 
@@ -142,7 +142,7 @@ def test_stateful_weighting_high_accuracy_raises():
         filters.WeightingFilter(fs=48000, stateful=True, high_accuracy=True)
 
 
-def test_stateful_weighting_invalid_curve_raises():
+def test_stateful_weighting_invalid_curve_raises() -> None:
     """Unknown weighting curves must be rejected at construction."""
     from phonometry import filters
 

--- a/tests/hearing/test_hearing_plot_i18n.py
+++ b/tests/hearing/test_hearing_plot_i18n.py
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from phonometry import hearing
 
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
-def _legend_labels(ax) -> list[str]:
+
+def _legend_labels(ax: Axes) -> list[str]:
     handles, labels = ax.get_legend_handles_labels()
     assert handles
     return labels

--- a/tests/hearing/test_iso9612_report.py
+++ b/tests/hearing/test_iso9612_report.py
@@ -18,17 +18,22 @@ the rendering contract.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.hearing import (
+    ExposureResult,
     Task,
     full_day_exposure,
     job_based_exposure,
     task_based_exposure,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _extract_text(path: str) -> str:
@@ -39,7 +44,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _two_task_result():
+def _two_task_result() -> ExposureResult:
     """Hand-derivable oracle: 4 h at 85 dB plus 4 h at 75 dB."""
     tasks = [
         Task(samples=(85.0,), duration_hours=4.0, label="machining"),
@@ -48,7 +53,7 @@ def _two_task_result():
     return task_based_exposure(tasks, warn=False)
 
 
-def _single_task_result(level: float):
+def _single_task_result(level: float) -> ExposureResult:
     """A whole nominal day at one level: LEX,8h equals the level exactly."""
     return task_based_exposure(
         [Task(samples=(level,), duration_hours=8.0, label="task")], warn=False
@@ -73,7 +78,7 @@ def test_two_task_hand_oracle_values() -> None:
     assert res.expanded_uncertainty == pytest.approx(1.65 * expected_u, abs=1e-9)
 
 
-def test_report_renders_hand_computed_values(tmp_path) -> None:
+def test_report_renders_hand_computed_values(tmp_path: Path) -> None:
     """The fiche prints the hand-derived LEX,8h = 82.4 dB and U = 2.7 dB."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -92,7 +97,7 @@ def test_report_renders_hand_computed_values(tmp_path) -> None:
     assert "IEC 61252" in text
 
 
-def test_annex_d_example_renders_pinned_numbers(tmp_path) -> None:
+def test_annex_d_example_renders_pinned_numbers(tmp_path: Path) -> None:
     """The ISO 9612 Annex D welders' day prints 84.3 dB and U = 3.2 dB."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -135,7 +140,7 @@ def test_annex_d_example_renders_pinned_numbers(tmp_path) -> None:
     ],
 )
 def test_directive_boundaries_on_displayed_value(
-    tmp_path, level: float, n_exceeded: int, verdict: str
+    tmp_path: Path, level: float, n_exceeded: int, verdict: str
 ) -> None:
     """The 80/85/87 dB(A) rows flip on the one-decimal displayed value."""
     pytest.importorskip("reportlab")
@@ -154,7 +159,7 @@ def test_directive_boundaries_on_displayed_value(
 # --- job-based and full-day layouts -------------------------------------------
 
 
-def test_job_based_report_renders_sampling_summary(tmp_path) -> None:
+def test_job_based_report_renders_sampling_summary(tmp_path: Path) -> None:
     """A job-based result renders the sampling summary (Annex E numbers)."""
     pytest.importorskip("reportlab")
     res = job_based_exposure(
@@ -171,7 +176,7 @@ def test_job_based_report_renders_sampling_summary(tmp_path) -> None:
     assert "3.8" in text  # U
 
 
-def test_full_day_report_renders(tmp_path) -> None:
+def test_full_day_report_renders(tmp_path: Path) -> None:
     """A full-day result renders the Clause 11 basis and one page."""
     pytest.importorskip("reportlab")
     res = full_day_exposure(
@@ -189,7 +194,7 @@ def test_full_day_report_renders(tmp_path) -> None:
 # --- metadata, verbose and instrumentation ------------------------------------
 
 
-def test_metadata_header_and_instrumentation_override(tmp_path) -> None:
+def test_metadata_header_and_instrumentation_override(tmp_path: Path) -> None:
     """Supplied metadata renders the header grid; instrumentation overrides."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -215,7 +220,7 @@ def test_metadata_header_and_instrumentation_override(tmp_path) -> None:
     assert "IEC 61252" not in text
 
 
-def test_verbose_adds_annex_c_columns(tmp_path) -> None:
+def test_verbose_adds_annex_c_columns(tmp_path: Path) -> None:
     """verbose=True adds the per-task u1a/u1b/u2 columns to the task table."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -237,7 +242,7 @@ def test_instrument_class_is_threaded_to_the_result() -> None:
     assert job.instrument == "class1"
 
 
-def test_class1_fallback_names_the_sound_level_meter(tmp_path) -> None:
+def test_class1_fallback_names_the_sound_level_meter(tmp_path: Path) -> None:
     """Without metadata, the class-1 instrument prints its IEC 61672-1 name."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -254,7 +259,7 @@ def test_class1_fallback_names_the_sound_level_meter(tmp_path) -> None:
 # --- Spanish fiche -------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the occupational vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -273,7 +278,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract --------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _two_task_result()
     out = str(tmp_path / "x.pdf")
@@ -281,7 +286,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _two_task_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/hearing/test_noise_induced_hearing_loss_report.py
+++ b/tests/hearing/test_noise_induced_hearing_loss_report.py
@@ -14,11 +14,16 @@ English and Spanish fiches are exercised.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.hearing import NoiseInducedHearingLossWarning, htlan, nipts
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _extract_text(path: str) -> str:
@@ -32,7 +37,7 @@ def _extract_text(path: str) -> str:
 # --- NIPTS fiche --------------------------------------------------------------
 
 
-def test_nipts_report_renders_annex_d_values(tmp_path) -> None:
+def test_nipts_report_renders_annex_d_values(tmp_path: Path) -> None:
     """The NIPTS fiche prints the Annex D N50 and fractile shift and one page."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -52,7 +57,7 @@ def test_nipts_report_renders_annex_d_values(tmp_path) -> None:
     assert "not a clinical diagnosis" in text
 
 
-def test_nipts_verbose_adds_spread_columns(tmp_path) -> None:
+def test_nipts_verbose_adds_spread_columns(tmp_path: Path) -> None:
     """verbose=True adds the du/dl spread columns to the NIPTS table."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -66,7 +71,7 @@ def test_nipts_verbose_adds_spread_columns(tmp_path) -> None:
     assert "dl[dB]" in flat
 
 
-def test_nipts_verdict_against_requirement(tmp_path) -> None:
+def test_nipts_verdict_against_requirement(tmp_path: Path) -> None:
     """A metadata requirement adds a PASS/FAIL verdict on the representative NIPTS."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -82,7 +87,7 @@ def test_nipts_verdict_against_requirement(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(out_fail))
 
 
-def test_nipts_states_iso_q_and_scope_caveat(tmp_path) -> None:
+def test_nipts_states_iso_q_and_scope_caveat(tmp_path: Path) -> None:
     """The fiche prints ISO 1999's own Q and the Scope NOTE 1 caveat."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -99,7 +104,7 @@ def test_nipts_states_iso_q_and_scope_caveat(tmp_path) -> None:
     assert "do not describe any individual person" in text
 
 
-def test_nipts_outside_domain_prints_extrapolation_caveat(tmp_path) -> None:
+def test_nipts_outside_domain_prints_extrapolation_caveat(tmp_path: Path) -> None:
     """Conditions beyond the validated domain carry the caveat on the fiche."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -118,7 +123,7 @@ def test_nipts_outside_domain_prints_extrapolation_caveat(tmp_path) -> None:
     assert "outside the validated domain" not in _extract_text(str(inside))
 
 
-def test_nipts_subset_boxes_peak_shift(tmp_path) -> None:
+def test_nipts_subset_boxes_peak_shift(tmp_path: Path) -> None:
     """Without the full 2/3/4 kHz set the fiche boxes the peak shift instead."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -133,7 +138,7 @@ def test_nipts_subset_boxes_peak_shift(tmp_path) -> None:
 # --- HTLAN fiche --------------------------------------------------------------
 
 
-def test_htlan_report_renders_components(tmp_path) -> None:
+def test_htlan_report_renders_components(tmp_path: Path) -> None:
     """The HTLAN fiche prints the combined threshold and one page."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -157,7 +162,7 @@ def test_htlan_report_renders_components(tmp_path) -> None:
     assert "ISO 7029:2017" in text
 
 
-def test_htlan_verbose_adds_compression_term(tmp_path) -> None:
+def test_htlan_verbose_adds_compression_term(tmp_path: Path) -> None:
     """verbose=True adds the H*N/120 compression column to the HTLAN table."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -170,7 +175,7 @@ def test_htlan_verbose_adds_compression_term(tmp_path) -> None:
     assert "N/120" in flat
 
 
-def test_htlan_metadata_header_renders(tmp_path) -> None:
+def test_htlan_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the header grid identity."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -192,7 +197,7 @@ def test_htlan_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_nipts_spanish_report(tmp_path) -> None:
+def test_nipts_spanish_report(tmp_path: Path) -> None:
     """language="es" renders the Spanish NIPTS vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -208,7 +213,7 @@ def test_nipts_spanish_report(tmp_path) -> None:
     assert "Fractil poblacional Q = 10 % (fracción con peor audición)" in text
 
 
-def test_htlan_spanish_report(tmp_path) -> None:
+def test_htlan_spanish_report(tmp_path: Path) -> None:
     """language="es" renders the Spanish HTLAN vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -231,7 +236,7 @@ def test_htlan_spanish_report(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_nipts_unknown_engine_rejected(tmp_path) -> None:
+def test_nipts_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = nipts(90.0, 20.0, 0.9)
     out = str(tmp_path / "x.pdf")
@@ -239,7 +244,7 @@ def test_nipts_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_htlan_unknown_language_rejected(tmp_path) -> None:
+def test_htlan_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = htlan(60, "male", 95.0, 30.0, 0.5)
     out = str(tmp_path / "bad.pdf")

--- a/tests/hearing/test_occupational_exposure.py
+++ b/tests/hearing/test_occupational_exposure.py
@@ -33,14 +33,14 @@ from phonometry.hearing.occupational_exposure import (
 # --------------------------------------------------------------------------- #
 # Closed-form oracles.
 # --------------------------------------------------------------------------- #
-def test_single_task_85db_8h_is_85():
+def test_single_task_85db_8h_is_85() -> None:
     """A single task at 85 dB sustained for 8 h gives LEX,8h = 85 exactly."""
     result = task_based_exposure([Task(samples=(85.0, 85.0, 85.0), duration_hours=8.0)])
     assert result.lex_8h == pytest.approx(85.0, abs=1e-9)
     assert result.strategy == "task"
 
 
-def test_two_equal_half_day_tasks_equal_level():
+def test_two_equal_half_day_tasks_equal_level() -> None:
     """Two 4-h tasks at level L give LEX,8h = L (energy sum, no time normalization loss)."""
     tasks = [
         Task(samples=(88.0,), duration_hours=4.0),
@@ -50,14 +50,14 @@ def test_two_equal_half_day_tasks_equal_level():
     assert result.lex_8h == pytest.approx(88.0, abs=1e-9)
 
 
-def test_halving_duration_drops_contribution_by_3db():
+def test_halving_duration_drops_contribution_by_3db() -> None:
     """Halving a task duration lowers its LEX,8h contribution by 10*log10(2) = 3.01 dB."""
     full = task_based_exposure([Task(samples=(90.0,), duration_hours=8.0)])
     half = task_based_exposure([Task(samples=(90.0,), duration_hours=4.0)])
     assert full.lex_8h - half.lex_8h == pytest.approx(10.0 * math.log10(2.0), abs=1e-9)
 
 
-def test_coverage_factor_is_1_65():
+def test_coverage_factor_is_1_65() -> None:
     """The one-sided 95 % coverage factor is exactly 1.65 and U = 1.65*u."""
     assert COVERAGE_FACTOR == 1.65
     result = job_based_exposure([80.0, 82.0, 84.0, 81.0, 83.0], 8.0)
@@ -66,7 +66,7 @@ def test_coverage_factor_is_1_65():
     )
 
 
-def test_energy_average_single_task_matches_lex_8h_primitive():
+def test_energy_average_single_task_matches_lex_8h_primitive() -> None:
     """Task energy average agrees with 10*log10(mean(10^(0.1 L)))."""
     samples = (80.1, 82.2, 79.6)
     result = task_based_exposure([Task(samples=samples, duration_hours=8.0)])
@@ -79,7 +79,7 @@ def test_energy_average_single_task_matches_lex_8h_primitive():
 # --------------------------------------------------------------------------- #
 # Table lookups.
 # --------------------------------------------------------------------------- #
-def test_table_c4_exact_cells():
+def test_table_c4_exact_cells() -> None:
     """Exact Table C.4 cells are returned at the tabulated (N, u1) grid points."""
     assert table_c4_contribution(6, 2.0) == pytest.approx(1.4, abs=1e-9)
     assert table_c4_contribution(3, 0.5) == pytest.approx(0.6, abs=1e-9)
@@ -88,19 +88,19 @@ def test_table_c4_exact_cells():
     assert table_c4_contribution(20, 2.0) == pytest.approx(0.5, abs=1e-9)
 
 
-def test_table_c4_interpolates_annex_f_cell():
+def test_table_c4_interpolates_annex_f_cell() -> None:
     """Annex F reads N=6, u1=1.65 dB as c1*u1 = 1.0 dB (interpolated)."""
     assert table_c4_contribution(6, 1.65) == pytest.approx(1.0, abs=0.05)
 
 
-def test_table_c4_origin_and_clamp():
+def test_table_c4_origin_and_clamp() -> None:
     """u1 = 0 gives 0 dB; below/above the grid clamps to the edge behaviour."""
     assert table_c4_contribution(6, 0.0) == pytest.approx(0.0, abs=1e-9)
     # Clamp N above 30 to the N=30 row.
     assert table_c4_contribution(50, 6.0) == pytest.approx(2.0, abs=1e-9)
 
 
-def test_table_1_minimum_durations():
+def test_table_1_minimum_durations() -> None:
     """Table 1 breakpoints for the cumulative measurement duration."""
     assert minimum_cumulative_duration_hours(5) == 5.0
     assert minimum_cumulative_duration_hours(6) == 5.5
@@ -110,7 +110,7 @@ def test_table_1_minimum_durations():
     assert minimum_cumulative_duration_hours(41) == 17.0
 
 
-def test_instrument_u2_values():
+def test_instrument_u2_values() -> None:
     """Table C.5 instrument standard uncertainties."""
     assert INSTRUMENT_U2["class1"] == 0.7
     assert INSTRUMENT_U2["class2"] == 1.5
@@ -138,7 +138,7 @@ def _annex_d_tasks() -> list[Task]:
     ]
 
 
-def test_annex_d_task_levels_and_contributions():
+def test_annex_d_task_levels_and_contributions() -> None:
     """Annex D: task levels 80.8/90.1 dB and contributions 62.7/78.8/82.8 dB."""
     with pytest.warns(OccupationalExposureWarning):  # cutting/grinding spans > 3 dB
         result = task_based_exposure(_annex_d_tasks())
@@ -156,13 +156,13 @@ def test_annex_d_task_levels_and_contributions():
     )
 
 
-def test_annex_d_daily_level():
+def test_annex_d_daily_level() -> None:
     """Annex D: LEX,8h = 84.3 dB."""
     result = task_based_exposure(_annex_d_tasks(), warn=False)
     assert result.lex_8h == pytest.approx(84.3, abs=0.05)
 
 
-def test_annex_d_sampling_uncertainties_and_sensitivities():
+def test_annex_d_sampling_uncertainties_and_sensitivities() -> None:
     """Annex D: u1a = 0.8/1.2 dB, c1a = 0.28/0.71 (Eq C.6, C.4)."""
     result = task_based_exposure(_annex_d_tasks(), warn=False)
     by_label = {t.label: t for t in result.tasks}
@@ -173,7 +173,7 @@ def test_annex_d_sampling_uncertainties_and_sensitivities():
     assert by_label["planning/breaks"].c1a == pytest.approx(0.0, abs=0.01)
 
 
-def test_annex_d_duration_sensitivities():
+def test_annex_d_duration_sensitivities() -> None:
     """Annex D: c1b = 0.24 (welding) and 2.1 (cutting) [dB/h] (Eq C.5)."""
     result = task_based_exposure(_annex_d_tasks(), warn=False)
     by_label = {t.label: t for t in result.tasks}
@@ -183,7 +183,7 @@ def test_annex_d_duration_sensitivities():
     assert by_label["cutting/grinding"].c1b == pytest.approx(2.1, abs=0.05)
 
 
-def test_duration_samples_u1b_is_standard_error_of_mean():
+def test_duration_samples_u1b_is_standard_error_of_mean() -> None:
     """Eq C.7 divides by J(J-1): samples (4, 6) h give u1b = 1.0 h, not sqrt(2)."""
     result = task_based_exposure(
         [Task(samples=(85.0, 85.0), duration_hours=5.0, duration_samples=(4.0, 6.0))],
@@ -192,7 +192,7 @@ def test_duration_samples_u1b_is_standard_error_of_mean():
     assert result.tasks[0].u1b == pytest.approx(1.0, abs=1e-9)
 
 
-def test_annex_d_expanded_uncertainty_without_duration():
+def test_annex_d_expanded_uncertainty_without_duration() -> None:
     """Annex D case a: U = 2.7 dB when the duration uncertainty is omitted."""
     result = task_based_exposure(
         _annex_d_tasks(), include_duration_uncertainty=False, warn=False
@@ -203,7 +203,7 @@ def test_annex_d_expanded_uncertainty_without_duration():
     assert result.expanded_uncertainty == pytest.approx(2.7, abs=0.05)
 
 
-def test_annex_d_expanded_uncertainty_with_duration():
+def test_annex_d_expanded_uncertainty_with_duration() -> None:
     """Annex D case b: U = 3.2 dB when the duration uncertainty is included."""
     result = task_based_exposure(_annex_d_tasks(), warn=False)
     assert result.combined_standard_uncertainty**2 == pytest.approx(3.83, abs=0.07)
@@ -211,7 +211,7 @@ def test_annex_d_expanded_uncertainty_with_duration():
     assert result.upper_limit == pytest.approx(84.3 + 3.2, abs=0.1)
 
 
-def test_annex_d_spread_rule_advisory():
+def test_annex_d_spread_rule_advisory() -> None:
     """The cutting/grinding task (range > 3 dB) trips the 3 dB spread advisory."""
     result = task_based_exposure(_annex_d_tasks(), warn=False)
     by_label = {t.label: t for t in result.tasks}
@@ -223,7 +223,7 @@ def test_annex_d_spread_rule_advisory():
 # --------------------------------------------------------------------------- #
 # Annex E — job-based worked example (production line, 18 workers).
 # --------------------------------------------------------------------------- #
-def test_annex_e_job_based():
+def test_annex_e_job_based() -> None:
     """Annex E: Lp,A,eqTe = 88.4, u1 = 2.0, c1u1 = 1.4, LEX,8h = 88.1, U = 3.8 dB."""
     samples = [88.1, 86.1, 89.7, 86.5, 91.1, 86.7]
     result = job_based_exposure(
@@ -244,14 +244,14 @@ def test_annex_e_job_based():
     assert result.strategy == "job"
 
 
-def test_annex_e_table1_satisfied_no_advisory():
+def test_annex_e_table1_satisfied_no_advisory() -> None:
     """Annex E: 12 h cumulative >= 10.75 h Table 1 minimum -> no advisory."""
     samples = [88.1, 86.1, 89.7, 86.5, 91.1, 86.7]
     result = job_based_exposure(samples, 7.5, n_workers=18, sample_duration_hours=2.0)
     assert result.sampling_advisory is False
 
 
-def test_job_based_below_table1_minimum_warns():
+def test_job_based_below_table1_minimum_warns() -> None:
     """Too-short cumulative duration raises the Table 1 advisory."""
     samples = [88.0, 86.0, 89.0, 86.0, 91.0]
     with pytest.warns(OccupationalExposureWarning):
@@ -264,7 +264,7 @@ def test_job_based_below_table1_minimum_warns():
 # --------------------------------------------------------------------------- #
 # Annex F — full-day worked example (forklift drivers).
 # --------------------------------------------------------------------------- #
-def test_annex_f_full_day():
+def test_annex_f_full_day() -> None:
     """Annex F: Lp,A,eqTe = 89.5, u1 = 1.65, c1u1 = 1.0, LEX,8h = 90.1, U = 3.4 dB."""
     samples = [88.0, 91.9, 87.6, 90.4, 89.0, 88.4]
     result = full_day_exposure(
@@ -279,14 +279,14 @@ def test_annex_f_full_day():
     assert result.strategy == "full_day"
 
 
-def test_full_day_three_measurements_spread_advisory():
+def test_full_day_three_measurements_spread_advisory() -> None:
     """Three full-day measurements spanning >= 3 dB trip the Clause 11.3 advisory."""
     with pytest.warns(OccupationalExposureWarning):
         result = full_day_exposure([85.0, 89.0, 86.0], 8.0)
     assert result.sampling_advisory is True
 
 
-def test_full_day_three_close_measurements_no_advisory():
+def test_full_day_three_close_measurements_no_advisory() -> None:
     """Three full-day measurements within 3 dB need no additional measurements."""
     result = full_day_exposure([85.0, 86.0, 87.0], 8.0)
     assert result.sampling_advisory is False
@@ -295,7 +295,7 @@ def test_full_day_three_close_measurements_no_advisory():
 # --------------------------------------------------------------------------- #
 # Validation and edge cases.
 # --------------------------------------------------------------------------- #
-def test_job_based_high_spread_triggers_c4_advisory():
+def test_job_based_high_spread_triggers_c4_advisory() -> None:
     """A large sampling spread pushes c1*u1 above 3.5 dB and warns (Clause 10.4)."""
     samples = [70.0, 80.0, 90.0, 75.0, 85.0]  # wide spread, small N
     with pytest.warns(OccupationalExposureWarning):
@@ -305,36 +305,36 @@ def test_job_based_high_spread_triggers_c4_advisory():
     assert result.sampling_advisory is True
 
 
-def test_task_based_requires_tasks():
+def test_task_based_requires_tasks() -> None:
     with pytest.raises(ValueError, match="At least one task"):
         task_based_exposure([])
 
 
-def test_task_rejects_nonpositive_duration():
+def test_task_rejects_nonpositive_duration() -> None:
     # Task.__post_init__ is what rejects it: task_based_exposure never gets to
     # see an object with a non-positive duration.
     with pytest.raises(ValueError, match="'duration_hours' must be positive"):
         Task(samples=(85.0,), duration_hours=0.0)
 
 
-def test_task_rejects_empty_samples():
+def test_task_rejects_empty_samples() -> None:
     with pytest.raises(ValueError, match="sample"):
         Task(samples=(), duration_hours=8.0)
 
 
-def test_job_based_rejects_nonpositive_sample_duration():
+def test_job_based_rejects_nonpositive_sample_duration() -> None:
     with pytest.raises(ValueError, match="sample_duration_hours"):
         job_based_exposure(
             [80.0, 82.0, 81.0], 8.0, n_workers=6, sample_duration_hours=0.0
         )
 
 
-def test_job_based_requires_two_samples():
+def test_job_based_requires_two_samples() -> None:
     with pytest.raises(ValueError, match="At least two samples"):
         job_based_exposure([85.0], 8.0)
 
 
-def test_duration_range_order_validated():
+def test_duration_range_order_validated() -> None:
     reversed_range = Task(
         samples=(85.0, 85.0), duration_hours=4.0, duration_range=(6.0, 4.0)
     )
@@ -342,7 +342,7 @@ def test_duration_range_order_validated():
         task_based_exposure([reversed_range])
 
 
-def test_result_dataclasses_are_frozen():
+def test_result_dataclasses_are_frozen() -> None:
     result = job_based_exposure([80.0, 82.0, 81.0, 83.0, 80.0], 8.0)
     with pytest.raises(AttributeError):
         result.lex_8h = 0.0  # type: ignore[misc]
@@ -366,7 +366,7 @@ def test_result_dataclasses_are_frozen():
     assert isinstance(result, ExposureResult)
 
 
-def test_per_task_instrument_override():
+def test_per_task_instrument_override() -> None:
     """A per-task instrument class overrides the call-level default u2."""
     result = task_based_exposure(
         [Task(samples=(85.0, 85.0, 85.0), duration_hours=8.0, instrument="class1")],

--- a/tests/io/test_io_chunks.py
+++ b/tests/io/test_io_chunks.py
@@ -30,6 +30,8 @@ from phonometry.io._chunks import WAVE_FORMAT_IMA_ADPCM, parse_wav_chunks
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from phonometry.io._chunks import BroadcastMetadata
+
 TONE = np.array([0, 8000, -8000, 32000], dtype=np.int64)
 
 
@@ -98,7 +100,7 @@ def _bext_payload(
     return buf + coding_history
 
 
-def _read_bext(tmp_path: Path, payload: bytes):
+def _read_bext(tmp_path: Path, payload: bytes | bytearray) -> BroadcastMetadata:
     image = pcm_wav(TONE, extra_chunks=chunk(b"bext", bytes(payload)))
     result = parse_wav_chunks(_write(tmp_path, image)).bext
     assert result is not None

--- a/tests/metrology/test_iec61043_report.py
+++ b/tests/metrology/test_iec61043_report.py
@@ -20,15 +20,22 @@ mpl.use("Agg")
 pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 
+from typing import TYPE_CHECKING
+
 import reference_data as ref
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, emission
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 _BANDS = [row[0] for row in ref.IEC61043_TABLE2]
 
 
-def _class1_chain(offset: float = 1.5, spacing: float = 0.025):
+def _class1_chain(
+    offset: float = 1.5, spacing: float = 0.025
+) -> emission.IntensityInstrumentComplianceResult:
     """A complete instrument that clears the class 1 minima by ``offset`` dB."""
     freqs, class1, _ = emission.residual_index_limits("instrument", spacing=spacing)
     return emission.intensity_class_compliance(class1 + offset, freqs, spacing=spacing)
@@ -50,13 +57,13 @@ def _metadata(**kwargs: object) -> ReportMetadata:
     return ReportMetadata(**base)  # type: ignore[arg-type]
 
 
-def test_compliant_chain_renders_one_page(tmp_path) -> None:
+def test_compliant_chain_renders_one_page(tmp_path: Path) -> None:
     result = _class1_chain()
     path = result.report(str(tmp_path / "iec61043.pdf"), metadata=_metadata())
     assert_one_page(path)
 
 
-def test_bare_fiche_without_metadata(tmp_path) -> None:
+def test_bare_fiche_without_metadata(tmp_path: Path) -> None:
     """A fiche without metadata still renders body, result and disclaimer."""
     result = _class1_chain()
     assert_one_page(result.report(str(tmp_path / "bare.pdf")))
@@ -70,13 +77,13 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def test_spanish_fiche_renders(tmp_path) -> None:
+def test_spanish_fiche_renders(tmp_path: Path) -> None:
     result = _class1_chain()
     path = result.report(str(tmp_path / "es.pdf"), metadata=_metadata(), language="es")
     assert_one_page(path)
 
 
-def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
+def test_spanish_fiche_translates_every_fixed_string(tmp_path: Path) -> None:
     """No English template survives into the Spanish fiche.
 
     ``_i18n.t`` falls back to the English text when a key is missing, so a
@@ -120,7 +127,7 @@ def test_spanish_fiche_translates_every_fixed_string(tmp_path) -> None:
         assert english not in text, english
 
 
-def test_required_class_verdict_both_ways(tmp_path) -> None:
+def test_required_class_verdict_both_ways(tmp_path: Path) -> None:
     """The verdict row renders whether the chain meets the requirement or not."""
     passing = _class1_chain()
     assert_one_page(
@@ -135,7 +142,7 @@ def test_required_class_verdict_both_ways(tmp_path) -> None:
     )
 
 
-def test_non_compliant_chain_renders(tmp_path) -> None:
+def test_non_compliant_chain_renders(tmp_path: Path) -> None:
     """A chain meeting neither class boxes a non-conformity statement."""
     freqs, _, class2 = emission.residual_index_limits("probe")
     result = emission.intensity_class_compliance(class2 - 2.0, freqs, device="probe")
@@ -143,7 +150,7 @@ def test_non_compliant_chain_renders(tmp_path) -> None:
     assert_one_page(result.report(str(tmp_path / "none.pdf"), metadata=_metadata()))
 
 
-def test_range_limited_note_renders(tmp_path) -> None:
+def test_range_limited_note_renders(tmp_path: Path) -> None:
     """A partial band set adds the clause 6.1 qualifying note."""
     bands = _BANDS[6:14]
     freqs, class1, _ = emission.residual_index_limits("processor", frequencies=bands)
@@ -153,7 +160,7 @@ def test_range_limited_note_renders(tmp_path) -> None:
 
 
 def test_range_limited_note_drops_the_class_wording_when_no_class_is_met(
-    tmp_path,
+    tmp_path: Path,
 ) -> None:
     """With no class reached there is no "stated class" for the note to qualify.
 
@@ -185,14 +192,14 @@ def test_range_limited_note_drops_the_class_wording_when_no_class_is_met(
     assert "la clase indicada acredita" not in es_text
 
 
-def test_unknown_engine_is_rejected(tmp_path) -> None:
+def test_unknown_engine_is_rejected(tmp_path: Path) -> None:
     result = _class1_chain()
     target = str(tmp_path / "engine.pdf")
     with pytest.raises(ValueError, match="Unknown report engine"):
         result.report(target, engine="weasyprint")
 
 
-def test_unknown_required_class_is_rejected(tmp_path) -> None:
+def test_unknown_required_class_is_rejected(tmp_path: Path) -> None:
     result = _class1_chain()
     target = str(tmp_path / "class0.pdf")
     metadata = _metadata(required_class=0)
@@ -200,7 +207,7 @@ def test_unknown_required_class_is_rejected(tmp_path) -> None:
         result.report(target, metadata=metadata)
 
 
-def test_unknown_language_is_rejected(tmp_path) -> None:
+def test_unknown_language_is_rejected(tmp_path: Path) -> None:
     result = _class1_chain()
     target = str(tmp_path / "xx.pdf")
     with pytest.raises(ValueError, match="Unknown language"):

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -20,11 +20,16 @@ from reference_data import GUM_ADDITIVE_UC, GUM_COVERAGE_K99_16, GUM_WELCH_VEFF
 from phonometry.metrology import uncertainty as u
 
 
-def _add4(a, b, c, d):  # type: ignore[no-untyped-def]
+def _add4(
+    a: float | np.ndarray,
+    b: float | np.ndarray,
+    c: float | np.ndarray,
+    d: float | np.ndarray,
+) -> float | np.ndarray:
     return a + b + c + d
 
 
-def _add2(a, b):  # type: ignore[no-untyped-def]
+def _add2(a: float, b: float) -> float:
     return a + b
 
 
@@ -253,7 +258,7 @@ def test_sensitivity_step_stays_local_on_nonlinear_model() -> None:
     """
     x0, ux = 1.0e9, 1.0e-3
 
-    def model(x):
+    def model(x: float) -> float:
         return math.sin((x - 1.0e9) / 1.0e-2)
 
     result = u.combine_uncertainty(model, [u.Quantity(x0, ux)])

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import dataclasses
 import re
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -40,6 +41,9 @@ from phonometry.noise_control.duct_path import (
     duct_path,
 )
 from phonometry.noise_control.hvac import OCTAVE_BANDS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 #: Long Table 14.9, row 1 of both paths: the fan sound power level, dB re 1 pW.
 FAN_LW = [90.0, 86.0, 82.0, 79.0, 77.0, 75.0, 71.0, 61.0]
@@ -456,7 +460,9 @@ def test_no_room_effect_at_all_is_still_allowed() -> None:
     ],
     ids=["stage-row", "contribution", "band-axis"],
 )
-def test_a_single_number_where_a_spectrum_belongs_says_so(what, build) -> None:
+def test_a_single_number_where_a_spectrum_belongs_says_so(
+    what: str, build: Callable[[DuctPathResult], dict[str, object]]
+) -> None:
     """A scalar in a nested field is named, not left to numpy or to len().
 
     Reaching the nested rows means indexing a shape or taking a length, and
@@ -485,7 +491,9 @@ def test_a_single_number_where_a_spectrum_belongs_says_so(what, build) -> None:
     ],
     ids=["stage-row", "contribution"],
 )
-def test_a_nested_row_with_an_extra_axis_is_refused(what, build) -> None:
+def test_a_nested_row_with_an_extra_axis_is_refused(
+    what: str, build: Callable[[DuctPathResult, np.ndarray], dict[str, object]]
+) -> None:
     """The nested rows are pinned by their axes, not only by their length.
 
     A row of shape ``(bands, 2)`` counts the right number of bands on its

--- a/tests/noise_control/test_duct_path_report.py
+++ b/tests/noise_control/test_duct_path_report.py
@@ -12,13 +12,18 @@ complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
-from phonometry.noise_control.duct_path import DuctElement, duct_path
+from phonometry.noise_control.duct_path import DuctElement, DuctPathResult, duct_path
 from phonometry.noise_control.hvac import OCTAVE_BANDS
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _extract_text(path: str) -> str:
@@ -28,7 +33,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _supply():
+def _supply() -> DuctPathResult:
     """The supply path of Long Table 14.9, from its published element rows."""
     return duct_path(
         OCTAVE_BANDS,
@@ -77,13 +82,13 @@ def _supply():
     )
 
 
-def _reportlab():
+def _reportlab() -> None:
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
     pytest.importorskip("matplotlib")
 
 
-def test_report_renders_the_published_sheet(tmp_path) -> None:
+def test_report_renders_the_published_sheet(tmp_path: Path) -> None:
     _reportlab()
     res = _supply()
     out = tmp_path / "duct_path.pdf"
@@ -114,7 +119,7 @@ def test_report_renders_the_published_sheet(tmp_path) -> None:
     assert "not a measurement" in text
 
 
-def test_non_verbose_sheet_drops_the_intermediate_rows(tmp_path) -> None:
+def test_non_verbose_sheet_drops_the_intermediate_rows(tmp_path: Path) -> None:
     _reportlab()
     res = _supply()
     plain = tmp_path / "plain.pdf"
@@ -135,7 +140,7 @@ def test_non_verbose_sheet_drops_the_intermediate_rows(tmp_path) -> None:
     assert verbose_text.count("Self-noise") == 3
 
 
-def test_metadata_header_and_requirement_override(tmp_path) -> None:
+def test_metadata_header_and_requirement_override(tmp_path: Path) -> None:
     _reportlab()
     res = _supply()
     out = tmp_path / "meta.pdf"
@@ -157,7 +162,7 @@ def test_metadata_header_and_requirement_override(tmp_path) -> None:
     assert "exceeded by" in text
 
 
-def test_verdict_passes_against_nc_30(tmp_path) -> None:
+def test_verdict_passes_against_nc_30(tmp_path: Path) -> None:
     _reportlab()
     res = _supply()
     out = tmp_path / "verdict.pdf"
@@ -167,7 +172,7 @@ def test_verdict_passes_against_nc_30(tmp_path) -> None:
     assert "no band exceeds NC 30" in text
 
 
-def test_spanish_sheet(tmp_path) -> None:
+def test_spanish_sheet(tmp_path: Path) -> None:
     _reportlab()
     res = _supply()
     out = tmp_path / "es.pdf"
@@ -184,7 +189,7 @@ def test_spanish_sheet(tmp_path) -> None:
     assert "Duct-borne noise path calculation" not in text
 
 
-def test_combined_paths_sheet_lists_its_contributions(tmp_path) -> None:
+def test_combined_paths_sheet_lists_its_contributions(tmp_path: Path) -> None:
     _reportlab()
     from phonometry.noise_control.duct_path import combine_duct_paths
 
@@ -208,7 +213,7 @@ def test_combined_paths_sheet_lists_its_contributions(tmp_path) -> None:
 
 
 @pytest.mark.parametrize("verbose", [False, True])
-def test_a_long_path_still_renders_on_one_page(tmp_path, verbose: bool) -> None:
+def test_a_long_path_still_renders_on_one_page(tmp_path: Path, verbose: bool) -> None:
     """A fiche is one page: a path too long for it elides its middle rows."""
     _reportlab()
     res = duct_path(
@@ -246,14 +251,14 @@ def test_a_long_path_still_renders_on_one_page(tmp_path, verbose: bool) -> None:
     assert len(res.table()) > 25
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     res = _supply()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="engine"):
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     res = _supply()
     out = str(tmp_path / "x.pdf")
     with pytest.raises(ValueError, match="language"):

--- a/tests/noise_control/test_enclosure_report.py
+++ b/tests/noise_control/test_enclosure_report.py
@@ -16,12 +16,16 @@ engines/languages) complete the rendering contract.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata, noise_control
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
 _PANEL_R = np.array([18, 22, 28, 33, 38, 42, 45], dtype=float)
@@ -37,7 +41,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _result():
+def _result() -> noise_control.EnclosureResult:
     return noise_control.enclosure_insertion_loss(
         _PANEL_R, _S_E, _S_I, _ALPHA, frequencies=_FREQS
     )
@@ -65,7 +69,7 @@ def test_hand_oracle_matches_library() -> None:
     np.testing.assert_allclose(res.insertion_loss, _oracle_il(), atol=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the mean IL and a couple of band R/C/IL values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -105,7 +109,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "prediction computed from the stated inputs" in text
 
 
-def test_verbose_adds_room_constant_column(tmp_path) -> None:
+def test_verbose_adds_room_constant_column(tmp_path: Path) -> None:
     """verbose=True adds the interior room constant R_i column."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -119,7 +123,7 @@ def test_verbose_adds_room_constant_column(tmp_path) -> None:
     assert f"{r_i:.1f}" in text
 
 
-def test_third_octave_labels_and_caption(tmp_path) -> None:
+def test_third_octave_labels_and_caption(tmp_path: Path) -> None:
     """A one-third-octave set is labelled by nominal centres and captioned."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -142,7 +146,9 @@ def test_third_octave_labels_and_caption(tmp_path) -> None:
     ("limit", "verdict"),
     [(20.0, "PASS"), (40.0, "FAIL")],
 )
-def test_verdict_against_declared_minimum(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_minimum(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared minimum yields a PASS/FAIL verdict (more insertion loss is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -158,7 +164,7 @@ def test_verdict_against_declared_minimum(tmp_path, limit: float, verdict: str) 
     assert math.isfinite(_oracle_mean_il())
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the machine, environment and identity fields."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -186,7 +192,7 @@ def test_metadata_header_renders(tmp_path) -> None:
         assert token in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the enclosure vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -202,7 +208,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert f"{_oracle_mean_il():.1f}".replace(".", ",") in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -210,7 +216,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/noise_control/test_hvac_report.py
+++ b/tests/noise_control/test_hvac_report.py
@@ -18,6 +18,7 @@ rendering contract.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -25,6 +26,9 @@ from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
 from phonometry.noise_control import hvac
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
 _U = 12.0  # flow velocity, m/s
@@ -42,7 +46,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _result():
+def _result() -> hvac.HvacSpectrumResult:
     return hvac.flow_noise_straight_duct(_FREQS, _U, _S)
 
 
@@ -73,7 +77,7 @@ def test_hand_oracle_matches_library() -> None:
     np.testing.assert_allclose(res.values, _oracle_lw(), atol=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the A-weighted total, the overall L_W and band values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -106,7 +110,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "prediction computed from the stated inputs" in text
 
 
-def test_verbose_adds_a_weighting_columns(tmp_path) -> None:
+def test_verbose_adds_a_weighting_columns(tmp_path: Path) -> None:
     """verbose=True adds the A-weighting correction and A-weighted band columns."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -127,7 +131,9 @@ def test_verbose_adds_a_weighting_columns(tmp_path) -> None:
     ("limit", "verdict"),
     [(45.0, "PASS"), (30.0, "FAIL")],
 )
-def test_power_verdict_lower_is_better(tmp_path, limit: float, verdict: str) -> None:
+def test_power_verdict_lower_is_better(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A regenerated-noise limit passes at or below the A-weighted level."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -142,7 +148,7 @@ def test_power_verdict_lower_is_better(tmp_path, limit: float, verdict: str) -> 
     assert math.isfinite(_oracle_lwa())
 
 
-def test_attenuation_report_mean_and_direction(tmp_path) -> None:
+def test_attenuation_report_mean_and_direction(tmp_path: Path) -> None:
     """An attenuation spectrum boxes the mean and passes when more is better."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -162,7 +168,7 @@ def test_attenuation_report_mean_and_direction(tmp_path) -> None:
     assert mean_att >= 1.0
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the HVAC vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -179,7 +185,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert "no son una medición de una probeta" in text
 
 
-def test_spanish_report_translates_the_element_label(tmp_path) -> None:
+def test_spanish_report_translates_the_element_label(tmp_path: Path) -> None:
     """The element label's descriptive words are translated, its numbers kept."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -227,7 +233,7 @@ def test_verdict_boundary_passes_on_the_displayed_value() -> None:
     assert lower
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -235,7 +241,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/noise_control/test_room_to_room_norton.py
+++ b/tests/noise_control/test_room_to_room_norton.py
@@ -152,7 +152,9 @@ _R418_LP2 = np.array([72.3, 60.4, 41.4, 41.0, 33.8, 30.7])
 _R418_LPA = np.array([56.2, 51.5, 38.2, 41.0, 35.0, 31.5])
 
 
-def _problem_4_18(source_model: str = "constant_volume"):  # type: ignore[no-untyped-def]
+def _problem_4_18(
+    source_model: str = "constant_volume",
+) -> noise_control.RoomToRoomResult:
     """The whole chain of problem 4.18, from the blower to the operator room."""
     # Plant room 8 x 10 x 3 m: floor and ceiling 80 m2 each, walls 108 m2.
     plant = [
@@ -321,7 +323,7 @@ def _enclosure_4_16() -> tuple[float, float, np.ndarray]:
     return external_area, external_area + bare_floor + machine, absorption
 
 
-def _problem_4_16(model: str = "norton"):  # type: ignore[no-untyped-def]
+def _problem_4_16(model: str = "norton") -> noise_control.EnclosureResult:
     """Required enclosure transmission loss of problem 4.16.
 
     ``model="norton"`` is Equation (4.115), which has no ``0.3`` floor inside

--- a/tests/noise_control/test_silencer_report.py
+++ b/tests/noise_control/test_silencer_report.py
@@ -15,11 +15,16 @@ complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry.noise_control import silencers as sl
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _FREQS = np.array([63, 125, 250, 500, 1000, 2000, 4000], dtype=float)
 _LENGTH = 0.5
@@ -35,7 +40,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _result():
+def _result() -> sl.ReactiveSilencerResult:
     return sl.expansion_chamber(_FREQS, _LENGTH, _S_EXP, _S_DUCT)
 
 
@@ -52,7 +57,7 @@ def test_hand_oracle_matches_library() -> None:
     np.testing.assert_allclose(res.transmission_loss, _oracle_tl(), atol=1e-9)
 
 
-def test_report_renders_oracle_values(tmp_path) -> None:
+def test_report_renders_oracle_values(tmp_path: Path) -> None:
     """The fiche prints the mean and peak TL and a couple of band TL values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -86,7 +91,7 @@ def test_report_renders_oracle_values(tmp_path) -> None:
     assert "prediction computed from the stated inputs" in text
 
 
-def test_insertion_loss_column_when_impedances_given(tmp_path) -> None:
+def test_insertion_loss_column_when_impedances_given(tmp_path: Path) -> None:
     """A result with end impedances renders the insertion-loss column."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -109,7 +114,7 @@ def test_insertion_loss_column_when_impedances_given(tmp_path) -> None:
     assert "Mean insertion loss IL" in text
 
 
-def test_resonator_reports_resonances(tmp_path) -> None:
+def test_resonator_reports_resonances(tmp_path: Path) -> None:
     """A tuned resonator lists its resonance frequencies in the boxed terms."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -128,7 +133,9 @@ def test_resonator_reports_resonances(tmp_path) -> None:
     ("limit", "verdict"),
     [(6.0, "PASS"), (12.0, "FAIL")],
 )
-def test_verdict_against_declared_minimum(tmp_path, limit: float, verdict: str) -> None:
+def test_verdict_against_declared_minimum(
+    tmp_path: Path, limit: float, verdict: str
+) -> None:
     """A declared minimum yields a PASS/FAIL verdict (more TL is better)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -144,7 +151,7 @@ def test_verdict_against_declared_minimum(tmp_path, limit: float, verdict: str) 
     assert (float(np.mean(_oracle_tl())) >= limit) == (verdict == "PASS")
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the silencer vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("svglib")
@@ -165,7 +172,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert "no son una medición de una probeta" in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
@@ -173,7 +180,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/signals/test_estimate_overloads.py
+++ b/tests/signals/test_estimate_overloads.py
@@ -21,6 +21,8 @@ be satisfied by accident.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from signal_contract import assert_same
@@ -51,6 +53,9 @@ from phonometry.signals import (
     time_synchronous_average,
     zoom_fft,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 8000
 CAL = 3.0
@@ -101,13 +106,17 @@ PAIR_IDS = [f.__name__ for f, _ in PAIRS]
 
 
 @pytest.mark.parametrize(("func", "kwargs"), SOLO, ids=SOLO_IDS)
-def test_an_uncalibrated_signal_computes_the_bare_array_result(func, kwargs) -> None:
+def test_an_uncalibrated_signal_computes_the_bare_array_result(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x = _record()
     assert_same(func(Signal(x, FS), **kwargs), func(x, FS, **kwargs))
 
 
 @pytest.mark.parametrize(("func", "kwargs"), SOLO, ids=SOLO_IDS)
-def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> None:
+def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     sig = Signal(_record(), FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
         func(sig, FS + 1, **kwargs)
@@ -116,14 +125,18 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, kwargs) -> No
 
 
 @pytest.mark.parametrize(("func", "kwargs"), SOLO, ids=SOLO_IDS)
-def test_a_bare_array_still_requires_fs(func, kwargs) -> None:
+def test_a_bare_array_still_requires_fs(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x = _record()
     with pytest.raises(ValueError, match="fs is required"):
         func(x, **kwargs)
 
 
 @pytest.mark.parametrize(("func", "kwargs"), SOLO, ids=SOLO_IDS)
-def test_a_multichannel_signal_is_refused_by_name(func, kwargs) -> None:
+def test_a_multichannel_signal_is_refused_by_name(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     """These estimates are defined on one record, and say so.
 
     Reducing a multichannel Signal to a mono one -- picking a channel, or
@@ -140,7 +153,9 @@ def test_a_multichannel_signal_is_refused_by_name(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), SOLO, ids=SOLO_IDS)
-def test_a_calibrated_signal_is_analysed_in_pascals(func, kwargs) -> None:
+def test_a_calibrated_signal_is_analysed_in_pascals(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x = _record()
     assert_same(
         func(Signal(x, FS, calibration_factor=CAL), **kwargs),
@@ -154,7 +169,9 @@ def test_a_calibrated_signal_is_analysed_in_pascals(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_a_pair_takes_the_rate_from_either_side(func, kwargs) -> None:
+def test_a_pair_takes_the_rate_from_either_side(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x, y = _record(0), _record(1)
     reference = func(x, y, FS, **kwargs)
     assert_same(func(Signal(x, FS), y, **kwargs), reference)
@@ -163,7 +180,9 @@ def test_a_pair_takes_the_rate_from_either_side(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_two_signals_at_different_rates_are_refused(func, kwargs) -> None:
+def test_two_signals_at_different_rates_are_refused(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     """Nothing here can say which rate is the truth, so neither is chosen."""
     x, y = _record(0), _record(1)
     first, second = Signal(x, FS), Signal(y, FS // 2)
@@ -172,14 +191,18 @@ def test_two_signals_at_different_rates_are_refused(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_a_pair_of_bare_arrays_still_requires_fs(func, kwargs) -> None:
+def test_a_pair_of_bare_arrays_still_requires_fs(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x, y = _record(0), _record(1)
     with pytest.raises(ValueError, match="fs is required"):
         func(x, y, **kwargs)
 
 
 @pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
-def test_a_calibrated_pair_is_analysed_in_pascals(func, kwargs) -> None:
+def test_a_calibrated_pair_is_analysed_in_pascals(
+    func: Callable[..., object], kwargs: dict[str, float]
+) -> None:
     x, y = _record(0), _record(1)
     assert_same(
         func(

--- a/tests/signals/test_spectra.py
+++ b/tests/signals/test_spectra.py
@@ -19,6 +19,7 @@ Bendat & Piersol's; it lives in ``test_multitaper.py``.
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 
@@ -29,6 +30,9 @@ import numpy as np
 import pytest
 
 import phonometry as ph
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 8192.0
 N = 32768
@@ -475,7 +479,9 @@ def test_psd_rejects_invalid_inputs() -> None:
     "func",
     [ph.signals.cross_spectral_density, ph.signals.coherent_output_spectrum],
 )
-def test_two_channel_functions_reject_mismatched_lengths(func) -> None:
+def test_two_channel_functions_reject_mismatched_lengths(
+    func: Callable[[np.ndarray, np.ndarray, float], object],
+) -> None:
     x = _white(13)
     with pytest.raises(
         ValueError, match=rf"{func.__name__}: 'x'.*'y'.*one value per sample"

--- a/tests/speech/test_sii_report.py
+++ b/tests/speech/test_sii_report.py
@@ -13,12 +13,17 @@ back from the PDF via pypdf text extraction.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
-from phonometry.speech import speech_intelligibility_index
+from phonometry.speech import SIIResult, speech_intelligibility_index
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _extract_text(path: str) -> str:
@@ -29,7 +34,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _example_c2():
+def _example_c2() -> SIIResult:
     """R CRAN "SII" Example C.2: SII = 0.851 (independent oracle)."""
     return speech_intelligibility_index(
         np.full(18, 54.0),
@@ -41,7 +46,7 @@ def _example_c2():
 # --- exact oracle --------------------------------------------------------------
 
 
-def test_example_c2_renders_index_and_band_importance(tmp_path) -> None:
+def test_example_c2_renders_index_and_band_importance(tmp_path: Path) -> None:
     """The Example C.2 fiche prints SII = 0.851 and a Table 3 Ii value."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -57,7 +62,7 @@ def test_example_c2_renders_index_and_band_importance(tmp_path) -> None:
     assert "0.0898" in text
 
 
-def test_standard_speech_in_quiet_renders(tmp_path) -> None:
+def test_standard_speech_in_quiet_renders(tmp_path: Path) -> None:
     """The standard normal spectrum in quiet rates to SII = 0.996."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -72,7 +77,7 @@ def test_standard_speech_in_quiet_renders(tmp_path) -> None:
 # --- verbose adds the disturbance column --------------------------------------
 
 
-def test_verbose_adds_disturbance_column(tmp_path) -> None:
+def test_verbose_adds_disturbance_column(tmp_path: Path) -> None:
     """verbose=True adds the equivalent disturbance spectrum level Di column."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -87,7 +92,7 @@ def test_verbose_adds_disturbance_column(tmp_path) -> None:
 # --- verdict direction (higher is better) -------------------------------------
 
 
-def test_verdict_passes_at_or_above_requirement(tmp_path) -> None:
+def test_verdict_passes_at_or_above_requirement(tmp_path: Path) -> None:
     """SII = 0.851 passes a 0.75 minimum and fails a 0.90 minimum."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -100,7 +105,7 @@ def test_verdict_passes_at_or_above_requirement(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(out_fail))
 
 
-def test_verdict_prints_the_requirement_at_full_precision(tmp_path) -> None:
+def test_verdict_prints_the_requirement_at_full_precision(tmp_path: Path) -> None:
     """The requirement is printed at the SII's own three decimals.
 
     A one-decimal requirement would print a 0.75 minimum as "0.8", above the
@@ -121,7 +126,7 @@ def test_verdict_prints_the_requirement_at_full_precision(tmp_path) -> None:
     assert "PASS" in text
 
 
-def test_verdict_boundary_at_the_displayed_precision(tmp_path) -> None:
+def test_verdict_boundary_at_the_displayed_precision(tmp_path: Path) -> None:
     """A requirement equal to the displayed SII passes; one digit above fails."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -134,7 +139,7 @@ def test_verdict_boundary_at_the_displayed_precision(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(out_over))
 
 
-def test_verdict_decides_on_the_requirement_it_prints(tmp_path) -> None:
+def test_verdict_decides_on_the_requirement_it_prints(tmp_path: Path) -> None:
     """A requirement with hidden digits is judged on the value shown.
 
     0.85104 prints as "0.851"; deciding on the unrounded number would fail an
@@ -153,7 +158,7 @@ def test_verdict_decides_on_the_requirement_it_prints(tmp_path) -> None:
 # --- metadata ------------------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the header grid; no requirement, no verdict."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -178,7 +183,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche -------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the SII vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -208,7 +213,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     ],
 )
 def test_non_default_procedure_fiche_names_its_procedure(
-    tmp_path, method: str, basis: str, caption: str
+    tmp_path: Path, method: str, basis: str, caption: str
 ) -> None:
     """A fiche for a non-default procedure names it and tables its own bands.
 
@@ -235,7 +240,7 @@ def test_non_default_procedure_fiche_names_its_procedure(
     assert f"{round(proc.frequencies[-1])}" in text
 
 
-def test_non_default_procedure_fiche_renders_in_spanish(tmp_path) -> None:
+def test_non_default_procedure_fiche_renders_in_spanish(tmp_path: Path) -> None:
     """The Spanish fiche translates the procedure name in the basis line."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -248,7 +253,7 @@ def test_non_default_procedure_fiche_renders_in_spanish(tmp_path) -> None:
     assert "Audibilidad por bandas de octava" in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _example_c2()
     out = str(tmp_path / "x.pdf")
@@ -256,7 +261,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _example_c2()
     out = str(tmp_path / "bad.pdf")

--- a/tests/speech/test_speech_signal_overloads.py
+++ b/tests/speech/test_speech_signal_overloads.py
@@ -21,6 +21,8 @@ not pass) and leave what it does to the definitions.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from signal_contract import assert_same
@@ -32,6 +34,9 @@ from phonometry.speech import (
     stipa_signal,
     stoi,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 48000
 STOI_FS = 10000
@@ -66,12 +71,16 @@ SOLO_IDS = [f.__name__ for f, _ in SOLO]
 
 
 @pytest.mark.parametrize(("func", "record"), SOLO, ids=SOLO_IDS)
-def test_an_uncalibrated_signal_computes_the_bare_array_result(func, record) -> None:
+def test_an_uncalibrated_signal_computes_the_bare_array_result(
+    func: Callable[..., object], record: np.ndarray
+) -> None:
     assert_same(func(Signal(record, FS)), func(record, FS))
 
 
 @pytest.mark.parametrize(("func", "record"), SOLO, ids=SOLO_IDS)
-def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, record) -> None:
+def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
+    func: Callable[..., object], record: np.ndarray
+) -> None:
     sig = Signal(record, FS)
     with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
         func(sig, FS + 1)
@@ -80,13 +89,17 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(func, record) -> No
 
 
 @pytest.mark.parametrize(("func", "record"), SOLO, ids=SOLO_IDS)
-def test_a_bare_array_still_requires_fs(func, record) -> None:
+def test_a_bare_array_still_requires_fs(
+    func: Callable[..., object], record: np.ndarray
+) -> None:
     with pytest.raises(ValueError, match="fs is required"):
         func(record)
 
 
 @pytest.mark.parametrize(("func", "record"), SOLO, ids=SOLO_IDS)
-def test_a_calibrated_signal_is_analysed_in_pascals(func, record) -> None:
+def test_a_calibrated_signal_is_analysed_in_pascals(
+    func: Callable[..., object], record: np.ndarray
+) -> None:
     assert_same(
         func(Signal(record, FS, calibration_factor=CAL)), func(CAL * record, FS)
     )

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -82,7 +82,7 @@ def _analytic_decay_sti(t60: float) -> float:
         ((5, 6), 0.302),  # 4000 + 8000 Hz
     ],
 )
-def test_weighting_factor_pairs(bands, expected):
+def test_weighting_factor_pairs(bands: tuple[int, int], expected: float) -> None:
     # m=1 -> SNR_eff clipped to +15 -> TI=1; m=0 -> -15 -> TI=0.
     mtf = _uniform_mtf(0.0)
     mtf[list(bands), :] = 1.0
@@ -111,14 +111,14 @@ def test_weighting_factor_pairs(bands, expected):
         (1.0, 1.0),
     ],
 )
-def test_m_to_sti_mapping(m, expected_sti):
+def test_m_to_sti_mapping(m: float, expected_sti: float) -> None:
     # Ed.5 A.3.1.2 pairs: uniform m across all bands and modulation
     # frequencies maps to the given STI (tol +/-0,01).
     result = _sti_from_mtf(_uniform_mtf(m))
     assert result.sti == pytest.approx(expected_sti, abs=0.01)
 
 
-def test_alpha_beta_artifact_truncated_to_one():
+def test_alpha_beta_artifact_truncated_to_one() -> None:
     # Ed.4 Table A.3 NOTE (= Ed.5 Table A.1): with the 250 Hz band knocked
     # out (TI=0) and all other bands at TI=1 the raw formula gives 1,036
     # (sum(alpha) - alpha_1 - sum(beta) + beta_0 + beta_1); it must be
@@ -143,7 +143,7 @@ def test_alpha_beta_artifact_truncated_to_one():
 # ---------------------------------------------------------------------------
 
 
-def test_delta_impulse_response_is_perfect_transmission():
+def test_delta_impulse_response_is_perfect_transmission() -> None:
     ir = np.zeros(FS // 2)
     ir[100] = 1.0
     result = speech.sti_from_impulse_response(ir, FS)
@@ -157,7 +157,7 @@ def test_delta_impulse_response_is_perfect_transmission():
     assert isinstance(result, speech.STIResult)
 
 
-def test_exponential_decay_matches_analytic_schroeder_mtf():
+def test_exponential_decay_matches_analytic_schroeder_mtf() -> None:
     fs = 24000
     stis = []
     for t60 in (0.5, 1.0, 2.0, 4.0):
@@ -168,7 +168,7 @@ def test_exponential_decay_matches_analytic_schroeder_mtf():
     assert all(a > b for a, b in pairwise(stis))
 
 
-def test_snr_degradation_on_impulse_response():
+def test_snr_degradation_on_impulse_response() -> None:
     fs = 24000
     ir = _decay_ir(1.0, fs)
     plain = speech.sti_from_impulse_response(ir, fs)
@@ -184,7 +184,7 @@ def test_snr_degradation_on_impulse_response():
     assert vec.sti == pytest.approx(zero_snr.sti, abs=1e-12)
 
 
-def test_level_corrections_reduce_sti():
+def test_level_corrections_reduce_sti() -> None:
     fs = 24000
     ir = _decay_ir(1.0, fs)
     plain = speech.sti_from_impulse_response(ir, fs)
@@ -213,11 +213,11 @@ def test_level_corrections_reduce_sti():
     ("level", "expected"),
     [(60.0, -35.0), (65.0, -29.9), (80.0, -19.8), (100.0, -10.0)],
 )
-def test_masking_amdb_control_points(level, expected):
+def test_masking_amdb_control_points(level: float, expected: float) -> None:
     assert _masking_amdb(level) == pytest.approx(expected, abs=1e-9)
 
 
-def test_masking_amdb_is_vectorized_and_continuous():
+def test_masking_amdb_is_vectorized_and_continuous() -> None:
     levels = np.array([62.999, 63.0, 66.999, 67.0, 99.999, 100.0, 120.0])
     out = _masking_amdb(levels)
     assert out.shape == levels.shape
@@ -241,7 +241,7 @@ def stipa_18s_seed1234() -> np.ndarray:
     return speech.stipa_signal(FS, seconds=18.0, seed=1234)
 
 
-def test_stipa_loopback_ideal_channel(stipa_18s_seed1234: np.ndarray):
+def test_stipa_loopback_ideal_channel(stipa_18s_seed1234: np.ndarray) -> None:
     x = stipa_18s_seed1234
     result = speech.stipa(x, FS)
     # Ideal loopback recovers STI 0.998 and min MTF 0.945 at 18 s; lock those
@@ -252,7 +252,7 @@ def test_stipa_loopback_ideal_channel(stipa_18s_seed1234: np.ndarray):
     assert np.all(result.mtf > 0.93)
 
 
-def test_stipa_short_recording_warns(stipa_18s_seed1234: np.ndarray):
+def test_stipa_short_recording_warns(stipa_18s_seed1234: np.ndarray) -> None:
     """A recording shorter than the recommended 15 s biases the recovered
     modulation depths (and STI) low; stipa should warn (IEC 60268-16 STIPA
     practice recommends 15 s to 25 s).
@@ -266,7 +266,7 @@ def test_stipa_short_recording_warns(stipa_18s_seed1234: np.ndarray):
         speech.stipa(stipa_18s_seed1234, FS)
 
 
-def test_stipa_with_noise_is_monotonic(stipa_18s_seed1234: np.ndarray):
+def test_stipa_with_noise_is_monotonic(stipa_18s_seed1234: np.ndarray) -> None:
     x = stipa_18s_seed1234
     rng = np.random.default_rng(7)
     rms = float(np.sqrt(np.mean(x**2)))
@@ -278,7 +278,7 @@ def test_stipa_with_noise_is_monotonic(stipa_18s_seed1234: np.ndarray):
     assert stis[-1] < 0.7  # 0 dB broadband SNR is clearly degraded
 
 
-def test_stipa_reference_normalization():
+def test_stipa_reference_normalization() -> None:
     x = speech.stipa_signal(FS, seconds=18.0, seed=99)
     with_nominal = speech.stipa(x, FS)
     with_reference = speech.stipa(0.25 * x, FS, reference=x)
@@ -288,7 +288,7 @@ def test_stipa_reference_normalization():
     assert with_nominal.sti == pytest.approx(with_reference.sti, abs=0.05)
 
 
-def test_stipa_signal_properties():
+def test_stipa_signal_properties() -> None:
     seconds = 18.0
     x = speech.stipa_signal(FS, seconds=seconds, seed=0)
     assert x.shape == (int(seconds * FS),)
@@ -310,7 +310,7 @@ def test_stipa_signal_properties():
 # ---------------------------------------------------------------------------
 
 
-def test_rating_letters_from_band_edges():
+def test_rating_letters_from_band_edges() -> None:
     assert _rating(0.74) == "A"
     # Compute the expected letter from the Annex F edges and assert the
     # helper is consistent across the whole scale, including boundaries.
@@ -331,7 +331,7 @@ def test_rating_letters_from_band_edges():
 # ---------------------------------------------------------------------------
 
 
-def test_invalid_inputs_raise():
+def test_invalid_inputs_raise() -> None:
     ir = np.zeros(FS // 4)
     ir[10] = 1.0
     # the signals are built outside the raises blocks, so each block holds
@@ -401,7 +401,7 @@ def test_invalid_inputs_raise():
         _sti_from_mtf(negative_mtf)
 
 
-def test_mtf_above_1_3_warns_and_truncates():
+def test_mtf_above_1_3_warns_and_truncates() -> None:
     with pytest.warns(UserWarning, match="1.3"):
         result = _sti_from_mtf(_uniform_mtf(1.4))
     assert result.sti == 1.0

--- a/tests/speech/test_sti_report.py
+++ b/tests/speech/test_sti_report.py
@@ -13,13 +13,18 @@ rejected engines/languages) complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
-from phonometry.speech import sti_from_impulse_response
+from phonometry.speech import STIResult, sti_from_impulse_response
 from phonometry.speech.sti import _MOD_FREQS, _NUM_BANDS, _sti_from_mtf
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _extract_text(path: str) -> str:
@@ -30,12 +35,12 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _uniform_result(m: float):
+def _uniform_result(m: float) -> STIResult:
     """An STIResult from a uniform MTF (pure arithmetic, platform-stable)."""
     return _sti_from_mtf(np.full((_NUM_BANDS, _MOD_FREQS.size), m))
 
 
-def _decay_result(t60: float, fs: int = 48000, seed: int = 0):
+def _decay_result(t60: float, fs: int = 48000, seed: int = 0) -> STIResult:
     """A deterministic full-STI indirect result from an exponential decay IR."""
     rng = np.random.default_rng(seed)
     n = int(2.0 * t60 * fs)
@@ -47,7 +52,7 @@ def _decay_result(t60: float, fs: int = 48000, seed: int = 0):
 # --- exact oracle --------------------------------------------------------------
 
 
-def test_uniform_mtf_half_renders_sti_half(tmp_path) -> None:
+def test_uniform_mtf_half_renders_sti_half(tmp_path: Path) -> None:
     """m = 0.5 in every band maps to STI = 0.50 (A.3.1.2), band G."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -65,7 +70,7 @@ def test_uniform_mtf_half_renders_sti_half(tmp_path) -> None:
     assert "full STI, indirect method" in text
 
 
-def test_stipa_method_is_named(tmp_path) -> None:
+def test_stipa_method_is_named(tmp_path: Path) -> None:
     """A two-column MTF (STIPA) names the direct method in the basis line."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -79,7 +84,7 @@ def test_stipa_method_is_named(tmp_path) -> None:
 # --- verdict direction (higher is better) -------------------------------------
 
 
-def test_verdict_passes_at_or_above_requirement(tmp_path) -> None:
+def test_verdict_passes_at_or_above_requirement(tmp_path: Path) -> None:
     """STI = 0.50 passes a 0.45 minimum and fails a 0.55 minimum."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -92,7 +97,7 @@ def test_verdict_passes_at_or_above_requirement(tmp_path) -> None:
     assert "FAIL" in _extract_text(str(out_fail))
 
 
-def test_verdict_passes_exactly_at_requirement(tmp_path) -> None:
+def test_verdict_passes_exactly_at_requirement(tmp_path: Path) -> None:
     """A minimum equal to the displayed STI passes (>= boundary)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -102,7 +107,7 @@ def test_verdict_passes_exactly_at_requirement(tmp_path) -> None:
     assert "PASS" in _extract_text(str(out))
 
 
-def test_verdict_prints_the_requirement_at_full_precision(tmp_path) -> None:
+def test_verdict_prints_the_requirement_at_full_precision(tmp_path: Path) -> None:
     """The requirement is printed at the STI's own two decimals.
 
     A one-decimal requirement would round 0.52 to "0.5" and read as a
@@ -124,7 +129,7 @@ def test_verdict_prints_the_requirement_at_full_precision(tmp_path) -> None:
     assert "0.90" in _extract_text(str(out_round))
 
 
-def test_verdict_decides_on_the_requirement_it_prints(tmp_path) -> None:
+def test_verdict_decides_on_the_requirement_it_prints(tmp_path: Path) -> None:
     """A requirement with hidden digits is judged on the value shown.
 
     0.5049 prints as "0.50"; deciding on the unrounded number would fail an
@@ -144,7 +149,7 @@ def test_verdict_decides_on_the_requirement_it_prints(tmp_path) -> None:
 # --- realistic indirect measurement -------------------------------------------
 
 
-def test_decay_measurement_renders_its_own_value(tmp_path) -> None:
+def test_decay_measurement_renders_its_own_value(tmp_path: Path) -> None:
     """A full-STI indirect fiche prints its STI, rating and a band MTI value."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -171,7 +176,7 @@ def test_decay_measurement_renders_its_own_value(tmp_path) -> None:
 # --- metadata ------------------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the header grid; no requirement, no verdict."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -196,7 +201,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche -------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the STI vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -214,7 +219,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract --------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _uniform_result(0.5)
     out = str(tmp_path / "x.pdf")
@@ -222,7 +227,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _uniform_result(0.5)
     out = str(tmp_path / "bad.pdf")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,7 @@
 """Basic test and usage example for phonometry."""
 
 import numpy as np
+import pytest
 
 import phonometry
 from phonometry._version import __version__
@@ -101,7 +102,7 @@ def test_detrend_acts_on_the_input_once_not_per_band() -> None:
     assert abs(float(np.mean(bands_off[0]))) < 1e-4
 
 
-def test_octave_filter_reuses_cached_bank(monkeypatch) -> None:
+def test_octave_filter_reuses_cached_bank(monkeypatch: pytest.MonkeyPatch) -> None:
     """Repeated octave_filter calls with identical params must not redesign the bank."""
     from phonometry.filters.core import OctaveFilterBank
 
@@ -109,7 +110,7 @@ def test_octave_filter_reuses_cached_bank(monkeypatch) -> None:
     calls = {"n": 0}
     original_init = OctaveFilterBank.__init__
 
-    def counting_init(self, *args, **kwargs):
+    def counting_init(self: OctaveFilterBank, *args: object, **kwargs: object) -> None:
         calls["n"] += 1
         original_init(self, *args, **kwargs)
 

--- a/tests/test_check_conformance_claims.py
+++ b/tests/test_check_conformance_claims.py
@@ -142,7 +142,9 @@ def _run(root: pathlib.Path, *args: str) -> int:
     return ccc.main([*args, "--root", str(root)])
 
 
-def test_check_reports_every_stale_claim(corpus, capsys):
+def test_check_reports_every_stale_claim(
+    corpus: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     """The read-only mode is the CI gate: it lists them all and exits 1."""
     assert _run(corpus) == 1
     errors = capsys.readouterr().err
@@ -160,7 +162,9 @@ def test_check_reports_every_stale_claim(corpus, capsys):
     assert f"claims {OLD_STANDARDS} standards, report says {STANDARDS}" in errors
 
 
-def test_write_moves_every_quoted_count(corpus, capsys):
+def test_write_moves_every_quoted_count(
+    corpus: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Every place that quotes a count is brought into line in one run."""
     assert _run(corpus, "--write") == 0
     assert "Rewrote" in capsys.readouterr().out
@@ -201,7 +205,7 @@ def test_write_moves_every_quoted_count(corpus, capsys):
     assert _run(corpus) == 0
 
 
-def test_write_leaves_the_decoys_alone(corpus):
+def test_write_leaves_the_decoys_alone(corpus: pathlib.Path) -> None:
     """A number that is not a conformance count is never touched.
 
     The decoys carry the stale counts in unrelated sentences: on their own
@@ -231,7 +235,7 @@ def test_write_leaves_the_decoys_alone(corpus):
         assert designation in zenodo["description"]
 
 
-def test_write_is_idempotent(corpus):
+def test_write_is_idempotent(corpus: pathlib.Path) -> None:
     """A second run changes nothing, byte for byte."""
     assert _run(corpus, "--write") == 0
     first = {p: p.read_bytes() for p in ccc.sources(corpus)}
@@ -239,7 +243,7 @@ def test_write_is_idempotent(corpus):
     assert {p: p.read_bytes() for p in ccc.sources(corpus)} == first
 
 
-def test_write_touches_only_the_files_that_quote_a_count(corpus):
+def test_write_touches_only_the_files_that_quote_a_count(corpus: pathlib.Path) -> None:
     """Excluded and count-free files come out byte-identical.
 
     ``stub/README.md`` is in the list for the same reason the root markdown is
@@ -258,7 +262,7 @@ def test_write_touches_only_the_files_that_quote_a_count(corpus):
     assert {p: p.read_bytes() for p in untouched} == before
 
 
-def test_a_crlf_file_stays_crlf(tmp_path):
+def test_a_crlf_file_stays_crlf(tmp_path: pathlib.Path) -> None:
     """The writer changes digits, not the file's line endings."""
     _write(tmp_path / "docs" / "CONFORMANCE.md", REPORT)
     page = tmp_path / "docs" / "getting-started.md"
@@ -275,7 +279,7 @@ def test_a_crlf_file_stays_crlf(tmp_path):
     )
 
 
-def test_line_endings_and_surrounding_prose_are_preserved():
+def test_line_endings_and_surrounding_prose_are_preserved() -> None:
     """Only the digits move: indentation, quoting and CRLF stay put."""
     expected = {"total": TOTAL, "domains": DOMAINS, "standards": STANDARDS}
     line = (
@@ -290,7 +294,7 @@ def test_line_endings_and_surrounding_prose_are_preserved():
     assert [claim.field for claim in fixed] == ["total", "standards"]
 
 
-def test_a_claim_read_two_ways_is_rejected(monkeypatch):
+def test_a_claim_read_two_ways_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
     """Two patterns that disagree about a number are a bug, not a coin toss."""
     import re
 
@@ -307,8 +311,10 @@ def test_a_claim_read_two_ways_is_rejected(monkeypatch):
 
 
 def test_an_ambiguous_pattern_pair_reports_instead_of_crashing(
-    corpus, monkeypatch, capsys
-):
+    corpus: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """The command exits 1 with the diagnostic, not with a traceback."""
     import re
 
@@ -324,14 +330,16 @@ def test_an_ambiguous_pattern_pair_reports_instead_of_crashing(
     assert "ambiguous conformance claim" in capsys.readouterr().err
 
 
-def test_a_report_without_a_headline_is_an_error(tmp_path, capsys):
+def test_a_report_without_a_headline_is_an_error(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     """A format change must fail loudly rather than rewrite prose to nothing."""
     _write(tmp_path / "docs" / "CONFORMANCE.md", "no headline here\n")
     assert _run(tmp_path, "--write") == 1
     assert "headline not found" in capsys.readouterr().err
 
 
-def test_the_real_corpus_needs_no_rewriting():
+def test_the_real_corpus_needs_no_rewriting() -> None:
     """The committed tree is already consistent, so the writer is a no-op.
 
     This is the same property the CI gate asserts, checked without touching

--- a/tests/test_check_figure_contrast.py
+++ b/tests/test_check_figure_contrast.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -31,9 +32,12 @@ import check_figure_contrast as cfc
 
 from phonometry._plot.common import theme_fill
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 
 @pytest.fixture(autouse=True)
-def _close_figures():
+def _close_figures() -> Iterator[None]:
     yield
     plt.close("all")
 

--- a/tests/test_check_jit_kernel.py
+++ b/tests/test_check_jit_kernel.py
@@ -38,7 +38,9 @@ def test_guard_verdict_follows_the_environment() -> None:
 
 
 @pytest.mark.skipif(not _JITTED, reason="numba is absent or the JIT is disabled")
-def test_a_pass_is_backed_by_a_printed_signature(capsys) -> None:
+def test_a_pass_is_backed_by_a_printed_signature(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """A pass has to name the compiled signatures, not just return zero."""
     assert check_jit_kernel.main() == 0
     out = capsys.readouterr().out

--- a/tests/test_check_subscript_slope.py
+++ b/tests/test_check_subscript_slope.py
@@ -15,12 +15,16 @@ from __future__ import annotations
 
 import pathlib
 import sys
+from typing import TYPE_CHECKING
 
 _SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)
 
 import check_subscript_slope as css
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _write(tmp_path: pathlib.Path, name: str, text: str) -> pathlib.Path:
@@ -29,7 +33,7 @@ def _write(tmp_path: pathlib.Path, name: str, text: str) -> pathlib.Path:
     return path
 
 
-def test_one_symbol_two_slopes_in_one_file_fails(tmp_path):
+def test_one_symbol_two_slopes_in_one_file_fails(tmp_path: pathlib.Path) -> None:
     """The defect the gate exists for, with both lines named."""
     path = _write(
         tmp_path,
@@ -46,7 +50,7 @@ def test_one_symbol_two_slopes_in_one_file_fails(tmp_path):
     assert "upright on line 3" in failures[0]
 
 
-def test_two_files_may_disagree(tmp_path):
+def test_two_files_may_disagree(tmp_path: pathlib.Path) -> None:
     """The silence the file scope depends on: D_z is both, one per module."""
     outdoor = _write(tmp_path, "outdoor.md", "Screening $D_z$ from the path.\n")
     shock = _write(tmp_path, "shock.md", "Dose $D_\\mathrm{z}$ up the spine.\n")
@@ -54,7 +58,7 @@ def test_two_files_may_disagree(tmp_path):
     assert failures == []
 
 
-def test_component_of_a_compound_subscript_is_read(tmp_path):
+def test_component_of_a_compound_subscript_is_read(tmp_path: pathlib.Path) -> None:
     """Half of one formula upright and half italic is the same defect."""
     path = _write(
         tmp_path,
@@ -66,7 +70,7 @@ def test_component_of_a_compound_subscript_is_read(tmp_path):
     assert "\\alpha_s" in failures[0]
 
 
-def test_a_run_inside_one_wrapper_is_upright_throughout(tmp_path):
+def test_a_run_inside_one_wrapper_is_upright_throughout(tmp_path: pathlib.Path) -> None:
     r"""``L_\mathrm{n,w,eq}`` sets three upright components, not one."""
     path = _write(
         tmp_path,
@@ -77,7 +81,9 @@ def test_a_run_inside_one_wrapper_is_upright_throughout(tmp_path):
     assert failures == []
 
 
-def test_an_index_beside_an_upright_run_is_not_a_collision(tmp_path):
+def test_an_index_beside_an_upright_run_is_not_a_collision(
+    tmp_path: pathlib.Path,
+) -> None:
     """The index keeps its own slope where the wrapper does not cover it."""
     path = _write(
         tmp_path,
@@ -88,7 +94,7 @@ def test_an_index_beside_an_upright_run_is_not_a_collision(tmp_path):
     assert failures == []
 
 
-def test_a_translation_pattern_is_not_a_label(tmp_path):
+def test_a_translation_pattern_is_not_a_label(tmp_path: pathlib.Path) -> None:
     """A regex spells a backslash twice; nothing in it is mathematics."""
     path = _write(
         tmp_path,
@@ -102,7 +108,7 @@ def test_a_translation_pattern_is_not_a_label(tmp_path):
     assert failures == []
 
 
-def test_docstring_mathematics_is_read(tmp_path):
+def test_docstring_mathematics_is_read(tmp_path: pathlib.Path) -> None:
     """A module states its formulae in ``:math:`` roles and ``.. math::``."""
     path = _write(
         tmp_path,
@@ -121,7 +127,9 @@ def test_docstring_mathematics_is_read(tmp_path):
     assert "L_i" in failures[0]
 
 
-def test_a_declared_page_is_left_alone(tmp_path, monkeypatch):
+def test_a_declared_page_is_left_alone(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The escape hatch, matched on the repository-relative tail of the path."""
     (tmp_path / "reference").mkdir()
     path = _write(
@@ -139,7 +147,7 @@ def test_a_declared_page_is_left_alone(tmp_path, monkeypatch):
     assert failures == []
 
 
-def test_the_excluded_trees_are_not_collected(tmp_path):
+def test_the_excluded_trees_are_not_collected(tmp_path: pathlib.Path) -> None:
     """Errata transcribe a source; drawing modules are filed by domain."""
     (tmp_path / "reference").mkdir()
     (tmp_path / "_plot").mkdir()
@@ -149,7 +157,7 @@ def test_the_excluded_trees_are_not_collected(tmp_path):
     assert collected == {"guide.md"}
 
 
-def test_the_tree_it_ships_with_passes():
+def test_the_tree_it_ships_with_passes() -> None:
     """The gate is green on this repository, which is what CI asserts."""
     root = pathlib.Path(__file__).resolve().parent.parent
     paths = css.collect([str(root / r) for r in css.DEFAULT_ROOTS])

--- a/tests/test_device_geometry_plots.py
+++ b/tests/test_device_geometry_plots.py
@@ -10,6 +10,8 @@ refusal paths and input validation, mirroring the materials geometry tests.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -20,11 +22,16 @@ import matplotlib.pyplot as plt
 
 import phonometry as pm
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from matplotlib.axes import Axes
+
 FREQ = np.linspace(50.0, 1600.0, 24)
 
 
 @pytest.fixture(autouse=True)
-def _close_figures():
+def _close_figures() -> Iterator[None]:
     yield
     plt.close("all")
 
@@ -88,7 +95,7 @@ def _chain(branch_length: float = 0.686) -> pm.noise_control.SilencerChain:
     )
 
 
-def _lengths_lettered(ax) -> set[str]:
+def _lengths_lettered(ax: Axes) -> set[str]:
     """Every measurement the drawing letters, as it letters it."""
     return {text.get_text() for text in ax.texts if text.get_text().endswith(" mm")}
 

--- a/tests/test_diagram_outline.py
+++ b/tests/test_diagram_outline.py
@@ -254,7 +254,7 @@ def test_collision_census_names_each_way_a_label_can_land_wrong(
     assert kinds == {"overprint", "escapes", "struck", "painted over"}
 
 
-def test_a_panel_over_the_title_is_reported(monkeypatch) -> None:
+def test_a_panel_over_the_title_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
     """The title is painted first, so a body panel can bury it.
 
     The collision census records every element as it is drawn and reports a
@@ -265,8 +265,9 @@ def test_a_panel_over_the_title_is_reported(monkeypatch) -> None:
     lets any panel cover it. This pins the order rather than the symptom.
     """
     from diagrams import outline, registry
+    from diagrams.canvas import SVG, Theme
 
-    def build(svg, th) -> None:
+    def build(svg: SVG, th: Theme) -> None:
         # An opaque panel across the top strip, where the title is set.
         svg.rect(100, 10, 700, 60, fill=th.fg)
 

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -21,6 +21,7 @@ import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from types import ModuleType
 
 pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
@@ -33,7 +34,7 @@ _SCRIPT = (
 )
 
 
-def _load_generator():
+def _load_generator() -> ModuleType:
     spec = importlib.util.spec_from_file_location("_generate_reports", _SCRIPT)
     assert spec is not None
     assert spec.loader is not None

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -17,6 +17,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -309,7 +310,9 @@ def test_io_imports_and_reads_without_matplotlib_and_soundfile() -> None:
     )
 
 
-def test_showfilter_raises_helpful_error_without_matplotlib(monkeypatch) -> None:
+def test_showfilter_raises_helpful_error_without_matplotlib(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Without matplotlib, plotting must fail with an actionable message."""
     import builtins
 
@@ -320,7 +323,7 @@ def test_showfilter_raises_helpful_error_without_matplotlib(monkeypatch) -> None
 
     real_import = builtins.__import__
 
-    def blocked_import(name, *args, **kwargs):
+    def blocked_import(name: str, *args: object, **kwargs: object) -> ModuleType:
         if name.startswith("matplotlib"):
             msg = "No module named 'matplotlib'"
             raise ImportError(msg)

--- a/tests/test_multichannel_rejection.py
+++ b/tests/test_multichannel_rejection.py
@@ -8,10 +8,15 @@ audit finding).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
 import phonometry as ph
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _STEREO = np.zeros((2, 4800))
 
@@ -26,6 +31,8 @@ _STEREO = np.zeros((2, 4800))
     ],
     ids=["loudness_ecma", "tonality_ecma", "roughness_ecma", "moore_glasberg"],
 )
-def test_stereo_input_is_rejected(analyze) -> None:
+def test_stereo_input_is_rejected(
+    analyze: Callable[[np.ndarray, float], object],
+) -> None:
     with pytest.raises(ValueError, match="1-D time series"):
         analyze(_STEREO, 48000.0)

--- a/tests/test_plot_common_i18n.py
+++ b/tests/test_plot_common_i18n.py
@@ -40,13 +40,15 @@ from phonometry._plot.common import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from matplotlib.axes import Axes
 
-def _axes():
+
+def _axes() -> Axes:
     _fig, ax = plt.subplots()
     return ax
 
 
-def _legend_texts(ax) -> list[str]:
+def _legend_texts(ax: Axes) -> list[str]:
     legend = ax.get_legend()
     return [] if legend is None else [t.get_text() for t in legend.get_texts()]
 

--- a/tests/test_report_layout.py
+++ b/tests/test_report_layout.py
@@ -9,7 +9,12 @@ is pinned here directly instead of through a ``report()`` call.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
 pytest.importorskip("reportlab")
 
@@ -107,7 +112,7 @@ def test_a_single_width_is_left_alone() -> None:
     ],
 )
 def test_the_octave_grouping_is_measured_from_the_band_centres(
-    centres, expected
+    centres: list[int] | None, expected: int | None
 ) -> None:
     """The rules group a table by octave, so they need rows that are bands.
 
@@ -134,7 +139,9 @@ def test_a_drawing_is_scaled_by_what_it_covers_not_by_what_it_declares() -> None
 
     from phonometry._report._layout import render_figure_drawing
 
-    def wide_legend(ax=None, language="en", **kwargs):
+    def wide_legend(
+        ax: Axes | None = None, language: str = "en", **kwargs: object
+    ) -> Axes:
         """A plot whose legend is far wider than its axes."""
         ax.plot([1.0, 2.0], [1.0, 2.0], label="a legend entry long enough to overhang")
         ax.legend(loc="lower left", bbox_to_anchor=(0.0, 1.005))

--- a/tests/test_result_plots.py
+++ b/tests/test_result_plots.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import ast
 import builtins
 import inspect
+from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 
@@ -77,6 +78,13 @@ from result_factories import (
 import phonometry as ph
 from phonometry._plot import common as _plotting
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import ModuleType
+
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+
 
 # --------------------------------------------------------------------------
 # Soft-dependency contract: lazy import + ImportError guidance
@@ -106,11 +114,13 @@ def test_plotting_module_has_no_toplevel_matplotlib_import() -> None:
                 assert node in allowed, "matplotlib imported at runtime module scope"
 
 
-def test_plot_raises_helpful_error_without_matplotlib(monkeypatch) -> None:
+def test_plot_raises_helpful_error_without_matplotlib(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Without matplotlib, .plot() fails with an actionable message."""
     real_import = builtins.__import__
 
-    def blocked(name, *args, **kwargs):
+    def blocked(name: str, *args: object, **kwargs: object) -> ModuleType:
         if name.startswith("matplotlib"):
             msg = "No module named 'matplotlib'"
             raise ImportError(msg)
@@ -176,7 +186,9 @@ _KWARG_PLOT_CASES = [
     _KWARG_PLOT_CASES,
     ids=[c[0] for c in _KWARG_PLOT_CASES],
 )
-def test_every_plot_forwards_kwargs_to_primary_artist(name, factory, kind) -> None:
+def test_every_plot_forwards_kwargs_to_primary_artist(
+    name: str, factory: Callable[[], object], kind: str
+) -> None:
     res = factory()
     out = res.plot(linewidth=2)
     ax = out[0] if isinstance(out, np.ndarray) else out
@@ -194,7 +206,7 @@ def test_every_plot_forwards_kwargs_to_primary_artist(name, factory, kind) -> No
     artists = ax.lines if kind == "line" else ax.patches
     red = plt.matplotlib.colors.to_rgba("red")
 
-    def _is_red(artist) -> bool:
+    def _is_red(artist: Line2D | Patch) -> bool:
         if kind == "line":
             return plt.matplotlib.colors.to_rgba(artist.get_color()) == red
         return tuple(artist.get_facecolor()) == red

--- a/tests/test_secondary_geometry_plots.py
+++ b/tests/test_secondary_geometry_plots.py
@@ -9,6 +9,8 @@ refusal paths and validation, mirroring the earlier geometry test files.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
@@ -19,11 +21,14 @@ import matplotlib.pyplot as plt
 
 import phonometry as pm
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 FREQ = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0])
 
 
 @pytest.fixture(autouse=True)
-def _close_figures():
+def _close_figures() -> Iterator[None]:
     yield
     plt.close("all")
 

--- a/tests/test_signal_contract_exemptions.py
+++ b/tests/test_signal_contract_exemptions.py
@@ -33,6 +33,7 @@ including the ones where it is optional because it only labels an axis.
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -66,6 +67,9 @@ from phonometry.vibration import (
     vibration_dose_value,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 FS = 48000
 CAL = 5.0
 
@@ -95,7 +99,9 @@ IN_PASCALS_IDS = [f.__name__ for f, _, _ in IN_PASCALS]
 
 
 @pytest.mark.parametrize(("func", "record", "kwargs"), IN_PASCALS, ids=IN_PASCALS_IDS)
-def test_a_calibrated_signal_is_analysed_in_pascals(func, record, kwargs) -> None:
+def test_a_calibrated_signal_is_analysed_in_pascals(
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, object]
+) -> None:
     """A calibrated Signal reads the same as the samples already in pascals."""
     assert_same(
         func(Signal(record, FS, calibration_factor=CAL), **kwargs),
@@ -105,7 +111,7 @@ def test_a_calibrated_signal_is_analysed_in_pascals(func, record, kwargs) -> Non
 
 @pytest.mark.parametrize(("func", "record", "kwargs"), IN_PASCALS, ids=IN_PASCALS_IDS)
 def test_an_uncalibrated_signal_computes_the_bare_array_result(
-    func, record, kwargs
+    func: Callable[..., object], record: np.ndarray, kwargs: dict[str, object]
 ) -> None:
     """With no factor to apply, the object and the bare array agree."""
     assert_same(func(Signal(record, FS), **kwargs), func(record, FS, **kwargs))
@@ -211,7 +217,9 @@ FULL_SCALE_IDS = [f.__name__ for f, _ in FULL_SCALE]
 
 
 @pytest.mark.parametrize(("func", "kwargs"), FULL_SCALE, ids=FULL_SCALE_IDS)
-def test_a_full_scale_reading_never_sees_the_calibration(func, kwargs) -> None:
+def test_a_full_scale_reading_never_sees_the_calibration(
+    func: Callable[..., object], kwargs: dict[str, object]
+) -> None:
     """LUFS and dBTP are counted from full scale, so pascals would shift them."""
     calibrated = func(Signal(_RECORD, FS, calibration_factor=CAL), **kwargs)
     assert_same(calibrated, func(_RECORD, FS, **kwargs))
@@ -221,7 +229,9 @@ def test_a_full_scale_reading_never_sees_the_calibration(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), FULL_SCALE, ids=FULL_SCALE_IDS)
-def test_a_full_scale_reading_still_resolves_the_rate(func, kwargs) -> None:
+def test_a_full_scale_reading_still_resolves_the_rate(
+    func: Callable[..., object], kwargs: dict[str, object]
+) -> None:
     """Exempt from the calibration, not from the rate: it still takes one."""
     sig = Signal(_RECORD, FS)
     assert_same(func(sig, **kwargs), func(_RECORD, FS, **kwargs))
@@ -246,7 +256,9 @@ NOT_PRESSURE_IDS = [f.__name__ for f, _ in NOT_PRESSURE]
 
 
 @pytest.mark.parametrize(("func", "kwargs"), NOT_PRESSURE, ids=NOT_PRESSURE_IDS)
-def test_a_non_pressure_record_never_sees_the_calibration(func, kwargs) -> None:
+def test_a_non_pressure_record_never_sees_the_calibration(
+    func: Callable[..., object], kwargs: dict[str, str]
+) -> None:
     """An acceleration in m/s2 and a force in N are not pascals waiting to be."""
     calibrated = func(Signal(_RECORD, FS, calibration_factor=CAL), **kwargs)
     assert_same(calibrated, func(_RECORD, FS, **kwargs))
@@ -256,7 +268,9 @@ def test_a_non_pressure_record_never_sees_the_calibration(func, kwargs) -> None:
 
 
 @pytest.mark.parametrize(("func", "kwargs"), NOT_PRESSURE, ids=NOT_PRESSURE_IDS)
-def test_a_non_pressure_record_still_resolves_the_rate(func, kwargs) -> None:
+def test_a_non_pressure_record_still_resolves_the_rate(
+    func: Callable[..., object], kwargs: dict[str, str]
+) -> None:
     """An acceleration is not a pressure, and it still needs a sample rate."""
     sig = Signal(_RECORD, FS)
     assert_same(func(sig, **kwargs), func(_RECORD, FS, **kwargs))

--- a/tests/test_signal_return_contract.py
+++ b/tests/test_signal_return_contract.py
@@ -32,12 +32,17 @@ which is exactly why the existing 160 tests of the contract did not.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pytest
 
-from phonometry.filters import parametric_eq, weighting_filter
+from phonometry.filters import EQSection, parametric_eq, weighting_filter
 from phonometry.io import Signal
 from phonometry.signals import leq
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 FS = 48000
 #: A factor big enough that a second application is unmistakable: applying it
@@ -55,10 +60,8 @@ def _record(seconds: float = 1.0, seed: int = 0) -> np.ndarray:
 _RECORD = _record()
 
 
-def _sections():
+def _sections() -> list[EQSection]:
     """One peaking section, so ``parametric_eq`` has something to do."""
-    from phonometry.filters import EQSection
-
     return [EQSection(filter_type="peaking", f0=1000.0, gain_db=3.0, q=1.0)]
 
 
@@ -72,14 +75,21 @@ TRANSFORMS = [
 IDS = [name for name, _ in TRANSFORMS]
 
 
-def _call(name, x, extra, fs=None):
+def _call(
+    name: str,
+    x: Signal | np.ndarray,
+    extra: Callable[[], dict[str, object]],
+    fs: float | None = None,
+) -> Signal | np.ndarray:
     """Call the transform by name, with or without an explicit rate."""
     func = {"weighting_filter": weighting_filter, "parametric_eq": parametric_eq}[name]
     return func(x, **extra()) if fs is None else func(x, fs, **extra())
 
 
 @pytest.mark.parametrize(("name", "extra"), TRANSFORMS, ids=IDS)
-def test_a_second_hop_does_not_apply_the_factor_again(name, extra) -> None:
+def test_a_second_hop_does_not_apply_the_factor_again(
+    name: str, extra: Callable[[], dict[str, object]]
+) -> None:
     """The defect this file exists for, asserted where it would appear.
 
     The level of the transformed record has to be the level of the
@@ -92,7 +102,9 @@ def test_a_second_hop_does_not_apply_the_factor_again(name, extra) -> None:
 
 
 @pytest.mark.parametrize(("name", "extra"), TRANSFORMS, ids=IDS)
-def test_the_returned_signal_says_its_conversion_is_done(name, extra) -> None:
+def test_the_returned_signal_says_its_conversion_is_done(
+    name: str, extra: Callable[[], dict[str, object]]
+) -> None:
     """One, not the input's factor, and not None either.
 
     None would give the same level but make ``Signal.plot()`` label a record
@@ -104,7 +116,9 @@ def test_the_returned_signal_says_its_conversion_is_done(name, extra) -> None:
 
 
 @pytest.mark.parametrize(("name", "extra"), TRANSFORMS, ids=IDS)
-def test_an_uncalibrated_record_stays_uncalibrated(name, extra) -> None:
+def test_an_uncalibrated_record_stays_uncalibrated(
+    name: str, extra: Callable[[], dict[str, object]]
+) -> None:
     """The object never invents a calibration it was not given."""
     out = _call(name, Signal(_RECORD, FS), extra)
     assert isinstance(out, Signal)
@@ -112,7 +126,9 @@ def test_an_uncalibrated_record_stays_uncalibrated(name, extra) -> None:
 
 
 @pytest.mark.parametrize(("name", "extra"), TRANSFORMS, ids=IDS)
-def test_a_bare_array_still_comes_back_bare(name, extra) -> None:
+def test_a_bare_array_still_comes_back_bare(
+    name: str, extra: Callable[[], dict[str, object]]
+) -> None:
     """The rule is conditional, so nothing that passes arrays today changes.
 
     Every call site inside the library resolves its input to an array before
@@ -124,7 +140,9 @@ def test_a_bare_array_still_comes_back_bare(name, extra) -> None:
 
 
 @pytest.mark.parametrize(("name", "extra"), TRANSFORMS, ids=IDS)
-def test_the_samples_are_the_same_ones_the_bare_call_computes(name, extra) -> None:
+def test_the_samples_are_the_same_ones_the_bare_call_computes(
+    name: str, extra: Callable[[], dict[str, object]]
+) -> None:
     """Wrapping changes what comes back, never what was computed."""
     wrapped = _call(name, Signal(_RECORD, FS), extra)
     bare = _call(name, _RECORD, extra, fs=FS)
@@ -132,7 +150,9 @@ def test_the_samples_are_the_same_ones_the_bare_call_computes(name, extra) -> No
 
 
 @pytest.mark.parametrize(("name", "extra"), TRANSFORMS, ids=IDS)
-def test_the_metadata_travels_with_the_samples(name, extra) -> None:
+def test_the_metadata_travels_with_the_samples(
+    name: str, extra: Callable[[], dict[str, object]]
+) -> None:
     """The rate and the labels are what the chain was losing."""
     labelled = Signal(
         np.stack([_RECORD, _RECORD]), FS, channel_labels=("left", "right")

--- a/tests/underwater/propagation/test_eigenrays.py
+++ b/tests/underwater/propagation/test_eigenrays.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import functools
 import warnings
+from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 
@@ -55,10 +56,14 @@ from phonometry import PhonometryWarning
 from phonometry.underwater.propagation.numerical import (
     EigenrayResult,
     FluidSeabed,
+    RayTraceResult,
     _caustic_crossings,
     eigenrays,
     ray_trace,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _C = 1500.0
 #: The isovelocity guide every image-lattice test below runs in.
@@ -104,7 +109,7 @@ def _image_arrivals(
     return out
 
 
-def _guide_trace(aperture: float = 48.0, step_deg: float = 0.5):
+def _guide_trace(aperture: float = 48.0, step_deg: float = 0.5) -> RayTraceResult:
     return ray_trace(
         [0.0, _GUIDE["depth"]],
         [_C, _C],
@@ -340,7 +345,12 @@ def _n2_speed(z: np.ndarray) -> np.ndarray:
     return np.asarray(_N2_C0 / np.sqrt(1.0 + _N2_G * z))
 
 
-def _n2_parabola(theta0_deg: float):
+def _n2_parabola(
+    theta0_deg: float,
+) -> tuple[
+    Callable[[np.ndarray | float], np.ndarray | float],
+    Callable[[np.ndarray | float], np.ndarray | float],
+]:
     """The exact ray as callables ``z(r)``, ``z'(r)`` (Eq. 3.195)."""
     th = np.radians(theta0_deg)
     n0 = np.sqrt(1.0 + _N2_G * _N2_SOURCE)

--- a/tests/vibration/human/test_human_vibration_report.py
+++ b/tests/vibration/human/test_human_vibration_report.py
@@ -16,12 +16,16 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import TYPE_CHECKING
 
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import ReportMetadata
-from phonometry.vibration import daily_vibration_exposure
+from phonometry.vibration import DailyVibrationExposure, daily_vibration_exposure
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _extract_text(path: str) -> str:
@@ -32,7 +36,7 @@ def _extract_text(path: str) -> str:
     return " ".join(raw.split())
 
 
-def _annex_e3_result():
+def _annex_e3_result() -> DailyVibrationExposure:
     """The ISO 5349-2:2001 Annex E.3 forestry worker's hand-arm day."""
     return daily_vibration_exposure(
         [4.6, 6.0, 3.6],
@@ -56,7 +60,7 @@ def test_annex_e3_hand_oracle_values() -> None:
     assert res.assessment.zone == "action"
 
 
-def test_report_renders_annex_e3_numbers(tmp_path) -> None:
+def test_report_renders_annex_e3_numbers(tmp_path: Path) -> None:
     """The fiche prints the E.3 magnitudes, partials and combined A(8)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -86,7 +90,7 @@ def test_report_renders_annex_e3_numbers(tmp_path) -> None:
     assert "PASS" in text
 
 
-def test_verbose_adds_energy_share_column(tmp_path) -> None:
+def test_verbose_adds_energy_share_column(tmp_path: Path) -> None:
     """verbose=True adds each operation's share of the daily vibration energy."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -115,7 +119,7 @@ def test_verbose_adds_energy_share_column(tmp_path) -> None:
     ],
 )
 def test_hav_directive_boundaries_on_displayed_value(
-    tmp_path, a_hv: float, n_exceeded: int, verdict: str
+    tmp_path: Path, a_hv: float, n_exceeded: int, verdict: str
 ) -> None:
     """The EAV/ELV rows flip on the two-decimal displayed value (8 h exposure)."""
     pytest.importorskip("reportlab")
@@ -145,7 +149,7 @@ def test_hav_directive_boundaries_on_displayed_value(
     ],
 )
 def test_boxed_zone_agrees_with_displayed_rows_and_verdict(
-    tmp_path, a_hv: float, box_phrase: str, n_exceeded: int, verdict: str
+    tmp_path: Path, a_hv: float, box_phrase: str, n_exceeded: int, verdict: str
 ) -> None:
     """The boxed zone phrase derives from the same displayed-rounded compare."""
     pytest.importorskip("reportlab")
@@ -161,7 +165,7 @@ def test_boxed_zone_agrees_with_displayed_rows_and_verdict(
     assert verdict in text
 
 
-def test_verdict_sentence_states_the_actual_relation(tmp_path) -> None:
+def test_verdict_sentence_states_the_actual_relation(tmp_path: Path) -> None:
     """The verdict sentence agrees with its PASS/FAIL banner, both directions."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -180,7 +184,7 @@ def test_verdict_sentence_states_the_actual_relation(tmp_path) -> None:
     assert "FAIL" in text
 
 
-def test_whole_body_thresholds_and_basis(tmp_path) -> None:
+def test_whole_body_thresholds_and_basis(tmp_path: Path) -> None:
     """A whole-body result names ISO 2631-1 and the 0.5 / 1.15 m/s2 values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -204,7 +208,7 @@ def test_whole_body_thresholds_and_basis(tmp_path) -> None:
     assert "Annex Part B point 1" in text
 
 
-def test_whole_body_spanish_states_part_b_basis(tmp_path) -> None:
+def test_whole_body_spanish_states_part_b_basis(tmp_path: Path) -> None:
     """The Spanish whole-body fiche carries the translated Part B basis note."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -221,7 +225,7 @@ def test_whole_body_spanish_states_part_b_basis(tmp_path) -> None:
 # --- metadata -----------------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the company, worker, workplace and traceability."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -249,7 +253,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the vibration vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -268,7 +272,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _annex_e3_result()
     out = str(tmp_path / "x.pdf")
@@ -276,7 +280,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _annex_e3_result()
     out = str(tmp_path / "bad.pdf")
@@ -285,7 +289,9 @@ def test_unknown_language_rejected(tmp_path) -> None:
 
 
 @pytest.mark.parametrize("field", ["total_values", "durations_s", "partials"])
-def test_report_rejects_per_operation_array_short_by_one(tmp_path, field: str) -> None:
+def test_report_rejects_per_operation_array_short_by_one(
+    tmp_path: Path, field: str
+) -> None:
     """A per-operation array one entry short is named in a ValueError.
 
     ``DailyVibrationExposure`` is a frozen dataclass with no ``__post_init__``,
@@ -302,7 +308,7 @@ def test_report_rejects_per_operation_array_short_by_one(tmp_path, field: str) -
     assert not out.exists()
 
 
-def test_report_rejects_fewer_labels_than_operations(tmp_path) -> None:
+def test_report_rejects_fewer_labels_than_operations(tmp_path: Path) -> None:
     """``labels`` sets the expected count, so dropping one is a mismatch too.
 
     The message names the array that disagreed rather than ``labels`` itself,
@@ -319,7 +325,7 @@ def test_report_rejects_fewer_labels_than_operations(tmp_path) -> None:
     assert not out.exists()
 
 
-def test_report_accepts_matching_per_operation_arrays(tmp_path) -> None:
+def test_report_accepts_matching_per_operation_arrays(tmp_path: Path) -> None:
     """Dropping the same operation from every array passes the guard."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")

--- a/tests/vibration/human/test_multiple_shock_report.py
+++ b/tests/vibration/human/test_multiple_shock_report.py
@@ -15,6 +15,8 @@ rejected engines/languages) complete the rendering contract.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Literal
+
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
@@ -32,6 +34,11 @@ from phonometry.vibration.human.multiple_shock import (
     injury_risk,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from numpy.typing import ArrayLike
+
 
 def _extract_text(path: str) -> str:
     """Whitespace-normalized page text (PDF line wraps fold to single spaces)."""
@@ -42,7 +49,12 @@ def _extract_text(path: str) -> str:
 
 
 def _result_from_peaks(
-    peaks, *, start_age=20.0, years=20, days_per_year=120.0, sex="male"
+    peaks: ArrayLike,
+    *,
+    start_age: float = 20.0,
+    years: int = 20,
+    days_per_year: float = 120.0,
+    sex: Literal["male", "female"] = "male",
 ) -> MultipleShockResult:
     """Build a result directly from the Annex C worked-example response peaks.
 
@@ -82,7 +94,7 @@ def _annex_c_male() -> MultipleShockResult:
 # --- published oracle (ISO 2631-5 Annex C worked example) ---------------------
 
 
-def test_report_renders_annex_c_numbers(tmp_path) -> None:
+def test_report_renders_annex_c_numbers(tmp_path: Path) -> None:
     """The fiche prints the Annex C dose, stress, R and injury-probability values."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -109,7 +121,7 @@ def test_report_renders_annex_c_numbers(tmp_path) -> None:
     assert "2.17" in text
 
 
-def test_report_classifies_worked_example_as_moderate(tmp_path) -> None:
+def test_report_classifies_worked_example_as_moderate(tmp_path: Path) -> None:
     """R = 1.22 is classified in the moderate band (the standard's conclusion)."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -134,7 +146,7 @@ def test_report_classifies_worked_example_as_moderate(tmp_path) -> None:
         (75.0, "very high probability of an adverse health effect"),
     ],
 )
-def test_risk_band_tracks_table_c2(tmp_path, peak: float, band: str) -> None:
+def test_risk_band_tracks_table_c2(tmp_path: Path, peak: float, band: str) -> None:
     """The boxed classification follows the Table C.2 stress-variable bands."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -148,7 +160,7 @@ def test_risk_band_tracks_table_c2(tmp_path, peak: float, band: str) -> None:
 # --- metadata -----------------------------------------------------------------
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the client, subject, workplace and traceability."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -176,7 +188,7 @@ def test_metadata_header_renders(tmp_path) -> None:
 # --- Spanish fiche ------------------------------------------------------------
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the multiple-shock vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -197,7 +209,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
 # --- rendering contract -------------------------------------------------------
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _annex_c_male()
     out = str(tmp_path / "x.pdf")
@@ -205,7 +217,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _annex_c_male()
     out = str(tmp_path / "bad.pdf")

--- a/tests/vibration/structural/test_experimental_sea.py
+++ b/tests/vibration/structural/test_experimental_sea.py
@@ -48,6 +48,7 @@ speed ``cL = sqrt(E/(rho(1 - nu^2))) = 5432,3 m/s`` of Eq. (6.25).
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -56,6 +57,7 @@ from phonometry.building.measurement.flanking_transmission import (
     modal_density as en12354_n,
 )
 from phonometry.vibration.structural.experimental_sea import (
+    PowerInjectionResult,
     bar_modal_density,
     beam_modal_density,
     cylindrical_shell_modal_density,
@@ -64,6 +66,9 @@ from phonometry.vibration.structural.experimental_sea import (
     power_injection_matrix,
     ring_frequency,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # --- Norton Appendix 4, aluminium ---
 _RHO = 2700.0
@@ -98,23 +103,23 @@ class TestNortonProblem610:
     """The single-drive inversion against the printed answers."""
 
     @pytest.fixture(scope="class")
-    def result(self):  # type: ignore[no-untyped-def]
+    def result(self) -> PowerInjectionResult:
         e_1, e_2, n_1, n_2 = _problem_610_inputs()
         return power_injection_clf(_BAND, e_1, e_2, 4.4e-3, 2.4e-3, n_1, n_2)
 
-    def test_coupling_loss_factor_12(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_coupling_loss_factor_12(self, result: PowerInjectionResult) -> None:
         """Printed answer eta_12 = 4,26e-4."""
         assert float(result.coupling_loss_factor12[0]) == pytest.approx(
             4.26e-4, rel=0.005
         )
 
-    def test_coupling_loss_factor_21(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_coupling_loss_factor_21(self, result: PowerInjectionResult) -> None:
         """Printed answer eta_21 = 3,92e-4."""
         assert float(result.coupling_loss_factor21[0]) == pytest.approx(
             3.92e-4, rel=0.005
         )
 
-    def test_input_power(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_input_power(self, result: PowerInjectionResult) -> None:
         """Printed answer Pi_in = 1,31 W."""
         assert float(result.input_power[0]) == pytest.approx(1.31, rel=0.005)
 
@@ -124,7 +129,7 @@ class TestNortonProblem610:
         assert f_r == pytest.approx(1152.8, rel=1e-3)
         assert _BAND / f_r < 0.48
 
-    def test_reciprocity_holds_exactly(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_reciprocity_holds_exactly(self, result: PowerInjectionResult) -> None:
         """Eq. (6.8): ``n_1 eta_12 = n_2 eta_21``."""
         assert float((result.modal_density1 * result.coupling_loss_factor12)[0]) == (
             pytest.approx(
@@ -138,13 +143,17 @@ class TestNortonProblem610:
         _, _, n_1, n_2 = _problem_610_inputs()
         assert 3.92e-4 / 4.26e-4 == pytest.approx(n_1 / n_2, rel=0.005)
 
-    def test_input_power_equals_dissipated_power(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_input_power_equals_dissipated_power(
+        self, result: PowerInjectionResult
+    ) -> None:
         """Eq. (6.10) collapses to the total dissipation in the steady state."""
         np.testing.assert_allclose(
             result.input_power, result.dissipated_power, rtol=1e-12
         )
 
-    def test_transmitted_power_leaves_subsystem_two_in_balance(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_transmitted_power_leaves_subsystem_two_in_balance(
+        self, result: PowerInjectionResult
+    ) -> None:
         """Eq. (6.11): the power crossing the junction is dissipated in 2."""
         omega = 2.0 * np.pi * result.frequencies
         np.testing.assert_allclose(
@@ -153,7 +162,7 @@ class TestNortonProblem610:
             rtol=1e-12,
         )
 
-    def test_coupling_is_weak(self, result) -> None:  # type: ignore[no-untyped-def]
+    def test_coupling_is_weak(self, result: PowerInjectionResult) -> None:
         """``eta_12 << eta_1``: the two-subsystem model is trustworthy here."""
         assert float(result.coupling_strength[0]) < 0.15
 
@@ -425,6 +434,8 @@ class TestValidation:
             (lambda: ring_frequency(0.0, 5150.0), "'mean_radius' must be positive"),
         ],
     )
-    def test_non_positive_geometry(self, call, message: str) -> None:  # type: ignore[no-untyped-def]
+    def test_non_positive_geometry(
+        self, call: Callable[[], object], message: str
+    ) -> None:
         with pytest.raises(ValueError, match=message):
             call()

--- a/tests/vibration/structural/test_mobility_report.py
+++ b/tests/vibration/structural/test_mobility_report.py
@@ -14,6 +14,7 @@ contract.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -22,6 +23,9 @@ from report_assertions import assert_one_page
 from phonometry import ReportMetadata
 from phonometry.vibration import sdof_mobility_result
 from phonometry.vibration.structural.mechanical_mobility import MobilityResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _M, _K, _C = 2.0, 8000.0, 5.0
 _F0 = math.sqrt(_K / _M) / (2.0 * math.pi)  # ~10.066 Hz
@@ -49,7 +53,7 @@ def test_result_peak_oracle() -> None:
     assert peak_f == pytest.approx(_F0, abs=1e-6)
 
 
-def test_report_renders_peak_and_basis(tmp_path) -> None:
+def test_report_renders_peak_and_basis(tmp_path: Path) -> None:
     """The fiche prints the peak mobility, the resonance frequency and ISO 7626."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -69,7 +73,7 @@ def test_report_renders_peak_and_basis(tmp_path) -> None:
     assert "Peak mobility" in text
 
 
-def test_transfer_frf_labels_transfer(tmp_path) -> None:
+def test_transfer_frf_labels_transfer(tmp_path: Path) -> None:
     """A transfer FRF (driving_point=False) is named a transfer mobility."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -87,7 +91,7 @@ def test_transfer_frf_labels_transfer(tmp_path) -> None:
     assert "driving-point" not in text
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the client, the specimen and the instrumentation."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -110,7 +114,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     assert "MOB-7626" in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the mobility vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -124,7 +128,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert "0,2" in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _driving_point_result()
     out = str(tmp_path / "x.pdf")
@@ -132,7 +136,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _driving_point_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/vibration/structural/test_transfer_stiffness_report.py
+++ b/tests/vibration/structural/test_transfer_stiffness_report.py
@@ -17,12 +17,16 @@ contract.
 from __future__ import annotations
 
 import warnings
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 from report_assertions import assert_one_page
 
 from phonometry import PhonometryWarning, ReportMetadata, vibration
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _FREQS = np.array(
     [
@@ -84,7 +88,7 @@ def test_low_frequency_plateau_oracle() -> None:
     )
 
 
-def test_report_renders_plateau_and_basis(tmp_path) -> None:
+def test_report_renders_plateau_and_basis(tmp_path: Path) -> None:
     """The fiche prints the low-frequency plateau, the level and ISO 10846."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -104,7 +108,7 @@ def test_report_renders_plateau_and_basis(tmp_path) -> None:
     assert "0.010" in text
 
 
-def test_indirect_method_labels_blocking_mass(tmp_path) -> None:
+def test_indirect_method_labels_blocking_mass(tmp_path: Path) -> None:
     """The indirect method names ISO 10846-3 and prints the blocking mass."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -128,7 +132,7 @@ def test_indirect_method_labels_blocking_mass(tmp_path) -> None:
     assert "50.0" in text
 
 
-def test_metadata_header_renders(tmp_path) -> None:
+def test_metadata_header_renders(tmp_path: Path) -> None:
     """Supplied metadata renders the client, the specimen and the instrumentation."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -151,7 +155,7 @@ def test_metadata_header_renders(tmp_path) -> None:
     assert "TS-10846" in text
 
 
-def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """language="es" renders the transfer-stiffness vocabulary and comma decimals."""
     pytest.importorskip("reportlab")
     pytest.importorskip("matplotlib")
@@ -165,7 +169,7 @@ def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
     assert "baja frecuencia" in text
 
 
-def test_unknown_engine_rejected(tmp_path) -> None:
+def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _direct_result()
     out = str(tmp_path / "x.pdf")
@@ -173,7 +177,7 @@ def test_unknown_engine_rejected(tmp_path) -> None:
         res.report(out, engine="weasyprint")
 
 
-def test_unknown_language_rejected(tmp_path) -> None:
+def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _direct_result()
     out = str(tmp_path / "bad.pdf")

--- a/tests/vibration/test_vibration_plot_i18n.py
+++ b/tests/vibration/test_vibration_plot_i18n.py
@@ -9,7 +9,7 @@ import pytest
 from phonometry import vibration
 
 
-def _result():
+def _result() -> vibration.MobilityResult:
     return vibration.sdof_mobility_result(np.linspace(1.0, 50.0, 200), 2.0, 8000.0, 5.0)
 
 


### PR DESCRIPTION
Stacked on the pull request below it, which annotated the first half of the suite.

The other half of the same reading work, plus the rule that keeps it done: ANN001 through ANN003 and the two return-type codes join the lint select, now that not one function in src, scripts, tests or the CI helpers is missing an annotation. 147 of the returns were settled by ruff's own fix, safe here because the whole suite stands witness; the rest were typed from what the code really holds, with `object` as the honest answer where a test dispatches on anything, since ANN401 closed the `Any` escape in the previous round.

Four stragglers turned up outside every census, in the CI comment assembler under `.github/scripts`, which no gate had ever swept; they are annotated with the rest and the enabled rule now covers them too.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Added comprehensive type annotations across project tooling and test suites.
  - Enabled stricter linting checks for function and return annotations.

- **Tests**
  - Added validation coverage for occupational exposure inputs.
  - Expanded report coverage for barrier models, metadata-free output, Spanish output, and oversized impulse sets.
  - Improved static typing throughout test fixtures and helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->