### PR TITLE
Refuse at construction across the remaining domains

### DIFF
--- a/site/src/content/docs/reference/api/electroacoustics/microphone.md
+++ b/site/src/content/docs/reference/api/electroacoustics/microphone.md
@@ -365,7 +365,7 @@ output voltage, and the band spectrum that voltage was measured over.
 | :--- | :--- |
 | `voltage` | Weighted r.m.s. output voltage due to inherent noise, in V (17.2 b); the equivalent noise level is computed from it. |
 | `equivalent_level_db` | Stated equivalent sound pressure level due to inherent noise, in dB SPL (17.1), when not computed from `voltage`. |
-| `weighting` | Weighting of the inherent-noise measurement (default `"A"`, the IEC 60268-1 6.2.1 recommendation). |
+| `weighting` | Weighting of the inherent-noise measurement: `"A"` (default, the IEC 60268-1 6.2.1 A-weighted r.m.s. recommendation) or `"CCIR"` (the 6.2.2 psophometric quasi-peak measurement to CCIR Recommendation 468). These are the two weighted wide-band noise measurements IEC 60268-1 defines; the unweighted band spectrum of 6.2.3 travels in `spectrum` instead. |
 | `spectrum` | Inherent-noise spectrum as `(frequencies, band_levels_db)` in (Hz, dB SPL) (17.2 b). |
 
 ## MicrophoneOverload

--- a/site/src/content/docs/reference/api/environment/ground-barriers.md
+++ b/site/src/content/docs/reference/api/environment/ground-barriers.md
@@ -204,7 +204,7 @@ Per-frequency barrier insertion loss (IL vs frequency).
 | `frequencies` | Frequencies, in hertz. |
 | `insertion_loss` | Insertion loss $\mathrm{IL} = 20 \log_{10} \lvert p_{\text{without}} / p_{\text{with}} \rvert$, in decibels, per frequency. |
 | `fresnel_number` | Fresnel number `N` per frequency (single-edge geometry; the double-edge `N` for a thick barrier). |
-| `method` | Diffraction model used, and the tag the fiche and the plot name it by: `"kurze_anderson"` or `"exact"`, the two the library implements. Any other tag is refused at construction. |
+| `method` | Diffraction model used, and the tag the fiche and the plot name it by: `"kurze_anderson"` or `"exact"`, the two models the library implements. Any other tag is refused at construction. |
 | `ground` | Whether the coherent four-path ground model was applied. |
 | `source_height` | Source height the loss was computed for, in metres, retained (with the other five geometry fields) so `plot_geometry` can draw the section; appended after the original fields and `None` for hand-built results. |
 | `barrier_distance` | Source-to-barrier horizontal distance, in metres. |

--- a/site/src/content/docs/reference/api/environment/ground-barriers.md
+++ b/site/src/content/docs/reference/api/environment/ground-barriers.md
@@ -204,7 +204,7 @@ Per-frequency barrier insertion loss (IL vs frequency).
 | `frequencies` | Frequencies, in hertz. |
 | `insertion_loss` | Insertion loss $\mathrm{IL} = 20 \log_{10} \lvert p_{\text{without}} / p_{\text{with}} \rvert$, in decibels, per frequency. |
 | `fresnel_number` | Fresnel number `N` per frequency (single-edge geometry; the double-edge `N` for a thick barrier). |
-| `method` | Diffraction model used (`"kurze_anderson"` or `"exact"`). |
+| `method` | Diffraction model used, and the tag the fiche and the plot name it by: `"kurze_anderson"` or `"exact"`, the two the library implements. Any other tag is refused at construction. |
 | `ground` | Whether the coherent four-path ground model was applied. |
 | `source_height` | Source height the loss was computed for, in metres, retained (with the other five geometry fields) so `plot_geometry` can draw the section; appended after the original fields and `None` for hand-built results. |
 | `barrier_distance` | Source-to-barrier horizontal distance, in metres. |

--- a/site/src/content/docs/reference/api/environment/spain.md
+++ b/site/src/content/docs/reference/api/environment/spain.md
@@ -134,9 +134,15 @@ Compliance of an activity or port infrastructure (Article 25).
 
 | Name | Description |
 | :--- | :--- |
-| `periods` | The per-period assessments, in day/evening/night order. |
+| `periods` | The per-period assessments, in day/evening/night order; at least one. |
 | `limits` | The limit table row the assessment was made against. |
 | `new_activity` | `True` when the activity is *new* in the sense of the regulation, so the annual criterion of Article 25.1 b i applies; for the inspection of an activity already in operation only the daily and phase criteria apply (Article 25.2). |
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If `periods` is empty. |
 
 ### ActivityAssessment.complies
 
@@ -657,6 +663,12 @@ The assessment of one evaluation period against its limit.
 | `phase_pass` | Whether every `LKeq,Ti` stays within `limit + 5` dB. |
 | `daily_pass` | Whether `LKeq,x` stays within `limit + 3` dB. |
 | `long_term_pass` | Whether `LK,x` stays at or below `limit`, or `None` when the criterion was not evaluated. |
