### PR TITLE
Name the refusal where the failure was anonymous

### DIFF
--- a/scripts/diagrams/canvas.py
+++ b/scripts/diagrams/canvas.py
@@ -688,6 +688,9 @@ class SVG:
         mono: bool = False,
         italic: bool = False,
     ) -> None:
+        if anchor not in ("start", "middle", "end"):
+            msg = f"'anchor' must be one of ('start', 'middle', 'end'); got {anchor!r}."
+            raise ValueError(msg)
         s = self.tr(s)
         fragment = self._emit_text(
             x,
@@ -792,6 +795,9 @@ class SVG:
         dashed witness lines connect it to the measured points. With
         ``offset=0`` the caller is responsible for any witness lines.
         """
+        if label_side not in ("left", "right"):
+            msg = f"'label_side' must be one of ('left', 'right'); got {label_side!r}."
+            raise ValueError(msg)
         th = self.th
         horizontal = abs(y2 - y1) < abs(x2 - x1)
         if horizontal:

--- a/site/src/content/docs/reference/api/aeroacoustics/certification.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/certification.md
@@ -301,4 +301,4 @@ excess `F` above the smoothed background, with the 1.5 dB threshold, the
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If the spectrum is not 24 finite levels. |
+| ValueError | If the spectrum is not 24 finite levels, or `start_band` is not an integer between 0 and 3. |

--- a/site/src/content/docs/reference/api/building/structure-borne-power.md
+++ b/site/src/content/docs/reference/api/building/structure-borne-power.md
@@ -139,7 +139,7 @@ arithmetic mean of Re{Y} over the contact points, Formula 16).
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if `Re{plate_mobility}` is not positive and finite. |
+| ValueError | if `Re{plate_mobility}` is not positive and finite, or the two shapes do not broadcast together. |
 
 ## equivalent_free_velocity_level
 
@@ -173,7 +173,7 @@ combine through Formula (19) into $|Y_{S,eq}| = v_f / F_b$.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if `Re{plate_mobility}` is not positive and finite. |
+| ValueError | if `Re{plate_mobility}` is not positive and finite, or the two shapes do not broadcast together. |
 
 ## mean_free_velocity_level
 
@@ -198,6 +198,12 @@ only the reference differs.
 | `levels` | Free velocity levels `Lvxi` at the `N` positions, in dB re 5e-8 m/s. |
 
 **Returns:** The mean free velocity level, in dB re 5e-8 m/s.
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | for an empty, multi-dimensional or non-finite input. |
 
 ## plate_loss_factor
 
@@ -289,6 +295,12 @@ $(10^{-9}/10^{-6})^2 = 10^{-6}$.
 
 **Returns:** The source mobility magnitude `|Y_S,eq|`, in m/(N.s).
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | for a non-finite level, or two shapes that do not broadcast together. |
+
 ## spatial_mean_velocity_level
 
 ```python
@@ -308,6 +320,12 @@ per-position velocity levels.
 | `levels` | Velocity levels `L_v,i` at the `N` positions, in dB. |
 
 **Returns:** The spatial mean velocity level, in dB.
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | for an empty, multi-dimensional or non-finite input. |
 
 ## structure_borne_power_level
 
@@ -362,7 +380,7 @@ the EN 12354-5 Annex I mobility correction
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | for a non-positive mass, area, reference, frequency or loss factor. |
+| ValueError | for a non-positive mass, area, reference, frequency or loss factor, or per-band inputs whose shapes do not broadcast together. |
 
 ## StructureBornePowerResult
 

--- a/site/src/content/docs/reference/api/building/structure-borne-power.md
+++ b/site/src/content/docs/reference/api/building/structure-borne-power.md
@@ -139,7 +139,7 @@ arithmetic mean of Re{Y} over the contact points, Formula 16).
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if `Re{plate_mobility}` is not positive and finite, or the two shapes do not broadcast together. |
+| ValueError | if `power_level` is not finite, `Re{plate_mobility}` is not positive and finite, or the two shapes do not broadcast together. |
 
 ## equivalent_free_velocity_level
 
@@ -173,7 +173,7 @@ combine through Formula (19) into $|Y_{S,eq}| = v_f / F_b$.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if `Re{plate_mobility}` is not positive and finite, or the two shapes do not broadcast together. |
+| ValueError | if `power_level` is not finite, `Re{plate_mobility}` is not positive and finite, or the two shapes do not broadcast together. |
 
 ## mean_free_velocity_level
 
@@ -380,7 +380,7 @@ the EN 12354-5 Annex I mobility correction
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | for a non-positive mass, area, reference, frequency or loss factor, or per-band inputs whose shapes do not broadcast together. |
+| ValueError | for a non-positive mass, area or reference, a frequency or loss factor that is not positive and finite, a non-finite velocity level, or per-band inputs whose shapes do not broadcast together. |
 
 ## StructureBornePowerResult
 

--- a/site/src/content/docs/reference/api/building/uncertainty.md
+++ b/site/src/content/docs/reference/api/building/uncertainty.md
@@ -257,7 +257,7 @@ reproducibility standard deviation with the product-homogeneity scatter over
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | Non-positive `n` or a negative standard deviation. |
+| ValueError | A non-integer or non-positive `n`, or a negative standard deviation. |
 
 ## reduce_by_independent_measurements
 

--- a/site/src/content/docs/reference/api/electroacoustics/distortion.md
+++ b/site/src/content/docs/reference/api/electroacoustics/distortion.md
@@ -101,7 +101,7 @@ amplitude relative to the total RMS.
 | `signal` | Captured signal (1-D). Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal), whose calibration is applied to the samples and then cancels: this is a ratio of amplitudes drawn from the same record, so the factor divides out and the answer is the same calibrated or not. |
 | `fs` | Sample rate, in Hz. Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
 | `fundamental` | Fundamental frequency $f_1$, in Hz. |
-| `order` | Harmonic order `n` (>= 2). |
+| `order` | Harmonic order `n` (an integer >= 2; an integral float such as `3.0` is accepted as its integer). |
 | `n_harmonics` | Highest harmonic order used for the total RMS. |
 | `window` | FFT window (default `'hann'`). |
 
@@ -111,7 +111,7 @@ amplitude relative to the total RMS.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If `order` \< 2 or the inputs are invalid. |
+| ValueError | If `order` is not an integer, `order` \< 2 or the inputs are invalid. |
 
 ## HarmonicDistortionResult
 

--- a/site/src/content/docs/reference/api/environment/ground-barriers.md
+++ b/site/src/content/docs/reference/api/environment/ground-barriers.md
@@ -431,6 +431,12 @@ at 0 dB (a barrier never amplifies).
 
 **Returns:** Attenuation `Delta`, in decibels (>= 0), matching the input shape.
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | for a non-numeric or non-finite `fresnel_number`. |
+
 ## plot_barrier_geometry
 
 ```python

--- a/site/src/content/docs/reference/api/filters/frequencies.md
+++ b/site/src/content/docs/reference/api/filters/frequencies.md
@@ -29,6 +29,12 @@ Calculate frequencies according to ANSI/IEC standards.
 
 **Returns:** Tuple of (center_freqs, lower_edges, upper_edges, nominal_labels).
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | for a non-positive or non-finite `fraction`. |
+
 ## normalized_frequencies
 
 ```python

--- a/site/src/content/docs/reference/api/materials/rating.md
+++ b/site/src/content/docs/reference/api/materials/rating.md
@@ -68,6 +68,12 @@ Sound absorption class for `alpha_w` (ISO 11654 Table B.1, Annex B).
 
 **Returns:** `"A"`, `"B"`, `"C"`, `"D"`, `"E"` or `"Not classified"`.
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | if `alpha_w` is not a finite value in `[0, 1]`. |
+
 ## AbsorptionRatingResult
 
 ```python
@@ -240,6 +246,12 @@ unfavourable deviations (measured below the shifted curve) is at most
 | `alpha_p` | The five octave practical coefficients for 250, 500, 1000, 2000 and 4000 Hz (e.g. from [`practical_absorption_coefficient`](/phonometry/reference/api/materials/rating/#practical_absorption_coefficient)), as a sequence ordered low to high or a mapping keyed by band centre frequency (Hz). Inputs are snapped to the 0,05 grid of Clause 4.1. |
 
 **Returns:** A frozen [`AbsorptionRatingResult`](/phonometry/reference/api/materials/rating/#absorptionratingresult) with `alpha_w`, the shape indicators, the applied shift, the fitted reference curve and the absorption class.
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | if any coefficient is negative or the wrong number of values is supplied. |
 
 ## weighted_absorption_from_third_octave
 

--- a/site/src/content/docs/reference/api/materials/sound-absorption.md
+++ b/site/src/content/docs/reference/api/materials/sound-absorption.md
@@ -216,7 +216,7 @@ with-specimen climates differ.
 | `volume` | Reverberation-room volume `V`, in cubic metres. A volume below the 150 m3 minimum of clause 6.1.1 emits an advisory [`AbsorptionWarning`](/phonometry/reference/api/materials/sound-absorption/#absorptionwarning). |
 | `area` | Area `S` covered by the test specimen, in square metres. An area outside the clause 6.2.1.1 range (10 m2 to 12 m2, upper limit scaled by $(V/200)^{2/3}$ for $V > 200$ m3) emits an advisory [`AbsorptionWarning`](/phonometry/reference/api/materials/sound-absorption/#absorptionwarning). |
 | `temperature` | Air temperature during the test, in degrees Celsius (default 20). Used for the speed of sound via Eq. (6) unless `speed_of_sound` is given; a temperature outside 15..30 degC emits an [`AbsorptionWarning`](/phonometry/reference/api/materials/sound-absorption/#absorptionwarning). |
-| `humidity` | Relative humidity during the test, in % (informational; recorded on the result but not used in the computation, which sees the climate only through `m`). `None` leaves it unrecorded. |
+| `humidity` | Relative humidity during the test, in % within `[0, 100]` (informational; recorded on the result but not used in the computation, which sees the climate only through `m`). `None` leaves it unrecorded. |
 | `speed_of_sound` | Explicit speed of sound `c`, in m/s; overrides `temperature` and Eq. (6) when supplied. |
 | `m` | Power attenuation coefficient of air `m`, in 1/m (a scalar or a per-band array matching `frequencies`; default 0, i.e. no air correction). Obtain it from an ISO 9613-1 attenuation coefficient with [`attenuation_from_alpha`](/phonometry/reference/api/materials/sound-absorption/#attenuation_from_alpha). |
 
@@ -226,7 +226,7 @@ with-specimen climates differ.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If the frequency and reverberation-time arrays do not share one shape, or an input is non-physical (see [`absorption_coefficient`](/phonometry/reference/api/materials/sound-absorption/#absorption_coefficient)). |
+| ValueError | If the frequency and reverberation-time arrays do not share one shape, `humidity` is not within `[0, 100]` %, or an input is non-physical (see [`absorption_coefficient`](/phonometry/reference/api/materials/sound-absorption/#absorption_coefficient)). |
 
 ## SoundAbsorptionMeasurement
 

--- a/site/src/content/docs/reference/api/noise_control/hvac.md
+++ b/site/src/content/docs/reference/api/noise_control/hvac.md
@@ -789,9 +789,15 @@ with the wavelength; it underpredicts the low-frequency loss by 5-10 dB.
 | `line_of_sight` | Straight-line inlet-to-outlet distance `r`, m. |
 | `wall_area` | Total internal wall area `S_\mathrm{w}`, m2. |
 | `mean_absorption` | Mean Sabine wall absorption `alpha` in `(0, 1)` (scalar or per-band). |
-| `angle` | Angle `theta` between the inlet axis and the line to the outlet, rad (default 0). |
+| `angle` | Angle `theta` between the inlet axis and the line to the outlet, in `[0, pi/2]` rad (default 0). |
 
 **Returns:** The transmission loss, dB (float for scalar absorption, else a per-band array).
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If a dimension is not positive, `mean_absorption` leaves `(0, 1)` or `angle` leaves `[0, pi/2]`. |
 
 ## plot_plenum_geometry
 

--- a/site/src/content/docs/reference/api/noise_control/silencers.md
+++ b/site/src/content/docs/reference/api/noise_control/silencers.md
@@ -121,6 +121,12 @@ outlet), broadcast over the frequency axis.
 
 **Returns:** The compound `(n_freq, 2, 2)` array.
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If a matrix is not a `(n_freq, 2, 2)` array or the matrices disagree on `n_freq`. |
+
 ## duct_matrix
 
 ```python
@@ -344,6 +350,12 @@ $$
 | `radiation_impedance` | Termination/radiation acoustic impedance `Z_r`, Pa s/m3 (scalar or per-frequency). |
 
 **Returns:** The insertion loss per frequency, dB.
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If an impedance is neither a scalar nor one value per analysis frequency. |
 
 ## plot_silencer_geometry
 

--- a/site/src/content/docs/reference/api/rooms/image-source.md
+++ b/site/src/content/docs/reference/api/rooms/image-source.md
@@ -91,7 +91,7 @@ impulses [`image_source_rir`](/phonometry/reference/api/rooms/image-source/#imag
 
 | Name | Description |
 | :--- | :--- |
-| `max_order` | Reflection-order cut-off `i0` (non-negative). |
+| `max_order` | Reflection-order cut-off `i0` (non-negative integer). |
 
 **Returns:** The audible image count.
 
@@ -154,7 +154,7 @@ reproduces the Eyring reverberation time of the room (Kuttruff Equation
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | for a non-positive dimension/sample-rate, a source/receiver outside the room, an absorption outside `[0, 1]` or of an unsupported shape, a negative `air_attenuation`, or a `frequencies` length that does not match the band count. |
+| ValueError | for a `dimensions` that is not three positive lengths, a non-positive sample rate, a non-integer or negative `max_order`, a source/receiver outside the room, an absorption outside `[0, 1]` or of an unsupported shape, a negative `air_attenuation`, or a `frequencies` length that does not match the band count. |
 
 ## ImageSourceResult
 

--- a/site/src/content/docs/reference/api/simulation/fdtd.md
+++ b/site/src/content/docs/reference/api/simulation/fdtd.md
@@ -290,7 +290,7 @@ cells), as a physical incident wave would be.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | For an unknown direction or non-positive `width`/`wavelength`. |
+| ValueError | For an unknown direction, a non-positive or non-finite `width`/`wavelength`, or a non-finite `center`/`amplitude`. |
 
 ### FDTD2D.add_source()
 

--- a/site/src/content/docs/reference/api/underwater/acoustics.md
+++ b/site/src/content/docs/reference/api/underwater/acoustics.md
@@ -49,6 +49,12 @@ only; see [`underwater_to_in_air_spl`](/phonometry/reference/api/underwater/acou
 
 **Returns:** The same pressure expressed in dB re 1 µPa.
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If the level is not a finite number. |
+
 ## peak_sound_pressure_level
 
 ```python
@@ -179,3 +185,9 @@ impedances.
 | `level` | Level in dB re 1 µPa. |
 
 **Returns:** The same pressure expressed in dB re 20 µPa.
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If the level is not a finite number. |

--- a/site/src/content/docs/reference/api/vibration/junction-transmission.md
+++ b/site/src/content/docs/reference/api/vibration/junction-transmission.md
@@ -252,7 +252,7 @@ source-plate bending-wave group velocity `cg_i`, the junction length
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | for a non-positive input. |
+| ValueError | for a non-positive input, or a coefficient and a frequency whose shapes cannot be broadcast together. |
 
 ## inline_transmission_coefficient
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -95,16 +95,30 @@ def check_engine(engine: str) -> None:
     raise ValueError(msg)
 
 
+def _as_float64(x: ArrayLike, name: str) -> np.ndarray:
+    """Convert *x* to ``float64``, naming the parameter when numpy cannot.
+
+    A string element raises numpy's anonymous "could not convert string to
+    float", and an unconvertible object a bare ``TypeError``; both would
+    escape the array guards below without saying which parameter refused.
+    """
+    try:
+        return np.asarray(x, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        msg = f"'{name}' must be numeric."
+        raise ValueError(msg) from exc
+
+
 def require_positive_array(x: ArrayLike, name: str) -> np.ndarray:
     """Coerce *x* to a 1-D float64 array of strictly positive, finite values.
 
     :param x: The input (scalar or 1-D array-like).
     :param name: Parameter name used in the error message.
     :return: The validated ``float64`` array (at least 1-D).
-    :raises ValueError: for an empty, multi-dimensional, non-finite or
-        non-positive input.
+    :raises ValueError: for a non-numeric, empty, multi-dimensional,
+        non-finite or non-positive input.
     """
-    arr = np.atleast_1d(np.asarray(x, dtype=np.float64))
+    arr = np.atleast_1d(_as_float64(x, name))
     if arr.ndim != 1 or arr.size == 0:
         msg = f"'{name}' must be a non-empty 1-D array."
         raise ValueError(msg)
@@ -127,9 +141,10 @@ def require_finite_array(x: ArrayLike, name: str) -> np.ndarray:
     :param x: The input (scalar or 1-D array-like).
     :param name: Parameter name used in the error message.
     :return: The validated ``float64`` array (at least 1-D).
-    :raises ValueError: for an empty, multi-dimensional or non-finite input.
+    :raises ValueError: for a non-numeric, empty, multi-dimensional or
+        non-finite input.
     """
-    arr = np.atleast_1d(np.asarray(x, dtype=np.float64))
+    arr = np.atleast_1d(_as_float64(x, name))
     if arr.ndim != 1 or arr.size == 0:
         msg = f"'{name}' must be a non-empty 1-D array."
         raise ValueError(msg)
@@ -426,7 +441,7 @@ def require_per_band(
     :return: The broadcast ``float64`` array, of ``bands.shape``.
     :raises ValueError: if *x* is neither a scalar nor of ``bands``' length.
     """
-    arr = np.asarray(x, dtype=np.float64)
+    arr = _as_float64(x, name)
     if arr.ndim != 0 and arr.shape != bands.shape:
         msg = (
             f"'{name}' must be a scalar or carry one value per band "
@@ -447,7 +462,7 @@ def require_1d_signal(x: ArrayLike, name: str = "signal") -> np.ndarray:
     :return: The validated ``float64`` array.
     :raises ValueError: for a non-1-D input.
     """
-    arr = np.asarray(x, dtype=np.float64)
+    arr = _as_float64(x, name)
     if arr.ndim != 1:
         msg = (
             f"{name} must be a 1-D time series; got shape {arr.shape}. "

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -234,7 +234,8 @@ def plot_modulation_distortion(
     :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the sideband marker ``plot`` call.
     :return: The axes.
-    :raises ValueError: If the result carries no sideband spectrum data.
+    :raises ValueError: If the result carries no sideband spectrum data, or its
+        sideband arrays do not carry the four products.
     """
     from .._i18n import decimal_comma, localize_axes
 
@@ -249,11 +250,18 @@ def plot_modulation_distortion(
             "from modulation_distortion()."
         )
         raise ValueError(msg)
+    sb_freqs = np.asarray(result.sideband_frequencies, dtype=np.float64)
+    sb_amps = np.asarray(result.sideband_amplitudes, dtype=np.float64)
+    if sb_freqs.shape != (4,) or sb_amps.shape != (4,):
+        msg = (
+            "'result.sideband_frequencies' and 'result.sideband_amplitudes' "
+            "must each carry the four products f2 +/- f1 and f2 +/- 2f1; got "
+            f"shapes {sb_freqs.shape} and {sb_amps.shape}."
+        )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_axes()
     tiny = np.finfo(np.float64).tiny
     carrier = float(result.carrier_amplitude)
-    sb_freqs = np.asarray(result.sideband_frequencies, dtype=np.float64)
-    sb_amps = np.asarray(result.sideband_amplitudes, dtype=np.float64)
     sb_db = 20.0 * np.log10(np.maximum(sb_amps, tiny) / carrier)
     floor = -120.0
 
@@ -540,9 +548,16 @@ def plot_piston_directivity(
         single ``ka``; ignored for a multi-``ka`` family so one user color or
         label cannot collapse the per-curve styling.
     :return: The (polar) axes.
+    :raises ValueError: If *ax* is not a polar axes.
     """
     from .._i18n import decimal_comma, localize_axes
 
+    if ax is not None and getattr(ax, "name", None) != "polar":
+        msg = (
+            "'ax' must be a polar axes (subplot_kw={'projection': 'polar'}); "
+            "pass ax=None to create one."
+        )
+        raise ValueError(msg)
     ax = ax if ax is not None else _new_polar_axes()
     theta = np.asarray(result.angles, dtype=np.float64)
     ka = np.asarray(result.ka, dtype=np.float64)
@@ -886,6 +901,12 @@ def _plot_one_quantity(
     drawer, polar, attr = table[quantity]
     if attr is not None and getattr(result, attr) is None:
         raise ValueError(missing[quantity])
+    if polar and ax is not None and getattr(ax, "name", None) != "polar":
+        msg = (
+            f"'ax' must be a polar axes for quantity {quantity!r}; "
+            "pass ax=None to create one."
+        )
+        raise ValueError(msg)
     if ax is None:
         ax = _new_polar_axes() if polar else _new_axes()
     drawer(result, ax, language=language)
@@ -918,8 +939,8 @@ def plot_loudspeaker_characteristics(
     :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Reserved for a uniform ``.plot()`` signature; unused.
     :return: The axes the characteristic was drawn on.
-    :raises ValueError: If ``quantity`` is unknown or the result carries no data
-        for it.
+    :raises ValueError: If ``quantity`` is unknown, the result carries no data
+        for it, or *ax* is not polar for a polar quantity.
     """
     del kwargs  # each panel is a fixed datasheet artist; no primary override
     missing = {
@@ -957,8 +978,8 @@ def plot_microphone_characteristics(
     :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Reserved for a uniform ``.plot()`` signature; unused.
     :return: The axes the characteristic was drawn on.
-    :raises ValueError: If ``quantity`` is unknown or the result carries no data
-        for it.
+    :raises ValueError: If ``quantity`` is unknown, the result carries no data
+        for it, or *ax* is not polar for a polar quantity.
     """
     del kwargs
     missing = {

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -379,12 +379,21 @@ def tone_correction(
         Step 1). The default 2 (80 Hz) is the aeroplane procedure; helicopters
         and tilt-rotors use 0 (50 Hz).
     :return: The tone-correction factor ``C``, in dB (0 if no tones qualify).
-    :raises ValueError: If the spectrum is not 24 finite levels.
+    :raises ValueError: If the spectrum is not 24 finite levels, or
+        ``start_band`` is not an integer between 0 and 3.
     """
-    if not 0 <= int(start_band) <= _MAX_TONE_START_BAND:
-        msg = "'start_band' must be between 0 (50 Hz) and 3 (100 Hz)."
+    # An integral float (0.0, 2.0) carries the same band index and is taken;
+    # anything the index cannot be (2.9, "aeroplane", None) is refused by name
+    # rather than left to fail inside int().
+    try:
+        start = int(start_band)
+        integral = start == start_band
+    except (TypeError, ValueError, OverflowError):
+        start, integral = -1, False
+    if not integral or not 0 <= start <= _MAX_TONE_START_BAND:
+        msg = "'start_band' must be an integer between 0 (50 Hz) and 3 (100 Hz)."
         raise ValueError(msg)
-    _, excess = _tone_background(spl, start=int(start_band))
+    _, excess = _tone_background(spl, start=start)
     factors = [_tone_factor(float(excess[i]), float(NOY_BANDS[i])) for i in range(24)]
     return float(max(factors))
 

--- a/src/phonometry/aircraft/measurement_system.py
+++ b/src/phonometry/aircraft/measurement_system.py
@@ -64,7 +64,7 @@ def _iec61265_directional_limit(frequency: float, angle: float) -> float:
             "(50 Hz-1.6 kHz, then 2, 2.5, 3.15, 4, 5, 6.3, 8, 10 kHz)."
         )
         raise ValueError(msg)
-    if angle <= 0.0 or angle > _IEC61265_ANGLES[-1]:
+    if not np.isfinite(angle) or angle <= 0.0 or angle > _IEC61265_ANGLES[-1]:
         msg = "'angle' must lie in (0, 150] degrees."
         raise ValueError(msg)
     col = next(i for i, a in enumerate(_IEC61265_ANGLES) if a >= angle)

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
 
 from ..._internal.validation import (
     check_engine,
+    require_finite_array,
     require_per_band,
     require_positive,
     require_ranks,
@@ -116,8 +117,9 @@ def spatial_mean_velocity_level(levels: ArrayLike) -> float:
 
     :param levels: Velocity levels ``L_v,i`` at the ``N`` positions, in dB.
     :return: The spatial mean velocity level, in dB.
+    :raises ValueError: for an empty, multi-dimensional or non-finite input.
     """
-    lv = np.asarray(levels, dtype=np.float64)
+    lv = require_finite_array(levels, "levels")
     return float(10.0 * np.log10(np.mean(10.0 ** (0.1 * lv))))
 
 
@@ -178,7 +180,7 @@ def structure_borne_power_level(
     :param reference_velocity: Velocity reference ``v0`` (Default: 1e-9 m/s).
     :return: The structure-borne sound power level ``L_Ws``, in dB re 1 pW.
     :raises ValueError: for a non-positive mass, area, reference, frequency or
-        loss factor.
+        loss factor, or per-band inputs whose shapes do not broadcast together.
     """
     mass_per_area = require_positive(mass_per_area, "mass_per_area")
     area = require_positive(area, "area")
@@ -192,6 +194,14 @@ def structure_borne_power_level(
     if not np.all(np.isfinite(eta)) or np.any(eta <= 0.0):
         msg = "'loss_factor' must contain positive, finite values."
         raise ValueError(msg)
+    try:
+        np.broadcast_shapes(lv.shape, f.shape, eta.shape)
+    except ValueError:
+        msg = (
+            "'velocity_level', 'frequency' and 'loss_factor' must broadcast "
+            f"together; got shapes {lv.shape}, {f.shape} and {eta.shape}."
+        )
+        raise ValueError(msg) from None
     offset = 10.0 * np.log10(reference_velocity**2 / REFERENCE_SOUND_POWER)
     lw = 10.0 * np.log10(2.0 * np.pi * f * eta * mass_per_area * area) + lv + offset
     return np.asarray(lw, dtype=np.float64)
@@ -396,7 +406,8 @@ def equivalent_blocked_force_level(
     :param plate_mobility: Equivalent plate mobility ``Y_R,low,eq`` (per
         band), in m/(N.s); complex values use their real part (Formula 16).
     :return: The equivalent blocked force level ``L_Fb,eq``, in dB re 1e-6 N.
-    :raises ValueError: if ``Re{plate_mobility}`` is not positive and finite.
+    :raises ValueError: if ``Re{plate_mobility}`` is not positive and finite,
+        or the two shapes do not broadcast together.
     """
     lw = np.asarray(power_level, dtype=np.float64)
     y = np.asarray(plate_mobility, dtype=np.complex128)
@@ -408,6 +419,14 @@ def equivalent_blocked_force_level(
     ):
         msg = "'plate_mobility' must be finite with a positive real part."
         raise ValueError(msg)
+    try:
+        np.broadcast_shapes(lw.shape, y.shape)
+    except ValueError:
+        msg = (
+            "'power_level' and 'plate_mobility' must broadcast together; "
+            f"got shapes {lw.shape} and {y.shape}."
+        )
+        raise ValueError(msg) from None
     return np.asarray(lw - 10.0 * np.log10(y_re / REFERENCE_MOBILITY), dtype=np.float64)
 
 
@@ -464,7 +483,8 @@ def equivalent_free_velocity_level(
     :param plate_mobility: Equivalent plate mobility ``Y_R,high,eq`` (per
         band, complex), in m/(N.s).
     :return: The equivalent free velocity level ``L_vf,eq``, in dB re 1e-9 m/s.
-    :raises ValueError: if ``Re{plate_mobility}`` is not positive and finite.
+    :raises ValueError: if ``Re{plate_mobility}`` is not positive and finite,
+        or the two shapes do not broadcast together.
     """
     lw = np.asarray(power_level, dtype=np.float64)
     y = np.asarray(plate_mobility, dtype=np.complex128)
@@ -476,6 +496,14 @@ def equivalent_free_velocity_level(
     ):
         msg = "'plate_mobility' must be finite with a positive real part."
         raise ValueError(msg)
+    try:
+        np.broadcast_shapes(lw.shape, y.shape)
+    except ValueError:
+        msg = (
+            "'power_level' and 'plate_mobility' must broadcast together; "
+            f"got shapes {lw.shape} and {y.shape}."
+        )
+        raise ValueError(msg) from None
     term = np.abs(y) ** 2 / (y_re * REFERENCE_MOBILITY)
     return np.asarray(lw + 10.0 * np.log10(term) + 60.0, dtype=np.float64)
 
@@ -497,9 +525,25 @@ def source_mobility_from_levels(
     :param blocked_force_level: Equivalent blocked force level ``L_Fb,eq``
         (per band), in dB re 1e-6 N (Formula 15).
     :return: The source mobility magnitude ``|Y_S,eq|``, in m/(N.s).
+    :raises ValueError: for a non-finite level, or two shapes that do not
+        broadcast together.
     """
     lv = np.asarray(free_velocity_level, dtype=np.float64)
     lf = np.asarray(blocked_force_level, dtype=np.float64)
+    if not np.all(np.isfinite(lv)):
+        msg = "'free_velocity_level' must contain only finite values."
+        raise ValueError(msg)
+    if not np.all(np.isfinite(lf)):
+        msg = "'blocked_force_level' must contain only finite values."
+        raise ValueError(msg)
+    try:
+        np.broadcast_shapes(lv.shape, lf.shape)
+    except ValueError:
+        msg = (
+            "'free_velocity_level' and 'blocked_force_level' must broadcast "
+            f"together; got shapes {lv.shape} and {lf.shape}."
+        )
+        raise ValueError(msg) from None
     return np.asarray(
         REFERENCE_MOBILITY * np.sqrt(10.0 ** ((lv - lf) / 10.0) * 1.0e-6),
         dtype=np.float64,
@@ -521,5 +565,6 @@ def mean_free_velocity_level(levels: ArrayLike) -> float:
     :param levels: Free velocity levels ``Lvxi`` at the ``N`` positions, in
         dB re 5e-8 m/s.
     :return: The mean free velocity level, in dB re 5e-8 m/s.
+    :raises ValueError: for an empty, multi-dimensional or non-finite input.
     """
     return spatial_mean_velocity_level(levels)

--- a/src/phonometry/building/measurement/structure_borne_power.py
+++ b/src/phonometry/building/measurement/structure_borne_power.py
@@ -179,17 +179,22 @@ def structure_borne_power_level(
     :param loss_factor: Plate loss factor ``eta`` (scalar or per band, > 0).
     :param reference_velocity: Velocity reference ``v0`` (Default: 1e-9 m/s).
     :return: The structure-borne sound power level ``L_Ws``, in dB re 1 pW.
-    :raises ValueError: for a non-positive mass, area, reference, frequency or
-        loss factor, or per-band inputs whose shapes do not broadcast together.
+    :raises ValueError: for a non-positive mass, area or reference, a
+        frequency or loss factor that is not positive and finite, a
+        non-finite velocity level, or per-band inputs whose shapes do not
+        broadcast together.
     """
     mass_per_area = require_positive(mass_per_area, "mass_per_area")
     area = require_positive(area, "area")
     reference_velocity = require_positive(reference_velocity, "reference_velocity")
     f = np.asarray(frequency, dtype=np.float64)
-    if np.any(f <= 0.0):
-        msg = "'frequency' must be positive."
+    if not np.all(np.isfinite(f)) or np.any(f <= 0.0):
+        msg = "'frequency' must contain positive, finite values."
         raise ValueError(msg)
     lv = np.asarray(velocity_level, dtype=np.float64)
+    if not np.all(np.isfinite(lv)):
+        msg = "'velocity_level' must contain only finite values."
+        raise ValueError(msg)
     eta = np.asarray(loss_factor, dtype=np.float64)
     if not np.all(np.isfinite(eta)) or np.any(eta <= 0.0):
         msg = "'loss_factor' must contain positive, finite values."
@@ -406,10 +411,14 @@ def equivalent_blocked_force_level(
     :param plate_mobility: Equivalent plate mobility ``Y_R,low,eq`` (per
         band), in m/(N.s); complex values use their real part (Formula 16).
     :return: The equivalent blocked force level ``L_Fb,eq``, in dB re 1e-6 N.
-    :raises ValueError: if ``Re{plate_mobility}`` is not positive and finite,
-        or the two shapes do not broadcast together.
+    :raises ValueError: if ``power_level`` is not finite,
+        ``Re{plate_mobility}`` is not positive and finite, or the two shapes
+        do not broadcast together.
     """
     lw = np.asarray(power_level, dtype=np.float64)
+    if not np.all(np.isfinite(lw)):
+        msg = "'power_level' must contain only finite values."
+        raise ValueError(msg)
     y = np.asarray(plate_mobility, dtype=np.complex128)
     y_re = np.real(y)
     if (
@@ -483,10 +492,14 @@ def equivalent_free_velocity_level(
     :param plate_mobility: Equivalent plate mobility ``Y_R,high,eq`` (per
         band, complex), in m/(N.s).
     :return: The equivalent free velocity level ``L_vf,eq``, in dB re 1e-9 m/s.
-    :raises ValueError: if ``Re{plate_mobility}`` is not positive and finite,
-        or the two shapes do not broadcast together.
+    :raises ValueError: if ``power_level`` is not finite,
+        ``Re{plate_mobility}`` is not positive and finite, or the two shapes
+        do not broadcast together.
     """
     lw = np.asarray(power_level, dtype=np.float64)
+    if not np.all(np.isfinite(lw)):
+        msg = "'power_level' must contain only finite values."
+        raise ValueError(msg)
     y = np.asarray(plate_mobility, dtype=np.complex128)
     y_re = np.real(y)
     if (

--- a/src/phonometry/building/measurement/uncertainty.py
+++ b/src/phonometry/building/measurement/uncertainty.py
@@ -52,7 +52,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from ..._internal.validation import require_equal_shapes
+from ..._internal.validation import require_choice, require_equal_shapes
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -500,17 +500,17 @@ def band_uncertainty(
     :param upper_limit: Select the ``σR95`` upper limit (airborne, situation A).
     :raises ValueError: Unknown measurand, or a situation not tabulated for it.
     """
+    # The measurand is validated on its own first, so an unknown one is
+    # refused by name instead of being misreported by the ``upper_limit``
+    # branch below as a real measurand that merely lacks a σR95 table.
+    require_choice(measurand, "measurand", tuple(sorted({m for m, _ in _BAND_TABLES})))
     try:
         frequencies, columns = _BAND_TABLES[(measurand, upper_limit)]
     except KeyError:
-        if upper_limit:
-            msg = (
-                f"No σR95 upper limit tabulated for measurand {measurand!r} "
-                "(only airborne, Annex D)."
-            )
-            raise ValueError(msg) from None
-        valid = ", ".join(sorted({m for m, _ in _BAND_TABLES}))
-        msg = f"Unknown measurand {measurand!r}. Valid: {valid}."
+        msg = (
+            f"No σR95 upper limit tabulated for measurand {measurand!r} "
+            "(only airborne, Annex D)."
+        )
         raise ValueError(msg) from None
     if situation not in columns:
         msg = (
@@ -713,9 +713,12 @@ def prediction_input_uncertainty(
     :param sigma_reproducibility: Reproducibility standard deviation ``σR``, in dB.
     :param sigma_product: Product-homogeneity standard deviation ``σ_product``, in dB.
     :param n: Number of measurements of the product (:math:`n \ge 1`).
-    :raises ValueError: Non-positive ``n`` or a negative standard deviation.
+    :raises ValueError: A non-integer or non-positive ``n``, or a negative
+        standard deviation.
     """
-    if n < 1:
+    # A fractional or NaN ``n`` sails past a bare ``n < 1`` and is divided
+    # by, so integrality is required explicitly (numpy integers included).
+    if not isinstance(n, (int, np.integer)) or n < 1:
         msg = "n must be a positive integer."
         raise ValueError(msg)
     if sigma_reproducibility < 0 or sigma_product < 0:

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -291,26 +291,39 @@ def harmonic_distortion(
         :class:`~phonometry.io.Signal` brings its own, and an explicit value
         that disagrees with it raises instead of silently winning.
     :param fundamental: Fundamental frequency :math:`f_1`, in Hz.
-    :param order: Harmonic order ``n`` (>= 2).
+    :param order: Harmonic order ``n`` (an integer >= 2; an integral float
+        such as ``3.0`` is accepted as its integer).
     :param n_harmonics: Highest harmonic order used for the total RMS.
     :param window: FFT window (default ``'hann'``).
     :return: nth-order harmonic distortion, as a ratio.
-    :raises ValueError: If ``order`` < 2 or the inputs are invalid.
+    :raises ValueError: If ``order`` is not an integer, ``order`` < 2 or the
+        inputs are invalid.
     """
     fs = resolve_fs(signal, fs, name="signal")
     sig = _validate_signal(signal)
     fs_v = _positive(fs, "fs")
     f0 = _positive(fundamental, "fundamental")
-    if order < _MIN_HARMONIC_ORDER:
+    # ``order`` indexes the harmonic amplitudes, so a non-integral value must
+    # be refused here by name instead of dying inside numpy's indexing. An
+    # integral float is the integer it prints as (the common accident is an
+    # order computed by a division) and is accepted.
+    if isinstance(order, (int, np.integer)) or (
+        isinstance(order, (float, np.floating)) and float(order).is_integer()
+    ):
+        order_v = int(order)
+    else:
+        msg = "'order' must be an integer."
+        raise ValueError(msg)
+    if order_v < _MIN_HARMONIC_ORDER:
         msg = "'order' must be at least 2."
         raise ValueError(msg)
-    n = max(n_harmonics, order)
+    n = max(n_harmonics, order_v)
     _, amps = _harmonic_amplitudes(sig, fs_v, f0, n, window)
-    if amps.size < order or amps[0] <= 0.0:
+    if amps.size < order_v or amps[0] <= 0.0:
         msg = "The requested harmonic order exceeds the Nyquist limit."
         raise ValueError(msg)
     total_rms = float(np.sqrt(np.sum(amps**2)))
-    return float(amps[order - 1] / total_rms)
+    return float(amps[order_v - 1] / total_rms)
 
 
 def _notched_residual(

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -109,16 +109,20 @@ def _welch_params(
     The guards run before the ``int()``/``float()`` coercions, so a bad
     value is refused by name instead of dying inside the standard library,
     and a fractional ``nperseg`` is refused instead of silently truncated.
+    The comparisons stay in exact int/float arithmetic and only floats are
+    probed for finiteness, because ``float()`` and ``math.isfinite`` both
+    overflow on an integer beyond float range; kept exact, such an integer
+    falls through to the range check, which refuses it by name.
     """
     if (
         not isinstance(overlap, (int, float, np.integer, np.floating))
-        or not 0.0 <= float(overlap) < 1.0
+        or not 0.0 <= overlap < 1.0
     ):
         msg = "'overlap' must be in [0, 1)."
         raise ValueError(msg)
     if nperseg is not None and (
         not isinstance(nperseg, (int, float, np.integer, np.floating))
-        or not math.isfinite(nperseg)
+        or (isinstance(nperseg, (float, np.floating)) and not math.isfinite(nperseg))
         or int(nperseg) != nperseg
     ):
         msg = "'nperseg' must be a positive integer."

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -23,6 +23,7 @@ to verify the implementation.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -98,6 +99,35 @@ def _spectra(
     implementation).
     """
     return _welch_pair(x, y, fs, nperseg, _noverlap_samples(nperseg, overlap))
+
+
+def _welch_params(
+    n: int, fs: float, nperseg: int | None, overlap: float
+) -> tuple[int, float]:
+    """Validated Welch segment length and overlap fraction.
+
+    The guards run before the ``int()``/``float()`` coercions, so a bad
+    value is refused by name instead of dying inside the standard library,
+    and a fractional ``nperseg`` is refused instead of silently truncated.
+    """
+    if (
+        not isinstance(overlap, (int, float, np.integer, np.floating))
+        or not 0.0 <= float(overlap) < 1.0
+    ):
+        msg = "'overlap' must be in [0, 1)."
+        raise ValueError(msg)
+    if nperseg is not None and (
+        not isinstance(nperseg, (int, float, np.integer, np.floating))
+        or not math.isfinite(nperseg)
+        or int(nperseg) != nperseg
+    ):
+        msg = "'nperseg' must be a positive integer."
+        raise ValueError(msg)
+    seg = _default_nperseg(n, fs) if nperseg is None else int(nperseg)
+    if seg < _MIN_SAMPLES or seg > n:
+        msg = "'nperseg' must be between 32 and the signal length."
+        raise ValueError(msg)
+    return seg, float(overlap)
 
 
 @dataclass(frozen=True)
@@ -217,15 +247,9 @@ def transfer_function(
     if estimator not in ("H1", "H2"):
         msg = "'estimator' must be 'H1' or 'H2'."
         raise ValueError(msg)
-    if not 0.0 <= float(overlap) < 1.0:
-        msg = "'overlap' must be in [0, 1)."
-        raise ValueError(msg)
-    seg = _default_nperseg(xa.size, fs_v) if nperseg is None else int(nperseg)
-    if seg < _MIN_SAMPLES or seg > xa.size:
-        msg = "'nperseg' must be between 32 and the signal length."
-        raise ValueError(msg)
+    seg, ovl = _welch_params(xa.size, fs_v, nperseg, overlap)
 
-    freqs, gxy, gxx, gyy = _spectra(xa, ya, fs_v, seg, float(overlap))
+    freqs, gxy, gxx, gyy = _spectra(xa, ya, fs_v, seg, ovl)
     if estimator == "H1":
         response = np.divide(gxy, gxx, out=np.zeros_like(gxy), where=gxx > 0.0)
     else:
@@ -291,14 +315,8 @@ def coherence(
     fs = resolve_pair_fs(x, y, fs)
     xa, ya = _validate_pair(x, y, "coherence")
     fs_v = _positive(fs, "fs")
-    if not 0.0 <= float(overlap) < 1.0:
-        msg = "'overlap' must be in [0, 1)."
-        raise ValueError(msg)
-    seg = _default_nperseg(xa.size, fs_v) if nperseg is None else int(nperseg)
-    if seg < _MIN_SAMPLES or seg > xa.size:
-        msg = "'nperseg' must be between 32 and the signal length."
-        raise ValueError(msg)
-    freqs, gxy, gxx, gyy = _spectra(xa, ya, fs_v, seg, float(overlap))
+    seg, ovl = _welch_params(xa.size, fs_v, nperseg, overlap)
+    freqs, gxy, gxx, gyy = _spectra(xa, ya, fs_v, seg, ovl)
     denom = gxx * gyy
     coh = np.divide(np.abs(gxy) ** 2, denom, out=np.zeros_like(gxx), where=denom > 0.0)
     return freqs, np.clip(coh, 0.0, 1.0)

--- a/src/phonometry/electroacoustics/intermodulation.py
+++ b/src/phonometry/electroacoustics/intermodulation.py
@@ -213,6 +213,9 @@ def modulation_distortion(
     fs_v = _positive(fs, "fs")
     fl = _positive(f_low, "f_low")
     fh = _positive(f_high, "f_high")
+    if fl >= fh:
+        msg = "'f_low' must be lower than 'f_high'."
+        raise ValueError(msg)
     freqs, amp = _amplitude_spectrum(sig, fs_v, window)
     df = float(freqs[1] - freqs[0]) if freqs.size > 1 else 0.0
     # Sidebands are spaced f1 apart: cap the search window well inside that.
@@ -448,6 +451,12 @@ def dynamic_intermodulation_distortion(
     fs_v = _positive(fs, "fs")
     fsine = _positive(f_sine, "f_sine")
     fsq = _positive(f_square, "f_square")
+    # The Table 2 products |k f_square - f_sine| all sit below f_sine only
+    # for f_square < f_sine; a swapped pair leaves the product set empty and
+    # would return a perfect 0.0 for a signal the metric is undefined on.
+    if fsq >= fsine:
+        msg = "'f_square' must be lower than 'f_sine'."
+        raise ValueError(msg)
     freqs, amp = _amplitude_spectrum(sig, fs_v, window)
     search = fsq * _DIM_SEARCH_FACTOR
     # Reference: the output amplitude at f_s, per the 14.12.9.1 definition

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -165,6 +165,14 @@ def piston_directivity(ka: ArrayLike, theta: ArrayLike) -> np.ndarray | float:
     if not np.all(np.isfinite(theta_arr)):
         msg = "'theta' must be finite."
         raise ValueError(msg)
+    try:
+        np.broadcast_shapes(ka_arr.shape, theta_arr.shape)
+    except ValueError:
+        msg = (
+            "'ka' and 'theta' must broadcast together; got shapes "
+            f"{ka_arr.shape} and {theta_arr.shape}."
+        )
+        raise ValueError(msg) from None
     u = ka_arr * np.sin(theta_arr)
     with np.errstate(invalid="ignore", divide="ignore"):
         out = 2.0 * special.j1(u) / u

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -56,6 +56,7 @@ IEC 61043:1993 Table 2 by
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -461,8 +462,13 @@ def _validate_band_options(fraction: int | None, limits: list[float] | None) -> 
     if fraction is not None and fraction not in (1, 3):
         msg = "'fraction' must be None, 1 (octave) or 3 (one-third octave)."
         raise ValueError(msg)
+    # NaN fails every comparison, so finiteness is tested explicitly: a NaN
+    # limit would otherwise pass and silently select no band at all.
     if limits is not None and (
-        len(limits) != 2 or limits[0] <= 0 or limits[1] <= limits[0]  # noqa: PLR2004
+        len(limits) != 2  # noqa: PLR2004
+        or not all(math.isfinite(v) for v in limits)
+        or limits[0] <= 0
+        or limits[1] <= limits[0]
     ):
         msg = "'limits' must be [f_min, f_max] with 0 < f_min < f_max."
         raise ValueError(msg)
@@ -862,6 +868,18 @@ def field_indicators(
     )
     if lp.shape[0] < _MIN_VARIATION_OBSERVATIONS:
         msg = "At least two measurement positions are required."
+        raise ValueError(msg)
+    # A NaN or infinite Lp would slip through the arithmetic and turn F2 and
+    # F3 into silent NaN, so it is rejected up front the way the intensity
+    # samples are (this argument is legitimately 2-D, so the 1-D array
+    # helpers cannot be reused).
+    if not np.all(np.isfinite(lp)):
+        msg = "'pressure_levels' must contain only finite values."
+        raise ValueError(msg)
+    # An empty band axis would leave the per-band loop below nothing to
+    # build, and the unpacking of its result dies inside numpy.
+    if lp.ndim == 2 and lp.shape[1] == 0:  # noqa: PLR2004
+        msg = "'pressure_levels' must have at least one band."
         raise ValueError(msg)
 
     n_bands = lp.shape[1] if lp.ndim == 2 else 1  # noqa: PLR2004

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -55,7 +55,15 @@ import numpy as np
 
 from .._internal.levels_math import energy_mean, energy_sum
 from .._internal.types import as_float_or_array
-from .._internal.validation import check_engine, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_non_negative,
+    require_per_band,
+    require_positive,
+    require_positive_array,
+    require_ranks,
+    require_same_length,
+)
 from ._shared import (
     _S0,
     Grade,
@@ -435,7 +443,7 @@ def background_noise_correction(
     """
     low, high = _K1_CRITERIA[_check_grade(grade)]
     src = np.asarray(source_levels, dtype=np.float64)
-    bg = np.asarray(background_levels, dtype=np.float64)
+    bg = require_per_band(background_levels, "background_levels", src, "source_levels")
     delta = src - bg
     clamped = np.maximum(delta, low)
     k1 = -10.0 * np.log10(1.0 - 10.0 ** (-0.1 * clamped))
@@ -509,12 +517,24 @@ def _room_absorption_area(
         "Eq. A.7",
     )
     if reverberation_time is not None and volume is not None:
+        if np.ndim(volume) != 0:
+            msg = (
+                "'volume' must be a scalar (m^3); only 'reverberation_time' "
+                "may vary per band."
+            )
+            raise ValueError(msg)
         t = np.asarray(reverberation_time, dtype=np.float64)
         if volume <= 0 or np.any(t <= 0.0):
             msg = "reverberation_time and volume must be > 0."
             raise ValueError(msg)
         return 0.16 * volume / t
     if mean_absorption_coefficient is not None and room_surface is not None:
+        if np.ndim(room_surface) != 0:
+            msg = (
+                "'room_surface' must be a scalar (m^2); only "
+                "'mean_absorption_coefficient' may vary per band."
+            )
+            raise ValueError(msg)
         alpha = np.asarray(mean_absorption_coefficient, dtype=np.float64)
         if room_surface <= 0 or np.any(alpha <= 0.0) or np.any(alpha > 1.0):
             msg = "mean_absorption_coefficient must be in (0, 1] and room_surface > 0."
@@ -562,6 +582,7 @@ def environmental_correction(
     :return: ``K2`` in decibels; a scalar for scalar inputs, otherwise an array
         per band.
     """
+    surface_area = require_positive(surface_area, "surface_area")
     if absorption_area is None:
         absorption_area = _room_absorption_area(
             reverberation_time, volume, mean_absorption_coefficient, room_surface
@@ -704,11 +725,14 @@ def _measurement_surface(
         if dimensions is None or distance is None:
             msg = "'dimensions' and 'distance' are required for a box."
             raise ValueError(msg)
-        if len(dimensions) != 3 or any(v <= 0 for v in dimensions) or distance <= 0:  # noqa: PLR2004
-            msg = "'dimensions' must be 3 positive values and 'distance' > 0."
+        dims = require_positive_array(dimensions, "dimensions")
+        if dims.size != 3:  # noqa: PLR2004
+            msg = "'dimensions' must be 3 positive values (l1, l2, l3)."
             raise ValueError(msg)
+        distance = require_positive(distance, "distance")
+        box = (float(dims[0]), float(dims[1]), float(dims[2]))
         return (
-            _box_area(dimensions, distance, reflecting_planes),
+            _box_area(box, distance, reflecting_planes),
             _MIN_BOX_POSITIONS[grade],
         )
     msg = "'surface' must be 'hemisphere' or 'box'."
@@ -809,7 +833,9 @@ def _a_weighted_total(
         # none supplied the A-weighted total is undefined (NaN). A single band
         # carries no weighting, so LWA = LW.
         return None, (float(lw[0]) if n_bands == 1 else float("nan"))
-    freqs = np.asarray(frequencies, dtype=np.float64)
+    # A scalar is one band's centre frequency, not a shape mistake: accept it
+    # for a single band (as 1-D) and reject it, by name, for several.
+    freqs = np.atleast_1d(np.asarray(frequencies, dtype=np.float64))
     if freqs.shape[0] != n_bands:
         msg = "'frequencies' length must match the number of bands."
         raise ValueError(msg)
@@ -866,9 +892,13 @@ def sound_power_pressure(
     :return: :class:`SoundPowerResult`.
     """
     grade = _check_grade(grade)
+    omc_uncertainty = require_non_negative(omc_uncertainty, "omc_uncertainty")
     levels = np.atleast_2d(np.asarray(levels_positions, dtype=np.float64))
     if levels.ndim != 2:  # noqa: PLR2004
         msg = "'levels_positions' must be a 2D (positions, bands) array."
+        raise ValueError(msg)
+    if levels.shape[1] == 0:
+        msg = "'levels_positions' must contain at least one frequency band."
         raise ValueError(msg)
     n_positions = levels.shape[0]
 

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -1182,6 +1182,27 @@ def precision_field_indicators(
     )
 
 
+def _checked_band_centres(
+    frequencies: np.ndarray | None, f_pi_signed: np.ndarray, n_bands: int
+) -> np.ndarray | None:
+    """The band centres validated against the indicator's band axis.
+
+    Split out of :func:`precision_qualification`, which was one branch past
+    what one reader holds: the centre validation is one idea, and it reads
+    the same whether the caller supplied centres or not.
+    """
+    if frequencies is None:
+        return None
+    freqs = require_positive_array(frequencies, "frequencies")
+    if freqs.shape != f_pi_signed.shape:
+        msg = (
+            "'frequencies' must carry one value per band "
+            f"({n_bands} in 'indicators.f_pi_signed'); got shape {freqs.shape}."
+        )
+        raise ValueError(msg)
+    return freqs
+
+
 def _spread_over_bands(value: ArrayLike, n_bands: int) -> np.ndarray:
     """Put a field non-uniformity on the band axis without inventing values.
 
@@ -1248,15 +1269,7 @@ def precision_qualification(
     f_pi_signed = indicators.f_pi_signed
     n_bands = f_pi_signed.shape[0]
 
-    freqs: np.ndarray | None = None
-    if frequencies is not None:
-        freqs = require_positive_array(frequencies, "frequencies")
-        if freqs.shape != f_pi_signed.shape:
-            msg = (
-                "'frequencies' must carry one value per band "
-                f"({n_bands} in 'indicators.f_pi_signed'); got shape {freqs.shape}."
-            )
-            raise ValueError(msg)
+    freqs = _checked_band_centres(frequencies, f_pi_signed, n_bands)
 
     # Criteria 3 and 4 are always available from the indicators.
     criterion_3 = np.asarray(

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -103,6 +103,8 @@ from .._internal.levels_math import energy_mean, weighted_energy_mean
 from .._internal.validation import (
     check_engine,
     require_equal_shapes,
+    require_per_band,
+    require_positive_array,
     require_ranks,
     require_same_length,
 )
@@ -399,12 +401,14 @@ def _validate_scan(
             f"the number of segment 'areas' ({n_seg})."
         )
         raise ValueError(msg)
-    if frequencies is not None and np.asarray(frequencies).shape != (
-        intensity.shape[1],
-    ):
+    if frequencies is not None:
         # Validate up front so a mismatched length raises the public ValueError
-        # rather than an IndexError from the Table 2 lookup during classification.
-        raise ValueError(_FREQUENCIES_BAND_COUNT_MSG)
+        # rather than an IndexError from the Table 2 lookup during
+        # classification, and a NaN or infinite band centre a named refusal
+        # rather than round()'s conversion error there.
+        if np.asarray(frequencies).shape != (intensity.shape[1],):
+            raise ValueError(_FREQUENCIES_BAND_COUNT_MSG)
+        require_positive_array(frequencies, "frequencies")
     if np.any(seg <= 0.0):
         msg = "All segment 'areas' must be positive."
         raise ValueError(msg)
@@ -1244,6 +1248,16 @@ def precision_qualification(
     f_pi_signed = indicators.f_pi_signed
     n_bands = f_pi_signed.shape[0]
 
+    freqs: np.ndarray | None = None
+    if frequencies is not None:
+        freqs = require_positive_array(frequencies, "frequencies")
+        if freqs.shape != f_pi_signed.shape:
+            msg = (
+                "'frequencies' must carry one value per band "
+                f"({n_bands} in 'indicators.f_pi_signed'); got shape {freqs.shape}."
+            )
+            raise ValueError(msg)
+
     # Criteria 3 and 4 are always available from the indicators.
     criterion_3 = np.asarray(
         (f_pi_signed - indicators.f_pi_unsigned) <= _F_PI_DIFF_LIMIT, dtype=bool
@@ -1253,14 +1267,24 @@ def precision_qualification(
     # Criterion 1: |LIn(1) - LIn(2)| <= s/2.
     criterion_1: np.ndarray | None = None
     if scan_intensity_level_1 is not None and scan_intensity_level_2 is not None:
-        l1 = np.asarray(scan_intensity_level_1, dtype=np.float64)
-        l2 = np.asarray(scan_intensity_level_2, dtype=np.float64)
+        l1 = require_per_band(
+            scan_intensity_level_1,
+            "scan_intensity_level_1",
+            f_pi_signed,
+            "indicators.f_pi_signed",
+        )
+        l2 = require_per_band(
+            scan_intensity_level_2,
+            "scan_intensity_level_2",
+            f_pi_signed,
+            "indicators.f_pi_signed",
+        )
         if repeatability_limit is not None:
             s = np.broadcast_to(
                 np.asarray(repeatability_limit, dtype=np.float64), (n_bands,)
             ).astype(np.float64)
-        elif frequencies is not None:
-            nominal = [round(float(f)) for f in np.asarray(frequencies)]
+        elif freqs is not None:
+            nominal = [round(float(f)) for f in freqs]
             s = np.array([_sigma_r0_9614_3(f) for f in nominal], dtype=np.float64)
         else:
             msg = (

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -351,7 +351,18 @@ def _background_corrected_mean(
         k1i, clamped = _k1_eq14(arr - bg, frequencies)
         corrected = energy_mean(arr - k1i, axis=0)
     else:
-        k1, clamped = _k1_eq14(raw_mean - _mean_level(background_levels), frequencies)
+        bg_mean = _mean_level(background_levels)
+        # The per-position branch's check, one axis down: a spectrum of the
+        # wrong band count used to die in the subtraction below with numpy's
+        # two-shape message, which names neither the argument nor the function.
+        if bg_mean.shape != raw_mean.shape:
+            msg = (
+                "'background_levels' must carry one value per band "
+                f"({raw_mean.size} in 'levels'); got shape "
+                f"{np.shape(background_levels)}."
+            )
+            raise ValueError(msg)
+        k1, clamped = _k1_eq14(raw_mean - bg_mean, frequencies)
         corrected = raw_mean - k1
     if clamped:
         warnings.warn(

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -387,9 +387,12 @@ class AtmosphericAttenuation:
         """
         if self.distance is None:
             return None
-        return np.asarray(
-            self.attenuation_coefficient * self.distance, dtype=np.float64
-        )
+        # Coerce before multiplying, as plot() does: the field is annotated as
+        # an array, but the frozen result can be built by hand with a plain
+        # list, and a list times a float is sequence repetition, not
+        # arithmetic.
+        alpha = np.asarray(self.attenuation_coefficient, dtype=np.float64)
+        return np.asarray(alpha * self.distance, dtype=np.float64)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -494,8 +494,18 @@ def kurze_anderson_attenuation(fresnel_number: ArrayLike) -> Real:
 
     :param fresnel_number: Fresnel number ``N`` (scalar or array).
     :return: Attenuation ``Delta``, in decibels (>= 0), matching the input shape.
+    :raises ValueError: for a non-numeric or non-finite ``fresnel_number``.
     """
-    n = np.asarray(fresnel_number, dtype=np.float64)
+    try:
+        n = np.asarray(fresnel_number, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        msg = "'fresnel_number' must be numeric."
+        raise ValueError(msg) from exc
+    # A NaN would pass through the closed form and come back as a NaN
+    # "attenuation", silently breaking the documented >= 0 dB contract.
+    if not np.all(np.isfinite(n)):
+        msg = "'fresnel_number' must contain only finite values."
+        raise ValueError(msg)
     # The formula is only meaningful for N > -0.2 (the illuminated-zone limit of
     # Maekawa's curve); beyond it the diffraction is negligible (0 dB), so the
     # intermediate argument is clipped at -0.2 to keep it clear of the tangent
@@ -733,12 +743,24 @@ def _validate_barrier_geometry(
 
     :return: The validated ``thickness`` (positive and finite) or ``None`` for a
         thin screen.
-    :raises ValueError: on a non-positive/ordered geometry, a barrier below the
-        line of sight, or a thick barrier whose far edge reaches the receiver.
+    :raises ValueError: on a non-positive or non-finite distance, a non-finite
+        height, a mis-ordered geometry, a barrier below the line of sight, or a
+        thick barrier whose far edge reaches the receiver.
     """
-    if barrier_distance <= 0.0 or receiver_distance <= 0.0:
-        msg = "Barrier and receiver distances must be positive."
-        raise ValueError(msg)
+    # require_positive rejects NaN/inf as well as non-positive distances and
+    # names the one that was wrong; a NaN height would sail through the
+    # ordering comparisons below (every comparison against NaN is False) and
+    # come back from the diffraction maths as an all-NaN insertion loss.
+    require_positive(barrier_distance, "barrier_distance")
+    require_positive(receiver_distance, "receiver_distance")
+    for name, height in (
+        ("source_height", source_height),
+        ("barrier_height", barrier_height),
+        ("receiver_height", receiver_height),
+    ):
+        if not np.isfinite(height):
+            msg = f"'{name}' must be finite."
+            raise ValueError(msg)
     if receiver_distance <= barrier_distance:
         msg = "'receiver_distance' must exceed 'barrier_distance'."
         raise ValueError(msg)

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -296,7 +296,7 @@ def ray_curvature_radius(
     if not (np.isfinite(gradient) and abs(gradient) > 0.0):
         msg = "'gradient' must be finite and non-zero (a curved ray)."
         raise ValueError(msg)
-    if abs(launch_angle_deg) >= _VERTICAL_DEG:
+    if not np.isfinite(launch_angle_deg) or abs(launch_angle_deg) >= _VERTICAL_DEG:
         msg = "'launch_angle_deg' must be within (-90, 90) degrees."
         raise ValueError(msg)
     return float(c0 / (abs(gradient) * np.cos(np.radians(launch_angle_deg))))
@@ -725,6 +725,16 @@ def atmospheric_parabolic_equation(
         if height_step is not None
         else lam / 10.0
     )
+    # The vertical grid samples midpoints z = (j + 0.5) dz, so the first node
+    # sits at dz / 2: a step of 2 * max_height or more leaves the output band
+    # [0, zmax] without a single node, and the empty field only failed later,
+    # in whatever read it, with a message naming neither parameter.
+    if dz >= 2.0 * zmax:
+        msg = (
+            "'height_step' must be less than twice 'max_height' "
+            "(the first grid node lies at half a step above the ground)."
+        )
+        raise ValueError(msg)
     dr = require_positive(range_step, "range_step") if range_step is not None else lam
     if dr > rmax:
         msg = "'range_step' must not exceed 'max_range'."

--- a/src/phonometry/filters/core.py
+++ b/src/phonometry/filters/core.py
@@ -16,6 +16,7 @@ from .._internal.utils import (
     _downsamplingfactor,
     _resample_to_length,
 )
+from .._internal.validation import require_choice, require_positive
 from .._internal.warnings import PhonometryWarning
 from ..io._resolve import (
     like_input,
@@ -158,6 +159,72 @@ def _validate_bank_design(
         msg = "Resampling and stateful behaviour (block processing) are not supported."
         raise ValueError(msg)
     return limits
+
+
+def _require_level_mode(mode: str) -> str:
+    """Check ``mode`` at the entry point the caller typed.
+
+    ``_calculate_level`` inspects the mode band by band, after the filtering
+    work is done and only when levels are computed at all, so a typo used to
+    surface late or, with ``calculate_level=False``, not at all. Lowercasing
+    before the membership check preserves the case-insensitivity the level
+    calculation always had.
+
+    :param mode: The requested level mode.
+    :return: The validated mode, lowercased.
+    :raises TypeError: for a non-string mode.
+    :raises ValueError: for a string that is neither ``'rms'`` nor ``'peak'``.
+    """
+    if not isinstance(mode, str):
+        msg = f"'mode' must be a string; got {type(mode).__name__}."
+        raise TypeError(msg)
+    return require_choice(mode.lower(), "mode", ("rms", "peak"))
+
+
+def _require_bank_input(x_proc: np.ndarray) -> None:
+    """Reject shapes the bank has no reading for, naming ``x``.
+
+    The shared ``require_1d_signal`` cannot be used here: this bank documents
+    2-D ``[channels, samples]`` input as legal. Anything beyond that used to
+    travel on and die in numpy broadcasting (or come back silently truncated
+    with ``sigbands=True``), and an empty signal reached scipy's ``sosfilt``
+    reshape after numpy had already warned about detrending an empty slice.
+
+    :param x_proc: The input, already resolved to an array (at least 1-D:
+        ``resolve_samples`` promotes a bare scalar).
+    :raises ValueError: for an array of more than two axes, or an input with
+        no samples.
+    """
+    if x_proc.ndim > 2:  # noqa: PLR2004
+        msg = (
+            "'x' must be a 1-D signal or a 2-D [channels, samples] array; "
+            f"got shape {x_proc.shape}."
+        )
+        raise ValueError(msg)
+    if x_proc.shape[-1] == 0:
+        msg = "'x' must contain at least one sample."
+        raise ValueError(msg)
+
+
+def _resolve_limits(limits: list[float] | None) -> list[float] | None:
+    """Check ``limits`` is a pair of numbers before it is hashed or compared.
+
+    The bank constructor owns the value checks (count, positivity, ordering,
+    and the default when ``None``); this rejects only the shapes those checks
+    would die on anonymously, in the cache key's ``float()`` coercion or in
+    ``len()``: a non-sequence, or a non-numeric entry.
+
+    :param limits: The requested frequency limits, or ``None`` for the default.
+    :return: The limits as a list of floats, or ``None``.
+    :raises ValueError: for a non-sequence or a non-numeric entry.
+    """
+    if limits is None:
+        return None
+    try:
+        return [float(f) for f in limits]
+    except (TypeError, ValueError):
+        msg = f"'limits' must be a pair of frequencies [f_min, f_max]; got {limits!r}."
+        raise ValueError(msg) from None
 
 
 class OctaveFilterBank:
@@ -416,6 +483,7 @@ class OctaveFilterBank:
         if zero_phase and self.stateful:
             msg = "zero_phase is not compatible with stateful processing."
             raise ValueError(msg)
+        mode = _require_level_mode(mode)
 
         x_proc, is_multichannel = self._prepare_signal(x, detrend)
         num_channels = x_proc.shape[0]
@@ -476,6 +544,7 @@ class OctaveFilterBank:
         """
         refuse_foreign_rate(x, self.fs, "filter bank")
         x_proc = resolve_samples(x, calibrate=self._default_calibration)
+        _require_bank_input(x_proc)
 
         if detrend:
             if self.stateful:
@@ -528,9 +597,12 @@ class OctaveFilterBank:
         if not 0 <= overlap < 1:
             msg = "overlap must be in [0, 1)."
             raise ValueError(msg)
+        mode = _require_level_mode(mode)
+        window_time = require_positive(window_time, "window_time")
 
         refuse_foreign_rate(x, self.fs, "filter bank")
         x_proc = resolve_samples(x, calibrate=self._default_calibration)
+        _require_bank_input(x_proc)
         is_multichannel = x_proc.ndim > 1
         n_samples = x_proc.shape[-1]
         win = round(window_time * self.fs)
@@ -844,6 +916,11 @@ def octave_filter(
         Tuple[np.ndarray, List[str], List[np.ndarray]]]
     """
     fs = resolve_fs(x, fs)
+    # Both branches see the same already-checked pair: without this, a
+    # malformed limits argument died in the cache key's float() coercion on
+    # one branch and in the constructor's len() on the other, with two
+    # different stdlib messages and neither naming 'limits'.
+    limits = _resolve_limits(limits)
     if response_plot.show or response_plot.file:
         # Plotting has side effects: bypass the cache.
         filter_bank = OctaveFilterBank(
@@ -857,12 +934,11 @@ def octave_filter(
         )
     else:
         # The bank is immutable in non-stateful mode: reuse the design.
-        # Pass limits through as-is (tuple for hashability); the bank
-        # constructor is the single place that validates them and owns
-        # the default when None. The option bundles are frozen dataclasses,
-        # so they are hashable and compare by value: equal options hit the
-        # same cache entry.
-        limits_key = tuple(map(float, limits)) if limits is not None else None
+        # Pass limits through (tuple for hashability); the bank constructor
+        # still owns the value checks and the default when None. The option
+        # bundles are frozen dataclasses, so they are hashable and compare
+        # by value: equal options hit the same cache entry.
+        limits_key = tuple(limits) if limits is not None else None
         filter_bank = _cached_filter_bank(
             fs, fraction, order, limits_key, design, calibration
         )

--- a/src/phonometry/filters/frequencies.py
+++ b/src/phonometry/filters/frequencies.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 import numpy as np
 
+from .._internal.validation import require_positive
 from .._internal.warnings import PhonometryWarning
 
 # IEC 61260-1 Annex E.3: a most-significant digit of 1-4 keeps three
@@ -37,7 +38,12 @@ def nominal_frequencies(
     :param fraction: Bandwidth fraction (e.g., 1, 3).
     :param limits: [f_min, f_max] limits.
     :return: Tuple of (center_freqs, lower_edges, upper_edges, nominal_labels).
+    :raises ValueError: for a non-positive or non-finite ``fraction``.
     """
+    # Zero used to reach _bandedge's division, NaN the index rounding, and a
+    # negative fraction never terminated: the band centres underflow to 0.0
+    # and the edge test stays true forever.
+    fraction = require_positive(fraction, "fraction")
     if limits is None:
         limits = [12, 20000]
 

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -661,9 +661,10 @@ def _prepare_time_weighting_initial_state(
 
     try:
         state = np.asarray(initial_state, dtype=x_sq.dtype)
-    except TypeError:
-        # numpy's float() message would name neither the parameter nor the
-        # accepted forms; the module's own message does both.
+    except (TypeError, ValueError):
+        # numpy refuses an object with TypeError and an unconvertible string
+        # array with ValueError; neither message names the parameter or the
+        # accepted forms, so both become the module's own TypeError.
         raise TypeError(invalid_initial_state_message) from None
     if state.shape == ():
         return np.full(state_shape, state.item(), dtype=x_sq.dtype)

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -53,6 +53,7 @@ import numpy as np
 from scipy import signal
 
 from .._internal.utils import _sos_initial_state, _sos_state_mismatch
+from .._internal.validation import require_positive
 from ..io._resolve import (
     like_input,
     refuse_foreign_rate,
@@ -65,7 +66,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import DTypeLike
 
-#: Rejection message shared by the three entry points that take ``fs``.
+#: Rejection message shared by the four entry points that take ``fs``.
 _FS_POSITIVE = "Sample rate 'fs' must be positive."
 
 try:
@@ -74,6 +75,24 @@ except ImportError:  # pragma: no cover - depends on install extras
     # unused-ignore: with numba absent its import is Any and the ignore is
     # unnecessary; with numba installed the assignment needs it.
     _numba_jit = None  # type: ignore[assignment, unused-ignore]
+
+
+def _require_str(value: object, name: str) -> str:
+    """Require *value* to be a string before any case folding touches it.
+
+    The choice checks in this module fold case first (``curve.upper()``,
+    ``mode.lower()``), so a non-string used to die in the stdlib's attribute
+    lookup before the module's own message could name the parameter.
+
+    :param value: The value to validate.
+    :param name: Parameter name used in the error message.
+    :return: The validated string.
+    :raises TypeError: for a non-string value.
+    """
+    if not isinstance(value, str):
+        msg = f"'{name}' must be a string; got {type(value).__name__}."
+        raise TypeError(msg)
+    return value
 
 
 class WeightingFilter:
@@ -127,6 +146,7 @@ class WeightingFilter:
         """
         if fs <= 0:
             raise ValueError(_FS_POSITIVE)
+        curve = _require_str(curve, "curve")
         if high_accuracy is None:
             high_accuracy = not stateful
         if high_accuracy and stateful:
@@ -639,7 +659,12 @@ def _prepare_time_weighting_initial_state(
             return np.asarray(np.take(x_sq, 0, axis=-1), dtype=x_sq.dtype).copy()
         raise ValueError(invalid_initial_state_message)
 
-    state = np.asarray(initial_state, dtype=x_sq.dtype)
+    try:
+        state = np.asarray(initial_state, dtype=x_sq.dtype)
+    except TypeError:
+        # numpy's float() message would name neither the parameter nor the
+        # accepted forms; the module's own message does both.
+        raise TypeError(invalid_initial_state_message) from None
     if state.shape == ():
         return np.full(state_shape, state.item(), dtype=x_sq.dtype)
 
@@ -725,6 +750,7 @@ def time_weighting(
     x_proc = resolve_samples(x)
     if fs <= 0:
         raise ValueError(_FS_POSITIVE)
+    mode = _require_str(mode, "mode")
     x_sq = x_proc**2
     initial = _prepare_time_weighting_initial_state(x_sq, initial_state)
 
@@ -776,6 +802,7 @@ class TimeWeighting:
         """
         if fs <= 0:
             raise ValueError(_FS_POSITIVE)
+        mode = _require_str(mode, "mode")
         if mode.lower() not in ("fast", "slow", "impulse"):
             msg = "Invalid time weighting mode. Use ['fast', 'slow', 'impulse']"
             raise ValueError(msg)
@@ -854,13 +881,27 @@ def linkwitz_riley(
     """
     fs = resolve_fs(x, fs)
     x_proc = resolve_samples(x)
+    if fs <= 0:
+        raise ValueError(_FS_POSITIVE)
     if order % 2 != 0:
         msg = "Linkwitz-Riley order must be even (typically 2 or 4)."
+        raise ValueError(msg)
+    if order <= 0:
+        # An even order of zero slipped through the parity check and returned
+        # both bands as the untouched input (their sum is twice the signal).
+        msg = (
+            f"'order' must be a positive even integer (typically 2 or 4); got {order}."
+        )
+        raise ValueError(msg)
+    freq = require_positive(freq, "freq")
+    nyquist = fs / 2
+    if freq >= nyquist:
+        msg = f"'freq' must be below the Nyquist frequency ({nyquist:g} Hz); got {freq:g}."
         raise ValueError(msg)
 
     # A Linkwitz-Riley filter of order N is two Butterworth filters of order N/2 in series
     half_order = order // 2
-    wn = freq / (fs / 2)
+    wn = freq / nyquist
 
     sos_lp = signal.butter(half_order, wn, btype="low", output="sos")
     sos_hp = signal.butter(half_order, wn, btype="high", output="sos")

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -387,6 +387,9 @@ def static_airflow_resistance(
     if u.size < _MIN_MEASUREMENT_STEPS:
         msg = "At least two measurement steps are required."
         raise ValueError(msg)
+    if not (np.all(np.isfinite(u)) and np.all(np.isfinite(dp))):
+        msg = "'velocities' and 'pressure_drops' must contain only finite values."
+        raise ValueError(msg)
     if bool(np.any(u <= 0.0)):
         msg = "All velocities must be positive."
         raise ValueError(msg)

--- a/src/phonometry/materials/absorbers/four_microphone.py
+++ b/src/phonometry/materials/absorbers/four_microphone.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from ..._internal.validation import require_positive
 from .impedance_tube import (
     _DIAMETER_POSITIVE,
     ImpedanceTubeWarning,
@@ -73,6 +74,10 @@ _ASTM_LOWER_WAVELENGTH_FRACTION = 100.0
 #: Shared message of the ``characteristic_impedance`` validation, repeated by
 #: every entry point that takes the air characteristic impedance ``rho c``.
 _IMPEDANCE_POSITIVE = "'characteristic_impedance' must be positive."
+
+#: A load is the tuple of the four microphone transfer functions H1..H4
+#: (ASTM E2611-19, Eqs. (17)-(20)).
+_LOAD_TRANSFER_FUNCTIONS = 4
 
 __all__ = [
     "TransferMatrix",
@@ -341,6 +346,7 @@ def face_quantities(
     """
     if characteristic_impedance <= 0.0:
         raise ValueError(_IMPEDANCE_POSITIVE)
+    thickness = require_positive(thickness, "thickness")
     av = np.asarray(a, dtype=np.complex128)
     bv = np.asarray(b, dtype=np.complex128)
     cv = np.asarray(c, dtype=np.complex128)
@@ -597,6 +603,7 @@ def air_layer_transfer_matrix(
 def _face_from_loads(
     load: tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike],
     *,
+    name: str,
     l1: float,
     s1: float,
     l2: float,
@@ -605,7 +612,19 @@ def _face_from_loads(
     wavenumber: ArrayLike,
     characteristic_impedance: float,
 ) -> tuple[Complex, Complex, Complex, Complex]:
-    """Face pressures/velocities for one termination (Eqs. (17)-(21))."""
+    """Face pressures/velocities for one termination (Eqs. (17)-(21)).
+
+    ``name`` is the load parameter as the caller of the public solver typed
+    it (``load_a``, ``load_b`` or ``load``), so a load of the wrong length is
+    refused by name instead of dying in tuple indexing; a too-long load would
+    otherwise even pass, with its extra entries silently dropped.
+    """
+    if len(load) != _LOAD_TRANSFER_FUNCTIONS:
+        msg = (
+            f"'{name}' must be the four transfer functions "
+            f"(H1, H2, H3, H4); got {len(load)}."
+        )
+        raise ValueError(msg)
     a, b, c, d = wave_decomposition(
         load[0],
         load[1],
@@ -744,6 +763,7 @@ def transfer_matrix_two_load(
         )
     p0a, pda, u0a, uda = _face_from_loads(
         load_a,
+        name="load_a",
         l1=l1,
         s1=s1,
         l2=l2,
@@ -754,6 +774,7 @@ def transfer_matrix_two_load(
     )
     p0b, pdb, u0b, udb = _face_from_loads(
         load_b,
+        name="load_b",
         l1=l1,
         s1=s1,
         l2=l2,
@@ -847,6 +868,7 @@ def transfer_matrix_one_load(
         )
     p0, pd, u0, ud = _face_from_loads(
         load,
+        name="load",
         l1=l1,
         s1=s1,
         l2=l2,

--- a/src/phonometry/materials/absorbers/impedance_tube.py
+++ b/src/phonometry/materials/absorbers/impedance_tube.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.validation import check_engine
+from ..._internal.validation import check_engine, require_equal_shapes, require_per_band
 from ..._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -143,6 +143,12 @@ def air_density_iso(
     """
     t = np.asarray(temperature, dtype=np.float64)
     pa = np.asarray(atmospheric_pressure, dtype=np.float64)
+    if t.ndim != 0 and pa.ndim != 0:
+        require_equal_shapes(
+            "air_density_iso",
+            {"temperature": t.shape, "atmospheric_pressure": pa.shape},
+            "measurement",
+        )
     if np.any(t <= 0.0):
         msg = "'temperature' must be positive (kelvin)."
         raise ValueError(msg)
@@ -238,12 +244,37 @@ def tube_wavenumber(
     if speed_of_sound <= 0.0:
         raise ValueError(_SPEED_OF_SOUND_POSITIVE)
     f = np.asarray(frequency, dtype=np.float64)
+    if not np.all(np.isfinite(f)) or bool(np.any(f < 0.0)):
+        msg = "'frequency' must be non-negative."
+        raise ValueError(msg)
     k_real = 2.0 * np.pi * f / speed_of_sound
     if attenuation is None:
         k_imag: NDArray[np.float64] = np.zeros_like(k_real)
     else:
-        k_imag = np.asarray(attenuation, dtype=np.float64)
+        k_imag = require_per_band(
+            attenuation, "attenuation", k_real, bands_name="frequency"
+        )
     return np.asarray(k_real - 1j * k_imag, dtype=np.complex128)
+
+
+def _require_h12_per_band(
+    h12: ArrayLike, bands: NDArray[np.float64] | Complex, bands_name: str
+) -> Complex:
+    """Coerce ``h12`` to complex128, as a scalar or one value per band.
+
+    The complex-aware twin of the shared ``require_per_band``, which coerces
+    to float64 and would silently discard the imaginary part of the measured
+    transfer function. Without it, a length mismatch dies in the arithmetic
+    as numpy's two-shapes broadcast error, naming neither argument.
+    """
+    h = np.asarray(h12, dtype=np.complex128)
+    if h.ndim != 0 and bands.ndim != 0 and h.shape != bands.shape:
+        msg = (
+            f"'h12' must be a scalar or carry one value per band "
+            f"({bands.size} in '{bands_name}'); got shape {h.shape}."
+        )
+        raise ValueError(msg)
+    return h
 
 
 # ---------------------------------------------------------------------------
@@ -284,8 +315,8 @@ def reflection_factor(
     if x1 <= 0.0:
         msg = "'x1' must be positive."
         raise ValueError(msg)
-    h = np.asarray(h12, dtype=np.complex128)
     k0 = np.asarray(wavenumber, dtype=np.complex128)
+    h = _require_h12_per_band(h12, k0, "wavenumber")
     h_i = np.exp(-1j * k0 * spacing)
     h_r = np.exp(1j * k0 * spacing)
     r = (h - h_i) / (h_r - h) * np.exp(2j * k0 * x1)
@@ -624,8 +655,9 @@ def two_microphone_impedance(
         the result).
     """
     f = np.asarray(frequency, dtype=np.float64)
+    h = _require_h12_per_band(h12, f, "frequency")
     k0 = tube_wavenumber(f, speed_of_sound, attenuation=attenuation)
-    r = reflection_factor(h12, spacing=spacing, x1=x1, wavenumber=k0)
+    r = reflection_factor(h, spacing=spacing, x1=x1, wavenumber=k0)
     canonical = _canonical_shape(shape)
     if diameter is not None:
         f_lower, f_upper = plane_wave_frequency_range(

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -484,8 +484,14 @@ def weighted_absorption(
     :returns: A frozen :class:`AbsorptionRatingResult` with ``alpha_w``, the
         shape indicators, the applied shift, the fitted reference curve and
         the absorption class.
+    :raises ValueError: if any coefficient is negative or the wrong number
+        of values is supplied.
     """
-    return _rate(_coerce(alpha_p, OCTAVE_BANDS, "alpha_p"))
+    values = _coerce(alpha_p, OCTAVE_BANDS, "alpha_p")
+    if any(v < 0.0 for v in values):
+        msg = "'alpha_p' must be non-negative."
+        raise ValueError(msg)
+    return _rate(values)
 
 
 def _rate(
@@ -578,7 +584,11 @@ def absorption_class(alpha_w: float) -> str:
         0,05 in ``[0, 1]``).
     :returns: ``"A"``, ``"B"``, ``"C"``, ``"D"``, ``"E"`` or
         ``"Not classified"``.
+    :raises ValueError: if ``alpha_w`` is not a finite value in ``[0, 1]``.
     """
+    if not math.isfinite(alpha_w) or not 0.0 <= alpha_w <= 1.0:
+        msg = "'alpha_w' must be a finite value in the range [0, 1]."
+        raise ValueError(msg)
     units = _to_units(alpha_w)
     for lowest, letter in _CLASS_TABLE:
         if units >= lowest:

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -79,6 +79,10 @@ _SABINE = 55.3
 _TEN_LG_E = 10.0 * math.log10(math.e)
 #: Validity range of the speed-of-sound Eq. (6), in degrees Celsius.
 _EQ6_TEMPERATURE_RANGE = (15.0, 30.0)
+#: Absolute zero in degrees Celsius, the hard floor of any air temperature.
+_KELVIN = 273.15
+#: Full-scale relative humidity (saturation), in percent.
+_MAX_RELATIVE_HUMIDITY_PERCENT = 100.0
 #: Minimum reverberation-room volume, ISO 354:2003 clause 6.1.1 (m3).
 _MIN_ROOM_VOLUME = 150.0
 #: Plane-absorber sample-area limits, ISO 354:2003 clause 6.2.1.1 (m2).
@@ -145,12 +149,19 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
 
     Warns when the speed is derived from a temperature outside the 15..30 degC
     validity range of Eq. (6). An explicit ``speed_of_sound`` bypasses the check.
+    Rejects a physically impossible ``temperature`` outright: Eq. (6) applied
+    below absolute zero would hand back a zero or negative speed of sound.
     """
     if speed_of_sound is not None:
         if speed_of_sound <= 0.0:
             msg = "'speed_of_sound' must be positive."
             raise ValueError(msg)
         return float(speed_of_sound)
+    # `not >` rather than `<=` so a NaN temperature is refused too, instead of
+    # propagating through Eq. (6) into every derived quantity.
+    if not temperature > -_KELVIN:
+        msg = "'temperature' must be above absolute zero (-273,15 degC)."
+        raise ValueError(msg)
     lo, hi = _EQ6_TEMPERATURE_RANGE
     if not lo <= temperature <= hi:
         warnings.warn(
@@ -607,9 +618,10 @@ def measure_sound_absorption(
         (default 20). Used for the speed of sound via Eq. (6) unless
         ``speed_of_sound`` is given; a temperature outside 15..30 degC emits an
         :class:`AbsorptionWarning`.
-    :param humidity: Relative humidity during the test, in % (informational;
-        recorded on the result but not used in the computation, which sees the
-        climate only through ``m``). ``None`` leaves it unrecorded.
+    :param humidity: Relative humidity during the test, in % within
+        ``[0, 100]`` (informational; recorded on the result but not used in the
+        computation, which sees the climate only through ``m``). ``None``
+        leaves it unrecorded.
     :param speed_of_sound: Explicit speed of sound ``c``, in m/s; overrides
         ``temperature`` and Eq. (6) when supplied.
     :param m: Power attenuation coefficient of air ``m``, in 1/m (a scalar or a
@@ -618,8 +630,8 @@ def measure_sound_absorption(
         :func:`attenuation_from_alpha`.
     :return: A frozen :class:`SoundAbsorptionMeasurement`.
     :raises ValueError: If the frequency and reverberation-time arrays do not
-        share one shape, or an input is non-physical (see
-        :func:`absorption_coefficient`).
+        share one shape, ``humidity`` is not within ``[0, 100]`` %, or an
+        input is non-physical (see :func:`absorption_coefficient`).
     """
     freqs = np.asarray(frequencies, dtype=np.float64)
     t1 = np.asarray(t_empty, dtype=np.float64)
@@ -636,6 +648,18 @@ def measure_sound_absorption(
     m_arr = np.broadcast_to(np.asarray(m, dtype=np.float64), freqs.shape).astype(
         np.float64, copy=True
     )
+    if humidity is None:
+        humidity_pct: float | None = None
+    else:
+        # A non-numeric humidity becomes NaN here so that it fails the range
+        # test below and is refused by name, instead of dying inside float().
+        try:
+            humidity_pct = float(humidity)
+        except ValueError:
+            humidity_pct = math.nan
+        if not 0.0 <= humidity_pct <= _MAX_RELATIVE_HUMIDITY_PERCENT:
+            msg = "'humidity' must be within [0, 100] %."
+            raise ValueError(msg)
     # Resolve the speed once (Eq. (6)); this emits the single temperature
     # advisory. Passing the resolved speed to the reused helpers below keeps
     # every advisory to exactly one, since both measurements share the climate.
@@ -666,7 +690,7 @@ def measure_sound_absorption(
         volume=float(volume),
         area=float(area),
         temperature=float(temperature),
-        humidity=None if humidity is None else float(humidity),
+        humidity=humidity_pct,
         speed_of_sound=c,
         air_attenuation=m_arr,
         absorption_area_empty=a1,

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -153,8 +153,10 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
     below absolute zero would hand back a zero or negative speed of sound.
     """
     if speed_of_sound is not None:
-        if speed_of_sound <= 0.0:
-            msg = "'speed_of_sound' must be positive."
+        # NaN passes a bare <= comparison and propagates into every derived
+        # quantity; infinity is positive but zeroes the speed-dependent terms.
+        if not math.isfinite(speed_of_sound) or speed_of_sound <= 0.0:
+            msg = "'speed_of_sound' must be finite and positive."
             raise ValueError(msg)
         return float(speed_of_sound)
     # NaN is named alongside the bound: a NaN temperature would otherwise
@@ -652,10 +654,11 @@ def measure_sound_absorption(
         humidity_pct: float | None = None
     else:
         # A non-numeric humidity becomes NaN here so that it fails the range
-        # test below and is refused by name, instead of dying inside float().
+        # test below and is refused by name, instead of dying inside float():
+        # ValueError for a string, TypeError for a list or a 1-d array.
         try:
             humidity_pct = float(humidity)
-        except ValueError:
+        except (TypeError, ValueError):
             humidity_pct = math.nan
         if not 0.0 <= humidity_pct <= _MAX_RELATIVE_HUMIDITY_PERCENT:
             msg = "'humidity' must be within [0, 100] %."

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -157,9 +157,9 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
             msg = "'speed_of_sound' must be positive."
             raise ValueError(msg)
         return float(speed_of_sound)
-    # `not >` rather than `<=` so a NaN temperature is refused too, instead of
-    # propagating through Eq. (6) into every derived quantity.
-    if not temperature > -_KELVIN:
+    # NaN is named alongside the bound: a NaN temperature would otherwise
+    # propagate through Eq. (6) into every derived quantity.
+    if math.isnan(temperature) or temperature <= -_KELVIN:
         msg = "'temperature' must be above absolute zero (-273,15 degC)."
         raise ValueError(msg)
     lo, hi = _EQ6_TEMPERATURE_RANGE

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -312,15 +312,24 @@ def _resolve_interior(
     v = _resolve_panel_r(values, freqs, name)
 
     alpha = np.asarray(internal_absorption, dtype=np.float64)
-    if alpha.ndim > 1:
-        msg = "'internal_absorption' must be a scalar or a 1-D array."
+    if alpha.ndim > 1 or alpha.size == 0:
+        msg = "'internal_absorption' must be a scalar or a non-empty 1-D array."
         raise ValueError(msg)
     if np.any(alpha <= 0.0) or np.any(alpha >= 1.0) or not np.all(np.isfinite(alpha)):
         msg = "'internal_absorption' must lie strictly in (0, 1)."
         raise ValueError(msg)
 
     r_i = np.atleast_1d(np.asarray(room_constant(s_i, alpha), dtype=np.float64))
-    r_i_b, v_b = np.broadcast_arrays(r_i, v)
+    try:
+        r_i_b, v_b = np.broadcast_arrays(r_i, v)
+    except ValueError:
+        # numpy reports the two shapes it could not reconcile without saying
+        # which argument carried which; name the culprit in the caller's words.
+        msg = (
+            f"'internal_absorption' must be a scalar or carry one value per "
+            f"band ({v.size} in '{name}'); got shape {alpha.shape}."
+        )
+        raise ValueError(msg) from None
     if freqs is not None:
         # The band count is whatever the spectrum and the absorption broadcast
         # to, so either of them can be the one that disagrees with the labels.
@@ -385,16 +394,30 @@ def enclosure_insertion_loss(
         Equation (4.115).
     :return: An :class:`EnclosureResult`.
     """
-    if (
-        not callable(panel_transmission_loss)
-        and not isinstance(panel_transmission_loss, (np.ndarray, list, tuple))
-        and hasattr(panel_transmission_loss, "transmission_loss")
-        and hasattr(panel_transmission_loss, "frequencies")
+    if not callable(panel_transmission_loss) and not isinstance(
+        panel_transmission_loss, (np.ndarray, list, tuple)
     ):
-        result = cast("PanelTransmissionResult", panel_transmission_loss)
-        if frequencies is None:
-            frequencies = result.frequencies
-        panel_transmission_loss = np.asarray(result.transmission_loss, dtype=np.float64)
+        if hasattr(panel_transmission_loss, "transmission_loss") and hasattr(
+            panel_transmission_loss, "frequencies"
+        ):
+            result = cast("PanelTransmissionResult", panel_transmission_loss)
+            if frequencies is None:
+                frequencies = result.frequencies
+            panel_transmission_loss = np.asarray(
+                result.transmission_loss, dtype=np.float64
+            )
+        elif not isinstance(panel_transmission_loss, (int, float)) and not hasattr(
+            panel_transmission_loss, "__array__"
+        ):
+            # Anything else would fall through to numpy's float() coercion,
+            # whose message names neither the parameter nor the accepted forms.
+            msg = (
+                "'panel_transmission_loss' must be a per-band array, a callable "
+                "of the frequency array, or a panel result carrying "
+                "'transmission_loss' and 'frequencies'; got "
+                f"{type(panel_transmission_loss).__name__}."
+            )
+            raise TypeError(msg)
 
     freqs, r_b, correction, r_i_b, s_e, s_i = _resolve_interior(
         panel_transmission_loss,

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -73,6 +73,7 @@ end-to-end fan-to-room calculation.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -706,14 +707,24 @@ def plenum_attenuation(
     :param mean_absorption: Mean Sabine wall absorption ``alpha`` in ``(0, 1)``
         (scalar or per-band).
     :param angle: Angle ``theta`` between the inlet axis and the line to the
-        outlet, rad (default 0).
+        outlet, in ``[0, pi/2]`` rad (default 0).
     :return: The transmission loss, dB (float for scalar absorption, else a
         per-band array).
+    :raises ValueError: If a dimension is not positive, ``mean_absorption``
+        leaves ``(0, 1)`` or ``angle`` leaves ``[0, pi/2]``.
     """
     s_out = require_positive(exit_area, "exit_area")
     r = require_positive(line_of_sight, "line_of_sight")
     s_w = require_positive(wall_area, "wall_area")
+    # Past pi/2 the direct term of Eq. (8.275) turns negative, which the
+    # method does not model; a NaN fails the same comparison and is refused.
+    if not (math.isfinite(angle) and 0.0 <= angle <= math.pi / 2.0):
+        msg = "'angle' must lie in [0, pi/2] radians."
+        raise ValueError(msg)
     alpha = np.asarray(mean_absorption, dtype=np.float64)
+    if alpha.ndim > 1 or alpha.size == 0:
+        msg = "'mean_absorption' must be a scalar or a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(alpha <= 0.0) or np.any(alpha >= 1.0) or not np.all(np.isfinite(alpha)):
         msg = "'mean_absorption' must lie strictly in (0, 1)."
         raise ValueError(msg)
@@ -827,7 +838,7 @@ def blade_passing_frequency(rotational_speed: float, blades: int) -> float:
     :raises ValueError: If ``blades`` is not a positive integer.
     """
     rpm = require_positive(rotational_speed, "rotational_speed")
-    if blades <= 0:
+    if blades <= 0 or not float(blades).is_integer():
         msg = "'blades' must be a positive integer."
         raise ValueError(msg)
     return rpm * float(blades) / 60.0
@@ -1423,7 +1434,7 @@ def silencer_self_noise(
     """
     f, idx = _octave_slots(frequencies)
     v = require_positive(airway_velocity, "airway_velocity")
-    if passages <= 0:
+    if passages <= 0 or not float(passages).is_integer():
         msg = "'passages' must be a positive integer."
         raise ValueError(msg)
     h_mm = require_positive(height, "height") * 1000.0
@@ -1515,7 +1526,7 @@ def diffuser_sound_power(
     flow_cfm = require_positive(volume_flow, "volume_flow") / _M3S_PER_CFM
     drop_in_wg = require_positive(pressure_drop, "pressure_drop") / _PA_PER_IN_WG
     profile = require_choice(shape, "shape", ("rectangular", "round"))
-    if count <= 0:
+    if count <= 0 or not float(count).is_integer():
         msg = "'count' must be a positive integer."
         raise ValueError(msg)
     # Eq. 13.28: Long prints "ft/min" under U_\mathrm{G} but defines it in the same
@@ -1567,14 +1578,15 @@ def air_terminal_velocity_limit(
     """
     side = require_choice(opening, "opening", ("supply", "return"))
     table = _TERMINAL_VELOCITY_LIMIT[side]
-    key = round(design_criterion)
-    if key not in table:
+    # The finiteness test keeps a NaN or infinite criterion out of round(),
+    # whose own refusal names neither the parameter nor the tabulated values.
+    if not math.isfinite(design_criterion) or round(design_criterion) not in table:
         msg = (
             f"'design_criterion' must be one of {sorted(table)}; "
             f"got {design_criterion!r}."
         )
         raise ValueError(msg)
-    return table[key]
+    return table[round(design_criterion)]
 
 
 def air_terminal_damper_correction(
@@ -1641,6 +1653,9 @@ def room_effect(
     r = require_positive(distance, "distance")
     q = require_positive(directivity, "directivity")
     r_const = np.asarray(room_constant, dtype=np.float64)
+    if r_const.ndim > 1 or r_const.size == 0:
+        msg = "'room_constant' must be a scalar or a non-empty 1-D array."
+        raise ValueError(msg)
     if np.any(r_const <= 0.0) or not np.all(np.isfinite(r_const)):
         msg = "'room_constant' must be positive and finite."
         raise ValueError(msg)

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -147,6 +147,9 @@ _MIN_GRID_FOR_INTERIOR_MINIMUM = 3
 
 _Complex = NDArray[np.complex128]
 
+#: Rank of a four-pole stack: the frequency axis plus the two matrix axes.
+_FOUR_POLE_NDIM = 3
+
 
 def _frequencies(frequencies: ArrayLike) -> NDArray[np.float64]:
     """Validate a strictly positive, finite 1-D frequency grid (Hz)."""
@@ -158,6 +161,24 @@ def _frequencies(frequencies: ArrayLike) -> NDArray[np.float64]:
         msg = "'frequencies' must be positive and finite."
         raise ValueError(msg)
     return f
+
+
+def _per_frequency(impedance: ArrayLike, name: str, n_freq: int) -> _Complex:
+    """Coerce an impedance to one complex value per analysis frequency.
+
+    A scalar is held constant over the grid; anything else must already be
+    the ``(n_freq,)`` per-frequency array.
+    """
+    z = np.asarray(impedance, dtype=np.complex128)
+    if z.ndim == 0:
+        return np.full(n_freq, z, dtype=np.complex128)
+    if z.shape != (n_freq,):
+        msg = (
+            f"'{name}' must be a scalar or hold one value per "
+            f"analysis frequency ({n_freq} values); got shape {z.shape}."
+        )
+        raise ValueError(msg)
+    return z
 
 
 def duct_matrix(
@@ -247,16 +268,28 @@ def cascade(*matrices: _Complex) -> _Complex:
 
     :param matrices: One or more ``(n_freq, 2, 2)`` arrays sharing ``n_freq``.
     :return: The compound ``(n_freq, 2, 2)`` array.
+    :raises ValueError: If a matrix is not a ``(n_freq, 2, 2)`` array or the
+        matrices disagree on ``n_freq``.
     """
     if not matrices:
         msg = "cascade() needs at least one matrix."
         raise ValueError(msg)
-    n = matrices[0].shape[0]
-    if any(m.shape[0] != n for m in matrices[1:]):
+    arrays: list[_Complex] = []
+    for i, matrix in enumerate(matrices):
+        arr = np.asarray(matrix, dtype=np.complex128)
+        if arr.ndim != _FOUR_POLE_NDIM or arr.shape[1:] != (2, 2):
+            msg = (
+                f"'matrices'[{i}] must be a (n_freq, 2, 2) four-pole array; "
+                f"got shape {arr.shape}."
+            )
+            raise ValueError(msg)
+        arrays.append(arr)
+    n = arrays[0].shape[0]
+    if any(m.shape[0] != n for m in arrays[1:]):
         msg = "cascade() matrices must share the same frequency grid (n_freq)."
         raise ValueError(msg)
-    total = matrices[0]
-    for m in matrices[1:]:
+    total = arrays[0]
+    for m in arrays[1:]:
         total = np.matmul(total, m)
     return total
 
@@ -331,10 +364,12 @@ def insertion_loss(
     :param radiation_impedance: Termination/radiation acoustic impedance
         ``Z_r``, Pa s/m3 (scalar or per-frequency).
     :return: The insertion loss per frequency, dB.
+    :raises ValueError: If an impedance is neither a scalar nor one value per
+        analysis frequency.
     """
     n = transfer_matrix.shape[0]
-    zs = np.broadcast_to(np.asarray(source_impedance, dtype=np.complex128), (n,))
-    zr = np.broadcast_to(np.asarray(radiation_impedance, dtype=np.complex128), (n,))
+    zs = _per_frequency(source_impedance, "source_impedance", n)
+    zr = _per_frequency(radiation_impedance, "radiation_impedance", n)
     t11 = transfer_matrix[:, 0, 0]
     t12 = transfer_matrix[:, 0, 1]
     t21 = transfer_matrix[:, 1, 0]
@@ -1107,16 +1142,9 @@ class SilencerChain:
         :raises ValueError: If ``branch_impedance`` is neither a scalar nor one
             value per analysis frequency.
         """
-        zb = np.asarray(branch_impedance, dtype=np.complex128)
-        if zb.ndim == 0:
-            zb = np.full(self._frequencies.size, zb, dtype=np.complex128)
-        if zb.shape != self._frequencies.shape:
-            msg = (
-                "'branch_impedance' must be a scalar or hold one value per "
-                f"analysis frequency ({self._frequencies.size} values); got "
-                f"shape {zb.shape}."
-            )
-            raise ValueError(msg)
+        zb = _per_frequency(
+            branch_impedance, "branch_impedance", self._frequencies.size
+        )
         self._elements.append(
             SilencerChainElement(
                 matrix=shunt_matrix(zb),

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -744,13 +744,15 @@ def loudness_ecma(
     if x.size == 0:
         msg = "signal must not be empty"
         raise ValueError(msg)
+    if not np.all(np.isfinite(x)):
+        msg = "'signal_in' must be finite."
+        raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:
         msg = "fs must be positive"
         raise ValueError(msg)
     if fs != _FS:
-        n_target = round(x.size * _FS / fs)
-        x = signal.resample(x, n_target)
+        x = signal.resample(x, max(1, round(x.size * _FS / fs)))
 
     n_tonal, n_noise, _, _, n_samples = _tonal_noise_split(x, field)
     n_single, n_spec, n_time, time = _assemble_loudness(n_tonal, n_noise, n_samples)

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -635,7 +635,7 @@ def roughness_ecma(
         msg = "fs must be positive"
         raise ValueError(msg)
     if fs != _FS:
-        x = signal.resample(x, round(x.size * _FS / fs))
+        x = signal.resample(x, max(1, round(x.size * _FS / fs)))
 
     envelopes, basis, block_times, _ = _front_end(x, field)
     spectra = _noise_reduced_spectra(envelopes, basis)

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -630,6 +630,9 @@ def roughness_ecma(
     if x.size == 0:
         msg = "signal must not be empty"
         raise ValueError(msg)
+    if not np.all(np.isfinite(x)):
+        msg = "'signal_in' must be finite."
+        raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:
         msg = "fs must be positive"

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -190,10 +190,10 @@ def _band_range(f_low: float | None, f_high: float | None) -> tuple[int, int]:
     Enforces the Formulae 56/57 preconditions: 16 Hz < f_L, f_H < 20 kHz and
     f_L < f_H.
     """
-    if f_low is not None and f_low <= _F_LOW_MIN_HZ:
+    if f_low is not None and (not math.isfinite(f_low) or f_low <= _F_LOW_MIN_HZ):
         msg = "'f_low' must exceed 16 Hz (Formula 56)."
         raise ValueError(msg)
-    if f_high is not None and f_high >= _F_HIGH_MAX_HZ:
+    if f_high is not None and (not math.isfinite(f_high) or f_high >= _F_HIGH_MAX_HZ):
         msg = "'f_high' must be below 20 kHz (Formula 57)."
         raise ValueError(msg)
     if f_low is not None and f_high is not None and f_low >= f_high:

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -819,6 +819,12 @@ def combined_tone_level(
     if fts.size == 0:
         msg = "At least one tone is required."
         raise ValueError(msg)
+    if not (np.all(np.isfinite(fts)) and np.all(fts > 0.0)):
+        msg = "'tone_frequencies' must be positive and finite."
+        raise ValueError(msg)
+    if not np.all(np.isfinite(lss)):
+        msg = "'mean_narrowband_levels' must be finite."
+        raise ValueError(msg)
     marked: set[int] = set()
     for ft, ls in zip(fts, lss, strict=True):
         peak = int(np.argmin(np.abs(freq - ft)))

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -44,7 +44,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from .._internal.utils import _typesignal
-from .._internal.validation import check_engine, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_finite_array,
+    require_ranks,
+    require_same_length,
+)
 from ..filters.core import OctaveFilterBank
 from ..io._resolve import apply_calibration, resolve_fs
 
@@ -588,6 +593,9 @@ def decay_curve(
         if band <= 0.0:
             msg = "Band centre frequency 'band' must be positive."
             raise ValueError(msg)
+        if fraction <= 0:
+            msg = "Bandwidth 'fraction' must be positive."
+            raise ValueError(msg)
         half_width = 2.0 ** (1.0 / (4.0 * fraction))
         bank = OctaveFilterBank(
             fs=fs,
@@ -602,6 +610,12 @@ def decay_curve(
             calculate_level=False,
             zero_phase=zero_phase,
         )
+        if len(freqs) == 0:
+            msg = (
+                f"'band' ({band:g} Hz) has no filter at fs={fs} Hz; "
+                "its upper edge exceeds the Nyquist frequency."
+            )
+            raise ValueError(msg)
         idx = int(np.argmin(np.abs(np.asarray(freqs, dtype=np.float64) - band)))
         # np.asarray, not a cast: a bank on the default calibration hands
         # back Signals, and the squaring below is array arithmetic.
@@ -678,6 +692,7 @@ def room_parameters(
         if len(limits) != 2:  # noqa: PLR2004
             msg = "'limits' must be a (f_min, f_max) pair or None."
             raise ValueError(msg)
+        require_finite_array(limits, "limits")
         bank = OctaveFilterBank(
             fs=fs, fraction=fraction, order=6, limits=[limits[0], limits[1]]
         )
@@ -691,6 +706,12 @@ def room_parameters(
         # np.asarray, not a cast: a bank on the default calibration hands
         # back Signals, and what follows is array arithmetic.
         band_signals = [np.asarray(band) for band in bands]
+        if not band_signals:
+            msg = (
+                f"'limits' {limits} leaves no band below the Nyquist "
+                f"frequency at fs={fs} Hz."
+            )
+            raise ValueError(msg)
         frequency = np.asarray(freqs, dtype=np.float64)
 
     values = np.array([_band_parameters(sig, fs) for sig in band_signals])

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -593,7 +593,7 @@ def decay_curve(
         if band <= 0.0:
             msg = "Band centre frequency 'band' must be positive."
             raise ValueError(msg)
-        if fraction <= 0:
+        if not np.isfinite(fraction) or fraction <= 0:
             msg = "Bandwidth 'fraction' must be positive."
             raise ValueError(msg)
         half_width = 2.0 ** (1.0 / (4.0 * fraction))

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -417,11 +417,17 @@ def _resolve_band_maps(
     ``m_bands`` broadcast to ``n_bands`` bands (``banded`` False for a single
     broadband curve).
 
-    :raises ValueError: for a non-finite/negative air attenuation, or an
-        ``absorption`` / ``air_attenuation`` band count that neither is 1 nor
-        matches the resolved band count.
+    :raises ValueError: for a non-finite/negative or multi-dimensional air
+        attenuation, or an ``absorption`` / ``air_attenuation`` band count
+        that neither is 1 nor matches the resolved band count.
     """
     m = np.asarray(air_attenuation, dtype=np.float64)
+    if m.ndim > 1:
+        msg = (
+            "'air_attenuation' must be a scalar or a 1-D per-band vector; "
+            f"got shape {m.shape}."
+        )
+        raise ValueError(msg)
     if not np.all(np.isfinite(m)) or np.any(m < 0.0):
         msg = "'air_attenuation' must be finite and non-negative."
         raise ValueError(msg)
@@ -606,21 +612,27 @@ def image_source_rir(
         per-band result. When given, its length must match the band count of
         ``absorption`` (or broadcast against it).
     :return: An :class:`ImageSourceResult`.
-    :raises ValueError: for a non-positive dimension/sample-rate, a
-        source/receiver outside the room, an absorption outside ``[0, 1]`` or
-        of an unsupported shape, a negative ``air_attenuation``, or a
-        ``frequencies`` length that does not match the band count.
+    :raises ValueError: for a ``dimensions`` that is not three positive
+        lengths, a non-positive sample rate, a non-integer or negative
+        ``max_order``, a source/receiver outside the room, an absorption
+        outside ``[0, 1]`` or of an unsupported shape, a negative
+        ``air_attenuation``, or a ``frequencies`` length that does not match
+        the band count.
     """
-    lx = require_positive(float(dimensions[0]), "Lx")
-    ly = require_positive(float(dimensions[1]), "Ly")
-    lz = require_positive(float(dimensions[2]), "Lz")
+    d = np.asarray(dimensions, dtype=np.float64)
+    if d.shape != (3,):
+        msg = "'dimensions' must be a 3-vector (Lx, Ly, Lz)."
+        raise ValueError(msg)
+    lx = require_positive(float(d[0]), "Lx")
+    ly = require_positive(float(d[1]), "Ly")
+    lz = require_positive(float(d[2]), "Lz")
     dims = (lx, ly, lz)
     if fs <= 0:
         msg = "Sample rate 'fs' must be positive."
         raise ValueError(msg)
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
-    if max_order < 0:
-        msg = "'max_order' must be non-negative."
+    if not isinstance(max_order, (int, np.integer)) or max_order < 0:
+        msg = "'max_order' must be a non-negative integer."
         raise ValueError(msg)
     src = _validate_point(source, dims, "source")
     rcv = _validate_point(receiver, dims, "receiver")
@@ -636,6 +648,15 @@ def image_source_rir(
     n_freq: int | None = None
     if frequencies is not None:
         freq = np.asarray(frequencies, dtype=np.float64)
+        if freq.ndim > 1 or freq.size == 0:
+            msg = (
+                "'frequencies' must be a scalar or a non-empty 1-D band "
+                f"vector; got shape {freq.shape}."
+            )
+            raise ValueError(msg)
+        if not np.all(np.isfinite(freq)) or np.any(freq <= 0.0):
+            msg = "'frequencies' must be finite and strictly positive."
+            raise ValueError(msg)
         n_freq = freq.size
     reflection, n_alpha_bands = _resolve_walls(absorption, n_freq)
     reflection, m_bands, n_bands, banded = _resolve_band_maps(
@@ -681,11 +702,11 @@ def audible_image_count(max_order: int) -> int:
     audible (no visibility test needed), so this is exactly the number of
     impulses :func:`image_source_rir` sums at that order.
 
-    :param max_order: Reflection-order cut-off ``i0`` (non-negative).
+    :param max_order: Reflection-order cut-off ``i0`` (non-negative integer).
     :return: The audible image count.
     """
-    if max_order < 0:
-        msg = "'max_order' must be non-negative."
+    if not isinstance(max_order, (int, np.integer)) or max_order < 0:
+        msg = "'max_order' must be a non-negative integer."
         raise ValueError(msg)
     i0 = int(max_order)
     return (2 * (2 * i0**3 + 3 * i0**2 + 4 * i0)) // 3

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -48,6 +48,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from .._internal.validation import (
     require_equal_counts,
+    require_positive,
     require_ranks,
     require_same_length,
 )
@@ -260,6 +261,17 @@ class PlaneWaveSource:
     offset: int = 0
     amplitude: float = 1.0
 
+    def __post_init__(self) -> None:
+        """Require a callable ``waveform`` and a finite ``amplitude``.
+
+        ``direction`` and ``offset`` are checked against the grid in
+        :meth:`FDTD2D.add_source`, which is the first place a grid exists.
+        """
+        if not callable(self.waveform):
+            msg = "waveform must be callable"
+            raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        _finite("amplitude", self.amplitude)
+
 
 Source = GaussianPulse | CWSource | SignalSource
 
@@ -410,9 +422,21 @@ def _validated_obstacle(
 
 def _resolve_c_map(c: float | Field2D, shape: tuple[int, int] | None) -> Field2D:
     """Broadcast/validate the sound-speed spec into a positive 2D map."""
+    if np.iscomplexobj(c):
+        msg = "c must be real; a complex sound speed is not supported"
+        raise ValueError(msg)
     if np.isscalar(c):
         if shape is None:
             msg = "shape is required when c is a scalar"
+            raise ValueError(msg)
+        valid = isinstance(shape, (tuple, list)) and len(shape) == 2  # noqa: PLR2004
+        if valid:
+            valid = all(
+                not isinstance(n, bool) and isinstance(n, (int, np.integer)) and n >= 1
+                for n in shape
+            )
+        if not valid:
+            msg = f"shape must be a pair of positive integers (ny, nx); got {shape!r}"
             raise ValueError(msg)
         c_map = np.full(shape, float(np.real(c)), dtype=np.float64)
     else:
@@ -426,6 +450,9 @@ def _resolve_c_map(c: float | Field2D, shape: tuple[int, int] | None) -> Field2D
 
 def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
     """Broadcast/validate the density spec into a positive ``(ny, nx)`` map."""
+    if np.iscomplexobj(rho):
+        msg = "rho must be real; a complex density is not supported"
+        raise ValueError(msg)
     rho_map = (
         np.full((ny, nx), float(np.real(rho)), dtype=np.float64)
         if np.isscalar(rho)
@@ -929,18 +956,18 @@ class FDTD2D:
         :param amplitude: Peak pressure of the envelope, in pascals.
         :param wavelength: Optional carrier wavelength, in metres; ``None``
             gives the pure Gaussian pulse.
-        :raises ValueError: For an unknown direction or non-positive
-            ``width``/``wavelength``.
+        :raises ValueError: For an unknown direction, a non-positive or
+            non-finite ``width``/``wavelength``, or a non-finite
+            ``center``/``amplitude``.
         """
         if direction not in _SIDE_TRAVEL:
             msg = "'direction' must be 'down', 'up', 'left' or 'right'."
             raise ValueError(msg)
-        if width <= 0.0:
-            msg = "'width' must be positive."
-            raise ValueError(msg)
-        if wavelength is not None and wavelength <= 0.0:
-            msg = "'wavelength' must be positive."
-            raise ValueError(msg)
+        width = require_positive(width, "width")
+        if wavelength is not None:
+            wavelength = require_positive(wavelength, "wavelength")
+        center = _finite("center", center)
+        amplitude = _finite("amplitude", amplitude)
 
         def profile(coord: NDArray[np.floating]) -> NDArray[np.float64]:
             envelope = amplitude * np.exp(-(((coord - center) / width) ** 2))
@@ -1362,7 +1389,12 @@ def _probe_indices(
     """Validate the probe cells into an ``(n_probes, 2)`` index array."""
     ny, nx = shape
     probe_ix = np.zeros((len(probes), 2), dtype=np.int_)
-    for k, (ix, iy) in enumerate(probes):
+    for k, entry in enumerate(probes):
+        try:
+            ix, iy = entry
+        except (TypeError, ValueError):
+            msg = f"probes must hold (ix, iy) index pairs; entry {k} is {entry!r}"
+            raise ValueError(msg) from None
         ix = _integer("probe ix", ix)
         iy = _integer("probe iy", iy)
         if not (0 <= ix < nx and 0 <= iy < ny):

--- a/src/phonometry/underwater/acoustics.py
+++ b/src/phonometry/underwater/acoustics.py
@@ -55,6 +55,20 @@ def _positive(value: float, name: str) -> float:
     return scalar
 
 
+def _finite(value: float, name: str) -> float:
+    msg = f"'{name}' must be a finite number."
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError):
+        # A per-band array (or anything else float() cannot take) would
+        # otherwise escape as numpy's or the built-in's TypeError, which
+        # names neither the parameter nor this function.
+        raise ValueError(msg) from None
+    if not np.isfinite(scalar):
+        raise ValueError(msg)
+    return scalar
+
+
 def _validate_pressure(
     pressure: SignalInput, *, min_samples: int = 1
 ) -> NDArray[np.float64]:
@@ -172,8 +186,9 @@ def underwater_to_in_air_spl(level: float) -> float:
 
     :param level: Level in dB re 1 µPa.
     :return: The same pressure expressed in dB re 20 µPa.
+    :raises ValueError: If the level is not a finite number.
     """
-    return float(float(level) - _REFERENCE_OFFSET_DB)
+    return float(_finite(level, "level") - _REFERENCE_OFFSET_DB)
 
 
 def in_air_to_underwater_spl(level: float) -> float:
@@ -185,5 +200,6 @@ def in_air_to_underwater_spl(level: float) -> float:
 
     :param level: Level in dB re 20 µPa.
     :return: The same pressure expressed in dB re 1 µPa.
+    :raises ValueError: If the level is not a finite number.
     """
-    return float(float(level) + _REFERENCE_OFFSET_DB)
+    return float(_finite(level, "level") + _REFERENCE_OFFSET_DB)

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -261,10 +261,19 @@ def strike_sel_spectrum(
     fs = resolve_fs(pressure, fs, name="pressure")
     sig = _validate_pressure(pressure, min_samples=2)
     fs_v = _positive(fs, "fs")
-    if int(fraction) not in (1, 3):
+    # The value the caller passed, not its truncation: int() would silently
+    # turn 3.9 into one-third octaves and 1.4 into octaves.
+    if fraction not in (1, 3):
         msg = "'fraction' must be 1 (octave) or 3 (one-third octave)."
         raise ValueError(msg)
-    lo, hi = (float(limits[0]), float(limits[1]))
+    # Unpacking rejects the short, the over-long and the non-iterable in one
+    # move, where indexing would escape as an IndexError or TypeError that
+    # names nothing and a third element would be silently ignored.
+    try:
+        lo, hi = (float(v) for v in limits)
+    except (TypeError, ValueError):
+        msg = "'limits' must be a (lower, upper) pair of frequencies in Hz."
+        raise ValueError(msg) from None
     if not (np.isfinite(lo) and np.isfinite(hi)) or not (0.0 < lo < hi):
         msg = "'limits' must be a finite, increasing, positive pair."
         raise ValueError(msg)

--- a/src/phonometry/underwater/sources/ship_radiated_noise.py
+++ b/src/phonometry/underwater/sources/ship_radiated_noise.py
@@ -30,6 +30,8 @@ import numpy as np
 
 from ..._internal.validation import (
     require_equal_shapes,
+    require_finite_array,
+    require_positive_array,
     require_ranks,
     require_same_length,
 )
@@ -94,14 +96,12 @@ def hydrophone_depths(
     :raises ValueError: If the distance or any angle is out of range.
     """
     cpa = _positive(cpa_distance, "cpa_distance")
-    ang = np.asarray(angles, dtype=np.float64)
-    if (
-        ang.size == 0
-        or not np.all(np.isfinite(ang))
-        or np.any(ang <= 0.0)
-        or np.any(ang >= _VERTICAL_DEG)
-    ):
-        msg = "'angles' must be finite and lie in the open interval (0, 90) degrees."
+    # The shared guard also pins the shape: a nested pair of pairs used to
+    # come back as a 2-D "depths" array, and a bare scalar as a 0-d one whose
+    # documented per-hydrophone read depths[0] died in numpy.
+    ang = require_positive_array(angles, "angles")
+    if np.any(ang >= _VERTICAL_DEG):
+        msg = "'angles' must be below 90 degrees."
         raise ValueError(msg)
     return np.asarray(cpa * np.tan(np.radians(ang)), dtype=np.float64)
 
@@ -238,14 +238,11 @@ def monopole_source_level(
     """
     d = _positive(draught, "draught")
     speed = _positive(c, "c")
-    freqs = np.atleast_1d(np.asarray(frequency, dtype=np.float64))
-    rnl_arr = np.atleast_1d(np.asarray(rnl, dtype=np.float64))
-    if np.any(freqs <= 0.0) or not np.all(np.isfinite(freqs)):
-        msg = "'frequency' must be positive and finite."
-        raise ValueError(msg)
-    if not np.all(np.isfinite(rnl_arr)):
-        msg = "'rnl' must be finite."
-        raise ValueError(msg)
+    # The shared guards also reject the empty array, which used to pass the
+    # sign and finiteness predicates vacuously and come back as a zero-band
+    # result whose .plot() died in a numpy reduction naming no argument.
+    freqs = require_positive_array(frequency, "frequency")
+    rnl_arr = require_finite_array(rnl, "rnl")
     if rnl_arr.size == 1 and freqs.size > 1:
         rnl_arr = np.full(freqs.shape, rnl_arr[0])
     require_equal_shapes(

--- a/src/phonometry/vibration/structural/junction_transmission.py
+++ b/src/phonometry/vibration/structural/junction_transmission.py
@@ -458,7 +458,8 @@ def coupling_loss_factor(
     :param frequency: Frequency ``f``, in hertz (scalar or array, > 0).
     :param plate_area: Source-plate area ``S_i``, in m^2 (> 0).
     :return: The coupling loss factor ``eta_ij`` (broadcast of the inputs).
-    :raises ValueError: for a non-positive input.
+    :raises ValueError: for a non-positive input, or a coefficient and a
+        frequency whose shapes cannot be broadcast together.
     """
     tau = np.asarray(transmission_coefficient, dtype=np.float64)
     if np.any(tau < 0.0):
@@ -471,6 +472,17 @@ def coupling_loss_factor(
         msg = "'frequency' must be positive."
         raise ValueError(msg)
     area = require_positive(plate_area, "plate_area")
+    # Reconcile the two array arguments before the arithmetic: numpy's bare
+    # "operands could not be broadcast together" reports the shapes but not
+    # which argument carried which.
+    try:
+        np.broadcast_shapes(tau.shape, freq.shape)
+    except ValueError:
+        msg = (
+            "'transmission_coefficient' and 'frequency' must be broadcastable; "
+            f"got shapes {tau.shape} and {freq.shape}."
+        )
+        raise ValueError(msg) from None
     eta = cg * lij * tau / (2.0 * math.pi**2 * freq * area)
     return np.asarray(eta, dtype=np.float64)
 

--- a/tests/aircraft/test_aircraft_noise_system.py
+++ b/tests/aircraft/test_aircraft_noise_system.py
@@ -63,6 +63,10 @@ def test_out_of_range_angle_raises() -> None:
         aircraft.verify_aircraft_noise_system(directional={4000.0: {0.0: 0.5}})
     with pytest.raises(ValueError, match="'angle' must lie in"):
         aircraft.verify_aircraft_noise_system(directional={4000.0: {160.0: 0.5}})
+    # NaN is on neither side of the range test; the guard must still catch it
+    # (a bare next() would otherwise surface it as StopIteration).
+    with pytest.raises(ValueError, match="'angle' must lie in"):
+        aircraft.verify_aircraft_noise_system(directional={4000.0: {float("nan"): 0.5}})
 
 
 def test_linearity_rejects_unknown_key() -> None:

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -191,6 +191,30 @@ def test_tone_correction_none_when_flat() -> None:
     assert tone_correction(np.full(24, 60.0)) == 0.0
 
 
+def test_tone_correction_start_band_must_be_an_integral_index() -> None:
+    """A non-integral or out-of-range start band is refused by name.
+
+    An integral float carries the same band index and is taken; 2.9 must not
+    be silently truncated to band 2, and a value int() cannot digest must not
+    surface as the builtin's own error.
+    """
+    spl = np.full(24, 70.0)
+    with pytest.raises(ValueError, match="'start_band' must be an integer"):
+        tone_correction(spl, start_band=2.9)
+    with pytest.raises(ValueError, match="'start_band' must be an integer"):
+        tone_correction(spl, start_band=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'start_band' must be an integer"):
+        tone_correction(spl, start_band="aeroplane")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'start_band' must be an integer"):
+        tone_correction(spl, start_band=-0.4)
+    with pytest.raises(ValueError, match="'start_band' must be an integer"):
+        tone_correction(spl, start_band=4)
+    assert tone_correction(spl, start_band=2.0) == tone_correction(spl, start_band=2)
+    assert tone_correction(spl, start_band=np.int64(0)) == tone_correction(
+        spl, start_band=0
+    )
+
+
 def test_epnl_table_44() -> None:
     # ETM Vol. I Table 4-4: integrated-method reference EPNL = 92.61892 EPNdB,
     # PNLTM = 97.40, window records 4-28 (0-based 3-27).

--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -545,8 +545,15 @@ def test_unknown_quantity() -> None:
 
 
 def test_unknown_measurand() -> None:
-    with pytest.raises(ValueError, match="Unknown measurand"):
+    with pytest.raises(ValueError, match="'measurand' must be one of"):
         band_uncertainty("magic", "A")  # type: ignore[arg-type]
+
+
+def test_unknown_measurand_with_upper_limit() -> None:
+    # The upper-limit branch used to misreport an unknown measurand as a
+    # real one that merely lacks a σR95 table.
+    with pytest.raises(ValueError, match="'measurand' must be one of"):
+        band_uncertainty("magic", "A", upper_limit=True)  # type: ignore[arg-type]
 
 
 def test_unknown_situation_single_number() -> None:
@@ -566,6 +573,18 @@ def test_band_uncertainty_to_arrays_roundtrip() -> None:
 def test_prediction_input_rejects_bad_n() -> None:
     with pytest.raises(ValueError, match="n must be a positive integer"):
         prediction_input_uncertainty(1.2, 1.0, 0)
+
+
+def test_prediction_input_rejects_fractional_n() -> None:
+    # A fractional n used to sail past the `n < 1` range check and be
+    # divided by, returning a wrong number without an error.
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        prediction_input_uncertainty(1.2, 1.0, 2.5)  # type: ignore[arg-type]
+
+
+def test_prediction_input_rejects_nan_n() -> None:
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        prediction_input_uncertainty(1.2, 1.0, float("nan"))  # type: ignore[arg-type]
 
 
 def test_the_bare_names_are_gone() -> None:

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -341,6 +341,37 @@ def test_power_level_rejects_nonpositive_loss_factor() -> None:
         building.structure_borne_power_level(80.0, 1000.0, 10.0, 1.0, [0.01, -0.01])
 
 
+def test_power_level_rejects_non_finite_frequency_and_velocity() -> None:
+    """A NaN slips past a sign check; Formula (14) refuses it by name."""
+    with pytest.raises(
+        ValueError, match="'frequency' must contain positive, finite values"
+    ):
+        building.structure_borne_power_level(80.0, float("nan"), 10.0, 1.0, 0.01)
+    with pytest.raises(
+        ValueError, match="'frequency' must contain positive, finite values"
+    ):
+        building.structure_borne_power_level(80.0, float("inf"), 10.0, 1.0, 0.01)
+    with pytest.raises(
+        ValueError, match="'velocity_level' must contain only finite values"
+    ):
+        building.structure_borne_power_level(
+            [80.0, float("nan")], [500.0, 1000.0], 10.0, 1.0, 0.01
+        )
+
+
+def test_force_and_velocity_levels_reject_non_finite_power_level() -> None:
+    """Formulae (15) and (18) refuse a NaN or infinite power level by name."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(
+            ValueError, match="'power_level' must contain only finite values"
+        ):
+            building.equivalent_blocked_force_level([80.0, bad], [1e-6, 2e-6])
+        with pytest.raises(
+            ValueError, match="'power_level' must contain only finite values"
+        ):
+            building.equivalent_free_velocity_level([80.0, bad], [1e-6, 2e-6])
+
+
 def test_spatial_mean_rejects_empty_nan_and_2d_input() -> None:
     """Formula 12 refuses input its energy mean cannot honestly average."""
     with pytest.raises(ValueError, match="'levels' must be a non-empty 1-D array"):

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -339,3 +339,56 @@ def test_power_level_rejects_nonpositive_loss_factor() -> None:
         building.structure_borne_power_level(80.0, 1000.0, 10.0, 1.0, 0.0)
     with pytest.raises(ValueError, match="loss_factor"):
         building.structure_borne_power_level(80.0, 1000.0, 10.0, 1.0, [0.01, -0.01])
+
+
+def test_spatial_mean_rejects_empty_nan_and_2d_input() -> None:
+    """Formula 12 refuses input its energy mean cannot honestly average."""
+    with pytest.raises(ValueError, match="'levels' must be a non-empty 1-D array"):
+        building.spatial_mean_velocity_level([])
+    with pytest.raises(ValueError, match="'levels' must contain only finite values"):
+        building.spatial_mean_velocity_level([80.0, float("nan")])
+    with pytest.raises(ValueError, match="'levels' must be a non-empty 1-D array"):
+        building.spatial_mean_velocity_level([[80.0, 82.0], [79.0, 81.0]])
+    # The ISO 9611 mean delegates and refuses the same way.
+    with pytest.raises(ValueError, match="'levels' must be a non-empty 1-D array"):
+        building.mean_free_velocity_level(np.empty(0))
+
+
+def test_power_level_rejects_mismatched_band_axes() -> None:
+    """A velocity level of the wrong band count is refused by name."""
+    with pytest.raises(
+        ValueError,
+        match="'velocity_level', 'frequency' and 'loss_factor' must broadcast",
+    ):
+        building.structure_borne_power_level(
+            [80.0, 82.0], [500.0, 1000.0, 2000.0], 10.0, 1.0, 0.01
+        )
+
+
+def test_force_and_velocity_levels_reject_mismatched_shapes() -> None:
+    """Formulae (15) and (18) name the pair a shape mismatch sits in."""
+    with pytest.raises(
+        ValueError, match="'power_level' and 'plate_mobility' must broadcast"
+    ):
+        building.equivalent_blocked_force_level([80.0, 82.0, 79.0], [1e-6, 2e-6])
+    with pytest.raises(
+        ValueError, match="'power_level' and 'plate_mobility' must broadcast"
+    ):
+        building.equivalent_free_velocity_level([80.0, 82.0, 79.0], [1e-6, 2e-6])
+
+
+def test_source_mobility_rejects_mismatch_and_nan() -> None:
+    """Formula (19) refuses a shape mismatch or a NaN level by name."""
+    with pytest.raises(
+        ValueError,
+        match="'free_velocity_level' and 'blocked_force_level' must broadcast",
+    ):
+        building.source_mobility_from_levels([80.0, 82.0, 79.0], [40.0, 41.0])
+    with pytest.raises(
+        ValueError, match="'free_velocity_level' must contain only finite values"
+    ):
+        building.source_mobility_from_levels([float("nan")], [40.0])
+    with pytest.raises(
+        ValueError, match="'blocked_force_level' must contain only finite values"
+    ):
+        building.source_mobility_from_levels([80.0], [float("nan")])

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -71,6 +71,31 @@ def test_harmonic_distortion_rejects_order_below_two() -> None:
         electroacoustics.harmonic_distortion(tone, FS, fundamental=1000.0, order=1)
 
 
+def test_harmonic_distortion_rejects_fractional_order() -> None:
+    # A fractional order used to sail past the range check and die inside
+    # numpy's indexing without naming the parameter.
+    x = _harmonic_signal()
+    with pytest.raises(ValueError, match="'order' must be an integer"):
+        electroacoustics.harmonic_distortion(x, FS, fundamental=1000.0, order=2.5)  # type: ignore[arg-type]
+
+
+def test_harmonic_distortion_rejects_non_numeric_order() -> None:
+    x = _harmonic_signal()
+    with pytest.raises(ValueError, match="'order' must be an integer"):
+        electroacoustics.harmonic_distortion(x, FS, fundamental=1000.0, order="2")  # type: ignore[arg-type]
+
+
+def test_harmonic_distortion_accepts_integral_float_order() -> None:
+    # 2.0 IS the integer 2 to a caller who divided to get it.
+    x = _harmonic_signal()
+    assert electroacoustics.harmonic_distortion(
+        x,
+        FS,
+        fundamental=1000.0,
+        order=2.0,  # type: ignore[arg-type]
+    ) == pytest.approx(ref.DISTORTION_D2, rel=1e-6)
+
+
 def test_thd_plus_noise_recovers_noise_floor() -> None:
     # Fundamental (RMS 1/sqrt2) + white noise of RMS 0.01; the notch removes
     # the fundamental, so THD+N ~ in-band noise_rms / total_rms with the
@@ -180,6 +205,22 @@ def test_modulation_distortion_iec_per_order() -> None:
     assert res.smpte == pytest.approx(smpte, rel=1e-6)
 
 
+def test_modulation_distortion_rejects_swapped_tones() -> None:
+    # A swapped pair used to return a near-zero d2/d3 (a false "no
+    # distortion" pass): the lower sideband went negative and read 0, the
+    # upper fell where nothing is.
+    tone = _tone(1000.0)
+    with pytest.raises(ValueError, match="'f_low' must be lower than 'f_high'"):
+        electroacoustics.modulation_distortion(tone, FS, f_low=8000.0, f_high=250.0)
+
+
+def test_modulation_distortion_rejects_equal_tones() -> None:
+    # Equal tones used to relabel the second-harmonic ratio as d_m,2.
+    tone = _tone(1000.0)
+    with pytest.raises(ValueError, match="'f_low' must be lower than 'f_high'"):
+        electroacoustics.modulation_distortion(tone, FS, f_low=1000.0, f_high=1000.0)
+
+
 def test_modulation_distortion_carries_sideband_spectrum() -> None:
     # The result carries the measured carrier and sideband amplitudes (the
     # data behind .plot()), in ascending frequency order:
@@ -245,6 +286,21 @@ def test_modulation_distortion_plot_marks_carrier_and_sidebands() -> None:
     bare = electroacoustics.ModulationDistortionResult(d2=0.1, d3=0.05, smpte=0.08)
     with pytest.raises(ValueError, match="no sideband spectrum"):
         bare.plot()
+    plt.close("all")
+    # Nor one whose sideband arrays are not the four annotated products (the
+    # per-order labels index fixed positions, which used to be an IndexError).
+    short = electroacoustics.ModulationDistortionResult(
+        d2=0.1,
+        d3=0.05,
+        smpte=0.08,
+        f_low=fl,
+        f_high=fh,
+        carrier_amplitude=1.0,
+        sideband_frequencies=np.array([fh - fl, fh + fl]),
+        sideband_amplitudes=np.array([0.01, 0.01]),
+    )
+    with pytest.raises(ValueError, match="must each carry the four products"):
+        short.plot()
     plt.close("all")
 
 
@@ -369,6 +425,16 @@ def test_dynamic_intermodulation_distortion() -> None:
     assert electroacoustics.dynamic_intermodulation_distortion(x, FS) == pytest.approx(
         expected, rel=1e-6
     )
+
+
+def test_dynamic_intermodulation_rejects_swapped_frequencies() -> None:
+    # A swapped pair leaves the Table 2 product set empty and used to return
+    # a perfect 0.0 for an argument pair the metric is undefined on.
+    x = _tone(15000.0) + _tone(3150.0, 0.8)
+    with pytest.raises(ValueError, match="'f_square' must be lower than 'f_sine'"):
+        electroacoustics.dynamic_intermodulation_distortion(
+            x, FS, f_sine=3150.0, f_square=15000.0
+        )
 
 
 def test_harmonic_analysis_bundle_and_plot() -> None:

--- a/tests/electroacoustics/test_frequency_response.py
+++ b/tests/electroacoustics/test_frequency_response.py
@@ -164,6 +164,22 @@ def test_rejects_non_finite_nperseg() -> None:
         electroacoustics.transfer_function(x, x, FS, nperseg=float("inf"))  # type: ignore[arg-type]
 
 
+def test_rejects_nperseg_beyond_float_range() -> None:
+    # Used to escape as OverflowError out of math.isfinite(); an integer is
+    # finite by construction, so it reaches the range check and its name.
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'nperseg' must be between 32"):
+        electroacoustics.transfer_function(x, x, FS, nperseg=10**10000)
+
+
+def test_rejects_overlap_beyond_float_range() -> None:
+    # Used to escape as OverflowError out of float(); the exact int/float
+    # comparison refuses it by name instead.
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match=r"'overlap' must be in \[0, 1\)"):
+        electroacoustics.transfer_function(x, x, FS, overlap=10**10000)
+
+
 def test_coherence_rejects_fractional_nperseg() -> None:
     x = np.zeros(1000)
     with pytest.raises(ValueError, match="'nperseg' must be a positive integer"):

--- a/tests/electroacoustics/test_frequency_response.py
+++ b/tests/electroacoustics/test_frequency_response.py
@@ -150,6 +150,46 @@ def test_rejects_bad_nperseg() -> None:
         electroacoustics.transfer_function(x, x, FS, nperseg=5000)
 
 
+def test_rejects_fractional_nperseg() -> None:
+    # int() used to truncate 64.7 to 64 silently instead of refusing.
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'nperseg' must be a positive integer"):
+        electroacoustics.transfer_function(x, x, FS, nperseg=64.7)  # type: ignore[arg-type]
+
+
+def test_rejects_non_finite_nperseg() -> None:
+    # Used to escape as OverflowError out of int().
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'nperseg' must be a positive integer"):
+        electroacoustics.transfer_function(x, x, FS, nperseg=float("inf"))  # type: ignore[arg-type]
+
+
+def test_coherence_rejects_fractional_nperseg() -> None:
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'nperseg' must be a positive integer"):
+        electroacoustics.coherence(x, x, FS, nperseg=64.7)  # type: ignore[arg-type]
+
+
+def test_rejects_non_numeric_overlap() -> None:
+    # Used to die as TypeError inside float().
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match=r"'overlap' must be in \[0, 1\)"):
+        electroacoustics.transfer_function(x, x, FS, overlap=None)  # type: ignore[arg-type]
+
+
+def test_coherence_rejects_non_numeric_overlap() -> None:
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match=r"'overlap' must be in \[0, 1\)"):
+        electroacoustics.coherence(x, x, FS, overlap="half")  # type: ignore[arg-type]
+
+
+def test_integral_float_nperseg_is_accepted() -> None:
+    # 64.0 IS the integer 64 to a caller who divided to get it.
+    x = np.zeros(1000)
+    res = electroacoustics.transfer_function(x, x, FS, nperseg=64.0)  # type: ignore[arg-type]
+    assert res.frequencies.size == 33
+
+
 def test_rejects_too_short_signal() -> None:
     too_short = np.zeros(10)
     with pytest.raises(ValueError, match="too short for a spectral estimate"):

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -382,6 +382,23 @@ def test_plot_rejects_unknown_quantity_and_missing_data() -> None:
         bare.plot(quantity="impedance")
 
 
+def test_plot_rejects_a_cartesian_axes_for_the_polar_quantity() -> None:
+    """A supplied non-polar axes is refused by name for ``directivity``.
+
+    The datasheet polar drawer calls polar-only methods, so a plain axes
+    used to die in matplotlib's AttributeError naming neither parameter.
+    """
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    result = _example_result()
+    _fig, cartesian = plt.subplots()
+    with pytest.raises(ValueError, match="'ax' must be a polar axes"):
+        result.plot(quantity="directivity", ax=cartesian)
+    plt.close("all")
+
+
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     result = _example_result()

--- a/tests/electroacoustics/test_piston.py
+++ b/tests/electroacoustics/test_piston.py
@@ -211,6 +211,21 @@ def test_directivity_pattern_plot_kwargs_single_ka_only() -> None:
     assert len(colors) == 3
 
 
+def test_directivity_pattern_plot_rejects_a_cartesian_axes() -> None:
+    # The drawer calls polar-only methods; a plain axes must be refused by
+    # name, not left to die in matplotlib's AttributeError.
+    import matplotlib as mpl
+
+    mpl.use("Agg")
+    import matplotlib.pyplot as plt
+
+    res = electroacoustics.piston_directivity_pattern([1.0, 3.0])
+    _fig, cartesian = plt.subplots()
+    with pytest.raises(ValueError, match="'ax' must be a polar axes"):
+        res.plot(ax=cartesian)
+    plt.close("all")
+
+
 def test_a_pattern_matrix_with_a_surplus_row_is_refused() -> None:
     """The matrix rows and the ``ka`` values are one enumeration, and only the
     surplus is quiet.
@@ -240,6 +255,15 @@ def test_directivity_pattern_validation() -> None:
         electroacoustics.piston_directivity_pattern(ka_one, angles=infinite_angles)
     with pytest.raises(ValueError, match="'ka' must be a non-empty"):
         electroacoustics.piston_directivity_pattern(empty_ka)
+
+
+def test_directivity_rejects_mismatched_shapes() -> None:
+    # A shape mismatch used to surface as numpy's broadcast message, which
+    # names neither argument.
+    three_ka = np.array([1.0, 2.0, 3.0])
+    two_angles = np.array([0.1, 0.2])
+    with pytest.raises(ValueError, match="'ka' and 'theta' must broadcast together"):
+        electroacoustics.piston_directivity(three_ka, two_angles)
 
 
 def test_validation() -> None:

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -268,6 +268,12 @@ def test_validation_errors() -> None:
         emission.sound_intensity(
             good, good, FS, spacing=SPACING, limits=[1000.0, 100.0]
         )
+    # A NaN limit fails every comparison and used to pass the guard, silently
+    # selecting no band at all.
+    with pytest.raises(ValueError, match="'limits' must be"):
+        emission.sound_intensity(
+            good, good, FS, spacing=SPACING, limits=[float("nan"), 1000.0]
+        )
     two_dimensional = np.zeros((2, 100))
     with pytest.raises(ValueError, match="1D"):
         emission.sound_intensity(two_dimensional, two_dimensional, FS, spacing=SPACING)
@@ -314,6 +320,22 @@ def test_field_indicators_validation() -> None:
     three_band_in = np.full((4, 3), 1e-3)
     with pytest.raises(ValueError, match="one entry per band"):
         emission.field_indicators(three_band_lp, three_band_in, [125.0, 250.0])
+
+
+def test_field_indicators_rejects_non_finite_pressure_levels() -> None:
+    # A NaN Lp used to turn F2 and F3 into a silent NaN instead of raising,
+    # while the sibling intensity samples were already rejected up front.
+    with pytest.raises(ValueError, match="'pressure_levels' must contain only finite"):
+        emission.field_indicators([np.nan, 90.0], [1e-3, 1e-3])
+
+
+def test_field_indicators_rejects_empty_band_axis() -> None:
+    # A (positions, 0) surface used to crash inside numpy's indexing without
+    # naming the argument.
+    no_band_lp = np.zeros((3, 0))
+    no_band_in = np.zeros((3, 0))
+    with pytest.raises(ValueError, match="'pressure_levels' must have at least one"):
+        emission.field_indicators(no_band_lp, no_band_in)
 
 
 def test_field_indicators_per_band_matches_per_column_scalars() -> None:

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -477,6 +477,112 @@ def test_invalid_surface_raises() -> None:
         emission.sound_power_pressure(levels, "sphere", radius=2.0)
 
 
+def test_k1_background_levels_length_mismatch_raises() -> None:
+    """A background spectrum of the wrong length is refused by name, not with
+    numpy's broadcast message.
+    """
+    source_three_bands = np.array([90.0, 92.0, 95.0])
+    background_two_bands = np.array([70.0, 71.0])
+    with pytest.raises(ValueError, match="'background_levels' must be a scalar"):
+        emission.background_noise_correction(source_three_bands, background_two_bands)
+
+
+def test_scalar_frequencies_with_several_bands_raises() -> None:
+    """A scalar 'frequencies' cannot span several bands: the named refusal,
+    not an IndexError from the 0-d shape.
+    """
+    levels = np.full((10, 3), 90.0)
+    with pytest.raises(ValueError, match="'frequencies' length must match"):
+        emission.sound_power_pressure(
+            levels, "hemisphere", radius=2.0, frequencies=1000.0
+        )
+
+
+def test_scalar_frequencies_with_single_band_is_accepted() -> None:
+    """One band has one centre frequency, so the scalar is that frequency
+    (at 1000 Hz the A-weighting is 0 dB and LWA = LW).
+    """
+    res = emission.sound_power_pressure(
+        np.full((10, 1), 90.0), "hemisphere", radius=2.0, frequencies=1000.0
+    )
+    assert res.sound_power_level_a == pytest.approx(float(res.sound_power_level[0]))
+
+
+def test_k2_negative_surface_area_raises() -> None:
+    with pytest.raises(ValueError, match="'surface_area' must be positive"):
+        emission.environmental_correction(-5.0, absorption_area=10.0)
+
+
+def test_k2_zero_surface_area_raises() -> None:
+    """S = 0 must not silently claim a free field (K2 = 0)."""
+    with pytest.raises(ValueError, match="'surface_area' must be positive"):
+        emission.environmental_correction(0.0, absorption_area=10.0)
+
+
+def test_negative_omc_uncertainty_raises() -> None:
+    """np.hypot squares sigma_omc, so a negative value would silently pass."""
+    levels = np.full((10, 1), 90.0)
+    with pytest.raises(ValueError, match="'omc_uncertainty' must be non-negative"):
+        emission.sound_power_pressure(
+            levels, "hemisphere", radius=2.0, omc_uncertainty=-5.0
+        )
+
+
+def test_k2_per_band_volume_array_raises() -> None:
+    """'volume' is a scalar; per-band variation belongs to the T array."""
+    per_band_t = np.array([1.2, 1.4])
+    with pytest.raises(ValueError, match="'volume' must be a scalar"):
+        emission.environmental_correction(
+            40.0, reverberation_time=per_band_t, volume=np.array([300.0, 300.0])
+        )
+
+
+def test_k2_per_band_room_surface_array_raises() -> None:
+    """'room_surface' is a scalar; per-band variation belongs to alpha."""
+    per_band_alpha = np.array([0.2, 0.3])
+    with pytest.raises(ValueError, match="'room_surface' must be a scalar"):
+        emission.environmental_correction(
+            40.0,
+            mean_absorption_coefficient=per_band_alpha,
+            room_surface=np.array([100.0, 100.0]),
+        )
+
+
+def test_box_non_sequence_dimensions_raises() -> None:
+    """A bare number for 'dimensions' is refused by name, not len()'s
+    TypeError.
+    """
+    levels = np.full((9, 1), 90.0)
+    with pytest.raises(ValueError, match="'dimensions' must be 3 positive values"):
+        emission.sound_power_pressure(levels, "box", dimensions=2.0, distance=1.0)
+
+
+def test_box_nan_dimension_raises() -> None:
+    """A NaN edge must not pass 'v <= 0' into a NaN surface area."""
+    levels = np.full((9, 1), 90.0)
+    with pytest.raises(ValueError, match="'dimensions' must be finite"):
+        emission.sound_power_pressure(
+            levels, "box", dimensions=(1.0, 2.0, float("nan")), distance=1.0
+        )
+
+
+def test_box_non_positive_distance_raises() -> None:
+    levels = np.full((9, 1), 90.0)
+    with pytest.raises(ValueError, match="'distance' must be positive"):
+        emission.sound_power_pressure(
+            levels, "box", dimensions=(1.0, 2.0, 3.0), distance=0.0
+        )
+
+
+def test_zero_band_levels_raises() -> None:
+    """An empty band axis must raise, not return empty spectra with
+    LWA = NaN.
+    """
+    no_bands = np.zeros((10, 0))
+    with pytest.raises(ValueError, match="'levels_positions' must contain at least"):
+        emission.sound_power_pressure(no_bands, "hemisphere", radius=2.0)
+
+
 def test_k2_over_validity_limit_warns() -> None:
     """K2 above 4 dB (engineering) exceeds the ISO 3744 validity limit."""
     r = 2.0

--- a/tests/emission/test_sound_power_intensity.py
+++ b/tests/emission/test_sound_power_intensity.py
@@ -328,6 +328,28 @@ def test_short_frequencies_raises_value_error_not_index_error() -> None:
         )
 
 
+def test_nan_frequency_raises() -> None:
+    """A NaN band centre is refused by name before the Table 2 lookup
+    rounds it to an integer.
+    """
+    areas = np.array([0.5, 0.5, 0.5, 0.5])
+    intensity = np.full((4, 3), 5.0e-4)
+    with pytest.raises(ValueError, match="'frequencies' must be finite"):
+        emission.sound_power_intensity(
+            intensity, areas, frequencies=np.array([500.0, float("nan"), 2000.0])
+        )
+
+
+def test_infinite_frequency_raises() -> None:
+    """An infinite band centre used to escape as round()'s OverflowError."""
+    areas = np.array([0.5, 0.5, 0.5, 0.5])
+    intensity = np.full((4, 3), 5.0e-4)
+    with pytest.raises(ValueError, match="'frequencies' must be finite"):
+        emission.sound_power_intensity(
+            intensity, areas, frequencies=np.array([500.0, float("inf"), 2000.0])
+        )
+
+
 def test_repeatability_uses_mean_of_two_scans_for_power() -> None:
     """Partial power uses the mean of the two scan intensities (Eq. 12)."""
     areas = np.array([0.5, 0.5, 0.5, 0.5])

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -715,6 +715,60 @@ def test_criterion_1_without_limit_raises() -> None:
         )
 
 
+def test_criterion_1_scan_level_1_wrong_length_raises() -> None:
+    """A scan level that does not span the indicator bands is refused by
+    name, not with numpy's broadcast message.
+    """
+    ind = precision_field_indicators(np.full((4, 3), 2.0e-6), np.full((4, 3), 60.0))
+    with pytest.raises(ValueError, match="'scan_intensity_level_1' must be a scalar"):
+        precision_qualification(
+            ind,
+            scan_intensity_level_1=np.full(4, 70.0),
+            scan_intensity_level_2=np.full(4, 70.0),
+            repeatability_limit=1.0,
+        )
+
+
+def test_criterion_1_scan_level_2_wrong_length_raises() -> None:
+    """The second scan is named when it is the one that disagrees."""
+    ind = precision_field_indicators(np.full((4, 3), 2.0e-6), np.full((4, 3), 60.0))
+    with pytest.raises(ValueError, match="'scan_intensity_level_2' must be a scalar"):
+        precision_qualification(
+            ind,
+            scan_intensity_level_1=np.full(3, 70.0),
+            scan_intensity_level_2=np.full(2, 70.0),
+            repeatability_limit=1.0,
+        )
+
+
+def test_precision_frequencies_wrong_length_raises() -> None:
+    """'frequencies' short of the indicator bands is refused up front, not at
+    the criterion-1 comparison.
+    """
+    ind = precision_field_indicators(np.full((4, 3), 2.0e-6), np.full((4, 3), 60.0))
+    with pytest.raises(ValueError, match="'frequencies' must carry one value per band"):
+        precision_qualification(
+            ind,
+            scan_intensity_level_1=np.full(3, 70.0),
+            scan_intensity_level_2=np.full(3, 70.0),
+            frequencies=np.array([500.0, 1000.0]),
+        )
+
+
+def test_precision_nan_frequency_raises() -> None:
+    """A NaN band centre is refused by name before the Table 1 lookup
+    rounds it to an integer.
+    """
+    ind = precision_field_indicators(np.full((4, 3), 2.0e-6), np.full((4, 3), 60.0))
+    with pytest.raises(ValueError, match="'frequencies' must be finite"):
+        precision_qualification(
+            ind,
+            scan_intensity_level_1=np.full(3, 70.0),
+            scan_intensity_level_2=np.full(3, 70.0),
+            frequencies=np.array([500.0, float("nan"), 2000.0]),
+        )
+
+
 def test_field_indicators_shape_mismatch_raises() -> None:
     intensity = np.full((4, 1), 1e-6)
     mismatched_levels = np.full((3, 1), 60.0)
@@ -800,18 +854,19 @@ def test_a_field_indicator_off_the_band_axis_is_refused() -> None:
 def test_criteria_from_a_one_band_scan_pair_are_refused() -> None:
     """Criterion 1 comes from the scan levels, the others from the indicators.
 
-    Nothing compares the two, so a repeatability pair read on a single band
-    (Eq. C.1) would otherwise decide 'qualified' for all four of them.
+    A repeatability pair read on a single band (Eq. C.1) would otherwise
+    decide 'qualified' for all four of them; the entry point refuses it by
+    the scan level's own name.
     """
     indicators = _four_band_indicators()
     one_band_scan = np.array([70.0])
-    with pytest.raises(ValueError, match="'criterion_1'"):
+    with pytest.raises(ValueError, match="'scan_intensity_level_1' must be a scalar"):
         precision_qualification(
             indicators,
             scan_intensity_level_1=one_band_scan,
             scan_intensity_level_2=one_band_scan,
             pressure_residual_index=14.0,
-            frequencies=np.array([1000.0]),
+            frequencies=np.array([1000.0, 2000.0, 4000.0, 5000.0]),
         )
 
 

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -299,6 +299,25 @@ def test_background_shape_mismatch_raises() -> None:
         )
 
 
+def test_background_band_mismatch_1d_levels_raises() -> None:
+    """A background of the wrong band count with 1D pre-averaged levels is
+    refused by name (it used to die in the K1 subtraction with numpy's
+    two-shape broadcast message).
+    """
+    freqs = np.array([100.0, 200.0, 400.0, 800.0, 1600.0])
+    with pytest.raises(
+        ValueError, match="'background_levels' must carry one value per band"
+    ):
+        emission.sound_power_reverberation(
+            np.full(5, 80.0),
+            1.0,
+            200.0,
+            210.0,
+            freqs,
+            background_levels=np.zeros(3),
+        )
+
+
 def test_preaveraged_1d_levels_keep_single_k1_path() -> None:
     """1D pre-averaged spectra carry no per-position data: a single K1 from
     the averaged spectra applies (documented approximation of 9.1.2).

--- a/tests/environment/propagation/test_air_absorption.py
+++ b/tests/environment/propagation/test_air_absorption.py
@@ -291,6 +291,22 @@ def test_atmospheric_attenuation_total_over_distance() -> None:
     assert res.distance == 200.0
 
 
+def test_atmospheric_attenuation_total_coerces_list_fields() -> None:
+    # The fields are annotated as arrays, but the frozen result can be built by
+    # hand with plain lists; total_attenuation used to hand the list straight
+    # to `list * float` (sequence repetition) and die with the builtin
+    # TypeError instead of multiplying.
+    res = environment.AtmosphericAttenuation(
+        frequencies=[100.0],
+        attenuation_coefficient=[0.001],
+        temperature=20.0,
+        relative_humidity=50.0,
+        pressure=101.325,
+        distance=10.0,
+    )
+    np.testing.assert_allclose(res.total_attenuation, [0.01])
+
+
 def test_atmospheric_attenuation_zero_distance_is_allowed() -> None:
     # A zero-length path is degenerate but well defined: A = 0 everywhere.
     res = environment.atmospheric_attenuation([1000.0], 20.0, 50.0, distance=0.0)

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -226,6 +226,20 @@ def test_kurze_anderson_is_monotone_in_fresnel_number() -> None:
     assert att[-1] - att[2] == pytest.approx(10.0, abs=1.0)
 
 
+def test_kurze_anderson_rejects_non_numeric_and_nan() -> None:
+    """The Fresnel number is guarded by name: a non-numeric input used to die
+    with numpy's own coercion message (or a bare TypeError for a complex one)
+    and a NaN came back as a NaN "attenuation" against the documented
+    >= 0 dB contract.
+    """
+    with pytest.raises(ValueError, match="'fresnel_number' must be numeric"):
+        environment.kurze_anderson_attenuation("loud")
+    with pytest.raises(ValueError, match="'fresnel_number' must be numeric"):
+        environment.kurze_anderson_attenuation(1.0 + 2.0j)
+    with pytest.raises(ValueError, match="'fresnel_number' must contain only finite"):
+        environment.kurze_anderson_attenuation(float("nan"))
+
+
 def test_kurze_anderson_bright_zone_falls_below_5_db() -> None:
     # Negative Fresnel number (receiver in line of sight) -> less than 5 dB.
     assert environment.kurze_anderson_attenuation(-0.2) < 5.0
@@ -398,3 +412,20 @@ def test_barrier_rejects_bad_geometry() -> None:
                 method="exact",
                 thickness=bad,
             )
+
+
+def test_barrier_rejects_non_finite_geometry() -> None:
+    """A NaN distance or height used to sail through the ordering comparisons
+    (every comparison against NaN is False) and come back from the diffraction
+    maths as an all-NaN insertion loss; each of the five is refused by name.
+    """
+    with pytest.raises(ValueError, match="'barrier_distance' must be positive"):
+        environment.barrier_insertion_loss(_BANDS, 2.0, float("nan"), 4.0, 50.0, 1.5)
+    with pytest.raises(ValueError, match="'receiver_distance' must be positive"):
+        environment.barrier_insertion_loss(_BANDS, 2.0, 1.0, 4.0, float("nan"), 1.5)
+    with pytest.raises(ValueError, match="'barrier_height' must be finite"):
+        environment.barrier_insertion_loss(_BANDS, 2.0, 1.0, float("nan"), 50.0, 1.5)
+    with pytest.raises(ValueError, match="'source_height' must be finite"):
+        environment.barrier_insertion_loss(_BANDS, float("nan"), 1.0, 4.0, 50.0, 1.5)
+    with pytest.raises(ValueError, match="'receiver_height' must be finite"):
+        environment.barrier_insertion_loss(_BANDS, 2.0, 1.0, 4.0, 50.0, float("nan"))

--- a/tests/environment/propagation/test_refraction.py
+++ b/tests/environment/propagation/test_refraction.py
@@ -112,6 +112,12 @@ def test_ray_curvature_radius_validation() -> None:
         ValueError, match=r"'launch_angle_deg' must be within \(-90, 90\)"
     ):
         ray_curvature_radius(0.1, launch_angle_deg=90.0)
+    with pytest.raises(
+        ValueError, match=r"'launch_angle_deg' must be within \(-90, 90\)"
+    ):
+        # abs(nan) >= 90 is False, so without the finiteness check a NaN
+        # slipped the range guard and came back as a NaN radius.
+        ray_curvature_radius(0.1, launch_angle_deg=float("nan"))
 
 
 def test_shadow_zone_distance_closed_form() -> None:
@@ -495,6 +501,41 @@ def test_pe_validation() -> None:
             range_step=1e9,
             max_range=100.0,
         )
+
+
+def test_pe_rejects_height_step_beyond_output_band() -> None:
+    """The vertical grid samples midpoints (j + 0.5) dz, so a step of twice
+    'max_height' or more leaves [0, max_height] without a single node; the
+    empty field used to be returned silently and only failed downstream
+    (argmin of an empty sequence in level_at_height, IndexError in plot).
+    """
+    prof = _flat_profile()
+    with pytest.raises(
+        ValueError, match="'height_step' must be less than twice 'max_height'"
+    ):
+        atmospheric_parabolic_equation(
+            500.0,
+            prof,
+            source_height=2.0,
+            impedance=Z_GRASS,
+            max_range=20.0,
+            max_height=10.0,
+            # Exactly 2 x max_height: the first node lands on 10.0 m and
+            # searchsorted leaves the output band empty (the border case).
+            height_step=20.0,
+        )
+    # Just under the boundary the band still holds one node and the call
+    # stands: the guard rejects only the steps that empty the grid.
+    res = atmospheric_parabolic_equation(
+        500.0,
+        prof,
+        source_height=2.0,
+        impedance=Z_GRASS,
+        max_range=20.0,
+        max_height=10.0,
+        height_step=19.0,
+    )
+    assert res.heights.size > 0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/filters/test_nominal_frequencies.py
+++ b/tests/filters/test_nominal_frequencies.py
@@ -13,6 +13,18 @@ from phonometry.filters.frequencies import (
     nominal_frequencies,
 )
 
+# --- nominal_frequencies ---
+
+
+@pytest.mark.parametrize("fraction", [0, -1, float("nan")])
+def test_nominal_frequencies_rejects_non_positive_fraction(fraction: float) -> None:
+    """Zero used to divide by zero, NaN to die in index rounding, and a
+    negative fraction never terminated (the band centres underflow to 0.0).
+    """
+    with pytest.raises(ValueError, match="'fraction' must be positive"):
+        nominal_frequencies(fraction)
+
+
 # --- _iec_e3_round ---
 
 

--- a/tests/filters/test_parametric_filters.py
+++ b/tests/filters/test_parametric_filters.py
@@ -227,6 +227,13 @@ def test_time_weighting_rejects_non_numeric_initial_state() -> None:
         filters.time_weighting(x, 48000, mode="fast", initial_state={"a": 1})  # type: ignore[arg-type]
 
 
+def test_time_weighting_rejects_unconvertible_initial_state_array() -> None:
+    """A string array used to get numpy's ValueError, which names nothing."""
+    x = np.ones(10)
+    with pytest.raises(TypeError, match="initial_state must be None"):
+        filters.time_weighting(x, 48000, mode="fast", initial_state=["invalid"])  # type: ignore[arg-type]
+
+
 def test_time_weighting_fast() -> None:
     r"""Verify Fast (125ms) time weighting response to a step.
 

--- a/tests/filters/test_parametric_filters.py
+++ b/tests/filters/test_parametric_filters.py
@@ -196,6 +196,37 @@ def test_weighting_filter_class_direct_use() -> None:
         filters.WeightingFilter(fs, curve="invalid")
 
 
+def test_weighting_filter_class_rejects_non_string_curve() -> None:
+    """A non-string curve used to die in str.upper before the curve message."""
+    with pytest.raises(TypeError, match="'curve' must be a string"):
+        filters.WeightingFilter(48000, curve=5)  # type: ignore[arg-type]
+
+
+def test_weighting_filter_rejects_non_string_curve() -> None:
+    x = np.zeros(100)
+    with pytest.raises(TypeError, match="'curve' must be a string"):
+        filters.weighting_filter(x, 48000, curve=5)  # type: ignore[arg-type]
+
+
+def test_time_weighting_rejects_non_string_mode() -> None:
+    """A non-string mode used to die in str.lower before the mode message."""
+    x = np.ones(10)
+    with pytest.raises(TypeError, match="'mode' must be a string"):
+        filters.time_weighting(x, 48000, mode=5)  # type: ignore[arg-type]
+
+
+def test_time_weighting_class_rejects_non_string_mode() -> None:
+    with pytest.raises(TypeError, match="'mode' must be a string"):
+        filters.TimeWeighting(48000, mode=5)  # type: ignore[arg-type]
+
+
+def test_time_weighting_rejects_non_numeric_initial_state() -> None:
+    """A dict used to get numpy's float() message, which names nothing."""
+    x = np.ones(10)
+    with pytest.raises(TypeError, match="initial_state must be None"):
+        filters.time_weighting(x, 48000, mode="fast", initial_state={"a": 1})  # type: ignore[arg-type]
+
+
 def test_time_weighting_fast() -> None:
     r"""Verify Fast (125ms) time weighting response to a step.
 

--- a/tests/filters/test_spectrogram.py
+++ b/tests/filters/test_spectrogram.py
@@ -68,3 +68,35 @@ def test_spectrogram_invalid_params_raise() -> None:
         bank.spectrogram(one_second, overlap=1.0)
     with pytest.raises(ValueError, match="window_time"):
         bank.spectrogram(shorter_than_the_window, window_time=1.0)
+
+
+@pytest.mark.parametrize("window_time", [float("nan"), float("inf"), -1.0, 0.0])
+def test_spectrogram_rejects_non_positive_window_time(window_time: float) -> None:
+    """A non-finite window length used to die in round(), naming nothing."""
+    bank = filters.OctaveFilterBank(fs=FS, fraction=1, limits=[100, 5000])
+    one_second = np.zeros(FS)
+    with pytest.raises(ValueError, match="'window_time' must be positive"):
+        bank.spectrogram(one_second, window_time=window_time)
+
+
+def test_spectrogram_rejects_non_string_mode() -> None:
+    """A non-string mode used to die in str.lower, deep in level calculation."""
+    bank = filters.OctaveFilterBank(fs=FS, fraction=1, limits=[100, 5000])
+    one_second = np.zeros(FS)
+    with pytest.raises(TypeError, match="'mode' must be a string"):
+        bank.spectrogram(one_second, mode=None)  # type: ignore[arg-type]
+
+
+def test_spectrogram_rejects_unknown_mode() -> None:
+    bank = filters.OctaveFilterBank(fs=FS, fraction=1, limits=[100, 5000])
+    one_second = np.zeros(FS)
+    with pytest.raises(ValueError, match="'mode' must be one of"):
+        bank.spectrogram(one_second, mode="bogus")
+
+
+def test_spectrogram_rejects_three_dimensional_input() -> None:
+    """A 3-D array used to reach numpy's sliding window before any refusal."""
+    bank = filters.OctaveFilterBank(fs=FS, fraction=1, limits=[100, 5000])
+    cube = np.zeros((2, 2, FS))
+    with pytest.raises(ValueError, match="'x' must be a 1-D signal or a 2-D"):
+        bank.spectrogram(cube)

--- a/tests/materials/absorbers/test_absorption_rating.py
+++ b/tests/materials/absorbers/test_absorption_rating.py
@@ -179,6 +179,13 @@ def test_practical_rejects_negative() -> None:
         practical_absorption_coefficient([-0.1] + [0.5] * 14)
 
 
+def test_weighted_rejects_negative() -> None:
+    # The octave entry point applies the same rule as the one-third-octave
+    # side; a negative alpha_p used to be silently clamped to 0.00.
+    with pytest.raises(ValueError, match="'alpha_p' must be non-negative"):
+        weighted_absorption([-0.5, -1.0, 0.6, 0.6, 0.6])
+
+
 def test_practical_wrong_length() -> None:
     with pytest.raises(ValueError, match=r"third_octave_alpha_s must have \d+ values"):
         practical_absorption_coefficient([0.5] * 14)
@@ -216,6 +223,14 @@ def test_practical_mapping_matches_sequence() -> None:
 )
 def test_absorption_class_boundaries(alpha_w: float, letter: str) -> None:
     assert absorption_class(alpha_w) == letter
+
+
+@pytest.mark.parametrize("alpha_w", [float("nan"), float("inf"), 5.0, -3.0])
+def test_absorption_class_rejects_out_of_range(alpha_w: float) -> None:
+    # NaN and infinity used to surface as math.floor's own messages, and
+    # out-of-range values were silently clamped into a class letter.
+    with pytest.raises(ValueError, match=r"'alpha_w' must be a finite value"):
+        absorption_class(alpha_w)
 
 
 # --- shift loop extremes --------------------------------------------------

--- a/tests/materials/absorbers/test_airflow_resistance.py
+++ b/tests/materials/absorbers/test_airflow_resistance.py
@@ -171,6 +171,14 @@ def test_static_velocity_above_limit_warns() -> None:
             lambda: static_airflow_resistance([1e-3, -2e-3], [12.0, 24.0], 0.008),
             "All velocities must be positive",
         ),
+        (  # nan u (would otherwise die inside np.linalg.lstsq)
+            lambda: static_airflow_resistance([1e-3, np.nan], [12.0, 24.0], 0.008),
+            "'velocities' and 'pressure_drops' must contain only finite",
+        ),
+        (  # inf dp (would otherwise return a result full of NaNs)
+            lambda: static_airflow_resistance([1e-3, 2e-3], [12.0, np.inf], 0.008),
+            "'velocities' and 'pressure_drops' must contain only finite",
+        ),
         (  # area
             lambda: static_airflow_resistance([1e-3, 2e-3], [12.0, 24.0], 0.0),
             "'area' must be positive",

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -102,6 +102,20 @@ def test_air_property_domain_errors() -> None:
         air_density_iso(293.0, -1.0)
 
 
+def test_air_density_mismatched_arrays_raise() -> None:
+    # Two arrays of different lengths must be refused by name, not left to
+    # numpy's two-shapes broadcast error.
+    with pytest.raises(ValueError, match="'temperature'.*'atmospheric_pressure'"):
+        air_density_iso([293.0, 300.0], [101.0, 100.0, 99.0])
+
+
+def test_air_density_scalar_beside_array_still_broadcasts() -> None:
+    # One shared temperature against several pressures stays legal.
+    rho = np.asarray(air_density_iso(293.0, [101.325, 100.0]))
+    assert rho.shape == (2,)
+    assert rho[0] == pytest.approx(1.186, abs=1e-9)
+
+
 def test_characteristic_impedance_is_real_product() -> None:
     assert characteristic_impedance(RHO, C0) == pytest.approx(RC)
     with pytest.raises(
@@ -168,6 +182,60 @@ def test_reflection_factor_round_trip_with_attenuation() -> None:
     h12 = _synth_h12(reflection, np.asarray(k0), x1, spacing)
     r = reflection_factor(h12, spacing=spacing, x1=x1, wavenumber=k0)
     assert np.allclose(r, reflection, atol=1e-12)
+
+
+def test_tube_wavenumber_rejects_negative_frequency() -> None:
+    with pytest.raises(ValueError, match="'frequency' must be non-negative"):
+        tube_wavenumber(np.array([-1000.0, 500.0]), C0)
+
+
+def test_tube_wavenumber_rejects_nan_frequency() -> None:
+    with pytest.raises(ValueError, match="'frequency' must be non-negative"):
+        tube_wavenumber(np.array([500.0, np.nan]), C0)
+
+
+def test_tube_wavenumber_rejects_mismatched_attenuation() -> None:
+    # A two-band attenuation against three frequencies used to die as
+    # numpy's two-shapes broadcast error, naming neither argument.
+    with pytest.raises(ValueError, match="'attenuation' must be a scalar or carry"):
+        tube_wavenumber(np.array([100.0, 200.0, 300.0]), C0, attenuation=[0.1, 0.2])
+
+
+def test_reflection_factor_rejects_mismatched_h12() -> None:
+    with pytest.raises(ValueError, match="'h12' must be a scalar or carry"):
+        reflection_factor(
+            np.array([0.5 + 0.1j, 0.4 + 0.2j]),
+            spacing=0.03,
+            x1=0.12,
+            wavenumber=np.array([1.0, 2.0, 3.0]),
+        )
+
+
+def test_two_microphone_rejects_mismatched_h12() -> None:
+    # Through the full reduction the mismatch is reported against
+    # 'frequency', the parameter name the caller actually typed.
+    with pytest.raises(ValueError, match="'h12'.*band.*'frequency'"):
+        two_microphone_impedance(
+            np.array([0.5 + 0.1j, 0.4 + 0.2j]),
+            frequency=np.array([500.0, 1000.0, 1500.0]),
+            spacing=0.03,
+            x1=0.12,
+            speed_of_sound=C0,
+            characteristic_impedance=RC,
+        )
+
+
+def test_two_microphone_rejects_nan_frequency() -> None:
+    # A NaN frequency used to come back as a silently NaN absorption.
+    with pytest.raises(ValueError, match="'frequency' must be non-negative"):
+        two_microphone_impedance(
+            np.array([0.5 + 0.1j, 0.4 + 0.2j]),
+            frequency=np.array([-1000.0, np.nan]),
+            spacing=0.03,
+            x1=0.12,
+            speed_of_sound=C0,
+            characteristic_impedance=RC,
+        )
 
 
 def test_two_microphone_impedance_result() -> None:
@@ -557,6 +625,63 @@ def test_two_load_warns_on_singular_load_pair() -> None:
             load,
             thickness=THICKNESS,
             wavenumber=k,
+            characteristic_impedance=RC,
+            **GEOM,
+        )
+
+
+def test_two_load_rejects_short_load() -> None:
+    # A three-element load used to die in tuple indexing (IndexError),
+    # naming neither load_a nor load_b.
+    load = (1.0 + 0j, 0.9 + 0j, 0.8 + 0j, 0.7 + 0j)
+    with pytest.raises(ValueError, match="'load_a' must be the four transfer"):
+        transfer_matrix_two_load(
+            load[:3],
+            load,
+            thickness=THICKNESS,
+            wavenumber=np.array([10.0]),
+            characteristic_impedance=RC,
+            **GEOM,
+        )
+
+
+def test_one_load_rejects_long_load() -> None:
+    # A five-element load used to be accepted with the extra entry
+    # silently dropped.
+    load = (1.0 + 0j, 0.9 + 0j, 0.8 + 0j, 0.7 + 0j, 0.6 + 0j)
+    with pytest.raises(ValueError, match="'load' must be the four transfer"):
+        transfer_matrix_one_load(
+            load,
+            thickness=THICKNESS,
+            wavenumber=np.array([10.0]),
+            characteristic_impedance=RC,
+            **GEOM,
+        )
+
+
+def test_face_quantities_rejects_non_positive_thickness() -> None:
+    # The same rule the module already applies to 'thickness' elsewhere;
+    # a zero-depth specimen was accepted silently.
+    with pytest.raises(ValueError, match="'thickness' must be positive"):
+        face_quantities(
+            1.0,
+            0.5,
+            0.7,
+            0.2,
+            wavenumber=10.0,
+            thickness=0.0,
+            characteristic_impedance=RC,
+        )
+
+
+def test_one_load_rejects_zero_thickness() -> None:
+    # Both public solvers inherit the face_quantities guard.
+    load = (1.0 + 0j, 0.9 + 0j, 0.8 + 0j, 0.7 + 0j)
+    with pytest.raises(ValueError, match="'thickness' must be positive"):
+        transfer_matrix_one_load(
+            load,
+            thickness=0.0,
+            wavenumber=np.array([10.0]),
             characteristic_impedance=RC,
             **GEOM,
         )

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -330,6 +330,18 @@ def test_temperature_outside_eq6_range_warns() -> None:
         materials.absorption_area(3.0, 200.0, temperature=5.0)
 
 
+def test_temperature_below_absolute_zero_raises() -> None:
+    # Below -273,15 degC Eq. (6) would hand back a non-positive speed of
+    # sound; the refusal is a hard error, not the out-of-range advisory.
+    with pytest.raises(ValueError, match="'temperature' must be above absolute zero"):
+        materials.absorption_area(3.0, 200.0, temperature=-600.0)
+
+
+def test_nan_temperature_raises() -> None:
+    with pytest.raises(ValueError, match="'temperature' must be above absolute zero"):
+        materials.absorption_area(3.0, 200.0, temperature=float("nan"))
+
+
 def test_no_temperature_warning_when_speed_supplied() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
@@ -490,6 +502,28 @@ def test_measurement_carries_conditions() -> None:
     assert res.humidity == 54.0
     np.testing.assert_array_equal(res.frequencies, _FREQS)
     np.testing.assert_allclose(res.air_attenuation, np.zeros_like(_FREQS))
+
+
+def test_measurement_negative_humidity_raises() -> None:
+    with pytest.raises(ValueError, match=r"'humidity' must be within \[0, 100\]"):
+        materials.measure_sound_absorption(
+            _FREQS, _T1, _T2, volume=200.0, area=10.8, humidity=-40.0
+        )
+
+
+def test_measurement_humidity_above_saturation_raises() -> None:
+    with pytest.raises(ValueError, match=r"'humidity' must be within \[0, 100\]"):
+        materials.measure_sound_absorption(
+            _FREQS, _T1, _T2, volume=200.0, area=10.8, humidity=150.0
+        )
+
+
+def test_measurement_non_numeric_humidity_raises_by_name() -> None:
+    # Not float()'s anonymous "could not convert string to float".
+    with pytest.raises(ValueError, match=r"'humidity' must be within \[0, 100\]"):
+        materials.measure_sound_absorption(
+            _FREQS, _T1, _T2, volume=200.0, area=10.8, humidity="wet"
+        )
 
 
 def test_measurement_air_attenuation_reduces_area() -> None:

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -342,6 +342,29 @@ def test_nan_temperature_raises() -> None:
         materials.absorption_area(3.0, 200.0, temperature=float("nan"))
 
 
+def test_nan_speed_of_sound_raises() -> None:
+    # NaN passes a bare <= 0 comparison and would reach every derived quantity.
+    with pytest.raises(
+        ValueError, match="'speed_of_sound' must be finite and positive"
+    ):
+        materials.absorption_area(3.0, 200.0, speed_of_sound=float("nan"))
+
+
+def test_infinite_speed_of_sound_raises() -> None:
+    # Infinity is positive but zeroes the speed-dependent terms of Eq. (5).
+    with pytest.raises(
+        ValueError, match="'speed_of_sound' must be finite and positive"
+    ):
+        materials.absorption_area(3.0, 200.0, speed_of_sound=float("inf"))
+
+
+def test_non_positive_speed_of_sound_raises() -> None:
+    with pytest.raises(
+        ValueError, match="'speed_of_sound' must be finite and positive"
+    ):
+        materials.absorption_area(3.0, 200.0, speed_of_sound=-343.0)
+
+
 def test_no_temperature_warning_when_speed_supplied() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
@@ -523,6 +546,15 @@ def test_measurement_non_numeric_humidity_raises_by_name() -> None:
     with pytest.raises(ValueError, match=r"'humidity' must be within \[0, 100\]"):
         materials.measure_sound_absorption(
             _FREQS, _T1, _T2, volume=200.0, area=10.8, humidity="wet"
+        )
+
+
+def test_measurement_one_element_array_humidity_raises_by_name() -> None:
+    # float() refuses a 1-d array with TypeError, not ValueError; the guard
+    # renames that failure too instead of dying inside float().
+    with pytest.raises(ValueError, match=r"'humidity' must be within \[0, 100\]"):
+        materials.measure_sound_absorption(
+            _FREQS, _T1, _T2, volume=200.0, area=10.8, humidity=np.array([54.0])
         )
 
 

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -211,8 +211,9 @@ def test_half_a_panel_result_is_refused_by_name() -> None:
     class Half:
         transmission_loss = np.array([20.0, 25.0])
 
+    half = Half()
     with pytest.raises(TypeError, match="'panel_transmission_loss' must be"):
-        noise_control.enclosure_insertion_loss(Half(), 12.0, 20.0, 0.2)
+        noise_control.enclosure_insertion_loss(half, 12.0, 20.0, 0.2)
 
 
 def test_stray_string_panel_spectrum_is_refused_by_name() -> None:

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -191,6 +191,35 @@ def test_validation() -> None:
         noise_control.enclosure_insertion_loss([20.0], 6.0, 5.0, 0.3, model="hansen")
 
 
+def test_absorption_off_the_band_count_is_refused_by_name() -> None:
+    # Not numpy's "shape mismatch" from inside broadcast_arrays: the message
+    # names the absorption and the spectrum it disagrees with.
+    with pytest.raises(ValueError, match=r"'internal_absorption'.*one value per band"):
+        noise_control.enclosure_insertion_loss(
+            [20.0, 25.0, 30.0, 35.0, 40.0], 12.0, 20.0, [0.1, 0.2, 0.3]
+        )
+
+
+def test_empty_absorption_is_refused() -> None:
+    # An empty array passes every vacuous np.any/np.all test and used to
+    # come back as an empty result instead of raising.
+    with pytest.raises(ValueError, match="'internal_absorption' must be a scalar"):
+        noise_control.enclosure_insertion_loss([20.0], 12.0, 20.0, [])
+
+
+def test_half_a_panel_result_is_refused_by_name() -> None:
+    class Half:
+        transmission_loss = np.array([20.0, 25.0])
+
+    with pytest.raises(TypeError, match="'panel_transmission_loss' must be"):
+        noise_control.enclosure_insertion_loss(Half(), 12.0, 20.0, 0.2)
+
+
+def test_stray_string_panel_spectrum_is_refused_by_name() -> None:
+    with pytest.raises(TypeError, match="'panel_transmission_loss' must be"):
+        noise_control.enclosure_insertion_loss("hello", 12.0, 20.0, 0.2)
+
+
 def test_frequency_labels_off_the_band_count_are_refused() -> None:
     """The labels must run over the bands the enclosure was solved on.
 

--- a/tests/noise_control/test_hvac.py
+++ b/tests/noise_control/test_hvac.py
@@ -111,6 +111,32 @@ def test_plenum_per_band() -> None:
     assert tl.shape == (3,)
 
 
+def test_plenum_angle_endpoints_accepted() -> None:
+    # cos(pi/2) = 0: at the endpoint only the reverberant term is left.
+    grazing = hvac.plenum_attenuation(0.1, 1.0, 20.0, 0.2, angle=math.pi / 2.0)
+    head_on = hvac.plenum_attenuation(0.1, 1.0, 20.0, 0.2, angle=0.0)
+    assert grazing > head_on
+
+
+@pytest.mark.parametrize("angle", [math.nan, math.pi, -0.3], ids=["nan", "pi", "neg"])
+def test_plenum_angle_outside_range_raises(angle: float) -> None:
+    # A NaN used to come back as a NaN result and an obtuse angle drove
+    # log10 negative with only a RuntimeWarning; both refuse by name now.
+    with pytest.raises(ValueError, match=r"'angle' must lie in \[0, pi/2\]"):
+        hvac.plenum_attenuation(0.1, 1.0, 20.0, 0.2, angle=angle)
+
+
+def test_plenum_empty_absorption_raises() -> None:
+    # np.any/np.all pass vacuously on an empty array; refuse it by name.
+    with pytest.raises(ValueError, match="'mean_absorption' must be a scalar"):
+        hvac.plenum_attenuation(0.1, 1.0, 20.0, [])
+
+
+def test_plenum_two_dimensional_absorption_raises() -> None:
+    with pytest.raises(ValueError, match="'mean_absorption' must be a scalar"):
+        hvac.plenum_attenuation(0.1, 1.0, 20.0, np.full((2, 3), 0.2))
+
+
 def test_flow_noise_straight_duct_formula() -> None:
     # Bies Eq. (8.251), VDI 2081-1: note the -2 constant term.
     f = np.array([250.0])

--- a/tests/noise_control/test_hvac_long.py
+++ b/tests/noise_control/test_hvac_long.py
@@ -121,6 +121,19 @@ def test_blade_passing_frequency_validation() -> None:
         hvac.blade_passing_frequency(1200.0, 0)
 
 
+def test_blade_passing_frequency_fractional_blades_raises() -> None:
+    # 2.5 blades used to slip past the sign check and return 50 Hz.
+    with pytest.raises(ValueError, match="'blades' must be a positive integer"):
+        hvac.blade_passing_frequency(1200.0, 2.5)  # type: ignore[arg-type]
+
+
+def test_blade_passing_frequency_integral_float_blades_accepted() -> None:
+    # 12.0 is the integer 12 to every caller who divided to get it.
+    assert hvac.blade_passing_frequency(1200.0, 12.0) == pytest.approx(  # type: ignore[arg-type]
+        240.0
+    )
+
+
 # ---------------------------------------------------------------------------
 # Straight ducts (Ch. 14)
 # ---------------------------------------------------------------------------
@@ -394,6 +407,12 @@ def test_silencer_self_noise_requires_passages() -> None:
         hvac.silencer_self_noise(None, 10.0, 0, 0.9)
 
 
+def test_silencer_self_noise_fractional_passages_raises() -> None:
+    # 2.5 passages used to slip past the sign check into 10 lg N.
+    with pytest.raises(ValueError, match="'passages' must be a positive integer"):
+        hvac.silencer_self_noise(None, 10.0, 2.5, 0.9)  # type: ignore[arg-type]
+
+
 def test_splitter_silencer_identical_airways_equal_one_passage() -> None:
     """Bies §8.10.5: identical airways give the loss of a single passage."""
     one = hvac.splitter_silencer_insertion_loss(None, 0.6, 1.5, 0.1, 0.2)
@@ -546,6 +565,7 @@ def test_diffuser_sound_power_counts_identical_devices() -> None:
         ({"pressure_drop": -1.0}, "pressure_drop"),
         ({"shape": "slot"}, "shape"),
         ({"count": 0}, "count"),
+        ({"count": 1.5}, "'count' must be a positive integer"),
     ],
 )
 def test_diffuser_sound_power_validation(kwargs: dict[str, object], match: str) -> None:
@@ -582,6 +602,16 @@ def test_air_terminal_velocity_limit_validation() -> None:
         hvac.air_terminal_velocity_limit(20)
     with pytest.raises(ValueError, match="opening"):
         hvac.air_terminal_velocity_limit(30, opening="exhaust")
+
+
+@pytest.mark.parametrize("criterion", [math.inf, math.nan], ids=["inf", "nan"])
+def test_air_terminal_velocity_limit_non_finite_criterion_raises(
+    criterion: float,
+) -> None:
+    # Both used to escape as CPython's own message from inside round():
+    # OverflowError for the infinity, an unnamed ValueError for the NaN.
+    with pytest.raises(ValueError, match="'design_criterion' must be one of"):
+        hvac.air_terminal_velocity_limit(criterion)
 
 
 @pytest.mark.parametrize(
@@ -638,3 +668,15 @@ def test_room_effect_validation() -> None:
         hvac.room_effect(0.0, 50.0)
     with pytest.raises(ValueError, match="room_constant"):
         hvac.room_effect(3.0, 0.0)
+
+
+def test_room_effect_empty_room_constant_raises() -> None:
+    # An empty array passes every vacuous np.any/np.all test and used to
+    # come back as an empty result.
+    with pytest.raises(ValueError, match="'room_constant' must be a scalar"):
+        hvac.room_effect(2.0, [])
+
+
+def test_room_effect_two_dimensional_room_constant_raises() -> None:
+    with pytest.raises(ValueError, match="'room_constant' must be a scalar"):
+        hvac.room_effect(2.0, np.full((2, 3), 50.0))

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -166,6 +166,15 @@ def test_cascade_order() -> None:
     assert np.allclose(both, whole, atol=1e-9)
 
 
+def test_cascade_refuses_what_is_not_a_four_pole_stack() -> None:
+    f = np.linspace(50.0, 500.0, 20)
+    t = sl.duct_matrix(f, 1.0, 0.05)
+    with pytest.raises(ValueError, match=r"'matrices'\[1\].*\(n_freq, 2, 2\)"):
+        sl.cascade(t, [[1.0, 0.0], [0.0, 1.0]])
+    with pytest.raises(ValueError, match=r"'matrices'\[1\].*\(n_freq, 2, 2\)"):
+        sl.cascade(t, np.ones(20, dtype=np.complex128))
+
+
 def test_extended_tube_reduces_to_expansion_chamber() -> None:
     f = np.linspace(20.0, 2000.0, 500)
     ext = sl.extended_tube_chamber(f, 0.3, 0.04, 0.01)
@@ -286,6 +295,22 @@ def test_insertion_loss_present_when_impedances_given() -> None:
     assert res.insertion_loss is not None
     plain = sl.expansion_chamber(f, 0.3, 0.04, 0.01)
     assert plain.insertion_loss is None
+
+
+def test_insertion_loss_impedance_off_the_grid_is_refused() -> None:
+    f = np.linspace(50.0, 500.0, 20)
+    with pytest.raises(
+        ValueError, match=r"'source_impedance' must be a scalar or hold one value"
+    ):
+        sl.expansion_chamber(
+            f, 0.3, 0.04, 0.01, source_impedance=np.ones(5), radiation_impedance=5e3
+        )
+    with pytest.raises(
+        ValueError, match=r"'radiation_impedance' must be a scalar or hold one value"
+    ):
+        sl.expansion_chamber(
+            f, 0.3, 0.04, 0.01, source_impedance=4e4, radiation_impedance=np.ones(5)
+        )
 
 
 def test_validation() -> None:

--- a/tests/psychoacoustics/loudness/test_ecma.py
+++ b/tests/psychoacoustics/loudness/test_ecma.py
@@ -162,6 +162,23 @@ def test_empty_signal() -> None:
         psychoacoustics.loudness_ecma(empty, FS)
 
 
+def test_non_finite_signal_raises() -> None:
+    # A poisoned sample must raise, not silently truncate the signal at the
+    # poison index (NaN fails the half-wave rectification comparison).
+    tone = _tone(1000.0, 40.0, seconds=0.5)
+    tone[100] = np.nan
+    with pytest.raises(ValueError, match="'signal_in' must be finite"):
+        psychoacoustics.loudness_ecma(tone, FS)
+
+
+def test_resample_length_clamps_to_one_sample() -> None:
+    # 1 sample at 96 kHz resamples to round(1 * 48000 / 96000) = round(0.5),
+    # which banker's rounding takes to 0 samples without the clamp; the
+    # clamped 1-sample signal must process cleanly.
+    res = psychoacoustics.loudness_ecma(np.zeros(1), 96000.0)
+    assert res.loudness == 0.0
+
+
 @pytest.mark.xdist_group("ecma-loudness-ref")
 def test_plot_smoke(ref_1k_40: psychoacoustics.EcmaLoudness) -> None:
     import matplotlib as mpl

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -225,6 +225,18 @@ def test_empty_signal_raises() -> None:
         psychoacoustics.roughness_ecma(empty, FS)
 
 
+def test_non_finite_signal_raises() -> None:
+    # A poisoned sample must raise, not silently report 0.0 asper (the NaN
+    # washes out in the envelope stages and the result looks like silence).
+    tone = _tone(1000.0, 60.0, 0.5)
+    tone[100] = np.nan
+    with pytest.raises(ValueError, match="'signal_in' must be finite"):
+        psychoacoustics.roughness_ecma(tone, FS)
+    tone[100] = np.inf
+    with pytest.raises(ValueError, match="'signal_in' must be finite"):
+        psychoacoustics.roughness_ecma(tone, FS)
+
+
 def test_resample_length_clamps_to_one_sample() -> None:
     # 1 sample at 96 kHz resamples to round(1 * 48000 / 96000) = round(0.5),
     # which banker's rounding takes to 0 samples without the clamp; the

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -225,6 +225,14 @@ def test_empty_signal_raises() -> None:
         psychoacoustics.roughness_ecma(empty, FS)
 
 
+def test_resample_length_clamps_to_one_sample() -> None:
+    # 1 sample at 96 kHz resamples to round(1 * 48000 / 96000) = round(0.5),
+    # which banker's rounding takes to 0 samples without the clamp; the
+    # clamped 1-sample signal must process cleanly.
+    res = psychoacoustics.roughness_ecma(np.zeros(1), 96000.0)
+    assert res.roughness == 0.0
+
+
 def test_deterministic(ref_calibration: psychoacoustics.EcmaRoughness) -> None:
     again = psychoacoustics.roughness_ecma(_am_tone(1000.0, 70.0, 1.0, 60.0), FS)
     assert again.roughness == pytest.approx(ref_calibration.roughness, abs=1e-9)

--- a/tests/psychoacoustics/quality/test_tonality_ecma.py
+++ b/tests/psychoacoustics/quality/test_tonality_ecma.py
@@ -221,6 +221,19 @@ def test_band_range_rejects_out_of_range_edges() -> None:
         psychoacoustics.tonality_ecma(x, FS, f_low=2000.0, f_high=500.0)
 
 
+def test_band_range_rejects_non_finite_edges() -> None:
+    # NaN fails every bare comparison and +inf passes the f_low one, so
+    # without the finiteness clause both slip through to an empty band
+    # (silent zero tonality) or a numpy reduction error naming no parameter.
+    x = _tone(1000.0, 40.0, seconds=0.5)
+    with pytest.raises(ValueError, match="'f_low' must exceed 16 Hz"):
+        psychoacoustics.tonality_ecma(x, FS, f_low=float("nan"))
+    with pytest.raises(ValueError, match="'f_low' must exceed 16 Hz"):
+        psychoacoustics.tonality_ecma(x, FS, f_low=float("inf"))
+    with pytest.raises(ValueError, match="'f_high' must be below 20 kHz"):
+        psychoacoustics.tonality_ecma(x, FS, f_high=float("nan"))
+
+
 def test_band_range_uses_edge_midpoints() -> None:
     # Formulae 56-57 select bands by the edge midpoints to the neighbours, not
     # by the centre frequency.  For an f_low that lies between band z's centre

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -447,6 +447,30 @@ def test_combined_tone_level_rejects_length_mismatch() -> None:
         )
 
 
+def test_combined_tone_level_rejects_non_finite_values() -> None:
+    # A NaN tone frequency sends np.argmin over an all-NaN array (index 0)
+    # and a NaN level collapses the line span to the peak line: both used to
+    # return a silently wrong level instead of the documented ValueError.
+    with pytest.raises(ValueError, match="'tone_frequencies' must be positive"):
+        psychoacoustics.combined_tone_level(
+            ref.ISO20065_E1_LEVELS,
+            ref.ISO20065_E1_FREQUENCIES,
+            [float("nan")],
+            [49.22],
+        )
+    with pytest.raises(ValueError, match="'tone_frequencies' must be positive"):
+        psychoacoustics.combined_tone_level(
+            ref.ISO20065_E1_LEVELS, ref.ISO20065_E1_FREQUENCIES, [-137.3], [49.22]
+        )
+    with pytest.raises(ValueError, match="'mean_narrowband_levels' must be finite"):
+        psychoacoustics.combined_tone_level(
+            ref.ISO20065_E1_LEVELS,
+            ref.ISO20065_E1_FREQUENCIES,
+            [137.3],
+            [float("nan")],
+        )
+
+
 # ---------------------------------------------------------------------------
 # Separate evaluation of two tones below 1000 Hz (Formulae (18)/(19))
 #

--- a/tests/room/test_acoustics.py
+++ b/tests/room/test_acoustics.py
@@ -330,6 +330,35 @@ def test_rejects_bad_input() -> None:
         room.decay_curve(silent, FS)  # silent
 
 
+def test_band_above_nyquist_is_refused_by_name() -> None:
+    # The bank trims bands above fs/2 with only a warning; the requested band
+    # must then be refused by name, not by numpy's empty-argmin message.
+    ir = exponential_ir(1.0, 1.0, fs=8000)
+    with pytest.raises(ValueError, match=r"'band'.*Nyquist"):
+        room.decay_curve(ir, 8000, band=3500.0)
+
+
+def test_limits_above_nyquist_are_refused_by_name() -> None:
+    ir = exponential_ir(1.0, 1.0, fs=8000)
+    with pytest.raises(ValueError, match=r"'limits'.*Nyquist"):
+        room.room_parameters(ir, 8000, limits=(20000.0, 22000.0))
+
+
+def test_non_positive_fraction_is_refused() -> None:
+    # fraction enters the half-width arithmetic before the bank validates it.
+    ir = exponential_ir(1.0, 1.0)
+    with pytest.raises(ValueError, match="'fraction' must be positive"):
+        room.decay_curve(ir, FS, band=1000.0, fraction=0)
+
+
+def test_non_finite_limits_are_refused() -> None:
+    ir = exponential_ir(1.0, 1.0)
+    with pytest.raises(ValueError, match="'limits' must contain only finite"):
+        room.room_parameters(ir, FS, limits=(float("nan"), 4000.0))
+    with pytest.raises(ValueError, match="'limits' must contain only finite"):
+        room.room_parameters(ir, FS, limits=(125.0, float("inf")))
+
+
 def test_parameters_off_the_band_axis_are_refused() -> None:
     """Every per-band array is pinned to the band axis when the result is built.
 

--- a/tests/room/test_acoustics.py
+++ b/tests/room/test_acoustics.py
@@ -351,6 +351,16 @@ def test_non_positive_fraction_is_refused() -> None:
         room.decay_curve(ir, FS, band=1000.0, fraction=0)
 
 
+def test_non_finite_fraction_is_refused() -> None:
+    # An infinite fraction makes the half-width exactly 1, so the bank would
+    # refuse the equal limits by their name instead of fraction's.
+    ir = exponential_ir(1.0, 1.0)
+    with pytest.raises(ValueError, match="'fraction' must be positive"):
+        room.decay_curve(ir, FS, band=1000.0, fraction=float("inf"))
+    with pytest.raises(ValueError, match="'fraction' must be positive"):
+        room.decay_curve(ir, FS, band=1000.0, fraction=float("nan"))
+
+
 def test_non_finite_limits_are_refused() -> None:
     ir = exponential_ir(1.0, 1.0)
     with pytest.raises(ValueError, match="'limits' must contain only finite"):

--- a/tests/room/test_image_source.py
+++ b/tests/room/test_image_source.py
@@ -423,6 +423,77 @@ def test_bad_dimension_and_fs() -> None:
         )
 
 
+def test_dimensions_must_be_three_lengths() -> None:
+    # A short room died as numpy's bare IndexError and a long one was
+    # silently truncated to its first three lengths.
+    src, rcv = (1.0, 1.0, 1.5), (3.0, 2.5, 1.2)
+    with pytest.raises(ValueError, match="'dimensions' must be a 3-vector"):
+        room.image_source_rir((5.0, 4.0), src, rcv, 0.2, fs=8000)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'dimensions' must be a 3-vector"):
+        room.image_source_rir((5.0, 4.0, 3.0, 2.0), src, rcv, 0.2, fs=8000)  # type: ignore[arg-type]
+
+
+def test_max_order_must_be_a_non_negative_integer() -> None:
+    # A fractional or NaN order used to pass the sign check and die inside
+    # range() as the builtin TypeError, naming nothing.
+    args = ((5.0, 4.0, 3.0), (1.0, 1.0, 1.5), (3.0, 2.5, 1.2), 0.2)
+    with pytest.raises(ValueError, match="'max_order' must be a non-negative integer"):
+        room.image_source_rir(*args, fs=8000, max_order=2.5)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'max_order' must be a non-negative integer"):
+        room.image_source_rir(*args, fs=8000, max_order=math.nan)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'max_order' must be a non-negative integer"):
+        room.image_source_rir(*args, fs=8000, max_order=-1)
+
+
+def test_frequencies_must_be_a_positive_band_vector() -> None:
+    # An empty, 2-D, NaN or negative band axis used to be accepted silently
+    # and set the band count of the whole result.
+    args = ((5.0, 4.0, 3.0), (1.0, 1.0, 1.5), (3.0, 2.5, 1.2), 0.2)
+    with pytest.raises(
+        ValueError, match="'frequencies' must be a scalar or a non-empty 1-D"
+    ):
+        room.image_source_rir(*args, fs=8000, frequencies=[])
+    with pytest.raises(
+        ValueError, match="'frequencies' must be a scalar or a non-empty 1-D"
+    ):
+        room.image_source_rir(
+            *args, fs=8000, frequencies=[[500.0, 1000.0], [2000.0, 4000.0]]
+        )
+    with pytest.raises(
+        ValueError, match="'frequencies' must be finite and strictly positive"
+    ):
+        room.image_source_rir(*args, fs=8000, frequencies=[math.nan, 1000.0])
+    with pytest.raises(
+        ValueError, match="'frequencies' must be finite and strictly positive"
+    ):
+        room.image_source_rir(*args, fs=8000, frequencies=[-500.0, 1000.0])
+
+
+def test_air_attenuation_must_be_a_band_vector() -> None:
+    # A 2-D input whose size matched the band count used to slip through the
+    # size check and die in np.broadcast_to with numpy's axis-remapping
+    # message, naming no argument.
+    with pytest.raises(ValueError, match="'air_attenuation' must be a scalar or a 1-D"):
+        room.image_source_rir(
+            (5.0, 4.0, 3.0),
+            (1.0, 1.0, 1.5),
+            (3.0, 2.5, 1.2),
+            0.2,
+            fs=8000,
+            frequencies=[125.0, 250.0, 500.0, 1000.0],
+            air_attenuation=[[1e-3, 2e-3], [3e-3, 4e-3]],
+        )
+
+
+def test_audible_image_count_requires_an_integer_order() -> None:
+    # A fractional order used to be truncated silently (2.9 returned the
+    # order-2 count) and a non-numeric one died on the comparison itself.
+    with pytest.raises(ValueError, match="'max_order' must be a non-negative integer"):
+        room.audible_image_count(2.9)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'max_order' must be a non-negative integer"):
+        room.audible_image_count(-1)
+
+
 def test_extra_axis_on_the_amplitude_table_is_refused() -> None:
     """A third axis on ``amplitudes`` passes every count, so pin the rank.
 

--- a/tests/simulation/test_fdtd.py
+++ b/tests/simulation/test_fdtd.py
@@ -600,6 +600,10 @@ def test_two_runs_are_bit_identical() -> None:
         ({"probes": [(99, 0)]}, "outside the grid"),
         ({"probes": [(2.5, 3)]}, "probe ix must be an integer"),
         ({"probes": [(2, 3.5)]}, "probe iy must be an integer"),
+        # A malformed entry used to be reported by the interpreter's
+        # unpacking message, naming neither probes nor the entry.
+        ({"probes": [(1, 2, 3)]}, r"probes must hold \(ix, iy\) index pairs"),
+        ({"probes": [5]}, r"probes must hold \(ix, iy\) index pairs"),
         (
             {"boundaries": "absorbing", "absorbing_layer_cells": 0},
             "absorbing_layer_cells",

--- a/tests/simulation/test_fdtd_plane_wave.py
+++ b/tests/simulation/test_fdtd_plane_wave.py
@@ -73,10 +73,38 @@ def test_packet_validation() -> None:
     sim = FDTD2D(C0, DX, shape=(20, 20))
     with pytest.raises(ValueError, match="direction"):
         sim.add_plane_wave("north", center=0.1, width=0.02)
-    with pytest.raises(ValueError, match="width"):
+    with pytest.raises(ValueError, match="'width' must be positive"):
         sim.add_plane_wave("down", center=0.1, width=0.0)
-    with pytest.raises(ValueError, match="wavelength"):
+    with pytest.raises(ValueError, match="'wavelength' must be positive"):
         sim.add_plane_wave("down", center=0.1, width=0.02, wavelength=-1.0)
+
+
+def test_packet_rejects_non_finite_parameters() -> None:
+    # A NaN width or centre used to be accepted and silently turn the whole
+    # pressure field into NaN; an infinite width painted a uniform amplitude
+    # over the entire domain.
+    sim = FDTD2D(C0, DX, shape=(20, 20))
+    with pytest.raises(ValueError, match="'width' must be positive"):
+        sim.add_plane_wave("down", center=0.1, width=np.nan)
+    with pytest.raises(ValueError, match="'width' must be positive"):
+        sim.add_plane_wave("down", center=0.1, width=np.inf)
+    with pytest.raises(ValueError, match="'wavelength' must be positive"):
+        sim.add_plane_wave("down", center=0.1, width=0.02, wavelength=np.nan)
+    with pytest.raises(ValueError, match="center must be finite"):
+        sim.add_plane_wave("down", center=np.nan, width=0.02)
+    with pytest.raises(ValueError, match="amplitude must be finite"):
+        sim.add_plane_wave("down", center=0.1, width=0.02, amplitude=np.nan)
+    assert float(np.abs(sim.p).max()) == 0.0  # nothing landed on the field
+
+
+def test_plane_wave_source_rejects_bad_waveform_and_amplitude() -> None:
+    # A non-callable waveform used to surface from inside _inject_plane as
+    # the interpreter's "'float' object is not callable", and a NaN
+    # amplitude silently NaNed the field step by step.
+    with pytest.raises(ValueError, match="waveform must be callable"):
+        PlaneWaveSource("down", 1.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="amplitude must be finite"):
+        PlaneWaveSource("down", lambda t: 0.0, amplitude=np.nan)
 
 
 def test_rigid_wall_doubles_incident_pressure() -> None:

--- a/tests/test_diagram_canvas_math.py
+++ b/tests/test_diagram_canvas_math.py
@@ -184,6 +184,22 @@ def test_anchor_resolves_from_the_measured_width() -> None:
     assert _uses(element, _BOLD)
 
 
+def test_unknown_anchor_raises_by_name() -> None:
+    # SVG's own vocabulary ("text-anchor: center" does not exist) is the
+    # realistic typo; it must break generation naming the parameter, not
+    # surface as a bare KeyError from the width lookup.
+    with pytest.raises(ValueError, match="'anchor' must be one of"):
+        _element("Sound level", size=15, anchor="center")
+
+
+def test_unknown_label_side_raises_instead_of_drawing_left() -> None:
+    # Every other value used to take the left branch silently, publishing a
+    # dimension label on the wrong side of the line; a typo must now fail.
+    svg = SVG(900, 400, LIGHT)
+    with pytest.raises(ValueError, match="'label_side' must be one of"):
+        svg.dim(200, 100, 200, 300, "1.20 m", 0, 15, label_side="rigth")
+
+
 def test_math_and_prose_escape_metacharacters_in_the_comment() -> None:
     element = _element("A & B $a<b$")
     assert "<!-- A &amp; B $a&lt;b$ -->" in element

--- a/tests/test_errors_and_edge_cases.py
+++ b/tests/test_errors_and_edge_cases.py
@@ -102,6 +102,39 @@ def test_linkwitz_riley_invalid() -> None:
         filters.linkwitz_riley(x, 48000, freq=1000, order=3)
 
 
+@pytest.mark.parametrize("order", [0, -2])
+def test_linkwitz_riley_rejects_non_positive_order(order: int) -> None:
+    """An even order of zero used to return both bands as the untouched input."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal(1000)
+    with pytest.raises(ValueError, match="'order' must be a positive even integer"):
+        filters.linkwitz_riley(x, 48000, freq=1000, order=order)
+
+
+@pytest.mark.parametrize("freq", [0.0, -100.0, float("nan")])
+def test_linkwitz_riley_rejects_non_positive_freq(freq: float) -> None:
+    """A bad crossover frequency used to surface as a scipy message without 'freq'."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal(1000)
+    with pytest.raises(ValueError, match="'freq' must be positive"):
+        filters.linkwitz_riley(x, 48000, freq=freq)
+
+
+def test_linkwitz_riley_rejects_freq_at_or_above_nyquist() -> None:
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal(1000)
+    with pytest.raises(ValueError, match="'freq' must be below the Nyquist frequency"):
+        filters.linkwitz_riley(x, 48000, freq=24000.0)
+
+
+def test_linkwitz_riley_rejects_non_positive_sample_rate() -> None:
+    """fs=0 used to die as ZeroDivisionError; the other entry points name it."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal(1000)
+    with pytest.raises(ValueError, match="Sample rate 'fs' must be positive"):
+        filters.linkwitz_riley(x, 0, freq=1000)
+
+
 def test_calculate_sensitivity_silent() -> None:
     """Verify error handling for silent reference signal.
 
@@ -246,6 +279,57 @@ def test_calculate_level_invalid_mode() -> None:
 
     with pytest.raises(ValueError, match="Invalid mode\\. Use 'rms' or 'peak'\\."):
         bank._calculate_level(signal, "invalid_mode")
+
+
+def test_filter_rejects_non_string_mode() -> None:
+    """A non-string mode used to die in str.lower, deep in level calculation."""
+    bank = filters.OctaveFilterBank(48000)
+    x = np.zeros(1000)
+    with pytest.raises(TypeError, match="'mode' must be a string"):
+        bank.filter(x, mode=None)  # type: ignore[arg-type]
+
+
+def test_filter_rejects_unknown_mode_even_without_levels() -> None:
+    """A misspelled mode was accepted in silence when no levels were computed."""
+    bank = filters.OctaveFilterBank(48000)
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'mode' must be one of"):
+        bank.filter(x, calculate_level=False, sigbands=True, mode="bogus")
+
+
+def test_filter_rejects_three_dimensional_input() -> None:
+    """A 3-D array used to fail in numpy broadcasting, or return truncated bands."""
+    bank = filters.OctaveFilterBank(48000)
+    cube = np.zeros((2, 2, 4800))
+    with pytest.raises(ValueError, match="'x' must be a 1-D signal or a 2-D"):
+        bank.filter(cube)
+
+
+def test_octave_filter_rejects_empty_signal() -> None:
+    """An empty signal used to reach scipy's sosfilt reshape, naming nothing."""
+    empty = np.array([])
+    with pytest.raises(ValueError, match="'x' must contain at least one sample"):
+        filters.octave_filter(empty, 48000)
+
+
+@pytest.mark.parametrize("limits", [1000, ["a", 5000]])
+def test_octave_filter_rejects_malformed_limits(limits: object) -> None:
+    """Malformed limits used to die in the cache key's float(), naming nothing."""
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'limits' must be a pair of frequencies"):
+        filters.octave_filter(x, 48000, limits=limits)  # type: ignore[arg-type]
+
+
+def test_octave_filter_rejects_malformed_limits_on_the_plotting_path() -> None:
+    """The plot branch bypasses the design cache; it must refuse the same way."""
+    x = np.zeros(1000)
+    with pytest.raises(ValueError, match="'limits' must be a pair of frequencies"):
+        filters.octave_filter(
+            x,
+            48000,
+            limits=1000,  # type: ignore[arg-type]
+            response_plot=filters.ResponsePlot(file="unused.png"),
+        )
 
 
 def test_process_bands_without_level_calculation() -> None:

--- a/tests/test_errors_and_edge_cases.py
+++ b/tests/test_errors_and_edge_cases.py
@@ -323,12 +323,13 @@ def test_octave_filter_rejects_malformed_limits(limits: object) -> None:
 def test_octave_filter_rejects_malformed_limits_on_the_plotting_path() -> None:
     """The plot branch bypasses the design cache; it must refuse the same way."""
     x = np.zeros(1000)
+    plot = filters.ResponsePlot(file="unused.png")
     with pytest.raises(ValueError, match="'limits' must be a pair of frequencies"):
         filters.octave_filter(
             x,
             48000,
             limits=1000,  # type: ignore[arg-type]
-            response_plot=filters.ResponsePlot(file="unused.png"),
+            response_plot=plot,
         )
 
 

--- a/tests/test_fdtd2d.py
+++ b/tests/test_fdtd2d.py
@@ -118,6 +118,17 @@ def test_source_outside_the_grid_is_rejected() -> None:
         ({"sponge_width": 4, "sponge_reflection": 1.0}, "sponge_reflection"),
         ({"sponge_width": 4, "sponge_sides": ("north",)}, "sponge sides"),
         ({"sponge_width": 4, "sponge_sides": "north"}, "sponge sides"),
+        # A malformed grid shape used to be reported by somebody else: numpy,
+        # or the sponge_width guard for a zero-length side, or a message
+        # blaming c. A complex c or rho ran to completion on its real part.
+        ({"shape": (0, 10)}, "shape must be a pair of positive integers"),
+        ({"shape": (-1, 10)}, "shape must be a pair of positive integers"),
+        ({"shape": (10, 10.5)}, "shape must be a pair of positive integers"),
+        ({"shape": 10}, "shape must be a pair of positive integers"),
+        ({"shape": (10, 10, 10)}, "shape must be a pair of positive integers"),
+        ({"c": 343.0 + 50.0j}, "c must be real"),
+        ({"c": np.full((10, 10), 343.0 + 50.0j)}, "c must be real"),
+        ({"rho": 1.2 + 3.0j}, "rho must be real"),
     ],
 )
 def test_constructor_rejects_invalid_arguments(

--- a/tests/test_internal_validation.py
+++ b/tests/test_internal_validation.py
@@ -22,13 +22,21 @@ refused according to a coincidence between its bands.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 from phonometry._internal.validation import (
     check_engine,
+    require_1d_signal,
     require_equal_shapes,
+    require_finite_array,
+    require_per_band,
+    require_positive_array,
     require_ranks,
     require_same_length,
     require_same_shape,
@@ -231,3 +239,27 @@ def test_an_unknown_engine_is_refused_by_name() -> None:
     """
     with pytest.raises(ValueError, match="Unknown report engine 'weasyprint'"):
         check_engine("weasyprint")
+
+
+@pytest.mark.parametrize(
+    ("validator", "args"),
+    [
+        (require_positive_array, ()),
+        (require_finite_array, ()),
+        (require_per_band, (np.array([100.0, 200.0]),)),
+        (require_1d_signal, ()),
+    ],
+)
+def test_garbage_input_is_refused_naming_the_parameter(
+    validator: Callable[..., object], args: tuple[object, ...]
+) -> None:
+    """Every coercing validator names the parameter numpy could not convert.
+
+    A tuple of strings used to escape as numpy's own "could not convert
+    string to float" and an object as a bare TypeError, neither saying which
+    parameter refused; the shared conversion now answers for all four
+    validators in one voice.
+    """
+    for garbage in (("bad",), object(), {"a": 1}):
+        with pytest.raises(ValueError, match="'x' must be numeric"):
+            validator(garbage, "x", *args)

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -194,6 +194,33 @@ def test_strike_sel_spectrum_validates_its_arguments() -> None:
         underwater.strike_sel_spectrum(silence, FS)
 
 
+def test_strike_sel_spectrum_rejects_a_non_integer_fraction() -> None:
+    # A non-integer fraction must be rejected, not silently truncated to int().
+    x = _pulse(50.0, 0.2)
+    with pytest.raises(ValueError, match="'fraction' must be 1"):
+        underwater.strike_sel_spectrum(x, FS, fraction=3.9)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'fraction' must be 1"):
+        underwater.strike_sel_spectrum(x, FS, fraction=1.4)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'fraction' must be 1"):
+        underwater.strike_sel_spectrum(x, FS, fraction=None)  # type: ignore[arg-type]
+
+
+def test_strike_sel_spectrum_rejects_a_malformed_limits_pair() -> None:
+    # Anything but a two-element pair must be refused by name, not indexed
+    # into an IndexError/TypeError or silently truncated to its first two.
+    x = _pulse(50.0, 0.2)
+    with pytest.raises(ValueError, match=r"'limits' must be a \(lower, upper\) pair"):
+        underwater.strike_sel_spectrum(x, FS, limits=(10.0,))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"'limits' must be a \(lower, upper\) pair"):
+        underwater.strike_sel_spectrum(x, FS, limits=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"'limits' must be a \(lower, upper\) pair"):
+        underwater.strike_sel_spectrum(
+            x,
+            FS,
+            limits=(10.0, 20_000.0, 99.0),  # type: ignore[arg-type]
+        )
+
+
 def test_strike_sel_spectrum_plot_returns_axes() -> None:
     spec = underwater.strike_sel_spectrum(_pulse(50.0, 0.2), FS)
     assert spec.plot() is not None

--- a/tests/underwater/sources/test_ship_radiated_noise.py
+++ b/tests/underwater/sources/test_ship_radiated_noise.py
@@ -108,6 +108,20 @@ def test_hydrophone_depths_rejects_non_finite_angles() -> None:
         underwater.hydrophone_depths(100.0, angles=(np.inf,))
 
 
+def test_hydrophone_depths_rejects_a_nested_angle_grid() -> None:
+    # A pair of pairs used to come back as a 2-D "depths" array as if valid.
+    with pytest.raises(ValueError, match="'angles' must be a non-empty 1-D array"):
+        underwater.hydrophone_depths(100.0, angles=((15.0, 30.0), (45.0, 60.0)))  # type: ignore[arg-type]
+
+
+def test_hydrophone_depths_normalises_a_single_angle() -> None:
+    # A bare scalar used to come back 0-d, so the documented per-hydrophone
+    # read depths[0] died in numpy; it is normalised to one entry instead.
+    depths = underwater.hydrophone_depths(100.0, angles=45.0)  # type: ignore[arg-type]
+    assert depths.shape == (1,)
+    assert float(depths[0]) == pytest.approx(100.0)
+
+
 def test_source_level_uncertainty_bands() -> None:
     assert underwater.source_level_uncertainty(63.0) == 5.0
     assert underwater.source_level_uncertainty(100.0) == 5.0
@@ -132,3 +146,16 @@ def test_rejects_shape_mismatch() -> None:
         match=r"monopole_source_level: 'rnl'.*must all have the same shape",
     ):
         underwater.monopole_source_level(levels_2_bands, frequencies_3_bands, 8.0)
+
+
+def test_monopole_source_level_rejects_empty_frequencies() -> None:
+    # An empty array used to pass the sign and finiteness predicates vacuously
+    # and come back as a zero-band result whose .plot() died inside numpy.
+    with pytest.raises(ValueError, match="'frequency' must be a non-empty 1-D array"):
+        underwater.monopole_source_level(np.array([]), np.array([]), 8.0)
+
+
+def test_monopole_source_level_rejects_a_two_dimensional_frequency_grid() -> None:
+    grid = np.array([[100.0, 200.0], [300.0, 400.0]])
+    with pytest.raises(ValueError, match="'frequency' must be a non-empty 1-D array"):
+        underwater.monopole_source_level(grid, grid, 8.0)

--- a/tests/underwater/sources/test_ship_radiated_noise.py
+++ b/tests/underwater/sources/test_ship_radiated_noise.py
@@ -114,6 +114,13 @@ def test_hydrophone_depths_rejects_a_nested_angle_grid() -> None:
         underwater.hydrophone_depths(100.0, angles=((15.0, 30.0), (45.0, 60.0)))  # type: ignore[arg-type]
 
 
+def test_hydrophone_depths_rejects_a_non_numeric_angle() -> None:
+    # A string element used to escape as numpy's anonymous "could not
+    # convert string to float" instead of naming the parameter.
+    with pytest.raises(ValueError, match="'angles' must be numeric"):
+        underwater.hydrophone_depths(100.0, angles=("bad",))  # type: ignore[arg-type]
+
+
 def test_hydrophone_depths_normalises_a_single_angle() -> None:
     # A bare scalar used to come back 0-d, so the documented per-hydrophone
     # read depths[0] died in numpy; it is normalised to one entry instead.
@@ -159,3 +166,12 @@ def test_monopole_source_level_rejects_a_two_dimensional_frequency_grid() -> Non
     grid = np.array([[100.0, 200.0], [300.0, 400.0]])
     with pytest.raises(ValueError, match="'frequency' must be a non-empty 1-D array"):
         underwater.monopole_source_level(grid, grid, 8.0)
+
+
+def test_monopole_source_level_rejects_non_numeric_inputs() -> None:
+    # Both shared array guards name the parameter a conversion failure sits
+    # in, instead of letting numpy's anonymous error escape.
+    with pytest.raises(ValueError, match="'frequency' must be numeric"):
+        underwater.monopole_source_level(140.0, ("bad",), 8.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'rnl' must be numeric"):
+        underwater.monopole_source_level(("bad",), 125.0, 8.0)  # type: ignore[arg-type]

--- a/tests/underwater/test_underwater_acoustics.py
+++ b/tests/underwater/test_underwater_acoustics.py
@@ -59,6 +59,21 @@ def test_reference_conversion_round_trip() -> None:
     ) == pytest.approx(100.0)
 
 
+def test_reference_conversion_rejects_a_per_band_level_array() -> None:
+    per_band = np.array([100.0, 110.0])
+    with pytest.raises(ValueError, match="'level' must be a finite number"):
+        underwater.underwater_to_in_air_spl(per_band)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="'level' must be a finite number"):
+        underwater.in_air_to_underwater_spl([74.0, 84.0])  # type: ignore[arg-type]
+
+
+def test_reference_conversion_rejects_a_non_finite_level() -> None:
+    with pytest.raises(ValueError, match="'level' must be a finite number"):
+        underwater.underwater_to_in_air_spl(np.nan)
+    with pytest.raises(ValueError, match="'level' must be a finite number"):
+        underwater.in_air_to_underwater_spl(np.inf)
+
+
 def test_rejects_invalid_signal() -> None:
     two_dimensional = np.zeros((2, 2))
     with_nan = np.array([np.nan, 1.0])

--- a/tests/vibration/structural/test_junction_transmission.py
+++ b/tests/vibration/structural/test_junction_transmission.py
@@ -460,6 +460,18 @@ def test_negative_parameters_rejected() -> None:
         vibration.junction_wave_parameters(-0.1, 3200.0, 240.0, 0.1, 3200.0, 240.0)
 
 
+def test_coupling_loss_factor_rejects_unreconcilable_shapes() -> None:
+    # A coefficient and a frequency of different lengths used to die in
+    # numpy's bare broadcast error, which names neither argument.
+    with pytest.raises(
+        ValueError,
+        match="'transmission_coefficient' and 'frequency' must be broadcastable",
+    ):
+        vibration.coupling_loss_factor(
+            [0.1, 0.2, 0.3], 100.0, 1.0, [125.0, 250.0, 500.0, 1000.0], 5.0
+        )
+
+
 def test_out_of_range_angle_rejected() -> None:
     with pytest.raises(ValueError, match=r"'angle' must lie in \[0, pi/2\]"):
         vibration.corner_transmission_coefficient(2.0, 1.0, 1.0, "X")  # > pi/2


### PR DESCRIPTION
An audit recorded the call sites where a bad input dies deep inside stdlib or numpy, in words that name neither the parameter nor the function: a `KeyError` spelling out a dict key, an `IndexError` about axis 0, LAPACK announcing that an SVD did not converge because a NaN reached it. These are observable failures of a published library, so changing them was held for an explicit decision; with that approval, 93 of the surviving sites now refuse by name at the entry point the caller actually typed, and the other six were measured and found already fixed by earlier waves.

Reproducing each failure before touching it is what the batch was for, and it paid in the usual currency: several sites were not loud and wrong but silent and wrong. A misspelt `label_side="rigth"` rendered byte-identically to the `left` it fell back to, in a module whose stated point is that a typo must break generation readably. A temperature below absolute zero returned an absorption area of minus 127 square metres behind a warning. An infinite airflow input returned an all-NaN result without a word, and a four-entry room dimension was silently truncated to three.

The guards use the shared validation helpers where one fits and the house voice where none does, and they sit at the public entry point rather than in the private helper the traceback used to end in. Two judgement calls worth naming: a scalar `frequencies` is accepted as the single band's centre and refused by name for several bands, the same reading the integer-order precedent takes of a value that arrived through arithmetic; and one site avoided `require_positive_array` because its coercion would have changed which scalars the function accepts, which is more than the finding licensed.

Every guard carries a refusal test matched on the parameter name, and the tests that pinned the old anonymous failures now pin the named ones. Fourteen reference pages move because the docstrings gained the `:raises` lines the guards now honour.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for invalid, non-finite, mismatched, and malformed inputs across acoustics, filters, materials, propagation, simulation, and psychoacoustics.
  * Replaced low-level errors and misleading results with clearer parameter-specific messages.
  * Improved array broadcasting, frequency-range checks, plotting-axis requirements, and handling of short signals and list-based attenuation data.

* **Documentation**
  * Expanded API documentation for accepted inputs and `ValueError` conditions.

* **Tests**
  * Added broad regression coverage for validation, edge cases, broadcasting, plotting, and short-signal processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->