### PR TITLE
Make a stored aggregate restate the column it came from

### DIFF
--- a/site/src/content/docs/reference/api/broadcast/program-loudness.md
+++ b/site/src/content/docs/reference/api/broadcast/program-loudness.md
@@ -362,8 +362,8 @@ EBU Mode loudness measurement of a programme (BS.1770-5 / EBU R 128).
 | `momentary_time` | Time of each `M` reading (window end), s. |
 | `short_term` | Short-term loudness series `S` (3 s, ungated), LUFS. |
 | `short_term_time` | Time of each `S` reading (window end), s. |
-| `max_momentary` | Maximum momentary loudness, LUFS. |
-| `max_short_term` | Maximum short-term loudness, LUFS. |
+| `max_momentary` | Maximum momentary loudness, LUFS: the largest reading of `momentary` (`-inf` when the excerpt is shorter than the 400 ms window and no reading exists). |
+| `max_short_term` | Maximum short-term loudness, LUFS: the largest reading of `short_term` (`-inf` when the excerpt is shorter than the 3 s window and no reading exists). |
 | `relative_threshold` | Relative gating threshold of the integrated measurement (10 LU below the absolute-gated loudness), LUFS. |
 | `lra_low` | Lower (10th percentile) edge of the loudness range, LUFS. |
 | `lra_high` | Upper (95th percentile) edge of the loudness range, LUFS. |

--- a/site/src/content/docs/reference/api/building/ceiling-plenum.md
+++ b/site/src/content/docs/reference/api/building/ceiling-plenum.md
@@ -170,8 +170,8 @@ Ceiling attenuation class (ASTM E1414 rated through ASTM E413).
 | `rounded` | The same data rounded to the nearest integer (clause 5.2), which is what the contour is fitted to. |
 | `shifted_reference` | The fitted reference contour, in dB. |
 | `deficiencies` | Per-band deficiency (shifted contour minus data, floored at zero), in dB. |
-| `deficiency_sum` | Sum of the deficiencies, in dB (at most 32). |
-| `max_deficiency` | Largest single deficiency, in dB (at most 8). |
+| `deficiency_sum` | Sum of `deficiencies`, in dB (at most 32). |
+| `max_deficiency` | Largest entry of `deficiencies`, in dB (at most 8). |
 | `rating` | The ceiling attenuation class CAC, read off the shifted contour at 500 Hz (clause 5.5), in dB. |
 
 ### CeilingAttenuationResult.plot()

--- a/site/src/content/docs/reference/api/building/ratings.md
+++ b/site/src/content/docs/reference/api/building/ratings.md
@@ -236,7 +236,7 @@ Single-number weighted impact rating and CI (ISO 717-2).
 | :--- | :--- |
 | `rating` | Weighted impact rating (`Ln,w`, `L'n,w`, `L'nT,w`), the shifted reference read at 500 Hz, in dB (Clause 4.3; octave-band ratings include the -5 dB reduction of Clause 4.3.2). Integer. |
 | `ci` | Spectrum adaptation term `CI` (Clause A.2.1), in dB. Integer. |
-| `unfavourable_sum` | Sum of unfavourable deviations at the final shift, in dB (Clause 4.3); at most 32,0 (16 bands) or 10,0 (5 bands). |
+| `unfavourable_sum` | Sum of unfavourable deviations at the final shift, in dB (Clause 4.3); at most 32,0 (16 bands) or 10,0 (5 bands). Restates `measured` against `shifted_reference`, with the impact sign, and is checked against them when both are present. |
 | `band_centers` | Band centre frequencies of the measured curve, in Hz. Defaults to `None` for backward-compatible construction. |
 | `measured` | The measured impact levels used for the rating (after the one-decimal reduction of Clause 4.3.1), in dB. Defaults to `None`. |
 | `shifted_reference` | Table 3 impact reference curve after the final shift, in dB. Defaults to `None`. |
@@ -522,7 +522,7 @@ Single-number weighted rating and adaptation terms (ISO 717-1).
 | `rating` | Weighted rating (`Rw`, `R'w`, `DnT,w` ...), the shifted reference read at 500 Hz, in dB (Clause 4.4). Integer. |
 | `c` | Spectrum adaptation term `C` (spectrum No. 1), in dB (Clause 4.5). Integer. |
 | `ctr` | Spectrum adaptation term `Ctr` (spectrum No. 2), in dB (Clause 4.5). Integer. |
-| `unfavourable_sum` | Sum of unfavourable deviations at the final shift, in dB (Clause 4.4); at most 32,0 (16 bands) or 10,0 (5 bands). |
+| `unfavourable_sum` | Sum of unfavourable deviations at the final shift, in dB (Clause 4.4); at most 32,0 (16 bands) or 10,0 (5 bands). Restates `measured` against `shifted_reference` and is checked against them when both are present. |
 | `band_centers` | Band centre frequencies of the measured curve, in Hz. Defaults to `None` for backward-compatible construction. |
 | `measured` | The measured band quantities used for the rating (after the one-decimal reduction of Clause 4.4), in dB. Defaults to `None`. |
 | `shifted_reference` | Table 3 reference curve after the final shift, in dB. Defaults to `None`. |

--- a/site/src/content/docs/reference/api/materials/rating.md
+++ b/site/src/content/docs/reference/api/materials/rating.md
@@ -101,7 +101,7 @@ Weighted sound absorption rating (ISO 11654:1997).
 | `shape_indicator` | Concatenated shape indicators, `L`/`M`/`H` in that order, or an empty string when none applies (Clause 4.3). |
 | `absorption_class` | Sound absorption class `A`-`E` or `"Not classified"` from Table B.1 (Annex B). |
 | `shift` | Downward shift applied to the reference curve, in absorption units (Clause 4.2); $\alpha_\mathrm{w} = 1.00 - \text{shift}$. |
-| `unfavourable_sum` | Sum of the unfavourable deviations at the final shift (Clause 4.2); at most 0.10. |
+| `unfavourable_sum` | Sum of the unfavourable deviations at the final shift (Clause 4.2): `shifted_reference - measured` over the bands where the measured coefficient falls below the curve, and nothing elsewhere; at most 0.10. |
 | `band_centers` | Octave rating-band centre frequencies, in Hz (250 Hz to 4000 Hz). |
 | `measured` | Practical absorption coefficients `alpha_p` used for the rating (snapped to the 0,05 grid of Clause 4.1). |
 | `shifted_reference` | Reference curve of Figure 1 after the final shift. |

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -1100,8 +1100,14 @@ class RotorcraftEventResult:
         if not np.all(np.isfinite(self.a_levels)):
             msg = "RotorcraftEventResult: 'a_levels' must be finite."
             raise ValueError(msg)
-        # An empty history has no peak; nothing there restates anything.
-        peak = float(np.max(self.a_levels)) if np.size(self.a_levels) else self.la_max
+        # An empty history has no peak, so there is nothing here to restate and
+        # the comparison is skipped rather than fed the stored value back. Fed
+        # its own value it would still refuse a NaN, since a NaN is close to
+        # nothing, not even to itself, and that is the one value an exempt
+        # field is most likely to hold.
+        if np.size(self.a_levels) == 0:
+            return
+        peak = float(np.max(self.a_levels))
         if not math.isclose(self.la_max, peak, rel_tol=0.0, abs_tol=1e-9):
             msg = (
                 "RotorcraftEventResult: 'la_max' must be the maximum of "

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -1056,8 +1056,21 @@ class RotorcraftEventResult:
         zero total noisiness, or a band grid short of the noy bands), flagged
         as such in its own documentation.
 
-        :raises ValueError: if a per-step or per-band quantity disagrees, or
-            ``a_levels`` carries a non-finite value.
+        ``la_max`` is that same history said once more as a number: the
+        producer takes it as ``max(a_levels)`` over the very column stored
+        here, so the two cannot part company except by hand or by
+        :func:`dataclasses.replace`. Parted, they are drawn together anyway.
+        The figure plots the marker at ``argmax(a_levels)`` and labels it
+        with ``la_max``, so a raised ``la_max`` prints itself over a point
+        the curve reaches ten decibels lower, and the 10 dB-down window,
+        read as ``a_levels >= la_max - 10``, quietly empties and stops being
+        shaded at all. A step whose level a measurement leaves undetermined
+        is refused above, so the peak of a history that exists is always a
+        number; an empty history has no peak to restate and is passed over.
+
+        :raises ValueError: if a per-step or per-band quantity disagrees,
+            ``a_levels`` carries a non-finite value, or ``la_max`` is not the
+            maximum of ``a_levels``.
         """
         require_ranks(
             self,
@@ -1086,6 +1099,15 @@ class RotorcraftEventResult:
         )
         if not np.all(np.isfinite(self.a_levels)):
             msg = "RotorcraftEventResult: 'a_levels' must be finite."
+            raise ValueError(msg)
+        # An empty history has no peak; nothing there restates anything.
+        peak = float(np.max(self.a_levels)) if np.size(self.a_levels) else self.la_max
+        if not math.isclose(self.la_max, peak, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "RotorcraftEventResult: 'la_max' must be the maximum of "
+                f"'a_levels', the history it is the peak of; got {self.la_max!r} "
+                f"where 'a_levels' peaks at {peak!r}."
+            )
             raise ValueError(msg)
 
     def plot(

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -40,7 +40,7 @@ ITU-R BS.1770). 1 LU is equivalent to 1 dB.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import ceil
+from math import ceil, isclose
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -706,6 +706,45 @@ def _block_geometry(fs: float) -> tuple[int, int]:
     return n_block, step
 
 
+def _require_series_maximum(owner: object, field: str, series: str) -> None:
+    """Pin a stored maximum against the series of readings it summarises.
+
+    EBU Tech 3341 section 2.2 leaves both sliding-window measurements ungated
+    ("The measurement is not gated.", said once of the 400 ms momentary window
+    and once of the 3 s short-term one), so their maxima run over every reading
+    of the stored series and not over a gated subset of it, as the integrated
+    loudness does. A window of digital silence reads ``-inf`` and stays in the
+    series, where the maximum passes over it; the maximum is undefined only
+    when the series itself is empty, which is what an excerpt shorter than one
+    window gives, and the measurement writes ``-inf`` for it.
+
+    A billionth of a decibel of slack lets a caller who recomputed the maximum
+    along another floating-point path restate it without being refused over the
+    last bit.
+
+    :param owner: The result carrying both the maximum and its series.
+    :param field: Name of the field holding the maximum.
+    :param series: Name of the field holding the readings it summarises.
+    :raises ValueError: if ``field`` is not the maximum of ``series``.
+    """
+    readings = np.asarray(getattr(owner, series), dtype=np.float64)
+    stored = float(getattr(owner, field))
+    peak = float(np.max(readings)) if readings.size else float("-inf")
+    if isclose(stored, peak, rel_tol=0.0, abs_tol=1e-9):
+        return
+    seen = (
+        f"'{series}' is empty, leaving the maximum undefined"
+        if readings.size == 0
+        else f"'{series}' peaks at {peak!r}"
+    )
+    msg = (
+        f"{type(owner).__name__}: '{field}' must be the maximum of "
+        f"'{series}', the ungated series of EBU Tech 3341 it summarises; "
+        f"got {stored!r} where {seen}."
+    )
+    raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class ProgramLoudnessResult:
     """EBU Mode loudness measurement of a programme (BS.1770-5 / EBU R 128).
@@ -717,8 +756,12 @@ class ProgramLoudnessResult:
     :ivar momentary_time: Time of each ``M`` reading (window end), s.
     :ivar short_term: Short-term loudness series ``S`` (3 s, ungated), LUFS.
     :ivar short_term_time: Time of each ``S`` reading (window end), s.
-    :ivar max_momentary: Maximum momentary loudness, LUFS.
-    :ivar max_short_term: Maximum short-term loudness, LUFS.
+    :ivar max_momentary: Maximum momentary loudness, LUFS: the largest reading
+        of ``momentary`` (``-inf`` when the excerpt is shorter than the 400 ms
+        window and no reading exists).
+    :ivar max_short_term: Maximum short-term loudness, LUFS: the largest
+        reading of ``short_term`` (``-inf`` when the excerpt is shorter than
+        the 3 s window and no reading exists).
     :ivar relative_threshold: Relative gating threshold of the integrated
         measurement (10 LU below the absolute-gated loudness), LUFS.
     :ivar lra_low: Lower (10th percentile) edge of the loudness range, LUFS.
@@ -768,8 +811,15 @@ class ProgramLoudnessResult:
         channel renders a complete fiche without a word, carrying a headline
         true peak for a channel the programme loudness never weighted.
 
+        The two headline maxima are silent in the same way. Each is the largest
+        reading of the series stored beside it, copied verbatim by every reader
+        and recomputed by none, so a maximum that contradicts its own column
+        prints on the fiche as an informational row above a graph of the very
+        readings that deny it, and is stamped into the ``bext`` chunk of a
+        broadcast WAV as ``MaxMomentaryLoudness``. Both are pinned here.
+
         :raises ValueError: if the two arrays of any of the three axes
-            disagree.
+            disagree, or if either maximum is not the maximum of its series.
         """
         require_ranks(
             self,
@@ -789,6 +839,8 @@ class ProgramLoudnessResult:
         require_same_length(
             self, "true_peak_per_channel", "channel_weights", axis="channel"
         )
+        _require_series_maximum(self, "max_momentary", "momentary")
+        _require_series_maximum(self, "max_short_term", "short_term")
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/measurement/ratings.py
+++ b/src/phonometry/building/measurement/ratings.py
@@ -147,6 +147,14 @@ _MAX_UNFAVOURABLE_OCTAVE = 10.0
 #: unfavourable-deviation sum (a true multiple of 0,1 dB) to the bound.
 _SHIFT_TOLERANCE = 1e-6
 
+#: Tolerance for checking a stored unfavourable-deviation sum against the two
+#: curves it summarises, so a caller who recomputed it along another
+#: floating-point path is not refused over the last bit (the impact search
+#: runs on negated curves and reaches the same tenths by a different route).
+#: Distinct from _SHIFT_TOLERANCE, which guards the search's own comparison
+#: to the bound rather than a field against its array.
+_SUM_TOLERANCE = 1e-9
+
 #: Tolerance for checking that ``scale * step`` reconstructs exactly 1,
 #: i.e. that the reference-curve shift step divides 1 dB exactly (1.0 or
 #: 0.1 dB per ISO 717 / ISO 12999-1:2020 Annex B.2), absorbing the
@@ -360,6 +368,66 @@ def _require_finite_curves(owner: object, *fields: str) -> None:
             raise ValueError(msg)
 
 
+def _require_unfavourable_sum(
+    owner: WeightedRatingResult | ImpactRatingResult, *, impact: bool
+) -> None:
+    """Require ``unfavourable_sum`` to restate *owner*'s own two curves.
+
+    The sum of unfavourable deviations is not a number kept beside the
+    curves; it *is* those curves, added up. ISO 717-1 Clause 4.4 counts a
+    band as unfavourable where the measurement falls below the shifted
+    reference and ISO 717-2 Clause 4.3 where it rises above it -- the one
+    structural difference between the two parts, which is why the sign
+    arrives as *impact* rather than being read off a field. Neither part
+    rounds the deviations any further: Table C.1 of each 2020 edition prints
+    them in the tenths the measurement was already reduced to (Clause 4.4
+    footnote 1) and adds those tenths straight up, reaching 31,8 dB and
+    28,0 dB against bounds of 32,0 dB.
+
+    A fiche prints the contradiction twice on one page. Its verbose Annex C
+    table recomputes the deviation column from the two curves and closes it
+    with a sum row, while the plot beside it titles itself from this field:
+    a rating whose ``measured`` was swapped through
+    :func:`dataclasses.replace` keeps the aggregate the old curve earned,
+    and the page then reads a sum row of 0,0 dB under a column of em dashes
+    next to a title claiming 31,8 dB.
+
+    The em dash there is Table C.1's own mark for a band with no
+    unfavourable deviation, not for one left undetermined: both curves are
+    finite by the time this runs (:func:`_require_finite_curves` goes
+    first), so the sum is always determined. A rating built from the single
+    numbers alone carries no curves and is skipped.
+
+    :param owner: The rating whose ``unfavourable_sum`` is checked.
+    :param impact: ``True`` for the ISO 717-2 sign (measurement above the
+        reference), ``False`` for the ISO 717-1 one.
+    :raises ValueError: if ``unfavourable_sum`` is not the sum its own
+        ``measured`` and ``shifted_reference`` state.
+    """
+    measured = owner.measured
+    shifted = owner.shifted_reference
+    if measured is None or shifted is None:
+        return
+    excess = np.asarray(measured, dtype=np.float64) - np.asarray(
+        shifted, dtype=np.float64
+    )
+    expected = float(np.sum(np.maximum(excess if impact else -excess, 0.0)))
+    if not math.isclose(
+        owner.unfavourable_sum, expected, rel_tol=0.0, abs_tol=_SUM_TOLERANCE
+    ):
+        sense = (
+            "'measured' above 'shifted_reference' (ISO 717-2 Clause 4.3)"
+            if impact
+            else "'measured' below 'shifted_reference' (ISO 717-1 Clause 4.4)"
+        )
+        msg = (
+            f"{type(owner).__name__}: 'unfavourable_sum' must be the sum of "
+            f"the unfavourable deviations of its own curves, {sense}; got "
+            f"{owner.unfavourable_sum!r} where the curves sum to {expected!r}."
+        )
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class WeightedRatingResult:
     """Single-number weighted rating and adaptation terms (ISO 717-1).