+
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If `period` is not one of [`RD1367_EVALUATION_PERIODS`](/phonometry/reference/api/environment/spain/#rd1367_evaluation_periods). |
 
 ### PeriodAssessment.complies
 

--- a/site/src/content/docs/reference/api/filters/compliance.md
+++ b/site/src/content/docs/reference/api/filters/compliance.md
@@ -159,6 +159,9 @@ the edition (the 1995 edition adds class 0; the 2014 edition keeps only
 classes 1 and 2). An empty result (a bank with no bands in range)
 carries no verdicts, so this returns an empty list.
 
+The first band answers for all of them: construction pins every band
+to the same margin classes.
+
 ### FilterComplianceResult.plot()
 
 ```python

--- a/site/src/content/docs/reference/api/metrology/uncertainty.md
+++ b/site/src/content/docs/reference/api/metrology/uncertainty.md
@@ -62,7 +62,7 @@ Combined standard uncertainty by the GUM law of propagation (clause 5).
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | for no inputs or a malformed correlation matrix. |
+| ValueError | for no inputs, a malformed correlation matrix, or a model that is not finite at the estimates or one evaluation step either side of them. |
 
 ## monte_carlo
 
@@ -107,7 +107,7 @@ probabilistically symmetric one (not the 5.3.4 shortest interval).
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | for no inputs, fewer than 2 trials or bad coverage. |
+| ValueError | for no inputs, fewer than 2 trials or bad coverage, or when the model returns a non-finite output for any trial. |
 
 ## MonteCarloResult
 

--- a/site/src/content/docs/reference/api/power/intensity-compliance.md
+++ b/site/src/content/docs/reference/api/power/intensity-compliance.md
@@ -156,7 +156,7 @@ result can redraw itself and render an accredited fiche.
 
 | Name | Description |
 | :--- | :--- |
-| `overall_class` | The loosest class every band meets (1 or 2), or `None` when at least one band meets neither. |
+| `overall_class` | The strictest class every band meets (1 or 2), or `None` when at least one band meets neither. It is the *largest* per-band class, because a band meeting class 1 meets class 2 as well. |
 | `bands` | The per-band verdict dictionaries of [`verify_intensity_class`](/phonometry/reference/api/power/intensity-compliance/#verify_intensity_class), as an immutable tuple. |
 | `frequency` | Nominal band centre frequencies, in Hz. |
 | `residual_index` | Measured `delta_pI0` per band, in dB. |

--- a/site/src/content/docs/reference/api/rooms/enclosed-space-absorption.md
+++ b/site/src/content/docs/reference/api/rooms/enclosed-space-absorption.md
@@ -173,6 +173,12 @@ Reverberation time from the equivalent absorption area (Formula 5).
 
 **Returns:** The reverberation time $T = \frac{55.3}{c_0} \frac{V (1 - \psi)}{A}$, s.
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | if `absorption_area` is not positive and finite. |
+
 ## ReverberationResult
 
 ```python

--- a/site/src/content/docs/reference/api/rooms/image-source.md
+++ b/site/src/content/docs/reference/api/rooms/image-source.md
@@ -249,7 +249,7 @@ Requires matplotlib (`pip install phonometry[plot]`); returns the
 | Name | Description |
 | :--- | :--- |
 | `ax` | Existing axes, or `None` to create a figure. |
-| `max_order` | Highest reflection order drawn; `None` draws up to order 3 (or the result's own maximum if lower). |
+| `max_order` | Highest reflection order drawn; `None` draws up to order 3 (or the result's own maximum if lower), and `0` draws the direct sound only. |
 | `language` | Label language, `"en"` (default) or `"es"`. |
 | `kwargs` | Forwarded to the room-outline rectangle. |
 

--- a/site/src/content/docs/reference/api/speech/sii.md
+++ b/site/src/content/docs/reference/api/speech/sii.md
@@ -169,6 +169,12 @@ Result of a Speech Intelligibility Index computation (ANSI S3.5-1997).
 | `level_distortion` | Per-band level-distortion factor `Li` in [0, 1] (clause 5.7), unity until the speech spectrum level rises above the standard normal-effort spectrum by more than 10 dB. |
 | `method` | The band procedure used, one of [`SII_METHODS`](/phonometry/reference/api/speech/sii/#sii_methods). |
 
+**Raises**
+
+| Exception | When |
+| :--- | :--- |
+| ValueError | If the per-band quantities disagree, `method` is not one of [`SII_METHODS`](/phonometry/reference/api/speech/sii/#sii_methods), or any quantity is not finite. |
+
 ### SIIResult.plot()
 
 ```python
@@ -264,7 +270,7 @@ equally-contributing critical bands or the 6 octave bands.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | if a spectrum has the wrong length, or the method or effort name is unknown. |
+| ValueError | if a spectrum has the wrong length or carries a non-finite value, or the method or effort name is unknown. |
 
 ## standard_speech_spectra
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
     from numpy.typing import ArrayLike
 
@@ -474,6 +474,104 @@ def require_finite_fields(owner: object, *fields: str) -> None:
         what = "be finite" if array.ndim == 0 else "contain only finite values"
         msg = f"{type(owner).__name__}: '{name}' must {what}."
         raise ValueError(msg)
+
+
+def is_class_designation(value: object, expected: Sequence[int]) -> bool:
+    """Whether *value* is one of *expected* as a designation, not merely equal.
+
+    A compliance class is a label rather than a measurement: a fiche prints it
+    verbatim into ``Class 1`` and readers splice it into the
+    ``margin_class1_db`` key they take the binding margin from. Equality with
+    a class is therefore too weak a test. ``1.0`` labels a band ``Class 1.0``
+    and builds ``margin_class1.0_db``, a key no band carries, and ``True`` is
+    an ``int`` in Python and would label one ``Class True``. NumPy integers
+    are admitted: they are the same designation and print as it.
+
+    :param value: The candidate designation.
+    :param expected: The classes the edition or standard defines.
+    :return: ``True`` when *value* designates one of *expected*.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        return False
+    return int(value) in expected
+
+
+def require_summary_class(
+    owner: object,
+    bands: Sequence[Mapping[str, object]],
+    overall: object,
+    expected: Sequence[int],
+    *,
+    field: str = "overall_class",
+) -> None:
+    """Pin a summary class against the per-band classes it restates.
+
+    Two standards in the library derive one the same way, IEC 61260-1 for a
+    filter bank and IEC 61043 for an intensity instrument: the strictest class
+    every band meets, which is the *largest* per-band class because a band
+    meeting the stricter one meets the looser too, and ``None`` as soon as one
+    band meets no class at all. Their fiches print the two halves side by
+    side, the per-band table from ``band["class"]`` and the boxed verdict from
+    the summary, so a summary that does not restate the rows boxes ``Class 1 -
+    COMPLIES`` above a table where a band reads ``Class 2``, with that band's
+    negative margin quoted beside the word COMPLIES, and passes the instrument
+    against a required class 1.
+
+    Both the per-band classes and the summary are pinned as *designations*
+    before the derivation runs, because the derivation cannot see the
+    difference: ``1.0 == 1`` is true in Python, so a summary of ``1.0``
+    restates a class 1 bank perfectly and still builds ``margin_class1.0_db``,
+    a key no band carries, when a reader splices it.
+
+    :param owner: The result instance, named in the messages.
+    :param bands: The per-band verdict mappings.
+    :param overall: The class stated for the whole instrument, or ``None``.
+    :param expected: The classes the standard defines.
+    :param field: Name of the summary field, for the message.
+    :raises ValueError: if a band carries no class or one that is no
+        designation, or the summary is not the class the bands derive.
+    """
+    who = type(owner).__name__
+    for band in bands:
+        if "class" not in band:
+            msg = (
+                f"{who}: 'bands' must carry a 'class' per band; the "
+                f"{_band_hz(band)} Hz entry has no 'class' key."
+            )
+            raise ValueError(msg)
+        band_class = band["class"]
+        if band_class is not None and not is_class_designation(band_class, expected):
+            msg = (
+                f"{who}: 'bands' must state a 'class' of {list(expected)} or "
+                f"None per band; the {_band_hz(band)} Hz entry states "
+                f"{band_class!r}."
+            )
+            raise ValueError(msg)
+    if overall is not None and not is_class_designation(overall, expected):
+        msg = (
+            f"{who}: '{field}' must be a class of {list(expected)} or None; "
+            f"got {overall!r}."
+        )
+        raise ValueError(msg)
+    if not bands:
+        return
+    classes = [band["class"] for band in bands]
+    derived = None if None in classes else max(cast("list[int]", classes))
+    if overall != derived:
+        binding = next(band for band in bands if band["class"] == derived)
+        msg = (
+            f"{who}: '{field}' must be the class the bands derive, the "
+            "strictest class every band meets and None as soon as one band "
+            f"meets none; got {overall!r} where the {_band_hz(binding)} Hz "
+            f"band states {derived!r}."
+        )
+        raise ValueError(msg)
+
+
+def _band_hz(band: Mapping[str, object]) -> str:
+    """The band centre of *band* for a message, or ``?`` when it carries none."""
+    freq = band.get("freq")
+    return f"{freq:g}" if isinstance(freq, (int, float, np.number)) else "?"
 
 
 def require_per_band(

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -528,8 +528,13 @@ def require_summary_class(
     :param overall: The class stated for the whole instrument, or ``None``.
     :param expected: The classes the standard defines.
     :param field: Name of the summary field, for the message.
+    An empty band list is refused a class of its own: a verdict attested over
+    nothing is not a verdict, and the readers that take a binding margin from
+    it die on an empty sequence instead.
+
     :raises ValueError: if a band carries no class or one that is no
-        designation, or the summary is not the class the bands derive.
+        designation, if a class is claimed over no bands at all, or the
+        summary is not the class the bands derive.
     """
     who = type(owner).__name__
     for band in bands:
@@ -554,6 +559,13 @@ def require_summary_class(
         )
         raise ValueError(msg)
     if not bands:
+        if overall is not None:
+            msg = (
+                f"{who}: '{field}' is {overall!r} but 'bands' is empty: a "
+                "class cannot be attested over no verified band. An "
+                "instrument with no bands in range carries a summary of None."
+            )
+            raise ValueError(msg)
         return
     classes = [band["class"] for band in bands]
     derived = None if None in classes else max(cast("list[int]", classes))

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import numpy as np
 
 from .._internal.validation import (
+    require_choice,
     require_equal_counts,
     require_ranks,
     require_same_length,
@@ -697,9 +698,19 @@ class FlyoverResult:
         refuses it at all; the extra axis rides out untouched to whatever the
         reader places on a map.
 
-        :raises ValueError: if either array has more than one axis.
+        ``metric`` is pinned to the two values the type states, because the
+        figure asks only one question of it: ``== "exposure"``, and anything
+        else falls into the LAmax branch. The entry points route every metric
+        through ``_checked_metric``, so an unknown tag can only be written in
+        by hand, and left unpinned it would not fail at all; it would label
+        the y-axis and the total line of a rendered figure as a maximum level
+        the result never claimed to hold.
+
+        :raises ValueError: if either array has more than one axis, or
+            ``metric`` is not ``"exposure"`` or ``"maximum"``.
         """
         require_ranks(self, segment_levels=1, observer=1)
+        require_choice(self.metric, "metric", ("exposure", "maximum"))
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1390,11 +1401,18 @@ class NoiseContourResult:
         it likes and as many y, and one count over both would reject every grid
         that is not square.
 
-        :raises ValueError: if the level grid disagrees with the x or y axis.
+        ``metric`` is pinned for the same reason as on
+        :class:`FlyoverResult`: the colorbar reads it as ``== "exposure"``
+        with LAmax as the fallback, so an unknown tag would label a rendered
+        contour map with a metric the grid was never computed in.
+
+        :raises ValueError: if the level grid disagrees with the x or y axis,
+            or ``metric`` is not ``"exposure"`` or ``"maximum"``.
         """
         require_ranks(self, x=1, y=1, level=2)
         require_same_length(self, "y", ("level", 0), axis="grid row")
         require_same_length(self, "x", ("level", 1), axis="grid column")
+        require_choice(self.metric, "metric", ("exposure", "maximum"))
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/aircraft/anp_fleet.py
+++ b/src/phonometry/aircraft/anp_fleet.py
@@ -266,9 +266,24 @@ class AnpProfile:
         against the path it was handed at the call, so it reports the trajectory
         rather than the export the pair actually came from.
 
-        :raises ValueError: if a mask does not carry one entry per path segment.
+        The column count of ``path`` is pinned too, not only its rank: the
+        type documents shape ``(N, 5)`` and the figure reads column 2 for the
+        altitude, so a path short of it passes every per-segment count above
+        and dies at ``path[:, 2]`` with an ``IndexError`` naming neither the
+        field nor the profile.
+
+        :raises ValueError: if a mask does not carry one entry per path
+            segment, or ``path`` does not carry the five documented columns.
         """
         require_ranks(self, path=2, ground_roll=1, landing_roll=1)
+        path_columns = 5
+        if np.shape(self.path)[1] != path_columns:
+            msg = (
+                "AnpProfile: 'path' must have shape (N, 5) "
+                "(x, y, z, power, speed); got shape "
+                f"{np.shape(self.path)}."
+            )
+            raise ValueError(msg)
         owner = type(self).__name__
         require_equal_counts(
             owner,

--- a/src/phonometry/aircraft/certification.py
+++ b/src/phonometry/aircraft/certification.py
@@ -569,12 +569,66 @@ class EPNLResult:
         records of the flyover, and the two lengths have nothing to say to each
         other.
 
-        :raises ValueError: if the per-record arrays disagree.
+        Finiteness is pinned on every array besides. The one producer,
+        :func:`effective_perceived_noise_level`, requires a finite spectral
+        history and computes finite PNL and tone corrections from it, so no
+        determination of the library's own carries a NaN record; one written
+        in by hand would not raise anywhere downstream, it would move the
+        figure's PNLTM marker to the NaN itself (``argmax`` of an array with
+        a NaN is the NaN's index) and leave it floating over the gap in the
+        curve, stated as the maximum without a word of complaint.
+
+        ``band_limits`` is the window those records are integrated over, and
+        it is checked against them because it is the one field a length can
+        never vouch for. An index past the last record stops the figure with
+        an ``IndexError`` that names neither this field nor this type, and a
+        negative one does something quieter and worse: Python wraps it, and
+        the 10 dB-down window is shaded over a stretch of the flyover the
+        integration never touched, with PNLTM and EPNL printed confidently
+        beside it.
+
+        :raises ValueError: if the per-record arrays disagree, an array or a
+            scalar determination carries a non-finite value, or
+            ``band_limits`` does not index the records.
         """
         require_ranks(self, frequencies=1, times=1, pnl=1, tone_correction=1, pnlt=1)
         require_same_length(
             self, "times", "pnl", "tone_correction", "pnlt", axis="record"
         )
+        for name in ("frequencies", "times", "pnl", "tone_correction", "pnlt"):
+            if not np.all(np.isfinite(getattr(self, name))):
+                msg = f"EPNLResult: '{name}' must be finite."
+                raise ValueError(msg)
+        # The scalar determinations are pinned for the same sheet: the
+        # producer floors the PNL and refuses non-finite spectra, so none of
+        # the library's own results carries a NaN here, and one written in by
+        # hand would print verbatim in the accredited metrics table ('pnltm',
+        # 'duration_correction', 'bandsharing_adjustment') or stop the boxed
+        # statement inside the display rounding with an error naming nothing
+        # ('epnl').
+        for name in ("pnltm", "bandsharing_adjustment", "duration_correction", "epnl"):
+            if not np.isfinite(float(getattr(self, name))):
+                msg = f"EPNLResult: '{name}' must be finite."
+                raise ValueError(msg)
+        limits = tuple(self.band_limits)
+        pair = 2
+        records = int(np.size(self.times))
+        if len(limits) != pair or not all(
+            isinstance(k, (int, np.integer)) for k in limits
+        ):
+            msg = (
+                "EPNLResult: 'band_limits' must be a pair of 0-based record "
+                f"indices (kF, kL); got {self.band_limits!r}."
+            )
+            raise ValueError(msg)
+        kf, kl = (int(limits[0]), int(limits[1]))
+        if not 0 <= kf <= kl < records:
+            msg = (
+                "EPNLResult: 'band_limits' must satisfy 0 <= kF <= kL < "
+                f"{records} (the record count of 'times'); got "
+                f"{self.band_limits!r}."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -1046,7 +1046,18 @@ class RotorcraftEventResult:
         another instant of the flyover; a band axis of the wrong length does
         the same to the spectrum the perceived-noise metrics were taken over.
 
-        :raises ValueError: if a per-step or per-band quantity disagrees.
+        ``a_levels`` is pinned finite besides. The one producer,
+        :func:`rotorcraft_event`, sums finite band levels into it, so a NaN
+        step can only be written in by hand, and it would not raise anywhere:
+        the figure places the ``LASmax`` marker at ``argmax(a_levels)``, which
+        an array with a NaN answers with the NaN's own index, so the marker
+        floats over the gap in the curve, stated as the maximum. ``pnlt`` is
+        exempt on purpose: it is the field licensed to carry NaN (a step of
+        zero total noisiness, or a band grid short of the noy bands), flagged
+        as such in its own documentation.
+
+        :raises ValueError: if a per-step or per-band quantity disagrees, or
+            ``a_levels`` carries a non-finite value.
         """
         require_ranks(
             self,
@@ -1073,6 +1084,9 @@ class RotorcraftEventResult:
             "pnlt",
             axis="emission step",
         )
+        if not np.all(np.isfinite(self.a_levels)):
+            msg = "RotorcraftEventResult: 'a_levels' must be finite."
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1115,11 +1129,19 @@ class RotorcraftNoiseContourResult:
         square grid handed over transposed: every count still agrees, and the
         footprint is drawn over ground that was never evaluated.
 
-        :raises ValueError: if the level grid disagrees with ``x`` or ``y``.
+        ``metric`` is pinned to the two values the type states because the
+        colorbar reads it one-sidedly, ``== "exposure"`` with LASmax as the
+        fallback: an unknown tag written in by hand would not fail, it would
+        label a rendered contour map with a metric the grid was never
+        computed in.
+
+        :raises ValueError: if the level grid disagrees with ``x`` or ``y``,
+            or ``metric`` is not ``"exposure"`` or ``"maximum"``.
         """
         require_ranks(self, x=1, y=1, level=2)
         require_same_length(self, "y", ("level", 0), axis="grid row")
         require_same_length(self, "x", ("level", 1), axis="grid column")
+        require_choice(self.metric, "metric", ("exposure", "maximum"))
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -47,6 +47,7 @@ the report never merely repeats a manufacturer number:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -55,6 +56,7 @@ import numpy as np
 from .._internal.validation import (
     check_engine,
     require_equal_shapes,
+    require_finite_fields,
     require_positive,
     require_ranks,
     require_same_length,
@@ -314,6 +316,39 @@ class LoudspeakerRatings:
 _DEFAULT_RATINGS = LoudspeakerRatings()
 
 
+def _require_frequency_pair(owner: object, name: str) -> None:
+    """Require the named field to be a finite ``(lo, hi)`` frequency pair.
+
+    The band edges are plain tuples no length check pins: the renderers
+    unpack them positionally (``_range_text(*pair)``), so a triple lands as a
+    ``TypeError`` about a helper's keyword argument and a reversed pair
+    prints the range backwards. Both ends must be positive frequencies, in
+    order; ``lo == hi`` is allowed because a response inside its tolerance at
+    a single sample yields a degenerate but honest range.
+
+    :param owner: The instance whose field is read.
+    :param name: Field name holding a ``(lo, hi)`` tuple or ``None``.
+    :raises ValueError: if the field is not a finite, ordered, positive pair.
+    """
+    value = getattr(owner, name)
+    if value is None:
+        return
+    owner_name = type(owner).__name__
+    if np.shape(value) != (2,):
+        msg = (
+            f"{owner_name}: '{name}' must be a (lo, hi) pair; "
+            f"got shape {np.shape(value)}."
+        )
+        raise ValueError(msg)
+    lo, hi = float(value[0]), float(value[1])
+    if not (math.isfinite(lo) and math.isfinite(hi) and 0.0 < lo <= hi):
+        msg = (
+            f"{owner_name}: '{name}' must be a finite (lo, hi) frequency pair "
+            "with 0 < lo <= hi."
+        )
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class LoudspeakerCharacteristics:
     """Rated loudspeaker characteristics for an IEC 60268-5 report.
@@ -400,11 +435,32 @@ class LoudspeakerCharacteristics:
         as an index error from inside a renderer rather than at the point the
         result was assembled.
 
-        The three ``(lo, hi)`` band edges are left out of every group: they
-        state the ends of a range rather than run along one, and their length
-        of two is a property of the pair, not of any curve.
+        The three ``(lo, hi)`` band edges are left out of every length group
+        -- they state the ends of a range rather than run along one -- and are
+        pinned apart as pairs: the fiche unpacks each positionally into its
+        range text, so a tuple that is not exactly an ordered pair of finite
+        frequencies surfaces as a ``TypeError`` about a helper's keyword
+        argument, or prints the range backwards, naming nothing.
 
-        :raises ValueError: if either half of a curve disagrees with the other.
+        The rated single numbers are pinned finite for the same reason. The
+        factory computes or validates every one of them, so no producer emits
+        a NaN here; one smuggled in through :func:`dataclasses.replace` prints
+        ``nan dB`` in the rated table, the boxed result and the verdict row of
+        an accredited fiche, and a NaN frequency dies in the fiche's
+        hertz rounding with an error naming no field.
+
+        The curves themselves are pinned finite alongside them. The frequency
+        curves arrive through :func:`_as_curve` and the pattern through the
+        polar resolver, and both already refuse a non-finite value, so again
+        no producer emits one; a NaN written into the on-axis frequency axis
+        stops the sheet inside matplotlib with ``Axis limits cannot be NaN or
+        Inf`` (the response panel is scaled by the decades the axis spans,
+        which a NaN makes unmeasurable), and a NaN level leaves a gap in a
+        drawn curve that reads as a frequency the data sheet never covered.
+
+        :raises ValueError: if either half of a curve disagrees with the
+            other, a curve or a scalar field is not finite, or a band-edge
+            pair is not an ordered pair of finite frequencies.
         """
         require_ranks(
             self,
@@ -423,6 +479,31 @@ class LoudspeakerCharacteristics:
         )
         require_same_length(self, "thd_frequencies", "thd_percent", axis="frequency")
         require_same_length(self, "polar_angles_deg", "polar_db", axis="angle")
+        require_finite_fields(
+            self,
+            "frequencies",
+            "spl_db",
+            "impedance_frequencies",
+            "impedance_modulus",
+            "thd_frequencies",
+            "thd_percent",
+            "polar_angles_deg",
+            "polar_db",
+            "rated_impedance",
+            "input_voltage",
+            "distance",
+            "tolerance_db",
+            "reference_level_db",
+            "sensitivity_level_db",
+            "rated_noise_power",
+            "rated_sinusoidal_power",
+            "resonance_frequency",
+            "polar_frequency",
+            "directivity_index_db",
+        )
+        _require_frequency_pair(self, "sensitivity_band")
+        _require_frequency_pair(self, "effective_range")
+        _require_frequency_pair(self, "rated_frequency_range")
 
     @property
     def characteristic_sensitivity_pa(self) -> float:

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -326,9 +326,21 @@ def _require_frequency_pair(owner: object, name: str) -> None:
     order; ``lo == hi`` is allowed because a response inside its tolerance at
     a single sample yields a degenerate but honest range.
 
+    The conversion to ``float`` is what refuses a pair of the right shape
+    whose members are not numbers at all, and its own complaint is caught for
+    the sake of it: ``("low", "high")`` reaches the guard as a ``ValueError``
+    reading ``could not convert string to float: 'low'`` and a pair of
+    arbitrary objects as a ``TypeError`` from inside ``float`` -- neither
+    names the field, neither names the result it belongs to, and the second
+    is not the ``ValueError`` this guard documents. The helper validates
+    fields of two result types (both loudspeaker band edges and
+    ``MicrophoneCharacteristics.effective_range``), so the owner's type name
+    is what tells the two apart in the message.
+
     :param owner: The instance whose field is read.
     :param name: Field name holding a ``(lo, hi)`` tuple or ``None``.
-    :raises ValueError: if the field is not a finite, ordered, positive pair.
+    :raises ValueError: if the field is not numeric, or is not a finite,
+        ordered, positive pair.
     """
     value = getattr(owner, name)
     if value is None:
@@ -340,7 +352,11 @@ def _require_frequency_pair(owner: object, name: str) -> None:
             f"got shape {np.shape(value)}."
         )
         raise ValueError(msg)
-    lo, hi = float(value[0]), float(value[1])
+    try:
+        lo, hi = float(value[0]), float(value[1])
+    except (TypeError, ValueError) as exc:
+        msg = f"{owner_name}: '{name}' must be numeric."
+        raise ValueError(msg) from exc
     if not (math.isfinite(lo) and math.isfinite(hi) and 0.0 < lo <= hi):
         msg = (
             f"{owner_name}: '{name}' must be a finite (lo, hi) frequency pair "

--- a/src/phonometry/electroacoustics/microphone.py
+++ b/src/phonometry/electroacoustics/microphone.py
@@ -69,12 +69,18 @@ import numpy as np
 
 from .._internal.validation import (
     check_engine,
+    require_choice,
     require_equal_shapes,
+    require_finite_fields,
     require_positive,
     require_ranks,
     require_same_length,
 )
-from .loudspeaker import _as_curve, _threshold_crossing
+from .loudspeaker import (
+    _as_curve,
+    _require_frequency_pair,
+    _threshold_crossing,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -286,8 +292,12 @@ class MicrophoneNoise:
     :ivar equivalent_level_db: Stated equivalent sound pressure level due to
         inherent noise, in dB SPL (17.1), when not computed from
         :attr:`voltage`.
-    :ivar weighting: Weighting of the inherent-noise measurement (default
-        ``"A"``, the IEC 60268-1 6.2.1 recommendation).
+    :ivar weighting: Weighting of the inherent-noise measurement: ``"A"``
+        (default, the IEC 60268-1 6.2.1 A-weighted r.m.s. recommendation) or
+        ``"CCIR"`` (the 6.2.2 psophometric quasi-peak measurement to CCIR
+        Recommendation 468). These are the two weighted wide-band noise
+        measurements IEC 60268-1 defines; the unweighted band spectrum of
+        6.2.3 travels in :attr:`spectrum` instead.
     :ivar spectrum: Inherent-noise spectrum as
         ``(frequencies, band_levels_db)`` in (Hz, dB SPL) (17.2 b).
     """
@@ -300,6 +310,12 @@ class MicrophoneNoise:
 
 #: No inherent-noise data supplied, A-weighted: the Clause 17 default.
 _DEFAULT_NOISE = MicrophoneNoise()
+
+#: The weighted wide-band inherent-noise measurements IEC 60268-1 defines:
+#: A-weighted r.m.s. (6.2.1) and psophometric quasi-peak to CCIR
+#: Recommendation 468 (6.2.2). The fiche prints the tag inside ``dB(...)``
+#: markup, so an arbitrary string is refused rather than interpolated.
+_NOISE_WEIGHTINGS = ("A", "CCIR")
 
 
 @dataclass(frozen=True)
@@ -459,8 +475,34 @@ class MicrophoneCharacteristics:
         a fine free-field response beside a coarse polar and a one-third-octave
         noise spectrum is the ordinary case, not a disagreement.
 
+        The rated single numbers are pinned finite, and the effective range
+        as an ordered pair of finite frequencies. The factory computes or
+        validates every one of them, so no producer emits a NaN here; one
+        smuggled in through :func:`dataclasses.replace` prints ``nan mV/Pa``
+        in the rated table and a self-contradicting boxed sensitivity, and a
+        NaN frequency dies in the fiche's hertz rounding naming no field.
+
+        The curves are pinned finite on the same grounds: the response, the
+        noise spectrum and the distortion curve reach the result through
+        :func:`_as_curve` and the pattern through :func:`_resolve_polar`,
+        and each already refuses a non-finite value. A NaN written into the
+        free-field frequency axis after the fact stops the sheet inside
+        matplotlib with ``Axis limits cannot be NaN or Inf`` -- the response
+        panel is scaled by the decades that axis spans, and a NaN makes the
+        span unmeasurable -- naming neither the field nor this result; a NaN
+        level is quieter, leaving a gap in the drawn response that reads as a
+        frequency never measured.
+
+        The noise weighting is pinned to the IEC 60268-1 measurements
+        (:data:`_NOISE_WEIGHTINGS`): the fiche interpolates the tag into its
+        ``dB(...)`` markup, where an arbitrary string is at best a wrong
+        accredited label and at worst a reportlab parse error naming neither
+        the field nor the result.
+
         :raises ValueError: if either member of a paired curve disagrees with
-            the other.
+            the other, a curve or a scalar field is not finite, the effective
+            range is not an ordered pair of finite frequencies, or the noise
+            weighting is not an IEC 60268-1 measurement.
         """
         require_ranks(
             self,
@@ -486,6 +528,31 @@ class MicrophoneCharacteristics:
             "distortion_thd_percent",
             axis="sound pressure level",
         )
+        require_finite_fields(
+            self,
+            "frequencies",
+            "response_db",
+            "distortion_spl_db",
+            "distortion_thd_percent",
+            "noise_frequencies",
+            "noise_band_levels_db",
+            "polar_angles_deg",
+            "polar_db",
+            "reference_frequency",
+            "sensitivity_mv_per_pa",
+            "sensitivity_level_db",
+            "tolerance_db",
+            "rated_impedance",
+            "minimum_load_impedance",
+            "equivalent_noise_level_db",
+            "max_spl_db",
+            "max_spl_thd_percent",
+            "polar_frequency",
+            "directivity_index_db",
+            "supply_current_ma",
+        )
+        _require_frequency_pair(self, "effective_range")
+        require_choice(self.noise_weighting, "noise_weighting", _NOISE_WEIGHTINGS)
 
     @property
     def sensitivity_v_per_pa(self) -> float:

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -427,6 +427,17 @@ class RadiatingPistonResult:
             axis="frequency",
         )
         require_same_length(self, "angles", ("directivity", 1), axis="polar angle")
+        # Finiteness is a construction invariant, not a rendering question:
+        # :func:`piston_directivity` validates its inputs and patches the
+        # on-axis 0/0 to its limit, so no producer emits a non-finite
+        # pattern; one smuggled NaN would silently drop the whole lobe from
+        # :meth:`plot_geometry` (the lobe's peak turns NaN and its `> 0`
+        # gate turns False).
+        for name in ("angles", "directivity"):
+            value = getattr(self, name)
+            if value is not None and not np.all(np.isfinite(value)):
+                msg = f"'{name}' must be finite."
+                raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -82,7 +82,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy import special
 
-from .._internal.validation import require_positive, require_ranks, require_same_length
+from .._internal.validation import (
+    require_finite_fields,
+    require_positive,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -432,12 +437,11 @@ class RadiatingPistonResult:
         # on-axis 0/0 to its limit, so no producer emits a non-finite
         # pattern; one smuggled NaN would silently drop the whole lobe from
         # :meth:`plot_geometry` (the lobe's peak turns NaN and its `> 0`
-        # gate turns False).
-        for name in ("angles", "directivity"):
-            value = getattr(self, name)
-            if value is not None and not np.all(np.isfinite(value)):
-                msg = f"'{name}' must be finite."
-                raise ValueError(msg)
+        # gate turns False). The shared guard is what runs it, so that a
+        # field holding something that is not a number at all is refused by
+        # name too, instead of reaching ``np.isfinite`` as an anonymous
+        # ``TypeError`` raised from inside numpy.
+        require_finite_fields(self, "angles", "directivity")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -73,6 +73,7 @@ from .._internal.validation import (
     require_equal_counts,
     require_ranks,
     require_same_length,
+    require_summary_class,
 )
 
 if TYPE_CHECKING:
@@ -402,8 +403,9 @@ class IntensityInstrumentComplianceResult:
     measured spectrum and the two Table 2 masks it was judged against, so the
     result can redraw itself and render an accredited fiche.
 
-    :ivar overall_class: The loosest class every band meets (1 or 2), or
-        ``None`` when at least one band meets neither.
+    :ivar overall_class: The strictest class every band meets (1 or 2), or
+        ``None`` when at least one band meets neither. It is the *largest*
+        per-band class, because a band meeting class 1 meets class 2 as well.
     :ivar bands: The per-band verdict dictionaries of
         :func:`verify_intensity_class`, as an immutable tuple.
     :ivar frequency: Nominal band centre frequencies, in Hz.
@@ -492,6 +494,7 @@ class IntensityInstrumentComplianceResult:
                         f"{key}={value!r}."
                     )
                     raise ValueError(msg)
+        require_summary_class(self, self.bands, self.overall_class, (1, 2))
 
     def reference_class(self) -> int:
         """The class whose mask the fiche and the plot read margins against.

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -450,7 +450,10 @@ class IntensityInstrumentComplianceResult:
         derived figure with them, so no producer emits a NaN here; one
         smuggled in through :func:`dataclasses.replace` either dies inside
         matplotlib's axis autoscaling naming no field, or prints ``nan`` in
-        an accredited table whose boxed verdict still declares COMPLIES.
+        an accredited table whose boxed verdict still declares COMPLIES. The
+        per-band scan tests :class:`numpy.floating` alongside :class:`float`
+        because only ``np.float64`` subclasses ``float``: a narrower NumPy
+        scalar such as ``np.float32("nan")`` would otherwise pass unread.
 
         :raises ValueError: if the per-band entries disagree, the device tag
             is not a Table 2 column group, or any numeric field is not
@@ -482,7 +485,7 @@ class IntensityInstrumentComplianceResult:
                 raise ValueError(msg)
         for band in self.bands:
             for key, value in band.items():
-                if isinstance(value, float) and not math.isfinite(value):
+                if isinstance(value, (float, np.floating)) and not math.isfinite(value):
                     msg = (
                         "'bands' must carry finite per-band values; the "
                         f"{band.get('freq', math.nan):g} Hz entry has "

--- a/src/phonometry/emission/intensity_compliance.py
+++ b/src/phonometry/emission/intensity_compliance.py
@@ -62,6 +62,7 @@ ISO 9614 dynamic capability :math:`L_\mathrm{d} = \delta_{pI0} - K` follows from
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -437,8 +438,25 @@ class IntensityInstrumentComplianceResult:
         of the whole instrument, so a band list short of an entry gives a
         sheet whose verdict covers a band that is nowhere in its table.
 
-        :raises ValueError: if the per-band entries disagree.
+        The device tag is pinned to the three Table 2 column groups. Two
+        readers dispatch on it -- the fiche's basis strip and the plot's
+        title -- and an unrecognised tag would send them apart: a bare
+        ``KeyError`` from one, a silently wrong "complete instrument" label
+        from the other.
+
+        The masks, the measured spectrum, the separation figures and the
+        numeric per-band verdict values are pinned finite.
+        :func:`verify_intensity_class` validates its inputs finite and every
+        derived figure with them, so no producer emits a NaN here; one
+        smuggled in through :func:`dataclasses.replace` either dies inside
+        matplotlib's axis autoscaling naming no field, or prints ``nan`` in
+        an accredited table whose boxed verdict still declares COMPLIES.
+
+        :raises ValueError: if the per-band entries disagree, the device tag
+            is not a Table 2 column group, or any numeric field is not
+            finite.
         """
+        _check_device(self.device)
         require_ranks(
             self,
             frequency=1,
@@ -454,6 +472,23 @@ class IntensityInstrumentComplianceResult:
             "limit_class1",
             "limit_class2",
         )
+        for name in ("frequency", "residual_index", "limit_class1", "limit_class2"):
+            if not np.all(np.isfinite(getattr(self, name))):
+                msg = f"'{name}' must be finite."
+                raise ValueError(msg)
+        for name in ("spacing", "spacing_offset_db"):
+            if not math.isfinite(getattr(self, name)):
+                msg = f"'{name}' must be finite."
+                raise ValueError(msg)
+        for band in self.bands:
+            for key, value in band.items():
+                if isinstance(value, float) and not math.isfinite(value):
+                    msg = (
+                        "'bands' must carry finite per-band values; the "
+                        f"{band.get('freq', math.nan):g} Hz entry has "
+                        f"{key}={value!r}."
+                    )
+                    raise ValueError(msg)
 
     def reference_class(self) -> int:
         """The class whose mask the fiche and the plot read margins against.

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -47,6 +47,7 @@ criterion of 3 dB instead of 6 dB (clause 8.4.1) and validity up to
 
 from __future__ import annotations
 
+import math
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
@@ -57,6 +58,7 @@ from .._internal.levels_math import energy_mean, energy_sum
 from .._internal.types import as_float_or_array
 from .._internal.validation import (
     check_engine,
+    require_choice,
     require_non_negative,
     require_per_band,
     require_positive,
@@ -257,8 +259,44 @@ class SoundPowerResult:
         so a spectrum of another length gives a sheet whose headline number
         sums bands its own table does not show.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        ``grade`` is pinned beside the shapes because the fiche names the
+        applied standard from it: a tag that is not exactly ``'survey'``
+        or ``'engineering'`` would print a survey (ISO 3746, grade 3)
+        measurement as ISO 3744 engineering grade 2, a stricter standard and
+        a better accuracy grade than the measurement had.
+
+        ``surface_area`` must be finite: no constructor can compute a
+        non-finite ``S`` (:func:`sound_power_pressure` derives it from a
+        validated positive geometry), and the boxed statement prints it as a
+        plain number, so a NaN here would reach the accredited sheet as a
+        literal ``nan``.
+
+        ``sound_power_level`` must be finite for the same reason, band by
+        band. The one producer, :func:`sound_power_pressure`, now requires
+        finite pressure levels and computes a finite ``K1`` (clamped at the
+        criterion) and ``K2`` from them, so a NaN band can only be written in
+        by hand -- and nothing downstream would refuse it: the spectrum
+        figure passes the bands through ``nan_to_num`` and would draw the NaN
+        as a fabricated 0 dB bar in the ordinary colour, while the A-weighted
+        total quietly vanishes from the title. This determination carries no
+        per-band validity flags; the intensity-scanning siblings, whose
+        standard does let a band be undeterminable, flag those bands and are
+        rendered hatched instead. ``sound_power_level_a`` stays unpinned on
+        purpose: several bands without band frequencies leave it NaN by
+        documented design.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            ``grade`` is neither ``'engineering'`` nor ``'survey'``,
+            ``surface_area`` is not finite, or ``sound_power_level`` carries
+            a non-finite band.
         """
+        require_choice(self.grade, "grade", ("engineering", "survey"))
+        if not math.isfinite(self.surface_area):
+            msg = (
+                "SoundPowerResult: 'surface_area' must be finite; "
+                f"got {self.surface_area!r}."
+            )
+            raise ValueError(msg)
         require_ranks(
             self,
             frequencies=1,
@@ -279,6 +317,9 @@ class SoundPowerResult:
             "environmental_correction",
             ("directivity_index", 1),
         )
+        if not np.all(np.isfinite(self.sound_power_level)):
+            msg = "SoundPowerResult: 'sound_power_level' must be finite."
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -899,6 +940,9 @@ def sound_power_pressure(
         raise ValueError(msg)
     if levels.shape[1] == 0:
         msg = "'levels_positions' must contain at least one frequency band."
+        raise ValueError(msg)
+    if not np.all(np.isfinite(levels)):
+        msg = "'levels_positions' must contain only finite values."
         raise ValueError(msg)
     n_positions = levels.shape[0]
 

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -103,6 +103,7 @@ from .._internal.levels_math import energy_mean, weighted_energy_mean
 from .._internal.validation import (
     check_engine,
     require_equal_shapes,
+    require_finite_fields,
     require_per_band,
     require_positive_array,
     require_ranks,
@@ -243,7 +244,18 @@ class SoundPowerIntensityResult:
         downstream can catch that, because a range is well formed whatever it
         was taken over.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        ``surface_area`` must also be finite. The scanned surface is the sum
+        of the segment areas, every one of which the determination refuses
+        unless it is positive and finite, so no scan can hand back a surface
+        that is not a number; the per-band levels are another matter, and
+        ``sound_power_level`` and ``sound_power_level_a`` stay unpinned here
+        because clause 9.2 makes ``NaN`` their reading for a band of negative
+        net power, which the fiche prints as an em dash and leaves out of its
+        totals. An unpinned surface reached the boxed result of the sheet as
+        the literal "Measurement surface S = nan m2".
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            or ``surface_area`` is not finite.
         """
         require_ranks(
             self,
@@ -282,6 +294,7 @@ class SoundPowerIntensityResult:
             "repeatability",
             axis="measurement segment",
         )
+        require_finite_fields(self, "surface_area")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -409,6 +422,12 @@ def _validate_scan(
         if np.asarray(frequencies).shape != (intensity.shape[1],):
             raise ValueError(_FREQUENCIES_BAND_COUNT_MSG)
         require_positive_array(frequencies, "frequencies")
+    # NaN beside the bound, not folded into it: a NaN compares False against
+    # every bound, so the positivity test alone passes it through to a
+    # measurement surface that is not a number.
+    if not np.all(np.isfinite(seg)):
+        msg = "All segment 'areas' must be finite."
+        raise ValueError(msg)
     if np.any(seg <= 0.0):
         msg = "All segment 'areas' must be positive."
         raise ValueError(msg)
@@ -960,7 +979,15 @@ class PrecisionIntensityResult:
         the bands on its second, so its band axis is index 1; the partial
         surfaces are its own axis, shared with no other field.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        ``surface_area`` must also be finite, for the reason it must be in
+        :class:`SoundPowerIntensityResult`: it is the sum of partial surfaces
+        the determination has already refused unless positive and finite, and
+        the clause 10 sheet prints it as "Measurement surface S = ... m2"
+        beside the boxed level. The per-band levels stay unpinned, ``NaN``
+        being clause 9.2's reading of a band the method does not apply to.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            or ``surface_area`` is not finite.
         """
         require_ranks(
             self,
@@ -980,6 +1007,7 @@ class PrecisionIntensityResult:
             "sound_power_level_normalized",
             "not_applicable_band",
         )
+        require_finite_fields(self, "surface_area")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -1417,6 +1445,11 @@ def sound_power_intensity_precision(
             f"'partial_intensity' first axis ({intensity.shape[0]}) must match "
             f"the number of 'areas' ({n_seg})."
         )
+        raise ValueError(msg)
+    # As in the Part 2 scan: a NaN passes every bound, and the surface area
+    # summed from it reaches the clause 10 sheet as a number that is not one.
+    if not np.all(np.isfinite(seg)):
+        msg = "All 'areas' must be finite."
         raise ValueError(msg)
     if np.any(seg <= 0.0):
         msg = "All 'areas' must be positive."

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -63,7 +63,12 @@ if TYPE_CHECKING:
     from .._report.metadata import ReportMetadata
 
 from .._internal.levels_math import energy_mean, energy_sum
-from .._internal.validation import check_engine, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_choice,
+    require_ranks,
+    require_same_length,
+)
 from ._shared import (
     SoundPowerWarning,
     _a_weighting_corrections,
@@ -142,8 +147,16 @@ class ReverberationSoundPowerResult:
         ``LWA`` and the total beneath it come from ``LW``, so nothing on the
         sheet is summed over the surplus and the fiche renders whole.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        ``method`` is pinned beside the shapes because the whole fiche
+        dispatches on it: a tag that is not exactly ``'direct'`` or
+        ``'comparison'`` would render a comparison measurement under the
+        direct method's basis line and equation, with the comparison result's
+        NaN ``c1`` printed as a correction on the accredited sheet.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            or ``method`` is neither ``'direct'`` nor ``'comparison'``.
         """
+        require_choice(self.method, "method", ("direct", "comparison"))
         require_ranks(
             self,
             frequencies=1,

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -299,7 +299,33 @@ class VibrationSoundPowerResult:
         the result supports, where any other mismatched length raises from
         numpy about two shapes that name neither field.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        Every quantity must also be finite, and the area positive. The one
+        producer, :func:`sound_power_from_vibration`, computes finite levels
+        from finite inputs and pins the area positive, so a non-finite value
+        here is never the library's own output; letting one through changes
+        what the fiche claims rather than crashing it. A single NaN band in
+        ``sound_power_level`` turns :attr:`sound_power_level_a` into NaN, so
+        the sheet silently swaps its boxed ``LWA`` for a partial unweighted
+        total ``LW`` (the energy sum skips the NaN band) and compares *that*
+        against the declared A-weighted limit, flipping the printed verdict;
+        a NaN ``area`` prints ``S = nan m2`` beside the boxed result; and an
+        all-NaN ``radiation_factor`` fails the ``epsilon = 1`` survey test,
+        so the basis line asserts an engineering-method determination whose
+        every epsilon cell is an em dash.
+
+        The determination must also cover at least one band. Four length-0
+        columns agree with each other, so every count and rank above is
+        satisfied, and what comes out is a complete accredited sound-power
+        test sheet: the basis line, an empty per-band table, a boxed
+        "Sound power level LW = — dB re 1 pW" over the em dash the energy sum
+        of no bands leaves behind, and the disclaimer under it. A single
+        broadband determination is not that, and is not refused here: it
+        carries one nought-dimensional level and no frequencies, which is one
+        band's worth of data on no band axis.
+
+        :raises ValueError: if any per-band quantity disagrees with the
+            rest, the determination covers no band, any quantity carries a
+            non-finite value, or the area is not a positive finite number.
         """
         require_ranks(
             self,
@@ -315,6 +341,26 @@ class VibrationSoundPowerResult:
             "radiation_factor",
             "frequencies",
         )
+        if np.asarray(self.sound_power_level).size == 0:
+            msg = (
+                "VibrationSoundPowerResult: 'sound_power_level' must carry at "
+                "least one band; the determination is empty."
+            )
+            raise ValueError(msg)
+        for name in (
+            "velocity_level",
+            "sound_power_level",
+            "radiation_factor",
+            "frequencies",
+        ):
+            value = getattr(self, name)
+            if value is not None and not np.all(np.isfinite(np.asarray(value))):
+                msg = (
+                    "VibrationSoundPowerResult: "
+                    f"'{name}' must contain only finite values."
+                )
+                raise ValueError(msg)
+        require_positive(self.area, "area")
 
     @property
     def total_level(self) -> float:

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -143,7 +143,20 @@ class ImpulseProminenceResult:
         taken over the whole set, so a column short of a row leaves a sheet
         whose headline covers an impulse that is not in the table.
 
-        :raises ValueError: if the per-impulse columns disagree.
+        The set must hold at least one impulse: four length-0 columns agree
+        with each other, and the fiche then dies hunting the governing row in
+        numpy's bare "argmax of an empty sequence", naming neither the field
+        nor the result. :func:`impulse_prominence` refuses empty input for the
+        same reason.
+
+        The values must be finite: the producer accepts only positive, finite
+        onset rates and level differences, so ``P`` and ``KI`` are finite by
+        construction, and a NaN smuggled into a hand-built result would
+        otherwise render an affirmative prominence note around a ``nan``
+        (or crash the verdict row anonymously when a requirement is set).
+
+        :raises ValueError: if the per-impulse columns disagree, are empty,
+            or carry a non-finite value.
         """
         require_ranks(
             self,
@@ -160,6 +173,26 @@ class ImpulseProminenceResult:
             "qualifies",
             axis="impulse",
         )
+        if np.asarray(self.onset_rates).size == 0:
+            msg = (
+                "ImpulseProminenceResult: 'onset_rates' must carry at least "
+                "one impulse; all per-impulse columns are empty."
+            )
+            raise ValueError(msg)
+        for name in ("onset_rates", "level_differences", "per_impulse"):
+            if not np.all(np.isfinite(np.asarray(getattr(self, name), np.float64))):
+                msg = (
+                    f"ImpulseProminenceResult: '{name}' must contain only "
+                    "finite values."
+                )
+                raise ValueError(msg)
+        for name in ("prominence", "adjustment"):
+            value = getattr(self, name)
+            if not math.isfinite(float(value)):
+                msg = (
+                    f"ImpulseProminenceResult: '{name}' must be finite; got {value!r}."
+                )
+                raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -86,6 +86,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    require_choice,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -1056,6 +1057,8 @@ class PeriodAssessment:
     :ivar daily_pass: Whether ``LKeq,x`` stays within ``limit + 3`` dB.
     :ivar long_term_pass: Whether ``LK,x`` stays at or below ``limit``, or
         ``None`` when the criterion was not evaluated.
+    :raises ValueError: If ``period`` is not one of
+        :data:`RD1367_EVALUATION_PERIODS`.
     """
 
     period: str
@@ -1070,6 +1073,27 @@ class PeriodAssessment:
     phase_pass: bool
     daily_pass: bool
     long_term_pass: bool | None
+
+    def __post_init__(self) -> None:
+        """Pin the evaluation period to the three the regulation defines.
+
+        :attr:`period` is a tag, not free text: the *acta* reads its heading
+        out of a table keyed by ``"day"``, ``"evening"`` and ``"night"``, and
+        the assessment plot labels its bars the same way. Anything else --
+        a capitalised ``"Day"``, the Spanish ``"dia"`` -- builds a period
+        that looks assessed and dies later as a bare ``KeyError: 'Day'``,
+        naming neither the field, nor the owner, nor the three names it had
+        to be one of. :func:`assess_activity` only ever writes the canonical
+        names, so nothing the library itself produces is refused here.
+
+        The check is exact rather than case-folding, because the field is
+        read as a key and a value normalised behind the caller's back would
+        no longer be the one they passed.
+
+        :raises ValueError: if ``period`` is not one of
+            :data:`RD1367_EVALUATION_PERIODS`.
+        """
+        require_choice(self.period, "period", RD1367_EVALUATION_PERIODS)
 
     @property
     def phase_limit(self) -> float:
@@ -1093,17 +1117,46 @@ class PeriodAssessment:
 class ActivityAssessment:
     """Compliance of an activity or port infrastructure (Article 25).
 
-    :ivar periods: The per-period assessments, in day/evening/night order.
+    :ivar periods: The per-period assessments, in day/evening/night order;
+        at least one.
     :ivar limits: The limit table row the assessment was made against.
     :ivar new_activity: ``True`` when the activity is *new* in the sense of the
         regulation, so the annual criterion of Article 25.1 b i applies; for
         the inspection of an activity already in operation only the daily and
         phase criteria apply (Article 25.2).
+    :raises ValueError: If ``periods`` is empty.
     """
 
     periods: tuple[PeriodAssessment, ...]
     limits: RegulationLimits
     new_activity: bool
+
+    def __post_init__(self) -> None:
+        """Reject an assessment made over no evaluation period at all.
+
+        An empty ``periods`` is not an assessment that found nothing, it is
+        an assessment that never happened, and every reader of it says the
+        opposite: :attr:`complies` is an ``all()`` over nothing and answers
+        ``True``, and the *acta* renders its title, its limit row, its
+        conclusion and its PASS verdict over a phase table with no rows --
+        a complete inspection report of a measurement campaign that does not
+        exist. What stops the sheet, when it stops at all, is the assessment
+        figure, with ``IndexError: index 0 is out of bounds for axis 0 with
+        size 0`` from inside matplotlib.
+
+        :func:`assess_activity` already refuses an empty ``measurements``
+        mapping and a mapping whose keys name no evaluation period, so this
+        pins the same requirement on the result the function returns.
+
+        :raises ValueError: if ``periods`` is empty.
+        """
+        if not self.periods:
+            msg = (
+                "ActivityAssessment: 'periods' must carry at least one "
+                "evaluation period; an assessment over none complies "
+                "vacuously and renders an inspection report with no data."
+            )
+            raise ValueError(msg)
 
     @property
     def complies(self) -> bool:

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -107,8 +107,11 @@ from scipy.special import fresnel, wofz
 
 from ..._internal.validation import (
     check_engine,
+    require_choice,
     require_positive,
     require_positive_array,
+    require_ranks,
+    require_same_length,
 )
 from ...materials.absorbers.porous import delany_bazley, miki
 
@@ -133,6 +136,11 @@ DEFAULT_FREQUENCIES: tuple[float, ...] = (
     4000.0,
     8000.0,
 )
+#: The diffraction models :func:`barrier_insertion_loss` implements, and the
+#: only tags a :class:`BarrierInsertionLoss` may carry: the fiche and the plot
+#: both name the model from this tag, so one they do not know would be printed
+#: as the basis of a prediction the library never made.
+_BARRIER_METHODS: tuple[str, ...] = ("kurze_anderson", "exact")
 #: Tolerance on |x|, x = sqrt(2*pi*N), below which x/tanh(x) is replaced by its
 #: x -> 0 limit of 1+0j (guards the 0/0 indeterminate form at N = 0).
 _X_OVER_TANH_EPS = 1e-9
@@ -623,7 +631,9 @@ class BarrierInsertionLoss:
         p_{\text{with}} \rvert`, in decibels, per frequency.
     :ivar fresnel_number: Fresnel number ``N`` per frequency (single-edge
         geometry; the double-edge ``N`` for a thick barrier).
-    :ivar method: Diffraction model used (``"kurze_anderson"`` or ``"exact"``).
+    :ivar method: Diffraction model used, and the tag the fiche and the plot
+        name it by: ``"kurze_anderson"`` or ``"exact"``, the two the library
+        implements. Any other tag is refused at construction.
     :ivar ground: Whether the coherent four-path ground model was applied.
     :ivar source_height: Source height the loss was computed for, in metres,
         retained (with the other five geometry fields) so
@@ -648,6 +658,65 @@ class BarrierInsertionLoss:
     receiver_distance: float | None = None
     receiver_height: float | None = None
     thickness: float | None = None
+
+    def __post_init__(self) -> None:
+        """Pin the model tag, and the loss finite on its frequency axis.
+
+        :attr:`method` names the diffraction model the sheet cites as its
+        basis, and both readers resolve it through a dict of model phrases
+        with the tag itself as the silent default. Unpinned, any string
+        passed construction and came out the other side as an accredited
+        claim: ``method="ISO 9613-2 Dz"`` printed "Barrier insertion loss IL
+        predicted with ISO 9613-2 Dz, a wave-acoustics complement to the
+        tabulated ISO 9613-2:1996 screening term", naming as the applied
+        model the very formula the fiche exists to distinguish itself from.
+        The tag is pinned here to the two models
+        :func:`barrier_insertion_loss` implements, so the dict lookups it
+        feeds cannot miss.
+
+        The fiche prints one table row per entry of :attr:`frequencies`,
+        reading :attr:`insertion_loss` (and, verbose, the Fresnel number) at
+        the same indices, and the plot draws one against the other. Neither
+        reader names a field when the lengths disagree: a loss one long
+        crashes as matplotlib's bare "x and y must have same first
+        dimension", one short as an ``IndexError`` out of the table. This
+        refusal is raised at construction and says which field is short.
+
+        The loss must also cover at least one frequency. Three length-0 axes
+        agree with each other and pass every count above, and the sheet then
+        asks matplotlib to log-scale an axis with nothing on it, which comes
+        back as "Data cannot be log-scaled because all values are <= 0" --
+        a complaint about values, from a result that has none.
+
+        Every value must also be finite. The one producer,
+        :func:`barrier_insertion_loss`, computes the loss from a geometry
+        and frequency axis it has already pinned finite, so a NaN here is
+        never the library's own output; letting one through renders a
+        ``nan`` table cell under a BOXED ``IL = nan dB`` headline
+        (``np.mean`` computes through it), and with a declared requirement
+        the verdict dies on ``display_round(nan)`` with an anonymous
+        "cannot convert float NaN to integer".
+
+        :raises ValueError: if the method is not a model the library
+            implements, the loss covers no frequency, or the per-frequency
+            fields disagree in length or carry a non-finite value.
+        """
+        require_choice(self.method, "method", _BARRIER_METHODS)
+        require_ranks(self, frequencies=1, insertion_loss=1, fresnel_number=1)
+        require_same_length(
+            self, "frequencies", "insertion_loss", "fresnel_number", axis="frequency"
+        )
+        if np.asarray(self.frequencies).size == 0:
+            msg = (
+                "BarrierInsertionLoss: 'frequencies' must carry at least one "
+                "frequency; the insertion loss is empty."
+            )
+            raise ValueError(msg)
+        for name in ("frequencies", "insertion_loss", "fresnel_number"):
+            value = np.asarray(getattr(self, name), dtype=np.float64)
+            if not np.all(np.isfinite(value)):
+                msg = f"BarrierInsertionLoss: '{name}' must contain only finite values."
+                raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -898,7 +967,7 @@ def barrier_insertion_loss(
             )
         )
     else:
-        msg = f"unknown method {method!r}; options: 'kurze_anderson', 'exact'."
+        msg = f"unknown method {method!r}; options: {_BARRIER_METHODS}."
         raise ValueError(msg)
     return BarrierInsertionLoss(
         frequencies=f,

--- a/src/phonometry/environment/propagation/ground_barriers.py
+++ b/src/phonometry/environment/propagation/ground_barriers.py
@@ -632,8 +632,8 @@ class BarrierInsertionLoss:
     :ivar fresnel_number: Fresnel number ``N`` per frequency (single-edge
         geometry; the double-edge ``N`` for a thick barrier).
     :ivar method: Diffraction model used, and the tag the fiche and the plot
-        name it by: ``"kurze_anderson"`` or ``"exact"``, the two the library
-        implements. Any other tag is refused at construction.
+        name it by: ``"kurze_anderson"`` or ``"exact"``, the two models the
+        library implements. Any other tag is refused at construction.
     :ivar ground: Whether the coherent four-path ground model was applied.
     :ivar source_height: Source height the loss was computed for, in metres,
         retained (with the other five geometry fields) so

--- a/src/phonometry/environment/propagation/outdoor_propagation.py
+++ b/src/phonometry/environment/propagation/outdoor_propagation.py
@@ -48,7 +48,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import check_engine, require_ranks, require_same_length
+from ..._internal.validation import (
+    check_engine,
+    require_finite_array,
+    require_ranks,
+    require_same_length,
+)
 from .air_absorption import air_attenuation
 
 if TYPE_CHECKING:
@@ -256,6 +261,27 @@ class SourceEmission:
     d_omega: float = 0.0
     cmet: float | None = None
 
+    def __post_init__(self) -> None:
+        """Reject an emission carrying a non-finite term.
+
+        Nothing computes a :class:`SourceEmission`; it is built by the caller
+        for :meth:`OutdoorAttenuation.report`, so a NaN here is never the
+        library's own output, and the fiche checks only that the band count
+        matches. One NaN band in ``sound_power_level`` (or a NaN scalar term,
+        which Eq. (3) adds to every band) renders a complete prediction sheet
+        whose BOXED headline reads ``LAT(DW) = nan dB``, and with a declared
+        requirement the verdict dies on ``display_round(nan)`` with an
+        anonymous "cannot convert float NaN to integer".
+
+        :raises ValueError: if any term is not finite.
+        """
+        require_finite_array(self.sound_power_level, "sound_power_level")
+        for name in ("directivity_index", "d_omega", "cmet"):
+            value = getattr(self, name)
+            if value is not None and not np.isfinite(float(value)):
+                msg = f"SourceEmission: '{name}' must be finite."
+                raise ValueError(msg)
+
 
 @dataclass(frozen=True)
 class OutdoorAttenuation:
@@ -298,7 +324,14 @@ class OutdoorAttenuation:
         the boxed figure underneath, so the sheet states a result over bands
         that appear nowhere in the table above it.
 
-        :raises ValueError: if any term disagrees with ``frequencies``.
+        The breakdown must also cover at least one band. Seven length-0 terms
+        agree with each other and satisfy every count above, and the sheet
+        then reads the first band of an axis that has none, dying inside the
+        renderer on numpy's "index 0 is out of bounds for axis 0 with size 0"
+        -- a message naming neither the field nor the result.
+
+        :raises ValueError: if any term disagrees with ``frequencies``, or
+            the breakdown covers no band.
         """
         require_ranks(
             self,
@@ -320,6 +353,12 @@ class OutdoorAttenuation:
             "a_total",
             "d_omega",
         )
+        if np.asarray(self.frequencies).size == 0:
+            msg = (
+                "OutdoorAttenuation: 'frequencies' must carry at least one "
+                "band; the breakdown is empty."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/environment/sources/wind_turbine.py
+++ b/src/phonometry/environment/sources/wind_turbine.py
@@ -24,6 +24,7 @@ uncertainty budgets) is out of scope; these are the underlying closed forms.
 
 from __future__ import annotations
 
+import math
 import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -235,11 +236,35 @@ class WindTurbineTonalityResult:
         of different lengths cannot be paired, so the frequency read off the
         drawing is not the one the tonality was computed at.
 
+        The Formula 30 to 34 chain is pinned finite.
+        :func:`wind_turbine_tonality` validates its spectrum finite and every
+        one of these numbers descends from it by an energy sum, a logarithm
+        of a positive energy or a subtraction, so no spectrum produces a NaN
+        here -- not even the ``has_identified_tone = False`` fallback, whose
+        fields are non-standard but still numbers. One smuggled in through
+        :func:`dataclasses.replace` either prints ``Tonality ΔLtn = nan dB``
+        in the boxed result beside a confident audibility decision, or dies
+        in the fiche's rounding of the metrics table with ``cannot convert
+        float NaN to integer``, naming no field, no result and no fiche.
+
         :raises ValueError: if ``frequencies`` and ``levels`` differ in
-            length, or either is not a 1-D spectrum.
+            length, either is not a 1-D spectrum, or a metric of the
+            Formula 30 to 34 chain is not finite.
         """
         require_ranks(self, frequencies=1, levels=1)
         require_same_length(self, "frequencies", "levels", axis="spectral line")
+        for name in (
+            "tone_frequency",
+            "critical_bandwidth",
+            "tone_level",
+            "masking_level",
+            "tonality",
+            "audibility_criterion",
+            "tonal_audibility",
+        ):
+            if not math.isfinite(getattr(self, name)):
+                msg = f"'{name}' must be finite."
+                raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -370,6 +370,44 @@ def verify_filter_class(
     return {"overall_class": overall, "range_limited": range_limited, "bands": bands}
 
 
+def _margin_classes(band: dict[str, Any]) -> list[int]:
+    """The classes one band verdict carries margins for, read off its keys."""
+    prefix, suffix = "margin_class", "_db"
+    return sorted(
+        int(key[len(prefix) : -len(suffix)])
+        for key in band
+        if key.startswith(prefix) and key.endswith(suffix)
+    )
+
+
+def _require_margin_classes(
+    bands: tuple[dict[str, Any], ...], edition: str, expected: list[int]
+) -> None:
+    """Pin the margin keys of every band to the classes the edition defines.
+
+    Two things reach here. A verdict verified against the other edition: its
+    bands carry that edition's margin keys, so the corridor would be drawn
+    from the wrong table under this edition's title. And a band list whose
+    entries disagree among themselves, which reading only the first band let
+    through: :meth:`FilterComplianceResult.plot` and the ``.report()`` fiche
+    read ``margin_class<c>_db`` out of *every* band, so one later band short
+    of the key dies in a bare ``KeyError`` halfway through the figure.
+
+    :raises ValueError: if a band carries margins for other classes than
+        ``expected`` (in any order).
+    """
+    wanted = sorted(expected)
+    for band in bands:
+        carried = _margin_classes(band)
+        if carried != wanted:
+            msg = (
+                f"'edition' ({edition!r}) defines classes {expected}, but the "
+                f"{band.get('freq', math.nan):g} Hz entry of 'bands' carries "
+                f"margins for classes {carried}."
+            )
+            raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class FilterComplianceResult:
     """IEC 61260-1 class-compliance verdict of an :class:`OctaveFilterBank`.
@@ -432,7 +470,11 @@ class FilterComplianceResult:
         whose edition disagrees with its margin keys would draw the other
         edition's corridor under this edition's title, and an overall class
         the bands carry no margins for dies in a bare ``KeyError`` halfway
-        through the figure.
+        through the figure. Every band is checked, not just the first:
+        :func:`verify_filter_class` fills each entry from the same list of
+        classes, so a band list whose entries disagree among themselves is
+        one no bank produced, and it is the later band that the fiche's
+        per-band table and the plot's worst-band search die on.
 
         A bank with no bands in range is an outcome
         :func:`verify_filter_class` does produce, and it always pairs it with
@@ -457,14 +499,8 @@ class FilterComplianceResult:
         require_ranks(self, band_frequencies=1)
         require_same_length(self, "bands", "sos", "band_frequencies", "factors")
         require_choice(self.edition, "edition", tuple(_FILTER_EDITIONS))
-        carried = self.available_classes()
         expected = list(_FILTER_EDITIONS[self.edition]["classes"])
-        if self.bands and carried != sorted(expected):
-            msg = (
-                f"'edition' ({self.edition!r}) defines classes {expected}, but "
-                f"the band verdicts carry margins for classes {carried}."
-            )
-            raise ValueError(msg)
+        _require_margin_classes(self.bands, self.edition, expected)
         if self.overall_class is not None and self.overall_class not in expected:
             msg = (
                 f"'overall_class' must be one of {expected} for edition "
@@ -495,15 +531,13 @@ class FilterComplianceResult:
         the edition (the 1995 edition adds class 0; the 2014 edition keeps only
         classes 1 and 2). An empty result (a bank with no bands in range)
         carries no verdicts, so this returns an empty list.
+
+        The first band answers for all of them: construction pins every band
+        to the same margin classes.
         """
         if not self.bands:
             return []
-        prefix, suffix = "margin_class", "_db"
-        return sorted(
-            int(key[len(prefix) : -len(suffix)])
-            for key in self.bands[0]
-            if key.startswith(prefix) and key.endswith(suffix)
-        )
+        return _margin_classes(self.bands[0])
 
     def reference_class(self) -> int:
         """The class whose corridor the fiche/plot overlays.

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -34,13 +34,19 @@ network applied to the whole signal against a design-goal response, live in
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from scipy import signal
 
-from .._internal.validation import check_engine, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_choice,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -419,10 +425,68 @@ class FilterComplianceResult:
         of the whole bank, so a band list short of an entry gives a sheet
         whose verdict covers a band that is nowhere in its table.
 
-        :raises ValueError: if the per-band entries disagree.
+        The edition and the class are pinned against the band verdicts they
+        summarise, because the three travel together: the plot and the fiche
+        pick the corridor from :attr:`edition` and read
+        ``margin_class<overall_class>_db`` out of :attr:`bands`. A verdict
+        whose edition disagrees with its margin keys would draw the other
+        edition's corridor under this edition's title, and an overall class
+        the bands carry no margins for dies in a bare ``KeyError`` halfway
+        through the figure.
+
+        A bank with no bands in range is an outcome
+        :func:`verify_filter_class` does produce, and it always pairs it with
+        ``overall_class = None`` so nothing is attested vacuously; the class
+        is therefore pinned against the emptiness too, because a stated class
+        over zero bands prints an accredited verdict box above a table that
+        reportlab then refuses to build, complaining about a table with no
+        rows and naming neither the bands nor the bank.
+
+        The per-band numbers are pinned finite. Every margin comes from a
+        ``min`` over the measured relative attenuation against the Table 1
+        mask, so no bank emits a NaN here; one smuggled in through
+        :func:`dataclasses.replace` prints ``Class 1 (+nan dB)`` in the
+        per-band table under a boxed verdict that still reads COMPLIES,
+        because the binding margin reads whichever band is untouched.
+
+        :raises ValueError: if the per-band entries disagree, the edition is
+            unknown or does not match the per-band margin keys, the overall
+            class is not one the bands carry margins for, a class is stated
+            over no bands at all, or a per-band value is not finite.
         """
         require_ranks(self, band_frequencies=1)
         require_same_length(self, "bands", "sos", "band_frequencies", "factors")
+        require_choice(self.edition, "edition", tuple(_FILTER_EDITIONS))
+        carried = self.available_classes()
+        expected = list(_FILTER_EDITIONS[self.edition]["classes"])
+        if self.bands and carried != sorted(expected):
+            msg = (
+                f"'edition' ({self.edition!r}) defines classes {expected}, but "
+                f"the band verdicts carry margins for classes {carried}."
+            )
+            raise ValueError(msg)
+        if self.overall_class is not None and self.overall_class not in expected:
+            msg = (
+                f"'overall_class' must be one of {expected} for edition "
+                f"{self.edition!r} (or None); got {self.overall_class!r}."
+            )
+            raise ValueError(msg)
+        if self.overall_class is not None and not self.bands:
+            msg = (
+                f"'overall_class' is {self.overall_class!r} but 'bands' is "
+                "empty: a class cannot be attested over no verified band. A "
+                "bank with no bands in range carries 'overall_class' None."
+            )
+            raise ValueError(msg)
+        for band in self.bands:
+            for key, value in band.items():
+                if isinstance(value, float) and not math.isfinite(value):
+                    msg = (
+                        "'bands' must carry finite per-band values; the "
+                        f"{band.get('freq', math.nan):g} Hz entry has "
+                        f"{key}={value!r}."
+                    )
+                    raise ValueError(msg)
 
     def available_classes(self) -> list[int]:
         """The performance classes carried by the per-band verdict dictionaries.

--- a/src/phonometry/filters/compliance.py
+++ b/src/phonometry/filters/compliance.py
@@ -43,9 +43,11 @@ from scipy import signal
 
 from .._internal.validation import (
     check_engine,
+    is_class_designation,
     require_choice,
     require_ranks,
     require_same_length,
+    require_summary_class,
 )
 
 if TYPE_CHECKING:
@@ -470,7 +472,13 @@ class FilterComplianceResult:
         whose edition disagrees with its margin keys would draw the other
         edition's corridor under this edition's title, and an overall class
         the bands carry no margins for dies in a bare ``KeyError`` halfway
-        through the figure. Every band is checked, not just the first:
+        through the figure. The class is pinned as a designation, not merely
+        as a value equal to one: ``1.0`` and ``True`` compare equal to class 1
+        yet build ``margin_class1.0_db`` and print ``Class True``. Being one
+        of the edition's classes is not enough either, so the class is pinned
+        against the per-band classes it summarises as well; see
+        :func:`~.._internal.validation.require_summary_class`. Every band is checked, not just the
+        first:
         :func:`verify_filter_class` fills each entry from the same list of
         classes, so a band list whose entries disagree among themselves is
         one no bank produced, and it is the later band that the fiche's
@@ -493,15 +501,19 @@ class FilterComplianceResult:
 
         :raises ValueError: if the per-band entries disagree, the edition is
             unknown or does not match the per-band margin keys, the overall
-            class is not one the bands carry margins for, a class is stated
-            over no bands at all, or a per-band value is not finite.
+            class is not one the bands carry margins for or not the one the
+            per-band classes derive, a band carries no class of the edition,
+            a class is stated over no bands at all, or a per-band value is not
+            finite.
         """
         require_ranks(self, band_frequencies=1)
         require_same_length(self, "bands", "sos", "band_frequencies", "factors")
         require_choice(self.edition, "edition", tuple(_FILTER_EDITIONS))
         expected = list(_FILTER_EDITIONS[self.edition]["classes"])
         _require_margin_classes(self.bands, self.edition, expected)
-        if self.overall_class is not None and self.overall_class not in expected:
+        if self.overall_class is not None and not is_class_designation(
+            self.overall_class, expected
+        ):
             msg = (
                 f"'overall_class' must be one of {expected} for edition "
                 f"{self.edition!r} (or None); got {self.overall_class!r}."
@@ -514,6 +526,7 @@ class FilterComplianceResult:
                 "bank with no bands in range carries 'overall_class' None."
             )
             raise ValueError(msg)
+        require_summary_class(self, self.bands, self.overall_class, expected)
         for band in self.bands:
             for key, value in band.items():
                 if isinstance(value, float) and not math.isfinite(value):

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -29,7 +29,12 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from .._internal.validation import check_engine, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_finite_fields,
+    require_ranks,
+    require_same_length,
+)
 from .._internal.warnings import PhonometryWarning
 from .threshold import age_threshold
 
@@ -187,12 +192,20 @@ class NiptsResult:
         PASS/FAIL verdict read off that mean, taken from positions belonging
         to whatever grid the array was computed on.
 
-        The two scalars the spectra were computed from are pinned finite as
+        The three scalars the prediction is stated for are pinned finite as
         well: a NaN ``l_ex`` (or ``years``) sails past every domain warning
         (no comparison fires on NaN) and turns every spectrum into NaN, so
         the plot would draw a completely blank axes under an ordinary title
-        ending "= nan dB". ``l_ex`` deliberately has no lower bound and
-        ``years`` no upper one; only finiteness is construction's business.
+        ending "= nan dB". ``fractile`` leaves the spectra intact and so
+        reaches the fiche unopposed: it is the population the whole sheet is
+        stated for, printed as ISO 1999's own ``Q = 100 (1 - fractile)``, and
+        a NaN prints there as "Population fractile Q = nan %" under the
+        non-median gloss (no comparison places it at the median either),
+        beside an extrapolation caveat earned the same empty way. An infinity
+        prints "Q = -inf %". ``l_ex`` deliberately has no lower bound and
+        ``years`` no upper one, and the fractile's own (0, 1) interval is
+        :func:`nipts`'s to enforce; only finiteness is construction's
+        business.
 
         The prediction must also cover at least one audiometric frequency:
         five length-0 spectra agree with each other (``nipts(frequencies=[])``
@@ -205,14 +218,10 @@ class NiptsResult:
         convert float NaN to integer".
 
         :raises ValueError: if any spectrum disagrees with ``frequencies``,
-            is empty or non-finite, or if ``l_ex`` or ``years`` is not finite.
+            is empty or non-finite, or if ``l_ex``, ``years`` or ``fractile``
+            is not finite.
         """
-        if not math.isfinite(self.l_ex):
-            msg = "'l_ex' must be finite."
-            raise ValueError(msg)
-        if not math.isfinite(self.years):
-            msg = "'years' must be finite."
-            raise ValueError(msg)
+        require_finite_fields(self, "l_ex", "years", "fractile")
         require_ranks(
             self,
             frequencies=1,
@@ -236,10 +245,9 @@ class NiptsResult:
                 "audiometric frequency; the prediction is empty."
             )
             raise ValueError(msg)
-        for name in ("frequencies", "median", "value", "spread_upper", "spread_lower"):
-            if not np.all(np.isfinite(np.asarray(getattr(self, name), np.float64))):
-                msg = f"NiptsResult: '{name}' must contain only finite values."
-                raise ValueError(msg)
+        require_finite_fields(
+            self, "frequencies", "median", "value", "spread_upper", "spread_lower"
+        )
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -359,9 +367,23 @@ class HtlanResult:
         smuggled into a hand-built result, where it would crash the fiche's
         rounding with a bare "cannot convert float NaN to integer".
 
+        The four scalars are pinned finite for a different reason: nothing
+        computes with them here, so nothing downstream trips over them. They
+        are the listener and exposure conditions the prediction is stated
+        for, and the fiche prints all four verbatim - "Listener: male, age
+        nan years", an exposure line, and the population as ISO 1999's
+        ``Q = 100 (1 - fractile)`` - as does the plot title. Left unguarded
+        they publish a finished, internally consistent-looking accredited
+        sheet whose stated conditions are nonsense. As in
+        :class:`NiptsResult`, only finiteness is construction's business: the
+        age floor of ISO 7029 and the fractile's (0, 1) interval belong to
+        :func:`htlan`.
+
         :raises ValueError: if any component disagrees with ``frequencies``,
-            is empty, or carries a non-finite value.
+            is empty, or carries a non-finite value, or if ``age``, ``l_ex``,
+            ``years`` or ``fractile`` is not finite.
         """
+        require_finite_fields(self, "age", "l_ex", "years", "fractile")
         require_ranks(self, frequencies=1, htla=1, nipts=1, threshold=1)
         require_same_length(
             self,
@@ -377,10 +399,7 @@ class HtlanResult:
                 "audiometric frequency; the prediction is empty."
             )
             raise ValueError(msg)
-        for name in ("frequencies", "htla", "nipts", "threshold"):
-            if not np.all(np.isfinite(np.asarray(getattr(self, name), np.float64))):
-                msg = f"HtlanResult: '{name}' must contain only finite values."
-                raise ValueError(msg)
+        require_finite_fields(self, "frequencies", "htla", "nipts", "threshold")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -187,8 +187,32 @@ class NiptsResult:
         PASS/FAIL verdict read off that mean, taken from positions belonging
         to whatever grid the array was computed on.
 
-        :raises ValueError: if any spectrum disagrees with ``frequencies``.
+        The two scalars the spectra were computed from are pinned finite as
+        well: a NaN ``l_ex`` (or ``years``) sails past every domain warning
+        (no comparison fires on NaN) and turns every spectrum into NaN, so
+        the plot would draw a completely blank axes under an ordinary title
+        ending "= nan dB". ``l_ex`` deliberately has no lower bound and
+        ``years`` no upper one; only finiteness is construction's business.
+
+        The prediction must also cover at least one audiometric frequency:
+        five length-0 spectra agree with each other (``nipts(frequencies=[])``
+        selects an empty subset without meeting an unknown one), and the fiche
+        then dies hunting the representative rows in numpy's bare "argmax of
+        an empty sequence", naming neither the field nor the result. And the
+        spectra must be finite: clause 6.3 emits finite shifts for finite
+        exposure conditions, so a NaN can only be smuggled into a hand-built
+        result, where it would crash the fiche's rounding with a bare "cannot
+        convert float NaN to integer".
+
+        :raises ValueError: if any spectrum disagrees with ``frequencies``,
+            is empty or non-finite, or if ``l_ex`` or ``years`` is not finite.
         """
+        if not math.isfinite(self.l_ex):
+            msg = "'l_ex' must be finite."
+            raise ValueError(msg)
+        if not math.isfinite(self.years):
+            msg = "'years' must be finite."
+            raise ValueError(msg)
         require_ranks(
             self,
             frequencies=1,
@@ -206,6 +230,16 @@ class NiptsResult:
             "spread_lower",
             axis="audiometric frequency",
         )
+        if np.asarray(self.frequencies).size == 0:
+            msg = (
+                "NiptsResult: 'frequencies' must carry at least one "
+                "audiometric frequency; the prediction is empty."
+            )
+            raise ValueError(msg)
+        for name in ("frequencies", "median", "value", "spread_upper", "spread_lower"):
+            if not np.all(np.isfinite(np.asarray(getattr(self, name), np.float64))):
+                msg = f"NiptsResult: '{name}' must contain only finite values."
+                raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -315,7 +349,18 @@ class HtlanResult:
         place of the failure: the field that disagrees, as the result is
         built, instead of a shape mismatch raised from inside the renderer.
 
-        :raises ValueError: if any component disagrees with ``frequencies``.
+        The threshold must also cover at least one audiometric frequency:
+        four length-0 components agree with each other
+        (``htlan(..., frequencies=[])`` selects an empty subset), and the
+        fiche then dies hunting the representative rows in numpy's bare
+        "argmax of an empty sequence", naming neither the field nor the
+        result. And the components must be finite: Formula (1) combines two
+        finite components into a finite threshold, so a NaN can only be
+        smuggled into a hand-built result, where it would crash the fiche's
+        rounding with a bare "cannot convert float NaN to integer".
+
+        :raises ValueError: if any component disagrees with ``frequencies``,
+            is empty, or carries a non-finite value.
         """
         require_ranks(self, frequencies=1, htla=1, nipts=1, threshold=1)
         require_same_length(
@@ -326,6 +371,16 @@ class HtlanResult:
             "threshold",
             axis="audiometric frequency",
         )
+        if np.asarray(self.frequencies).size == 0:
+            msg = (
+                "HtlanResult: 'frequencies' must carry at least one "
+                "audiometric frequency; the prediction is empty."
+            )
+            raise ValueError(msg)
+        for name in ("frequencies", "htla", "nipts", "threshold"):
+            if not np.all(np.isfinite(np.asarray(getattr(self, name), np.float64))):
+                msg = f"HtlanResult: '{name}' must contain only finite values."
+                raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -46,13 +46,18 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field, replace
-from math import log10, sqrt
+from math import isfinite, log10, sqrt
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
 from .._internal.levels_math import energy_mean
-from .._internal.validation import check_engine
+from .._internal.validation import (
+    check_engine,
+    require_choice,
+    require_finite_array,
+    require_positive,
+)
 from .._internal.warnings import PhonometryWarning
 
 if TYPE_CHECKING:
@@ -294,13 +299,18 @@ class Task:
     instrument: InstrumentClass | None = None
 
     def __post_init__(self) -> None:
-        """Reject an empty ``samples`` tuple and a non-positive ``duration_hours``."""
+        """Reject empty or non-finite ``samples`` and a bad ``duration_hours``.
+
+        Both helpers reject NaN as well: a NaN sample (or duration) would
+        pass a bare emptiness/sign check, make ``lex_8h`` NaN, and stop the
+        exposure plot inside matplotlib with "Axis limits cannot be NaN or
+        Inf" -- naming neither the task nor the sample that carried it.
+        """
         if len(self.samples) == 0:
             msg = "A Task needs at least one Lp,A,eqT sample."
             raise ValueError(msg)
-        if self.duration_hours <= 0.0:
-            msg = "'duration_hours' must be positive."
-            raise ValueError(msg)
+        require_finite_array(self.samples, "samples")
+        require_positive(self.duration_hours, "duration_hours")
 
 
 @dataclass(frozen=True)
@@ -320,6 +330,34 @@ class TaskContribution:
     c1b: float  # duration sensitivity coefficient (Eq C.5), dB/h
     u2: float  # instrument standard uncertainty (Table C.5), dB
     u3: float  # microphone-position standard uncertainty (Clause C.6), dB
+
+    def __post_init__(self) -> None:
+        """Reject a contribution carrying a non-finite term.
+
+        :func:`task_based_exposure` computes every term from a :class:`Task`
+        whose samples and duration are already pinned finite, so a NaN here is
+        never the library's own output. The fiche prints the levels through
+        the same one-decimal formatter as the daily total, whose
+        ``math.floor`` dies on NaN with "cannot convert float NaN to integer"
+        -- naming neither the field, the class nor the cause.
+
+        :raises ValueError: if any numeric term is not finite.
+        """
+        for name in (
+            "lp_aeqt",
+            "duration_hours",
+            "lex_8h_contribution",
+            "sample_range_db",
+            "u1a",
+            "c1a",
+            "u1b",
+            "c1b",
+            "u2",
+            "u3",
+        ):
+            if not isfinite(float(getattr(self, name))):
+                msg = f"TaskContribution: '{name}' must be finite."
+                raise ValueError(msg)
 
     @property
     def variance_contribution(self) -> float:
@@ -365,6 +403,85 @@ class ExposureResult:
     sampling_advisory: bool = False  # c1*u1 > 3.5 dB, or 3 dB spread on 3 samples
     instrument: InstrumentClass | None = None
     tasks: tuple[TaskContribution, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Pin the tags, the levels and the record the strategy owes the fiche.
+
+        The strategy is a tag the fiche resolves through a dict to name the
+        applied ISO 9612 clause in its basis line; unpinned, an unknown tag
+        passes construction and dies there as a bare ``KeyError`` naming
+        neither the field nor the accepted values. The instrument class is a
+        ``Literal`` with no runtime force behind it and meets the same dict.
+        Both are pinned here, by name.
+
+        The levels and uncertainties must be finite: every strategy computes
+        them from samples already pinned finite, so NaN is never the
+        library's own output, and each is printed through a formatter whose
+        ``math.floor`` dies on NaN with an anonymous "cannot convert float
+        NaN to integer".
+
+        Each strategy must also carry its work analysis, because the fiche
+        renders it unconditionally (Clause 15 b/d): a task-based result its
+        per-task contributions, a job-based or full-day result the sampling
+        summary (``N``, ``Lp,A,eqTe``, ``T_e`` and the Formula (C.9) budget
+        terms). Built bare, the sheet would print the literal string ``None``
+        for ``N`` and a fabricated 0,0 for every budget term -- an accredited
+        page stating a zero uncertainty budget nobody measured.
+
+        :raises ValueError: for an unknown strategy or instrument tag, a
+            non-finite level or uncertainty, or a result missing the work
+            analysis its strategy reports.
+        """
+        require_choice(self.strategy, "strategy", ("task", "job", "full_day"))
+        if self.instrument is not None:
+            require_choice(self.instrument, "instrument", tuple(INSTRUMENT_U2))
+        for name in (
+            "lex_8h",
+            "combined_standard_uncertainty",
+            "expanded_uncertainty",
+            "coverage_factor",
+            "lp_aeqte",
+            "effective_duration_hours",
+            "u1",
+            "c1u1",
+            "u2",
+            "u3",
+        ):
+            value = getattr(self, name)
+            if value is not None and not isfinite(float(value)):
+                msg = f"ExposureResult: '{name}' must be finite."
+                raise ValueError(msg)
+        if self.strategy == "task":
+            if not self.tasks:
+                msg = (
+                    "ExposureResult: 'tasks' is empty; a task-based result "
+                    "carries one TaskContribution per task of the nominal day "
+                    "(ISO 9612:2009 Clause 15 b)."
+                )
+                raise ValueError(msg)
+            return
+        missing = [
+            name
+            for name in (
+                "n_samples",
+                "lp_aeqte",
+                "effective_duration_hours",
+                "u1",
+                "c1u1",
+                "u2",
+                "u3",
+            )
+            if getattr(self, name) is None
+        ]
+        if missing:
+            listed = ", ".join(f"'{name}'" for name in missing)
+            msg = (
+                f"ExposureResult: {listed} must be supplied for a "
+                f"{self.strategy!r} result; the fiche prints the sampling "
+                "summary and its Formula (C.9) budget (ISO 9612:2009 "
+                "Clause 15 d)."
+            )
+            raise ValueError(msg)
 
     @property
     def upper_limit(self) -> float:

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -990,6 +990,30 @@ class PeakStatisticsResult:
     duration: float
     fs: float
 
+    def __post_init__(self) -> None:
+        """Reject standardized peak heights that are not sorted ascending.
+
+        The plot pairs :attr:`peak_values` positionally with the empirical
+        exceedance ``1 - rank/n``, and spans its Rice curves from the first
+        entry to the last: both readings are statements about the sorted
+        order :func:`peak_statistics` writes, not about the array as such.
+        An unsorted array is accepted by every count -- nothing changes
+        length -- and publishes a wrong exceedance under the ordinary title,
+        so the order is pinned here, where the mistake can be named.
+
+        :raises ValueError: if the peak heights carry more than one axis or
+            are not in ascending order.
+        """
+        require_ranks(self, peak_values=1)
+        values = np.asarray(self.peak_values)
+        if values.ndim == 1 and np.any(np.diff(values) < 0.0):
+            msg = (
+                "PeakStatisticsResult: 'peak_values' must be sorted "
+                "ascending; the empirical exceedance pairs each peak with "
+                "its rank."
+            )
+            raise ValueError(msg)
+
     def peak_exceedance(
         self, z: NDArray[np.float64] | list[float] | float
     ) -> NDArray[np.float64]:

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -79,6 +79,7 @@ from scipy import special
 from .._internal.validation import (
     require_axis_count,
     require_equal_counts,
+    require_finite_fields,
     require_ranks,
     require_same_length,
 )
@@ -991,7 +992,7 @@ class PeakStatisticsResult:
     fs: float
 
     def __post_init__(self) -> None:
-        """Reject standardized peak heights that are not sorted ascending.
+        """Reject standardized peak heights that are not finite and sorted.
 
         The plot pairs :attr:`peak_values` positionally with the empirical
         exceedance ``1 - rank/n``, and spans its Rice curves from the first
@@ -1001,10 +1002,22 @@ class PeakStatisticsResult:
         length -- and publishes a wrong exceedance under the ordinary title,
         so the order is pinned here, where the mistake can be named.
 
-        :raises ValueError: if the peak heights carry more than one axis or
-            are not in ascending order.
+        Finiteness is pinned first, and not out of tidiness: the order check
+        is a comparison, and every comparison against a ``NaN`` is false, so
+        a ``NaN`` is not merely admitted -- it also hides the descent on
+        either side of it, which is the one thing this guard exists to catch.
+        Two equal infinities differ by a ``NaN`` and read as sorted for the
+        same reason. Either one then reaches the curves' span, a ``linspace``
+        between the first entry and the last, and the empirical exceedance is
+        published against heights that are not heights.
+        :func:`peak_statistics` cannot emit them -- the record is validated
+        finite and ``sigma`` is positive -- so nothing measurable is refused.
+
+        :raises ValueError: if the peak heights carry more than one axis,
+            are not finite throughout, or are not in ascending order.
         """
         require_ranks(self, peak_values=1)
+        require_finite_fields(self, "peak_values")
         values = np.asarray(self.peak_values)
         if values.ndim == 1 and np.any(np.diff(values) < 0.0):
             msg = (

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 from .._internal.validation import (
     require_axis_count,
     require_equal_counts,
+    require_non_negative,
     require_ranks,
     require_same_length,
 )
@@ -93,10 +94,15 @@ class Quantity:
     name: str = ""
 
     def __post_init__(self) -> None:
-        """Reject a negative uncertainty, an unrecognised PDF or non-positive dof."""
-        if self.uncertainty < 0.0:
-            msg = "uncertainty must be non-negative."
-            raise ValueError(msg)
+        """Reject a bad uncertainty, an unrecognised PDF or non-positive dof.
+
+        The uncertainty must be finite and non-negative: a bare ``< 0.0``
+        would pass NaN, which no propagation recovers from:
+        it flows through :func:`combine_uncertainty` into a NaN contribution
+        the budget plot draws as an invisible bar -- indistinguishable from a
+        zero contribution -- under a legend reading ``u_c = nan``.
+        """
+        require_non_negative(self.uncertainty, "uncertainty")
         if self.distribution not in DISTRIBUTIONS:
             msg = (
                 f"distribution must be one of {DISTRIBUTIONS}; "
@@ -190,16 +196,30 @@ class UncertaintyResult:
         budget the plot fills in with ``x1``, ``x2``, ... itself, which is why
         the labels are counted only when there are some.
 
+        The numbers of the budget must also be finite. The estimate, the
+        combined uncertainty and the per-input contributions come from
+        :func:`combine_uncertainty`, which refuses a model that is not finite
+        where clause 5.1 evaluates it, so NaN here is never the library's own
+        output; unrefused, a NaN contribution reaches the chart as a bar of
+        width NaN -- drawn nowhere, and so indistinguishable from an input
+        that contributes nothing -- beneath a combined-uncertainty line drawn
+        nowhere either and a legend reading "u_c = nan". The effective degrees
+        of freedom are the documented exception: NaN is their defined value
+        for a correlated budget with finite input dof, which is why
+        :meth:`expanded` asks for an explicit coverage factor there.
+
         :raises ValueError: if the coefficients or the contributions carry
-            more than one axis, or if the coefficients, the contributions or
-            the labels span different numbers of input quantities.
+            more than one axis, if the coefficients, the contributions or
+            the labels span different numbers of input quantities, or if the
+            estimate, the combined uncertainty, a coefficient or a
+            contribution is not finite.
         """
+        owner = type(self).__name__
         require_ranks(self, sensitivities=1, contributions=1)
         require_same_length(
             self, "sensitivities", "contributions", axis=_INPUT_QUANTITY_AXIS
         )
         if self.names:
-            owner = type(self).__name__
             require_equal_counts(
                 owner,
                 {
@@ -214,6 +234,14 @@ class UncertaintyResult:
                 },
                 _INPUT_QUANTITY_AXIS,
             )
+        for name in ("value", "combined_uncertainty"):
+            if not math.isfinite(float(getattr(self, name))):
+                msg = f"{owner}: '{name}' must be finite."
+                raise ValueError(msg)
+        for name in ("sensitivities", "contributions"):
+            if not bool(np.all(np.isfinite(np.asarray(getattr(self, name))))):
+                msg = f"{owner}: '{name}' must contain only finite values."
+                raise ValueError(msg)
 
     def expanded(
         self, coverage: float = 0.95, *, coverage_factor_override: float | None = None
@@ -437,7 +465,9 @@ def combine_uncertainty(
     :return: An :class:`UncertaintyResult` with :math:`u_\mathrm{c}(y)`, the
         sensitivity
         coefficients, the contributions and the effective degrees of freedom.
-    :raises ValueError: for no inputs or a malformed correlation matrix.
+    :raises ValueError: for no inputs, a malformed correlation matrix, or a
+        model that is not finite at the estimates or one evaluation step
+        either side of them.
     """
     if len(quantities) == 0:
         msg = "at least one input quantity is required."
@@ -445,10 +475,42 @@ def combine_uncertainty(
     values = np.array([q.value for q in quantities], dtype=np.float64)
     uncert = np.array([q.uncertainty for q in quantities], dtype=np.float64)
     n = values.size
+    labels = tuple(q.name or f"x{i + 1}" for i, q in enumerate(quantities))
 
     r = _validated_correlation(correlation, n)
 
     coeffs = _sensitivity(model, values, uncert)
+    estimate = float(model(*values))
+    # Clause 5.1 evaluates the model at the estimates and probes it one step
+    # either side of each input; a model undefined there (sqrt of an input
+    # estimated at zero, say) poisons the budget the same way an undefined
+    # model poisons a Monte Carlo run, and monte_carlo refuses that by name.
+    # Unrefused, the NaN contribution reaches the budget chart as a bar of
+    # width NaN -- drawn nowhere, so indistinguishable from an input that
+    # contributes nothing -- under a legend reading "u_c = nan".
+    if not math.isfinite(estimate):
+        msg = (
+            "'model' returned a non-finite output at the input estimates, so "
+            "the value, the combined standard uncertainty and every "
+            "contribution are undefined; check that the estimates lie inside "
+            "the model's domain."
+        )
+        raise ValueError(msg)
+    undefined = [
+        name
+        for name, coeff in zip(labels, coeffs, strict=True)
+        if not math.isfinite(coeff)
+    ]
+    if undefined:
+        msg = (
+            "'model' returned a non-finite output when probing "
+            f"{', '.join(undefined)} by the evaluation step, so the "
+            "sensitivity coefficient and the contribution of "
+            f"{'each' if len(undefined) > 1 else 'that'} input are undefined; "
+            "check that the model is defined within one standard uncertainty "
+            "of the estimates."
+        )
+        raise ValueError(msg)
     contributions = np.abs(coeffs) * uncert  # ui(y) = |ci| u(xi)
 
     correlated = r is not None and not np.allclose(r, np.eye(n))
@@ -463,12 +525,12 @@ def combine_uncertainty(
     effective_dof = _effective_dof(dofs, contributions, combined, correlated=correlated)
 
     return UncertaintyResult(
-        value=float(model(*values)),
+        value=estimate,
         combined_uncertainty=combined,
         sensitivities=coeffs,
         contributions=contributions,
         effective_dof=effective_dof,
-        names=tuple(q.name or f"x{i + 1}" for i, q in enumerate(quantities)),
+        names=labels,
     )
 
 
@@ -563,7 +625,8 @@ def monte_carlo(
         float per trial) so :meth:`MonteCarloResult.plot` can draw the
         output-distribution histogram.
     :return: A :class:`MonteCarloResult`.
-    :raises ValueError: for no inputs, fewer than 2 trials or bad coverage.
+    :raises ValueError: for no inputs, fewer than 2 trials or bad coverage,
+        or when the model returns a non-finite output for any trial.
     """
     if len(quantities) == 0:
         msg = "at least one input quantity is required."
@@ -578,6 +641,21 @@ def monte_carlo(
     rng = np.random.default_rng(seed)
     samples = [_sample(q, trials, rng) for q in quantities]
     output = np.asarray(model(*samples), dtype=np.float64)
+    # A model undefined over part of the sampled input domain (sqrt of a
+    # Gaussian straddling zero, say) poisons every statistic below: the mean,
+    # the standard deviation and both quantiles come out NaN, and the plot
+    # would draw a histogram of only the finite trials under a title reading
+    # "u(y) = nan" with an invisible coverage band. Supplement 1 assumes the
+    # model is defined wherever the input PDFs put mass; refuse and say so.
+    bad = int(np.count_nonzero(~np.isfinite(output)))
+    if bad:
+        msg = (
+            f"'model' returned a non-finite output for {bad} of {trials} "
+            "trials, so the estimate, its standard uncertainty and the "
+            "coverage interval are undefined; restrict the input PDFs to the "
+            "model's domain or fix the model."
+        )
+        raise ValueError(msg)
 
     low_q = 0.5 * (1.0 - coverage)
     high_q = 0.5 * (1.0 + coverage)

--- a/src/phonometry/noise_control/_criterion.py
+++ b/src/phonometry/noise_control/_criterion.py
@@ -123,10 +123,19 @@ class CriterionCarrier(Protocol):
 
 
 def rating_of(result: CriterionCarrier) -> NCResult | RCResult:
-    """Rate the received spectrum against its criterion family."""
+    """Rate the received spectrum against its criterion family.
+
+    The family is re-checked here rather than assumed pinned upstream: an
+    unknown tag used to fall through the ``NC`` test into an RC Mark II
+    rating, so a sheet could print one family's name over the other family's
+    numbers.
+
+    :raises ValueError: if the carrier's ``criterion`` is not a known family.
+    """
     from ..room.noise_criteria import noise_criterion, room_criterion
 
-    if result.criterion == "NC":
+    family = require_choice(result.criterion, "criterion", CRITERION_FAMILIES)
+    if family == "NC":
         return noise_criterion(result.received_level, result.frequencies)
     return room_criterion(result.received_level, result.frequencies)
 

--- a/src/phonometry/noise_control/duct_path.py
+++ b/src/phonometry/noise_control/duct_path.py
@@ -56,11 +56,13 @@ import numpy as np
 from .._internal.validation import (
     check_engine,
     require_axis_count,
+    require_choice,
     require_equal_counts,
     require_ranks,
     require_same_length,
 )
 from ._criterion import (
+    CRITERION_FAMILIES,
     as_band_spectrum,
     curve_of,
     exceedance_of,
@@ -177,7 +179,7 @@ class DuctPathResult:
     contributions: tuple[tuple[str, np.ndarray], ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
-        """Reject a sheet whose rows do not all run over the same bands.
+        """Reject a sheet whose rows, criterion or received spectrum lie.
 
         The calculation sheet prints one row per element under a single band
         header and a running total beneath them, so a row of the wrong length
@@ -185,8 +187,26 @@ class DuctPathResult:
         the sheet then shows a total summing a band that appears nowhere in
         the column above it.
 
-        :raises ValueError: if any spectrum disagrees with ``frequencies``.
+        The criterion family is pinned here and not only in the entry points,
+        because the sheet routes through it three times: :attr:`rating` picks
+        the rating procedure by it, the verdict is computed against its curve,
+        and the basis strip attributes that curve to ANSI/ASA S12.2-2019. An
+        unpinned tag used to fall through to an RC Mark II rating while the
+        sheet printed the unknown family's name over it.
+
+        ``received_level`` is additionally held finite: both builders derive
+        it from spectra they validate finite (:func:`duct_path` subtracts
+        finite attenuations from a finite source and energy-sums a possibly
+        ``-inf`` self-noise floor, which stays finite; ``combine_duct_paths``
+        energy-sums finite received spectra), so a non-finite band can only be
+        planted by hand -- and it would silently poison the rating and crash
+        the verdict's rounding with an error naming nothing.
+
+        :raises ValueError: if any spectrum disagrees with ``frequencies``,
+            ``criterion`` is not one of the known families, or
+            ``received_level`` carries a non-finite band.
         """
+        require_choice(self.criterion, "criterion", CRITERION_FAMILIES)
         require_ranks(
             self,
             frequencies=1,
@@ -197,6 +217,13 @@ class DuctPathResult:
         require_same_length(
             self, "frequencies", "source_level", "room_effect", "received_level"
         )
+        received = np.asarray(self.received_level, dtype=np.float64)
+        if not np.all(np.isfinite(received)):
+            msg = (
+                "DuctPathResult: 'received_level' must contain only finite "
+                "values; the criterion rating and the verdict read every band."
+            )
+            raise ValueError(msg)
         owner = type(self).__name__
         bands = require_axis_count(self.frequencies, owner, "frequencies", rank=None)
         for i, stage in enumerate(self.stages):

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -134,8 +134,16 @@ class EnclosureResult:
         renders an ordinary-looking plain sheet and fails only when someone
         asks for the verbose one.
 
-        :raises ValueError: if the per-band quantities disagree, or one of them
-            carries an extra axis.
+        The two area scalars are held positive and finite beside the length
+        checks: both producers (:func:`enclosure_insertion_loss` and
+        :func:`enclosure_required_transmission_loss`) validate them on the way
+        in, so a NaN here can only be planted by hand -- and the fiche would
+        print it verbatim in the accredited extended-result line
+        (``External surface area SE = nan m2``) without a word.
+
+        :raises ValueError: if the per-band quantities disagree, one of them
+            carries an extra axis, or ``external_area`` or ``internal_area``
+            is not positive and finite.
         """
         require_ranks(
             self,
@@ -153,6 +161,8 @@ class EnclosureResult:
             "insertion_loss",
             "room_constant",
         )
+        require_positive(self.external_area, "external_area")
+        require_positive(self.internal_area, "internal_area")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -486,11 +486,22 @@ class HvacSpectrumResult:
         ``TypeError: only 0-dimensional arrays can be converted to Python
         scalars`` raised while formatting the first row.
 
-        :raises ValueError: if ``values`` does not carry one entry per band, or
-            either field carries an extra axis.
+        The ``quantity`` tag is pinned here as well, because everything the
+        fiche says hangs off it: the basis line, the caption, the boxed
+        figure and -- decisively -- the verdict's direction. The tag is a
+        ``Literal`` for the type checker only; at run time an unexpected
+        string used to fall through every ``== "sound_power_level"`` test and
+        render a regenerated-noise spectrum as an attenuation sheet whose
+        higher-is-better verdict passed 85 dB of duct noise against a 40 dB
+        maximum.
+
+        :raises ValueError: if ``values`` does not carry one entry per band,
+            either field carries an extra axis, or ``quantity`` is not one of
+            the two tags.
         """
         require_ranks(self, frequencies=1, values=1)
         require_same_length(self, "frequencies", "values")
+        require_choice(self.quantity, "quantity", ("attenuation", "sound_power_level"))
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -108,6 +108,7 @@ they describe the plane-wave mode alone and a measurement will show the rest.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -457,6 +458,25 @@ def quarter_wave_impedance(
     return np.asarray(zb, dtype=np.complex128)
 
 
+#: The keys :attr:`ReactiveSilencerResult.geometry` may carry: the keyword
+#: parameters of the geometry renderer it is splatted into (the union over
+#: the four named constructors, each of which stores a subset).
+_GEOMETRY_KEYS = frozenset(
+    {
+        "length",
+        "chamber_area",
+        "pipe_area",
+        "inlet_extension",
+        "outlet_extension",
+        "duct_area",
+        "neck_area",
+        "neck_length",
+        "cavity_volume",
+        "branch_area",
+    }
+)
+
+
 @dataclass(frozen=True)
 class ReactiveSilencerResult:
     """Transmission and insertion loss of a reactive silencer over frequency.
@@ -528,9 +548,30 @@ class ReactiveSilencerResult:
         for a branch tube -- and has nothing to do with how finely the
         response was sampled.
 
-        :raises ValueError: if the curves disagree, or the matrix is not a
-            stack of four-poles over frequency.
+        :attr:`geometry` is pinned to the keyword names of
+        :func:`~phonometry._plot.geometry.noise_control.plot_silencer_geometry`,
+        because :meth:`plot_geometry` splats it straight into that call: an
+        unknown key would die there in a ``TypeError`` naming the plot
+        function's kwarg rather than the field that carried it, and a
+        non-finite value would draw a part-blank device.
+
+        :raises ValueError: if the curves disagree, the matrix is not a
+            stack of four-poles over frequency, or the retained geometry
+            carries an unknown key or a non-finite value.
         """
+        if self.geometry is not None:
+            unknown = sorted(set(self.geometry) - _GEOMETRY_KEYS)
+            if unknown:
+                msg = (
+                    f"'geometry' carries unknown keys {unknown}; it retains "
+                    "the constructor arguments plot_geometry() redraws, one "
+                    f"of {sorted(_GEOMETRY_KEYS)}."
+                )
+                raise ValueError(msg)
+            for key, value in self.geometry.items():
+                if not math.isfinite(value):
+                    msg = f"'geometry[{key!r}]' must be finite."
+                    raise ValueError(msg)
         require_ranks(
             self,
             frequencies=1,

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -477,6 +477,32 @@ _GEOMETRY_KEYS = frozenset(
 )
 
 
+def _require_finite_dimension(key: str, value: float) -> None:
+    """Refuse a retained dimension :meth:`plot_geometry` could not draw.
+
+    Two defects, one door. A ``NaN`` or an infinity passes every ``<= 0.0``
+    in the renderer and draws a part-blank device, and ``math.isfinite``
+    reports it as ``False``. A value that is not a number at all never gets
+    that far: ``math.isfinite`` raises a ``TypeError`` from inside the
+    standard library that names neither the field nor the key it came from,
+    and the string ``"0.3"`` -- a dimension that only looks like one -- is
+    the case a caller most plausibly reaches it with. Both leave here as the
+    ``ValueError`` that names the entry.
+
+    :param key: The geometry key, used in the error message.
+    :param value: The retained dimension.
+    :raises ValueError: if *value* is not numeric, or is not finite.
+    """
+    try:
+        finite = math.isfinite(value)
+    except TypeError as exc:
+        msg = f"'geometry[{key!r}]' must be numeric."
+        raise ValueError(msg) from exc
+    if not finite:
+        msg = f"'geometry[{key!r}]' must be finite."
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class ReactiveSilencerResult:
     """Transmission and insertion loss of a reactive silencer over frequency.
@@ -557,7 +583,7 @@ class ReactiveSilencerResult:
 
         :raises ValueError: if the curves disagree, the matrix is not a
             stack of four-poles over frequency, or the retained geometry
-            carries an unknown key or a non-finite value.
+            carries an unknown key or a value that is not a finite number.
         """
         if self.geometry is not None:
             unknown = sorted(set(self.geometry) - _GEOMETRY_KEYS)
@@ -569,9 +595,7 @@ class ReactiveSilencerResult:
                 )
                 raise ValueError(msg)
             for key, value in self.geometry.items():
-                if not math.isfinite(value):
-                    msg = f"'geometry[{key!r}]' must be finite."
-                    raise ValueError(msg)
+                _require_finite_dimension(key, value)
         require_ranks(
             self,
             frequencies=1,

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -37,6 +37,7 @@ from scipy import signal
 from ..._internal.utils import _typesignal
 from ..._internal.validation import (
     check_engine,
+    require_choice,
     require_positive,
     require_ranks,
     require_same_length,
@@ -181,12 +182,36 @@ class ZwickerLoudness:
         ``fill_between`` rather than anything the caller passed. Both take
         ``.report()`` down with them and write no PDF at all.
 
-        :raises ValueError: if ``specific`` is not one-dimensional, or if
+        The scalar loudness quantities must be finite. No constructor can
+        emit a non-finite one -- both entry points refuse non-finite input,
+        the total/maximum loudness is summed from a finite pattern,
+        ``_sone_to_phon`` maps any finite loudness to a finite level, and the
+        percentiles come off a finite trace -- and the fiche prints them
+        raw: a NaN ``loudness`` dies inside ``display_round`` in a bare
+        ``ValueError: cannot convert float NaN to integer`` that names
+        neither the field nor the type, while a NaN ``loudness_level``,
+        ``n5`` or ``n10`` renders a literal ``nan`` on the accredited sheet.
+
+        ``field`` is one of the items clause 7 makes a loudness report state,
+        and the fiche dispatches on it: pinning it here keeps a mistyped tag
+        from silently dropping the mandatory "Sound field" declaration.
+        ``None`` (backward-compatible manual construction, sound field not
+        recorded) is allowed and stays unstated.
+
+        :raises ValueError: if ``specific`` is not one-dimensional, if
             ``time`` and ``loudness_vs_time`` are not both one-dimensional and
-            of one length.
+            of one length, if a loudness quantity is not finite, or if
+            ``field`` is given and is neither ``'free'`` nor ``'diffuse'``.
         """
         require_ranks(self, specific=1, time=1, loudness_vs_time=1)
         require_same_length(self, "time", "loudness_vs_time", axis="time step")
+        for name in ("loudness", "loudness_level", "n5", "n10"):
+            value = getattr(self, name)
+            if value is not None and not math.isfinite(float(value)):
+                msg = f"ZwickerLoudness: '{name}' must be finite; got {value!r}."
+                raise ValueError(msg)
+        if self.field is not None:
+            require_choice(self.field, "field", ("free", "diffuse"))
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -1109,16 +1109,32 @@ def _require_group_counts(counts: NDArray[np.int_] | None) -> None:
     count truncates past the ``<= 1`` the entry-type label tests and prints
     ``Single`` on every row, and the sheet then reads as complete.
 
+    Reaching those three at all takes a tally that is a number to begin
+    with, and the cast to ``float64`` is what settles that: a field holding
+    strings comes back from numpy as ``could not convert string to float``, a
+    field of arbitrary objects as a ``TypeError`` raised from inside it, and
+    a count written as an integer too large for a double as an
+    ``OverflowError``. None of the three names the field, none names the
+    result, and two of them are not the ``ValueError`` this guard documents,
+    so the cast is made under the same wording the shared
+    :func:`~phonometry._internal.validation.require_finite_fields` uses for
+    the measured columns beside it.
+
     ``None`` is skipped: :func:`assess_tones` builds a result from bare
     levels, which never ran Step 3, and that absence is documented.
 
     :param counts: The ``group_sizes`` field, or ``None`` when the Step 3
         combination was not performed.
-    :raises ValueError: if a count is non-finite, fractional, or below one.
+    :raises ValueError: if the field is not numeric, or a count is
+        non-finite, fractional, or below one.
     """
     if counts is None:
         return
-    values = np.asarray(counts, dtype=np.float64).ravel()
+    try:
+        values = np.asarray(counts, dtype=np.float64).ravel()
+    except (TypeError, ValueError, OverflowError) as exc:
+        msg = "ToneAudibilityResult: 'group_sizes' must be numeric."
+        raise ValueError(msg) from exc
     whole = np.isfinite(values) & (values >= 1.0) & (values == np.floor(values))
     if bool(np.all(whole)):
         return
@@ -1126,6 +1142,51 @@ def _require_group_counts(counts: NDArray[np.int_] | None) -> None:
     msg = (
         "ToneAudibilityResult: 'group_sizes' must contain whole counts of one "
         f"tone or more; entry {first} is {values[first]}."
+    )
+    raise ValueError(msg)
+
+
+def _require_line_spacing(spacing: float) -> None:
+    """Require ``line_spacing`` to be the frequency resolution it names.
+
+    ``Δf`` is the bin width of the narrow-band analysis the assessment was
+    read from, and the accredited sheet prints it twice: once in the header
+    grid and once in the statement beside the decisive tone. It is not a
+    measured quantity either, so finite is the weaker half of its contract
+    here too, and each half fails the sheet differently.
+
+    A non-finite spacing prints ``nan Hz`` in both places. A zero or a
+    negative one is the quiet failure: measured on a two-tone assessment, the
+    header grid reads ``Δf [Hz] = 0.0`` and the statement ``Δf = -3.0 Hz``,
+    an analysis resolution no FFT produced, with the tone frequencies, the
+    audibilities and the verdict printing normally around it, so the sheet
+    reads as complete. No producer emits either: :func:`assess_tones` takes
+    the spacing through ``_positive``, and :func:`analyze_spectrum` derives
+    it from the spacing of the supplied frequency axis.
+
+    A spacing that is not a number at all never reaches those checks:
+    ``float`` refuses a string with ``could not convert string to float``, a
+    ``None`` or an arbitrary object with a ``TypeError``, and an integer too
+    large for a double with an ``OverflowError``. All three are raised from
+    inside the standard library, naming neither the field nor the result, and
+    two are not the ``ValueError`` documented here, so they leave under the
+    wording the shared
+    :func:`~phonometry._internal.validation.require_finite_fields` uses.
+
+    :param spacing: The ``line_spacing`` field, in Hz.
+    :raises ValueError: if the field is not numeric, or is not a positive,
+        finite resolution.
+    """
+    try:
+        value = float(spacing)
+    except (TypeError, ValueError, OverflowError) as exc:
+        msg = "ToneAudibilityResult: 'line_spacing' must be numeric."
+        raise ValueError(msg) from exc
+    if math.isfinite(value) and value > 0.0:
+        return
+    msg = (
+        "ToneAudibilityResult: 'line_spacing' must be a positive, finite "
+        f"frequency resolution; got {spacing!r}."
     )
     raise ValueError(msg)
 
@@ -1218,15 +1279,19 @@ class ToneAudibilityResult:
         audibility column crashes the statement's rounding with a bare
         "cannot convert float NaN to integer".
 
-        ``group_sizes`` is held to more than that, because it is not a
-        measured quantity but a tally of tones, and a count that is fractional
-        or below one is as impossible as one that is ``NaN``. It gets its own
-        guard, :func:`_require_group_counts`, which says what each of the
-        three refusals catches.
+        Two of them are held to more than finite, because neither is a
+        measured quantity: ``group_sizes`` is a tally of tones, where a count
+        that is fractional or below one is as impossible as one that is
+        ``NaN``, and ``line_spacing`` is the bin width of the analysis, where
+        zero and negative are as impossible as ``NaN``. Each gets its own
+        guard, :func:`_require_group_counts` and
+        :func:`_require_line_spacing`, which say what every refusal catches
+        and what a field that is not a number at all does without them.
 
         :raises ValueError: if any per-tone quantity disagrees with the rest,
-            any quantity is non-finite, or a group size is not a whole count
-            of one tone or more.
+            any quantity is non-numeric or non-finite, the line spacing is not
+            positive, or a group size is not a whole count of one tone or
+            more.
         """
         require_ranks(
             self,
@@ -1257,12 +1322,7 @@ class ToneAudibilityResult:
             "group_sizes",
             axis="tone entry",
         )
-        if not math.isfinite(float(self.line_spacing)):
-            msg = (
-                "ToneAudibilityResult: 'line_spacing' must be finite; got "
-                f"{self.line_spacing!r}."
-            )
-            raise ValueError(msg)
+        _require_line_spacing(self.line_spacing)
         for name in (
             "tone_frequencies",
             "tone_levels",

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -93,6 +93,7 @@ reading, matching its executable Annex J reference program; the ISO/PAS
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -1162,7 +1163,19 @@ class ToneAudibilityResult:
         builds a result from bare levels, which carries neither the per-line
         uncertainties nor the Step 3 grouping, and that is not a disagreement.
 
-        :raises ValueError: if any per-tone quantity disagrees with the rest.
+        Every quantity must also be finite. The assessment has no
+        undeterminable tone: :func:`assess_tones` refuses non-finite tone
+        frequencies, levels and masking levels on the way in and derives the
+        rest with finite arithmetic, so a NaN can only be smuggled into a
+        hand-built result. Without this pin a NaN tone level renders as a
+        literal ``nan`` cell in the accredited key-quantity table while the
+        decisive audibility and verdict print normally around it, a NaN line
+        spacing prints ``nan Hz`` in the header grid, and an all-NaN
+        audibility column crashes the statement's rounding with a bare
+        "cannot convert float NaN to integer".
+
+        :raises ValueError: if any per-tone quantity disagrees with the rest,
+            or any quantity is non-finite.
         """
         require_ranks(
             self,
@@ -1193,6 +1206,30 @@ class ToneAudibilityResult:
             "group_sizes",
             axis="tone entry",
         )
+        if not math.isfinite(float(self.line_spacing)):
+            msg = (
+                "ToneAudibilityResult: 'line_spacing' must be finite; got "
+                f"{self.line_spacing!r}."
+            )
+            raise ValueError(msg)
+        for name in (
+            "tone_frequencies",
+            "tone_levels",
+            "mean_narrowband_levels",
+            "critical_bandwidths",
+            "lower_corners",
+            "upper_corners",
+            "critical_band_levels",
+            "masking_indices",
+            "audibilities",
+            "extended_uncertainties",
+        ):
+            value = getattr(self, name)
+            if value is not None and not np.all(
+                np.isfinite(np.asarray(value, dtype=np.float64))
+            ):
+                msg = f"ToneAudibilityResult: '{name}' must contain only finite values."
+                raise ValueError(msg)
 
     @property
     def audible(self) -> NDArray[np.bool_]:

--- a/src/phonometry/psychoacoustics/quality/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/quality/tone_audibility.py
@@ -1086,6 +1086,50 @@ def mean_audibility_uncertainty(
 # --------------------------------------------------------------------------- #
 # Result
 # --------------------------------------------------------------------------- #
+def _require_group_counts(counts: NDArray[np.int_] | None) -> None:
+    """Require ``group_sizes`` to be whole counts of one tone or more.
+
+    A group size is not a measured quantity but a tally: how many tones
+    :func:`analyze_spectrum` put behind an entry, ``1`` for a tone rated on
+    its own and ``N >= 2`` for the FG entry of a critical band shared by
+    ``N`` of them (Clause 5.3.8 Step 3). Nothing it counts is fractional,
+    none of it is undeterminable, and no entry stands for fewer than the one
+    tone it rates: ``_step3_groups`` yields only clusters of two members or
+    more, and every other entry is written as a literal ``1``. So the finite
+    check the measured quantities get is the weaker half of this contract,
+    and the three failures it would let through are the three the fiche
+    handles worst.
+
+    A ``NaN`` or an infinity reaches the accredited key-quantity table as
+    ``int()`` refusing it -- a bare "cannot convert float NaN to integer",
+    an ``OverflowError`` for the infinity -- raised from inside the row
+    builder, naming neither the field nor the tone it was on. A fractional
+    count is the silent one: ``2.5`` truncates to ``2`` and the table states
+    ``FG (2)``, a group size no assessment produced. A zero or a negative
+    count truncates past the ``<= 1`` the entry-type label tests and prints
+    ``Single`` on every row, and the sheet then reads as complete.
+
+    ``None`` is skipped: :func:`assess_tones` builds a result from bare
+    levels, which never ran Step 3, and that absence is documented.
+
+    :param counts: The ``group_sizes`` field, or ``None`` when the Step 3
+        combination was not performed.
+    :raises ValueError: if a count is non-finite, fractional, or below one.
+    """
+    if counts is None:
+        return
+    values = np.asarray(counts, dtype=np.float64).ravel()
+    whole = np.isfinite(values) & (values >= 1.0) & (values == np.floor(values))
+    if bool(np.all(whole)):
+        return
+    first = int(np.flatnonzero(~whole)[0])
+    msg = (
+        "ToneAudibilityResult: 'group_sizes' must contain whole counts of one "
+        f"tone or more; entry {first} is {values[first]}."
+    )
+    raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class ToneAudibilityResult:
     r"""Audibility of the tones of a narrow-band spectrum (ISO/PAS 20065).
@@ -1174,8 +1218,15 @@ class ToneAudibilityResult:
         audibility column crashes the statement's rounding with a bare
         "cannot convert float NaN to integer".
 
+        ``group_sizes`` is held to more than that, because it is not a
+        measured quantity but a tally of tones, and a count that is fractional
+        or below one is as impossible as one that is ``NaN``. It gets its own
+        guard, :func:`_require_group_counts`, which says what each of the
+        three refusals catches.
+
         :raises ValueError: if any per-tone quantity disagrees with the rest,
-            or any quantity is non-finite.
+            any quantity is non-finite, or a group size is not a whole count
+            of one tone or more.
         """
         require_ranks(
             self,
@@ -1230,6 +1281,7 @@ class ToneAudibilityResult:
             ):
                 msg = f"ToneAudibilityResult: '{name}' must contain only finite values."
                 raise ValueError(msg)
+        _require_group_counts(self.group_sizes)
 
     @property
     def audible(self) -> NDArray[np.bool_]:

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 from .._internal.types import as_float_or_array
 from .._internal.validation import (
     check_engine,
+    require_finite_fields,
     require_fraction,
     require_positive,
     require_ranks,
@@ -212,11 +213,18 @@ def reverberation_time(
         :data:`SPEED_OF_SOUND`, giving the factor ``0.16``).
     :return: The reverberation time
         :math:`T = \frac{55.3}{c_0} \frac{V (1 - \psi)}{A}`, s.
+    :raises ValueError: if ``absorption_area`` is not positive and finite.
     """
     volume = require_positive(volume, "volume")
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
     object_fraction = require_fraction(object_fraction, "object_fraction")
     area = np.asarray(absorption_area, dtype=np.float64)
+    # A NaN compares False against the bound below, so it has to be named
+    # separately or a band of absorption that is not a number returns a
+    # reverberation time that is not one either.
+    if not np.all(np.isfinite(area)):
+        msg = "absorption_area must be finite."
+        raise ValueError(msg)
     if np.any(area <= 0.0):
         msg = "absorption_area must be positive."
         raise ValueError(msg)
@@ -258,11 +266,30 @@ class ReverberationResult:
         dimensions; either spectrum one entry too short raises an index error
         from the table builder, about neither field by name.
 
-        :raises ValueError: if the two spectra and the band axis disagree.
+        Every field must also be finite. Clause 4 has no undeterminable
+        band: :func:`reverberation_time` refuses an absorption area that is
+        not positive and finite, and the volume and the object fraction are
+        pinned by :func:`require_positive` and :func:`require_fraction`
+        before either is used, so nothing the model computes can be ``NaN``.
+        Unpinned, a ``NaN`` band printed as the literal ``nan`` in the ``A``
+        column of the accredited table while the ``T`` cell of the same row
+        showed the deliberate em dash, and a ``NaN`` volume as
+        "Room volume V [m3]: nan" in the header grid.
+
+        :raises ValueError: if the two spectra and the band axis disagree, or
+            any field carries a non-finite value.
         """
         require_ranks(self, frequencies=1, absorption_area=1, reverberation_time=1)
         require_same_length(
             self, "frequencies", "absorption_area", "reverberation_time"
+        )
+        require_finite_fields(
+            self,
+            "frequencies",
+            "absorption_area",
+            "reverberation_time",
+            "volume",
+            "object_fraction",
         )
 
     def plot(

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -371,7 +371,8 @@ class ImageSourceResult:
 
         :param ax: Existing axes, or ``None`` to create a figure.
         :param max_order: Highest reflection order drawn; ``None`` draws up
-            to order 3 (or the result's own maximum if lower).
+            to order 3 (or the result's own maximum if lower), and ``0``
+            draws the direct sound only.
         :param language: Label language, ``"en"`` (default) or ``"es"``.
         :param kwargs: Forwarded to the room-outline rectangle.
         """

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -361,20 +361,50 @@ class RCResult:
         comparison are false for a ``NaN``, so the flag reads ``True`` for
         every spectrum rather than answering for the rating.
 
-        ``levels`` is deliberately absent from that list: a spectrum may be
-        rated from a subset of the bands, and :func:`room_criterion` marks
-        each band it was not given with a ``NaN`` that the fiche renders as
-        an em dash.
+        Finite is too weak a pin for the rating alone: it is a designation
+        rather than a measured level. Clause D.4 rounds the mid-frequency
+        average to the nearest decibel and clause D.3.5 names the curve by
+        that whole number, which :attr:`label` prints verbatim, so the field
+        is typed :class:`int` and anything else is a type violation rather
+        than a value out of range. A finite fractional rating boxes
+        ``RC-25.5(N)`` on the fiche as an accredited designation; an integral
+        float is no better, since it boxes ``RC-30.0(N)``; and a ``bool``,
+        being an ``int`` in Python, boxes ``RC-True(N)`` and reads out of the
+        tabulated family. ``lmf`` carries the unrounded average for the
+        reader who wants the tenths. NumPy integers are admitted: they are
+        the same designation and print as it.
+
+        ``lmf`` and ``reference_curve`` take no such pin: the average is a
+        level in decibels, and the reference curve is the closed-form Annex D
+        rule evaluated at the rating, which :func:`rc_curve` defines for any
+        index. ``levels`` is deliberately absent from every list above: a
+        spectrum may be rated from a subset of the bands, and
+        :func:`room_criterion` marks each band it was not given with a
+        ``NaN`` that the fiche renders as an em dash.
 
         :raises ValueError: if the three per-band arrays do not share one
             length, 'frequencies' is not the ten tabulated octave bands,
-            'rating', 'lmf' or 'reference_curve' is not finite, or
-            'classification' is not one of ``N``, ``R``, ``H`` or ``RH``.
+            'rating', 'lmf' or 'reference_curve' is not finite, 'rating' is
+            not an integer, or 'classification' is not one of ``N``, ``R``,
+            ``H`` or ``RH``.
         """
         require_ranks(self, frequencies=1, levels=1, reference_curve=1)
         require_same_length(self, "frequencies", "levels", "reference_curve")
         _require_table1_bands(type(self).__name__, self.frequencies)
         require_finite_fields(self, "rating", "lmf", "reference_curve")
+        # The designation is printed verbatim into the RC-NN(A) label, so an
+        # integral float labels the curve RC-30.0(N); a bool is an int in
+        # Python, so it is excluded explicitly.
+        if isinstance(self.rating, bool) or not isinstance(
+            self.rating, (int, np.integer)
+        ):
+            msg = (
+                f"RCResult: 'rating' must be an integer number of decibels "
+                f"(ANSI/ASA S12.2-2019 clause D.4 rounds the mid-frequency "
+                f"average to the nearest decibel and clause D.3.5 designates "
+                f"the curve by that whole number); got {self.rating!r}."
+            )
+            raise ValueError(msg)
         if self.classification == "RV":
             msg = (
                 "RCResult: classification 'RV' (vibration and rattle, "

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -40,6 +40,7 @@ import numpy as np
 
 from .._internal.validation import (
     check_engine,
+    require_choice,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -125,6 +126,33 @@ NCMethod = Literal["SIL", "tangency"]
 NCOutOfRange = Literal["above", "below"]
 
 
+def _require_table1_bands(owner: str, frequencies: np.ndarray) -> None:
+    """Require the band axis to be the ten tabulated octave bands.
+
+    ANSI/ASA S12.2-2019 defines both rating families over one fixed axis: the
+    ten octave bands 16 Hz to 8000 Hz of Table 1 (NC) and Table D.1 (RC).
+    :func:`noise_criterion` and :func:`room_criterion` always align onto that
+    axis (absent bands NaN), and the fiche prints the tabulated nominal band
+    labels, so an axis on any other bands would put every level beside the
+    wrong frequency. Nominal spellings within 3 % of a tabulated centre are
+    accepted, matching the alignment tolerance of the entry points.
+
+    :param owner: Name of the result type, for the error message.
+    :param frequencies: The band axis to check, already rank-1.
+    :raises ValueError: if the axis is not the ten tabulated octave bands.
+    """
+    freqs = np.asarray(frequencies, dtype=np.float64)
+    if freqs.shape == OCTAVE_BANDS.shape and np.all(
+        np.isclose(freqs, OCTAVE_BANDS, rtol=0.03)
+    ):
+        return
+    msg = (
+        f"{owner}: 'frequencies' must be the ten ANSI/ASA S12.2-2019 octave "
+        f"bands 16 Hz - 8000 Hz (Table 1 / Table D.1); got {freqs.tolist()}."
+    )
+    raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class NCResult:
     """Result of a Noise Criteria (NC) rating (ANSI/ASA S12.2-2019, 5.2).
@@ -165,15 +193,42 @@ class NCResult:
     out_of_range: NCOutOfRange | None = None
 
     def __post_init__(self) -> None:
-        """Reject a rating whose spectrum and band axis disagree.
+        """Reject a rating whose axis, spectrum or rating/range pair disagree.
 
         The rating names a governing band, so a spectrum of the wrong length
-        names the wrong one.
+        names the wrong one; the standard fixes the band axis itself (the ten
+        Table 1 octave bands), and the fiche prints those nominal labels, so
+        any other axis would table every level at the wrong frequency. The
+        rating and ``out_of_range`` are one statement made twice: a spectrum
+        outside the NC-15 to NC-70 family has no NC rating (``rating`` NaN),
+        and inside it the rating is a number. Left unpinned, a NaN rating with
+        ``out_of_range`` cleared boxes ``NC-nan`` on the fiche and crashes the
+        verdict.
 
-        :raises ValueError: if 'frequencies' and 'levels' differ in length.
+        :raises ValueError: if 'frequencies' and 'levels' differ in length,
+            'frequencies' is not the ten Table 1 octave bands, 'out_of_range'
+            is an unknown tag, or 'rating' and 'out_of_range' contradict each
+            other.
         """
         require_ranks(self, frequencies=1, levels=1)
         require_same_length(self, "frequencies", "levels")
+        _require_table1_bands(type(self).__name__, self.frequencies)
+        if self.out_of_range is not None:
+            require_choice(self.out_of_range, "out_of_range", ("above", "below"))
+            if not math.isnan(float(self.rating)):
+                msg = (
+                    "NCResult: 'rating' must be NaN when 'out_of_range' is "
+                    "set; a spectrum outside the NC-15 to NC-70 family has "
+                    "no NC rating (ANSI/ASA S12.2-2019, Table 1)."
+                )
+                raise ValueError(msg)
+        elif not math.isfinite(float(self.rating)):
+            msg = (
+                "NCResult: 'rating' must be finite when 'out_of_range' is "
+                "None; only a spectrum outside the NC-15 to NC-70 family "
+                "carries a NaN rating, flagged by 'out_of_range'."
+            )
+            raise ValueError(msg)
 
     @property
     def label(self) -> str:
@@ -280,16 +335,34 @@ class RCResult:
     levels: np.ndarray
 
     def __post_init__(self) -> None:
-        """Reject a rating whose spectrum, curve and band axis disagree.
+        """Reject a rating whose axis, spectrum, curve or tag disagree.
 
         The fiche draws the reference curve over the measured spectrum and
         tabulates both, so a curve of the wrong length is compared band by
-        band against the wrong bands.
+        band against the wrong bands; the standard fixes the band axis itself
+        (the ten Table D.1 octave bands), and the fiche prints those nominal
+        labels. The classification is pinned to the tags the library rates
+        with, because the fiche prints a spectral-quality sentence for each:
+        an unknown tag would be boxed verbatim over a fabricated quality. The
+        ``RV`` designation of clause D.3.4 is refused by name: it requires
+        the Table 6 vibration/rattle criterion test, which this library does
+        not implement, so it is never mapped to a neighbouring tag.
 
-        :raises ValueError: if the three do not share one length.
+        :raises ValueError: if the three per-band arrays do not share one
+            length, 'frequencies' is not the ten tabulated octave bands, or
+            'classification' is not one of ``N``, ``R``, ``H`` or ``RH``.
         """
         require_ranks(self, frequencies=1, levels=1, reference_curve=1)
         require_same_length(self, "frequencies", "levels", "reference_curve")
+        _require_table1_bands(type(self).__name__, self.frequencies)
+        if self.classification == "RV":
+            msg = (
+                "RCResult: classification 'RV' (vibration and rattle, "
+                "ANSI/ASA S12.2-2019 clause D.3.4) requires the Table 6 "
+                "criterion test, which this library does not implement."
+            )
+            raise ValueError(msg)
+        require_choice(self.classification, "classification", ("N", "R", "H", "RH"))
 
     @property
     def label(self) -> str:

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -42,6 +42,7 @@ from .._internal.validation import (
     check_engine,
     require_choice,
     require_equal_shapes,
+    require_finite_fields,
     require_ranks,
     require_same_length,
 )
@@ -348,13 +349,32 @@ class RCResult:
         the Table 6 vibration/rattle criterion test, which this library does
         not implement, so it is never mapped to a neighbouring tag.
 
+        The rating, its mid-frequency average and the reference curve are
+        pinned finite. Clause D.4 rates the average of three bands the rater
+        requires to be present, so the producer has no undetermined case to
+        express: the curve is generated from the rounded rating by the
+        closed-form -5 dB/octave rule of Annex D, which is finite in all ten
+        bands even when most of the spectrum was never measured. A ``NaN``
+        rating survives every shape guard and reaches the fiche as the
+        literal ``RC-nan(N)`` boxed as an accredited designation, and it
+        empties :attr:`out_of_family` of meaning: both sides of that chained
+        comparison are false for a ``NaN``, so the flag reads ``True`` for
+        every spectrum rather than answering for the rating.
+
+        ``levels`` is deliberately absent from that list: a spectrum may be
+        rated from a subset of the bands, and :func:`room_criterion` marks
+        each band it was not given with a ``NaN`` that the fiche renders as
+        an em dash.
+
         :raises ValueError: if the three per-band arrays do not share one
-            length, 'frequencies' is not the ten tabulated octave bands, or
+            length, 'frequencies' is not the ten tabulated octave bands,
+            'rating', 'lmf' or 'reference_curve' is not finite, or
             'classification' is not one of ``N``, ``R``, ``H`` or ``RH``.
         """
         require_ranks(self, frequencies=1, levels=1, reference_curve=1)
         require_same_length(self, "frequencies", "levels", "reference_curve")
         _require_table1_bands(type(self).__name__, self.frequencies)
+        require_finite_fields(self, "rating", "lmf", "reference_curve")
         if self.classification == "RV":
             msg = (
                 "RCResult: classification 'RV' (vibration and rattle, "

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -78,6 +78,7 @@ from numpy.typing import ArrayLike, NDArray
 from .._internal.types import as_float_or_array
 from .._internal.validation import (
     check_engine,
+    require_finite_fields,
     require_non_negative,
     require_positive,
     require_ranks,
@@ -598,8 +599,17 @@ class ReverberationModelResult:
         arrays can be converted to Python scalars`` raised while formatting a
         table cell.
 
-        :raises ValueError: if the five curves and the band axis disagree, or
-            any of them carries an extra axis.
+        The room itself must be finite: :attr:`volume` and
+        :attr:`surface_area` are products of the three room lengths, each of
+        which :func:`_axial_geometry` has already required to be positive and
+        finite, so no prediction can hand back a geometry that is not a
+        number. The header grid of the fiche prints both without asking, and
+        a ``NaN`` volume reached the sheet as "Room volume V [m3]: nan". The
+        five curves are left unpinned: they are what the models return, and
+        the fiche prints a non-finite time as an em dash on purpose.
+
+        :raises ValueError: if the five curves and the band axis disagree,
+            any of them carries an extra axis, or the geometry is not finite.
         """
         require_ranks(
             self,
@@ -619,6 +629,7 @@ class ReverberationModelResult:
             "fitzroy",
             "arau_puchades",
         )
+        require_finite_fields(self, "frequencies", "volume", "surface_area")
 
     @property
     def models(self) -> dict[str, np.ndarray]:

--- a/src/phonometry/signals/windows.py
+++ b/src/phonometry/signals/windows.py
@@ -25,6 +25,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .._internal.validation import (
+    require_axis_count,
+    require_equal_counts,
+    require_ranks,
+)
 from .spectra import _positive
 
 if TYPE_CHECKING:
@@ -91,6 +96,35 @@ class WindowMetricsResult:
     worst_case_processing_loss_db: float
     highest_sidelobe_db: float
     mainlobe_width_3db_bins: float
+
+    def __post_init__(self) -> None:
+        """Reject taps that disagree with the declared window length.
+
+        Every figure of merit here was computed from ``n`` samples, and the
+        waveform panel of :meth:`plot` draws :attr:`taps` against a sample
+        index counted out of the declared :attr:`n` rather than out of the
+        array beside it, so taps of another length are a different window
+        than the one the metrics rate. Matplotlib does refuse to draw the
+        two against each other, but from inside the renderer and about
+        first dimensions, naming neither the field nor the result; the
+        declared count is the authority here, and checking it at
+        construction says which one moved.
+
+        :raises ValueError: if the taps span a different number of samples
+            than the declared length.
+        """
+        require_ranks(self, taps=1)
+        owner = type(self).__name__
+        require_equal_counts(
+            owner,
+            {
+                "n": self.n,
+                "taps": require_axis_count(
+                    self.taps, owner, "taps", "sample", rank=None
+                ),
+            },
+            "sample",
+        )
 
     def enbw_hz(self, fs: float) -> float:
         """Equivalent noise bandwidth in Hz for a sample rate ``fs``.

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -49,7 +49,9 @@ import numpy as np
 from .._internal.validation import (
     check_engine,
     require_axis_count,
+    require_choice,
     require_equal_counts,
+    require_finite_fields,
     require_ranks,
     require_same_length,
 )
@@ -734,6 +736,8 @@ class SIIResult:
         (clause 5.7), unity until the speech spectrum level rises above the
         standard normal-effort spectrum by more than 10 dB.
     :ivar method: The band procedure used, one of :data:`SII_METHODS`.
+    :raises ValueError: If the per-band quantities disagree, ``method`` is not
+        one of :data:`SII_METHODS`, or any quantity is not finite.
     """
 
     sii: float
@@ -758,8 +762,41 @@ class SIIResult:
         the band that vanished is nowhere on the page to contradict the boxed
         ``SII`` beside it, and every number that did print is well formed.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        :attr:`method` is pinned to the four procedure names for the reason
+        :class:`SIIProcedure` pins it, and one more: the fiche reads both the
+        standard-basis sentence and the band-table caption out of tables keyed
+        by it, and an unrecognised name used to fall back to the
+        one-third-octave wording. A result computed over the 21 critical
+        bands, mistyped as ``"critical band"``, then printed the
+        one-third-octave-band procedure over a table of critical bands, with
+        nothing on the page to contradict it.
+
+        :attr:`sii` is pinned finite. The index is the sum of the band
+        audibilities weighted by their importance, over spectra the entry
+        point has already refused unless finite, so no computation can
+        return a ``NaN``; one reaching the fiche crashed the boxed statement
+        inside the display rounder, as "cannot convert float NaN to integer",
+        naming neither the field nor the result type.
+
+        The per-band quantities are pinned with it, for a symptom that raises
+        nothing at all. The plot draws the importance-weighted series scaled
+        by its own peak, and a ``NaN`` anywhere in :attr:`band_audibility` or
+        :attr:`band_importance` makes that peak ``NaN``: ``peak > 0.0`` is
+        False, so the series the legend calls "(scaled)" is drawn at its raw
+        height, a tenth of the axis instead of filling it, beside a title
+        showing a perfectly finite index. A ``NaN`` in :attr:`frequencies`
+        labels a band ``nan`` on the axis and in the fiche's frequency column.
+        The same producer argument covers every one of them, and the entry
+        point is the only producer there is: each field is arithmetic over
+        spectra it has already required to be finite, and none of them is a
+        quantity a measurement can leave undeterminable, so there is nothing
+        here to flag and render as an em dash.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            ``method`` is not one of :data:`SII_METHODS`, or any quantity
+            carries a non-finite value.
         """
+        require_choice(self.method, "method", SII_METHODS)
         require_ranks(
             self,
             band_audibility=1,
@@ -772,6 +809,17 @@ class SIIResult:
         )
         require_same_length(
             self,
+            "band_audibility",
+            "band_importance",
+            "frequencies",
+            "speech_spectrum",
+            "disturbance",
+            "masking",
+            "level_distortion",
+        )
+        require_finite_fields(
+            self,
+            "sii",
             "band_audibility",
             "band_importance",
             "frequencies",
@@ -973,7 +1021,13 @@ def standard_speech_spectra(
 def _as_band_vector(
     values: ArrayLike, name: str, procedure: _BandProcedure | None = None
 ) -> np.ndarray:
-    """Validate and return a band vector of the procedure's length."""
+    """Validate and return a finite band vector of the procedure's length.
+
+    Finiteness is required alongside the shape, as the STOI and STI entry
+    points already require of their inputs: one NaN band poisons the upward
+    spread of masking of every band above it, and the index, the title of the
+    plot and its bar scaling all compute through it in silence.
+    """
     proc = _PROCEDURES["one-third-octave"] if procedure is None else procedure
     expected = proc.band_importance.size
     arr = np.atleast_1d(np.asarray(values, dtype=np.float64))
@@ -987,6 +1041,9 @@ def _as_band_vector(
             f"{proc.method} band values "
             f"({centres[0]:g} Hz - {centres[-1]:g} Hz); got shape {arr.shape}."
         )
+        raise ValueError(msg)
+    if not np.all(np.isfinite(arr)):
+        msg = f"{name!r} must contain only finite values."
         raise ValueError(msg)
     return arr
 
@@ -1090,8 +1147,8 @@ def speech_intelligibility_index(
         standard's Annex B tabulates functions for specific speech test
         materials); ``None`` uses the tabulated average-speech function.
     :return: An :class:`SIIResult` with the overall index and its ``.plot()``.
-    :raises ValueError: if a spectrum has the wrong length, or the method or
-        effort name is unknown.
+    :raises ValueError: if a spectrum has the wrong length or carries a
+        non-finite value, or the method or effort name is unknown.
     """
     proc = _procedure(method)
     n_bands = proc.band_importance.size
@@ -1203,8 +1260,26 @@ class SIIProcedure:
         value more than the bands, because it bounds them from outside rather
         than labelling them.
 
-        :raises ValueError: if the band axes disagree.
+        :attr:`method` is pinned to the four procedure names, because the
+        plot's legend reads its label out of a table keyed by them: an unknown
+        name would come back as a bare ``KeyError`` naming no field, no owner
+        and none of the valid choices.
+
+        The five columns are pinned finite as well. This is a transcription of
+        one of the standard's printed tables, so no entry of it is a quantity
+        anything could leave undetermined, and :func:`sii_procedure`, the only
+        producer, copies the tabulated arrays. A ``NaN`` reaching the step
+        plot is quieter than the disagreements above: the band it belongs to
+        is simply not drawn, and the y-limit, taken from the maximum of the
+        column, is scaled to a peak that is not the table's, so a band-
+        importance function is overlaid on the others missing one of its
+        bands and stretched to the wrong height, with nothing on the axes
+        saying so.
+
+        :raises ValueError: if the band axes disagree, ``method`` is not one
+            of :data:`SII_METHODS`, or a column carries a non-finite value.
         """
+        require_choice(self.method, "method", SII_METHODS)
         require_ranks(
             self,
             frequencies=1,
@@ -1216,6 +1291,14 @@ class SIIProcedure:
         require_same_length(
             self,
             "frequencies",
+            "band_importance",
+            "internal_noise",
+            "speech_spectrum",
+        )
+        require_finite_fields(
+            self,
+            "frequencies",
+            "band_edges",
             "band_importance",
             "internal_noise",
             "speech_spectrum",

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -32,7 +32,12 @@ if TYPE_CHECKING:
 from scipy import signal
 
 from .._internal.utils import _typesignal
-from .._internal.validation import check_engine, require_ranks, require_same_length
+from .._internal.validation import (
+    check_engine,
+    require_finite_fields,
+    require_ranks,
+    require_same_length,
+)
 from .._internal.warnings import PhonometryWarning
 from ..filters.core import OctaveFilterBank
 from ..filters.frequencies import nominal_frequencies
@@ -136,10 +141,21 @@ class STIResult:
         ``mti`` is the per-band index the fiche tabulates beside the band
         levels and the modulation matrix, all three on the same band axis.
 
-        :raises ValueError: if the band axes disagree.
+        ``sti`` is pinned finite. Every path to a result runs through
+        :func:`_truncated_mtf`, which refuses a modulation transfer matrix
+        carrying anything that is not a finite number, and the chain from
+        there to the index is arithmetic on values clipped into [0, 1]: no
+        measurement can hand back an ``STI`` that is not a number. One built
+        by hand crashed the boxed statement of the fiche inside the display
+        rounder with "cannot convert float NaN to integer", a message naming
+        neither the field nor the result it came from.
+
+        :raises ValueError: if the band axes disagree, or ``sti`` is not
+            finite.
         """
         require_ranks(self, mti=1, mtf=2, band_levels=1)
         require_same_length(self, "mti", ("mtf", 0), "band_levels")
+        require_finite_fields(self, "sti")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/tests/aircraft/test_airport_noise.py
+++ b/tests/aircraft/test_airport_noise.py
@@ -304,6 +304,28 @@ def test_flyover_arrays_are_refused_a_second_axis() -> None:
         dataclasses.replace(res, observer=stacked_observer)
 
 
+def test_flyover_metric_outside_the_two_the_type_states_is_refused() -> None:
+    """The figure asks one question of ``metric``, and everything else is LAmax.
+
+    Left unpinned the tag does not fail at all: the y-axis and the total line
+    of the rendered figure are labelled as a maximum level the result never
+    claimed to hold.
+    """
+    xs = np.linspace(-20000.0, 20000.0, 21)
+    path = np.column_stack(
+        [
+            xs,
+            np.zeros_like(xs),
+            np.full_like(xs, 300.0),
+            np.full_like(xs, 10000.0),
+            np.full_like(xs, _VREF),
+        ]
+    )
+    res = event_level(path, [0.0, 300.0, 0.0], _NP, _ND, _NSEL, _NMAX)
+    with pytest.raises(ValueError, match="'metric' must be one of"):
+        dataclasses.replace(res, metric="bogus")
+
+
 def test_event_level_farther_receiver_is_quieter() -> None:
     xs = np.linspace(-20000.0, 20000.0, 401)
     path = np.column_stack(
@@ -601,6 +623,35 @@ def test_noise_contour_grid_is_pinned_to_both_axes() -> None:
     flattened = res.level.ravel()
     with pytest.raises(ValueError, match=r"'level' must have 2 axes"):
         dataclasses.replace(res, level=flattened)
+
+
+def test_noise_contour_metric_outside_the_two_the_type_states_is_refused() -> None:
+    """The colorbar reads the tag one-sidedly, with LAmax as its fallback.
+
+    An unknown tag labels a rendered contour map with a metric the grid was
+    never computed in, and nothing raises.
+    """
+    xs = np.linspace(0.0, 15000.0, 12)
+    path = np.column_stack(
+        [
+            xs,
+            np.zeros_like(xs),
+            np.clip(xs * 0.1, 0.0, 2000.0),
+            np.full_like(xs, 10000.0),
+            np.full_like(xs, _VREF),
+        ]
+    )
+    res = noise_contour(
+        path,
+        _NP,
+        _ND,
+        _NSEL,
+        _NMAX,
+        x=np.linspace(-2000.0, 16000.0, 7),
+        y=np.linspace(-4000.0, 4000.0, 5),
+    )
+    with pytest.raises(ValueError, match="'metric' must be one of"):
+        dataclasses.replace(res, metric="LAeq")
 
 
 def test_event_level_invalid_inputs() -> None:

--- a/tests/aircraft/test_anp_fleet.py
+++ b/tests/aircraft/test_anp_fleet.py
@@ -235,6 +235,20 @@ def test_profile_names_the_segments_and_not_the_vertices_it_counted() -> None:
         dataclasses.replace(prof, ground_roll=surplus, landing_roll=surplus)
 
 
+def test_profile_rejects_a_path_short_of_the_five_documented_columns() -> None:
+    """The rank pin passes a two-column path; the figure dies reading column 2.
+
+    ``path`` is documented as ``(N, 5)`` and the altitude the trajectory plot
+    draws is column 2, so a path without it clears every per-segment count and
+    stops at ``path[:, 2]`` with an ``IndexError`` that names neither the field
+    nor the profile it came from.
+    """
+    prof = _DB.profile("747100", "departure")
+    flat = np.asarray(prof.path)[:, :2]
+    with pytest.raises(ValueError, match=r"'path' must have shape \(N, 5\)"):
+        dataclasses.replace(prof, path=flat)
+
+
 def test_a_profile_with_no_path_reports_no_segments_rather_than_minus_one() -> None:
     """An empty path has nought segments, which is a count and not an error."""
     prof = _DB.profile("747100", "departure")

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -425,3 +425,75 @@ def test_a_history_carrying_an_extra_axis_is_refused() -> None:
     two_columns = np.column_stack([result.pnl, result.pnl])
     with pytest.raises(ValueError, match="'pnl' must have one axis"):
         dataclasses.replace(result, pnl=two_columns)
+
+
+# --------------------------------------------------------------------------
+# Determinations the certification sheet would state without a word of warning
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "field", ["frequencies", "times", "pnl", "tone_correction", "pnlt"]
+)
+def test_a_non_finite_record_is_refused(field: str) -> None:
+    """A NaN anywhere in the histories moves the PNLTM marker onto the gap.
+
+    ``argmax`` of an array carrying a NaN answers with the NaN's own index, so
+    the figure marks the maximum at a record the flyover never reached and
+    prints ``PNLTM`` beside it. Nothing downstream raises: the marker simply
+    floats over the break in the curve.
+    """
+    import dataclasses
+
+    result = _flyover()
+    values = np.asarray(getattr(result, field), dtype=np.float64).copy()
+    values[0] = np.nan
+    with pytest.raises(ValueError, match=f"'{field}' must be finite"):
+        dataclasses.replace(result, **{field: values})
+
+
+@pytest.mark.parametrize(
+    "field", ["pnltm", "bandsharing_adjustment", "duration_correction", "epnl"]
+)
+def test_a_non_finite_determination_is_refused(field: str) -> None:
+    """The scalars are what the sheet states, so a NaN reaches it as ``nan``.
+
+    Three of them are printed verbatim in the metrics table and the fourth is
+    the boxed EPNL itself, which stops inside the display rounding with an
+    error naming nothing at all.
+    """
+    import dataclasses
+
+    result = _flyover()
+    with pytest.raises(ValueError, match=f"'{field}' must be finite"):
+        dataclasses.replace(result, **{field: float("nan")})
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [(-30, -1), (0, 999), (12, 4)],
+    ids=["negative", "past-the-last-record", "reversed"],
+)
+def test_a_window_that_does_not_index_the_records_is_refused(
+    limits: tuple[int, int],
+) -> None:
+    """``band_limits`` is the one field no length can vouch for.
+
+    Python wraps a negative index, so the 10 dB-down window is shaded over a
+    stretch of the flyover the integration never touched, with PNLTM and EPNL
+    printed confidently beside it; an index past the last record stops the
+    figure at ``times[kL]`` with an ``IndexError`` naming neither this field
+    nor this type.
+    """
+    import dataclasses
+
+    result = _flyover()
+    with pytest.raises(ValueError, match=r"'band_limits' must satisfy"):
+        dataclasses.replace(result, band_limits=limits)
+
+
+def test_a_window_that_is_not_a_pair_of_indices_is_refused() -> None:
+    """Three limits, or fractional ones, index nothing at all."""
+    import dataclasses
+
+    result = _flyover()
+    with pytest.raises(ValueError, match=r"'band_limits' must be a pair"):
+        dataclasses.replace(result, band_limits=(0.5, 9.5))

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -1498,6 +1498,20 @@ def test_event_history_and_spectrum_must_line_up() -> None:
         dataclasses.replace(res, frequencies=extra_band)
 
 
+def test_a_non_finite_a_weighted_step_is_refused() -> None:
+    """The figure marks LASmax at ``argmax(a_levels)``, which a NaN wins.
+
+    ``argmax`` of an array carrying a NaN answers with the NaN's own index, so
+    the marker floats over the break in the curve and is labelled as the
+    maximum. ``pnlt`` is the field licensed to hold NaN, and stays exempt.
+    """
+    _t, _pos, res = _flyover(bands=[31.5], span=1000.0)
+    with_gap = np.asarray(res.a_levels, dtype=np.float64).copy()
+    with_gap[0] = np.nan
+    with pytest.raises(ValueError, match="'a_levels' must be finite"):
+        dataclasses.replace(res, a_levels=with_gap)
+
+
 def test_event_plot() -> None:
     _, _, res = _flyover(level=90.0, bands=_NORAH_BANDS, span=1000.0)
     assert res.plot() is not None
@@ -1573,6 +1587,25 @@ def test_contour_level_grid_must_span_its_coordinates() -> None:
     extra_y = np.append(res.y, 500.0)
     with pytest.raises(ValueError, match=r"'y'.*per grid row"):
         dataclasses.replace(res, y=extra_y)
+
+
+def test_contour_metric_outside_the_two_the_type_states_is_refused() -> None:
+    # The entry point checks the tag at the call, but a grid rewritten by hand
+    # reaches the colorbar, which asks only whether it is "exposure" and calls
+    # everything else LASmax: the map is labelled with a metric it was never
+    # computed in, and nothing raises.
+    hems, spd, ang, t, pos = _contour_inputs()
+    res = rotorcraft_noise_contour(
+        hems,
+        spd,
+        ang,
+        t,
+        pos,
+        x=np.array([-200.0, 0.0, 150.0]),
+        y=np.array([-300.0, 100.0]),
+    )
+    with pytest.raises(ValueError, match="'metric' must be one of"):
+        dataclasses.replace(res, metric="epnl")
 
 
 def test_contour_plot() -> None:

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -218,6 +218,61 @@ def test_fiche_pins_displayed_numbers(tmp_path: Path) -> None:
     assert "Quality Control (EBU R 128 item i)." in text
 
 
+def test_gated_silence_renders_dashes_and_fails(tmp_path: Path) -> None:
+    """A programme gated to -inf LUFS is a sheet of em dashes, not a crash.
+
+    :func:`program_loudness` returns ``-inf`` when every block falls below the
+    absolute gate, which digital silence does, so the fiche has to print the
+    house missing-value em dash for the measured loudness, its delta and the
+    true peak instead of formatting an infinity - and the verdict has to read
+    the gated measurement as a failure, since no tolerance about any target
+    contains ``-inf``.
+    """
+    result = program_loudness(_stereo(np.zeros(5 * FS)), FS)
+    assert result.integrated == -np.inf
+    _text, passed = _verdict(result, -23.0)
+    assert passed is False
+    out = tmp_path / "silence.pdf"
+    result.report(str(out), metadata=ReportMetadata(requirement=-23.0))
+    assert_one_page(str(out))
+    text = _extract_text(str(out)).replace("\n", " ")
+    assert "— LUFS" in text  # the measured integrated loudness
+    assert "— LU)" in text  # its delta from the target
+    assert "I = — LUFS" in text  # the boxed single-number result
+    assert "— dBTP" in text  # the true peak of a digitally silent programme
+    # The informational maxima are gated away with it, and no reading anywhere
+    # on the sheet is printed as an infinity.
+    assert result.max_momentary == -np.inf
+    assert result.max_short_term == -np.inf
+    assert "-inf" not in text  # neither the ASCII hyphen form ...
+    assert "−inf" not in text  # ... nor the typographic minus the fiche uses
+    # The basis strip says what the glyph means, so a FAIL beside an em dash
+    # is not an unexplained verdict.
+    assert "An em dash marks a reading the measurement leaves undefined" in text
+
+
+def test_gated_silence_note_absent_from_a_measured_fiche(tmp_path: Path) -> None:
+    """A fiche with five finite readings carries no em-dash explanation."""
+    result = _case1_result()
+    assert np.isfinite(result.max_short_term)
+    out = tmp_path / "measured.pdf"
+    result.report(str(out), metadata=ReportMetadata(requirement=-23.0))
+    text = _extract_text(str(out)).replace("\n", " ")
+    assert "An em dash marks" not in text
+    assert "—" not in text
+
+
+def test_gated_silence_renders_in_spanish(tmp_path: Path) -> None:
+    """The Spanish sheet dashes the same readings and translates the note."""
+    result = program_loudness(_stereo(np.zeros(5 * FS)), FS)
+    out = tmp_path / "silence_es.pdf"
+    result.report(str(out), metadata=ReportMetadata(requirement=-23.0), language="es")
+    assert_one_page(str(out))
+    text = _extract_text(str(out)).replace("\n", " ")
+    assert "I = — LUFS" in text
+    assert "La raya indica una lectura que la medición deja indefinida" in text
+
+
 def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
     """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
     import re

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -304,6 +304,28 @@ def test_modulation_distortion_plot_marks_carrier_and_sidebands() -> None:
     plt.close("all")
 
 
+def test_modulation_distortion_plot_refuses_a_result_without_its_modulator() -> None:
+    """``f_low`` is the fifth spectral field, and the title states it as fact.
+
+    Defaulted with ``float(result.f_low or 0.0)``, the figure printed
+    "$f_1$ = 0Hz" beside the SMPTE percentage it belongs to: a modulation
+    frequency no measurement produced, where the four sibling fields it is
+    checked with were refused outright.
+    """
+    import matplotlib.pyplot as plt
+
+    fl, fh = 250.0, 8000.0
+    x = _tone(fl) + _tone(fh, 0.25) + _tone(fh + fl, 0.02) + _tone(fh - fl, 0.02)
+    res = electroacoustics.modulation_distortion(x, FS, f_low=fl, f_high=fh)
+    # Stated, the tone reaches the title as the measurement's own 250 Hz.
+    assert "$f_1$ = 250Hz" in res.plot().get_title()
+    plt.close("all")
+    without_modulator = dataclasses.replace(res, f_low=None)
+    with pytest.raises(ValueError, match=r"'f_low' unset"):
+        without_modulator.plot()
+    plt.close("all")
+
+
 def test_difference_frequency_distortion_iec() -> None:
     # IEC 60268-3 14.12.8.1: equal tones f1 = 13 kHz, f2 = 14 kHz (amp 0.5);
     # 2nd-order product at f2 - f1 = 1 kHz (0.03); 3rd-order at 2f1 - f2 and

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -20,6 +20,7 @@ rejected engines/languages.
 
 from __future__ import annotations
 
+import dataclasses
 import math
 from typing import TYPE_CHECKING
 
@@ -451,3 +452,160 @@ def test_a_narrow_curve_is_still_fine_where_no_panel_scales_by_it() -> None:
     )
     assert result.thd_frequencies is not None
     assert result.thd_frequencies.size == 3
+
+
+# --------------------------------------------------------------------------
+# A curve the data sheet could not have measured
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("field", "bad"),
+    [
+        ("frequencies", float("nan")),
+        ("frequencies", float("inf")),
+        ("spl_db", float("nan")),
+        ("impedance_modulus", float("nan")),
+        ("thd_percent", float("nan")),
+        ("polar_db", float("nan")),
+    ],
+)
+def test_a_non_finite_curve_is_refused_where_the_result_is_built(
+    field: str, bad: float
+) -> None:
+    """No producer emits one, and the fiche cannot say what it would mean.
+
+    Every curve reaches the result through the shared curve validator, and
+    the piston pattern floors its own non-finite levels, so a NaN here is
+    never a measurement outcome. Written in afterwards it used to travel to
+    the sheet unmeasured: a NaN frequency makes the span of the on-axis
+    response unmeasurable and the panel is scaled by the decades that span
+    covers, so the render stopped inside matplotlib with ``Axis limits cannot
+    be NaN or Inf``, naming neither the field nor this result; a NaN level or
+    modulus was quieter, drawn as a gap in a curve under rated numbers
+    computed before the gap existed.
+    """
+    result = _example_result()
+    spoilt = np.array(getattr(result, field), dtype=float)
+    spoilt[0] = bad
+    with pytest.raises(
+        ValueError,
+        match=rf"LoudspeakerCharacteristics: '{field}' must contain only finite",
+    ):
+        dataclasses.replace(result, **{field: spoilt})
+
+
+def test_a_non_finite_response_axis_no_longer_reaches_the_fiche(
+    tmp_path: Path,
+) -> None:
+    """The render that used to fail anonymously cannot now be asked for.
+
+    This is the route the sheet took: construction accepted the axis, the
+    panel scaling turned it into a ``nan`` box aspect, and matplotlib stopped
+    the fiche naming nothing. The refusal now lands before the PDF is opened.
+    """
+    result = _example_result()
+    axis = np.array(result.frequencies, dtype=float)
+    axis[10] = float("nan")
+    out = tmp_path / "non_finite_axis.pdf"
+    with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
+        dataclasses.replace(result, frequencies=axis).report(str(out))
+    assert not out.exists()
+
+
+# --------------------------------------------------------------------------
+# A rated number the data sheet could not have measured
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "field",
+    [
+        "sensitivity_level_db",
+        "reference_level_db",
+        "rated_impedance",
+        "resonance_frequency",
+        "polar_frequency",
+    ],
+)
+def test_a_non_finite_rated_number_is_refused_where_the_result_is_built(
+    field: str,
+) -> None:
+    """The single numbers are pinned by name, as the curves already were.
+
+    ``require_ranks`` and ``require_same_length`` pin only the paired curves,
+    so a scalar written in afterwards reached the sheet untouched; every one
+    of them is computed or validated by :func:`loudspeaker_characteristics`,
+    so no producer emits a NaN here.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=rf"LoudspeakerCharacteristics: '{field}' must be finite",
+    ):
+        dataclasses.replace(result, **{field: float("nan")})
+
+
+def test_a_non_finite_sensitivity_level_no_longer_reaches_the_verdict(
+    tmp_path: Path,
+) -> None:
+    """The rated table, the boxed result and the verdict row all read it.
+
+    A NaN sensitivity level printed ``nan dB`` in all three, and the verdict
+    decided FAIL because ``nan >= requirement`` is False: an accredited fiche
+    failing a loudspeaker against a number it never measured.
+    """
+    result = _example_result()
+    out = tmp_path / "non_finite_sensitivity_level.pdf"
+    with pytest.raises(ValueError, match=r"'sensitivity_level_db' must be finite"):
+        dataclasses.replace(result, sensitivity_level_db=float("nan")).report(
+            str(out), metadata=ReportMetadata(requirement=86.0)
+        )
+    assert not out.exists()
+
+
+def test_a_non_finite_resonance_frequency_no_longer_reaches_the_fiche(
+    tmp_path: Path,
+) -> None:
+    """The other end of the same gap: a NaN hertz killed the render outright.
+
+    The rated table rounds every stated frequency to whole hertz, so a NaN
+    resonance frequency stopped the fiche with ``cannot convert float NaN to
+    integer`` -- an error naming neither the field nor this result.
+    """
+    result = _example_result()
+    out = tmp_path / "non_finite_resonance.pdf"
+    with pytest.raises(ValueError, match=r"'resonance_frequency' must be finite"):
+        dataclasses.replace(result, resonance_frequency=float("nan")).report(str(out))
+    assert not out.exists()
+
+
+# --------------------------------------------------------------------------
+# A band edge that is not a pair of frequencies
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "field", ["effective_range", "sensitivity_band", "rated_frequency_range"]
+)
+def test_a_band_edge_that_is_not_a_pair_is_refused(field: str) -> None:
+    """The fiche unpacks each range positionally into its range text.
+
+    ``_range_text(*result.effective_range, language=...)`` turns a triple into
+    a ``TypeError`` about the helper's own ``language`` argument, naming
+    neither the field nor the result; the guard names the field instead.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=rf"LoudspeakerCharacteristics: '{field}' must be a \(lo, hi\) pair",
+    ):
+        dataclasses.replace(result, **{field: (45.0, 18000.0, 3.0)})
+
+
+def test_a_band_edge_in_the_wrong_order_is_refused() -> None:
+    """A reversed pair passes every shape check and prints the range backwards.
+
+    Nothing between the result and the printed ``45 to 18 000 Hz`` re-orders
+    the two ends, so the sheet states an effective range running downwards.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=r"LoudspeakerCharacteristics: 'effective_range' must be a finite",
+    ):
+        dataclasses.replace(result, effective_range=(18000.0, 45.0))

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -595,6 +595,28 @@ def test_a_band_edge_that_is_not_a_pair_is_refused(field: str) -> None:
         dataclasses.replace(result, **{field: (45.0, 18000.0, 3.0)})
 
 
+@pytest.mark.parametrize(
+    "field", ["effective_range", "sensitivity_band", "rated_frequency_range"]
+)
+@pytest.mark.parametrize("pair", [("low", "high"), (object(), object())])
+def test_a_band_edge_that_is_not_numeric_is_refused(
+    field: str, pair: tuple[object, object]
+) -> None:
+    """A correctly shaped pair of non-numbers is refused by its own name.
+
+    The conversion to ``float`` already stopped these, but with its own
+    wording: ``could not convert string to float: 'low'`` for the strings and
+    a ``TypeError`` from inside ``float`` for the objects, neither naming the
+    field nor the result, and the second not even the documented type.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=rf"LoudspeakerCharacteristics: '{field}' must be numeric\.",
+    ):
+        dataclasses.replace(result, **{field: pair})
+
+
 def test_a_band_edge_in_the_wrong_order_is_refused() -> None:
     """A reversed pair passes every shape check and prints the range backwards.
 

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -507,7 +507,7 @@ def test_a_non_finite_response_axis_no_longer_reaches_the_fiche(
     axis[10] = float("nan")
     out = tmp_path / "non_finite_axis.pdf"
     with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
-        dataclasses.replace(result, frequencies=axis).report(str(out))
+        dataclasses.replace(result, frequencies=axis)
     assert not out.exists()
 
 
@@ -554,9 +554,7 @@ def test_a_non_finite_sensitivity_level_no_longer_reaches_the_verdict(
     result = _example_result()
     out = tmp_path / "non_finite_sensitivity_level.pdf"
     with pytest.raises(ValueError, match=r"'sensitivity_level_db' must be finite"):
-        dataclasses.replace(result, sensitivity_level_db=float("nan")).report(
-            str(out), metadata=ReportMetadata(requirement=86.0)
-        )
+        dataclasses.replace(result, sensitivity_level_db=float("nan"))
     assert not out.exists()
 
 
@@ -572,7 +570,7 @@ def test_a_non_finite_resonance_frequency_no_longer_reaches_the_fiche(
     result = _example_result()
     out = tmp_path / "non_finite_resonance.pdf"
     with pytest.raises(ValueError, match=r"'resonance_frequency' must be finite"):
-        dataclasses.replace(result, resonance_frequency=float("nan")).report(str(out))
+        dataclasses.replace(result, resonance_frequency=float("nan"))
     assert not out.exists()
 
 

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -704,6 +704,25 @@ def test_an_effective_range_that_is_not_a_pair_is_refused() -> None:
         dataclasses.replace(result, effective_range=(45.0, 18000.0, 3.0))
 
 
+@pytest.mark.parametrize("pair", [("low", "high"), (object(), object())])
+def test_an_effective_range_that_is_not_numeric_is_refused(
+    pair: tuple[object, object],
+) -> None:
+    """The shared guard names *this* result, not the loudspeaker it also serves.
+
+    The conversion to ``float`` already stopped these, but with its own
+    wording: ``could not convert string to float: 'low'`` for the strings and
+    a ``TypeError`` from inside ``float`` for the objects, neither naming the
+    field nor the result, and the second not even the documented type.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=r"MicrophoneCharacteristics: 'effective_range' must be numeric\.",
+    ):
+        dataclasses.replace(result, effective_range=pair)
+
+
 # --------------------------------------------------------------------------
 # A weighting the measurement standard does not define
 # --------------------------------------------------------------------------

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -618,7 +618,7 @@ def test_a_non_finite_response_axis_no_longer_reaches_the_fiche(
     axis[10] = float("nan")
     out = tmp_path / "non_finite_axis.pdf"
     with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
-        dataclasses.replace(result, frequencies=axis).report(str(out))
+        dataclasses.replace(result, frequencies=axis)
     assert not out.exists()
 
 
@@ -669,7 +669,7 @@ def test_a_non_finite_sensitivity_no_longer_reaches_the_fiche(
     result = _example_result()
     out = tmp_path / "non_finite_sensitivity.pdf"
     with pytest.raises(ValueError, match=r"'sensitivity_mv_per_pa' must be finite"):
-        dataclasses.replace(result, sensitivity_mv_per_pa=float("nan")).report(str(out))
+        dataclasses.replace(result, sensitivity_mv_per_pa=float("nan"))
     assert not out.exists()
 
 
@@ -685,7 +685,7 @@ def test_a_non_finite_polar_frequency_no_longer_reaches_the_fiche(
     result = _example_result()
     out = tmp_path / "non_finite_polar_frequency.pdf"
     with pytest.raises(ValueError, match=r"'polar_frequency' must be finite"):
-        dataclasses.replace(result, polar_frequency=float("nan")).report(str(out))
+        dataclasses.replace(result, polar_frequency=float("nan"))
     assert not out.exists()
 
 
@@ -721,15 +721,12 @@ def test_a_weighting_outside_iec_60268_1_is_refused_at_construction(
     1 unclosed tags``, naming neither the field nor the result.
     """
     f, rel = _flat_response()
+    noise = electroacoustics.MicrophoneNoise(
+        equivalent_level_db=14.0, weighting=weighting
+    )
     with pytest.raises(ValueError, match=r"'noise_weighting' must be one of"):
         electroacoustics.microphone_characteristics(
-            f,
-            rel,
-            _M_MV,
-            tolerance_db=_TOL,
-            noise=electroacoustics.MicrophoneNoise(
-                equivalent_level_db=14.0, weighting=weighting
-            ),
+            f, rel, _M_MV, tolerance_db=_TOL, noise=noise
         )
 
 

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -25,6 +25,7 @@ rejected engines/languages.
 
 from __future__ import annotations
 
+import dataclasses
 import math
 from typing import TYPE_CHECKING
 
@@ -564,3 +565,192 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     out = str(tmp_path / "bad.pdf")
     with pytest.raises(ValueError, match="language"):
         result.report(out, language="xx")
+
+
+# --------------------------------------------------------------------------
+# A curve the data sheet could not have measured
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("field", "bad"),
+    [
+        ("frequencies", float("nan")),
+        ("frequencies", float("inf")),
+        ("response_db", float("nan")),
+        ("polar_db", float("nan")),
+        ("noise_band_levels_db", float("nan")),
+    ],
+)
+def test_a_non_finite_curve_is_refused_where_the_result_is_built(
+    field: str, bad: float
+) -> None:
+    """No producer emits one, and the fiche cannot say what it would mean.
+
+    Every curve reaches the result through the shared curve validator, which
+    already refuses a non-finite frequency or value, so a NaN here is never a
+    measurement outcome. Written in afterwards it used to travel to the sheet
+    unmeasured: a NaN frequency makes the span of the response unmeasurable
+    and the panel is scaled by the decades that span covers, so the render
+    stopped inside matplotlib with ``Axis limits cannot be NaN or Inf``,
+    naming neither the field nor this result; a NaN level was quieter, drawn
+    as a gap indistinguishable from a frequency never measured.
+    """
+    result = _example_result()
+    spoilt = np.array(getattr(result, field), dtype=float)
+    spoilt[0] = bad
+    with pytest.raises(
+        ValueError,
+        match=rf"MicrophoneCharacteristics: '{field}' must contain only finite",
+    ):
+        dataclasses.replace(result, **{field: spoilt})
+
+
+def test_a_non_finite_response_axis_no_longer_reaches_the_fiche(
+    tmp_path: Path,
+) -> None:
+    """The render that used to fail anonymously cannot now be asked for.
+
+    This is the route the sheet took: construction accepted the axis, the
+    panel scaling turned it into a ``nan`` box aspect, and matplotlib stopped
+    the fiche naming nothing. The refusal now lands before the PDF is opened.
+    """
+    result = _example_result()
+    axis = np.array(result.frequencies, dtype=float)
+    axis[10] = float("nan")
+    out = tmp_path / "non_finite_axis.pdf"
+    with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
+        dataclasses.replace(result, frequencies=axis).report(str(out))
+    assert not out.exists()
+
+
+# --------------------------------------------------------------------------
+# A rated number the sheet could not have measured
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "field",
+    [
+        "sensitivity_mv_per_pa",
+        "sensitivity_level_db",
+        "reference_frequency",
+        "polar_frequency",
+        "equivalent_noise_level_db",
+        "tolerance_db",
+        "directivity_index_db",
+    ],
+)
+def test_a_non_finite_rated_number_is_refused_where_the_result_is_built(
+    field: str,
+) -> None:
+    """The single numbers are pinned by name, as the curves already were.
+
+    Every one of them is computed or validated by
+    :func:`microphone_characteristics`, so no producer emits a NaN here. The
+    curve guard never saw them: only the arrays were checked, and a scalar
+    written in afterwards travelled to the sheet untouched.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=rf"MicrophoneCharacteristics: '{field}' must be finite",
+    ):
+        dataclasses.replace(result, **{field: float("nan")})
+
+
+def test_a_non_finite_sensitivity_no_longer_reaches_the_fiche(
+    tmp_path: Path,
+) -> None:
+    """The rated table and the boxed result used to disagree with themselves.
+
+    A NaN sensitivity passed the shape-only guard and printed ``nan mV/Pa`` in
+    the rated-characteristics table beside a boxed headline that still gave
+    the level re 1 V/Pa to a tenth of a decibel: an accredited sheet stating
+    a sensitivity it did not have. The refusal now lands before the PDF is
+    opened.
+    """
+    result = _example_result()
+    out = tmp_path / "non_finite_sensitivity.pdf"
+    with pytest.raises(ValueError, match=r"'sensitivity_mv_per_pa' must be finite"):
+        dataclasses.replace(result, sensitivity_mv_per_pa=float("nan")).report(str(out))
+    assert not out.exists()
+
+
+def test_a_non_finite_polar_frequency_no_longer_reaches_the_fiche(
+    tmp_path: Path,
+) -> None:
+    """The other end of the same gap: a NaN hertz killed the render outright.
+
+    The directivity-index label rounds its frequency to whole hertz, so a NaN
+    stopped the fiche with ``cannot convert float NaN to integer`` -- an error
+    naming neither the field nor this result.
+    """
+    result = _example_result()
+    out = tmp_path / "non_finite_polar_frequency.pdf"
+    with pytest.raises(ValueError, match=r"'polar_frequency' must be finite"):
+        dataclasses.replace(result, polar_frequency=float("nan")).report(str(out))
+    assert not out.exists()
+
+
+def test_an_effective_range_that_is_not_a_pair_is_refused() -> None:
+    """The fiche unpacks the range positionally into its range text.
+
+    ``_range_text(*result.effective_range, language=...)`` turns a triple into
+    a ``TypeError`` about the helper's own ``language`` argument, naming
+    neither the field nor the result; the guard names the field instead.
+    """
+    result = _example_result()
+    with pytest.raises(
+        ValueError,
+        match=r"MicrophoneCharacteristics: 'effective_range' must be a \(lo, hi\) pair",
+    ):
+        dataclasses.replace(result, effective_range=(45.0, 18000.0, 3.0))
+
+
+# --------------------------------------------------------------------------
+# A weighting the measurement standard does not define
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("weighting", ["A<b", "Z", "a"])
+def test_a_weighting_outside_iec_60268_1_is_refused_at_construction(
+    weighting: str,
+) -> None:
+    """The tag reaches the fiche inside ``dB(...)`` markup, so it is pinned.
+
+    IEC 60268-1 defines the A-weighted r.m.s. and the CCIR quasi-peak
+    wide-band inherent-noise measurements, and the fiche interpolates whatever
+    it is given between the parentheses of its noise rows and its verdict. An
+    arbitrary tag was at best a wrong accredited label; a tag-like one reached
+    reportlab's paragraph parser and ended the render with ``parse ended with
+    1 unclosed tags``, naming neither the field nor the result.
+    """
+    f, rel = _flat_response()
+    with pytest.raises(ValueError, match=r"'noise_weighting' must be one of"):
+        electroacoustics.microphone_characteristics(
+            f,
+            rel,
+            _M_MV,
+            tolerance_db=_TOL,
+            noise=electroacoustics.MicrophoneNoise(
+                equivalent_level_db=14.0, weighting=weighting
+            ),
+        )
+
+
+def test_the_ccir_quasi_peak_weighting_is_accepted(tmp_path: Path) -> None:
+    """The other measurement of IEC 60268-1 6.2 still renders its own label.
+
+    The guard pins the tag to the two wide-band measurements the standard
+    defines, so the psophometric one must reach the sheet intact.
+    """
+    pytest.importorskip("reportlab")
+    pytest.importorskip("matplotlib")
+    f, rel = _flat_response()
+    result = electroacoustics.microphone_characteristics(
+        f,
+        rel,
+        _M_MV,
+        tolerance_db=_TOL,
+        noise=electroacoustics.MicrophoneNoise(
+            equivalent_level_db=14.0, weighting="CCIR"
+        ),
+    )
+    out = tmp_path / "ccir.pdf"
+    result.report(str(out))
+    assert "dB(CCIR)" in _extract_text(str(out))

--- a/tests/electroacoustics/test_piston.py
+++ b/tests/electroacoustics/test_piston.py
@@ -148,6 +148,35 @@ def test_a_directivity_index_column_of_another_length_is_refused() -> None:
         dataclasses.replace(result, directivity_index=one_frequency_short)
 
 
+def test_a_non_finite_directivity_pattern_is_refused() -> None:
+    """One NaN poisons the peak the geometry drawing scales the lobe by, its
+    ``> 0`` gate turns False, and the requested lobe disappears from an
+    otherwise complete baffled-piston figure.
+
+    ``piston_directivity`` patches the on-axis 0/0 to its limit, so no
+    producer emits a non-finite pattern.
+    """
+    result = electroacoustics.radiating_piston(
+        0.1, [200.0, 800.0], angles=np.radians(np.linspace(-90.0, 90.0, 37))
+    )
+    assert result.directivity is not None
+    poisoned = result.directivity.copy()
+    poisoned[0, 10] = np.nan
+    with pytest.raises(ValueError, match="'directivity' must be finite"):
+        dataclasses.replace(result, directivity=poisoned)
+
+
+def test_a_non_finite_angle_grid_is_refused() -> None:
+    result = electroacoustics.radiating_piston(
+        0.1, [200.0, 800.0], angles=np.radians(np.linspace(-90.0, 90.0, 37))
+    )
+    assert result.angles is not None
+    poisoned = result.angles.copy()
+    poisoned[3] = np.inf
+    with pytest.raises(ValueError, match="'angles' must be finite"):
+        dataclasses.replace(result, angles=poisoned)
+
+
 def test_directivity_pattern_result_and_properties() -> None:
     # Default grid is 361 points over the front hemisphere -90 deg .. +90 deg.
     res = electroacoustics.piston_directivity_pattern([3.0, 8.0])

--- a/tests/electroacoustics/test_piston.py
+++ b/tests/electroacoustics/test_piston.py
@@ -162,7 +162,9 @@ def test_a_non_finite_directivity_pattern_is_refused() -> None:
     assert result.directivity is not None
     poisoned = result.directivity.copy()
     poisoned[0, 10] = np.nan
-    with pytest.raises(ValueError, match="'directivity' must be finite"):
+    with pytest.raises(
+        ValueError, match="'directivity' must contain only finite values"
+    ):
         dataclasses.replace(result, directivity=poisoned)
 
 
@@ -173,8 +175,24 @@ def test_a_non_finite_angle_grid_is_refused() -> None:
     assert result.angles is not None
     poisoned = result.angles.copy()
     poisoned[3] = np.inf
-    with pytest.raises(ValueError, match="'angles' must be finite"):
+    with pytest.raises(ValueError, match="'angles' must contain only finite values"):
         dataclasses.replace(result, angles=poisoned)
+
+
+def test_a_non_numeric_angle_grid_is_refused_by_name() -> None:
+    """An angle grid of strings passes every rank and length check, and
+    reaches ``np.isfinite`` as a ``TypeError`` from inside numpy that names
+    neither the field nor the result it belongs to.
+    """
+    result = electroacoustics.radiating_piston(
+        0.1, [200.0, 800.0], angles=np.radians(np.linspace(-90.0, 90.0, 37))
+    )
+    assert result.angles is not None
+    lettered = np.array(["bad"] * result.angles.size, dtype=object)
+    with pytest.raises(
+        ValueError, match="RadiatingPistonResult: 'angles' must be numeric"
+    ):
+        dataclasses.replace(result, angles=lettered)
 
 
 def test_directivity_pattern_result_and_properties() -> None:

--- a/tests/electroacoustics/test_sound_reinforcement.py
+++ b/tests/electroacoustics/test_sound_reinforcement.py
@@ -236,10 +236,12 @@ def test_geometry_drawing_annotates_every_path() -> None:
     assert "feedback loop" in ax.get_title()
     plt.close("all")
 
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'talker_distance' must be positive"):
         electroacoustics.plot_sound_reinforcement_geometry(0.0, 4.0, 12.0)
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'microphone_distance' must be positive"):
         electroacoustics.plot_sound_reinforcement_geometry(0.3, math.inf, 12.0)
+    with pytest.raises(ValueError, match="'listener_distance' must be positive"):
+        electroacoustics.plot_sound_reinforcement_geometry(0.3, 4.0, math.nan)
 
 
 @pytest.mark.parametrize("bad", [0, -1, 2.5])

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -525,3 +525,27 @@ def test_a_non_finite_per_band_verdict_value_is_refused() -> None:
     bands[0]["residual_index_db"] = float("nan")
     with pytest.raises(ValueError, match=r"'bands' must carry finite per-band"):
         dataclasses.replace(result, bands=bands)
+
+
+def test_a_narrow_numpy_nan_per_band_value_is_refused() -> None:
+    """A NaN margin held as ``np.float32`` is a NaN the boxed verdict misses.
+
+    ``np.float64`` subclasses ``float`` and ``np.float32`` does not, so a
+    single-precision NaN margin used to reach :meth:`binding_margin`, where
+    :func:`min` compares it away against whichever value it meets first and
+    returns a finite binding margin for a band that has none.
+    """
+    import copy
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0),
+        frequencies,
+        device="instrument",
+        spacing=0.025,
+    )
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    bands[1]["margin_class1_db"] = np.float32("nan")
+    with pytest.raises(ValueError, match=r"'bands' must carry finite per-band"):
+        dataclasses.replace(result, bands=bands)

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -527,6 +527,55 @@ def test_a_non_finite_per_band_verdict_value_is_refused() -> None:
         dataclasses.replace(result, bands=bands)
 
 
+def test_a_verdict_refuses_a_class_its_own_bands_do_not_derive() -> None:
+    """The box and the table are one statement, and the box is not measured.
+
+    The certificate prints the per-band classes in its table and the class of
+    the whole instrument in its box, so a summary that does not restate the
+    rows is the sheet contradicting itself. Built by hand it did: an
+    instrument with one band meeting no class at all, whose honest summary is
+    therefore ``None``, was accepted claiming class 1 and printed ``Class 1 -
+    COMPLIES (binding margin -6.81 dB)``, a negative binding margin beside the
+    word COMPLIES.
+
+    The producer cannot emit the pair: it derives the summary from the band
+    classes in one line. Only a result assembled by hand can hold it, which is
+    why the guard is at construction.
+    """
+    import dataclasses
+
+    frequencies = np.array([100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0])
+    measured = np.full(frequencies.size, 18.0)
+    measured[4] = 9.0  # this band meets neither class
+    result = emission.intensity_class_compliance(
+        measured, frequencies, device="instrument", spacing=0.012
+    )
+    assert result.overall_class is None
+    with pytest.raises(
+        ValueError, match=r"'overall_class' must be the class the bands derive"
+    ):
+        dataclasses.replace(result, overall_class=1)
+
+
+def test_a_verdict_refuses_a_class_that_is_no_designation() -> None:
+    """A class is a label the readers splice into a key, not a number.
+
+    ``1.0`` reads as class 1 to every comparison and builds
+    ``margin_class1.0_db``, a key no band carries, so it reached the boxed
+    statement as a bare ``KeyError`` naming neither the field nor the result.
+    """
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0), frequencies, device="instrument", spacing=0.025
+    )
+    with pytest.raises(
+        ValueError, match=r"'overall_class' must be a class of \[1, 2\] or None"
+    ):
+        dataclasses.replace(result, overall_class=1.0)
+
+
 def test_a_narrow_numpy_nan_per_band_value_is_refused() -> None:
     """A NaN margin held as ``np.float32`` is a NaN the boxed verdict misses.
 

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -454,3 +454,74 @@ def test_an_instrument_verdict_refuses_per_band_entries_that_disagree() -> None:
     )
     with pytest.raises(ValueError, match="'bands'"):
         dataclasses.replace(result, bands=result.bands[:-1])
+
+
+def test_a_verdict_whose_device_is_not_a_table_2_column_is_refused() -> None:
+    """Two readers dispatch on ``device``, and neither survives an unknown tag.
+
+    :func:`verify_intensity_class` checks the tag at the call, but a verdict
+    rewritten by hand reaches the plot's title lookup once the masks are drawn
+    and dies there with a bare ``KeyError`` naming the string alone, while the
+    fiche's basis strip labels the same result as a complete instrument.
+    """
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0),
+        frequencies,
+        device="instrument",
+        spacing=0.025,
+    )
+    with pytest.raises(ValueError, match="'device' must be"):
+        dataclasses.replace(result, device="microphone")
+
+
+@pytest.mark.parametrize(
+    "field_name", ["frequency", "residual_index", "limit_class1", "limit_class2"]
+)
+def test_a_non_finite_band_of_the_verdict_is_refused(field_name: str) -> None:
+    """A NaN band prints as ``nan`` under a boxed verdict that still complies.
+
+    Every comparison the class rests on is ``>=`` against a mask, and a NaN
+    loses each of them silently: the band is marked failing, or the figure's
+    axis autoscaling stops inside matplotlib naming no field at all.
+    """
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0),
+        frequencies,
+        device="instrument",
+        spacing=0.025,
+    )
+    values = np.asarray(getattr(result, field_name), dtype=float).copy()
+    values[1] = float("nan")
+    with pytest.raises(ValueError, match=f"'{field_name}' must be finite"):
+        dataclasses.replace(result, **{field_name: values})
+
+
+def test_a_non_finite_per_band_verdict_value_is_refused() -> None:
+    """The certificate's table and its boxed verdict read different keys.
+
+    The per-band rows print ``residual_index_db`` and the margin taken from
+    it, while the box reads ``margin_class<n>_db``; a NaN in one of them gave
+    an accredited verification certificate reading ``nan`` and ``+nan`` in the
+    results table while still declaring ``Class 1 - COMPLIES``. Every one of
+    these numbers descends from a spectrum the verifier validated finite.
+    """
+    import copy
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0),
+        frequencies,
+        device="instrument",
+        spacing=0.025,
+    )
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    bands[0]["residual_index_db"] = float("nan")
+    with pytest.raises(ValueError, match=r"'bands' must carry finite per-band"):
+        dataclasses.replace(result, bands=bands)

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -557,6 +557,32 @@ def test_a_verdict_refuses_a_class_its_own_bands_do_not_derive() -> None:
         dataclasses.replace(result, overall_class=1)
 
 
+def test_a_verdict_refuses_a_class_attested_over_no_bands() -> None:
+    """A class over nothing is not a verdict, and the readers cannot hold it.
+
+    An instrument stripped of its bands kept its class, so the certificate
+    would have boxed a compliance class with an empty results table under it;
+    :meth:`binding_margin` gave the anonymous "min() iterable argument is
+    empty" instead, naming neither the field nor the result.
+    """
+    import dataclasses
+
+    frequencies = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = emission.intensity_class_compliance(
+        np.full(frequencies.size, 20.0), frequencies, device="instrument", spacing=0.025
+    )
+    empty = np.array([])
+    with pytest.raises(ValueError, match=r"'overall_class' is 1 but 'bands' is empty"):
+        dataclasses.replace(
+            result,
+            bands=(),
+            frequency=empty,
+            residual_index=empty,
+            limit_class1=empty,
+            limit_class2=empty,
+        )
+
+
 def test_a_verdict_refuses_a_class_that_is_no_designation() -> None:
     """A class is a label the readers splice into a key, not a number.
 

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -645,3 +645,73 @@ def test_the_directivity_index_is_pinned_on_its_band_axis() -> None:
     result = _ten_position_determination()
     with pytest.raises(ValueError, match=r"'directivity_index \(axis 1\)'"):
         dataclasses.replace(result, directivity_index=result.directivity_index[:, :-1])
+
+
+def test_an_unknown_grade_tag_is_refused() -> None:
+    """The fiche names the applied standard from ``grade``, so it is pinned.
+
+    A tag that is not exactly ``'survey'`` or ``'engineering'`` used to fall
+    through to engineering, printing a survey determination as "ISO 3744:2010,
+    engineering method, accuracy grade 2": a stricter standard and a better
+    accuracy grade than the measurement had.
+    """
+    import dataclasses
+
+    result = emission.sound_power_pressure(
+        np.tile(np.array([80.0, 78.0, 76.0, 74.0]), (10, 1)),
+        "hemisphere",
+        radius=2.0,
+        frequencies=np.array([250.0, 500.0, 1000.0, 2000.0]),
+        grade="survey",
+    )
+    assert result.grade == "survey"
+    with pytest.raises(ValueError, match="'grade' must be one of"):
+        dataclasses.replace(result, grade="Survey")
+
+
+def test_a_non_finite_surface_area_is_refused() -> None:
+    """``S`` is printed as a plain number inside the boxed result.
+
+    No producer can compute a non-finite measurement surface, so a NaN here
+    could only reach the accredited sheet as a literal ``nan``.
+    """
+    import dataclasses
+
+    result = _ten_position_determination()
+    with pytest.raises(ValueError, match="'surface_area' must be finite"):
+        dataclasses.replace(result, surface_area=float("nan"))
+
+
+def test_a_non_finite_band_of_the_spectrum_is_refused() -> None:
+    """``LW`` carries no validity flags, so a NaN band cannot be marked.
+
+    The spectrum figure passes the bands through ``nan_to_num`` and would draw
+    the band as a fabricated 0 dB bar in the ordinary colour, while the
+    A-weighted total quietly vanishes from the title.
+    """
+    import dataclasses
+
+    result = _ten_position_determination()
+    spectrum = np.asarray(result.sound_power_level, dtype=np.float64).copy()
+    spectrum[2] = np.nan
+    with pytest.raises(ValueError, match="'sound_power_level' must be finite"):
+        dataclasses.replace(result, sound_power_level=spectrum)
+
+
+def test_non_finite_position_levels_are_refused() -> None:
+    """The producer refuses a non-finite band of ``levels_positions``.
+
+    It is the entry point that keeps the spectrum finite: an unevaluable
+    position band used to average straight through into ``LW``.
+    """
+    levels = np.tile(np.array([80.0, 78.0, 76.0, 74.0]), (10, 1))
+    levels[3, 2] = np.nan
+    with pytest.raises(
+        ValueError, match="'levels_positions' must contain only finite values"
+    ):
+        emission.sound_power_pressure(
+            levels,
+            "hemisphere",
+            radius=2.0,
+            frequencies=np.array([250.0, 500.0, 1000.0, 2000.0]),
+        )

--- a/tests/emission/test_sound_power_intensity.py
+++ b/tests/emission/test_sound_power_intensity.py
@@ -516,6 +516,19 @@ def test_non_positive_area_raises() -> None:
         emission.sound_power_intensity(intensity, zero_area)
 
 
+def test_non_finite_area_raises() -> None:
+    """A NaN segment area compares False against the positivity bound.
+
+    Folded into that one test it reached the determination as a measurement
+    surface that is not a number, and the fiche printed "Measurement surface
+    S = nan m2" in the boxed result.
+    """
+    intensity = np.full((4, 1), 1e-4)
+    nan_area = np.array([0.5, 0.5, 0.5, float("nan")])
+    with pytest.raises(ValueError, match="segment 'areas' must be finite"):
+        emission.sound_power_intensity(intensity, nan_area)
+
+
 def test_fewer_than_four_segments_warns() -> None:
     """Clause 8.2 requires at least 4 segments."""
     intensity = np.full((3, 1), 5e-4)
@@ -586,3 +599,32 @@ def test_a_per_segment_quantity_off_the_segment_axis_is_refused() -> None:
     result = _five_band_determination()
     with pytest.raises(ValueError, match="measurement segment"):
         dataclasses.replace(result, repeatability=result.repeatability[:-1])
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_a_non_finite_measurement_surface_is_refused(bad: float) -> None:
+    """The scanned surface is pinned at construction, unlike the levels.
+
+    A shape check cannot see it: the surface keeps its shape whatever number
+    it holds, so the sheet rendered in full with "Measurement surface
+    S = nan m2" beside the boxed A-weighted level.
+    """
+    import dataclasses
+
+    result = _five_band_determination()
+    with pytest.raises(ValueError, match="'surface_area' must be finite"):
+        dataclasses.replace(result, surface_area=bad)
+
+
+def test_a_non_determinable_band_level_stays_a_nan() -> None:
+    """The per-band levels are not pinned: clause 9.2 reads them as NaN.
+
+    A band of negative net power is outside the method, and the fiche prints
+    the em dash the result asked it to; refusing the NaN here would refuse
+    the library's own determination.
+    """
+    intensity = np.tile(np.array([6e-4, -5e-4]), (4, 1))
+    with pytest.warns(emission.SoundPowerWarning):
+        result = emission.sound_power_intensity(intensity, np.full(4, 0.5))
+    assert np.isnan(result.sound_power_level[1])
+    assert np.isfinite(result.surface_area)

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -506,6 +506,16 @@ def test_intensity_nonpositive_area_raises() -> None:
         sound_power_intensity_precision(intensity, areas_with_zero)
 
 
+def test_intensity_non_finite_area_raises() -> None:
+    """A NaN partial surface passes the positivity bound and sums to a
+    measurement surface the clause 10 sheet prints as "nan".
+    """
+    intensity = np.full((2,), 1e-5)
+    areas_with_nan = np.array([1.0, float("nan")])
+    with pytest.raises(ValueError, match="All 'areas' must be finite"):
+        sound_power_intensity_precision(intensity, areas_with_nan)
+
+
 def test_intensity_single_segment_2d_input_not_transposed() -> None:
     # A genuine (1, N) single-segment, N-band array must NOT be read as N
     # segments, even when N equals a plausible segment count. One area -> one
@@ -839,6 +849,22 @@ def test_partial_power_off_the_band_axis_is_refused() -> None:
     three_bands = result.partial_power[:, :-1]
     with pytest.raises(ValueError, match=r"'partial_power \(axis 1\)'"):
         dataclasses.replace(result, partial_power=three_bands)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_a_non_finite_measurement_surface_is_refused(bad: float) -> None:
+    """The summed partial surfaces are pinned; the per-band levels are not.
+
+    Clause 10 has the sheet state the measurement surface area beside the
+    boxed level, and an unpinned one printed there as "nan"; ``NaN`` in
+    ``sound_power_level`` is clause 9.2's own reading of a band the method
+    does not apply to and stays.
+    """
+    import dataclasses
+
+    result = _four_band_determination()
+    with pytest.raises(ValueError, match="'surface_area' must be finite"):
+        dataclasses.replace(result, surface_area=bad)
 
 
 def test_a_field_indicator_off_the_band_axis_is_refused() -> None:

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -630,3 +630,23 @@ def test_per_band_columns_must_share_one_band_axis(field: str) -> None:
     missing = column[:-1]
     with pytest.raises(ValueError, match=rf"'{field}' \(3\).*one value per band"):
         dataclasses.replace(good, **{field: missing})
+
+
+def test_unknown_method_tag_rejected() -> None:
+    """The method tag is pinned at construction, not read with a default.
+
+    The whole ISO 3741 fiche dispatches on this one string: the basis line,
+    the Eq. 20/21 model strip and the corrections line. A tag that is not
+    exactly ``'direct'`` or ``'comparison'`` used to fall through to the
+    direct method, printing a comparison measurement under the direct
+    method's basis and its NaN ``C1`` as an applied correction.
+    """
+    good = emission.sound_power_comparison(
+        np.array([80.0, 82.0, 84.0]),
+        np.array([75.0, 76.0, 77.0]),
+        np.array([85.0, 86.0, 87.0]),
+        frequencies=np.array([500.0, 1000.0, 2000.0]),
+    )
+    assert good.method == "comparison"
+    with pytest.raises(ValueError, match="'method' must be one of"):
+        dataclasses.replace(good, method="Comparison")

--- a/tests/emission/test_vibration_sound_power.py
+++ b/tests/emission/test_vibration_sound_power.py
@@ -228,6 +228,73 @@ def test_a_stray_single_frequency_is_refused() -> None:
         dataclasses.replace(result, frequencies=one_band)
 
 
+@pytest.mark.parametrize(
+    "field_name",
+    ["velocity_level", "sound_power_level", "radiation_factor", "frequencies"],
+)
+def test_a_non_finite_band_quantity_is_refused(field_name: str) -> None:
+    """A NaN band changes which quantity the fiche boxes and compares.
+
+    ``sound_power_level_a`` sums through every band, so one NaN ``LW`` turns
+    L_WA into NaN and the sheet falls back to the unweighted total, whose
+    energy sum skips the NaN band: the box then carries a partial ``LW`` and
+    the verdict compares *that* against the declared A-weighted limit, which
+    flips the printed PASS/FAIL on unchanged physical data. An all-NaN
+    ``radiation_factor`` fails the ``epsilon = 1`` survey test, so the basis
+    line asserts an engineering-method determination whose every epsilon cell
+    is an em dash. :func:`sound_power_from_vibration` computes finite levels
+    from finite inputs, so none of these is ever the library's own output.
+    """
+    import dataclasses
+
+    result = _four_band_determination()
+    values = np.asarray(getattr(result, field_name), dtype=float).copy()
+    values[1] = float("nan")
+    with pytest.raises(ValueError, match=f"VibrationSoundPowerResult: '{field_name}'"):
+        dataclasses.replace(result, **{field_name: values})
+
+
+def test_a_non_finite_radiating_area_is_refused() -> None:
+    """A NaN area prints ``S = nan m2`` beside the boxed sound-power result.
+
+    The area is a scalar of the measurement chain, fixed by the test setup and
+    pinned positive by :func:`sound_power_from_vibration`, so no producer can
+    leave it undetermined; the fiche prints it unconditionally in the extended
+    terms of a fully rendered page.
+    """
+    import dataclasses
+
+    result = _four_band_determination()
+    with pytest.raises(ValueError, match="'area' must be positive"):
+        dataclasses.replace(result, area=float("nan"))
+
+
+def test_a_determination_covering_no_band_is_refused() -> None:
+    """Four empty columns agree, and the sheet comes out complete and blank.
+
+    Length-0 arrays satisfy every rank and count, so the fiche rendered a
+    full accredited sound-power test sheet: the ISO/TS 7849-1 basis line, an
+    empty per-band table, a boxed "Sound power level LW = — dB re 1 pW" over
+    the em dash an energy sum of no bands leaves behind, and the disclaimer
+    under it. It is reachable straight from the entry point, which read an
+    empty velocity level as a determination of nothing.
+    """
+    empty = np.array([], dtype=float)
+    with pytest.raises(
+        ValueError, match="'sound_power_level' must carry at least one band"
+    ):
+        emission.sound_power_from_vibration(empty, 1.5, frequencies=empty)
+
+
+def test_a_broadband_determination_is_not_read_as_empty() -> None:
+    """One level and no band axis is one band's worth of data, not none."""
+    result = emission.sound_power_from_vibration(100.0, 1.5)
+    assert result.frequencies is None
+    levels = np.atleast_1d(result.sound_power_level)
+    assert levels.size == 1
+    assert result.total_level == pytest.approx(float(levels[0]))
+
+
 def test_radiated_power_norton_diesel_engine_example() -> None:
     # Norton & Karczub, Fundamentals of Noise and Vibration Analysis for
     # Engineers 2e (CUP, 2003), problem 3.9 (p. 580) with the published

--- a/tests/environment/assessment/test_impulse_prominence.py
+++ b/tests/environment/assessment/test_impulse_prominence.py
@@ -177,3 +177,46 @@ def test_per_impulse_columns_that_disagree_are_refused(trim: bool) -> None:
     wrong = values[:-1] if trim else np.append(values, values[-1])
     with pytest.raises(ValueError, match="per impulse"):
         dataclasses.replace(result, qualifies=wrong)
+
+
+def test_an_empty_set_of_impulses_is_refused() -> None:
+    """Four length-0 columns agree with each other, and the fiche then dies.
+
+    :func:`impulse_prominence` refuses empty input, so an empty set can only be
+    hand-built; the fiche went hunting the governing row and raised numpy's
+    bare "attempt to get argmax of an empty sequence", naming neither the field
+    nor the result.
+    """
+    import dataclasses
+
+    result = nt.impulse_prominence(
+        onset_rates=[25.0, 40.0], level_differences=[8.0, 12.0]
+    )
+    empty = np.array([])
+    with pytest.raises(ValueError, match="'onset_rates' must carry at least one"):
+        dataclasses.replace(
+            result,
+            onset_rates=empty,
+            level_differences=empty,
+            per_impulse=empty,
+            qualifies=np.array([], dtype=bool),
+        )
+
+
+@pytest.mark.parametrize("field", ["prominence", "adjustment"])
+def test_a_non_finite_governing_value_is_refused(field: str) -> None:
+    """The note and the boxed result print the governing values raw.
+
+    The producer accepts only positive, finite onset rates and level
+    differences, so a NaN can only be hand-built; without the pin the note
+    affirmed "a prominent impulse is present (governing P = nan > 5)" and the
+    verdict row crashed in the display rounding with a bare "cannot convert
+    float NaN to integer".
+    """
+    import dataclasses
+
+    result = nt.impulse_prominence(
+        onset_rates=[25.0, 40.0], level_differences=[8.0, 12.0]
+    )
+    with pytest.raises(ValueError, match=f"'{field}' must be finite"):
+        dataclasses.replace(result, **{field: float("nan")})

--- a/tests/environment/assessment/test_spain.py
+++ b/tests/environment/assessment/test_spain.py
@@ -700,10 +700,9 @@ def test_an_assessment_over_no_period_is_refused() -> None:
     with no rows before the figure gave up with an ``IndexError`` about
     axis 0 of size 0.
     """
+    limits = rd.activity_limits("a")
     with pytest.raises(ValueError, match="'periods' must carry at least one"):
-        rd.ActivityAssessment(
-            periods=(), limits=rd.activity_limits("a"), new_activity=False
-        )
+        rd.ActivityAssessment(periods=(), limits=limits, new_activity=False)
 
 
 def test_long_term_level_validation() -> None:

--- a/tests/environment/assessment/test_spain.py
+++ b/tests/environment/assessment/test_spain.py
@@ -652,6 +652,60 @@ def test_assess_activity_validation() -> None:
         )
 
 
+def _one_period(period: str = "day") -> rd.PeriodAssessment:
+    """One assessed period, laid out as :func:`assess_activity` returns it."""
+    return rd.PeriodAssessment(
+        period=period,
+        phases=(rd.NoisePhase(hours=12.0, laeq=52.0, kt=3.0),),
+        duration_hours=12.0,
+        evaluation_period_level=55.2,
+        reported_level=55,
+        long_term_corrected_level=None,
+        reported_long_term=None,
+        limit=55.0,
+        max_phase_level=55.0,
+        phase_pass=True,
+        daily_pass=True,
+        long_term_pass=None,
+    )
+
+
+@pytest.mark.parametrize("bad", ["Day", "dia", "afternoon"])
+def test_a_period_the_regulation_does_not_define_is_refused(bad: str) -> None:
+    """The period is a tag read as a key, so it is pinned at construction.
+
+    The *acta* takes its period heading, and the assessment plot its bar
+    label, from tables keyed by the three names of Annex I; anything else
+    used to build a period that looked assessed and died in the renderer as
+    a bare ``KeyError: 'Day'``.
+    """
+    with pytest.raises(ValueError, match="'period' must be one of"):
+        _one_period(bad)
+
+
+def test_the_three_evaluation_periods_are_accepted() -> None:
+    """The pin admits exactly what the regulation defines, and all of it."""
+    assert [_one_period(name).period for name in rd.RD1367_EVALUATION_PERIODS] == [
+        "day",
+        "evening",
+        "night",
+    ]
+
+
+def test_an_assessment_over_no_period_is_refused() -> None:
+    """An empty assessment complied vacuously and rendered an empty acta.
+
+    ``complies`` is an ``all()`` over nothing, so it answered ``True``, and
+    the fiche printed its conclusion and PASS verdict over a phase table
+    with no rows before the figure gave up with an ``IndexError`` about
+    axis 0 of size 0.
+    """
+    with pytest.raises(ValueError, match="'periods' must carry at least one"):
+        rd.ActivityAssessment(
+            periods=(), limits=rd.activity_limits("a"), new_activity=False
+        )
+
+
 def test_long_term_level_validation() -> None:
     """The annual average needs at least one finite level and matching weights."""
     with pytest.raises(ValueError, match="At least one"):

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -27,12 +27,14 @@ Primary oracles (analytic limits + published statements):
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import warnings
 
 import numpy as np
 import pytest
 
 from phonometry import environment
+from phonometry.environment.propagation import ground_barriers
 from phonometry.materials import delany_bazley
 
 _BANDS = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0])
@@ -382,6 +384,24 @@ def test_a_barrier_method_the_library_does_not_implement_is_refused() -> None:
     res = environment.barrier_insertion_loss(_BANDS, 1.0, 50.0, 4.0, 100.0, 1.5)
     with pytest.raises(ValueError, match="'method' must be one of"):
         dataclasses.replace(res, method="ISO 9613-2 Dz")
+
+
+def test_the_method_docstring_names_every_model_and_counts_them_right() -> None:
+    """The ``method`` prose is published verbatim as the API reference row.
+
+    ``scripts/generate_api_docs.py`` copies this ivar into the attributes
+    table of the ground-barriers page, so a stale count there is a published
+    claim about the library's coverage. Pin the sentence to
+    ``_BARRIER_METHODS``: a third model added to the tuple without a rewrite
+    of the prose fails here rather than shipping "the two models the library
+    implements" over three.
+    """
+    doc = inspect.getdoc(environment.BarrierInsertionLoss) or ""
+    prose = " ".join(doc.split())
+    assert len(ground_barriers._BARRIER_METHODS) == 2
+    for tag in ground_barriers._BARRIER_METHODS:
+        assert f'``"{tag}"``' in prose
+    assert "the two models the library implements" in prose
 
 
 @pytest.mark.parametrize("field_name", ["insertion_loss", "fresnel_number"])

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -369,6 +369,84 @@ def test_barrier_result_type_and_plot() -> None:
     assert res.insertion_loss.shape == _BANDS.shape
 
 
+def test_a_barrier_method_the_library_does_not_implement_is_refused() -> None:
+    """The fiche cites the method tag as the basis of the prediction.
+
+    Both readers resolved it through a dict of model phrases with the tag
+    itself as the silent default, so any string became an accredited claim:
+    ``method="ISO 9613-2 Dz"`` printed "predicted with ISO 9613-2 Dz, a
+    wave-acoustics complement to the tabulated ISO 9613-2:1996 screening
+    term", naming as the applied model the very formula the sheet exists to
+    distinguish itself from.
+    """
+    res = environment.barrier_insertion_loss(_BANDS, 1.0, 50.0, 4.0, 100.0, 1.5)
+    with pytest.raises(ValueError, match="'method' must be one of"):
+        dataclasses.replace(res, method="ISO 9613-2 Dz")
+
+
+@pytest.mark.parametrize("field_name", ["insertion_loss", "fresnel_number"])
+@pytest.mark.parametrize("trim", [True, False], ids=["short", "long"])
+def test_a_barrier_series_off_the_frequency_axis_is_refused(
+    field_name: str, trim: bool
+) -> None:
+    """The fiche and the plot both pair these two with the frequency axis.
+
+    One entry too many crashed in the plot as matplotlib's bare "x and y must
+    have same first dimension, but have shapes (8,) and (9,)"; one too few
+    crashed in the table as "index 7 is out of bounds for axis 0 with size 7".
+    Neither names the class or a field.
+    """
+    res = environment.barrier_insertion_loss(_BANDS, 1.0, 50.0, 4.0, 100.0, 1.5)
+    values = np.asarray(getattr(res, field_name))
+    wrong = values[:-1] if trim else np.append(values, values[-1])
+    with pytest.raises(ValueError, match=f"'{field_name}'"):
+        dataclasses.replace(res, **{field_name: wrong})
+
+
+@pytest.mark.parametrize(
+    "field_name", ["frequencies", "insertion_loss", "fresnel_number"]
+)
+def test_a_non_finite_barrier_value_is_refused(field_name: str) -> None:
+    """``np.mean`` computes through a NaN, so it becomes the boxed headline.
+
+    One NaN band rendered a fiche with a ``nan`` table cell under a BOXED
+    "Mean insertion loss (63 Hz to 8 kHz) IL = nan dB", and with a declared
+    requirement the verdict then died on ``display_round(nan)``. The one
+    producer, :func:`barrier_insertion_loss`, computes the loss from a
+    geometry and frequency axis it has already pinned finite.
+    """
+    res = environment.barrier_insertion_loss(_BANDS, 1.0, 50.0, 4.0, 100.0, 1.5)
+    values = np.asarray(getattr(res, field_name), dtype=float).copy()
+    values[3] = float("nan")
+    with pytest.raises(
+        ValueError, match=f"BarrierInsertionLoss: '{field_name}' must contain"
+    ):
+        dataclasses.replace(res, **{field_name: values})
+
+
+def test_a_barrier_loss_covering_no_frequency_is_refused() -> None:
+    """Three empty axes agree, and the plot complains about values there are none of.
+
+    Length-0 axes satisfy every rank and count, so the result was built and
+    the fiche asked matplotlib to log-scale an axis with nothing on it, which
+    came back as "Data cannot be log-scaled because all values are <= 0" --
+    a complaint about values, from a result that has none.
+    :func:`barrier_insertion_loss` refuses an empty frequency axis of its
+    own, so an empty loss can only be hand-built.
+    """
+    empty = np.array([], dtype=float)
+    with pytest.raises(
+        ValueError, match="'frequencies' must carry at least one frequency"
+    ):
+        environment.BarrierInsertionLoss(
+            frequencies=empty,
+            insertion_loss=empty,
+            fresnel_number=empty,
+            method="kurze_anderson",
+            ground=False,
+        )
+
+
 def test_barrier_rejects_bad_geometry() -> None:
     with pytest.raises(ValueError, match="must exceed"):
         # barrier not taller than source/receiver -> no shadow.

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -101,6 +101,51 @@ def test_attenuation_emission_length_mismatch_raises(tmp_path: Path) -> None:
         result.report(out, source_emission=bad)
 
 
+@pytest.mark.parametrize(
+    "field_name", ["sound_power_level", "directivity_index", "d_omega", "cmet"]
+)
+def test_a_non_finite_emission_term_is_refused(field_name: str) -> None:
+    """Eq. (3) adds every one of these into the band levels the fiche boxes.
+
+    Nothing computes a :class:`SourceEmission`; the caller builds it for the
+    report, so one NaN band of ``Lw`` (or a NaN scalar term, which reaches
+    every band) rendered a complete prediction sheet whose BOXED headline read
+    ``LAT(DW) = nan dB``, and with a declared requirement the verdict died on
+    ``display_round(nan)`` with an anonymous "cannot convert float NaN to
+    integer".
+    """
+    values: dict[str, object] = {"sound_power_level": np.full(8, 100.0)}
+    if field_name == "sound_power_level":
+        holed = np.full(8, 100.0)
+        holed[3] = float("nan")
+        values["sound_power_level"] = holed
+    else:
+        values[field_name] = float("nan")
+    with pytest.raises(ValueError, match=f"'{field_name}' must"):
+        environment.SourceEmission(**values)  # type: ignore[arg-type]
+
+
+def test_a_breakdown_covering_no_band_is_refused() -> None:
+    """Seven empty terms agree with each other, and the sheet has no bands.
+
+    Length-0 terms satisfy every rank and count, so the breakdown was built
+    and the prediction sheet died reading the first band of an axis with
+    none: numpy's "index 0 is out of bounds for axis 0 with size 0", from
+    inside the renderer, naming no field.
+    """
+    empty = np.array([], dtype=float)
+    with pytest.raises(ValueError, match="'frequencies' must carry at least one band"):
+        environment.OutdoorAttenuation(
+            frequencies=empty,
+            a_div=empty,
+            a_atm=empty,
+            a_gr=empty,
+            a_bar=empty,
+            a_total=empty,
+            d_omega=empty,
+        )
+
+
 def test_attenuation_verbose_adds_a_weighted_band(tmp_path: Path) -> None:
     """``verbose=True`` adds the A-weighted band-level column."""
     result = _attenuation()

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -241,6 +241,42 @@ def test_candidate_below_20hz_rejected() -> None:
         wind_turbine_tonality(levels, freqs, tone_frequency=10.0)
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "tone_frequency",
+        "critical_bandwidth",
+        "tone_level",
+        "masking_level",
+        "tonality",
+        "audibility_criterion",
+        "tonal_audibility",
+    ],
+)
+def test_tonality_result_refuses_a_non_finite_metric(field: str) -> None:
+    """Every Formula 30-34 metric is pinned finite, by name, at construction.
+
+    The spectrum is validated finite and each metric descends from it, so no
+    producer emits a NaN here. One reaching the fiche prints ``nan dB`` in the
+    boxed result beside a confident audibility decision, or dies in the
+    metrics table's rounding with ``cannot convert float NaN to integer``.
+    """
+    import dataclasses
+
+    res = wind_turbine_tonality(*_synthetic_tone())
+    with pytest.raises(ValueError, match=rf"'{field}' must be finite"):
+        dataclasses.replace(res, **{field: float("nan")})
+
+
+def test_tonality_result_refuses_an_infinite_metric() -> None:
+    """Infinity is refused by the same guard: it overflows the same rounding."""
+    import dataclasses
+
+    res = wind_turbine_tonality(*_synthetic_tone())
+    with pytest.raises(ValueError, match=r"'tonal_audibility' must be finite"):
+        dataclasses.replace(res, tonal_audibility=float("inf"))
+
+
 def test_slant_distance_vertical_axis() -> None:
     """Formula 2: a vertical-axis turbine measures R0 = H + D."""
     h, d = 30.0, 20.0

--- a/tests/filters/test_compliance.py
+++ b/tests/filters/test_compliance.py
@@ -399,3 +399,100 @@ def test_a_filter_verdict_refuses_an_unknown_edition() -> None:
     )
     with pytest.raises(ValueError, match="'edition' must be one of"):
         dataclasses.replace(result, edition="2003")
+
+
+def test_a_filter_verdict_refuses_a_class_its_bands_do_not_derive() -> None:
+    """The boxed class must restate the per-band classes under it.
+
+    ``verify_filter_class`` derives the overall class from the band verdicts
+    by one rule, the strictest class every band meets, so a summary that
+    contradicts a row is one no bank produced. Unpinned, the fiche boxed
+    ``Class 1 - COMPLIES (margin -0.35 dB)`` above a table whose 1 kHz row
+    read ``Class 2 (-0.35 dB)``, and passed the bank against a required
+    class 1.
+    """
+    import copy
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    assert result.overall_class == 1
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    # A band that misses class 1 by a hair and meets class 2: the shape
+    # ``_verify_band`` emits for a filter just outside the tighter corridor.
+    bands[1].update({"class": 2, "margin_class1_db": -0.35})
+    with pytest.raises(
+        ValueError, match=r"'overall_class' must be the class the bands derive"
+    ):
+        dataclasses.replace(result, bands=bands, overall_class=1)
+
+
+def test_a_filter_verdict_refuses_a_class_over_a_band_that_meets_none() -> None:
+    """A band that meets no class carries ``None``, and the producer then
+    states ``None`` for the bank too: a bank is no better than its worst
+    band. A class boxed over such a table attests compliance for a band whose
+    own row reads ``none``.
+    """
+    import copy
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    bands[1]["class"] = None
+    # The producer's own pairing of that band list is accepted.
+    assert dataclasses.replace(result, bands=bands, overall_class=None) is not None
+    with pytest.raises(
+        ValueError, match=r"'overall_class' must be the class the bands derive"
+    ):
+        dataclasses.replace(result, bands=bands, overall_class=1)
+
+
+def test_a_filter_verdict_refuses_a_class_that_is_no_designation() -> None:
+    """The class is a designation, not a measured value.
+
+    Both halves are spliced into text and into a key: the overall class into
+    ``margin_class<c>_db``, which the boxed statement reads the binding margin
+    from, so ``1.0`` died in a bare ``KeyError`` for ``margin_class1.0_db``;
+    the per-band class into the table, which printed ``Class 1.0``. Equal to
+    a class is therefore not the same as being one.
+    """
+    import copy
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    bands[1]["class"] = 1.0
+    with pytest.raises(ValueError, match=r"'overall_class' must be one of"):
+        dataclasses.replace(result, overall_class=1.0)
+    with pytest.raises(ValueError, match=r"'bands' must state a 'class' of"):
+        dataclasses.replace(result, bands=bands)
+
+
+def test_a_filter_verdict_refuses_a_band_carrying_no_class_at_all() -> None:
+    """Every band verdict carries its own class, and the fiche's per-band
+    table reads it by name; a band short of the key died in a bare
+    ``KeyError`` halfway through the table.
+    """
+    import copy
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    del bands[1]["class"]
+    with pytest.raises(ValueError, match=r"'bands' must carry a 'class' per band"):
+        dataclasses.replace(result, bands=bands)

--- a/tests/filters/test_compliance.py
+++ b/tests/filters/test_compliance.py
@@ -277,3 +277,95 @@ def test_a_filter_verdict_refuses_per_band_entries_that_disagree() -> None:
     )
     with pytest.raises(ValueError, match="'bands'"):
         dataclasses.replace(result, bands=result.bands[:-1])
+
+
+def test_a_filter_verdict_refuses_a_class_its_bands_carry_no_margins_for() -> None:
+    """Class 0 exists only in the 1995 edition, so a 2014 verdict has no
+    ``margin_class0_db`` keys; an unpinned class would die in a bare
+    ``KeyError`` halfway through the corridor figure.
+    """
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    with pytest.raises(ValueError, match="'overall_class' must be one of"):
+        dataclasses.replace(result, overall_class=0)
+
+
+def test_a_filter_verdict_refuses_an_edition_that_disagrees_with_its_bands() -> None:
+    """A 2014 verdict relabelled 1995 would silently draw the other
+    edition's corridor under the same title.
+    """
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    with pytest.raises(ValueError, match="'edition'"):
+        dataclasses.replace(result, edition="1995")
+
+
+def test_a_filter_verdict_refuses_a_non_finite_per_band_value() -> None:
+    """Every margin is a ``min`` over the measured attenuation against the
+    Table 1 mask, so no bank emits a NaN; one smuggled in prints
+    ``Class 1 (+nan dB)`` in the per-band table under a boxed verdict that
+    still reads COMPLIES, because the binding margin reads another band.
+    """
+    import copy
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    bands[0][f"margin_class{result.reference_class()}_db"] = float("nan")
+    with pytest.raises(ValueError, match=r"'bands' must carry finite per-band"):
+        dataclasses.replace(result, bands=bands)
+
+
+def test_a_filter_verdict_refuses_a_class_stated_over_no_bands() -> None:
+    """A bank with no bands in range is a real outcome, always paired with
+    ``overall_class = None``. A class stated over zero bands would print an
+    accredited verdict box above a table reportlab then refuses to build,
+    complaining about a table with no rows and naming neither the bands nor
+    the bank.
+    """
+    import dataclasses
+
+    import numpy as np
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    empty = {
+        "bands": (),
+        "sos": (),
+        "band_frequencies": np.asarray([], dtype=float),
+        "factors": (),
+    }
+    # The same emptiness with overall_class None is the producer's own output.
+    assert dataclasses.replace(result, overall_class=None, **empty).bands == ()
+    with pytest.raises(ValueError, match=r"'overall_class' is 1 but 'bands' is empty"):
+        dataclasses.replace(result, overall_class=1, **empty)
+
+
+def test_a_filter_verdict_refuses_an_unknown_edition() -> None:
+    """The edition is a pinned tag, refused by name at construction."""
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    with pytest.raises(ValueError, match="'edition' must be one of"):
+        dataclasses.replace(result, edition="2003")

--- a/tests/filters/test_compliance.py
+++ b/tests/filters/test_compliance.py
@@ -310,6 +310,36 @@ def test_a_filter_verdict_refuses_an_edition_that_disagrees_with_its_bands() -> 
         dataclasses.replace(result, edition="1995")
 
 
+def test_a_filter_verdict_refuses_a_later_band_short_of_a_margin_key() -> None:
+    """The margin keys are read off every band, not only the first.
+
+    ``verify_filter_class`` fills each entry from the same list of classes, so
+    a band list whose entries disagree among themselves is one no bank
+    produced. Accepting it on the strength of the first band alone left the
+    ``KeyError`` for the reader: the fiche's per-band table and the plot's
+    worst-band search read ``margin_class<c>_db`` out of every band, for the
+    reference class. The key dropped here is that one, so the band list is
+    exactly the one that used to construct and then die mid-figure.
+    """
+    import copy
+    import dataclasses
+
+    from phonometry.filters.core import OctaveFilterBank
+
+    result = filters.filter_class_compliance(
+        OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
+    )
+    # The producer's own bands all carry the same margin keys, so the guard
+    # cannot refuse a verdict a bank emitted.
+    assert len({frozenset(band) for band in result.bands}) == 1
+    bands = tuple(copy.deepcopy(band) for band in result.bands)
+    del bands[1][f"margin_class{result.reference_class()}_db"]
+    with pytest.raises(
+        ValueError, match=r"entry of 'bands' carries margins for classes \[2\]"
+    ):
+        dataclasses.replace(result, bands=bands)
+
+
 def test_a_filter_verdict_refuses_a_non_finite_per_band_value() -> None:
     """Every margin is a ``min`` over the measured attenuation against the
     Table 1 mask, so no bank emits a NaN; one smuggled in prints

--- a/tests/hearing/test_noise_induced_hearing_loss.py
+++ b/tests/hearing/test_noise_induced_hearing_loss.py
@@ -329,3 +329,33 @@ def test_htlan_rejects_a_non_finite_component() -> None:
     threshold[3] = np.nan
     with pytest.raises(ValueError, match="'threshold' must contain only finite"):
         dataclasses.replace(result, threshold=threshold)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_nipts_rejects_a_non_finite_fractile(value: float) -> None:
+    """The fractile leaves the spectra intact, so only construction catches it.
+
+    It is the population the whole sheet is stated for, printed as ISO 1999's
+    ``Q = 100 (1 - fractile)``. Unguarded, a NaN reached a finished fiche as
+    "Population fractile Q = nan %" and an infinity as "Q = -inf %", each
+    under the non-median gloss and an extrapolation caveat that no comparison
+    had actually earned.
+    """
+    result = m.nipts(95.0, 20.0, 0.9)
+    with pytest.raises(ValueError, match="'fractile' must be finite"):
+        dataclasses.replace(result, fractile=value)
+
+
+@pytest.mark.parametrize("field", ["age", "l_ex", "years", "fractile"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_htlan_rejects_a_non_finite_condition(field: str, value: float) -> None:
+    """Nothing here computes with the four conditions, so nothing tripped on them.
+
+    The fiche prints all four verbatim as the listener and exposure the
+    prediction is stated for, and the plot titles itself with three of them:
+    a NaN age published a complete accredited sheet headed "Listener: male,
+    age nan years" beside components that were all perfectly finite.
+    """
+    result = m.htlan(60, "male", 95.0, 20.0, 0.5)
+    with pytest.raises(ValueError, match=f"'{field}' must be finite"):
+        dataclasses.replace(result, **{field: value})

--- a/tests/hearing/test_noise_induced_hearing_loss.py
+++ b/tests/hearing/test_noise_induced_hearing_loss.py
@@ -269,3 +269,63 @@ def test_plots_return_axes() -> None:
     assert isinstance(m.nipts(95.0, 20.0, 0.9).plot(), plt.Axes)
     assert isinstance(m.htlan(60, "male", 95.0, 20.0, 0.9).plot(), plt.Axes)
     plt.close("all")
+
+
+def test_nipts_rejects_nan_exposure_level() -> None:
+    """A NaN L_EX,8h fires no domain warning and NaNs every spectrum.
+
+    Without the construction guard the plot draws a completely blank axes
+    under a title ending "= nan dB", with no warning of any category.
+    """
+    with pytest.raises(ValueError, match="'l_ex' must be finite"):
+        m.nipts(l_ex=float("nan"), years=10.0)
+
+
+def test_nipts_rejects_nan_years() -> None:
+    with (
+        pytest.warns(m.NoiseInducedHearingLossWarning, match="outside the 1-40"),
+        pytest.raises(ValueError, match="'years' must be finite"),
+    ):
+        m.nipts(l_ex=85.0, years=float("nan"))
+
+
+def test_nipts_rejects_an_empty_frequency_subset() -> None:
+    """An empty subset is reachable from the public entry point.
+
+    ``frequencies=[]`` meets no unknown frequency, so it selected nothing and
+    handed back five length-0 spectra that agreed with each other; the fiche
+    then went hunting the representative 2/3/4 kHz rows and raised numpy's
+    bare "attempt to get argmax of an empty sequence".
+    """
+    with pytest.raises(ValueError, match="'frequencies' must carry at least one"):
+        m.nipts(95.0, 20.0, 0.9, frequencies=[])
+
+
+def test_htlan_rejects_an_empty_frequency_subset() -> None:
+    """The combined threshold takes the same empty subset the same way."""
+    with pytest.raises(ValueError, match="'frequencies' must carry at least one"):
+        m.htlan(60, "male", 95.0, 20.0, 0.5, frequencies=[])
+
+
+@pytest.mark.parametrize("field", ["median", "value"])
+def test_nipts_rejects_a_non_finite_spectrum(field: str) -> None:
+    """Clause 6.3 emits finite shifts, and the fiche rounds every cell it prints.
+
+    A NaN can only reach a hand-built result, where it crashed the table on the
+    first cell with a bare "cannot convert float NaN to integer" naming neither
+    the field nor the result.
+    """
+    result = m.nipts(95.0, 20.0, 0.9)
+    spectrum = np.asarray(getattr(result, field), dtype=np.float64).copy()
+    spectrum[3] = np.nan  # the 3 kHz audiometric frequency
+    with pytest.raises(ValueError, match=f"'{field}' must contain only finite"):
+        dataclasses.replace(result, **{field: spectrum})
+
+
+def test_htlan_rejects_a_non_finite_component() -> None:
+    """Formula (1) combines two finite components, and the fiche rounds them."""
+    result = m.htlan(60, "male", 95.0, 20.0, 0.5)
+    threshold = np.asarray(result.threshold, dtype=np.float64).copy()
+    threshold[3] = np.nan
+    with pytest.raises(ValueError, match="'threshold' must contain only finite"):
+        dataclasses.replace(result, threshold=threshold)

--- a/tests/hearing/test_occupational_exposure.py
+++ b/tests/hearing/test_occupational_exposure.py
@@ -322,6 +322,20 @@ def test_task_rejects_empty_samples() -> None:
         Task(samples=(), duration_hours=8.0)
 
 
+def test_task_rejects_nan_sample() -> None:
+    # A NaN sample would pass the emptiness check, make lex_8h NaN and stop
+    # the exposure plot inside matplotlib ("Axis limits cannot be NaN or
+    # Inf"), naming neither the task nor the sample.
+    with pytest.raises(ValueError, match="'samples' must contain only finite"):
+        Task(samples=(float("nan"), 84.0, 85.2), duration_hours=4.0)
+
+
+def test_task_rejects_nan_duration() -> None:
+    # NaN passes a bare `<= 0.0`; require_positive refuses it by name.
+    with pytest.raises(ValueError, match="'duration_hours' must be positive"):
+        Task(samples=(85.0,), duration_hours=float("nan"))
+
+
 def test_job_based_rejects_nonpositive_sample_duration() -> None:
     with pytest.raises(ValueError, match="sample_duration_hours"):
         job_based_exposure(
@@ -340,6 +354,82 @@ def test_duration_range_order_validated() -> None:
     )
     with pytest.raises(ValueError, match=r"duration_range must be \(T_min, T_max\)"):
         task_based_exposure([reversed_range])
+
+
+def test_result_rejects_an_unknown_strategy_tag() -> None:
+    """The fiche resolves the strategy through a dict to name its clause.
+
+    Unpinned, ``"daily"`` passed construction and died inside the renderer as
+    a bare ``KeyError: 'daily'``, naming neither the field, the class nor the
+    three strategies ISO 9612 defines.
+    """
+    import dataclasses
+
+    result = job_based_exposure([80.0, 82.0, 81.0, 83.0, 80.0], 8.0)
+    with pytest.raises(ValueError, match="'strategy' must be one of"):
+        dataclasses.replace(result, strategy="daily")
+
+
+def test_result_rejects_an_unknown_instrument_tag() -> None:
+    """``instrument`` is a ``Literal`` with no runtime force behind it.
+
+    The fiche's instrumentation line meets the same dict lookup, so
+    ``"Class 1"`` -- the human spelling of the tag ``"class1"`` -- reached it
+    as a bare ``KeyError: 'Class 1'`` out of the middle of the render.
+    """
+    import dataclasses
+
+    result = job_based_exposure([80.0, 82.0, 81.0, 83.0, 80.0], 8.0)
+    with pytest.raises(ValueError, match="'instrument' must be one of"):
+        dataclasses.replace(result, instrument="Class 1")
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["lex_8h", "combined_standard_uncertainty", "expanded_uncertainty", "u1", "u2"],
+)
+def test_result_rejects_a_non_finite_level(field_name: str) -> None:
+    """Every level on the fiche is printed through ``display_round``.
+
+    Its ``math.floor`` dies on a NaN with "cannot convert float NaN to
+    integer", a crash that names no field, no class and no cause. Each
+    strategy computes these from samples already pinned finite, so a NaN is
+    never the library's own output.
+    """
+    import dataclasses
+
+    result = job_based_exposure([80.0, 82.0, 81.0, 83.0, 80.0], 8.0)
+    with pytest.raises(ValueError, match=f"ExposureResult: '{field_name}' must be"):
+        dataclasses.replace(result, **{field_name: float("nan")})
+
+
+def test_a_job_result_without_its_sampling_summary_is_refused() -> None:
+    """The sampling summary is Clause 15 d), and the fiche prints it always.
+
+    Built on the field defaults, the sheet rendered the literal string
+    ``None`` for the number of samples and a fabricated 0,0 for every
+    Formula (C.9) budget term, then closed on a normal PASS verdict: an
+    accredited page stating a zero uncertainty budget nobody measured. The
+    refusal names every term that is missing.
+    """
+    with pytest.raises(ValueError, match="'n_samples'.*must be supplied for a 'job'"):
+        ExposureResult(
+            lex_8h=82.0,
+            combined_standard_uncertainty=1.2,
+            expanded_uncertainty=2.0,
+            strategy="job",
+        )
+
+
+def test_a_task_result_without_its_task_contributions_is_refused() -> None:
+    """A task-based fiche renders one row per task (Clause 15 b)."""
+    with pytest.raises(ValueError, match="'tasks' is empty"):
+        ExposureResult(
+            lex_8h=85.0,
+            combined_standard_uncertainty=1.0,
+            expanded_uncertainty=1.65,
+            strategy="task",
+        )
 
 
 def test_result_dataclasses_are_frozen() -> None:

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -184,7 +184,7 @@ def test_trend_test_validation() -> None:
     with pytest.raises(ValueError, match="one-dimensional"):
         ph.metrology.trend_test(two_dim)
     with_nan = np.r_[np.arange(19.0), np.nan]
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match="'values' must be finite"):
         ph.metrology.trend_test(with_nan)
     good = list(range(12))
     with pytest.raises(ValueError, match="method"):
@@ -342,7 +342,7 @@ def test_level_crossing_default_levels_and_validation() -> None:
     with pytest.raises(ValueError, match="levels"):
         ph.metrology.level_crossing_rate(x, FS, levels=empty_levels)
     nan_levels = [0.0, np.nan]
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match="'levels' must be finite"):
         ph.metrology.level_crossing_rate(x, FS, levels=nan_levels)
 
 
@@ -452,6 +452,34 @@ def test_peak_statistics_rejects_unsorted_peak_values() -> None:
     rng.shuffle(shuffled)
     with pytest.raises(ValueError, match="'peak_values' must be sorted"):
         dataclasses.replace(res, peak_values=shuffled)
+
+
+def test_peak_statistics_rejects_non_finite_peak_values() -> None:
+    """The order check does not catch a NaN; a NaN switches it off.
+
+    ``np.diff`` of a lone NaN is empty, and every comparison against a NaN is
+    false, so a NaN walks through the ascending check and takes the descent on
+    either side of it along -- ``[5, NaN, 1]`` reads as sorted. Two equal
+    infinities differ by a NaN and read as sorted for the same reason. Either
+    one then spans the Rice curves, ``linspace(peaks[0], peaks[-1])``, under
+    an empirical exceedance drawn against heights that are not heights.
+    """
+    res = ph.metrology.peak_statistics(
+        np.random.default_rng(9).standard_normal(1 << 14), FS
+    )
+    lone_nan = np.array([np.nan])
+    hidden_descent = np.array([5.0, np.nan, 1.0])
+    repeated_inf = np.array([1.0, np.inf, np.inf])
+    with np.errstate(invalid="ignore"):  # the order check alone admits all three
+        assert not np.any(np.diff(lone_nan) < 0.0)
+        assert not np.any(np.diff(hidden_descent) < 0.0)
+        assert not np.any(np.diff(repeated_inf) < 0.0)
+    with pytest.raises(ValueError, match="'peak_values' must contain only finite"):
+        dataclasses.replace(res, peak_values=lone_nan)
+    with pytest.raises(ValueError, match="'peak_values' must contain only finite"):
+        dataclasses.replace(res, peak_values=hidden_descent)
+    with pytest.raises(ValueError, match="'peak_values' must contain only finite"):
+        dataclasses.replace(res, peak_values=repeated_inf)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -439,6 +439,21 @@ def test_peak_statistics_validation_and_fields() -> None:
         ph.metrology.peak_statistics(constant, FS)
 
 
+def test_peak_statistics_rejects_unsorted_peak_values() -> None:
+    """The empirical exceedance pairs each peak with its rank positionally.
+
+    An unsorted array passes every count, so the order is pinned at
+    construction; unshuffled producer output keeps constructing (asserted by
+    the sorted check above).
+    """
+    rng = np.random.default_rng(9)
+    res = ph.metrology.peak_statistics(rng.standard_normal(1 << 14), FS)
+    shuffled = np.array(res.peak_values)
+    rng.shuffle(shuffled)
+    with pytest.raises(ValueError, match="'peak_values' must be sorted"):
+        dataclasses.replace(res, peak_values=shuffled)
+
+
 # ---------------------------------------------------------------------------
 # Plots (English default; ES parity lives in test_metrology_plot_i18n.py)
 # ---------------------------------------------------------------------------

--- a/tests/metrology/test_iec61043_report.py
+++ b/tests/metrology/test_iec61043_report.py
@@ -212,3 +212,29 @@ def test_unknown_language_is_rejected(tmp_path: Path) -> None:
     target = str(tmp_path / "xx.pdf")
     with pytest.raises(ValueError, match="Unknown language"):
         result.report(target, language="xx")
+
+
+def test_the_fiche_refuses_a_device_tag_it_cannot_name() -> None:
+    """The certificate never labels an unidentified device as the chain.
+
+    The tag is pinned where the verdict is built, so this is the second
+    reader of it agreeing with the first. It used to hold the only silent
+    default: the phrase fell back to "complete instrument" for anything it
+    did not recognise, so the boxed "Verified as:" line and the basis strip
+    attested the Table 2 column group of the whole chain for a device the
+    fiche could not name, while the plot's own lookup of the same tag died
+    on a bare ``KeyError``.
+    """
+    from phonometry._report.iec61043 import _device_phrase
+
+    with pytest.raises(ValueError, match=r"'device' must be one of"):
+        _device_phrase("sonda", "en")
+
+
+def test_each_table_2_column_group_keeps_its_own_phrase() -> None:
+    """The refusal is not vacuous: the three tags each name a column group."""
+    from phonometry._report.iec61043 import _device_phrase
+
+    assert _device_phrase("probe", "en") == "probe"
+    assert _device_phrase("processor", "en") == "processor"
+    assert _device_phrase("instrument", "en") == "complete instrument"

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -439,3 +439,113 @@ def test_unlabelled_budget_is_not_a_disagreement() -> None:
     """An empty ``names`` is the budget the plot labels ``x1``, ``x2``, ... itself."""
     good = u.combine_uncertainty(_add2, [u.Quantity(1.0, 0.1), u.Quantity(2.0, 0.2)])
     assert dataclasses.replace(good, names=()).names == ()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("value", float("nan"), r"'value' must be finite"),
+        (
+            "combined_uncertainty",
+            float("inf"),
+            r"'combined_uncertainty' must be finite",
+        ),
+        (
+            "contributions",
+            np.array([0.1, float("nan")]),
+            r"'contributions' must contain only finite values",
+        ),
+        (
+            "sensitivities",
+            np.array([float("nan"), 1.0]),
+            r"'sensitivities' must contain only finite values",
+        ),
+    ],
+)
+def test_budget_numbers_must_be_finite(field: str, value: object, match: str) -> None:
+    """A NaN number of the budget is drawn as nothing at all.
+
+    The bar of a NaN contribution has width NaN, so matplotlib draws it
+    nowhere and the input reads as one that contributes nothing; the
+    combined-uncertainty line goes the same way, under a legend printing
+    "u_c = nan".
+    """
+    good = u.combine_uncertainty(_add2, [u.Quantity(1.0, 0.1), u.Quantity(2.0, 0.2)])
+    with pytest.raises(ValueError, match=match):
+        dataclasses.replace(good, **{field: value})
+
+
+def test_undefined_effective_dof_is_not_a_non_finite_number() -> None:
+    """NaN effective dof is the GUM's own value for a correlated budget.
+
+    Annex G.4 defines no Welch-Satterthwaite form for correlated inputs, so
+    the finiteness guard must leave that one field alone and ``expanded``
+    must keep asking for an explicit coverage factor there.
+    """
+    pair = [u.Quantity(0.0, 1.0, dof=5), u.Quantity(0.0, 1.0, dof=5)]
+    with pytest.warns(u.UncertaintyWarning, match="Welch-Satterthwaite"):
+        correlated = u.combine_uncertainty(
+            _add2, pair, correlation=np.array([[1.0, 0.5], [0.5, 1.0]])
+        )
+    assert math.isnan(correlated.effective_dof)
+    k, big = correlated.expanded(coverage_factor_override=2.0)
+    assert (k, big) == (2.0, 2.0 * correlated.combined_uncertainty)
+
+
+def test_quantity_rejects_nan_uncertainty() -> None:
+    # NaN passes a bare `< 0.0` and flows into a NaN contribution the budget
+    # plot draws as an invisible bar under a legend reading "u_c = nan".
+    with pytest.raises(ValueError, match="'uncertainty' must be non-negative"):
+        u.Quantity(2.0, float("nan"), name="length")
+
+
+def test_combine_uncertainty_rejects_model_undefined_at_the_estimates() -> None:
+    """The other producer of the NaN contribution the budget bar hides.
+
+    Pinning ``Quantity.uncertainty`` finite closes only one route: a model
+    that is not defined at its own input estimates returns NaN there and
+    leaves value, combined uncertainty and every contribution undefined.
+    """
+
+    def outside_domain(a: float, b: float) -> float:
+        return math.sqrt(a - 1.0) + b if a >= 1.0 else math.nan
+
+    inputs = [u.Quantity(0.0, 1.0, name="a"), u.Quantity(2.0, 0.1, name="b")]
+    with pytest.raises(
+        ValueError, match=r"'model' returned a non-finite output at the input estimates"
+    ):
+        u.combine_uncertainty(outside_domain, inputs)
+
+
+def test_combine_uncertainty_rejects_model_undefined_one_step_away() -> None:
+    """A model finite at the estimate but not where clause 5.1 probes it.
+
+    ``sqrt`` at an input estimated at zero is finite at the estimate and NaN
+    a step below it, so the central difference, that input's contribution and
+    the whole budget come out NaN; the chart then draws the input as a bar of
+    width NaN, indistinguishable from one contributing nothing. The refusal
+    names the input whose probe left the domain.
+    """
+
+    def half_domain(a: float, b: float) -> float:
+        return math.sqrt(a) + b if a >= 0.0 else math.nan
+
+    inputs = [u.Quantity(0.0, 1.0, name="a"), u.Quantity(2.0, 0.1, name="b")]
+    with pytest.raises(ValueError, match=r"non-finite output when probing a by"):
+        u.combine_uncertainty(half_domain, inputs)
+
+
+def test_monte_carlo_rejects_model_with_non_finite_output() -> None:
+    """A model undefined over part of the sampled domain poisons every statistic.
+
+    Without the guard the histogram shows only the finite trials under a
+    title reading "u(y) = nan" and an invisible coverage band.
+    """
+
+    def partial_model(x: np.ndarray) -> np.ndarray:
+        return np.where(x < 0.0, np.nan, 0.0)
+
+    with pytest.raises(ValueError, match=r"'model' returned a non-finite output"):
+        u.monte_carlo(
+            partial_model, [u.Quantity(0.0, 1.0, name="x")], trials=2000, seed=1
+        )

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -545,7 +545,6 @@ def test_monte_carlo_rejects_model_with_non_finite_output() -> None:
     def partial_model(x: np.ndarray) -> np.ndarray:
         return np.where(x < 0.0, np.nan, 0.0)
 
+    inputs = [u.Quantity(0.0, 1.0, name="x")]
     with pytest.raises(ValueError, match=r"'model' returned a non-finite output"):
-        u.monte_carlo(
-            partial_model, [u.Quantity(0.0, 1.0, name="x")], trials=2000, seed=1
-        )
+        u.monte_carlo(partial_model, inputs, trials=2000, seed=1)

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -434,6 +434,35 @@ def test_a_stage_row_off_the_band_axis_is_refused(field_name: str, trim: bool) -
         dataclasses.replace(result, stages=stages)
 
 
+def test_a_sheet_refuses_a_criterion_family_it_cannot_rate() -> None:
+    """The criterion is pinned on the sheet, not only in the entry point.
+
+    The tag is read three times over: :attr:`rating` picks NC or RC by it,
+    the verdict is computed against that curve, and the basis strip
+    attributes the curve to ANSI/ASA S12.2-2019. An unpinned ``"NR"`` fell
+    through to an RC Mark II rating, so the sheet boxed an RC designation
+    under an "NR 30" criterion and credited the NR family to a standard that
+    does not define one.
+    """
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    with pytest.raises(ValueError, match="'criterion' must be one of"):
+        dataclasses.replace(result, criterion="NR")
+
+
+def test_a_received_spectrum_with_a_non_finite_band_is_refused() -> None:
+    """Every band of the received spectrum is rated and compared.
+
+    Both builders derive it from spectra they hold finite, so a NaN band can
+    only be planted by hand - and it poisons the criterion rating silently
+    before crashing the verdict's rounding with an error naming no field.
+    """
+    result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
+    poisoned = np.asarray(result.received_level, dtype=np.float64).copy()
+    poisoned[3] = np.nan
+    with pytest.raises(ValueError, match="'received_level' must contain only finite"):
+        dataclasses.replace(result, received_level=poisoned)
+
+
 def test_a_room_effect_off_the_band_axis_is_refused() -> None:
     """The room effect is applied band by band, so it must have the bands."""
     result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -260,3 +260,18 @@ def test_a_room_constant_off_the_band_axis_is_refused(trim: bool) -> None:
     wrong = r_i[:-1] if trim else np.append(r_i, r_i[-1])
     with pytest.raises(ValueError, match=r"'room_constant'.*one value per band"):
         dataclasses.replace(res, room_constant=wrong)
+
+
+@pytest.mark.parametrize("field", ["external_area", "internal_area"])
+def test_a_non_finite_enclosure_area_is_refused(field: str) -> None:
+    """The two areas are printed on the sheet, not only used to build ``C``.
+
+    The band table renders a missing value as an em dash, but the extended
+    result line formats these two directly: a NaN planted here would print
+    ``External surface area SE = nan m2`` on an otherwise normal fiche.
+    """
+    res = noise_control.enclosure_insertion_loss(
+        [20.0, 30.0, 40.0], 6.0, 5.0, 0.3, frequencies=[125.0, 250.0, 500.0]
+    )
+    with pytest.raises(ValueError, match=f"'{field}' must be positive"):
+        dataclasses.replace(res, **{field: float("nan")})

--- a/tests/noise_control/test_hvac.py
+++ b/tests/noise_control/test_hvac.py
@@ -216,3 +216,19 @@ def test_spectrum_must_run_over_one_band_axis() -> None:
     for field, value, fragment in cases:
         with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
             dataclasses.replace(good, **{field: value})
+
+
+def test_a_spectrum_refuses_a_quantity_tag_it_cannot_report() -> None:
+    """The tag decides what the sheet says and which way the verdict runs.
+
+    ``quantity`` is a ``Literal`` for the type checker only; at run time an
+    unexpected string used to fall through every ``== "sound_power_level"``
+    test, so a regenerated-noise spectrum with a typo'd tag rendered a
+    complete attenuation sheet on which 85 dB of duct noise PASSED a 40 dB
+    maximum requirement.
+    """
+    good = hvac.elbow_insertion_loss(
+        [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0], 0.4, lined=True
+    )
+    with pytest.raises(ValueError, match="'quantity' must be one of"):
+        dataclasses.replace(good, quantity="power")  # type: ignore[arg-type]

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -375,6 +375,18 @@ def test_a_retained_geometry_with_a_nan_value_is_refused() -> None:
         dataclasses.replace(res, geometry={**res.geometry, "length": float("nan")})
 
 
+def test_a_retained_geometry_with_a_string_dimension_is_refused() -> None:
+    """A dimension that only looks like one never reaches the finiteness
+    check: ``math.isfinite("0.3")`` raises a ``TypeError`` from inside the
+    standard library naming neither the field nor the key.
+    """
+    res = sl.expansion_chamber(np.linspace(50.0, 400.0, 8), 0.3, 0.1, 0.01)
+    assert res.geometry is not None
+    geometry = {**res.geometry, "length": "0.3"}
+    with pytest.raises(ValueError, match=r"'geometry\['length'\]' must be numeric"):
+        dataclasses.replace(res, geometry=geometry)
+
+
 def test_chain_matches_the_hand_built_cascade() -> None:
     # The chain is the same three calls a hand-built layout makes, so its
     # compound matrix must equal the cascade of the bare matrices exactly.

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -352,6 +352,29 @@ def test_a_four_pole_stack_that_lost_its_frequency_axis_is_refused() -> None:
         dataclasses.replace(res, transfer_matrix=one_matrix)
 
 
+def test_a_retained_geometry_with_an_unknown_key_is_refused() -> None:
+    """``plot_geometry`` splats the dict straight into the renderer, so an
+    unknown key would die there in a ``TypeError`` naming the plot
+    function's kwarg rather than the field that carried it.
+    """
+    res = sl.expansion_chamber(np.linspace(50.0, 400.0, 8), 0.3, 0.1, 0.01)
+    assert res.geometry is not None
+    with pytest.raises(
+        ValueError, match=r"'geometry' carries unknown keys \['bogus'\]"
+    ):
+        dataclasses.replace(res, geometry={**res.geometry, "bogus": 1.0})
+
+
+def test_a_retained_geometry_with_a_nan_value_is_refused() -> None:
+    """A non-finite dimension passes every ``<= 0.0`` in the renderer and
+    draws a part-blank device.
+    """
+    res = sl.expansion_chamber(np.linspace(50.0, 400.0, 8), 0.3, 0.1, 0.01)
+    assert res.geometry is not None
+    with pytest.raises(ValueError, match=r"'geometry\['length'\]' must be finite"):
+        dataclasses.replace(res, geometry={**res.geometry, "length": float("nan")})
+
+
 def test_chain_matches_the_hand_built_cascade() -> None:
     # The chain is the same three calls a hand-built layout makes, so its
     # compound matrix must equal the cascade of the bare matrices exactly.

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -564,3 +564,42 @@ def test_specific_pattern_matches_reported_max() -> None:
         _tone(1000.0, 70.0, seconds=2.0, pad_ms=0.0), FS
     )
     assert float(np.sum(res.specific) * 0.1) == pytest.approx(res.loudness, rel=0.03)
+
+
+@pytest.mark.parametrize("name", ["loudness", "loudness_level", "n5", "n10"])
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")], ids=["nan", "inf"])
+def test_non_finite_loudness_quantities_refused(name: str, bad: float) -> None:
+    """The scalar loudness quantities are pinned finite at construction.
+
+    No producer can emit one: both entry points refuse non-finite input, the
+    total is summed from a finite specific-loudness pattern and the
+    percentiles come off a finite trace. The ISO 532-1 fiche prints them raw,
+    so a NaN ``loudness`` used to die inside ``display_round`` in a bare
+    ``ValueError: cannot convert float NaN to integer`` naming neither the
+    field nor the type, and a NaN ``loudness_level``, ``n5`` or ``n10``
+    rendered a literal ``nan`` on the accredited sheet.
+    """
+    result = psychoacoustics.loudness_zwicker_from_spectrum(np.full(28, 60.0))
+    trace = {
+        "time": np.linspace(0.0, 1.0, 8),
+        "loudness_vs_time": np.linspace(1.0, 2.0, 8),
+        "n5": 1.9,
+        "n10": 1.8,
+    }
+    result = dataclasses.replace(result, **trace)
+    with pytest.raises(ValueError, match=f"'{name}' must be finite"):
+        dataclasses.replace(result, **{name: bad})
+
+
+def test_unknown_sound_field_tag_refused() -> None:
+    """``field`` is pinned because the fiche dispatches on it.
+
+    ISO 532-1:2017 clause 7 c)/d) makes the sound field a mandatory
+    declaration of the loudness report; a tag that is neither ``'free'`` nor
+    ``'diffuse'`` used to be read as absent, dropping that statement from the
+    sheet without a word.
+    """
+    result = psychoacoustics.loudness_zwicker_from_spectrum(np.full(28, 60.0))
+    assert result.field == "free"
+    with pytest.raises(ValueError, match="'field' must be one of"):
+        dataclasses.replace(result, field="Free")

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -757,6 +757,57 @@ def test_result_rejects_a_non_finite_line_spacing() -> None:
         dataclasses.replace(good, line_spacing=float("nan"))
 
 
+@pytest.mark.parametrize(
+    "bad",
+    [np.nan, np.inf, 0.0, -3.0, 2.5],
+    ids=["nan", "infinity", "zero", "negative", "fractional"],
+)
+def test_result_rejects_a_group_size_that_is_not_a_count(bad: float) -> None:
+    """A group size tallies tones, so finite alone is the weaker half of it.
+
+    Measured on the nine Annex E tones against the unguarded library, the
+    entry-type column of the accredited key-quantity table takes each of the
+    five differently and none of them well. ``NaN`` and infinity reach
+    ``int()`` and come back as a bare "cannot convert float NaN to integer"
+    (an ``OverflowError`` for the infinity) raised from inside the row
+    builder, naming neither the field nor the tone. ``2.5`` truncates to
+    ``2`` and the sheet states ``FG (2)``, a group size no assessment
+    produced. ``0`` and ``-3`` truncate past the ``<= 1`` the label tests and
+    print ``Single`` on every row, and the sheet renders whole at the same
+    size as the intact one.
+    """
+    good = _annex_e_result()
+    counts = np.ones(good.tone_frequencies.size, dtype=np.float64)
+    counts[0] = bad
+    with pytest.raises(
+        ValueError, match="'group_sizes' must contain whole counts of one tone or more"
+    ):
+        dataclasses.replace(good, group_sizes=counts)
+
+
+def test_result_accepts_every_group_size_step_3_can_produce() -> None:
+    """The guard refuses the impossible counts without narrowing the real range.
+
+    Step 3 writes ``1`` for a tone rated on its own and ``len(group)`` for an
+    FG entry, and ``_step3_groups`` yields only clusters of two members or
+    more, so every count :func:`analyze_spectrum` emits is a whole number of
+    one or more. The absent field is legitimate too, and is the case
+    :func:`assess_tones` produces: built from bare levels, it never ran the
+    combination. A whole count handed over as a float names the same number
+    of tones and renders the same ``FG (N)`` label, so it is accepted as
+    well.
+    """
+    good = _annex_e_result()
+    assert good.group_sizes is None
+    counts = np.ones(good.tone_frequencies.size, dtype=np.int_)
+    counts[0] = 3
+    combined = dataclasses.replace(good, group_sizes=counts)
+    assert combined.group_sizes is not None
+    assert combined.group_sizes.tolist() == [3, *[1] * (counts.size - 1)]
+    as_floats = dataclasses.replace(good, group_sizes=counts.astype(np.float64))
+    assert as_floats.group_sizes is not None
+
+
 # ---------------------------------------------------------------------------
 # Table E.2 full columns: LG, av, band limits and uncertainty U
 # ---------------------------------------------------------------------------

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -750,11 +750,70 @@ def test_result_rejects_a_non_finite_per_tone_column(field: str) -> None:
         dataclasses.replace(good, **{field: column})
 
 
-def test_result_rejects_a_non_finite_line_spacing() -> None:
-    """The header grid prints the line spacing, so a NaN reads as "nan Hz"."""
+@pytest.mark.parametrize(
+    "bad",
+    [np.nan, np.inf, 0.0, -3.0],
+    ids=["nan", "infinity", "zero", "negative"],
+)
+def test_result_rejects_a_line_spacing_that_is_not_a_resolution(bad: float) -> None:
+    """Δf is the analysis bin width, so finite is the weaker half of it.
+
+    The accredited sheet prints the spacing twice, in the header grid and in
+    the statement beside the decisive tone, and against the unguarded library
+    each of the four prints. A NaN or an infinity reads "nan Hz" / "inf Hz" in
+    both places. Zero and negative are the quiet ones: the header grid reads
+    "Δf [Hz] = 0.0" and the statement "Δf = −3.0 Hz", an analysis resolution
+    no FFT produced, with the tone frequencies, the audibilities and the
+    verdict printing normally around it, so the sheet reads as complete.
+    """
     good = _annex_e_result()
-    with pytest.raises(ValueError, match="'line_spacing' must be finite"):
-        dataclasses.replace(good, line_spacing=float("nan"))
+    with pytest.raises(
+        ValueError,
+        match=r"ToneAudibilityResult: 'line_spacing' must be a positive, finite",
+    ):
+        dataclasses.replace(good, line_spacing=bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["1.0e-3 Hz", None, 10**400],
+    ids=["string", "none", "huge-integer"],
+)
+def test_result_rejects_a_line_spacing_that_is_not_numeric(bad: object) -> None:
+    """A spacing that is not a number never reaches the resolution check.
+
+    ``float`` stops all three first, under its own wording and its own types:
+    ``could not convert string to float: '1.0e-3 Hz'``, a ``TypeError`` for
+    the ``None`` and an ``OverflowError`` for the integer too large for a
+    double. None of them names the field or the result, and two are not the
+    ``ValueError`` the guard documents.
+    """
+    good = _annex_e_result()
+    with pytest.raises(
+        ValueError, match=r"ToneAudibilityResult: 'line_spacing' must be numeric\."
+    ):
+        dataclasses.replace(good, line_spacing=bad)
+
+
+@pytest.mark.parametrize(
+    "fill",
+    ["two", object(), 10**400],
+    ids=["string", "object", "huge-integer"],
+)
+def test_result_rejects_group_sizes_that_are_not_numeric(fill: object) -> None:
+    """A tally that is not a number never reaches the count check either.
+
+    The cast to ``float64`` stops all three inside numpy: ``could not convert
+    string to float`` for the strings, a ``TypeError`` for the arbitrary
+    objects and an ``OverflowError`` for the integers too large for a double.
+    They leave under the same wording the measured columns beside them get.
+    """
+    good = _annex_e_result()
+    counts = np.array([fill] * good.tone_frequencies.size, dtype=object)
+    with pytest.raises(
+        ValueError, match=r"ToneAudibilityResult: 'group_sizes' must be numeric\."
+    ):
+        dataclasses.replace(good, group_sizes=counts)
 
 
 @pytest.mark.parametrize(

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -732,6 +732,31 @@ def test_result_rejects_per_tone_length_mismatch(field: str) -> None:
         dataclasses.replace(good, **{field: missing})
 
 
+@pytest.mark.parametrize("field", ["tone_levels", "audibilities"])
+def test_result_rejects_a_non_finite_per_tone_column(field: str) -> None:
+    """The fiche prints the per-tone columns raw, so they are pinned finite.
+
+    :func:`assess_tones` refuses non-finite frequencies, levels and masking
+    levels on the way in, so a NaN can only reach a hand-built result; without
+    the pin a NaN ``LT`` printed a literal ``nan`` cell in the accredited
+    key-quantity table while the verdict printed normally around it, and a NaN
+    audibility crashed the statement's rounding with a bare "cannot convert
+    float NaN to integer".
+    """
+    good = _annex_e_result()
+    column = np.asarray(getattr(good, field), dtype=np.float64).copy()
+    column[0] = np.nan
+    with pytest.raises(ValueError, match=f"'{field}' must contain only finite"):
+        dataclasses.replace(good, **{field: column})
+
+
+def test_result_rejects_a_non_finite_line_spacing() -> None:
+    """The header grid prints the line spacing, so a NaN reads as "nan Hz"."""
+    good = _annex_e_result()
+    with pytest.raises(ValueError, match="'line_spacing' must be finite"):
+        dataclasses.replace(good, line_spacing=float("nan"))
+
+
 # ---------------------------------------------------------------------------
 # Table E.2 full columns: LG, av, band limits and uncertainty U
 # ---------------------------------------------------------------------------

--- a/tests/room/test_enclosed_space_absorption.py
+++ b/tests/room/test_enclosed_space_absorption.py
@@ -212,6 +212,46 @@ def test_absorption_area_with_an_extra_axis_is_refused() -> None:
         dataclasses.replace(result, absorption_area=stacked)
 
 
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "frequencies",
+        "absorption_area",
+        "reverberation_time",
+        "volume",
+        "object_fraction",
+    ],
+)
+def test_a_non_finite_quantity_is_refused(field_name: str) -> None:
+    """Clause 4 has no undeterminable band, so nothing here may be a NaN.
+
+    The A column printed the literal ``nan`` inside the accredited table
+    while the T cell of the same row showed the deliberate em dash, and a
+    NaN volume reached the header grid as "Room volume V [m3]: nan".
+    """
+    result = _prediction()
+    value = getattr(result, field_name)
+    bad = (
+        float("nan")
+        if np.ndim(value) == 0
+        else np.concatenate([[float("nan")], np.asarray(value)[1:]])
+    )
+    with pytest.raises(ValueError, match=f"'{field_name}' must "):
+        dataclasses.replace(result, **{field_name: bad})
+
+
+def test_a_non_finite_absorption_area_is_refused_where_the_time_is_computed() -> None:
+    """The producer conflated NaN with the positivity bound it checks.
+
+    A NaN absorption coefficient sailed through the non-negativity check, was
+    summed into the area, and compared False against ``area <= 0``, so the
+    prediction returned a reverberation time that is not a number.
+    """
+    alpha = np.array([0.10, 0.12, float("nan"), 0.18, 0.20, 0.22, 0.24])
+    with pytest.raises(ValueError, match="absorption_area must be finite"):
+        m.enclosed_space_reverberation([(20.0, alpha)], 50.0)
+
+
 def test_air_condition_requires_standard_bands() -> None:
     # The built-in Table 1 profiles cover the standard octave bands only.
     with pytest.raises(ValueError, match="OCTAVE_BANDS"):

--- a/tests/room/test_impulse_response.py
+++ b/tests/room/test_impulse_response.py
@@ -547,3 +547,16 @@ def test_plot_excitation_short_and_empty_guards() -> None:
     empty_result = room.ImpulseResponseResult(ir=empty, fs=FS, method="spectral")
     with pytest.raises(ValueError, match="empty"):
         empty_result.plot()
+
+
+def test_plot_excitation_rejects_unknown_kind() -> None:
+    """An unknown ``kind`` must be refused, not published as a sweep.
+
+    A one-sided ``== "mls"`` sent every other tag down the sweep branch, so
+    the typo ``"msl"`` for an actual MLS array drew the sequence under the
+    title "ISO 18233 exponential sine sweep" beside a spectrogram panel
+    announcing an exponential frequency rise, with no warning.
+    """
+    mls = room.mls_signal(12).astype(float)
+    with pytest.raises(ValueError, match="'kind' must be one of"):
+        room.plot_excitation(mls, FS, kind="msl")

--- a/tests/room/test_iso3382_3_report.py
+++ b/tests/room/test_iso3382_3_report.py
@@ -6,9 +6,9 @@ a valid single-page PDF is written for an open-plan result, the four
 single-number quantities carry the closed-form values of a documented synthetic
 measurement line, unknown engines/languages are rejected, XML specials in
 metadata do not break reportlab, the optional target-D2,S verdict renders both
-ways, a degenerate result (no in-range positions) still renders, and the
-Spanish fiche is translated with comma decimals. Pixel or layout content is
-never inspected.
+ways and is withheld when D2,S is not finite, a degenerate result (no in-range
+positions) still renders, and the Spanish fiche is translated with comma
+decimals. Pixel or layout content is never inspected.
 
 Oracle. The A-weighted speech level is collinear in the logarithmic distance
 axis, Lp,A,S(r) = 62.0 - 7.0*log2(r) dB, so the ISO 3382-3:2012 Clause 6.2
@@ -28,6 +28,7 @@ pytest.importorskip("reportlab")
 pytest.importorskip("svglib")
 pytest.importorskip("pypdf")
 
+import dataclasses
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -202,6 +203,49 @@ def test_degenerate_result_renders_without_plot(tmp_path: Path) -> None:
     res.report(str(out), metadata=_full_metadata())
     assert_one_page(str(out))
     assert "—" in _extract_text(str(out))  # em-dash empty-cell symbol
+
+
+def test_degenerate_result_with_requirement_withholds_the_verdict(
+    tmp_path: Path,
+) -> None:
+    """A NaN ``D2,S`` plus a target renders the fiche and prints no badge.
+
+    ``display_round`` floors its argument, so the finiteness check has to come
+    before it or the fiche dies in a bare ``ValueError`` naming nothing. And
+    with fewer than two positions in the 2 m to 16 m range nothing was
+    measured against the target, so neither badge may be printed: the
+    em-dashed metrics row is what the sheet has to say.
+    """
+    near = np.array([0.5, 1.0, 1.5, 1.8])
+    res = room.open_plan_metrics(near, 60.0 - 5.0 * near, 0.7 - 0.1 * near)
+    assert not np.isfinite(res.d2s)
+    out = tmp_path / "degenerate_requirement.pdf"
+    res.report(str(out), metadata=_full_metadata(requirement=7.0))
+    assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "PASS" not in text
+    assert "FAIL" not in text
+    assert "—" in text
+
+
+def test_infinite_decay_rate_with_requirement_withholds_the_verdict(
+    tmp_path: Path,
+) -> None:
+    """An infinite ``D2,S`` takes the same route as the NaN one.
+
+    ``display_round`` floors an infinity into an ``OverflowError`` as bare as
+    the NaN ``ValueError``, so the guard is read off the raw value and covers
+    both: the fiche renders, the em-dashed metrics row stands, and no badge
+    claims the target was met or missed.
+    """
+    res = dataclasses.replace(_result(), d2s=float("inf"))
+    out = tmp_path / "infinite_requirement.pdf"
+    res.report(str(out), metadata=_full_metadata(requirement=7.0))
+    assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "PASS" not in text
+    assert "FAIL" not in text
+    assert "—" in text
 
 
 def test_report_escapes_xml_specials_in_metadata(tmp_path: Path) -> None:

--- a/tests/room/test_iso3382_report.py
+++ b/tests/room/test_iso3382_report.py
@@ -6,8 +6,9 @@ facts: a valid single-page PDF is written for a room-acoustics result, the
 per-band table and the mid-frequency descriptor carry the closed-form values
 of a documented synthetic decay, unknown engines/languages are rejected, XML
 specials in metadata do not break reportlab, the optional target-RT verdict
-renders both ways, and the Spanish fiche is translated with comma decimals.
-Pixel or layout content is never inspected.
+renders both ways and is withheld when no band could be evaluated, and the
+Spanish fiche is translated with comma decimals. Pixel or layout content is
+never inspected.
 
 Oracle. The impulse response is a deterministic single-slope decay: one sine
 carrier per octave band, each modulated by its own exponential energy envelope
@@ -278,6 +279,28 @@ def test_verdict_uses_display_rounded_values(tmp_path: Path) -> None:
     assert "1.15" in text
     assert "PASS" in text
     assert "FAIL" not in text
+
+
+def test_no_evaluable_band_withholds_the_verdict(tmp_path: Path) -> None:
+    """A room whose every T30 band is non-evaluable gets no PASS/FAIL badge.
+
+    Undecaying noise is the documented "could not be evaluated" state: every
+    T30 band comes back NaN with its validity flag clear. Nothing was measured
+    against the requirement, so a FAIL badge would assert a failure the room
+    never earned and a PASS the opposite; the fiche still renders, with the
+    em-dashed value in the boxed statement saying what happened.
+    """
+    noise = np.random.default_rng(20268).normal(size=_FS)
+    res = room.room_parameters(noise, _FS)
+    assert not np.any(np.isfinite(res.t30))
+    assert not np.any(res.t30_valid)
+    out = tmp_path / "no_verdict.pdf"
+    res.report(str(out), metadata=_full_metadata(requirement=1.30))
+    assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "PASS" not in text
+    assert "FAIL" not in text
+    assert "—" in text  # the boxed T30 says there was no number
 
 
 def test_single_band_is_not_labeled_broadband(tmp_path: Path) -> None:

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -406,6 +406,43 @@ def test_an_rc_rating_refuses_a_non_finite_rating_average_or_curve(
         dataclasses.replace(result, **{field: replacement})
 
 
+@pytest.mark.parametrize(
+    "bad",
+    [25.5, 30.0, True],
+    ids=["fractional", "integral-float", "bool"],
+)
+def test_an_rc_rating_refuses_a_rating_that_is_not_an_integer(bad: object) -> None:
+    """Finite is too weak: the rating is a designation, not a level.
+
+    Clause D.4 rounds the mid-frequency average to the nearest decibel and
+    clause D.3.5 names the curve by that whole number, which ``label`` prints
+    verbatim. Every value here is finite, so the finite guard passes it, and
+    each one boxes a designation the standard does not define: ``RC-25.5(N)``
+    for the fractional average, ``RC-30.0(N)`` for a float that is a whole
+    number but does not print as one, and ``RC-True(N)`` for a ``bool``,
+    which is an ``int`` in Python and additionally reads out of the
+    tabulated family.
+    """
+    result = rn.room_criterion(rn.rc_curve(35.0))
+    with pytest.raises(ValueError, match="'rating' must be an integer"):
+        dataclasses.replace(result, rating=bad)
+
+
+def test_an_rc_rating_admits_a_numpy_integer_and_a_fractional_average() -> None:
+    """The integer pin belongs to the designation alone, and only to it.
+
+    ``rating`` is what the ``RC-NN(A)`` label prints, so the pin refuses
+    every value that does not print as a whole number of decibels, and
+    nothing further: a NumPy integer prints as the same designation. ``lmf``
+    is the level clause D.4 rounds *to* that designation, so it keeps its
+    tenths and must stay pinned no more tightly than finite.
+    """
+    result = rn.room_criterion(rn.rc_curve(35.0))
+    rated = dataclasses.replace(result, rating=np.int64(35), lmf=35.4)
+    assert rated.label == "RC-35(N)"
+    assert rated.lmf == pytest.approx(35.4)
+
+
 def test_an_rc_rating_keeps_the_bands_it_was_never_given() -> None:
     """The finite guard must not reach ``levels``: absent bands are ``NaN``.
 

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -13,6 +13,8 @@ range rather than clamped to a fabricated rating.
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 from reference_data import (
@@ -320,11 +322,78 @@ def test_an_nc_rating_refuses_levels_off_the_band_axis(trim: bool) -> None:
     A spectrum of the wrong length would have the rating name a band the
     levels never had.
     """
-    import dataclasses
-
     bands = [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
     result = rn.noise_criterion([50.0, 45.0, 40.0, 38.0, 35.0, 32.0, 30.0, 28.0], bands)
     levels = np.asarray(result.levels)
     wrong = levels[:-1] if trim else np.append(levels, levels[-1])
     with pytest.raises(ValueError, match="'levels'"):
         dataclasses.replace(result, levels=wrong)
+
+
+# --------------------------------------------------------------------------
+# The band axis the standard fixes, the spectral tag and the rating/range pair
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("family", ["nc", "rc"])
+def test_a_rating_refuses_a_band_axis_off_table_1(family: str) -> None:
+    """Both families are defined over the ten tabulated octave bands.
+
+    ANSI/ASA S12.2-2019 rates against Table 1 (NC) and Table D.1 (RC), both
+    tabulated on the fixed 16 Hz - 8000 Hz octave axis, and the fiche prints
+    those nominal labels rather than the stored axis. An axis shifted an
+    octave keeps the band count, so nothing downstream notices: every
+    measured level would be tabled against the label of its neighbour while
+    the plot on the same page draws it at its true frequency.
+    """
+    result: rn.NCResult | rn.RCResult = (
+        rn.noise_criterion(rn.nc_curve(40.0))
+        if family == "nc"
+        else rn.room_criterion(rn.rc_curve(35.0))
+    )
+    one_octave_up = rn.OCTAVE_BANDS * 2.0
+    with pytest.raises(ValueError, match="'frequencies' must be the ten"):
+        dataclasses.replace(result, frequencies=one_octave_up)
+
+
+def test_an_rc_rating_refuses_the_unimplemented_rv_tag() -> None:
+    """``RV`` is a clause D.3.5 designation this library does not rate.
+
+    The vibration/rattle tag of clause D.3.4 needs the Table 6 criterion
+    test, so it is refused by name instead of being mapped onto a
+    neighbouring letter: the fiche prints one spectral-quality sentence per
+    tag and would have boxed ``RC-nn(RV)`` over "Spectral quality: neutral".
+    """
+    result = rn.room_criterion(rn.rc_curve(35.0))
+    with pytest.raises(ValueError, match="classification 'RV'"):
+        dataclasses.replace(result, classification="RV")
+
+
+def test_an_rc_rating_refuses_an_unknown_spectral_tag() -> None:
+    """A tag outside N/R/H/RH has no spectral-quality sentence to print."""
+    result = rn.room_criterion(rn.rc_curve(35.0))
+    with pytest.raises(ValueError, match="'classification' must be one of"):
+        dataclasses.replace(result, classification="Q")
+
+
+def test_an_nc_rating_outside_the_family_keeps_its_flag() -> None:
+    """A NaN rating without ``out_of_range`` boxes ``NC-nan`` on the fiche.
+
+    The rating and the flag are one statement made twice: outside the NC-15
+    to NC-70 family of Table 1 there is no NC rating, and the fiche reads the
+    flag to print ``>NC-70`` / ``<NC-15`` instead of the number. Clearing the
+    flag alone leaves the NaN to be formatted verbatim and to crash the
+    verdict's rounding.
+    """
+    over = rn.NC_CURVES[-1].copy()
+    over[2] += 1.0  # 63 Hz, 1 dB above the highest tabulated curve
+    result = rn.noise_criterion(over)
+    assert result.out_of_range == "above"
+    with pytest.raises(ValueError, match="'rating' must be finite"):
+        dataclasses.replace(result, out_of_range=None)
+
+
+def test_an_nc_rating_inside_the_family_cannot_be_flagged_out_of_it() -> None:
+    """A flagged result carries no number: the fiche prints the flag instead."""
+    result = rn.noise_criterion(rn.nc_curve(40.0))
+    assert result.out_of_range is None
+    with pytest.raises(ValueError, match="'rating' must be NaN"):
+        dataclasses.replace(result, out_of_range="above")

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -374,6 +374,56 @@ def test_an_rc_rating_refuses_an_unknown_spectral_tag() -> None:
         dataclasses.replace(result, classification="Q")
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")], ids=["nan", "inf"])
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("rating", "'rating' must be finite"),
+        ("lmf", "'lmf' must be finite"),
+        ("reference_curve", "'reference_curve' must contain only finite values"),
+    ],
+)
+def test_an_rc_rating_refuses_a_non_finite_rating_average_or_curve(
+    field: str, message: str, bad: float
+) -> None:
+    """Clause D.4 leaves none of the three undetermined, so none may be stored.
+
+    The rater refuses a spectrum whose 500/1000/2000 Hz bands are not all
+    present, so ``LMF`` and the rating rounded from it always exist, and the
+    reference curve is generated from that rating by the closed-form
+    -5 dB/octave rule of Annex D, which is finite in all ten bands. A
+    non-finite value therefore describes no measurement, yet it clears every
+    shape guard: the fiche boxes the literal ``RC-nan(N)`` as an accredited
+    designation, and ``out_of_family`` stops being a verdict: both sides of
+    its chained comparison are false for a ``NaN``, so it reads ``True`` for
+    every spectrum rather than answering for the rating.
+    """
+    result = rn.room_criterion(rn.rc_curve(35.0))
+    curve = np.asarray(result.reference_curve, dtype=float).copy()
+    curve[3] = bad
+    replacement = curve if field == "reference_curve" else bad
+    with pytest.raises(ValueError, match=message):
+        dataclasses.replace(result, **{field: replacement})
+
+
+def test_an_rc_rating_keeps_the_bands_it_was_never_given() -> None:
+    """The finite guard must not reach ``levels``: absent bands are ``NaN``.
+
+    Clause D.4 needs only the mid-frequency bands to rate, so a spectrum may
+    be given as a subset of the ten and the rater marks every band it was not
+    handed with a ``NaN`` that the fiche renders as an em dash. That is a
+    quantity the measurement legitimately left undetermined, unlike the
+    rating and the curve derived from it, which are finite here even though
+    seven of the ten bands were never measured.
+    """
+    with pytest.warns(UserWarning, match="31.5 Hz to 4000 Hz octave bands"):
+        result = rn.room_criterion([35.0, 32.0, 30.0], [500.0, 1000.0, 2000.0])
+    absent = np.isnan(np.asarray(result.levels))
+    assert absent.sum() == 7
+    assert np.isfinite(np.asarray(result.reference_curve)).all()
+    assert np.isfinite([result.rating, result.lmf]).all()
+
+
 def test_an_nc_rating_outside_the_family_keeps_its_flag() -> None:
     """A NaN rating without ``out_of_range`` boxes ``NC-nan`` on the fiche.
 

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -249,6 +249,23 @@ def test_model_curves_must_run_over_one_band_axis() -> None:
             dataclasses.replace(good, **{field: value})
 
 
+@pytest.mark.parametrize("field", ["frequencies", "volume", "surface_area"])
+@pytest.mark.parametrize("bad", [math.nan, math.inf])
+def test_a_non_finite_room_is_refused(field: str, bad: float) -> None:
+    """The geometry the fiche prints is pinned; the five curves are not.
+
+    Volume and surface area are products of three room lengths the bundle
+    has already required to be positive and finite, so no prediction can
+    return a room that is not a number; unpinned, a NaN volume reached the
+    header grid of the sheet as "Room volume V [m3]: nan".
+    """
+    good = room.reverberation_time_models(DIMS, (0.2, 0.15, 0.3), frequencies=1000.0)
+    value = getattr(good, field)
+    replacement = bad if np.ndim(value) == 0 else np.full_like(np.asarray(value), bad)
+    with pytest.raises(ValueError, match=f"'{field}' must "):
+        dataclasses.replace(good, **{field: replacement})
+
+
 def test_models_single_frequency_is_a_band_axis_of_one() -> None:
     """A scalar ``frequencies`` labels one band, as ``None`` already does.
 

--- a/tests/signals/test_time_frequency.py
+++ b/tests/signals/test_time_frequency.py
@@ -139,6 +139,29 @@ class TestSpectrogramValidation:
             signals.spectrogram(x, 1000.0, nperseg=2048)
 
 
+def test_silent_recording_renders_an_empty_spectrogram() -> None:
+    """A silent recording is a legal input, so its figure must draw.
+
+    Every cell is zero power and so -inf dB: the colour range has no
+    strongest cell to anchor to, and taking the maximum of the finite
+    levels used to reduce an empty array, stopping the plot with numpy's
+    "zero-size array to reduction operation maximum". The fallback anchors
+    the range at 0 dB and every cell sits below the 80 dB floor.
+    """
+    import matplotlib as mpl
+
+    mpl.use("Agg")
+    import matplotlib.pyplot as plt
+
+    res = signals.spectrogram(np.zeros(48000), fs=48000)
+    assert float(np.max(res.power)) == 0.0
+    ax = res.plot()
+    image = ax.get_images()[0]
+    assert image.get_clim() == (-80.0, 0.0)
+    assert np.all(np.isneginf(np.ma.getdata(image.get_array())))
+    plt.close("all")
+
+
 # ---------------------------------------------------------------------------
 # Zoom FFT: machine-precision oracles
 # ---------------------------------------------------------------------------

--- a/tests/signals/test_window_metrics.py
+++ b/tests/signals/test_window_metrics.py
@@ -139,6 +139,21 @@ def test_window_metrics_invalid_inputs() -> None:
         ph.signals.window_metrics("hann", 8)
 
 
+def test_window_metrics_rejects_taps_of_another_length() -> None:
+    """Taps that disagree with the declared ``n`` are a different window.
+
+    Every figure of merit was computed from ``n`` samples and the waveform
+    panel draws the taps against a sample index counted out of ``n``, so a
+    mismatch used to stop inside matplotlib about first dimensions, naming
+    neither the field nor the result.
+    """
+    res = ph.signals.window_metrics("hann", N)
+    with pytest.raises(
+        ValueError, match=r"WindowMetricsResult: 'n' \(1034\), 'taps' \(1024\)"
+    ):
+        dataclasses.replace(res, n=1034)
+
+
 def test_window_metrics_plot_two_panels_and_single_axes() -> None:
     res = ph.signals.window_metrics("hann", N)
     axes = res.plot(linewidth=2)

--- a/tests/speech/test_sii.py
+++ b/tests/speech/test_sii.py
@@ -322,6 +322,130 @@ def test_invalid_inputs_raise() -> None:
         sii.standard_speech_spectrum("whisper")
 
 
+@pytest.mark.parametrize("bad", ["critical band", "third-octave", "CRITICAL-BAND"])
+def test_a_result_procedure_outside_the_standard_is_refused(bad: str) -> None:
+    """The procedure tag decides what the fiche says the sheet is.
+
+    Both the standard-basis sentence and the band-table caption are read out
+    of tables keyed by it, and both used to fall back to the one-third-octave
+    wording: a result computed over the 21 critical bands, mistyped, printed
+    a page claiming the one-third-octave-band procedure over a table of
+    critical-band rows.
+    """
+    result = sii.speech_intelligibility_index("normal", method="critical-band")
+    with pytest.raises(ValueError, match="'method' must be one of"):
+        dataclasses.replace(result, method=bad)
+
+
+@pytest.mark.parametrize("name", ["speech_spectrum", "noise_spectrum", "threshold"])
+def test_a_non_finite_band_vector_is_refused_by_parameter_name(name: str) -> None:
+    """One NaN band poisons every band above it through the spread of masking.
+
+    The index came back NaN, the plot's title printed "SII = nan", and the
+    weighted bars were left unscaled because ``contribution.max()`` being NaN
+    made the ``peak > 0`` test False -- so the series the legend calls
+    "(scaled)" was drawn at its raw height, indistinguishable from a low
+    score. The bands above the corrupt one simply went missing from the
+    figure. The STOI and STI entry points already refuse non-finite input;
+    this is the same refusal, naming the parameter the caller typed.
+    """
+    corrupt = sii.standard_speech_spectrum("normal").copy()
+    corrupt[9] = np.nan
+    arguments: dict[str, object] = {
+        "speech_spectrum": "normal",
+        "noise_spectrum": None,
+        "threshold": None,
+    }
+    arguments[name] = corrupt
+    with pytest.raises(ValueError, match=f"{name!r} must contain only finite"):
+        sii.speech_intelligibility_index(**arguments)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", ["critical band", "third-octave", "CRITICAL-BAND"])
+def test_a_procedure_tag_outside_the_standard_is_refused(bad: str) -> None:
+    """The band-importance plot reads its legend label out of a table keyed by it.
+
+    ``SIIProcedure`` is the object the four procedures overlay from, and its
+    renderer indexes ``_SII_METHOD_LABELS[result.method]`` directly: a tag
+    outside the four names used to reach it and come back as a bare
+    ``KeyError`` naming no field, no owner and none of the valid choices.
+    """
+    procedure = sii.sii_procedure("one-third-octave")
+    with pytest.raises(ValueError, match="'method' must be one of"):
+        dataclasses.replace(procedure, method=bad)
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_a_non_finite_index_is_refused(bad: float) -> None:
+    """The index is a weighted sum over spectra already required to be finite.
+
+    Nothing the computation can return is a NaN, and one reaching the fiche
+    crashed its boxed statement inside the display rounder with "cannot
+    convert float NaN to integer", a message naming neither field nor owner.
+    """
+    result = sii.speech_intelligibility_index("normal")
+    with pytest.raises(ValueError, match="'sii' must be finite"):
+        dataclasses.replace(result, sii=bad)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "band_audibility",
+        "band_importance",
+        "frequencies",
+        "speech_spectrum",
+        "disturbance",
+        "masking",
+        "level_distortion",
+    ],
+)
+def test_a_non_finite_band_quantity_is_refused_by_field_name(name: str) -> None:
+    """The index stays finite while the figure quietly stops meaning anything.
+
+    Pinning the entry point closed the way in through the spectra; a result
+    assembled or amended by hand is the other door, and the plot is where it
+    shows. The weighted series is scaled by its own peak, so one NaN band
+    makes that peak NaN, ``peak > 0.0`` False and the series the legend calls
+    "(scaled)" is drawn at its raw height: 0,0898 of the axis instead of
+    filling it, with the corrupt band missing and the title still reading
+    "SII = 0.996". A NaN in ``frequencies`` labels a band ``nan``, on the axis
+    and in the fiche's frequency column.
+    """
+    result = sii.speech_intelligibility_index("normal")
+    corrupt = np.asarray(getattr(result, name), dtype=np.float64).copy()
+    corrupt[9] = np.nan
+    with pytest.raises(ValueError, match=f"'{name}' must contain only finite"):
+        dataclasses.replace(result, **{name: corrupt})
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "frequencies",
+        "band_edges",
+        "band_importance",
+        "internal_noise",
+        "speech_spectrum",
+    ],
+)
+def test_a_non_finite_procedure_column_is_refused_by_field_name(name: str) -> None:
+    """A transcribed table has no undeterminable entry to make room for.
+
+    The step plot draws each band flat across its own width and takes its
+    headroom from the maximum of the column, so a NaN drops that band out of
+    the curve and scales the panel to a peak that is not the table's. The
+    procedures are meant to be overlaid and compared; one of them silently
+    short of a band, stretched to the wrong height, is the comparison going
+    wrong with nothing on the axes to say so.
+    """
+    procedure = sii.sii_procedure("octave")
+    corrupt = np.asarray(getattr(procedure, name), dtype=np.float64).copy()
+    corrupt[0] = np.inf
+    with pytest.raises(ValueError, match=f"'{name}' must contain only finite"):
+        dataclasses.replace(procedure, **{name: corrupt})
+
+
 def test_result_fields_present() -> None:
     result = sii.speech_intelligibility_index("normal")
     assert result.band_audibility.shape == (18,)
@@ -881,3 +1005,59 @@ def test_sii_result_plot_for_every_procedure() -> None:
         ax = result.plot()
         assert len(ax.patches) == 2 * proc.frequencies.size
         plt.close("all")
+
+
+def test_the_weighted_series_fills_the_axis_the_legend_says_it_is_scaled_to() -> None:
+    """What "(scaled)" claims, measured: the tallest bar reaches exactly 1.
+
+    This is the half of the finiteness pin that a refusal test cannot state,
+    because the poisoned result can no longer be built. The defect was never
+    an exception: with one NaN band the peak the series divides by was NaN,
+    ``peak > 0.0`` came out False and the whole series was drawn raw, topping
+    out at 0,0898 under a legend still promising "(scaled)" and a title still
+    reading a finite index. Assert the scaling itself, so that removing it
+    fails here rather than passing quietly behind an intact guard.
+    """
+    pytest.importorskip("matplotlib")
+    import matplotlib as mpl
+
+    mpl.use("Agg")
+    import matplotlib.pyplot as plt
+
+    result = sii.speech_intelligibility_index("normal")
+    bands = result.band_audibility.size
+    ax = result.plot()
+    # The audibility bars are drawn first, the weighted series second.
+    weighted = np.array([patch.get_height() for patch in ax.patches][bands:])
+    assert weighted.size == bands
+    assert np.all(np.isfinite(weighted))
+    assert weighted.max() == pytest.approx(1.0)
+    legend = [text.get_text() for text in ax.get_legend().get_texts()]
+    assert legend[1] == r"Importance-weighted $I_i\,A_i$ (scaled)"
+    assert ax.get_title() == "ANSI S3.5 SII = 0.996"
+    plt.close("all")
+
+
+def test_the_procedure_step_draws_every_band_and_its_own_headroom() -> None:
+    """The step carries the table, and the y-limit carries the table's peak.
+
+    The other half of the same pin. A NaN column entry left its band out of
+    the curve and scaled the panel to the largest of the bands that remained,
+    which for the octave procedure moved the top of the axis from 0,30452 to
+    0,275295: a band-importance function overlaid on the others short of a
+    band and stretched to a height that is not its own.
+    """
+    pytest.importorskip("matplotlib")
+    import matplotlib as mpl
+
+    mpl.use("Agg")
+    import matplotlib.pyplot as plt
+
+    procedure = sii.sii_procedure("octave")
+    ax = procedure.plot()
+    # A post-step repeats the last band's value to close the final interval.
+    expected = np.append(procedure.band_importance, procedure.band_importance[-1])
+    np.testing.assert_allclose(ax.get_lines()[0].get_ydata(), expected)
+    assert ax.get_ylim()[1] == pytest.approx(1.15 * procedure.band_importance.max())
+    assert ax.get_ylim()[1] == pytest.approx(0.30452)
+    plt.close("all")

--- a/tests/speech/test_sii_report.py
+++ b/tests/speech/test_sii_report.py
@@ -253,6 +253,55 @@ def test_non_default_procedure_fiche_renders_in_spanish(tmp_path: Path) -> None:
     assert "Audibilidad por bandas de octava" in text
 
 
+def test_a_procedure_the_fiche_has_no_wording_for_is_refused() -> None:
+    """The two wording tables refuse an unknown procedure, not default to one.
+
+    Both readings used to fall back to the one-third-octave wording, which is
+    a procedure of the standard in its own right: a 21-band critical-band
+    result mistyped as ``"critical band"`` printed a sheet claiming the
+    one-third-octave-band method over a table of critical-band rows.
+    """
+    from phonometry._report.sii import _METHOD_NAMES, _procedure_wording
+
+    with pytest.raises(ValueError, match="band procedure 'critical band'"):
+        _procedure_wording(_METHOD_NAMES, "critical band", "basis-line wording")
+
+
+def test_the_caption_table_refuses_the_same_unknown_procedure() -> None:
+    """The caption is the second reading of the tag, and it refuses too.
+
+    The basis line and the table caption are read from two tables, and both
+    fell back to the one-third-octave entry; pinning only the first would
+    have left the caption alone in claiming a procedure the sheet did not
+    follow.
+    """
+    from phonometry._report.sii import _TABLE_CAPTIONS, _procedure_wording
+
+    with pytest.raises(ValueError, match="band procedure 'critical band'"):
+        _procedure_wording(_TABLE_CAPTIONS, "critical band", "band-table caption")
+
+
+def test_every_procedure_the_result_accepts_has_its_own_wording() -> None:
+    """The refusal is not vacuous: each of the four tags words differently.
+
+    This is what the refusal is there to catch. ``SIIResult`` pins ``method``
+    to :data:`SII_METHODS`, so a fifth procedure added to that tuple without
+    wording in the two fiche tables would now be refused rather than printed
+    as one-third-octave.
+    """
+    from phonometry._report.sii import (
+        _METHOD_NAMES,
+        _TABLE_CAPTIONS,
+        _procedure_wording,
+    )
+    from phonometry.speech.sii import SII_METHODS
+
+    basis = [_procedure_wording(_METHOD_NAMES, m, "basis") for m in SII_METHODS]
+    captions = [_procedure_wording(_TABLE_CAPTIONS, m, "caption") for m in SII_METHODS]
+    assert len(set(basis)) == len(SII_METHODS)
+    assert len(set(captions)) == len(SII_METHODS)
+
+
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _example_c2()

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -505,6 +505,31 @@ def test_an_sti_result_refuses_an_mti_off_the_band_axis() -> None:
         dataclasses.replace(result, mti=result.mti[:-1])
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_an_sti_result_refuses_a_non_finite_index(bad: float) -> None:
+    """No measurement can return an STI that is not a number.
+
+    Every path runs through the modulation-transfer validation, which refuses
+    a non-finite matrix, and the chain from there is arithmetic on values
+    clipped into [0, 1]. One built by hand used to crash the boxed statement
+    of the fiche as "cannot convert float NaN to integer", from inside the
+    display rounder, naming neither the field nor the result type.
+    """
+    import dataclasses
+
+    from phonometry.speech.sti import STIResult
+
+    result = STIResult(
+        sti=0.75,
+        mti=np.full(7, 0.75),
+        mtf=np.full((7, 2), 0.75),
+        band_levels=np.full(7, 60.0),
+        rating="B",
+    )
+    with pytest.raises(ValueError, match="'sti' must be finite"):
+        dataclasses.replace(result, sti=bad)
+
+
 def test_an_sti_result_refuses_a_bare_number_for_a_band_column() -> None:
     """One number is not seven bands, however few axes it has.
 


### PR DESCRIPTION
This carries the same construction guard to the domains the branch below did not cover: speech, environment, aircraft, electroacoustics, emission, broadcast, metrology, hearing, room acoustics, signals, filters and noise control.

## What the pages were doing

The speech intelligibility page is the one worth spelling out, because it fails in both directions at once and says nothing about it. `SIIResult` pinned only `sii`, so one non-finite band left the importance-weighted series peaking at 0.0898 of the axis instead of filling it, nine bars short, under a legend that still read `(scaled)` and a title that still read `SII = 0.996`. Nothing on the page tells the reader which of those two numbers to believe. The band procedure had the same gap: a non-finite band importance dropped a band out of the step curve and pulled the octave panel's y limit from 0.30452 to 0.275295, so the curve was scaled to a peak that is not the one in the table.

Elsewhere the failure was a crash that named nothing. An evaluation period of `"Day"` instead of `"day"` passed construction and died inside the sheet as a bare `KeyError: 'Day'`, naming neither the field nor the choices it had. An activity assessment built with no periods at all reported itself compliant, vacuously, and then died in the plot with an index error about an axis of size zero. A filter verification claimed `overall_class = 1` over an empty set of verified bands, which is a class attested over nothing.

## What changed

Each result type refuses the value in `__post_init__`, naming the field and the type. Tags are checked against the values that exist, per-band columns against each other, and quantities that no producer can leave undetermined against being finite.

For the speech results I checked the producers before pinning anything, because a guard is only right if nothing legitimate can trip it. Each class has exactly one producer, every field is arithmetic over spectra the entry point already requires to be finite, and neither class carries a validity flag or any band-wise quantity a measurement can leave undetermined. So all twelve fields are pinned with nothing exempt.

## Tests

One refusal test per guard, naming the field, plus rendering tests that read the artifact back and pin the numbers rather than asserting that no exception escaped. The weighted series has to peak at exactly 1.0 with the legend and title intact, and the octave step has to match the tabulated column with its y limit at 1.15 times the maximum. A test that only asserts a refusal survives someone deleting the scaling; one that asserts the peak does not.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation across acoustic, environmental, metrology, hearing, speech, and room-analysis features.
  * Invalid, incomplete, non-finite, unsupported, or inconsistent values now produce clearer errors earlier.
  * Added checks for supported methods, classifications, metrics, frequency bands, array shapes, and required assessment data.
  * Improved handling of silent or unavailable measurements, including em-dash output and withheld report verdicts.

* **Documentation**
  * Expanded API guidance for supported options, parameter constraints, and error conditions.
  * Clarified microphone weighting options and direct-sound-only geometry plotting with `max_order=0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->