### PR TITLE
Gate the identity snapshot against the document it mirrors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -186,6 +186,18 @@ jobs:
         # twelve days it took to notice.
         run: pnpm run check:structured-data
         working-directory: site
+      - name: Check the identity snapshot against its canonical document
+        # The `#person` entity every page links its author to is fetched live
+        # at build time; the committed snapshot is only the fallback for a
+        # build with no network. Nothing read it, so it froze on the day it
+        # was added: by the time this step existed the canonical document had
+        # grown its Spanish half, and the snapshot was still publishing an
+        # English-only job title and description on a site that ships both
+        # locales. A stale fallback fails nothing, renders nothing wrong and
+        # is invisible in review, which is exactly why it needs a gate rather
+        # than a habit.
+        run: pnpm run identity:check
+        working-directory: site
       - name: Check every formula rendered
         # KaTeX does not fail a build on a parse error: it emits a
         # `katex-error` span and ships the page. A display block whose `$$`

--- a/site/identity/person.snapshot.json
+++ b/site/identity/person.snapshot.json
@@ -13,14 +13,43 @@
     "Jose Manuel Requena-Plens",
     "Jose Manuel Requena Plens"
   ],
-  "jobTitle": "R&D · Firmware & Software Engineer",
-  "description": "Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.",
+  "jobTitle": [
+    {
+      "@value": "R&D · Firmware & Software Engineer",
+      "@language": "en"
+    },
+    {
+      "@value": "I+D · Ingeniero de Firmware y Software",
+      "@language": "es"
+    }
+  ],
+  "description": [
+    {
+      "@value": "Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.",
+      "@language": "en"
+    },
+    {
+      "@value": "Ingeniero de firmware y software en Valencia — sistemas embebidos industriales, herramientas open source e infraestructura self-hosted.",
+      "@language": "es"
+    }
+  ],
+  "email": "mail@jmrp.io",
   "url": "https://jmrp.io/",
+  "mainEntityOfPage": "https://jmrp.io/about/",
+  "publishingPrinciples": "https://jmrp.io/about/#editorial",
   "image": {
     "@type": "ImageObject",
-    "url": "https://github.com/jmrplens.png",
-    "width": "460",
-    "height": "460"
+    "url": "https://jmrp.io/identity/avatar.png",
+    "width": {
+      "@type": "QuantitativeValue",
+      "value": 460,
+      "unitCode": "E37"
+    },
+    "height": {
+      "@type": "QuantitativeValue",
+      "value": 460,
+      "unitCode": "E37"
+    }
   },
   "alumniOf": [
     {
@@ -56,15 +85,49 @@
       }
     }
   ],
+  "hasOccupation": {
+    "@type": "Occupation",
+    "name": [
+      {
+        "@value": "Firmware & Software Engineer",
+        "@language": "en"
+      },
+      {
+        "@value": "Ingeniero de Firmware y Software",
+        "@language": "es"
+      }
+    ]
+  },
+  "knowsLanguage": [
+    {
+      "@type": "Language",
+      "name": "Spanish",
+      "alternateName": "es"
+    },
+    {
+      "@type": "Language",
+      "name": "English",
+      "alternateName": "en"
+    }
+  ],
+  "homeLocation": {
+    "@type": "Place",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Valencia",
+      "addressRegion": "Valencian Community",
+      "addressCountry": "ES"
+    }
+  },
   "knowsAbout": [
     {
       "@type": "Thing",
-      "name": "Embedded Systems",
+      "name": "embedded system",
       "@id": "http://www.wikidata.org/entity/Q193040"
     },
     {
       "@type": "Thing",
-      "name": "Firmware",
+      "name": "firmware",
       "@id": "http://www.wikidata.org/entity/Q104851"
     },
     {
@@ -84,22 +147,22 @@
     },
     {
       "@type": "Thing",
-      "name": "Cryptography",
+      "name": "cryptography",
       "@id": "http://www.wikidata.org/entity/Q8789"
     },
     {
       "@type": "Thing",
-      "name": "Network Security",
+      "name": "network security",
       "@id": "http://www.wikidata.org/entity/Q989632"
     },
     {
       "@type": "Thing",
-      "name": "Nginx",
+      "name": "nginx",
       "@id": "http://www.wikidata.org/entity/Q306144"
     },
     {
       "@type": "Thing",
-      "name": "MikroTik RouterOS",
+      "name": "RouterOS",
       "@id": "http://www.wikidata.org/entity/Q12036888"
     },
     {
@@ -114,12 +177,12 @@
     },
     {
       "@type": "Thing",
-      "name": "Acoustics",
+      "name": "acoustics",
       "@id": "http://www.wikidata.org/entity/Q82811"
     },
     {
       "@type": "Thing",
-      "name": "Signal Processing",
+      "name": "signal processing",
       "@id": "http://www.wikidata.org/entity/Q208163"
     },
     {
@@ -144,7 +207,7 @@
     },
     {
       "@type": "Thing",
-      "name": "Software Testing",
+      "name": "software testing",
       "@id": "http://www.wikidata.org/entity/Q188522"
     },
     {
@@ -173,6 +236,9 @@
       "@id": "https://github.com/jmrplens/TFG-TFM_EPS#software"
     },
     {
+      "@id": "https://github.com/jmrplens/portainer-mcp#software"
+    },
+    {
       "@id": "https://github.com/jmrplens/A-Lab#software"
     },
     {
@@ -186,14 +252,37 @@
     },
     {
       "@id": "https://github.com/jmrplens/FDTDexamples#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/CATT2Matlab#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/FFT2octave#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/getANSIfrequencies#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/dBFA2Matlab#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/MATLAB_Instruments#software"
+    },
+    {
+      "@id": "https://mcp.jmrp.io/gitlab#api"
+    },
+    {
+      "@id": "https://mcp.jmrp.io/libgen#api"
     }
   ],