@@ -372,7 +440,8 @@ class WeightedRatingResult:
         (Clause 4.5). Integer.
     :ivar unfavourable_sum: Sum of unfavourable deviations at the final
         shift, in dB (Clause 4.4); at most 32,0 (16 bands) or 10,0 (5
-        bands).
+        bands). Restates ``measured`` against ``shifted_reference`` and is
+        checked against them when both are present.
     :ivar band_centers: Band centre frequencies of the measured curve, in
         Hz. Defaults to ``None`` for backward-compatible construction.
     :ivar measured: The measured band quantities used for the rating (after
@@ -426,12 +495,17 @@ class WeightedRatingResult:
         "deviation below 0,05 dB" -- asserting no unfavourable deviation for
         a band that was never determined.
 
-        :raises ValueError: if the band curves supplied disagree, or one of
-            them carries a non-finite value.
+        Last, ``unfavourable_sum`` must be the sum those same two curves
+        state, for the reasons set out on :func:`_require_unfavourable_sum`.
+
+        :raises ValueError: if the band curves supplied disagree, one of them
+            carries a non-finite value, or ``unfavourable_sum`` is not their
+            own sum of unfavourable deviations.
         """
         require_ranks(self, band_centers=1, measured=1, shifted_reference=1)
         require_same_length(self, "band_centers", "measured", "shifted_reference")
         _require_finite_curves(self, "band_centers", "measured", "shifted_reference")
+        _require_unfavourable_sum(self, impact=False)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -515,7 +589,8 @@ class ImpactRatingResult:
         Integer.
     :ivar unfavourable_sum: Sum of unfavourable deviations at the final
         shift, in dB (Clause 4.3); at most 32,0 (16 bands) or 10,0 (5
-        bands).
+        bands). Restates ``measured`` against ``shifted_reference``, with the
+        impact sign, and is checked against them when both are present.
     :ivar band_centers: Band centre frequencies of the measured curve, in
         Hz. Defaults to ``None`` for backward-compatible construction.
     :ivar measured: The measured impact levels used for the rating (after
@@ -556,12 +631,18 @@ class ImpactRatingResult:
         :class:`WeightedRatingResult` (no constructor can emit a non-finite
         band; the fiche prints them raw or crashes namelessly on them).
 
-        :raises ValueError: if the band curves supplied disagree, or one of
-            them carries a non-finite value.
+        Last, ``unfavourable_sum`` must be the sum those same two curves
+        state, taken with the impact sign of Clause 4.3; see
+        :func:`_require_unfavourable_sum`.
+
+        :raises ValueError: if the band curves supplied disagree, one of them
+            carries a non-finite value, or ``unfavourable_sum`` is not their
+            own sum of unfavourable deviations.
         """
         require_ranks(self, band_centers=1, measured=1, shifted_reference=1)
         require_same_length(self, "band_centers", "measured", "shifted_reference")
         _require_finite_curves(self, "band_centers", "measured", "shifted_reference")
+        _require_unfavourable_sum(self, impact=True)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/building/prediction/ceiling_plenum.py
+++ b/src/phonometry/building/prediction/ceiling_plenum.py
@@ -102,6 +102,7 @@ reads the rating off the shifted contour at 500 Hz (clause 5.5). See
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, overload
 
@@ -248,6 +249,81 @@ def normalized_ceiling_attenuation(
     return np.asarray(l1 - l2 - 10.0 * np.log10(area / a0), dtype=np.float64)
 
 
+def _require_deficiency_totals(result: CeilingAttenuationResult) -> None:
+    """Require the two totals to restate the deficiency column beside them.
+
+    ASTM E413-22 clause 5.4 counts only deficiencies, the shifted contour
+    standing above the clause 5.2 integer-rounded data, floored at zero, and
+    it stops the contour rising on two numbers read off that one column: its
+    sum (clause 5.4.1, at or below 32 dB) and its largest entry (clause 5.4.2,
+    at or below 8 dB). Both are plain arithmetic over decibel deviations, the
+    way the standard writes them, and both are closed: everything they are
+    taken over is the ``deficiencies`` array the result already stores. A
+    result whose totals disagree with that column is one whose rating was
+    fitted to a column it no longer carries, which is what
+    :func:`dataclasses.replace` leaves behind the moment a variant restates
+    the contour.
+
+    Nothing downstream catches it. The plot prints ``deficiency_sum`` in its
+    title beside the rating and draws the data against ``shifted_reference``,
+    so the stale total is read out over a gap that no longer sums to it: the
+    Intertek J7488.04 spectrum with its fitted contour lifted one decibel
+    titles the figure ``ASTM E413 CAC = 26 dB (Sigma unfav. = 24.0 dB)`` over
+    a column that sums to 36 dB, four decibels past the limit clause 5.4.1
+    sets for a fit to be admissible at all, and reports a largest deficiency
+    of 5 dB where the drawn one is 6 dB.
+
+    A deficiency is never left undetermined here: the entry point takes only
+    finite levels, and a band the contour clears is a zero, not a gap. So a
+    non-finite column is refused rather than excused, and it is refused first,
+    where it can still be named, instead of surfacing as a total that will not
+    restate anything. The column is read flat so that the band it names is a
+    position in it either way: a result whose every pinned field is a bare
+    number is passed over whole by
+    :func:`~phonometry._internal.validation.require_ranks`, and read
+    unflattened its one band has no axis to index, so naming it would raise
+    :exc:`IndexError` over the field this is here to name. An empty column is
+    passed over: no entry point makes one, and there is no total in it to
+    contradict. Both comparisons allow a
+    billionth of a decibel, so a caller who recomputed either total along
+    another floating-point path is not refused over the last bit.
+
+    :param result: The rating whose totals are checked.
+    :raises ValueError: if the column is not finite, or either total does not
+        restate it.
+    """
+    column = np.asarray(result.deficiencies, dtype=np.float64).ravel()
+    if column.size == 0:
+        return
+    finite = np.isfinite(column)
+    if not bool(np.all(finite)):
+        first = int(np.flatnonzero(~finite)[0])
+        msg = (
+            "CeilingAttenuationResult: 'deficiencies' must be finite for "
+            "'deficiency_sum' and 'max_deficiency' to restate it; got "
+            f"{column[first]!r} in band {first}."
+        )
+        raise ValueError(msg)
+    total = float(np.sum(column))
+    if not math.isclose(result.deficiency_sum, total, rel_tol=0.0, abs_tol=1e-9):
+        msg = (
+            "CeilingAttenuationResult: 'deficiency_sum' must be the sum of "
+            "'deficiencies', the total ASTM E413-22 clause 5.4.1 holds at or "
+            f"below {_MAX_DEFICIENCY_SUM:.0f} dB; got {result.deficiency_sum!r} "
+            f"where 'deficiencies' sums to {total!r}."
+        )
+        raise ValueError(msg)
+    worst = float(np.max(column))
+    if not math.isclose(result.max_deficiency, worst, rel_tol=0.0, abs_tol=1e-9):
+        msg = (
+            "CeilingAttenuationResult: 'max_deficiency' must be the largest "
+            "entry of 'deficiencies', the one ASTM E413-22 clause 5.4.2 holds "
+            f"at or below {_MAX_SINGLE_DEFICIENCY:.0f} dB; got "
+            f"{result.max_deficiency!r} where the largest is {worst!r}."
+        )
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class CeilingAttenuationResult:
     """Ceiling attenuation class (ASTM E1414 rated through ASTM E413).
@@ -260,8 +336,8 @@ class CeilingAttenuationResult:
     :ivar shifted_reference: The fitted reference contour, in dB.
     :ivar deficiencies: Per-band deficiency (shifted contour minus data, floored
         at zero), in dB.
-    :ivar deficiency_sum: Sum of the deficiencies, in dB (at most 32).
-    :ivar max_deficiency: Largest single deficiency, in dB (at most 8).
+    :ivar deficiency_sum: Sum of ``deficiencies``, in dB (at most 32).
+    :ivar max_deficiency: Largest entry of ``deficiencies``, in dB (at most 8).
     :ivar rating: The ceiling attenuation class CAC, read off the shifted
         contour at 500 Hz (clause 5.5), in dB.
     """
@@ -276,7 +352,7 @@ class CeilingAttenuationResult:
     rating: int
 
     def __post_init__(self) -> None:
-        """Reject a rating whose curves do not share the contour band set.
+        """Reject a rating whose curves disagree, or whose totals contradict them.
 
         ASTM E413 is a contour fitted band by band: the sum of the
         deficiencies and the largest of them are what stop the contour rising,
@@ -286,11 +362,15 @@ class CeilingAttenuationResult:
         is drawn and in terms of two shapes it cannot put a name to. The
         other two, ``rounded`` and ``deficiencies``, no reader in the library
         opens at all: a deficiency column that has lost or gained a band is
-        paired with the frequencies by whoever prints it, ``zip`` truncates
-        the two to the shorter without a word, and the total beside it stays
-        the sum of the column as it was fitted.
+        paired with the frequencies by whoever prints it, and ``zip``
+        truncates the two to the shorter without a word.
 
-        :raises ValueError: if the per-band curves disagree.
+        The two totals are then held against that column by
+        :func:`_require_deficiency_totals`: they are what clause 5.4 stops the
+        contour on, and both are taken over the very array stored beside them.
+
+        :raises ValueError: if the per-band curves disagree, or the totals do
+            not restate the deficiency column.
         """
         require_ranks(
             self,
@@ -308,6 +388,7 @@ class CeilingAttenuationResult:
             "shifted_reference",
             "deficiencies",
         )
+        _require_deficiency_totals(self)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -138,11 +138,18 @@ def _expected_total_intensity_level(total_intensity: float, stored: float) -> fl
     zero total is returned as its own expectation; every other total is
     measured against the floored form the producer writes.
 
+    Both halves of that test are written as bounds rather than equalities.
+    A total of exactly zero is what ``abs(...) <= 0.0`` says, for ``-0.0`` as
+    well, and it is the only total this branch is for; an equality against
+    ``0.0`` would say the same thing while reading as the floating-point
+    comparison this is not. The infinity is tested by :func:`math.isinf` and
+    its sign, which is how the rest of the tree spells it.
+
     :param total_intensity: The broadband total the level restates, W/m^2.
     :param stored: The level the result carries, dB.
     :return: The level the two fields state together.
     """
-    if total_intensity == 0.0 and stored == -math.inf:
+    if abs(total_intensity) <= 0.0 and math.isinf(stored) and stored < 0.0:
         return stored
     return _level(abs(total_intensity), _I0)
 

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -73,6 +73,7 @@ from .._internal.validation import (
     require_axis_count,
     require_equal_counts,
     require_equal_shapes,
+    require_finite_fields,
     require_ranks,
     require_same_length,
 )
@@ -126,6 +127,52 @@ def _finite_difference_correction(k_dr: np.ndarray) -> np.ndarray:
         return np.where(kd > 0.0, kd / np.sin(kd), 1.0)
 
 
+def _expected_total_intensity_level(total_intensity: float, stored: float) -> float:
+    r"""The level ``total_intensity_level`` must restate, in the caller's spelling.
+
+    :func:`_level` floors its argument at the smallest positive double, so a
+    broadband total of exactly zero leaves the producer as about -2957 dB
+    rather than the :math:`-\infty` that :math:`10 \lg 0` is. A result built
+    by hand from the unfloored arithmetic holds that infinity, and the two
+    spell the same absence of net intensity, so a stored ``-inf`` beside a
+    zero total is returned as its own expectation; every other total is
+    measured against the floored form the producer writes.
+
+    :param total_intensity: The broadband total the level restates, W/m^2.
+    :param stored: The level the result carries, dB.
+    :return: The level the two fields state together.
+    """
+    if total_intensity == 0.0 and stored == -math.inf:
+        return stored
+    return _level(abs(total_intensity), _I0)
+
+
+def _require_total_restates(
+    result: IntensityResult, field: str, expected: float, statement: str
+) -> None:
+    """Pin one broadband total against the totals it is computed from.
+
+    A billionth of a decibel of slack lets a caller who recomputed the total
+    along another floating-point path restate it without being refused over
+    the last bit.
+
+    :param result: The result carrying both the total and the fields it
+        restates.
+    :param field: Name of the field holding the restated total.
+    :param expected: The value the fields beside it state.
+    :param statement: What the field must be, completing ``'<field>' must``.
+    :raises ValueError: if ``field`` does not restate ``expected``.
+    """
+    stored = float(getattr(result, field))
+    if math.isclose(stored, expected, rel_tol=0.0, abs_tol=1e-9):
+        return
+    msg = (
+        f"{type(result).__name__}: '{field}' must {statement}; got {stored!r} "
+        f"where the fields beside it state {expected!r}."
+    )
+    raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class IntensityResult:
     r"""Result of a p-p sound intensity measurement.
@@ -167,7 +214,7 @@ class IntensityResult:
     spacing: float | None = None
 
     def __post_init__(self) -> None:
-        """Reject a measurement whose per-band arrays do not share the bands.
+        r"""Reject a measurement whose own fields contradict one another.
 
         The band figure draws Lp and LI against ``frequency`` and lays the
         pressure-intensity index over them as one bar per band. A bar chart
@@ -180,8 +227,40 @@ class IntensityResult:
         Either the band ``fraction`` was requested and all seven arrays are
         present, or none of them is; ``None`` is not a disagreement.
 
-        :raises ValueError: if two of the per-band arrays disagree in length,
-            or one is a single number.
+        Two of the broadband totals are not measurements of their own but
+        restatements of the ones beside them: ``total_intensity_level`` is the
+        level of the magnitude of ``total_intensity`` (the sign is reported
+        separately in ``total_direction``), and
+        ``total_pressure_intensity_index`` is ``total_pressure_level`` minus
+        ``total_intensity_level``, the broadband form of the ISO 9614-1:1993
+        (A.3) indicator. A variant built with :func:`dataclasses.replace`
+        moves the field it is given and leaves the rest where they were, so a
+        result scaled by ten in intensity keeps a level ten decibels under the
+        intensity it claims to state, and an index put in by hand goes
+        straight into the band figure's title: the title carries the index and
+        nothing else, so a probe whose own two levels differ by 0.0 dB is
+        titled with a reactivity of 25 dB, past any dynamic capability an
+        instrument has, over curves that agree with neither number.
+
+        ``total_intensity`` and ``total_pressure_level`` are pinned to being
+        finite and to nothing else, in particular not to the band columns
+        beside them. Both are summed over the spectral bins of the broadband
+        range, while the columns are the same two densities integrated into
+        IEC 61260-1 bands, whose edges do not follow ``limits`` and which drop
+        any band narrower than the spectral resolution; the two sums
+        legitimately differ, by about 10 % of the intensity and 0.4 dB of the
+        pressure level on a 100 Hz to 5 kHz noise measurement, so neither
+        column is an oracle for the total over it. ``max_valid_frequency`` is
+        pinned to nothing at all: it is the usable-bandwidth bound
+        :math:`0.1 \, c / \Delta r`, not the largest band measured, and the
+        bands above it are exactly the ones ``bias_correction`` exists to
+        compensate.
+
+        :raises ValueError: if two of the per-band arrays disagree in length
+            or one is a single number; if ``total_intensity`` or
+            ``total_pressure_level`` is not finite; or if
+            ``total_intensity_level`` or ``total_pressure_intensity_index``
+            does not restate the totals it is computed from.
         """
         require_ranks(
             self,
@@ -202,6 +281,23 @@ class IntensityResult:
             "pressure_intensity_index",
             "direction",
             "bias_correction",
+        )
+        require_finite_fields(self, "total_intensity", "total_pressure_level")
+        _require_total_restates(
+            self,
+            "total_intensity_level",
+            _expected_total_intensity_level(
+                self.total_intensity, self.total_intensity_level
+            ),
+            "be the level of the magnitude of 'total_intensity' referred to "
+            "1 pW/m^2, the sign being reported in 'total_direction'",
+        )
+        _require_total_restates(
+            self,
+            "total_pressure_intensity_index",
+            self.total_pressure_level - self.total_intensity_level,
+            "be 'total_pressure_level' minus 'total_intensity_level', the "
+            "broadband form of the ISO 9614-1 (A.3) index",
         )
 
     def plot(

--- a/src/phonometry/materials/absorbers/rating.py
+++ b/src/phonometry/materials/absorbers/rating.py
@@ -218,6 +218,30 @@ def _coerce(
 # --- result --------------------------------------------------------------
 
 
+def _unfavourable_deviation_sum(
+    shifted_reference: NDArray[np.float64], measured: NDArray[np.float64]
+) -> float:
+    """Sum the unfavourable deviations of Clause 4.2 over the rating bands.
+
+    A deviation is unfavourable only where the measured practical coefficient
+    falls below the shifted reference curve, and it counts as
+    ``curve - measured``; a band above the curve contributes nothing, and is
+    reported as a shape indicator instead (Clause 4.3).
+
+    The sum is arithmetic and is taken as it stands. ISO 11654 shifts a curve
+    of absorption coefficients in steps of 0,05 and rounds nothing afterwards:
+    the grid comes from the practical coefficients of Clause 4.1 and from the
+    step of the shift itself, so the whole-decibel rounding of the ISO 717
+    unfavourable sum has no counterpart here, and neither has an energy sum --
+    these are coefficients, not levels.
+
+    :param shifted_reference: The reference curve of Figure 1 after the shift.
+    :param measured: The practical coefficients rated against it.
+    :returns: The sum of the deviations, in absorption-coefficient units.
+    """
+    return float(np.sum(np.maximum(shifted_reference - measured, 0.0)))
+
+
 @dataclass(frozen=True)
 class AbsorptionRatingResult:
     r"""Weighted sound absorption rating (ISO 11654:1997).
@@ -232,7 +256,9 @@ class AbsorptionRatingResult:
     :ivar shift: Downward shift applied to the reference curve, in
         absorption units (Clause 4.2); :math:`\alpha_\mathrm{w} = 1.00 - \text{shift}`.
     :ivar unfavourable_sum: Sum of the unfavourable deviations at the final
-        shift (Clause 4.2); at most 0.10.
+        shift (Clause 4.2): ``shifted_reference - measured`` over the bands
+        where the measured coefficient falls below the curve, and nothing
+        elsewhere; at most 0.10.
     :ivar band_centers: Octave rating-band centre frequencies, in Hz
         (250 Hz to 4000 Hz).
     :ivar measured: Practical absorption coefficients ``alpha_p`` used for
@@ -303,10 +329,33 @@ class AbsorptionRatingResult:
         requirement anyway, where ``nan >= requirement`` is ``False`` and the
         page printed a definitive FAIL computed from nothing.
 
+        ``unfavourable_sum`` is not a further measurement but a sentence about
+        the two octave curves stored beside it, and the two readers of this
+        result take it from opposite ends: :meth:`plot` shades the deviations
+        it reads off the curves and prints the *field* in the title, while the
+        fiche totals the column it recomputes from those same curves. Nothing
+        held them together. A rating whose 250 Hz band is re-measured and swapped
+        in with :func:`dataclasses.replace`, leaving the rest of the rating
+        stale, is titled by the plot "unfav. = 0.05" over a band it shades
+        0,35 low, and printed by the fiche a page later with "sum 0.35" under
+        that very deviation. Both pages are definitive, neither is marked, and
+        they disagree. The comparison allows a billionth so a
+        caller who recomputed the sum along another floating-point path is not
+        refused over the last bit.
+
+        No band of this rating may be left undetermined, so neither may the
+        sum: ISO 11654 rates the whole reference range 250 Hz to 4000 Hz
+        (Clause 1) and :func:`_coerce` already refuses a non-finite
+        coefficient. The em dash the fiche prints in the deviation column is
+        not an undetermined value either; it marks a band that is *at or above*
+        the curve and therefore contributes zero.
+
         :raises ValueError: if ``alpha_w`` is not a finite value in ``[0, 1]``,
             if the octave curves disagree with each other, if the retained
-            one-third-octave ``alpha_s`` disagrees with its band centres, or
-            if it does not hold three bands per rating octave.
+            one-third-octave ``alpha_s`` disagrees with its band centres, if it
+            does not hold three bands per rating octave, or if
+            ``unfavourable_sum`` does not restate the deviations between the
+            two octave curves.
         """
         if not math.isfinite(self.alpha_w) or not 0.0 <= self.alpha_w <= 1.0:
             msg = (
@@ -358,6 +407,19 @@ class AbsorptionRatingResult:
                 },
                 _THIRD_OCTAVE_AXIS,
             )
+        stated = _unfavourable_deviation_sum(
+            np.asarray(self.shifted_reference, dtype=np.float64),
+            np.asarray(self.measured, dtype=np.float64),
+        )
+        if not math.isclose(self.unfavourable_sum, stated, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                f"{type(self).__name__}: 'unfavourable_sum' must be the sum of "
+                "the unfavourable deviations of Clause 4.2, 'shifted_reference' "
+                "minus 'measured' at the bands where the measured coefficient "
+                f"falls below the curve; got {self.unfavourable_sum!r} where "
+                f"the two curves state {stated!r}."
+            )
+            raise ValueError(msg)
 
     @property
     def rating_label(self) -> str:

--- a/src/phonometry/metrology/data_qualification.py
+++ b/src/phonometry/metrology/data_qualification.py
@@ -70,6 +70,7 @@ expectations.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -307,6 +308,98 @@ def _count_runs(flags: NDArray[np.bool_]) -> int:
 # Trend and stationarity tests
 # ---------------------------------------------------------------------------
 
+#: Where each null mean is written down, by the method that counts it. Only
+#: the two keys here yield a moment in :func:`_null_trend_mean`, so a message
+#: is only ever built for a method this maps.
+_NULL_MEAN_SOURCES = {
+    "reverse_arrangements": "B&P Eq. (4.54)",
+    "runs": "Wald & Wolfowitz 1940",
+}
+
+
+def _null_trend_mean(
+    values: NDArray[np.float64], method: str, median: float | None
+) -> float | None:
+    r"""Null mean of the trend statistic counted on *values*, or ``None``.
+
+    Restates what the producers store: ``n(n-1)/4`` over the whole sequence
+    for reverse arrangements (B&P Eq. (4.54)), and the Wald & Wolfowitz
+    ``1 + 2 n_1 n_2 / n`` for runs, counted on the values that differ from
+    *median* -- the classification median, which for a
+    :class:`TrendTestResult` is the one it kept and for a
+    :class:`StationarityTestResult` is the median of the segment sequence
+    :func:`trend_test` took itself. Re-filtering an already filtered
+    sequence removes nothing, so one form serves both.
+
+    ``None`` where no moment is determined: a ``method`` this module does
+    not count, a runs result carrying no classification median, or a runs
+    sequence with nothing on one side of it. There is no null mean to
+    measure a hand-built result against in any of those, and inventing one
+    would refuse a result the producers simply never reach.
+
+    :param values: The sequence the statistic was counted on.
+    :param method: ``"reverse_arrangements"`` or ``"runs"``.
+    :param median: Classification median for ``"runs"``, else ignored.
+    :return: The null mean, or ``None`` when it is not determined.
+    """
+    seq = np.asarray(values, dtype=np.float64)
+    if method == "reverse_arrangements":
+        return _reverse_arrangement_moments(seq.size)[0]
+    if method != "runs" or median is None:
+        return None
+    kept = seq[np.abs(seq - median) > 0.0]
+    n1 = int(np.count_nonzero(kept > median))
+    n2 = int(kept.size - n1)
+    if n1 == 0 or n2 == 0:
+        return None
+    return _runs_moments(n1, n2)[0]
+
+
+def _check_null_mean(
+    owner: str,
+    sequence: str,
+    values: NDArray[np.float64],
+    method: str,
+    median: float | None,
+    mean: float,
+) -> None:
+    """Require ``mean`` to restate the sequence it was counted on.
+
+    ``mean`` is not an average of the values beside it: it is the mean of
+    the *statistic* under the no-trend hypothesis, fixed by the method and
+    by how many observations were counted. That makes it a closed function
+    of fields the result already carries, and the one the reader divides by
+    -- ``(statistic - mean) / std`` is the standardized departure the whole
+    test is read through, and it is computed by the caller, not by any
+    renderer here, so a mean that belongs to another sequence is never
+    caught downstream. A billionth is allowed so a caller who recomputed
+    the moment along another floating-point path is not refused over the
+    last bit.
+
+    The two methods do not share a moment or a source, so the message cites
+    the one the count came from: ``n(n-1)/4`` is B&P Eq. (4.54), and
+    ``1 + 2 n_1 n_2 / n`` is Wald & Wolfowitz. Any other method leaves
+    :func:`_null_trend_mean` with nothing to state and returns above.
+
+    :param owner: Name of the result type, used in the error message.
+    :param sequence: Name of the field the statistic was counted on.
+    :param values: That sequence.
+    :param method: The trend test the count came from.
+    :param median: Classification median for ``"runs"``, else ignored.
+    :param mean: The stored null mean.
+    :raises ValueError: if the stored mean is not the null mean of the
+        statistic counted on that sequence.
+    """
+    expected = _null_trend_mean(values, method, median)
+    if expected is None or math.isclose(mean, expected, rel_tol=0.0, abs_tol=1e-9):
+        return
+    msg = (
+        f"{owner}: 'mean' must be the null mean of the {method!r} statistic "
+        f"counted on '{sequence}' ({_NULL_MEAN_SOURCES[method]}); got "
+        f"{mean!r} where that sequence states {expected!r}."
+    )
+    raise ValueError(msg)
+
 
 @dataclass(frozen=True)
 class TrendTestResult:
@@ -374,8 +467,19 @@ class TrendTestResult:
         authority here, and checking it at construction says which sequence
         moved.
 
+        :attr:`mean` is pinned for the same reason one step further in: it
+        is the null mean of the *statistic*, ``n(n-1)/4`` for reverse
+        arrangements, not an average of :attr:`values`, so it is fixed by
+        the count and the method and nothing else. Nothing here reads it --
+        the plot states the count and the bounds -- which is exactly why it
+        goes unchecked otherwise: the caller is the reader, standardizing
+        the departure as ``(statistic - mean) / std``, and a mean belonging
+        to another sequence turns an ordinary count into a flat rejection
+        with no array anywhere the wrong length.
+
         :raises ValueError: if the tested sequence spans a different number
-            of observations than the declared count.
+            of observations than the declared count, or the null mean is not
+            the one that sequence and method state.
         """
         require_ranks(self, values=1)
         owner = type(self).__name__
@@ -388,6 +492,9 @@ class TrendTestResult:
                 ),
             },
             "observation",
+        )
+        _check_null_mean(
+            owner, "values", self.values, self.method, self.median, self.mean
         )
 
     def plot(
@@ -593,8 +700,19 @@ class StationarityTestResult:
         than the one the legend rates, so the declared count is taken as the
         authority here and the two sequences have to follow it.
 
+        :attr:`mean` follows from the same sequence: it is the null mean of
+        the count, not an average of :attr:`segment_values`, and
+        :func:`stationarity_test` takes it from the trend test it ran on
+        exactly this array -- for ``"runs"``, on the values that differ from
+        the array's own median, which is the median
+        :func:`~phonometry._plot.metrology.plot_stationarity_test` draws.
+        So it is recomputable from what is stored, and worth recomputing:
+        the caller standardizes the count as ``(count - mean) / std`` and no
+        renderer here would notice a mean belonging to another record.
+
         :raises ValueError: if either per-segment sequence disagrees with the
-            other or with the declared number of segments.
+            other or with the declared number of segments, or the null mean
+            is not the one those segment values and that method state.
         """
         require_ranks(self, segment_values=1, segment_times=1)
         require_same_length(self, "segment_values", "segment_times", axis="segment")
@@ -608,6 +726,12 @@ class StationarityTestResult:
                 ),
             },
             "segment",
+        )
+        centre = (
+            float(np.median(self.segment_values)) if self.method == "runs" else None
+        )
+        _check_null_mean(
+            owner, "segment_values", self.segment_values, self.method, centre, self.mean
         )
 
     def plot(
@@ -956,6 +1080,109 @@ def _rice_peak_density(
     return np.asarray(gaussian + r * z * tail * phi_second, dtype=np.float64)
 
 
+def _check_measured_peak_rate(
+    peak_rate: float, peaks: int, duration: float, owner: str
+) -> None:
+    """Require ``peak_rate`` to count the peaks stored beside it.
+
+    The measured rate is a count over a record length, and both are in
+    hand: the count is how many entries :attr:`PeakStatisticsResult.
+    peak_values` holds -- every detected maximum is standardized and kept,
+    none are dropped -- and the length is :attr:`~PeakStatisticsResult.
+    duration`. The plot draws the empirical exceedance from that same count
+    and floors the axis at ``1/n``, so a rate that disagrees with it puts a
+    number in the caller's hands that the figure beside it contradicts,
+    with neither one wrong on its face.
+
+    The slack is relative as well as absolute here, unlike the decibel
+    margins the other guards in the tree compare: a rate has no bounded
+    scale, and a record sampled fast enough carries maxima in the millions
+    per second, where a billionth of an absolute unit is under one bit.
+
+    :param peak_rate: The stored measured rate, in 1/s.
+    :param peaks: Number of detected maxima stored on the result.
+    :param duration: Record length the rate was taken over, in seconds.
+    :param owner: Name of the result type, used in the error message.
+    :raises ValueError: if the duration is not a positive finite record
+        length, or the rate is not the peak count over it.
+    """
+    if not math.isfinite(duration) or duration <= 0.0:
+        msg = (
+            f"{owner}: 'duration' must be a positive, finite record length "
+            f"for 'peak_rate' to be a rate over it; got {duration!r}."
+        )
+        raise ValueError(msg)
+    expected = peaks / duration
+    if math.isclose(peak_rate, expected, rel_tol=1e-9, abs_tol=1e-9):
+        return
+    msg = (
+        f"{owner}: 'peak_rate' must be the number of maxima in 'peak_values' "
+        f"over 'duration'; got {peak_rate!r} where {peaks} peaks over "
+        f"{duration!r} s state {expected!r}."
+    )
+    raise ValueError(msg)
+
+
+def _check_rice_peak_rate(
+    peak_rate_rice: float,
+    zero_crossing_rate_rice: float,
+    irregularity: float,
+    owner: str,
+) -> None:
+    r"""Require ``irregularity_factor`` to restate the rates it came from.
+
+    :math:`M = \sqrt{m_4/m_2}` is a moment of a Welch autospectrum the
+    result does not store, so on its own there is nothing to measure it
+    against. It is closed all the same, because the result carries the two
+    scalars it was combined with: :func:`peak_statistics` writes
+    :math:`r = \min(1, N_0 / 2M)` (B&P Eq. (5.220), capped where the
+    Schwartz inequality is tight to the last bit), and that identity pins
+    the three of them together. The cap is reproduced rather than divided
+    away, so a narrow-band record whose ratio rounds past 1 still passes.
+
+    This is the one the reader publishes. :meth:`PeakStatisticsResult.plot`
+    labels its Rice curve with ``r`` and draws it from
+    :meth:`~PeakStatisticsResult.peak_exceedance`, itself a function of
+    ``r`` alone, so a triple that does not close paints a peak-height
+    distribution under a legend the record's own rates contradict. It is
+    the factor the message names: ``M`` and ``N0`` are read off the
+    spectrum, and ``r`` is the one of the three the producer derives.
+
+    Only a zero ``M`` is turned away before the ratio, and only because
+    the division needs it. A non-finite ``M`` is not: an amplitude large
+    enough to overflow the spectral moments has :func:`peak_statistics`
+    emitting :math:`M = \infty` beside :math:`r = 0` (and, further up,
+    ``NaN`` beside 1), and the identity closes over both -- capped, they
+    are exactly what ``min(1, N_0/2M)`` states. Refusing them would refuse
+    the producer's own output over an amplitude, which is not this guard's
+    business.
+
+    :param peak_rate_rice: Expected rate of maxima ``M``, in 1/s.
+    :param zero_crossing_rate_rice: Expected zero-crossing rate ``N0``, 1/s.
+    :param irregularity: The stored irregularity factor ``r``.
+    :param owner: Name of the result type, used in the error message.
+    :raises ValueError: if the expected maxima rate is zero or negative, or
+        the three rates do not state one irregularity factor.
+    """
+    if peak_rate_rice <= 0.0:
+        msg = (
+            f"{owner}: 'peak_rate_rice' must be a positive expected rate of "
+            f"maxima to state a ratio; got {peak_rate_rice!r}."
+        )
+        raise ValueError(msg)
+    stated = min(1.0, zero_crossing_rate_rice / (2.0 * peak_rate_rice))
+    if math.isclose(irregularity, stated, rel_tol=0.0, abs_tol=1e-9):
+        return
+    msg = (
+        f"{owner}: 'irregularity_factor' must be the r that 'peak_rate_rice' "
+        "and 'zero_crossing_rate_rice' state, r = min(1, N0 / 2M) "
+        f"(B&P Eq. (5.220)); got r {irregularity!r} where M "
+        f"{peak_rate_rice!r} beside N0 {zero_crossing_rate_rice!r} state "
+        f"{stated!r}."
+    )
+    raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class PeakStatisticsResult:
     r"""Peak (maxima) statistics of a record against the Rice expectations.
@@ -1013,8 +1240,18 @@ class PeakStatisticsResult:
         :func:`peak_statistics` cannot emit them -- the record is validated
         finite and ``sigma`` is positive -- so nothing measurable is refused.
 
+        The rates beside the heights are pinned too, each against what the
+        result already holds: :attr:`peak_rate` against the peaks it counts
+        over :attr:`duration`, and :attr:`irregularity_factor` against the
+        two expected rates it was derived from. See
+        :func:`_check_measured_peak_rate` and :func:`_check_rice_peak_rate`
+        for why each one closes.
+
         :raises ValueError: if the peak heights carry more than one axis,
-            are not finite throughout, or are not in ascending order.
+            are not finite throughout, or are not in ascending order; if the
+            measured rate is not the stored peaks over the stored duration;
+            or if the expected rates and the irregularity factor do not
+            state one another.
         """
         require_ranks(self, peak_values=1)
         require_finite_fields(self, "peak_values")
@@ -1026,6 +1263,14 @@ class PeakStatisticsResult:
                 "its rank."
             )
             raise ValueError(msg)
+        owner = type(self).__name__
+        _check_measured_peak_rate(self.peak_rate, values.size, self.duration, owner)
+        _check_rice_peak_rate(
+            self.peak_rate_rice,
+            self.zero_crossing_rate_rice,
+            self.irregularity_factor,
+            owner,
+        )
 
     def peak_exceedance(
         self, z: NDArray[np.float64] | list[float] | float

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -558,7 +558,34 @@ class MooreGlasbergLoudness:
         pattern, and the total loudness printed in the title was integrated
         over a grid the answer no longer describes.
 
-        :raises ValueError: if the three disagree.
+        ``loudness_level`` is not a second measurement but the same one said
+        in the other unit: clause 8.2 fixes the loudness level of a sound as
+        the level of the 1 kHz free-field binaural tone of equal calculated
+        loudness, and Table 5 tabulates that correspondence, which
+        :func:`_loudness_level` reads. Both numbers go into the chart title
+        together, so a pair that disagrees is printed side by side without a
+        word: a result carrying 1.00 sone - the loudness of 40 phon by the
+        definition of the sone - beside 100.0 phon titles itself
+        ``ISO 532-2 loudness N = 1.00 sone (100.0 phon)``, in which each
+        figure alone is a plausible reading and only the pairing is wrong.
+        The pin restates the field through the same Table 5 mapping the
+        producer used, flat extrapolation above 337.6 sone included, and
+        allows a billionth of a phon so a caller who recomputed the mapping
+        along another floating-point path is not refused over the last bit.
+
+        ``loudness`` is pinned only as a finite, non-negative sone value,
+        which is what makes the restatement above readable: the pattern it
+        integrates is non-negative everywhere and no entry point admits a
+        non-finite input, so no calculation here can produce anything else,
+        and a NaN would otherwise map to a NaN level and compare equal to
+        nothing at all. It is not pinned against ``specific``: the stored
+        pattern is one ear's, taken before binaural inhibition, and the
+        divisors of Formulae (12) and (13) that separate it from the total
+        are not among the fields the result keeps.
+
+        :raises ValueError: if the three arrays disagree, if ``loudness`` is
+            not a finite non-negative sone value, or if ``loudness_level``
+            does not restate ``loudness`` through Table 5.
         """
         require_ranks(self, specific=1, erb_number=1, centre_frequencies=1)
         require_same_length(
@@ -568,6 +595,21 @@ class MooreGlasbergLoudness:
             "centre_frequencies",
             axis="auditory filter",
         )
+        if not math.isfinite(self.loudness) or self.loudness < 0.0:
+            msg = (
+                "MooreGlasbergLoudness: 'loudness' must be a finite, "
+                f"non-negative total loudness in sone; got {self.loudness!r}."
+            )
+            raise ValueError(msg)
+        stated = _loudness_level(self.loudness)
+        if not math.isclose(self.loudness_level, stated, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "MooreGlasbergLoudness: 'loudness_level' must be 'loudness' "
+                "read through the loudness/loudness-level relationship of "
+                f"ISO 532-2:2017 Table 5; got {self.loudness_level!r} phon "
+                f"where 'loudness' {self.loudness!r} sone states {stated!r}."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg_time.py
@@ -56,6 +56,7 @@ required.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -396,8 +397,39 @@ class MooreGlasbergTimeVaryingLoudness:
         still were, reporting at every index the level of a different instant,
         with nothing anywhere to catch it.
 
+        The two headline scalars are then held to the trace they summarise.
+        ``n_max`` is the maximum of the long-term loudness and nothing else
+        (clause 7.9), and ``loudness_level_max`` is that one value carried
+        through Table 5; clause 9 f) and h) ask for the pair and for the trace
+        beneath it in the same report. The figure prints both in its title and
+        rules a dashed line across the axes at ``n_max``, so a pair that
+        contradicts its own column does not merely mislabel the chart: the
+        line is drawn wherever the wrong number says, the y-axis is stretched
+        to reach it, and the long-term trace the title claims to summarise is
+        flattened against the bottom of a plot that reports a peak it never
+        attained.
+
+        Neither comparison can stand on its own, because both pass vacuously
+        on a value that is not a loudness at all. ``n_max`` is therefore
+        pinned first as a finite, non-negative sone value, exactly as the
+        steady-state ``MooreGlasbergLoudness`` of ISO 532-2 pins the total it
+        reports the same way: an all-infinite trace restates its own infinite
+        maximum, and :func:`_loudness_level` reads flat off both ends of
+        Table 5, so ``inf`` sone states 120.0 phon and every negative sone
+        states 0.0 phon - each pair agreeing with itself while the title
+        prints ``N = inf sone`` over a plot with no finite peak to draw. A
+        NaN escapes the other way, comparing equal to nothing at all. The
+        producer emits none of these: the trace is a maximum of non-negative
+        loudnesses and no entry point admits a non-finite input.
+
+        Both comparisons allow a billionth so a caller who recomputed the peak
+        or re-read Table 5 along another floating-point path is not refused
+        over the last bit.
+
         :raises ValueError: if a trace or a level curve disagrees with the
-            frame axis.
+            frame axis, if ``n_max`` is not a finite non-negative sone value
+            or is not the maximum of ``long_term_loudness``, or if
+            ``loudness_level_max`` is not ``n_max`` through Table 5.
         """
         require_ranks(
             self,
@@ -416,6 +448,32 @@ class MooreGlasbergTimeVaryingLoudness:
             "long_term_loudness_level",
             axis="frame",
         )
+        if not math.isfinite(self.n_max) or self.n_max < 0.0:
+            msg = (
+                "MooreGlasbergTimeVaryingLoudness: 'n_max' must be a finite, "
+                "non-negative peak long-term loudness in sone; got "
+                f"{self.n_max!r}."
+            )
+            raise ValueError(msg)
+        long_term = np.asarray(self.long_term_loudness, dtype=np.float64)
+        peak = float(long_term.max()) if long_term.size else 0.0
+        if not math.isclose(self.n_max, peak, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "MooreGlasbergTimeVaryingLoudness: 'n_max' must be the maximum "
+                "of 'long_term_loudness', the peak long-term loudness "
+                f"ISO 532-3 reports; got {self.n_max!r} where the trace peaks "
+                f"at {peak!r}."
+            )
+            raise ValueError(msg)
+        phon = float(_loudness_level(self.n_max))
+        if not math.isclose(self.loudness_level_max, phon, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "MooreGlasbergTimeVaryingLoudness: 'loudness_level_max' must be "
+                "'n_max' through the Table 5 sone-to-phon relationship; got "
+                f"{self.loudness_level_max!r} where 'n_max' {self.n_max!r} maps "
+                f"to {phon!r}."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/room/crowd_noise.py
+++ b/src/phonometry/room/crowd_noise.py
@@ -75,6 +75,7 @@ measured levels along a line of workstations, and predicts nothing.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -82,6 +83,7 @@ import numpy as np
 
 from .._internal.types import as_float_or_array
 from .._internal.validation import (
+    require_finite_fields,
     require_positive,
     require_ranks,
     require_same_length,
@@ -260,7 +262,7 @@ class CrowdNoiseResult:
     communication_level: float
 
     def __post_init__(self) -> None:
-        """Reject a grid whose levels do not span its two axes.
+        """Reject a grid that does not span its axes, or a level that lies.
 
         :attr:`levels` is a surface over two independent axes -- one row per
         absorption area, one column per occupancy -- and the plot reads it as
@@ -281,12 +283,84 @@ class CrowdNoiseResult:
         comparing occupancies with absorption areas would refuse the ordinary
         study of twenty occupancies against three areas.
 
+        The two scalar levels are pinned to the fields they restate. Neither
+        is data: :attr:`signal_level` is Equation (17.50) evaluated at
+        :attr:`distance` for a talker of :attr:`sound_power_level` and
+        :attr:`directivity`, all three of which the result stores beside it,
+        and :attr:`communication_level` is that signal against the fixed
+        :data:`COMMUNICATION_SNR` of Equation (17.53). Both reach the reader
+        as a horizontal line whose caption is drawn from a *different* field
+        than its height: the speech line is placed at ``signal_level`` and
+        labelled with ``distance``, the limit line is placed at
+        ``communication_level`` under a legend entry that spells the -6 dB
+        out. A variant built with :func:`dataclasses.replace` that moves one
+        of those fields alone therefore prints a line captioned for a talker
+        it was never computed for -- ``distance`` reading 3 m over the 1.2 m
+        level, or a title announcing 85 dB per talker above curves drawn at
+        70 -- and a ``communication_level`` set to the -9 dB privacy bound of
+        Equation (17.54) is drawn as though it were the communication limit.
+        :meth:`speech_to_noise` subtracts the same ``signal_level`` from the
+        grid, and Equation (17.52) is independent of the talker's power only
+        while both sides carry the one power, so a signal that has drifted
+        from ``sound_power_level`` silently biases every ratio.
+
+        ``sound_power_level``, ``distance`` and ``directivity`` are inputs and
+        are pinned no further than finiteness: they are what the caller chose,
+        not summaries of anything. They are refused as ``NaN`` because the
+        producer does not check the talker's power for finiteness, and one
+        that is not finite reaches the plot as a title reading "``L_W`` = nan
+        dB per talker" over two reference lines at no height at all. Nothing
+        in this model is legitimately undetermined -- every point of the grid
+        is a closed form of finite inputs, and no quantity here is flagged and
+        rendered as an em dash -- so no field is exempt from that.
+
+        The identities allow a billionth of a decibel, so a caller who
+        recomputed them along another floating-point path is not refused over
+        the last bit.
+
         :raises ValueError: if ``levels`` is not a two-dimensional grid of one
-            row per absorption area and one column per talker count.
+            row per absorption area and one column per talker count, if a
+            scalar field is not finite, if ``signal_level`` does not restate
+            the direct field of Equation (17.50) for the stored geometry, or
+            if ``communication_level`` does not restate ``signal_level``
+            against :data:`COMMUNICATION_SNR`.
         """
         require_ranks(self, talkers=1, absorption_areas=1, levels=2)
         require_same_length(self, "absorption_areas", "levels", axis="absorption area")
         require_same_length(self, "talkers", ("levels", 1), axis="talker count")
+        require_finite_fields(
+            self,
+            "distance",
+            "directivity",
+            "sound_power_level",
+            "signal_level",
+            "communication_level",
+        )
+        direct = float(
+            speech_direct_level(
+                self.distance,
+                sound_power_level=self.sound_power_level,
+                directivity=self.directivity,
+            )
+        )
+        if not math.isclose(self.signal_level, direct, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "CrowdNoiseResult: 'signal_level' must be the direct field of "
+                "Equation (17.50) at 'distance' for a talker of "
+                "'sound_power_level' and 'directivity'; got "
+                f"{self.signal_level!r} where those fields state {direct!r}."
+            )
+            raise ValueError(msg)
+        limit = self.signal_level - COMMUNICATION_SNR
+        if not math.isclose(self.communication_level, limit, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "CrowdNoiseResult: 'communication_level' must be the noise "
+                "level at which the speech-to-noise ratio falls to the "
+                f"{COMMUNICATION_SNR:g} dB limit of Equation (17.53), that is "
+                f"'signal_level' minus it; got {self.communication_level!r} "
+                f"where 'signal_level' {self.signal_level!r} states {limit!r}."
+            )
+            raise ValueError(msg)
 
     def speech_to_noise(self) -> np.ndarray:
         """Speech-to-noise ratio for every point of :attr:`levels`, dB."""

--- a/src/phonometry/room/crowd_noise.py
+++ b/src/phonometry/room/crowd_noise.py
@@ -335,6 +335,9 @@ class CrowdNoiseResult:
             "sound_power_level",
             "signal_level",
             "communication_level",
+            "talkers",
+            "absorption_areas",
+            "levels",
         )
         direct = float(
             speech_direct_level(

--- a/src/phonometry/signals/envelope.py
+++ b/src/phonometry/signals/envelope.py
@@ -47,6 +47,7 @@ modulation lines read low by the taper's scalloping loss.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -305,12 +306,61 @@ class EnvelopeSpectrumResult:
         end, so it is a pair rather than an axis and stays out of both
         groups.
 
+        :attr:`mean_level` is the third statement about the upper panel, and
+        it is closed over the panel's own column: it is the plain mean of
+        :attr:`envelope`, the DC that Figure 13.11's remover subtracts before
+        the transform, so ``envelope - mean_level`` is what the lines below
+        were measured on. Nothing about it is a decibel -- the detector output
+        is a linear amplitude (or its square), and the documented closed forms
+        :math:`A_0` and :math:`A_0^2 (1 + m^2/2)` are exactly the arithmetic
+        means of those two columns -- so neither a level of the column nor its
+        energy mean restates it. :meth:`plot` draws it as the labelled rule
+        across the envelope panel, where the reader takes the modulation as
+        the trace's excursion about that rule: a mean level belonging to
+        another detector, or to the same column expressed some other way,
+        lands as a rule the trace never crosses, silently stretching the
+        panel's limits to reach it.
+
+        The slack is relative and only relative, unlike the peak-rate guard
+        of :mod:`phonometry.metrology.data_qualification` and unlike the
+        decibel margins elsewhere in the tree: an envelope mean carries the
+        record's own units and no bounded scale, so a caller who recomputed
+        the mean along another summation path must not be refused over the
+        last bit, while an absolute floor would be a floor in nothing --
+        a squared detector reading a tone at the threshold of hearing means
+        some :math:`10^{-9}` Pa^2, and a floor that size would wave through
+        every statement about it, zero and negatives included.
+
+        An empty pair is left alone: it carries no mean to restate, and the
+        transform never makes one. So is an undetermined one:
+        :func:`envelope_spectrum` refuses a non-finite record, but a finite
+        one can still overflow inside the Hilbert transform and detect an
+        all-NaN envelope, and NaN is then the mean's honest restatement --
+        which no comparison of NaN with NaN can confirm. Such a column is
+        one the producer legitimately emits, so it is passed rather than
+        refused; only a column with a mean is held to it.
+
         :raises ValueError: if the spectrum disagrees with its frequency
-            axis, or the envelope with its time axis.
+            axis, the envelope with its time axis, or ``mean_level`` with the
+            envelope it is the mean of.
         """
         require_ranks(self, frequencies=1, amplitude=1, times=1, envelope=1)
         require_same_length(self, "frequencies", "amplitude", axis="frequency")
         require_same_length(self, "times", "envelope", axis="sample")
+        detector = np.asarray(self.envelope, dtype=np.float64)
+        if detector.size == 0:
+            return
+        expected = float(np.mean(detector))
+        if math.isnan(expected):
+            return
+        if not math.isclose(self.mean_level, expected, rel_tol=1e-9, abs_tol=0.0):
+            msg = (
+                "EnvelopeSpectrumResult: 'mean_level' must be the plain mean "
+                "of 'envelope', the DC removed before the transform (Bendat & "
+                f"Piersol Figure 13.11); got {self.mean_level!r} where "
+                f"'envelope' means {expected!r}."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -40,6 +40,7 @@ out-of-band the filter gain never exceeds the
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -82,6 +83,64 @@ class TimedResponse(Protocol):
     def __array__(
         self, dtype: DTypeLike | None = None, copy: bool | None = None
     ) -> np.ndarray: ...
+
+
+def _require_band_flatness(result: InverseFilterResult) -> None:
+    r"""Pin ``flatness_db`` against the equalized magnitude it summarises.
+
+    The flatness is closed over what the result already stores. The equalized
+    magnitude is the elementwise product of
+    :attr:`~InverseFilterResult.response_spectrum` and
+    :attr:`~InverseFilterResult.spectrum` -- the modeling delay carried in the
+    latter is a unit-modulus factor and cannot move a magnitude -- and the band
+    it is worst over is the part of
+    :attr:`~InverseFilterResult.frequencies` inside
+    :attr:`~InverseFilterResult.f_range`. :meth:`InverseFilterResult.plot`
+    prints the number in the figure title and draws that same product on the
+    axes below it, so a result built by hand, or by :func:`dataclasses.replace`
+    on a genuine one, can title a figure with a ripple its own curve never
+    shows.
+
+    A band the inversion cannot fill -- an equalized magnitude that touches
+    zero at some bin, where the measured response has a null -- is infinitely
+    far from 0 dB, and the design reports ``inf`` for it. That value is a
+    reading, not a defect: it is kept, and :func:`math.isclose` accepts it
+    against itself.
+
+    A billionth of a decibel of slack lets a caller who recomputed the
+    deviation along another floating-point path restate it without being
+    refused over the last bit.
+
+    :param result: The result carrying both the flatness and the spectra.
+    :raises ValueError: if ``f_range`` selects no bin of ``frequencies``, or
+        ``flatness_db`` is not the worst deviation from 0 dB that the stored
+        spectra show across that band.
+    """
+    freqs = np.asarray(result.frequencies, dtype=np.float64)
+    f1, f2 = result.f_range
+    band = (freqs >= f1) & (freqs <= f2)
+    n_band = int(np.count_nonzero(band))
+    if n_band == 0:
+        msg = (
+            "InverseFilterResult: 'f_range' must select at least one bin of "
+            "'frequencies' for 'flatness_db' to summarise; got "
+            f"({f1!r}, {f2!r}) against {freqs.size} bin(s)."
+        )
+        raise ValueError(msg)
+    equalized = np.abs(
+        np.asarray(result.response_spectrum) * np.asarray(result.spectrum)
+    )
+    with np.errstate(divide="ignore"):
+        worst = float(np.max(np.abs(20.0 * np.log10(equalized[band]))))
+    if math.isclose(result.flatness_db, worst, rel_tol=0.0, abs_tol=1e-9):
+        return
+    msg = (
+        "InverseFilterResult: 'flatness_db' must be the largest deviation "
+        "from 0 dB of the equalized magnitude 'response_spectrum' times "
+        f"'spectrum' across 'f_range'; got {result.flatness_db!r} where those "
+        f"spectra deviate by {worst!r} over the {n_band} band bin(s)."
+    )
+    raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -133,7 +192,7 @@ class InverseFilterResult:
     max_gain_db: float
 
     def __post_init__(self) -> None:
-        r"""Reject a design whose spectra do not share one frequency grid.
+        r"""Reject a design whose spectra, or whose flatness, disagree.
 
         The three spectra and the regularization profile are the design at
         one frequency each, but only three of the four are read by anything
@@ -165,8 +224,22 @@ class InverseFilterResult:
         every length check, draws exactly as before, and doubles the sample
         count :attr:`size` reports.
 
+        Of the two reported decibel figures only :attr:`flatness_db` is pinned,
+        by :func:`_require_band_flatness`, because only it is closed over the
+        fields stored here. :attr:`max_gain_db` is the achieved gain -- not the
+        :math:`1/(2\sqrt{\epsilon})` ceiling -- but it is the largest gain over
+        the band padded by ``transition_octaves``, and that padding is a design
+        argument the result does not keep. Two genuine designs can therefore
+        agree in every field above, profile included, and still report a
+        different :attr:`max_gain_db`: put the padded edge exactly on a bin for
+        one and just above it for the other and the profile is the same array
+        while the bin falls inside one maximum and outside the other. Nothing
+        computable from what is stored can tell the two apart, so nothing is
+        claimed about it.
+
         :raises ValueError: if a spectrum or the profile disagrees with the
-            frequency grid, or a field carries an extra axis.
+            frequency grid, a field carries an extra axis, or
+            :attr:`flatness_db` does not restate the equalized magnitude.
         """
         require_ranks(
             self,
@@ -184,6 +257,7 @@ class InverseFilterResult:
             "regularization",
             axis="frequency",
         )
+        _require_band_flatness(self)
 
     def __array__(
         self, dtype: DTypeLike | None = None, copy: bool | None = None

--- a/src/phonometry/underwater/bioacoustics/weighting.py
+++ b/src/phonometry/underwater/bioacoustics/weighting.py
@@ -56,6 +56,7 @@ injury = TTS + 20 dB identities.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -63,6 +64,7 @@ import numpy as np
 
 from ..._internal.validation import (
     require_equal_shapes,
+    require_finite_fields,
     require_ranks,
     require_same_length,
 )
@@ -775,12 +777,51 @@ class WeightedExposureResult:
         picture. The figure is the only reader that would object, and it
         objects after the verdict has already been formed.
 
-        :raises ValueError: if any per-band quantity disagrees with the rest.
+        The chain from those arrays to the verdict is closed link by link,
+        because every link but one restates the fields stored beside it:
+        ``weighted_band_sel`` is ``band_sel`` plus ``weighting`` band by band,
+        the two exposure totals are the energy sums of those two rows,
+        ``cumulative_sel`` adds the accumulation of ``n_events`` events to the
+        weighted one, each of the four margins is a stored level less a
+        published criterion, and the two verdicts are what those margins say.
+        An undetermined total exempts nothing: a spectrum whose every band
+        carries no energy sums to ``-inf`` and takes its SEL margins with it,
+        and the identity still holds exactly, minus infinity less a finite
+        criterion being minus infinity again. What ``-inf`` excuses is being
+        required to be finite, which is a different demand and one this result
+        makes of no total.
+
+        The one link taken as given is ``peak_spl``. It is not a summary of
+        anything stored here: it is the flat zero-to-peak level of the record
+        the spectrum came from, in dB re 1 µPa against band exposures in
+        dB re 1 µPa²·s, and no band column carries the crest factor that would
+        relate the two. It is refused only when it is not a number at all --
+        ``None``, the state the producer uses for a level that was never
+        supplied, is left alone. Its two margins *are* closed: each is that
+        stored level less a stored criterion, and ``None`` exactly when there
+        is no level to compare or no criterion published to compare it with,
+        the non-impulsive tables publishing none at all.
+
+        Nothing recomputes any of these downstream, and the readers all go the
+        wrong way round them: ``exceeds_injury`` and ``exceeds_tts`` are formed
+        from the margins and never look at the levels, and the guide prints
+        level and margin side by side. A variant built with a louder peak
+        therefore kept the quiet one's margins and was reported compliant
+        against criteria its own stored level clears.
+
+        :raises ValueError: if any per-band quantity disagrees with the rest,
+            if ``peak_spl`` is not finite, or if a band row, a total, a margin
+            or a verdict does not restate what it is formed from.
         """
         require_ranks(self, frequencies=1, band_sel=1, weighting=1, weighted_band_sel=1)
         require_same_length(
             self, "frequencies", "band_sel", "weighting", "weighted_band_sel"
         )
+        require_finite_fields(self, "peak_spl")
+        _require_rows_restate(self)
+        _require_totals_restate(self)
+        _require_margins_restate(self)
+        _require_verdicts_restate(self)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -800,6 +841,204 @@ def _energy_sum(levels: NDArray[np.float64]) -> float:
 
 def _margin(value: float, criterion: float | None) -> float | None:
     return None if criterion is None else float(value - criterion)
+
+
+def _margins_agree(margin: float | None, expected: float | None) -> bool:
+    """Whether a stored margin is the one its level and criterion imply.
+
+    :func:`_margin` read backwards, for :func:`_require_margins_restate`. An
+    absent margin and an absent expectation are the same statement -- there
+    was no level to compare, or no criterion published to compare it with --
+    and one of each is a contradiction whichever way round it falls. Where both
+    are present a billionth of a decibel is allowed, so a caller who recomputed
+    the subtraction along another floating-point path is not refused over the
+    last bit.
+
+    :param margin: The margin carried by the result, or ``None``.
+    :param expected: The margin the result's own level and criterion give, or
+        ``None``.
+    :return: Whether the two agree.
+    """
+    if margin is None or expected is None:
+        return margin is None and expected is None
+    return math.isclose(margin, expected, rel_tol=0.0, abs_tol=1e-9)
+
+
+def _require_rows_restate(result: WeightedExposureResult) -> None:
+    """Pin the weighted band row against the two rows it is formed from.
+
+    ``weighted_band_sel`` is what the energy sums, the margins and the verdict
+    are built on, and it is the row the figure draws; a band moved in it alone
+    moves the whole assessment without moving the spectrum it was weighted
+    from.
+
+    :param result: The assessment carrying all three band rows.
+    :raises ValueError: if a band of ``weighted_band_sel`` is not its
+        ``band_sel`` plus its ``weighting``.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        expected = result.band_sel + result.weighting
+        disagree = np.flatnonzero(
+            ~np.isclose(result.weighted_band_sel, expected, rtol=0.0, atol=1e-9)
+        )
+    if disagree.size == 0:
+        return
+    band = int(disagree[0])
+    msg = (
+        "WeightedExposureResult: 'weighted_band_sel' must be 'band_sel' plus "
+        f"'weighting' in every band; got {float(result.weighted_band_sel[band])!r} "
+        f"in the band at {float(result.frequencies[band])!r} Hz where the two "
+        f"beside it state {float(expected[band])!r}."
+    )
+    raise ValueError(msg)
+
+
+def _require_restates(
+    result: WeightedExposureResult, field: str, expected: float, statement: str
+) -> None:
+    """Pin one total against the row or the fields it restates.
+
+    A billionth of a decibel of slack lets a caller who recomputed the total
+    along another floating-point path restate it without being refused over
+    the last bit. An undetermined total is compared like any other: ``-inf``
+    agrees with ``-inf`` and with nothing else.
+
+    :param result: The assessment carrying both the total and its sources.
+    :param field: Name of the field holding the total.
+    :param expected: The total the fields beside it state.
+    :param statement: What the field must be, completing ``'<field>' must``.
+    :raises ValueError: if ``field`` does not restate ``expected``.
+    """
+    stored = float(getattr(result, field))
+    if math.isclose(stored, expected, rel_tol=0.0, abs_tol=1e-9):
+        return
+    msg = (
+        f"WeightedExposureResult: '{field}' must {statement}; got {stored!r} "
+        f"where the fields beside it state {expected!r}."
+    )
+    raise ValueError(msg)
+
+
+def _require_totals_restate(result: WeightedExposureResult) -> None:
+    """Pin the three exposure totals against the rows they are summed over.
+
+    A band that carries no energy enters the sums as ``-inf``, which is the
+    neutral element of an energy sum and the whole sum when every band is one;
+    the recomputation is made with the divide-by-zero that spells it silenced,
+    the producer having already reported it once.
+
+    :param result: The assessment carrying the totals and their band rows.
+    :raises ValueError: if a total is not the sum of the row beside it.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        unweighted = _energy_sum(result.band_sel)
+        weighted = _energy_sum(result.weighted_band_sel)
+        cumulative = result.weighted_sel + 10.0 * float(np.log10(result.n_events))
+    _require_restates(
+        result, "unweighted_sel", unweighted, "be the energy sum of 'band_sel'"
+    )
+    _require_restates(
+        result, "weighted_sel", weighted, "be the energy sum of 'weighted_band_sel'"
+    )
+    _require_restates(
+        result,
+        "cumulative_sel",
+        cumulative,
+        "be 'weighted_sel' accumulated over the 'n_events' events",
+    )
+
+
+def _require_margins_restate(result: WeightedExposureResult) -> None:
+    """Pin all four margins against the level and the criterion each restates.
+
+    Both halves of the dual metric are closed on both sides, injury and TTS
+    onset alike: a peak level raised on its own leaves ``tts_peak_margin``
+    stating the quiet one's headroom just as surely as ``peak_margin``, and
+    ``exceeds_tts`` is printed beside them from the margins alone.
+
+    :param result: The assessment carrying the margins, the levels and the
+        criteria.
+    :raises ValueError: if a margin is not its level less its criterion, or is
+        present when one of them is absent.
+    """
+    criteria = result.criteria
+    checks: tuple[tuple[str, float | None, str, float | None, str], ...] = (
+        (
+            "sel_margin",
+            result.cumulative_sel,
+            "cumulative_sel",
+            criteria.injury_sel,
+            "injury_sel",
+        ),
+        (
+            "tts_margin",
+            result.cumulative_sel,
+            "cumulative_sel",
+            criteria.tts_sel,
+            "tts_sel",
+        ),
+        (
+            "peak_margin",
+            result.peak_spl,
+            "peak_spl",
+            criteria.injury_peak_spl,
+            "injury_peak_spl",
+        ),
+        (
+            "tts_peak_margin",
+            result.peak_spl,
+            "peak_spl",
+            criteria.tts_peak_spl,
+            "tts_peak_spl",
+        ),
+    )
+    for field, level, level_name, criterion, criterion_name in checks:
+        expected = None if level is None else _margin(level, criterion)
+        stored = getattr(result, field)
+        if _margins_agree(stored, expected):
+            continue
+        msg = (
+            f"WeightedExposureResult: '{field}' must be '{level_name}' minus "
+            f"the criteria's '{criterion_name}', and None when either of them "
+            f"is None; got {stored!r} where '{level_name}' {level!r} against "
+            f"{criterion!r} gives {expected!r}."
+        )
+        raise ValueError(msg)
+
+
+def _require_verdicts_restate(result: WeightedExposureResult) -> None:
+    """Pin the two verdicts against the margins they are formed from.
+
+    They are the fields an assessment is read for and the last link of the
+    chain: a variant that keeps its margins and flips a verdict reports
+    compliance its own stored numbers deny.
+
+    :param result: The assessment carrying the verdicts and their margins.
+    :raises ValueError: if a verdict is not what its margins say.
+    """
+    verdicts: tuple[tuple[str, tuple[float | None, float | None], str], ...] = (
+        (
+            "exceeds_injury",
+            (result.sel_margin, result.peak_margin),
+            "'sel_margin' or 'peak_margin'",
+        ),
+        (
+            "exceeds_tts",
+            (result.tts_margin, result.tts_peak_margin),
+            "'tts_margin' or 'tts_peak_margin'",
+        ),
+    )
+    for field, margins, named in verdicts:
+        expected = _any_positive(*margins)
+        stored = bool(getattr(result, field))
+        if stored == expected:
+            continue
+        msg = (
+            f"WeightedExposureResult: '{field}' must be True exactly when "
+            f"{named} has reached its criterion; got {stored!r} where the "
+            f"margins beside it state {expected!r}."
+        )
+        raise ValueError(msg)
 
 
 def weighted_exposure(

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -220,8 +220,22 @@ class PileStrikeResult:
             one-dimensional trace, or ``peak_spl`` is not its zero-to-peak
             level.
         """
+        trace = np.asarray(self.pressure)
+        # The rank helper waives its pin when every field it was given is a
+        # bare number, an exemption meant for the entry points that answer in
+        # scalars. Here 'pressure' is the only field listed, so a lone number
+        # satisfies the whole set and walks past it, with a size of one and a
+        # peak of its own that the comparison below is happy to confirm. A
+        # trace of one sample is a trace; a number is not one, so the rank is
+        # pinned here in its own right.
+        if trace.ndim != 1:
+            msg = (
+                "PileStrikeResult: 'pressure' must be a one-dimensional "
+                f"waveform; got shape {trace.shape}."
+            )
+            raise ValueError(msg)
         require_ranks(self, pressure=1)
-        if np.asarray(self.pressure).size == 0:
+        if trace.size == 0:
             msg = (
                 "PileStrikeResult: 'pressure' must carry at least one sample; "
                 "a strike with no waveform has no peak to state."

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -133,6 +133,69 @@ def _pulse_duration(pressure: NDArray[np.float64], fs: float) -> float:
     return float((hi - lo) / fs)
 
 
+def _require_metrics_restate(result: PileStrikeResult) -> None:
+    """Pin all four stored metrics against the trace they were taken off.
+
+    None of them is a measurement of its own. ISO 18406 6.4.2 reads every one
+    off the waveform, and :func:`pile_strike_metrics` computes the four from
+    the same ``(pressure, fs)`` pair it goes on to store, so a result whose
+    trace was substituted, for a filtered or de-spiked one, carries three
+    numbers describing a waveform that is no longer there.
+
+    Restating the peak alone is not enough and is the more dangerous half,
+    because it looks like diligence. Halve a trace and the peak level follows
+    it down by six decibels, so a caller who recomputes that one sees a result
+    that agrees with itself where they looked, while the exposure and the
+    pressure level beside it are still the old trace's, six decibels high, and
+    the marine-mammal dual-metric rule is decided on both.
+
+    The pulse duration is the quiet one: it is a ratio of energies, so it does
+    not move when a trace is merely scaled, and only a change of shape parts
+    it from its waveform. That is precisely why it needs the guard rather than
+    being excused by it.
+
+    :param result: The strike whose stored metrics are measured.
+    :raises ValueError: if any of the four does not restate ``pressure``, or
+        ``pulse_duration`` does not restate it at ``fs``.
+    """
+    trace = result.pressure
+    # A trace carrying no energy has no exposure and no pressure level, and
+    # the two entry points that compute them say so by refusing outright. The
+    # peak and the duration do answer for it, at minus infinity and zero. So
+    # the neutral value is supplied here rather than the refusal being let
+    # through: a silent strike is a legitimate result whose three levels are
+    # all minus infinity, the same neutral this module gives an empty band,
+    # and a guard that crashed on it would refuse what it exists to protect.
+    silent = not np.any(trace)
+    for name, expected, what in (
+        ("peak_spl", _peak_level(trace), "the zero-to-peak level, 20 lg(max|p|)"),
+        (
+            "single_strike_sel",
+            -math.inf if silent else sound_exposure_level(trace, result.fs),
+            "the exposure",
+        ),
+        (
+            "spl",
+            -math.inf if silent else sound_pressure_level(trace),
+            "the pressure level",
+        ),
+        (
+            "pulse_duration",
+            _pulse_duration(trace, result.fs),
+            "the 5 % to 95 % energy duration",
+        ),
+    ):
+        stored = float(getattr(result, name))
+        if math.isclose(stored, expected, rel_tol=0.0, abs_tol=1e-9):
+            continue
+        msg = (
+            f"PileStrikeResult: '{name}' must be {what} of 'pressure', the "
+            f"trace it summarises; got {stored!r} where the trace states "
+            f"{expected!r}."
+        )
+        raise ValueError(msg)
+
+
 def _peak_level(pressure: NDArray[np.float64]) -> float:
     r"""Zero-to-peak level of *pressure*, in dB re 1 µPa.
 
@@ -191,34 +254,33 @@ class PileStrikeResult:
     fs: float
 
     def __post_init__(self) -> None:
-        """Reject a strike whose peak level is not the peak of its own trace.
+        """Reject a strike whose stored metrics are not its own trace's.
 
-        :attr:`peak_spl` is not a measurement of its own: ISO 18406 6.4.2.1.3
-        takes it off the very waveform stored here, and
-        :func:`pile_strike_metrics` computes it as
-        :func:`~phonometry.underwater.acoustics.peak_sound_pressure_level` of
-        the trace it goes on to store beside it. The two cannot part company
-        except by hand or by :func:`dataclasses.replace`, which is how a
-        variant of a frozen result is built -- substitute a filtered or
-        de-spiked waveform and the peak level that travels through with it is
-        the old trace's.
+        None of the four is a measurement of its own: ISO 18406 6.4.2 reads
+        every one off the waveform, and :func:`pile_strike_metrics` computes
+        them from the same ``(pressure, fs)`` pair it goes on to store. They
+        cannot part company except by hand or by :func:`dataclasses.replace`,
+        which is how a variant of a frozen result is built: substitute a
+        filtered or de-spiked waveform and all four numbers that travel
+        through with it are the old trace's.
 
-        Parted, they are still drawn together. The figure marks the sample at
-        ``argmax(|pressure|)`` and labels that marker with ``peak_spl``, so a
-        peak level from another trace prints itself over the one sample that
-        disproves it. The number is also the one half of the marine-mammal
-        dual-metric rule that is compared unweighted, against a fixed
-        peak-pressure injury threshold: a strike that clears the threshold on
-        its own waveform is failed against it, or the reverse, with the
-        waveform beneath saying otherwise.
+        Parted, they are still read together. The figure marks the sample at
+        ``argmax(|pressure|)`` and labels that marker with :attr:`peak_spl`,
+        so a peak level from another trace prints itself over the one sample
+        that disproves it. That level and :attr:`single_strike_sel` are also
+        the two halves of the marine-mammal dual-metric rule, one compared
+        unweighted against a peak-pressure threshold and the other summed over
+        a pile: a strike that clears the thresholds on its own waveform is
+        failed against them, or the reverse, with the waveform beneath saying
+        otherwise.
 
-        The comparison allows a billionth of a decibel so a caller who
-        recomputed the peak along another floating-point path is not refused
+        The comparisons allow a billionth of a decibel so a caller who
+        recomputed a metric along another floating-point path is not refused
         over the last bit.
 
         :raises ValueError: if ``pressure`` is not a non-empty, finite,
-            one-dimensional trace, or ``peak_spl`` is not its zero-to-peak
-            level.
+            one-dimensional trace, or any of the four stored metrics does not
+            restate it.
         """
         trace = np.asarray(self.pressure)
         # The rank helper waives its pin when every field it was given is a
@@ -242,15 +304,7 @@ class PileStrikeResult:
             )
             raise ValueError(msg)
         require_finite_fields(self, "pressure")
-        peak = _peak_level(self.pressure)
-        if not math.isclose(self.peak_spl, peak, rel_tol=0.0, abs_tol=1e-9):
-            msg = (
-                "PileStrikeResult: 'peak_spl' must be the zero-to-peak level of "
-                "'pressure', 20 lg(max|p| / 1 uPa), the trace it summarises; "
-                f"got {self.peak_spl!r} where the trace peaks at {peak!r} dB "
-                "re 1 uPa."
-            )
-            raise ValueError(msg)
+        _require_metrics_restate(self)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/src/phonometry/underwater/sources/pile_driving_noise.py
+++ b/src/phonometry/underwater/sources/pile_driving_noise.py
@@ -23,14 +23,21 @@ hammer strike. ISO 18406 characterises them with:
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.levels_math import energy_sum
+from ..._internal.validation import (
+    require_finite_fields,
+    require_ranks,
+    require_same_length,
+)
 from ...io._resolve import SignalInput, resolve_fs
 from ..acoustics import (
+    UNDERWATER_REFERENCE_PRESSURE,
     _positive,
     _validate_pressure,
     peak_sound_pressure_level,
@@ -126,6 +133,44 @@ def _pulse_duration(pressure: NDArray[np.float64], fs: float) -> float:
     return float((hi - lo) / fs)
 
 
+def _peak_level(pressure: NDArray[np.float64]) -> float:
+    r"""Zero-to-peak level of *pressure*, in dB re 1 µPa.
+
+    :func:`~phonometry.underwater.acoustics.peak_sound_pressure_level` is the
+    measurement and refuses a silent record outright, which is right there and
+    wrong in a guard: what a guard has to tell apart is a level that restates
+    its trace from one that contradicts it, and an exception raised about the
+    trace answers neither. A silent trace peaks at ``-inf``, the level of zero
+    pressure -- the same neutral value :attr:`StrikeSelSpectrum.band_sel`
+    carries for a band that holds no energy, so the two guards in this module
+    treat an undetermined level the same way.
+
+    :param pressure: The strike waveform, in Pa (non-empty).
+    :return: :math:`20 \log_{10}(\max\lvert p \rvert / 1\,\mu\mathrm{Pa})`,
+        ``-inf`` for an all-zero trace.
+    """
+    peak = float(np.max(np.abs(np.asarray(pressure, dtype=np.float64))))
+    with np.errstate(divide="ignore"):
+        return float(20.0 * np.log10(peak / UNDERWATER_REFERENCE_PRESSURE))
+
+
+def _band_energy_sum(band_sel: NDArray[np.float64]) -> float:
+    r"""Energy sum of the band levels *band_sel*, in dB re 1 µPa²·s.
+
+    :math:`10 \log_{10} \sum_b 10^{\mathrm{SEL}_b/10}`, the only sum a column
+    of decibels has: adding the decibels themselves totals a strike at some
+    thousands of dB. A band at ``-inf`` contributes an exact zero, so a
+    spectrum with an empty band sums as though the band were not there; a
+    spectrum with *every* band empty sums to ``-inf``, the level of no
+    exposure at all, which is the truthful total over such a column.
+
+    :param band_sel: Per-band single-strike SELs, in dB re 1 µPa²·s.
+    :return: Their energy sum, in dB re 1 µPa²·s.
+    """
+    with np.errstate(divide="ignore"):
+        return energy_sum(np.asarray(band_sel, dtype=np.float64))
+
+
 @dataclass(frozen=True)
 class PileStrikeResult:
     """Per-strike pile-driving metrics (ISO 18406).
@@ -144,6 +189,54 @@ class PileStrikeResult:
     pulse_duration: float
     pressure: NDArray[np.float64]
     fs: float
+
+    def __post_init__(self) -> None:
+        """Reject a strike whose peak level is not the peak of its own trace.
+
+        :attr:`peak_spl` is not a measurement of its own: ISO 18406 6.4.2.1.3
+        takes it off the very waveform stored here, and
+        :func:`pile_strike_metrics` computes it as
+        :func:`~phonometry.underwater.acoustics.peak_sound_pressure_level` of
+        the trace it goes on to store beside it. The two cannot part company
+        except by hand or by :func:`dataclasses.replace`, which is how a
+        variant of a frozen result is built -- substitute a filtered or
+        de-spiked waveform and the peak level that travels through with it is
+        the old trace's.
+
+        Parted, they are still drawn together. The figure marks the sample at
+        ``argmax(|pressure|)`` and labels that marker with ``peak_spl``, so a
+        peak level from another trace prints itself over the one sample that
+        disproves it. The number is also the one half of the marine-mammal
+        dual-metric rule that is compared unweighted, against a fixed
+        peak-pressure injury threshold: a strike that clears the threshold on
+        its own waveform is failed against it, or the reverse, with the
+        waveform beneath saying otherwise.
+
+        The comparison allows a billionth of a decibel so a caller who
+        recomputed the peak along another floating-point path is not refused
+        over the last bit.
+
+        :raises ValueError: if ``pressure`` is not a non-empty, finite,
+            one-dimensional trace, or ``peak_spl`` is not its zero-to-peak
+            level.
+        """
+        require_ranks(self, pressure=1)
+        if np.asarray(self.pressure).size == 0:
+            msg = (
+                "PileStrikeResult: 'pressure' must carry at least one sample; "
+                "a strike with no waveform has no peak to state."
+            )
+            raise ValueError(msg)
+        require_finite_fields(self, "pressure")
+        peak = _peak_level(self.pressure)
+        if not math.isclose(self.peak_spl, peak, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "PileStrikeResult: 'peak_spl' must be the zero-to-peak level of "
+                "'pressure', 20 lg(max|p| / 1 uPa), the trace it summarises; "
+                f"got {self.peak_spl!r} where the trace peaks at {peak!r} dB "
+                "re 1 uPa."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any
@@ -187,7 +280,7 @@ class StrikeSelSpectrum:
     fs: float
 
     def __post_init__(self) -> None:
-        """Reject a band spectrum whose levels do not match its band centres.
+        r"""Reject a band spectrum whose levels do not match its band centres.
 
         The two arrays state one measurement twice over -- a nominal centre
         frequency, and the exposure the band at that frequency carries -- and
@@ -204,10 +297,60 @@ class StrikeSelSpectrum:
         curves fall by tens of decibels across a decade, so a misaligned
         spectrum returns an injury margin that reads like any other.
 
-        :raises ValueError: if the band levels disagree with the centres.
+        :attr:`total_sel` is then held to the column it totals. It is the
+        *energy* sum of ``band_sel``, :math:`10 \log_{10} \sum_b
+        10^{\mathrm{SEL}_b/10}`, which is what :func:`strike_sel_spectrum`
+        computes by summing the band energies before taking the logarithm
+        once; the arithmetic sum of the same decibels totals a strike at some
+        thousands of dB and is simply a different number. The figure rules a
+        dashed line across the axes at ``total_sel`` and labels it
+        :math:`\mathrm{SEL}_{\mathrm{ss}}`, so a total kept from another
+        column -- a mitigated spectrum substituted through
+        :func:`dataclasses.replace` is exactly that -- is drawn as a broadband
+        level the bands beneath it never reach.
+
+        A band at ``-inf`` is admitted, and only ``-inf``: it is the level of
+        zero exposure this class documents for a band narrower than the FFT
+        bin spacing, and it is the neutral element of the energy sum, so it
+        passes through the total without disturbing it. Nothing else
+        non-finite is a level, and a ``NaN`` band would otherwise be reported
+        as a wrong total rather than as the wrong band it is.
+
+        :attr:`broadband_sel` is left unpinned deliberately. It is the SEL of
+        the whole record, :math:`\int p^2 dt` over the waveform, and the
+        waveform is not stored here; it exceeds ``total_sel`` by exactly the
+        energy falling outside ``limits``, which nothing in hand can measure.
+
+        The total's comparison allows a billionth of a decibel so a caller who
+        re-summed the bands along another floating-point path is not refused
+        over the last bit.
+
+        :raises ValueError: if the band levels disagree with the centres, if a
+            band is non-finite otherwise than ``-inf``, or if ``total_sel`` is
+            not the energy sum of ``band_sel``.
         """
         require_ranks(self, frequencies=1, band_sel=1)
         require_same_length(self, "frequencies", "band_sel")
+        band_sel = np.asarray(self.band_sel, dtype=np.float64)
+        undetermined = np.flatnonzero(~(np.isfinite(band_sel) | np.isneginf(band_sel)))
+        if undetermined.size:
+            i = int(undetermined[0])
+            msg = (
+                "StrikeSelSpectrum: 'band_sel' must be finite, or -inf for a "
+                "band that holds no energy at all; the "
+                f"{float(np.asarray(self.frequencies)[i]):g} Hz band states "
+                f"{float(band_sel[i])!r}."
+            )
+            raise ValueError(msg)
+        total = _band_energy_sum(band_sel)
+        if not math.isclose(self.total_sel, total, rel_tol=0.0, abs_tol=1e-9):
+            msg = (
+                "StrikeSelSpectrum: 'total_sel' must be the energy sum of "
+                "'band_sel', 10 lg(sum 10^(SEL/10)) over the bands beside it "
+                f"and not their arithmetic sum; got {self.total_sel!r} where "
+                f"the bands sum to {total!r}."
+            )
+            raise ValueError(msg)
 
     def plot(
         self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -1512,6 +1512,38 @@ def test_a_non_finite_a_weighted_step_is_refused() -> None:
         dataclasses.replace(res, a_levels=with_gap)
 
 
+def test_la_max_must_be_the_peak_of_its_own_history() -> None:
+    """``la_max`` is ``max(a_levels)``, and the figure draws both at once.
+
+    The marker is placed at ``argmax(a_levels)`` and labelled with ``la_max``,
+    and the shaded window is ``a_levels >= la_max - 10``. Raised by 12 dB, the
+    label printed 74.0 dB(A) over a marker sitting at 62.0 dB(A) and the window
+    emptied, so the figure lost its shading without losing its legend.
+    """
+    _t, _pos, res = _flyover(bands=[31.5], span=1000.0)
+    peak = float(np.max(res.a_levels))
+    assert res.la_max == pytest.approx(peak, abs=1e-12)
+    with pytest.raises(ValueError, match="'la_max' must be the maximum of"):
+        dataclasses.replace(res, la_max=peak + 12.0)
+
+
+def test_la_max_below_its_history_is_refused() -> None:
+    # The other direction: a peak short of the curve it summarises would shade
+    # a 10 dB-down window narrower than the level history it is read from.
+    _t, _pos, res = _flyover(bands=[31.5], span=1000.0)
+    quieter = float(np.max(res.a_levels)) - 5.0
+    with pytest.raises(ValueError, match="'la_max' must be the maximum of"):
+        dataclasses.replace(res, la_max=quieter)
+
+
+def test_la_max_survives_a_recomputation_along_another_path() -> None:
+    # A caller who rebuilt the peak with numpy's own reduction is not refused
+    # over the last bit; the guard allows a billionth of a decibel.
+    _t, _pos, res = _flyover(bands=[31.5], span=1000.0)
+    nudged = dataclasses.replace(res, la_max=res.la_max + 1e-12)
+    assert nudged.la_max == pytest.approx(float(np.max(res.a_levels)), abs=1e-9)
+
+
 def test_event_plot() -> None:
     _, _, res = _flyover(level=90.0, bands=_NORAH_BANDS, span=1000.0)
     assert res.plot() is not None

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -14,6 +14,7 @@ heterogeneous event chain, is tested in ``test_rotorcraft_terrain.py``.
 from __future__ import annotations
 
 import dataclasses
+import math
 
 import matplotlib as mpl
 
@@ -22,6 +23,7 @@ import numpy as np
 import pytest
 
 from phonometry.aircraft.rotorcraft_noise import (
+    RotorcraftEventResult,
     RotorcraftHemisphere,
     hemisphere_source_level,
 )
@@ -1510,6 +1512,35 @@ def test_a_non_finite_a_weighted_step_is_refused() -> None:
     with_gap[0] = np.nan
     with pytest.raises(ValueError, match="'a_levels' must be finite"):
         dataclasses.replace(res, a_levels=with_gap)
+
+
+def test_an_empty_history_keeps_its_undetermined_peak() -> None:
+    """The exemption the docstring grants, which the guard used to take back.
+
+    A history with no records has no peak, so ``la_max`` is undetermined and
+    the producer writes a ``NaN``. Feeding the stored value back as its own
+    expectation looked like a way to pass the comparison over, but a ``NaN``
+    is close to nothing, not even to itself, so the exempt case was the one
+    the guard refused.
+    """
+    empty = np.array([])
+    result = RotorcraftEventResult(
+        frequencies=empty,
+        emission_times=empty,
+        times=empty,
+        distance=empty,
+        azimuth=empty,
+        polar=empty,
+        band_levels=np.zeros((0, 0)),
+        a_levels=empty,
+        la_max=float("nan"),
+        sel=float("nan"),
+        sel_10db=float("nan"),
+        pnlt=empty,
+        pnltm=float("nan"),
+        epnl=float("nan"),
+    )
+    assert math.isnan(result.la_max)
 
 
 def test_la_max_must_be_the_peak_of_its_own_history() -> None:

--- a/tests/broadcast/test_program_loudness.py
+++ b/tests/broadcast/test_program_loudness.py
@@ -610,6 +610,49 @@ def test_result_rejects_weights_that_miss_a_channel() -> None:
         replace(res, channel_weights=short)
 
 
+def test_result_rejects_a_maximum_its_own_series_denies() -> None:
+    """The headline maxima are the maxima of the series stored beside them.
+
+    No reader recomputes them: the fiche prints each as an informational row
+    above a graph of the very readings that would deny it, and the ``bext``
+    writer stamps them into a broadcast WAV.
+    """
+    res = program_loudness(_steps(((-23.0, 10.0),)), FS)
+    assert res.max_momentary == pytest.approx(float(np.max(res.momentary)))
+    with pytest.raises(ValueError, match="'max_momentary'"):
+        replace(res, max_momentary=0.0)
+    with pytest.raises(ValueError, match="'max_short_term'"):
+        replace(res, max_short_term=0.0)
+
+
+def test_result_rejects_a_maximum_over_an_empty_series() -> None:
+    """An excerpt too short to fill one window holds no maximum at all."""
+    res = program_loudness(_stereo(_sine(-23.0, 0.2)), FS)
+    assert res.momentary.size == 0
+    with pytest.raises(ValueError, match="'max_momentary'"):
+        replace(res, max_momentary=-23.0)
+
+
+def test_maximum_passes_over_readings_left_undetermined() -> None:
+    """A window of digital silence reads -inf and the maximum steps over it.
+
+    EBU Tech 3341 leaves both sliding windows ungated, so the -inf readings of
+    a silent passage stay in the series; only a wholly silent programme leaves
+    the maximum itself undetermined, and the guard accepts that -inf too.
+    """
+    lead_in = _stereo(np.concatenate([np.zeros(2 * FS), _sine(-23.0, 5.0)]))
+    res = program_loudness(lead_in, FS)
+    assert np.any(np.isneginf(res.momentary))
+    assert res.max_momentary == pytest.approx(-23.0, abs=0.1)
+    silent = program_loudness(np.zeros((2, 5 * FS)), FS)
+    assert bool(np.all(np.isneginf(silent.momentary)))
+    assert silent.max_momentary == float("-inf")
+    # A caller who recomputed the maximum along another path is not refused
+    # over the last bit of floating point.
+    nudged = replace(res, max_momentary=res.max_momentary + 1e-12)
+    assert nudged.max_momentary != res.max_momentary
+
+
 def test_program_loudness_matches_integrated_loudness() -> None:
     x = _steps(((-26.0, 5.0), (-20.0, 5.0)))
     assert program_loudness(x, FS).integrated == pytest.approx(

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -127,9 +127,20 @@ def test_informational_rows_do_not_change_verdict(tmp_path: Path) -> None:
     _text, passed = _verdict(result, -23.0)
     assert passed is True
     # Force extreme informational values; the verdict must stay PASS because it
-    # is driven only by the integrated loudness and the maximum true peak.
+    # is driven only by the integrated loudness and the maximum true peak. Each
+    # maximum is raised through its own series, which is where the result reads
+    # it from: a maximum its column denies is refused at construction.
+    momentary = result.momentary.copy()
+    momentary[0] = 0.0
+    short_term = result.short_term.copy()
+    short_term[0] = 0.0
     tampered = dataclasses.replace(
-        result, loudness_range=999.0, max_momentary=0.0, max_short_term=0.0
+        result,
+        loudness_range=999.0,
+        momentary=momentary,
+        max_momentary=0.0,
+        short_term=short_term,
+        max_short_term=0.0,
     )
     _text2, passed2 = _verdict(tampered, -23.0)
     assert passed2 is True

--- a/tests/building/measurement/test_insulation.py
+++ b/tests/building/measurement/test_insulation.py
@@ -27,6 +27,7 @@ import math
 import numpy as np
 import pytest
 from reference_data import ISO717_1_ANNEX_C_R as _ANNEX_C_R
+from reference_data import ISO717_2_ANNEX_C1_LN as _ANNEX_C1_LN
 
 from phonometry import building
 
@@ -689,3 +690,71 @@ def test_impact_rating_band_curves_must_be_finite() -> None:
         ValueError, match="ImpactRatingResult: 'measured' must contain only finite"
     ):
         dataclasses.replace(result, measured=measured)
+
+
+def test_rating_unfavourable_sum_must_restate_its_own_curves() -> None:
+    """The sum is the two curves added up, so it is pinned to them.
+
+    ISO 717-1:2020 Table C.1 rates its example at Rw = 30 dB with the
+    unfavourable deviations summing to 31,8 dB. Swapping ``measured`` for a
+    curve lying on the shifted reference leaves no unfavourable deviation at
+    all, and the stale 31,8 dB used to survive the swap: the verbose Annex C
+    fiche then printed an em dash in every deviation row and closed the
+    table with "sum 0,0 dB", beside a plot titled
+    ``... = 30 dB (Sigma unfav. = 31.8 dB)``.
+    """
+    result = building.weighted_rating(_ANNEX_C_R)
+    on_the_reference = np.asarray(result.shifted_reference, dtype=np.float64)
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"WeightedRatingResult: 'unfavourable_sum' must be the sum of the "
+            r"unfavourable deviations of its own curves"
+        ),
+    ):
+        dataclasses.replace(result, measured=on_the_reference)
+
+
+def test_impact_unfavourable_sum_must_restate_its_own_curves() -> None:
+    """The ISO 717-2 sum is pinned the same way, with the opposite sign.
+
+    ISO 717-2:2020 Table C.1 rates the bare heavy floor at Ln,w = 79 dB with
+    the deviations -- here where the measurement *exceeds* the reference --
+    summing to 28,0 dB. A ``measured`` curve laid on the shifted reference
+    leaves none of them, and the refusal must name the impact sense rather
+    than the airborne one.
+    """
+    result = building.weighted_impact_rating(_ANNEX_C1_LN)
+    on_the_reference = np.asarray(result.shifted_reference, dtype=np.float64)
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"ImpactRatingResult: 'unfavourable_sum' must be the sum of the "
+            r"unfavourable deviations of its own curves, 'measured' above "
+            r"'shifted_reference'"
+        ),
+    ):
+        dataclasses.replace(result, measured=on_the_reference)
+
+
+def test_unfavourable_sum_accepts_a_variant_that_keeps_its_curves() -> None:
+    """A coherent variant is not refused over floating-point slack.
+
+    Raising both curves by the same 3 dB leaves every deviation, and so the
+    sum, exactly as it was; recomputing the sum along a different path (band
+    by band in plain Python rather than one numpy reduction) must still land
+    inside the guard's tolerance.
+    """
+    result = building.weighted_rating(_ANNEX_C_R)
+    measured = np.asarray(result.measured, dtype=np.float64) + 3.0
+    shifted = np.asarray(result.shifted_reference, dtype=np.float64) + 3.0
+    recomputed = math.fsum(
+        max(0.0, r - m) for m, r in zip(measured, shifted, strict=True)
+    )
+    moved = dataclasses.replace(
+        result,
+        measured=measured,
+        shifted_reference=shifted,
+        unfavourable_sum=recomputed,
+    )
+    assert moved.unfavourable_sum == pytest.approx(31.8, abs=1e-9)

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -262,11 +262,17 @@ def test_report_rejects_band_count_mismatch(tmp_path: Path) -> None:
 
     res = _airborne_result()
     assert res.rating is not None
+    centers = res.rating.band_centers[:-1]
+    measured = res.rating.measured[:-1]
+    shifted = res.rating.shifted_reference[:-1]
     short = dataclasses.replace(
         res.rating,
-        band_centers=res.rating.band_centers[:-1],
-        measured=res.rating.measured[:-1],
-        shifted_reference=res.rating.shifted_reference[:-1],
+        band_centers=centers,
+        measured=measured,
+        shifted_reference=shifted,
+        # Dropping the top band drops its unfavourable deviation with it, and
+        # WeightedRatingResult refuses a sum its own two curves do not state.
+        unfavourable_sum=float(np.sum(np.maximum(shifted - measured, 0.0))),
     )
     bad = dataclasses.replace(res, rating=short)
     out = str(tmp_path / "x.pdf")

--- a/tests/building/prediction/test_ceiling_plenum.py
+++ b/tests/building/prediction/test_ceiling_plenum.py
@@ -361,6 +361,118 @@ def test_rating_result_rejects_a_short_deficiency_column() -> None:
         dataclasses.replace(res, deficiencies=short)
 
 
+def _raised_contour_variant(
+    res: building.CeilingAttenuationResult,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """The contour of *res* lifted one decibel, with its column and rating.
+
+    The clause 5.3 loop stops at the highest admissible contour, so one more
+    decibel is always a contour ASTM E413 refuses; the deficiency column is
+    restated against it exactly as clause 5.4 defines it, over the clause 5.2
+    rounded data. Used to build results whose totals were left behind.
+    """
+    raised = res.shifted_reference + 1.0
+    column = np.maximum(raised - res.rounded, 0.0)
+    return raised, column, res.rating + 1
+
+
+def test_rating_result_rejects_a_stale_deficiency_sum() -> None:
+    """Intertek J7488.04 with its contour lifted: the printed total lags it.
+
+    ``deficiency_sum`` is what clause 5.4.1 stops the contour on, and the plot
+    prints it in the title beside the rating while drawing the data against
+    ``shifted_reference``. A variant built with ``dataclasses.replace`` that
+    restates the contour and its column but not the total drew
+    "CAC = 26 dB (sum unfav. = 24.0 dB)" over a column summing to 36 dB, past
+    the 32 dB at which a fit stops being admissible at all.
+    """
+    res = building.ceiling_attenuation_class(INTERTEK_2019_DNC)
+    raised, column, rating = _raised_contour_variant(res)
+    assert float(np.sum(column)) == pytest.approx(36.0)
+    with pytest.raises(ValueError, match="'deficiency_sum' must be the sum"):
+        dataclasses.replace(
+            res, shifted_reference=raised, deficiencies=column, rating=rating
+        )
+
+
+def test_rating_result_rejects_a_stale_max_deficiency() -> None:
+    """The same variant with only the clause 5.4.2 maximum left behind.
+
+    The total is restated here, so nothing but ``max_deficiency`` disagrees:
+    the column's largest entry is 6 dB where the field still says 5 dB.
+    """
+    res = building.ceiling_attenuation_class(INTERTEK_2019_DNC)
+    raised, column, rating = _raised_contour_variant(res)
+    total = float(np.sum(column))
+    assert float(np.max(column)) == pytest.approx(6.0)
+    assert res.max_deficiency == pytest.approx(5.0)
+    with pytest.raises(ValueError, match="'max_deficiency' must be the largest"):
+        dataclasses.replace(
+            res,
+            shifted_reference=raised,
+            deficiencies=column,
+            rating=rating,
+            deficiency_sum=total,
+        )
+
+
+def test_rating_result_rejects_an_undetermined_deficiency() -> None:
+    """A deficiency is a floored difference, never a gap.
+
+    ``ceiling_attenuation_class`` takes only finite levels and clause 5.4
+    counts a band the contour clears as a zero, so a non-finite entry is a
+    column no total can restate, and it is named rather than surfacing as a
+    total that will not compare.
+    """
+    res = building.ceiling_attenuation_class(INTERTEK_2019_DNC)
+    column = res.deficiencies.copy()
+    column[3] = np.nan
+    with pytest.raises(ValueError, match="'deficiencies' must be finite"):
+        dataclasses.replace(res, deficiencies=column)
+
+
+def test_rating_result_names_the_field_on_an_all_scalar_column() -> None:
+    """A result of bare numbers throughout is named, not indexed.
+
+    ``require_ranks`` passes over whole a result whose every pinned field is
+    nought-dimensional, so such a column reaches the totals check. Read
+    unflattened, its one band has no axis to index and the caller got
+    ``IndexError: too many indices`` naming no field at all.
+    """
+    res = building.ceiling_attenuation_class(INTERTEK_2019_DNC)
+    band = int(np.flatnonzero(res.frequencies == 500.0)[0])
+    scalars = {
+        "frequencies": np.asarray(res.frequencies[band]),
+        "measured": np.asarray(res.measured[band]),
+        "rounded": np.asarray(res.rounded[band]),
+        "shifted_reference": np.asarray(res.shifted_reference[band]),
+        "deficiencies": np.asarray(np.nan),
+    }
+    with pytest.raises(ValueError, match="'deficiencies' must be finite"):
+        dataclasses.replace(res, deficiency_sum=3.0, max_deficiency=3.0, **scalars)
+
+
+def test_rating_result_accepts_a_fully_restated_variant() -> None:
+    """The whole point is a variant that restates itself, not a frozen result.
+
+    Lifting the contour and restating all three of column, total and maximum
+    is accepted, and so is a total recomputed along another floating-point
+    path: the comparison allows a billionth of a decibel.
+    """
+    res = building.ceiling_attenuation_class(INTERTEK_2019_DNC)
+    raised, column, rating = _raised_contour_variant(res)
+    variant = dataclasses.replace(
+        res,
+        shifted_reference=raised,
+        deficiencies=column,
+        rating=rating,
+        deficiency_sum=float(sum(float(d) for d in column)) + 1e-12,
+        max_deficiency=float(np.max(column)),
+    )
+    assert variant.rating == INTERTEK_2019_CAC + 1
+    assert variant.deficiency_sum == pytest.approx(36.0)
+
+
 # ---------------------------------------------------------------------------
 # Normalization (ISO 140-9:1985 clause 3.3)
 # ---------------------------------------------------------------------------

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -671,3 +671,124 @@ def test_an_intensity_band_quantity_off_the_band_axis_is_refused(
     wrong = values[:-1] if trim else np.append(values, values[-1])
     with pytest.raises(ValueError, match=f"'{field_name}'"):
         dataclasses.replace(result, **{field_name: wrong})
+
+
+def _broadband_result() -> emission.IntensityResult:
+    """A one-third-octave measurement of noise reaching past its own limits."""
+    p1, p2 = _plane_wave_pair(delay_s=SPACING / C, f_lo=20.0, f_hi=10000.0)
+    return emission.sound_intensity(
+        p1, p2, FS, spacing=SPACING, rho=RHO, c=C, fraction=3, limits=[100.0, 5000.0]
+    )
+
+
+def test_the_broadband_level_must_restate_the_broadband_intensity() -> None:
+    """LI is the level of the total intensity, not a number of its own.
+
+    Scaling the source by 10 dB through
+    :func:`dataclasses.replace`, the sanctioned way to build a variant, moves
+    the field it is handed and leaves the levels where they were: the result
+    then answers ``86,4`` dB to the docs snippet printing
+    ``total_intensity_level`` beside ``total_direction`` while the
+    ``total_intensity`` on the same object is 10 lg of ``96,4`` dB.
+    """
+    import dataclasses
+
+    result = _broadband_result()
+    louder = 10.0 * result.total_intensity
+    with pytest.raises(ValueError, match="'total_intensity_level' must be"):
+        dataclasses.replace(result, total_intensity=louder)
+
+
+def test_the_broadband_index_must_restate_the_two_broadband_levels() -> None:
+    r"""The index the band figure is titled with must be Lp - LI.
+
+    plot() puts ``total_pressure_intensity_index`` in the title and nothing
+    else of the totals, so before this guard an index written in by hand
+    titled the figure ``ISO 9614 $L_p$ vs $L_I$  (total $\delta_{pI}$ =
+    25.0 dB)`` -- a field so reactive no instrument would qualify for it under
+    ISO 9614-1 criterion 1 -- over a result whose own two totals differ by
+    -0,006 dB, and over band curves that agree with neither number.
+    """
+    import dataclasses
+
+    result = _broadband_result()
+    with pytest.raises(ValueError, match="'total_pressure_intensity_index' must be"):
+        dataclasses.replace(result, total_pressure_intensity_index=25.0)
+
+
+@pytest.mark.parametrize("field_name", ["total_intensity", "total_pressure_level"])
+def test_a_non_finite_broadband_total_is_refused(field_name: str) -> None:
+    """The two totals the restatements are measured against must be finite.
+
+    Nothing in IEC 61043 or ISO 9614-1 leaves a broadband total undetermined,
+    and no reader renders one as an em dash: a NaN passes every shape guard
+    and reaches the band figure's title as the literal ``nan dB``.
+    """
+    import dataclasses
+
+    result = _broadband_result()
+    with pytest.raises(ValueError, match=f"'{field_name}' must be finite"):
+        dataclasses.replace(result, **{field_name: float("nan")})
+
+
+def test_a_nan_sample_is_refused_at_the_result_instead_of_titling_the_figure() -> None:
+    """The same guard catches the producer path: NaN in, refusal out."""
+    p1, p2 = _plane_wave_pair(delay_s=SPACING / C)
+    p1[10] = np.nan
+    with pytest.raises(ValueError, match="'total_intensity' must be finite"):
+        emission.sound_intensity(p1, p2, FS, spacing=SPACING, rho=RHO, c=C, fraction=3)
+
+
+@pytest.mark.parametrize("spelling", ["floored", "infinite"])
+def test_a_zero_total_may_state_its_level_either_way(spelling: str) -> None:
+    """No net intensity has no level, and both spellings of that are accepted.
+
+    The producer floors the argument of the logarithm at the smallest positive
+    double, so a zero total leaves it as about -2957 dB; a caller who took
+    10 lg 0 along the unfloored path holds -inf. They say the same thing.
+    """
+    level = (
+        float(10.0 * np.log10(np.finfo(float).tiny / 1e-12))
+        if spelling == "floored"
+        else float("-inf")
+    )
+    result = emission.IntensityResult(
+        frequency=None,
+        intensity=None,
+        intensity_level=None,
+        pressure_level=None,
+        pressure_intensity_index=None,
+        direction=None,
+        bias_correction=None,
+        total_intensity=0.0,
+        total_intensity_level=level,
+        total_pressure_level=60.0,
+        total_pressure_intensity_index=60.0 - level,
+        total_direction=1,
+        max_valid_frequency=0.1 * C / SPACING,
+    )
+    assert result.total_intensity_level == level
+
+
+def test_the_broadband_totals_are_not_pinned_to_the_band_columns() -> None:
+    """The totals are summed over the bins, the columns over the bands.
+
+    ``limits`` clips the broadband sum at 100 Hz and 5 kHz, while the band
+    column keeps every band whose centre falls inside those limits, edges and
+    all, out to 5,6 kHz; bands narrower than the spectral resolution are
+    dropped from the column outright. The two sums are therefore different
+    quantities and disagree by 11 % of the intensity and 0,42 dB of the
+    pressure level on this measurement -- which is why no guard equates them.
+    """
+    result = _broadband_result()
+    assert result.intensity is not None
+    assert result.pressure_level is not None
+    band_sum = float(np.sum(result.intensity))
+    band_energy = 10.0 * np.log10(np.sum(10.0 ** (0.1 * result.pressure_level)))
+    assert band_sum / result.total_intensity == pytest.approx(1.11, abs=0.01)
+    assert band_energy - result.total_pressure_level == pytest.approx(0.42, abs=0.01)
+    assert result.frequency is not None
+    assert result.frequency[-1] > 5000.0
+    # And the cutoff is not the top of the band column either: the bands above
+    # it are the ones 'bias_correction' exists to compensate.
+    assert result.max_valid_frequency < result.frequency[-1]

--- a/tests/materials/absorbers/test_absorption_rating.py
+++ b/tests/materials/absorbers/test_absorption_rating.py
@@ -323,6 +323,38 @@ def test_a_retained_alpha_s_off_the_octave_triple_is_refused() -> None:
         dataclasses.replace(res, third_octave_alpha_s=twelve, third_octave_bands=bands)
 
 
+def test_a_sum_contradicting_its_own_curves_is_refused() -> None:
+    """Clause 4.2 makes the sum a sentence about the two octave curves.
+
+    The readers take it from opposite ends and used to disagree in print:
+    re-measuring the 250 Hz band and swapping it in with
+    ``dataclasses.replace`` left the sum stale, and plot() titled the figure
+    "unfav. = 0.05" over a band it shaded 0,35 low while the fiche printed
+    "sum 0.35" under that very deviation, both definitive, neither marked.
+    """
+    import dataclasses
+
+    res = weighted_absorption(_ANNEX_A2_ALPHA_P)  # sum 0.05, all of it at 250 Hz
+    assert _almost(res.unfavourable_sum, 0.05)
+    remeasured = np.asarray([0.05, *_ANNEX_A2_ALPHA_P[1:]], dtype=float)
+    with pytest.raises(ValueError, match="'unfavourable_sum' must be the sum"):
+        dataclasses.replace(res, measured=remeasured)
+
+
+def test_a_sum_off_by_a_last_bit_is_kept() -> None:
+    """A caller who recomputed the sum along another float path is not refused.
+
+    The deviations live on the 0,05 grid, so a billionth of a coefficient is
+    never a disagreement about the rating; it is the last bit of a different
+    summation order.
+    """
+    import dataclasses
+
+    res = weighted_absorption(_ANNEX_A2_ALPHA_P)
+    kept = dataclasses.replace(res, unfavourable_sum=res.unfavourable_sum + 1e-12)
+    assert _almost(kept.unfavourable_sum, res.unfavourable_sum)
+
+
 def test_weighted_mapping_matches_sequence() -> None:
     mapping = dict(zip(OCTAVE_BANDS, _ANNEX_A2_ALPHA_P, strict=True))
     res_map = weighted_absorption(mapping)

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -196,6 +196,46 @@ def test_trend_test_validation() -> None:
         ph.metrology.trend_test(constant, method="runs")
 
 
+def test_trend_test_rejects_null_mean_of_another_sequence() -> None:
+    """'mean' is the null moment of the count, not an average of 'values'.
+
+    Nothing in the library reads it: the plot states the count and the
+    bounds. The caller is the reader, standardizing the departure as
+    ``(statistic - mean) / std``, so a mean belonging to another sequence
+    turns an ordinary count into a flat rejection with no array anywhere
+    the wrong length. Before this guard, a 25-observation reverse
+    arrangement result whose null mean 150 was replaced by 10 kept its
+    A = 135 and its verdict, and handed the caller z = +5.84 where the
+    sequence states z = -0.70.
+    """
+    res = ph.metrology.trend_test(np.random.default_rng(9).standard_normal(25))
+    assert res.mean == 25 * 24 / 4  # B&P Eq. (4.54), from the count alone
+    with pytest.raises(ValueError, match=r"'mean' must be the null mean"):
+        dataclasses.replace(res, mean=10.0)
+
+
+def test_trend_test_runs_null_mean_is_recounted_about_the_median() -> None:
+    """The runs moment needs n1 and n2, neither of them a stored field.
+
+    Both are recoverable all the same: ``values`` holds what survived the
+    median filter and ``median`` the value they were classified against,
+    so ``1 + 2 n1 n2 / n`` closes over the result. The arithmetic mean of
+    the same values -- the quantity the field's name invites -- is refused
+    here; it was accepted before, giving z = +8.65 for a run count that
+    stands at z = +1.92. The refusal cites where that moment is written
+    down, which for runs is Wald & Wolfowitz and not the reverse-
+    arrangement equation the other method counts by.
+    """
+    res = ph.metrology.trend_test(
+        np.random.default_rng(9).standard_normal(40), method="runs"
+    )
+    above = int(np.count_nonzero(res.values > res.median))
+    assert res.mean == 1.0 + 2.0 * above * (res.n - above) / res.n
+    arithmetic = float(np.mean(res.values))
+    with pytest.raises(ValueError, match=r"'mean' must be the null mean.*Wolfowitz"):
+        dataclasses.replace(res, mean=arithmetic)
+
+
 # ---------------------------------------------------------------------------
 # Stationarity test (B&P Sec. 10.3.1.1)
 # ---------------------------------------------------------------------------
@@ -265,6 +305,28 @@ def test_stationarity_validation() -> None:
         ph.metrology.stationarity_test(x, FS, n_segments=4096)
     with pytest.raises(ValueError, match="fs"):
         ph.metrology.stationarity_test(x, 0.0)
+
+
+def test_stationarity_rejects_null_mean_of_another_record() -> None:
+    """The stationarity moment closes over 'segment_values' both ways.
+
+    For reverse arrangements it is fixed by the segment count alone; for
+    runs it is recounted about the median of the segment sequence, the
+    same median the plot draws as the classification line. Neither is an
+    average of the segment values, and neither is read by any renderer, so
+    a null mean from another record used to travel: the 20-segment result
+    below kept A = 94 under a mean of 0, handing the caller z = +6.10
+    where its own segments state z = -0.06.
+    """
+    rng = np.random.default_rng(9)
+    x = rng.standard_normal(1 << 14)
+    res = ph.metrology.stationarity_test(x, FS)
+    assert res.mean == res.n_segments * (res.n_segments - 1) / 4
+    with pytest.raises(ValueError, match=r"'mean' must be the null mean"):
+        dataclasses.replace(res, mean=0.0)
+    runs = ph.metrology.stationarity_test(x, FS, method="runs")
+    with pytest.raises(ValueError, match=r"'mean' must be the null mean"):
+        dataclasses.replace(runs, mean=runs.mean + 4.0)
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +542,90 @@ def test_peak_statistics_rejects_non_finite_peak_values() -> None:
         dataclasses.replace(res, peak_values=hidden_descent)
     with pytest.raises(ValueError, match="'peak_values' must contain only finite"):
         dataclasses.replace(res, peak_values=repeated_inf)
+
+
+def test_peak_statistics_rejects_rate_that_miscounts_its_peaks() -> None:
+    """A rate is a count over a duration, and both are stored here.
+
+    ``peak_values`` holds every detected maximum -- none are dropped on the
+    way in -- and ``duration`` is the record length the rate was taken
+    over, so ``peak_rate`` restates the two beside it. Halving the heights
+    used to leave the rate untouched: the figure then drew 2731 peaks and
+    floored its axis at 1/2731 = 3.662e-04, stating 1365.5833 maxima per
+    second, while ``peak_rate`` reported 2730.6667 over the very same
+    ``duration``.
+    """
+    res = ph.metrology.peak_statistics(
+        np.random.default_rng(9).standard_normal(1 << 14), FS
+    )
+    assert res.peak_rate == res.peak_values.size / res.duration
+    half = res.peak_values[::2]
+    with pytest.raises(ValueError, match=r"'peak_rate' must be the number of maxima"):
+        dataclasses.replace(res, peak_values=half)
+
+
+def test_peak_statistics_rejects_rice_rates_that_contradict_r() -> None:
+    """M is a spectral moment the result drops, but not an unpinned one.
+
+    ``peak_rate_rice`` is sqrt(m4/m2) and neither moment is stored; the
+    irregularity factor is, and ``r = min(1, N0 / 2M)`` closes the three
+    rates on each other. This is the pair the reader publishes: doubling M
+    used to leave the plot labelling its Rice curve "Rice ($r$ = 0.747)"
+    while the rates stored beside it stated r = 0.374, and that curve is a
+    function of r alone.
+    """
+    res = ph.metrology.peak_statistics(
+        np.random.default_rng(9).standard_normal(1 << 14), FS
+    )
+    stated = min(1.0, res.zero_crossing_rate_rice / (2.0 * res.peak_rate_rice))
+    assert res.irregularity_factor == stated
+    with pytest.raises(ValueError, match=r"'irregularity_factor' must be the r"):
+        dataclasses.replace(res, peak_rate_rice=res.peak_rate_rice * 2.0)
+
+
+def test_peak_statistics_rice_guard_reproduces_the_narrowband_cap() -> None:
+    """The cap is reproduced, not divided away.
+
+    ``peak_statistics`` writes ``min(1, N0 / 2M)`` because the Schwartz
+    inequality behind r <= 1 is tight for narrow-band data and floating
+    point can carry the ratio a hair past 1. Solving the identity for M
+    instead -- checking ``M == N0 / 2r`` -- would refuse exactly those
+    results. The guard applies the same cap, so a triple whose ratio
+    overshoots is accepted at r = 1, and only there.
+    """
+    fs, n = 20480.0, 1 << 16
+    res = ph.metrology.peak_statistics(
+        _bandlimited_gaussian(2, fs, n, 950.0, 1050.0), fs
+    )
+    assert res.irregularity_factor > 0.99
+    overshooting = 2.0 * res.peak_rate_rice * (1.0 + 1e-9)
+    capped = dataclasses.replace(
+        res, zero_crossing_rate_rice=overshooting, irregularity_factor=1.0
+    )
+    assert capped.irregularity_factor == 1.0
+    with pytest.raises(ValueError, match=r"'irregularity_factor' must be the r"):
+        dataclasses.replace(res, zero_crossing_rate_rice=overshooting)
+
+
+def test_peak_statistics_admits_the_rice_rates_an_overflow_produces() -> None:
+    """A non-finite M is producer output, and the identity closes over it.
+
+    An amplitude large enough to overflow the spectral moments has
+    ``peak_statistics`` writing M = inf beside r = 0, and further up a NaN
+    beside r = 1. Both are exactly what ``min(1, N0 / 2M)`` states, so the
+    guard has nothing to say about either: only a zero M is turned away,
+    and only because the ratio cannot be taken.
+    """
+    base = np.random.default_rng(0).standard_normal(1000)
+    with np.errstate(over="ignore", invalid="ignore"):
+        overflowed = ph.metrology.peak_statistics(base * 1e150, 1000.0)
+        saturated = ph.metrology.peak_statistics(base * 1e155, 1000.0)
+    assert np.isinf(overflowed.peak_rate_rice)
+    assert overflowed.irregularity_factor == 0.0
+    assert np.isnan(saturated.peak_rate_rice)
+    assert saturated.irregularity_factor == 1.0
+    with pytest.raises(ValueError, match=r"'peak_rate_rice' must be a positive"):
+        dataclasses.replace(overflowed, peak_rate_rice=0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/psychoacoustics/loudness/test_moore_glasberg.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg.py
@@ -445,3 +445,57 @@ def test_a_result_refuses_a_centre_frequency_column_of_pairs() -> None:
     pairs = np.column_stack([result.centre_frequencies, result.centre_frequencies])
     with pytest.raises(ValueError, match="'centre_frequencies'"):
         dataclasses.replace(result, centre_frequencies=pairs)
+
+
+# --------------------------------------------------------------------------
+# The one loudness the two units say
+# --------------------------------------------------------------------------
+
+
+def test_a_result_refuses_a_loudness_level_its_own_sone_value_does_not_state() -> None:
+    """The chart prints both numbers, and says nothing when they disagree.
+
+    The definitional anchor of clause 3.17 gives 1.000 sone, which Table 5
+    puts at 40 phon; a result carrying that sone value beside 100.0 phon
+    titled itself ``ISO 532-2 loudness N = 1.00 sone (100.0 phon)`` - the
+    sone of one loudness and the phon of another, each plausible alone.
+    """
+    anchor = psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, 40.0)])
+    assert anchor.loudness == pytest.approx(1.0, abs=1e-3)
+    with pytest.raises(ValueError, match="'loudness_level' must be 'loudness'"):
+        dataclasses.replace(anchor, loudness_level=100.0)
+
+
+def test_a_result_refuses_a_loudness_level_off_by_more_than_float_noise() -> None:
+    """The pin allows the last bit and nothing above it.
+
+    A caller who recomputes the Table 5 mapping along another floating-point
+    path keeps the result; one who rounds the phon value to the tenth the
+    title displays does not, because a tenth of a phon is a different
+    loudness level and the sone value beside it is the one that means it.
+    """
+    result = psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, 60.0)])
+    recomputed = dataclasses.replace(
+        result, loudness_level=result.loudness_level + 1e-12
+    )
+    assert recomputed.loudness_level == pytest.approx(result.loudness_level)
+    rounded = round(result.loudness_level, 1)
+    with pytest.raises(ValueError, match="'loudness_level' must be 'loudness'"):
+        dataclasses.replace(result, loudness_level=rounded)
+
+
+def test_a_result_refuses_a_loudness_that_is_not_a_sone_value() -> None:
+    """A NaN loudness maps to a NaN level, which restates nothing.
+
+    No calculation here can produce one - the pattern integrated is
+    non-negative everywhere and every entry point refuses non-finite input -
+    but a hand-built NaN would pass a restatement test by comparing equal to
+    nothing, and reach the title as ``N = nan sone (nan phon)``.
+    """
+    result = psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, 60.0)])
+    with pytest.raises(ValueError, match="'loudness' must be a finite"):
+        dataclasses.replace(result, loudness=float("nan"))
+    # Below the table Table 5 is read flat, so a negative sone value would
+    # otherwise restate 0.0 phon and pass the pin above.
+    with pytest.raises(ValueError, match="'loudness' must be a finite"):
+        dataclasses.replace(result, loudness=-1.0, loudness_level=0.0)

--- a/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg_time.py
@@ -520,6 +520,120 @@ def test_level_curve_off_the_frame_axis_is_refused(mg_tone: MgTone) -> None:
         dataclasses.replace(res, short_term_loudness_level=short_term)
 
 
+def test_n_max_that_contradicts_its_trace_is_refused(mg_tone: MgTone) -> None:
+    """A peak the long-term trace never reaches is refused at construction.
+
+    ``n_max`` is the maximum of the long-term loudness (clause 7.9) and the
+    chart takes it on trust: it prints it in the title and rules a dashed line
+    across the axes at it.  Before this guard a peak of 12 sone stapled onto a
+    trace that peaks at 1.000 drew that line at 12, stretched the y-axis to
+    reach it, and flattened the trace it claimed to summarise against the
+    bottom of the plot.
+    """
+    res = mg_tone(1000.0, 40.0)
+    with pytest.raises(
+        ValueError, match="'n_max' must be the maximum of 'long_term_loudness'"
+    ):
+        dataclasses.replace(res, n_max=12.0, loudness_level_max=76.5)
+
+
+def test_n_max_left_behind_by_a_cropped_trace_is_refused(mg_tone: MgTone) -> None:
+    """Cropping every trace consistently still has to restate the peak.
+
+    The frame-axis guard passes a crop that keeps all five columns the same
+    length, so nothing else notices that the window no longer contains the
+    instant the stored peak was taken at.
+    """
+    res = mg_tone(1000.0, 40.0)
+    head = slice(0, 50)  # the attack, well below the settled peak
+    cropped = {
+        "time": res.time[head],
+        "short_term_loudness": res.short_term_loudness[head],
+        "long_term_loudness": res.long_term_loudness[head],
+        "short_term_loudness_level": res.short_term_loudness_level[head],
+        "long_term_loudness_level": res.long_term_loudness_level[head],
+    }
+    with pytest.raises(
+        ValueError, match="'n_max' must be the maximum of 'long_term_loudness'"
+    ):
+        dataclasses.replace(res, **cropped)
+
+
+def test_loudness_level_max_must_be_n_max_through_table_5(mg_tone: MgTone) -> None:
+    """The phon headline has to be the sone headline, not a second opinion.
+
+    ``loudness_level_max`` is ``n_max`` read through Table 5 and nothing else
+    (clause 9 f) and h) ask for the pair), so a phon value that belongs to a
+    different loudness is caught here or nowhere: the chart prints the two side
+    by side in one title without ever comparing them.
+    """
+    res = mg_tone(1000.0, 40.0)
+    with pytest.raises(
+        ValueError, match="'loudness_level_max' must be 'n_max' through the Table 5"
+    ):
+        dataclasses.replace(res, loudness_level_max=res.loudness_level_max + 5.0)
+
+
+@pytest.mark.parametrize(
+    ("fill", "n_max", "phon"),
+    [
+        (np.inf, np.inf, 120.0),
+        (-np.inf, -np.inf, 0.0),
+        (-5.0, -5.0, 0.0),
+        (np.nan, np.nan, 0.0),
+    ],
+    ids=["+inf", "-inf", "negative", "nan"],
+)
+def test_n_max_that_is_not_a_loudness_is_refused(
+    mg_tone: MgTone, fill: float, n_max: float, phon: float
+) -> None:
+    """A peak that is no loudness at all is refused before any restatement.
+
+    Restatement alone cannot catch these: a trace filled with the value
+    restates it as its own maximum, and ``_loudness_level`` reads flat off
+    both ends of Table 5, so ``inf`` sone maps to 120 phon and every negative
+    sone maps to 0 phon.  The first three triples below therefore agreed with
+    themselves and were admitted before this pin, titling the chart
+    ``N = inf sone (120.0 phon)`` over a trace with no finite peak to draw.
+    NaN went the other way - it compares equal to nothing, so the maximum
+    comparison already refused it, but for the wrong reason.
+    """
+    res = mg_tone(1000.0, 40.0)
+    trace = np.full(res.long_term_loudness.size, fill, dtype=np.float64)
+    with pytest.raises(ValueError, match="'n_max' must be a finite, non-negative peak"):
+        dataclasses.replace(
+            res, long_term_loudness=trace, n_max=n_max, loudness_level_max=phon
+        )
+
+
+def test_producer_pair_survives_and_an_empty_trace_peaks_at_zero(
+    mg_tone: MgTone,
+) -> None:
+    """The guard admits what the producer builds, and the empty trace it never does.
+
+    The producer never emits an empty trace - an empty signal is refused
+    outright and one sample still yields one frame - so the zero the peak
+    falls back to on an empty column is reachable only by a caller assembling
+    the result by hand.  It is pinned here so that fallback keeps stating
+    zero instead of raising on the maximum of nothing.
+    """
+    res = mg_tone(1000.0, 40.0)
+    assert res.n_max == pytest.approx(float(res.long_term_loudness.max()))
+    empty = np.empty(0, dtype=np.float64)
+    blank = dataclasses.replace(
+        res,
+        time=empty,
+        short_term_loudness=empty,
+        long_term_loudness=empty,
+        short_term_loudness_level=empty,
+        long_term_loudness_level=empty,
+        n_max=0.0,
+        loudness_level_max=0.0,
+        percentiles={},
+    )
+    assert blank.n_max == 0.0
+
+
 def test_plot_smoke() -> None:
     """The lazy .plot() renders without error when matplotlib is present."""
     matplotlib = pytest.importorskip("matplotlib")

--- a/tests/result_factories.py
+++ b/tests/result_factories.py
@@ -265,15 +265,17 @@ def _intensity_wide() -> ph.emission.IntensityResult:
     """
     freqs = np.array([100.0, 1000.0, 10000.0])
     n = freqs.size
+    # 1 uW/m^2 is 60 dB re 1 pW/m^2 exactly, the level the bands and the
+    # broadband total both carry here.
     return ph.emission.IntensityResult(
         frequency=freqs,
-        intensity=np.zeros(n),
+        intensity=np.full(n, 1.0e-6),
         intensity_level=np.full(n, 60.0),
         pressure_level=np.full(n, 62.0),
         pressure_intensity_index=np.full(n, 2.0),
         direction=np.ones(n),
         bias_correction=np.ones(n),
-        total_intensity=0.0,
+        total_intensity=1.0e-6,
         total_intensity_level=60.0,
         total_pressure_level=62.0,
         total_pressure_intensity_index=2.0,

--- a/tests/room/test_crowd_noise.py
+++ b/tests/room/test_crowd_noise.py
@@ -344,3 +344,19 @@ def test_a_variant_that_restates_itself_is_accepted() -> None:
 def test_validation_errors(call: object, match: str) -> None:
     with pytest.raises(ValueError, match=match):
         call()  # type: ignore[operator]
+
+
+@pytest.mark.parametrize("field", ["talkers", "absorption_areas", "levels"])
+def test_a_crowd_grid_carrying_a_non_finite_value_is_refused(field: str) -> None:
+    """The three arrays the figure is drawn from were the ones left unpinned.
+
+    The scalars around them were already required to be finite, so a NaN could
+    only enter through the occupancy axis, the absorption axis or the grid of
+    levels itself, and each of those is read straight into the plot and into
+    :func:`speech_to_noise_ratio`.
+    """
+    result = room.crowd_noise([50.0, 100.0, 200.0], talkers=[10, 20, 30])
+    poisoned = np.asarray(getattr(result, field), dtype=float).copy()
+    poisoned.flat[0] = np.nan
+    with pytest.raises(ValueError, match=rf"'{field}' must contain only finite values"):
+        dataclasses.replace(result, **{field: poisoned})

--- a/tests/room/test_crowd_noise.py
+++ b/tests/room/test_crowd_noise.py
@@ -254,6 +254,76 @@ def test_extra_axis_on_the_level_grid_is_refused() -> None:
         dataclasses.replace(result, levels=stacked)
 
 
+def test_speech_line_labelled_for_a_distance_it_was_not_computed_at() -> None:
+    """Long Equation (17.50): the signal is the geometry, not a free label.
+
+    The plot places the speech line at ``signal_level`` and captions it with
+    ``distance``, so moving the distance alone drew the 1.2 m level of
+    60.4 dB under the legend entry "Speech at 3 m", where Equation (17.50)
+    puts a talker 3 m away at 52.5 dB.
+    """
+    result = room.crowd_noise([20.0], distance=1.2)
+    with pytest.raises(ValueError, match="'signal_level' must be the direct field"):
+        dataclasses.replace(result, distance=3.0)
+
+
+def test_title_announcing_a_power_the_curves_were_not_drawn_at() -> None:
+    """The talker's power is an input, and the signal is the input restated.
+
+    ``sound_power_level`` is not pinned as a summary of anything -- it is what
+    the caller chose -- but it is one term of Equation (17.50), so a variant
+    that raises it alone no longer states its own ``signal_level``. Before
+    this, the figure was titled "Lw = 85 dB per talker" over the curves and
+    the speech line of a 70 dB talker.
+    """
+    result = room.crowd_noise([20.0])
+    with pytest.raises(ValueError, match="'signal_level' must be the direct field"):
+        dataclasses.replace(result, sound_power_level=85.0)
+
+
+def test_privacy_bound_passed_off_as_the_communication_limit() -> None:
+    """Long Equations (17.53) and (17.54) are two different lines.
+
+    The legend spells the -6 dB out, so a ``communication_level`` set to the
+    -9 dB privacy bound was drawn 3 dB high under a caption that said
+    communication limit.
+    """
+    result = room.crowd_noise([20.0])
+    privacy_bound = result.signal_level - room.PRIVACY_SNR
+    with pytest.raises(ValueError, match="'communication_level' must be the noise"):
+        dataclasses.replace(result, communication_level=privacy_bound)
+
+
+def test_undetermined_talker_power_is_refused() -> None:
+    """A talker power the producer never checked reached the title as ``nan``.
+
+    ``crowd_noise`` coerces ``sound_power_level`` with a bare ``float()``, so
+    a ``NaN`` power built a whole result of ``NaN``: a title reading
+    "Lw = nan dB per talker" over two reference lines at no height at all.
+    Nothing in this model is legitimately undetermined.
+    """
+    with pytest.raises(ValueError, match="'sound_power_level' must be finite"):
+        room.crowd_noise([20.0], sound_power_level=math.nan)
+
+
+def test_a_variant_that_restates_itself_is_accepted() -> None:
+    """The guard pins the identity, not the values: a consistent move passes.
+
+    Moving the listener to 3 m and restating both levels for that distance is
+    the sanctioned way to build a variant, and it is not refused.
+    """
+    result = room.crowd_noise([20.0], distance=1.2)
+    signal = float(np.asarray(room.speech_direct_level(3.0))[()])
+    moved = dataclasses.replace(
+        result,
+        distance=3.0,
+        signal_level=signal,
+        communication_level=signal - room.COMMUNICATION_SNR,
+    )
+    assert round(moved.signal_level, 1) == 52.5
+    assert moved.communication_level == pytest.approx(signal + 6.0)
+
+
 @pytest.mark.parametrize(
     ("call", "match"),
     [

--- a/tests/signals/test_envelope.py
+++ b/tests/signals/test_envelope.py
@@ -12,6 +12,7 @@ the plain-subsampling decimation with the ECMA-internal convention.
 from __future__ import annotations
 
 import dataclasses
+import math
 
 import matplotlib as mpl
 
@@ -411,6 +412,82 @@ def test_envelope_spectrum_panels_must_lie_on_their_own_axes() -> None:
         for wrong, fragment in cases:
             with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
                 dataclasses.replace(good, **{field: wrong})
+
+
+def test_envelope_spectrum_mean_level_must_be_the_mean_of_its_own_envelope() -> None:
+    """The rule across the envelope panel is the mean of the trace beneath it.
+
+    ``mean_level`` is the DC the Figure 13.11 remover took out, so the lines
+    in the lower panel were measured on ``envelope - mean_level``; the upper
+    panel draws it as the labelled rule the reader reads the modulation
+    excursion against. Nothing about it is a decibel, and nothing about it is
+    an energy mean: for this AM tone the column means ``A0 = 2.0``, whose
+    decibel is 3.01 and whose rms is 2.06, and either lands as a rule the
+    trace (1.3 to 2.7) either never crosses or crosses in the wrong places --
+    the first stretching the panel's limits to reach it, neither failing
+    anywhere. The mean of the squared detector is the same mistake made
+    across ``kind``.
+    """
+    good = ph.signals.envelope_spectrum(_am_signal(), FS)
+    column = np.asarray(good.envelope)
+    assert good.mean_level == pytest.approx(float(np.mean(column)), rel=1e-12)
+    wrong_statements = (
+        10.0 * np.log10(float(np.mean(column))),  # a level of the column
+        float(np.sqrt(np.mean(column**2))),  # its energy mean
+        float(np.mean(column**2)),  # the squared detector's mean
+        0.0,
+    )
+    for wrong in wrong_statements:
+        with pytest.raises(
+            ValueError, match=r"'mean_level' must be the plain mean of 'envelope'"
+        ):
+            dataclasses.replace(good, mean_level=wrong)
+    # A caller who recomputed the mean along another summation path is not
+    # refused over the last bit: the slack is relative, and only relative,
+    # since the column carries the record's units and no bounded scale. A
+    # deliberate relative nudge, not a recomputation that lands bitwise back
+    # on the producer's own value, is what exercises that slack.
+    nudged = good.mean_level * (1.0 + 1e-12)
+    assert nudged != good.mean_level
+    assert dataclasses.replace(good, mean_level=nudged).mean_level == nudged
+
+
+def test_envelope_spectrum_mean_level_holds_a_column_to_its_own_scale() -> None:
+    """The rule is pinned in the column's units, which have no floor.
+
+    A squared detector is read in Pa^2, so a 1 kHz tone at the reference
+    threshold of hearing means about 1e-9 Pa^2 -- the whole column sits
+    where an absolute tolerance of that size would wave anything through,
+    zero and a negative mean of a strictly non-negative column included.
+    Band-filtered columns land further down still.
+    """
+    fs = 48000.0
+    t = np.arange(int(0.2 * fs)) / fs
+    quiet = ph.signals.envelope_spectrum(
+        20e-6 * np.sqrt(2.0) * np.sin(2.0 * np.pi * 1000.0 * t), fs, kind="squared"
+    )
+    assert quiet.mean_level < 1e-9
+    for wrong in (0.0, -1e-10, 1e-9):
+        with pytest.raises(
+            ValueError, match=r"'mean_level' must be the plain mean of 'envelope'"
+        ):
+            dataclasses.replace(quiet, mean_level=wrong)
+
+
+def test_envelope_spectrum_mean_level_restates_an_undetermined_envelope() -> None:
+    """A column the detector could not determine carries no mean to restate.
+
+    ``envelope_spectrum`` refuses a non-finite record, but a finite one can
+    still overflow inside the Hilbert transform: the detector then reads an
+    all-NaN envelope whose plain mean is NaN, which is the honest pair the
+    producer emits. No comparison of NaN with NaN can confirm it, so the
+    guard passes such a column instead of refusing what it just built.
+    """
+    overflowing = ph.signals.envelope_spectrum(np.full(4096, 1e307), 8192.0)
+    assert not np.isfinite(np.asarray(overflowing.envelope)).any()
+    assert math.isnan(overflowing.mean_level)
+    restated = dataclasses.replace(overflowing, mean_level=float("nan"))
+    assert math.isnan(restated.mean_level)
 
 
 def test_envelope_spectrum_plot_two_panels_and_external_ax() -> None:

--- a/tests/signals/test_inversion.py
+++ b/tests/signals/test_inversion.py
@@ -214,6 +214,79 @@ def test_design_must_lie_on_one_frequency_grid() -> None:
             dataclasses.replace(res, **{field: value})
 
 
+def test_flatness_must_restate_the_equalized_magnitude() -> None:
+    """The figure title cannot claim a ripple the drawn curve never shows.
+
+    ``plot_inverse_filter`` prints ``flatness_db`` in the title and draws
+    ``|H*H_inv|`` on the axes below it, so before this guard a variant built
+    with ``dataclasses.replace`` titled the figure "flatness 6.00 dB" over a
+    curve that never left 0.00 dB.
+    """
+    res = signals.regularized_inverse_filter(_biquad_ir(), FS, f_range=(500.0, 8000.0))
+    with pytest.raises(ValueError, match=r"'flatness_db' must be the largest"):
+        dataclasses.replace(res, flatness_db=6.0)
+
+
+def test_flatness_must_follow_the_spectra_it_summarises() -> None:
+    """Restating a spectrum restates the flatness, or the pair is refused."""
+    res = signals.regularized_inverse_filter(_biquad_ir(), FS, f_range=(500.0, 8000.0))
+    band = np.flatnonzero((res.frequencies >= 500.0) & (res.frequencies <= 8000.0))
+    notched = res.response_spectrum.copy()
+    notched[band[0]] = 0.0  # a null the inversion cannot fill: |H*H_inv| = 0
+    with pytest.raises(ValueError, match=r"'flatness_db' must be the largest"):
+        dataclasses.replace(res, response_spectrum=notched)
+    # The same null with the flatness it implies is a reading, not a defect:
+    # infinitely far from 0 dB is what that band is, and it is accepted.
+    with_null = dataclasses.replace(res, response_spectrum=notched, flatness_db=np.inf)
+    assert with_null.flatness_db == np.inf
+
+
+def test_flatness_needs_a_band_to_be_worst_over() -> None:
+    """A band between two bins summarises nothing, and is refused."""
+    res = signals.regularized_inverse_filter(_biquad_ir(), FS, f_range=(500.0, 8000.0))
+    step = FS / res.size  # 46.875 Hz: no bin falls in (100, 101)
+    empty = (2.0 * step + 1.0, 3.0 * step - 1.0)
+    with pytest.raises(ValueError, match=r"'f_range' must select at least one bin"):
+        dataclasses.replace(res, f_range=empty)
+
+
+def test_max_gain_is_not_determined_by_the_stored_design() -> None:
+    """Two genuine designs agree in every stored field and differ in gain.
+
+    ``max_gain_db`` is the achieved gain outside the band *padded by*
+    ``transition_octaves``, and the padding is an argument the result does not
+    keep. On a 128-bin grid (375 Hz apart) with the band reaching Nyquist, a
+    one-octave padding puts the lower edge exactly on the first positive bin
+    and a half-octave padding puts it just above: the profile is the same
+    array either way, while that bin falls outside one maximum and inside the
+    other. Nothing computable from the stored fields separates ``-inf`` from
+    ``-6.13 dB`` here, which is why ``__post_init__`` claims nothing about it.
+    """
+    b, a = signal.butter(2, 300.0, btype="highpass", fs=FS)
+    imp = np.zeros(128)
+    imp[0] = 1.0
+    h = signal.lfilter(b, a, imp)
+    design = {"f_range": (750.0, FS / 2.0), "n_fft": 128}
+    wide = signals.regularized_inverse_filter(h, FS, transition_octaves=1.0, **design)
+    narrow = signals.regularized_inverse_filter(h, FS, transition_octaves=0.5, **design)
+    for field in (
+        "inverse",
+        "frequencies",
+        "spectrum",
+        "response_spectrum",
+        "regularization",
+    ):
+        assert np.array_equal(getattr(wide, field), getattr(narrow, field)), field
+    assert (wide.f_range, wide.delay, wide.fs) == (
+        narrow.f_range,
+        narrow.delay,
+        narrow.fs,
+    )
+    assert wide.flatness_db == narrow.flatness_db
+    assert wide.max_gain_db == -np.inf
+    assert narrow.max_gain_db == pytest.approx(-6.133314, abs=1e-6)
+
+
 def test_apply_rejects_non_1d() -> None:
     h = _biquad_ir()
     res = signals.regularized_inverse_filter(h, FS, f_range=(500.0, 8000.0))

--- a/tests/underwater/bioacoustics/test_weighting.py
+++ b/tests/underwater/bioacoustics/test_weighting.py
@@ -595,6 +595,153 @@ def test_an_exposure_row_that_does_not_run_over_the_bands_is_refused() -> None:
             dataclasses.replace(good, **{field: value})
 
 
+def test_a_peak_margin_that_contradicts_its_own_peak_level_is_refused() -> None:
+    """``peak_margin`` is the stored level less the stored criterion, or nothing.
+
+    Nothing downstream recomputes the subtraction, and both readers go the
+    wrong way round it: ``exceeds_injury`` is formed from the margin and never
+    looks at the level, and the guide prints the pair side by side. Before the
+    guard, raising the guide's own assessment from its 153.8 dB peak to 250 dB
+    -- 28 dB clear of the 222 dB auditory-injury criterion -- left the quiet
+    one's margin in place and printed ``peak_spl=250.0 peak_margin=-68.2
+    exceeds_injury=False``. Dropping the level to ``None`` printed a margin of
+    -68.2 dB for a peak that was not there.
+    """
+    good = weighted_exposure([1000.0], [100.0], "VHF", impulsive=True, peak_spl=210.0)
+    assert (good.peak_spl, good.peak_margin) == (210.0, 8.0)
+    cases: tuple[tuple[str, float | None], ...] = (
+        ("peak_spl", 150.0),
+        ("peak_spl", None),
+        ("peak_margin", None),
+        ("peak_margin", -8.0),
+    )
+    for field, value in cases:
+        with pytest.raises(ValueError, match=r"'peak_margin' must be 'peak_spl' minus"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_a_non_finite_peak_level_is_refused_at_construction() -> None:
+    """The entry point refuses a non-finite ``peak_spl``; so must a variant.
+
+    ``None`` is how an assessment says no peak was supplied, so a ``NaN`` is
+    never the undetermined state -- it is a level that failed to be measured,
+    and it reaches the margin as a subtraction that quietly answers ``NaN``.
+    """
+    good = weighted_exposure([1000.0], [100.0], "VHF", impulsive=True, peak_spl=210.0)
+    with pytest.raises(ValueError, match=r"'peak_spl' must be finite"):
+        dataclasses.replace(good, peak_spl=float("nan"))
+
+
+def test_the_tts_half_of_the_peak_metric_is_pinned_too() -> None:
+    """``tts_peak_margin`` is the same subtraction against the other criterion.
+
+    It has the provenance ``peak_margin`` has -- the stored level less a
+    stored criterion -- and ``exceeds_tts``, which the guide prints beside the
+    injury verdict, is formed from it and never looks at the level. Moving the
+    level and the injury margin together while leaving this one behind left a
+    200 dB peak carrying the 190 dB one's -6 dB of TTS headroom, 4 dB over the
+    196 dB TTS-onset criterion, and still reporting ``exceeds_tts=False``.
+    """
+    good = weighted_exposure([1000.0], [80.0], "VHF", impulsive=True, peak_spl=190.0)
+    assert (good.tts_peak_margin, good.exceeds_tts) == (-6.0, False)
+    named = r"'tts_peak_margin' must be 'peak_spl' minus"
+    with pytest.raises(ValueError, match=named):
+        dataclasses.replace(good, peak_spl=200.0, peak_margin=-2.0)
+    for value in (None, 0.0):
+        with pytest.raises(ValueError, match=named):
+            dataclasses.replace(good, tts_peak_margin=value)
+
+
+def test_the_peak_metric_may_be_restated_whole_or_left_out_whole() -> None:
+    """The guard pins the relations, not the presence of a peak metric.
+
+    A variant that moves the level with both its margins is the sanctioned way
+    to build one and must pass; so must an assessment with no peak at all, and
+    one whose guidance publishes no peak criteria to compare against (the
+    non-impulsive tables publish none).
+    """
+    good = weighted_exposure([1000.0], [100.0], "VHF", impulsive=True, peak_spl=210.0)
+    louder = dataclasses.replace(
+        good, peak_spl=250.0, peak_margin=48.0, tts_peak_margin=54.0
+    )
+    assert (louder.peak_margin, louder.tts_peak_margin) == (48.0, 54.0)
+    assert (louder.exceeds_injury, louder.exceeds_tts) == (True, True)
+    absent = dataclasses.replace(
+        good,
+        peak_spl=None,
+        peak_margin=None,
+        tts_peak_margin=None,
+        exceeds_injury=False,
+        exceeds_tts=False,
+    )
+    assert (absent.peak_spl, absent.peak_margin, absent.tts_peak_margin) == (
+        None,
+        None,
+        None,
+    )
+    flat = weighted_exposure([1000.0], [150.0], "LF", impulsive=False, peak_spl=250.0)
+    assert (flat.peak_margin, flat.tts_peak_margin) == (None, None)
+
+
+def test_a_total_that_does_not_sum_the_row_beside_it_is_refused() -> None:
+    """Every exposure total is an energy sum of a whole row, accumulation aside.
+
+    Nothing recomputes them: the figure draws the rows and prints the totals,
+    and the margins and both verdicts are formed from ``cumulative_sel``
+    alone. A variant that edits one row, one total or the event count it is
+    accumulated over therefore reports an exposure its own bands do not carry.
+    """
+    good = weighted_exposure([125.0, 250.0, 500.0, 1000.0], [180.0] * 4, "LF")
+    cases: tuple[tuple[str, object, str], ...] = (
+        ("weighted_band_sel", good.weighted_band_sel + 3.0, "weighted_band_sel"),
+        ("band_sel", good.band_sel - 3.0, "weighted_band_sel"),
+        ("unweighted_sel", 0.0, "unweighted_sel"),
+        ("weighted_sel", 0.0, "weighted_sel"),
+        ("cumulative_sel", good.cumulative_sel + 6.0, "cumulative_sel"),
+        ("n_events", 4, "cumulative_sel"),
+    )
+    for field, value, named in cases:
+        with pytest.raises(ValueError, match=rf"'{named}' must be"):
+            dataclasses.replace(good, **{field: value})
+
+
+def test_a_verdict_that_contradicts_its_own_margins_is_refused() -> None:
+    """The two verdicts are what the stored margins say, and the last link.
+
+    They are what an assessment is read for, and they are formed from the
+    margins and never from the levels. Before the guard, a result 28 dB over
+    the 202 dB auditory-injury peak criterion could be built reporting no
+    exceedance at all, every margin beside it still stating one.
+    """
+    over = weighted_exposure([1000.0], [100.0], "VHF", impulsive=True, peak_spl=230.0)
+    assert over.peak_margin == 28.0
+    assert (over.exceeds_injury, over.exceeds_tts) == (True, True)
+    for field in ("exceeds_injury", "exceeds_tts"):
+        with pytest.raises(ValueError, match=rf"'{field}' must be True exactly when"):
+            dataclasses.replace(over, **{field: False})
+
+
+def test_an_all_empty_spectrum_keeps_its_undetermined_totals() -> None:
+    """``band_sel`` admits ``-inf``, so the sums over it may be ``-inf`` too.
+
+    That licence is about being finite, and being finite is not what the
+    totals are held to: minus infinity less a finite criterion is minus
+    infinity, so an empty spectrum's totals restate its bands and its SEL
+    margins restate those totals exactly, and each is pinned to it like any
+    other. The peak metric is measured from the waveform, not from those
+    bands, so it stays a number.
+    """
+    with np.errstate(divide="ignore"):
+        res = weighted_exposure(
+            [100.0, 200.0], [-np.inf, -np.inf], "LF", peak_spl=200.0
+        )
+    assert (res.unweighted_sel, res.weighted_sel, res.cumulative_sel) == (-np.inf,) * 3
+    assert (res.sel_margin, res.tts_margin) == (-np.inf, -np.inf)
+    assert res.peak_margin == pytest.approx(-22.0, abs=1e-9)
+    with pytest.raises(ValueError, match=r"'cumulative_sel' must be 'weighted_sel'"):
+        dataclasses.replace(res, cumulative_sel=200.0)
+
+
 def test_plot_returns_axes() -> None:
     freqs = np.logspace(1.0, 5.5, 200)
     assert auditory_weighting(freqs, "VHF").plot() is not None

--- a/tests/underwater/bioacoustics/test_weighting.py
+++ b/tests/underwater/bioacoustics/test_weighting.py
@@ -735,7 +735,11 @@ def test_an_all_empty_spectrum_keeps_its_undetermined_totals() -> None:
         res = weighted_exposure(
             [100.0, 200.0], [-np.inf, -np.inf], "LF", peak_spl=200.0
         )
-    assert (res.unweighted_sel, res.weighted_sel, res.cumulative_sel) == (-np.inf,) * 3
+    assert (res.unweighted_sel, res.weighted_sel, res.cumulative_sel) == (
+        -np.inf,
+        -np.inf,
+        -np.inf,
+    )
     assert (res.sel_margin, res.tts_margin) == (-np.inf, -np.inf)
     assert res.peak_margin == pytest.approx(-22.0, abs=1e-9)
     with pytest.raises(ValueError, match=r"'cumulative_sel' must be 'weighted_sel'"):

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -7,6 +7,8 @@ is the exact energy sum, equal to SEL_ss + 10·lg(N) for identical strikes.
 
 from __future__ import annotations
 
+import dataclasses
+
 import matplotlib as mpl
 
 mpl.use("Agg")
@@ -91,6 +93,62 @@ def test_pile_strike_metrics_rejects_short_signal() -> None:
     too_short = np.array([1.0])
     with pytest.raises(ValueError, match="'pressure' must contain at least"):
         underwater.pile_strike_metrics(too_short, FS)
+
+
+def test_pile_strike_result_rejects_a_peak_level_its_trace_never_reached() -> None:
+    """``peak_spl`` is the peak of the stored trace, and the figure marks it there.
+
+    The waveform panel plots the sample at ``argmax(|pressure|)`` and labels
+    that marker with ``peak_spl``, so a level raised by 12 dB used to print
+    itself over the one sample that disproves it.
+    """
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    with pytest.raises(ValueError, match="'peak_spl' must be the zero-to-peak"):
+        dataclasses.replace(res, peak_spl=res.peak_spl + 12.0)
+
+
+def test_pile_strike_result_rejects_a_trace_the_peak_no_longer_summarises() -> None:
+    """Substituting the waveform without restating the peak is the same lie."""
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    halved = np.asarray(res.pressure) / 2.0
+    with pytest.raises(ValueError, match="'peak_spl' must be the zero-to-peak"):
+        dataclasses.replace(res, pressure=halved)
+
+
+def test_pile_strike_result_accepts_a_peak_recomputed_along_another_path() -> None:
+    """A variant that restates both halves is a legitimate result."""
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    halved = np.asarray(res.pressure) / 2.0
+    variant = dataclasses.replace(
+        res,
+        pressure=halved,
+        peak_spl=20.0 * np.log10(float(np.max(np.abs(halved))) / 1e-6),
+    )
+    assert variant.peak_spl == pytest.approx(res.peak_spl - 20.0 * np.log10(2.0))
+
+
+def test_pile_strike_result_rejects_an_empty_trace() -> None:
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    with pytest.raises(ValueError, match="'pressure' must carry at least one sample"):
+        dataclasses.replace(res, pressure=np.array([]))
+
+
+def test_pile_strike_result_accepts_a_silent_trace_peaking_at_minus_infinity() -> None:
+    """Zero pressure peaks at ``-inf`` dB, and ``-inf`` is what restates it.
+
+    The producer refuses a silent record outright, but the guard must not
+    answer an undetermined peak with a crash or a spurious contradiction: it
+    is the same neutral value ``band_sel`` carries for an empty band.
+    """
+    silent = underwater.PileStrikeResult(
+        single_strike_sel=-np.inf,
+        peak_spl=-np.inf,
+        spl=-np.inf,
+        pulse_duration=0.0,
+        pressure=np.zeros(16),
+        fs=float(FS),
+    )
+    assert silent.peak_spl == -np.inf
 
 
 # ---------------------------------------------------------------------------
@@ -226,3 +284,60 @@ def test_strike_sel_spectrum_plot_returns_axes() -> None:
     assert spec.plot() is not None
     assert spec.plot(language="es") is not None
     plt.close("all")
+
+
+def test_total_sel_rejects_a_column_it_no_longer_totals() -> None:
+    """A mitigated band column keeps the unmitigated total, and the plot draws it.
+
+    A bubble curtain taking 10 dB out of every band is substituted the
+    sanctioned way, through :func:`dataclasses.replace`. The figure rules its
+    dashed SEL_ss line at ``total_sel``, so the old total used to be drawn
+    17 dB above the loudest band in the column beneath it.
+    """
+    spec = underwater.strike_sel_spectrum(_pulse(50.0, 0.2), FS)
+    mitigated = np.asarray(spec.band_sel) - 10.0
+    with pytest.raises(ValueError, match="'total_sel' must be the energy sum"):
+        dataclasses.replace(spec, band_sel=mitigated)
+
+
+def test_total_sel_is_the_energy_sum_and_not_the_arithmetic_one() -> None:
+    """Adding the decibels themselves totals a strike at thousands of dB."""
+    spec = underwater.strike_sel_spectrum(_pulse(50.0, 0.2), FS)
+    bands = np.asarray(spec.band_sel)
+    arithmetic = float(np.sum(bands[np.isfinite(bands)]))
+    assert arithmetic > spec.total_sel + 1000.0
+    with pytest.raises(ValueError, match="'total_sel' must be the energy sum"):
+        dataclasses.replace(spec, total_sel=arithmetic)
+
+
+def test_total_sel_accepts_a_mitigated_column_restated() -> None:
+    """A uniform 10 dB attenuation moves the energy sum by exactly 10 dB."""
+    spec = underwater.strike_sel_spectrum(_pulse(50.0, 0.2), FS)
+    mitigated = np.asarray(spec.band_sel) - 10.0
+    variant = dataclasses.replace(
+        spec, band_sel=mitigated, total_sel=spec.total_sel - 10.0
+    )
+    assert variant.total_sel == pytest.approx(spec.total_sel - 10.0)
+
+
+def test_total_sel_admits_empty_bands_but_not_a_nan_one() -> None:
+    """``-inf`` is the level of zero exposure; nothing else non-finite is a level."""
+    spec = underwater.strike_sel_spectrum(_pulse(50.0, 0.2), FS)
+    assert np.any(np.isneginf(spec.band_sel))  # the guard passed them already
+    spoiled = np.asarray(spec.band_sel).copy()
+    spoiled[int(np.argmax(spoiled))] = np.nan
+    with pytest.raises(ValueError, match="'band_sel' must be finite, or -inf"):
+        dataclasses.replace(spec, band_sel=spoiled)
+
+
+def test_total_sel_of_an_all_empty_column_is_minus_infinity() -> None:
+    """Every band empty sums to ``-inf``, which is the truthful total over it."""
+    spectrum = underwater.StrikeSelSpectrum(
+        frequencies=np.array([100.0, 125.0, 160.0]),
+        band_sel=np.full(3, -np.inf),
+        total_sel=-np.inf,
+        broadband_sel=140.0,
+        fraction=3,
+        fs=float(FS),
+    )
+    assert spectrum.total_sel == -np.inf

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -115,16 +115,27 @@ def test_pile_strike_result_rejects_a_trace_the_peak_no_longer_summarises() -> N
         dataclasses.replace(res, pressure=halved)
 
 
-def test_pile_strike_result_accepts_a_peak_recomputed_along_another_path() -> None:
-    """A variant that restates both halves is a legitimate result."""
+def test_pile_strike_result_accepts_a_variant_that_restates_every_metric() -> None:
+    """A substituted waveform is legitimate once all four numbers follow it.
+
+    The peak is recomputed here along a path of its own rather than through
+    the library's, so the tolerance is exercised too: the two agree to the
+    last bit but need not, and a caller who reached the same level another way
+    must not be refused over it.
+    """
     res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
     halved = np.asarray(res.pressure) / 2.0
     variant = dataclasses.replace(
         res,
         pressure=halved,
         peak_spl=20.0 * np.log10(float(np.max(np.abs(halved))) / 1e-6),
+        single_strike_sel=underwater.sound_exposure_level(halved, FS),
+        spl=underwater.sound_pressure_level(halved),
     )
     assert variant.peak_spl == pytest.approx(res.peak_spl - 20.0 * np.log10(2.0))
+    assert variant.single_strike_sel == pytest.approx(
+        res.single_strike_sel - 20.0 * np.log10(2.0)
+    )
 
 
 def test_pile_strike_result_rejects_an_empty_trace() -> None:
@@ -358,3 +369,41 @@ def test_a_strike_whose_trace_is_a_bare_number_is_refused() -> None:
         ValueError, match=r"'pressure' must be a one-dimensional waveform"
     ):
         dataclasses.replace(res, pressure=lone)
+
+
+def test_restating_the_peak_alone_does_not_save_the_other_three() -> None:
+    """The dangerous half, because it looks like diligence.
+
+    Halve a trace and the peak level follows it down by six decibels, so a
+    caller who recomputes that one sees a result agreeing with itself where
+    they looked. The exposure and the pressure level beside it are still the
+    old trace's, six decibels high, and the marine-mammal dual-metric rule is
+    decided on the peak and the exposure together.
+    """
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    halved = np.asarray(res.pressure) / 2.0
+    with pytest.raises(ValueError, match=r"'single_strike_sel' must be the exposure"):
+        dataclasses.replace(
+            res,
+            pressure=halved,
+            peak_spl=underwater.peak_sound_pressure_level(halved),
+        )
+
+
+def test_a_pulse_duration_left_behind_by_a_new_shape_is_refused() -> None:
+    """The quiet one: a ratio of energies does not move when a trace is scaled.
+
+    Only a change of shape parts it from its waveform, which is why scaling
+    tests pass it over and it needs a guard of its own rather than being
+    excused by one. Here the other three are restated and it alone is stale.
+    """
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    reshaped = _pulse(100.0, 0.05)
+    with pytest.raises(ValueError, match=r"'pulse_duration' must be the 5 % to 95 %"):
+        dataclasses.replace(
+            res,
+            pressure=reshaped,
+            peak_spl=underwater.peak_sound_pressure_level(reshaped),
+            single_strike_sel=underwater.sound_exposure_level(reshaped, FS),
+            spl=underwater.sound_pressure_level(reshaped),
+        )

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -382,12 +382,9 @@ def test_restating_the_peak_alone_does_not_save_the_other_three() -> None:
     """
     res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
     halved = np.asarray(res.pressure) / 2.0
+    restated_peak = underwater.peak_sound_pressure_level(halved)
     with pytest.raises(ValueError, match=r"'single_strike_sel' must be the exposure"):
-        dataclasses.replace(
-            res,
-            pressure=halved,
-            peak_spl=underwater.peak_sound_pressure_level(halved),
-        )
+        dataclasses.replace(res, pressure=halved, peak_spl=restated_peak)
 
 
 def test_a_pulse_duration_left_behind_by_a_new_shape_is_refused() -> None:
@@ -399,11 +396,10 @@ def test_a_pulse_duration_left_behind_by_a_new_shape_is_refused() -> None:
     """
     res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
     reshaped = _pulse(100.0, 0.05)
+    restated = {
+        "peak_spl": underwater.peak_sound_pressure_level(reshaped),
+        "single_strike_sel": underwater.sound_exposure_level(reshaped, FS),
+        "spl": underwater.sound_pressure_level(reshaped),
+    }
     with pytest.raises(ValueError, match=r"'pulse_duration' must be the 5 % to 95 %"):
-        dataclasses.replace(
-            res,
-            pressure=reshaped,
-            peak_spl=underwater.peak_sound_pressure_level(reshaped),
-            single_strike_sel=underwater.sound_exposure_level(reshaped, FS),
-            spl=underwater.sound_pressure_level(reshaped),
-        )
+        dataclasses.replace(res, pressure=reshaped, **restated)

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -341,3 +341,20 @@ def test_total_sel_of_an_all_empty_column_is_minus_infinity() -> None:
         fs=float(FS),
     )
     assert spectrum.total_sel == -np.inf
+
+
+def test_a_strike_whose_trace_is_a_bare_number_is_refused() -> None:
+    """One sample is a trace; one number is not, and the peak check cannot tell.
+
+    The shared rank helper waives its pin when every field it was handed is a
+    bare number, an exemption written for the entry points that answer in
+    scalars. ``PileStrikeResult`` lists only ``pressure``, so a lone number
+    satisfied the whole set and walked past it, carrying a size of one and a
+    peak of its own that the comparison beside it was happy to confirm.
+    """
+    res = underwater.pile_strike_metrics(_pulse(100.0, 0.25), FS)
+    lone = np.float64(np.max(np.abs(res.pressure)))
+    with pytest.raises(
+        ValueError, match=r"'pressure' must be a one-dimensional waveform"
+    ):
+        dataclasses.replace(res, pressure=lone)


### PR DESCRIPTION
A result that carries a total beside the bands it was taken over is making a promise about them, and nothing checked it. A `dataclasses.replace` on a frozen result is the sanctioned way to build a variant, so the two could part on a public path.

## What the pages were doing

A rotorcraft event printed a maximum its own level history never reaches, with the marker still sitting at the true peak of the curve and the ten decibel window shaded from the stated maximum quietly gone. A ceiling attenuation boxed a sum of deficiencies its own column does not add up to. A weighted rating printed an unfavourable sum that no longer described the curve beside it. A time-varying loudness titled its chart `N = inf sone (120.0 phon)` over a trace peaking at 1.0.

## What is not a promise

Most of the work was deciding which scalars are summaries and which only look like one. Four are not, and stay unpinned:

- the source and noise levels of a sonar equation are the terms supplied to it, not a summary of the excess it produced
- the sound power of a steady field is what drives the field rather than something read off it
- the maximum frequency of a room mode enumeration is the cutoff it ran up to, not the largest frequency it found
- a correlation peak is derivable in principle but not from anything the result keeps

Pinning any of those would have invented a constraint the physics does not impose, so each is recorded with the producer line that settles it.

## Where the rule comes from a standard, it is the standard's

An energy sum where the quantity is energy, not an arithmetic one over decibels. The rounding step of ISO 717, ISO 11654 and ASTM E413 where those standards round before they sum, read from the text rather than assumed, because a rounding invented here would look right forever.

Where a total can legitimately be undetermined it still restates its bands: minus infinity less a finite criterion is minus infinity again, and two of those compare equal. What an undetermined total is excused from is being finite, which is a different demand and is not made here. That distinction had been written down backwards, and correcting it closed a whole chain that the false version had excused: the per-band rows, the three totals, all four margins and both verdicts of an underwater exposure now restate what they are formed from, in order of provenance so the message names the most specific cause.

## Review

Each class was decided by reading its producer, then an independent skeptic tried to refute the result from a scratch copy of the pre-change module. Five of fourteen came back refuted, none of them on the decision to pin and all of them on the execution, and the second pass fixed what they named:

- one guard refused output the producer legitimately emits, because a finite record can overflow inside the Hilbert transform and give an all-NaN envelope whose NaN mean is the honest, self-consistent pair
- one certified as closed a hole that was still open, so an infinite loudness reached the chart title
- one named the wrong field on an all-scalar result, raising an index error in place of the refusal its own documentation promises
- two carried explanations that were false beside guards that were correct, which is the failure that outlives the code, since nobody rereads the reasoning behind a guard that never fires

Full suite green: 10106 passed, 16 skipped.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistency checks across measurement, loudness, rating, noise, exposure, and signal-analysis results.
  * Invalid or contradictory derived values are now rejected with clear validation errors.
  * Improved handling of empty, silent, non-finite, and near-equal values.
  * Prevented reports and calculations from using stale or mismatched summary metrics.

* **Documentation**
  * Clarified definitions, calculation rules, window requirements, and edge-case behavior for loudness, ratings, attenuation, and absorption results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->