-  "identifier": {
-    "@type": "PropertyValue",
-    "propertyID": "ORCID",
-    "value": "0000-0003-1250-6212",
-    "url": "https://orcid.org/0000-0003-1250-6212"
-  },
+  "identifier": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "ORCID",
+      "value": "0000-0003-1250-6212",
+      "url": "https://orcid.org/0000-0003-1250-6212"
+    }
+  ],
   "sameAs": [
     "https://github.com/jmrplens",
     "https://www.linkedin.com/in/jmrplens",
@@ -208,6 +297,7 @@
     "https://codeberg.org/jmrplens",
     "https://gitlab.com/jmrp",
     "https://pypi.org/user/jmrplens/",
-    "https://hub.docker.com/u/jmrplens"
+    "https://hub.docker.com/u/jmrplens",
+    "https://tangled.org/jmrp.io"
   ]
 }

--- a/site/identity/person.snapshot.json
+++ b/site/identity/person.snapshot.json
@@ -269,6 +269,9 @@
       "@id": "https://github.com/jmrplens/MATLAB_Instruments#software"
     },
     {
+      "@id": "https://github.com/jmrplens/picoScopeMATLAB#software"
+    },
+    {
       "@id": "https://mcp.jmrp.io/gitlab#api"
     },
     {

--- a/site/package.json
+++ b/site/package.json
@@ -16,6 +16,7 @@
     "dev": "astro dev",
     "html-validate": "html-validate 'dist/**/*.html'",
     "icons:sheet": "node scripts/icon-sheet.mjs",
+    "identity:check": "node scripts/sync-identity.mjs --check",
     "identity:sync": "node scripts/sync-identity.mjs",
     "lighthouse": "node scripts/lighthouse-audit.mjs",
     "pa11y": "node scripts/with-preview.mjs -- ./node_modules/.bin/pa11y-ci",


### PR DESCRIPTION
Every page links its author to the canonical `#person` entity, which the build fetches live; the committed snapshot is only the fallback for a build with no network. Nothing ever read that file, so it froze on the day it was added.

It had been stale long enough to matter. The canonical document has since grown a Spanish half, and the snapshot was still carrying an English-only job title and description on a site that ships both locales. A build without a network would have published that, and nothing here would have said so: a stale fallback fails no test, renders nothing wrong, and looks identical in review to a fresh one.

The check already existed behind a `--check` flag on the sync script and nothing called it. It is now `identity:check` in the site package and a step in the site job, matching how the same snapshot is gated in cs-routeros-bouncer.

## Proof

Run against the refreshed snapshot it prints `Identity snapshot matches the canonical document`; with one field edited it exits 1 with `identity/person.snapshot.json is stale`. I proved that locally rather than by pushing a deliberately red commit, so what CI confirms here is that the step runs and passes, not that it fails when it should.

## One limitation worth knowing

The site job runs on pull requests under a path filter, so this catches a stale snapshot only on a pull request that already touches `site/` or `docs/`. The snapshot goes stale when the *upstream* document changes, which is unrelated to anything happening in this repository, so a stretch with no site work leaves it unguarded. Closing that needs a scheduled run rather than a pull-request gate; I have not added one here because it is a separate decision about how often to spend a job on it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Prevent stale identity fallback data by validating the committed snapshot against its canonical document during site checks.

Enhancements:
- Add a site validation command that verifies the committed identity snapshot matches the canonical person document.
- Run the identity snapshot validation in the documentation workflow to prevent stale fallback identity data from being merged.

CI:
- Gate the site job on identity snapshot consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation builds now verify that the published identity information matches its canonical source.
  * Builds will flag outdated identity content before documentation is released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->