### PR TITLE
Make a refusal test pin the refusal it is named for (1 of 3)

### DIFF
--- a/tests/aircraft/test_aircraft_atmospheric_absorption.py
+++ b/tests/aircraft/test_aircraft_atmospheric_absorption.py
@@ -102,9 +102,9 @@ def test_large_attenuation_no_nan_or_warning() -> None:
 
 
 def test_invalid_inputs_rejected() -> None:
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be strictly positive"):
         sae_band_attenuation([-1.0], 100.0)
-    with pytest.raises(ValueError, match="path_length"):
+    with pytest.raises(ValueError, match=r"'path_length' must be non-negative"):
         sae_band_attenuation([1000.0], -5.0)
 
 
@@ -115,13 +115,13 @@ def test_per_band_arrays_must_agree() -> None:
     # band of that spectrum. The other three stop the figure instead.
     res = sae_band_attenuation([500.0, 1000.0, 2000.0, 4000.0], 1000.0)
     collapsed = res.coefficient[:1]
-    with pytest.raises(ValueError, match="'coefficient'"):
+    with pytest.raises(ValueError, match=r"'coefficient' \(1\)"):
         replace(res, coefficient=collapsed)
     scalar = float(res.coefficient[0])
-    with pytest.raises(ValueError, match="'coefficient'"):
+    with pytest.raises(ValueError, match=r"'coefficient' must have one axis"):
         replace(res, coefficient=scalar)
     short = res.band_attenuation[:-1]
-    with pytest.raises(ValueError, match="'band_attenuation'"):
+    with pytest.raises(ValueError, match=r"'band_attenuation' \(3\)"):
         replace(res, band_attenuation=short)
 
 

--- a/tests/aircraft/test_airport_noise.py
+++ b/tests/aircraft/test_airport_noise.py
@@ -112,11 +112,11 @@ def test_npd_curve_levels_are_pinned_to_their_own_distances() -> None:
 
 
 def test_invalid_table_rejected() -> None:
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'levels' must have shape"):
         npd_level(_P, _D, [[100.0, 94.0]], 1000.0, 200.0)  # wrong levels shape
-    with pytest.raises(ValueError, match="increasing"):
+    with pytest.raises(ValueError, match=r"'powers' must be strictly increasing"):
         npd_level([2000.0, 1000.0], _D, _L[::-1], 1500.0, 200.0)
-    with pytest.raises(ValueError, match="distance"):
+    with pytest.raises(ValueError, match=r"'distance' must be finite and strictly"):
         npd_level(_P, _D, _L, 1000.0, -100.0)
 
 
@@ -184,7 +184,7 @@ def test_impedance_adjustment() -> None:
     assert impedance_adjustment(15.0, 101.325) == pytest.approx(0.074, abs=5e-4)
     # Hotter, lower-pressure air is less dense: negative adjustment.
     assert impedance_adjustment(35.0, 95.0) < 0.0
-    with pytest.raises(ValueError, match="pressure"):
+    with pytest.raises(ValueError, match=r"'pressure' must be positive"):
         impedance_adjustment(15.0, 0.0)
 
 
@@ -418,9 +418,9 @@ def test_start_of_roll_directivity_properties() -> None:
     assert start_of_roll_directivity(120.0, 300.0, "prop") == pytest.approx(
         start_of_roll_directivity(120.0, 300.0, "turboprop")
     )
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"'engine' must be"):
         start_of_roll_directivity(120.0, 300.0, "rocket")
-    with pytest.raises(ValueError, match="distance_m"):
+    with pytest.raises(ValueError, match=r"'distance_m' must be positive"):
         start_of_roll_directivity(120.0, -1.0, "jet")
 
 
@@ -463,7 +463,9 @@ def test_event_level_ground_roll_applies_directivity() -> None:
     expected_delta = _dc(vref, 0.5 * (40.0 + 60.0)) - _dc(vref, 60.0)
     assert flagged_ahead - plain_ahead == pytest.approx(expected_delta, abs=1e-9)
     mismatched_roll = FlightSegmentState(ground_roll=[True, False])
-    with pytest.raises(ValueError, match="ground_roll"):
+    with pytest.raises(
+        ValueError, match=r"'ground_roll' must have length \d+ \(one per segment\)"
+    ):
         event_level(path, obs, _NP, _ND, _NSEL, _NMAX, segments=mismatched_roll)
     # The directivity is also applied on the maximum metric (Eq. 4-9a) and with
     # a propeller mounting (turboprop ΔSOR curve).
@@ -655,19 +657,19 @@ def test_noise_contour_metric_outside_the_two_the_type_states_is_refused() -> No
 
 
 def test_event_level_invalid_inputs() -> None:
-    with pytest.raises(ValueError, match="path"):
+    with pytest.raises(ValueError, match=r"'path' must have shape"):
         event_level(
             [[0.0, 0.0, 0.0, 1.0, 1.0]], [0.0, 0.0, 0.0], _NP, _ND, _NSEL, _NMAX
         )
     good = [[0.0, 0.0, 300.0, 10000.0, _VREF], [1000.0, 0.0, 300.0, 10000.0, _VREF]]
-    with pytest.raises(ValueError, match="metric"):
+    with pytest.raises(ValueError, match=r"'metric' must be 'exposure'"):
         event_level(good, [0.0, 100.0, 0.0], _NP, _ND, _NSEL, _NMAX, metric="Lden")
-    with pytest.raises(ValueError, match="lateral_m"):
+    with pytest.raises(ValueError, match=r"'lateral_m' must be non-negative"):
         lateral_attenuation(30.0, -1.0)
-    with pytest.raises(ValueError, match="mounting"):
+    with pytest.raises(ValueError, match=r"'mounting' must be"):
         engine_installation_correction(20.0, "tail")
-    # Non-finite path, negative power and non-positive speed are rejected.
-    with pytest.raises(ValueError, match="finite"):
+    # Non-finite path, negative power and zero mean speed are rejected.
+    with pytest.raises(ValueError, match=r"'path' must contain only finite"):
         event_level(
             [[0.0, 0.0, np.inf, 1e4, _VREF], good[1]],
             [0.0, 100.0, 0.0],
@@ -676,7 +678,9 @@ def test_event_level_invalid_inputs() -> None:
             _NSEL,
             _NMAX,
         )
-    with pytest.raises(ValueError, match="power"):
+    with pytest.raises(
+        ValueError, match=r"'path' power settings .*must be non-negative"
+    ):
         event_level(
             [[0.0, 0.0, 300.0, -1.0, _VREF], good[1]],
             [0.0, 100.0, 0.0],
@@ -685,7 +689,9 @@ def test_event_level_invalid_inputs() -> None:
             _NSEL,
             _NMAX,
         )
-    with pytest.raises(ValueError, match="speed"):
+    with pytest.raises(
+        ValueError, match=r"zero mean speed \(stationary segment in 'path'\)"
+    ):
         event_level(
             [[0.0, 0.0, 300.0, 1e4, 0.0], good[1]],
             [0.0, 100.0, 0.0],
@@ -699,7 +705,7 @@ def test_event_level_invalid_inputs() -> None:
 def test_impedance_adjustment_rejects_absolute_zero() -> None:
     from phonometry.aircraft.airport_noise import impedance_adjustment
 
-    with pytest.raises(ValueError, match="absolute zero"):
+    with pytest.raises(ValueError, match=r"'temperature' must be above absolute zero"):
         impedance_adjustment(-300.0, 101.325)
 
 
@@ -826,7 +832,9 @@ def test_bank_angle_side_asymmetry() -> None:
     assert port != pytest.approx(stbd)
     assert same_p == pytest.approx(same_s)
     mismatched_bank = FlightSegmentState(bank=[1.0, 2.0])
-    with pytest.raises(ValueError, match="bank"):
+    with pytest.raises(
+        ValueError, match=r"'bank' must have length \d+ \(one per segment\)"
+    ):
         event_level(
             path, [0.0, 500.0, 0.0], _NP, _ND, _NSEL, _NMAX, segments=mismatched_bank
         )
@@ -919,7 +927,9 @@ def test_noise_contour_accepts_bank() -> None:
     assert banked.level[0, 0] != pytest.approx(banked.level[1, 0])
     assert level.level[0, 0] == pytest.approx(level.level[1, 0])
     mismatched_bank = FlightSegmentState(bank=[1.0, 2.0])
-    with pytest.raises(ValueError, match="bank"):
+    with pytest.raises(
+        ValueError, match=r"'bank' must have length \d+ \(one per segment\)"
+    ):
         noise_contour(path, _NP, _ND, _NSEL, _NMAX, segments=mismatched_bank, **kw)
 
 

--- a/tests/aircraft/test_anp_fleet.py
+++ b/tests/aircraft/test_anp_fleet.py
@@ -93,7 +93,11 @@ def test_modern_aircraft_has_npd_but_no_fixed_point_profile() -> None:
     """A320-211 ships only procedural steps: NPD loads, the profile guard fires."""
     curves = _DB.npd_curves("A320-211", "departure", "SEL")
     assert curves.levels.shape[1] == 10
-    with pytest.raises(KeyError, match="procedural-step"):
+    with pytest.raises(
+        KeyError,
+        match=r"no fixed-point profile for aircraft 'A320-211'.*"
+        r"only procedural-step profiles",
+    ):
         _DB.profile("A320-211", "departure")
 
 
@@ -157,9 +161,9 @@ def test_external_directory_load(tmp_path: object) -> None:
 def test_error_paths() -> None:
     with pytest.raises(KeyError):
         _DB.aircraft("NOPE")
-    with pytest.raises(ValueError, match="metric"):
+    with pytest.raises(ValueError, match=r"'metric' must be one of"):
         _DB.npd_curves("747100", "departure", "EPNL")
-    with pytest.raises(ValueError, match="operation"):
+    with pytest.raises(ValueError, match=r"'operation' must be 'departure'"):
         _DB.npd_curves("747100", "sideways", "SEL")
     with pytest.raises(KeyError):
         _DB.profile("PA31", "departure", stage_length=9)
@@ -185,7 +189,9 @@ def test_npd_curves_reject_level_table_short_of_its_powers() -> None:
     """A level table one power row short cannot be built into a curve set."""
     curves = _DB.npd_curves("747100", "departure", "SEL")
     short = curves.levels[:-1]
-    with pytest.raises(ValueError, match="'levels'"):
+    with pytest.raises(
+        ValueError, match=r"'levels'.*must each carry one value per power setting"
+    ):
         dataclasses.replace(curves, levels=short)
 
 
@@ -209,7 +215,9 @@ def test_profile_rejects_roll_mask_missing_a_segment() -> None:
     """The roll masks are per segment, so one entry short is not a profile."""
     prof = _DB.profile("747100", "departure")
     short = prof.ground_roll[:-1]
-    with pytest.raises(ValueError, match="'ground_roll'"):
+    with pytest.raises(
+        ValueError, match=r"'ground_roll'.*must each carry one value per segment"
+    ):
         dataclasses.replace(prof, ground_roll=short)
 
 
@@ -283,7 +291,7 @@ def test_pick_ambiguous_table_raises(tmp_path: object) -> None:
     (root / "Default_fixed_point_profiles.csv").write_text(
         src.joinpath("Default_fixed_point_profiles.csv").read_text()
     )
-    with pytest.raises(ValueError, match="ambiguous"):
+    with pytest.raises(ValueError, match=r"ambiguous ANP table for 'aircraft'"):
         load_anp_database(root)
 
 
@@ -336,7 +344,7 @@ def test_plot_smoke_en_es() -> None:
     prof = _DB.profile("747100", "departure")
     ax2 = prof.plot(language="es")
     assert ax2.get_xlabel().startswith("Distancia")
-    with pytest.raises(ValueError, match="Unknown language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         npd.plot(language="xx")
     plt.close("all")
 
@@ -462,13 +470,19 @@ def test_ambiguous_profiles_without_default_raise(tmp_path: object) -> None:
     assert (
         db.profile("747100", "departure", 1, profile_id="LIGHT").profile_id == "LIGHT"
     )
-    with pytest.raises(KeyError, match="available profiles"):
+    with pytest.raises(
+        KeyError, match=r"no fixed-point profile 'NOPE' for aircraft '747100'"
+    ):
         db.profile("747100", "departure", 1, profile_id="NOPE")
 
 
 def test_duplicate_point_numbers_raise(tmp_path: object) -> None:
     """A malformed table with duplicate point numbers errors instead of merging."""
-    with pytest.raises(ValueError, match="point numbers"):
+    with pytest.raises(
+        ValueError,
+        match=r"fixed-point profile for aircraft '747100'.*"
+        r"duplicate or non-consecutive point numbers",
+    ):
         _synthetic_db(
             tmp_path,
             [

--- a/tests/aircraft/test_certification.py
+++ b/tests/aircraft/test_certification.py
@@ -298,7 +298,7 @@ def test_helicopter_procedure_catches_low_frequency_rotor_tone() -> None:
 
 def test_effective_perceived_noise_level_rejects_bad_procedure() -> None:
     spectra = np.zeros((5, 24))
-    with pytest.raises(ValueError, match="procedure"):
+    with pytest.raises(ValueError, match=r"Unknown procedure"):
         effective_perceived_noise_level(spectra, procedure="rocket")
 
 
@@ -393,7 +393,7 @@ def test_a_tone_correction_off_the_record_axis_is_refused(trim: bool) -> None:
     result = _flyover()
     values = np.asarray(result.tone_correction)
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match="'tone_correction'"):
+    with pytest.raises(ValueError, match=rf"'tone_correction' \({wrong.size}\)"):
         dataclasses.replace(result, tone_correction=wrong)
 
 
@@ -407,7 +407,7 @@ def test_a_drawn_history_off_the_record_axis_is_refused() -> None:
 
     result = _flyover()
     one_short = np.asarray(result.pnlt)[:-1]
-    with pytest.raises(ValueError, match="'pnlt'"):
+    with pytest.raises(ValueError, match=rf"'pnlt' \({one_short.size}\)"):
         dataclasses.replace(result, pnlt=one_short)
 
 

--- a/tests/aircraft/test_epnl_report.py
+++ b/tests/aircraft/test_epnl_report.py
@@ -57,7 +57,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _flyover()  # constructed outside pytest.raises (Sonar S5778)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -166,5 +166,5 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _flyover()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -89,7 +89,7 @@ def test_spherical_spreading_matches_inverse_square() -> None:
     assert spherical_spreading_adjustment(60.0) == pytest.approx(0.0)
     assert spherical_spreading_adjustment(600.0) == pytest.approx(-20.0)
     assert spherical_spreading_adjustment(120.0) == pytest.approx(-20.0 * np.log10(2.0))
-    with pytest.raises(ValueError, match="distance"):
+    with pytest.raises(ValueError, match=r"'distance' must be positive"):
         spherical_spreading_adjustment(0.0)
 
 
@@ -160,9 +160,9 @@ def test_ground_effect_class_letters_and_values_agree() -> None:
 
 
 def test_ground_effect_invalid_inputs() -> None:
-    with pytest.raises(ValueError, match="horizontal_distance"):
+    with pytest.raises(ValueError, match=r"'horizontal_distance' must be positive"):
         ground_effect_adjustment([500.0], 100.0, 1.5, 0.0)
-    with pytest.raises(ValueError, match="flow_resistivity"):
+    with pytest.raises(ValueError, match=r"'flow_resistivity' class must be one of"):
         ground_effect_adjustment([500.0], 100.0, 1.5, 300.0, flow_resistivity="Z")
 
 
@@ -1009,32 +1009,34 @@ def test_hover_derived_approach2_measured_offset() -> None:
 def test_hover_helpers_validation() -> None:
     freqs = [500.0, 1000.0]
     ring = _ring(np.full(12, 80.0))
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be strictly positive"):
         hover_ring_hemisphere([500.0, 0.0], _RING_BEARINGS, ring)
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be strictly positive"):
         hover_ring_hemisphere([500.0, -1000.0], _RING_BEARINGS, ring)
-    with pytest.raises(ValueError, match="bearings"):
+    with pytest.raises(ValueError, match=r"'bearings' must be 1-D"):
         hover_ring_hemisphere(freqs, [0.0], [[80.0, 80.0]])
-    with pytest.raises(ValueError, match="bearings"):
+    with pytest.raises(
+        ValueError, match=r"'bearings' must be finite and strictly increasing"
+    ):
         hover_ring_hemisphere(freqs, _RING_BEARINGS[::-1], ring)
-    with pytest.raises(ValueError, match="bearings"):
+    with pytest.raises(ValueError, match=r"'bearings' must lie within"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS + 200.0, ring)
-    with pytest.raises(ValueError, match="levels"):
+    with pytest.raises(ValueError, match=r"'levels' must have shape"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS, ring[:, :1])
-    with pytest.raises(ValueError, match="levels"):
+    with pytest.raises(ValueError, match=r"'levels' must be finite"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS, np.where(ring > 0.0, np.nan, ring))
-    with pytest.raises(ValueError, match="distance"):
+    with pytest.raises(ValueError, match=r"'distance' must be positive"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS, ring, distance=0.0)
-    with pytest.raises(ValueError, match="azimuth_step"):
+    with pytest.raises(ValueError, match=r"'azimuth_step' must divide"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS, ring, azimuth_step=7.0)
-    with pytest.raises(ValueError, match="polar_step"):
+    with pytest.raises(ValueError, match=r"'polar_step' must divide"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS, ring, polar_step=1000.0)
-    with pytest.raises(ValueError, match="mapping"):
+    with pytest.raises(ValueError, match=r"'mapping' must be one of"):
         hover_ring_hemisphere(freqs, _RING_BEARINGS, ring, mapping="nearest")
     h = hover_ring_hemisphere(freqs, _RING_BEARINGS, ring)
-    with pytest.raises(ValueError, match="condition"):
+    with pytest.raises(ValueError, match=r"'condition' must be one of"):
         hover_derived_hemisphere(h, "hover")
-    with pytest.raises(ValueError, match="offset_db"):
+    with pytest.raises(ValueError, match=r"'offset_db' must be finite"):
         hover_derived_hemisphere(h, "full_rpm_idle", offset_db=float("nan"))
 
 
@@ -1147,13 +1149,15 @@ def test_fc_weights_validation() -> None:
         flight_condition_weights([50.0, 60.0], [0.0], 55.0, 0.0)
     with pytest.raises(ValueError, match=r"'airspeeds'.*non-empty"):
         flight_condition_weights([[50.0, 60.0]], [[0.0, 1.0]], 55.0, 0.0)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'airspeed' and 'path_angle' must be finite"):
         flight_condition_weights([50.0, 60.0], [0.0, 0.0], np.nan, 0.0)
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'triangles' must have shape"):
         flight_condition_weights(
             [50.0, 60.0, 70.0], [0.0, 1.0, 2.0], 55.0, 0.0, triangles=[[0, 1]]
         )
-    with pytest.raises(ValueError, match="indices"):
+    with pytest.raises(
+        ValueError, match=r"'triangles' indices must address the database conditions"
+    ):
         flight_condition_weights(
             [50.0, 60.0, 70.0], [0.0, 1.0, 2.0], 55.0, 0.0, triangles=[[0, 1, 9]]
         )
@@ -1176,9 +1180,12 @@ def test_interpolated_source_level_hand_checked_blend() -> None:
 def test_interpolated_source_level_validates_band_grids() -> None:
     hems = [_uniform_hemisphere(100.0), _uniform_hemisphere(90.0, [63.0])]
     single = [_uniform_hemisphere(100.0)]
-    with pytest.raises(ValueError, match="band grid"):
+    with pytest.raises(ValueError, match=r"All hemispheres must share one band grid"):
         interpolated_source_level(hems, [50.0, 70.0], [0.0, 0.0], 60.0, 0.0, 0.0, 90.0)
-    with pytest.raises(ValueError, match="equal length"):
+    with pytest.raises(
+        ValueError,
+        match=r"'hemispheres' and the flight conditions must have equal length",
+    ):
         interpolated_source_level(
             single, [50.0, 70.0], [0.0, 0.0], 60.0, 0.0, 0.0, 90.0
         )
@@ -1265,11 +1272,11 @@ def test_kinematics_hover_is_finite() -> None:
 
 
 def test_kinematics_validation() -> None:
-    with pytest.raises(ValueError, match="strictly increasing"):
+    with pytest.raises(ValueError, match=r"'times' must be strictly increasing"):
         flight_path_kinematics([0.0, 0.0], [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'positions' must have shape"):
         flight_path_kinematics([0.0, 1.0], [[0.0, 0.0], [1.0, 0.0]])
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(ValueError, match=r"'times'.*at least two"):
         flight_path_kinematics([0.0], [[0.0, 0.0, 0.0]])
 
 
@@ -1452,10 +1459,10 @@ def test_event_validation() -> None:
     hems = [_uniform_hemisphere(100.0)]
     t = np.array([0.0, 1.0])
     pos = np.array([[0.0, -50.0, 100.0], [0.0, 50.0, 100.0]])
-    with pytest.raises(ValueError, match="receiver"):
+    with pytest.raises(ValueError, match=r"'receiver' must be a finite"):
         rotorcraft_event_level(hems, [50.0], [0.0], t, pos, (0.0, 0.0, 0.0, 0.0))
     unknown_method_atmosphere = RotorcraftAtmosphere(atmospheric_method="exact")
-    with pytest.raises(ValueError, match="atmospheric_method"):
+    with pytest.raises(ValueError, match=r"'atmospheric_method' must be one of"):
         rotorcraft_event_level(
             hems,
             [50.0],
@@ -1466,7 +1473,9 @@ def test_event_validation() -> None:
             atmosphere=unknown_method_atmosphere,
         )
     mismatched_airspeed_state = RotorcraftTrackState(airspeed=[50.0, 50.0, 50.0])
-    with pytest.raises(ValueError, match="airspeed"):
+    with pytest.raises(
+        ValueError, match=r"'airspeed' must be a scalar or match the track length"
+    ):
         rotorcraft_event_level(
             hems,
             [50.0],
@@ -1476,12 +1485,14 @@ def test_event_validation() -> None:
             (0.0, 0.0),
             track_state=mismatched_airspeed_state,
         )
-    with pytest.raises(ValueError, match="level_offset"):
+    with pytest.raises(
+        ValueError, match=r"'level_offset' must be a scalar or match the track length"
+    ):
         rotorcraft_event_level(
             hems, [50.0], [0.0], t, pos, (0.0, 0.0), level_offset=[1.0, 2.0, 3.0]
         )
     nan_elevation_ground = RotorcraftGround(ground_elevation=np.nan)
-    with pytest.raises(ValueError, match="ground_elevation"):
+    with pytest.raises(ValueError, match=r"'ground_elevation' must be finite"):
         rotorcraft_event_level(
             hems, [50.0], [0.0], t, pos, (0.0, 0.0), ground=nan_elevation_ground
         )
@@ -1622,11 +1633,11 @@ def test_contour_is_symmetric_across_the_track() -> None:
 
 def test_contour_validation() -> None:
     hems, spd, ang, t, pos = _contour_inputs()
-    with pytest.raises(ValueError, match="metric"):
+    with pytest.raises(ValueError, match=r"'metric' must be one of"):
         rotorcraft_noise_contour(
             hems, spd, ang, t, pos, x=[0.0, 1.0], y=[0.0, 1.0], metric="epnl"
         )
-    with pytest.raises(ValueError, match="grid"):
+    with pytest.raises(ValueError, match=r"'x' and 'y' must each be finite"):
         rotorcraft_noise_contour(hems, spd, ang, t, pos, x=[0.0], y=[0.0, 1.0])
 
 

--- a/tests/aircraft/test_rotorcraft_terrain.py
+++ b/tests/aircraft/test_rotorcraft_terrain.py
@@ -63,9 +63,11 @@ def test_mean_ground_plane_equivalent_height_is_orthogonal() -> None:
 
 
 def test_mean_ground_plane_validation_and_plot() -> None:
-    with pytest.raises(ValueError, match="strictly increasing"):
+    with pytest.raises(ValueError, match=r"'distances' must be strictly increasing"):
         aircraft.mean_ground_plane([0.0, 0.0], [1.0, 2.0])
-    with pytest.raises(ValueError, match="equal size"):
+    with pytest.raises(
+        ValueError, match=r"'distances' and 'heights' must be 1-D of equal size"
+    ):
         aircraft.mean_ground_plane([0.0, 1.0, 2.0], [1.0, 2.0])
     assert (
         aircraft.mean_ground_plane([0.0, 30.0, 100.0], [2.0, 8.0, 3.0]).plot()
@@ -236,7 +238,7 @@ def test_screening_per_segment_resistivity_uses_log_mean() -> None:
 
 def test_screening_validation_and_plot() -> None:
     f = [500.0]
-    with pytest.raises(ValueError, match="cover"):
+    with pytest.raises(ValueError, match=r"The terrain section must cover"):
         aircraft.terrain_screening_adjustment(
             f, (-10.0, 5.0), (100.0, 1.2), [0.0, 100.0], [0.0, 0.0]
         )
@@ -382,7 +384,10 @@ def test_event_and_contour_array_argument_validation() -> None:
     elevation_with_dem_ground = aircraft.RotorcraftGround(
         terrain=dem, ground_elevation=np.zeros(4)
     )
-    with pytest.raises(ValueError, match="scalar"):
+    with pytest.raises(
+        ValueError,
+        match=r"A single receiver takes scalar 'flow_resistivity' and 'ground_elevation'",
+    ):
         aircraft.rotorcraft_event_level(
             hems, spd, ang, t, pos, (0.0, 0.0), ground=vector_sigma_ground
         )
@@ -408,11 +413,15 @@ def test_event_and_contour_array_argument_validation() -> None:
             y=[0.0, 100.0],
             ground=mismatched_elevation_ground,
         )
-    with pytest.raises(ValueError, match="elevation model"):
+    with pytest.raises(
+        ValueError, match=r"'terrain' must be an \(x, y, z\) elevation model"
+    ):
         aircraft.rotorcraft_event_level(
             hems, spd, ang, t, pos, (0.0, 0.0), ground=incomplete_dem_ground
         )
-    with pytest.raises(ValueError, match="strictly increasing"):
+    with pytest.raises(
+        ValueError, match=r"'terrain' x and y must be strictly increasing"
+    ):
         aircraft.rotorcraft_event_level(
             hems, spd, ang, t, pos, (0.0, 0.0), ground=reversed_dem_ground
         )
@@ -420,7 +429,10 @@ def test_event_and_contour_array_argument_validation() -> None:
         aircraft.rotorcraft_event_level(
             hems, spd, ang, t, pos, (0.0, 0.0), ground=short_sigma_map_ground
         )
-    with pytest.raises(ValueError, match="left scalar"):
+    with pytest.raises(
+        ValueError,
+        match=r"'ground_elevation' comes from the elevation model and must be left scalar",
+    ):
         aircraft.rotorcraft_noise_contour(
             hems,
             spd,

--- a/tests/building/measurement/test_building_uncertainty.py
+++ b/tests/building/measurement/test_building_uncertainty.py
@@ -150,7 +150,9 @@ def test_table4_impact_every_band(situation: str, col: int) -> None:
 
 
 def test_impact_has_no_situation_a() -> None:
-    with pytest.raises(ValueError, match="not tabulated"):
+    with pytest.raises(
+        ValueError, match=r"Situation 'A' is not tabulated for measurand 'impact'"
+    ):
         band_uncertainty("impact", "A")
 
 
@@ -191,7 +193,9 @@ def test_table6_reduction_every_band() -> None:
 
 @pytest.mark.parametrize("situation", ["B", "C"])
 def test_reduction_only_situation_a(situation: str) -> None:
-    with pytest.raises(ValueError, match="not tabulated"):
+    with pytest.raises(
+        ValueError, match=r"is not tabulated for measurand 'impact_reduction'"
+    ):
         band_uncertainty("impact_reduction", situation)
 
 
@@ -232,7 +236,9 @@ def test_tabled1_sigma_r95_bands() -> None:
 
 
 def test_sigma_r95_only_airborne() -> None:
-    with pytest.raises(ValueError, match="σR95"):
+    with pytest.raises(
+        ValueError, match=r"No σR95 upper limit tabulated for measurand 'impact'"
+    ):
         band_uncertainty("impact", "B", upper_limit=True)
 
 
@@ -327,7 +333,7 @@ def test_table7_delta_lw() -> None:
 
 @pytest.mark.parametrize("situation", ["B", "C"])
 def test_delta_lw_only_situation_a(situation: str) -> None:
-    with pytest.raises(ValueError, match="not tabulated"):
+    with pytest.raises(ValueError, match=r"is not tabulated for descriptor 'delta_lw'"):
         single_number_uncertainty("delta_lw", situation)
 
 
@@ -360,7 +366,7 @@ def test_sigma_r95_single_number_requires_situation_a() -> None:
 
 
 def test_sigma_r95_single_number_impact_absent() -> None:
-    with pytest.raises(ValueError, match="No σR95"):
+    with pytest.raises(ValueError, match=r"No σR95 upper limit tabulated for 'ln_w'"):
         single_number_uncertainty("ln_w", "A", upper_limit=True)
 
 
@@ -398,7 +404,10 @@ def test_table8_one_sided(confidence: float, k: float) -> None:
 
 
 def test_coverage_factor_unknown_confidence() -> None:
-    with pytest.raises(ValueError, match="not tabulated"):
+    with pytest.raises(
+        ValueError,
+        match=r"Confidence level .* is not tabulated for the two-sided test",
+    ):
         insulation_coverage_factor(0.925)
 
 
@@ -685,7 +694,13 @@ def test_annex_b_correlated_adaptation_sum_uncertainties() -> None:
 def test_uncorrelated_rejects_non_finite_reference_differences() -> None:
     nan_reference = [0.0, float("nan")]
     inf_uncertainty = [1.0, float("inf")]
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError,
+        match=r"band_uncertainties and reference_differences must contain only finite",
+    ):
         single_number_uncertainty_uncorrelated([1.0, 1.0], nan_reference)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError,
+        match=r"band_uncertainties and reference_differences must contain only finite",
+    ):
         single_number_uncertainty_uncorrelated(inf_uncertainty, [0.0, 0.0])

--- a/tests/building/measurement/test_facade_field_report.py
+++ b/tests/building/measurement/test_facade_field_report.py
@@ -206,7 +206,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _facade_dnt()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -214,7 +214,7 @@ def test_unknown_quantity_rejected(tmp_path: Path) -> None:
     """An unknown facade quantity raises ``ValueError``."""
     result = _facade_dnt()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="quantity"):
+    with pytest.raises(ValueError, match=r"Unknown facade quantity"):
         result.report(out, quantity="dnt")
 
 
@@ -222,9 +222,9 @@ def test_missing_quantity_rejected(tmp_path: Path) -> None:
     """Requesting d_2m_n / r_prime without their inputs raises ``ValueError``."""
     bare = building.facade_insulation(_ANNEX_C_R + 40.0, np.full(16, 40.0), _T_AT_T0)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="d_2m_n"):
+    with pytest.raises(ValueError, match=r"The result carries no 'd_2m_n' curve"):
         bare.report(out, quantity="d_2m_n")
-    with pytest.raises(ValueError, match="r_prime"):
+    with pytest.raises(ValueError, match=r"The result carries no 'r_prime' curve"):
         bare.report(out, quantity="r_prime")
 
 
@@ -234,5 +234,8 @@ def test_non_core_band_count_rejected(tmp_path: Path) -> None:
         np.full(21, 70.0), np.full(21, 30.0), np.full(21, 0.5)
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="16 core"):
+    with pytest.raises(
+        ValueError,
+        match=r"The facade field report rates the 16 core one-third-octave bands",
+    ):
         result.report(out)

--- a/tests/building/measurement/test_facade_insulation.py
+++ b/tests/building/measurement/test_facade_insulation.py
@@ -247,7 +247,9 @@ def test_surface_and_area_without_volume_raises() -> None:
     # a clear error naming 'volume' as the missing input.
     outdoor, indoor, rt = _flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5)
     surface = _flat(3, 72.0)
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(
+        ValueError, match=r"'volume' is required with 'surface_level' and 'area'"
+    ):
         building.facade_insulation(
             outdoor, indoor, rt, area=10.0, surface_level=surface
         )
@@ -389,7 +391,7 @@ def test_rating_path_reproduces_known_rw() -> None:
 # --------------------------------------------------------------------------
 def test_result_is_frozen() -> None:
     res = building.facade_insulation(_flat(3, 70.0), _flat(3, 30.0), _flat(3, 0.5))
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.d_2m = np.zeros(3)  # type: ignore[misc]
 
 

--- a/tests/building/measurement/test_flanking_transmission.py
+++ b/tests/building/measurement/test_flanking_transmission.py
@@ -200,7 +200,9 @@ def test_octave_bands_reject_misaligned_triples() -> None:
     res = building.vibration_reduction_index(
         np.zeros(len(freqs)), 2.0, 4.0, 4.0, frequency=freqs
     )
-    with pytest.raises(ValueError, match="octave triples"):
+    with pytest.raises(
+        ValueError, match=r"octave_bands\(\) needs whole octave triples"
+    ):
         res.octave_bands()
 
 
@@ -259,7 +261,7 @@ def test_modal_overlap_propagates_to_octave_bands() -> None:
 
 
 def test_modal_overlap_rejects_nonpositive() -> None:
-    with pytest.raises(ValueError, match="modal_overlap"):
+    with pytest.raises(ValueError, match=r"'modal_overlap' must contain positive"):
         building.vibration_reduction_index(
             [5.0], 2.0, 4.0, 4.0, frequency=[500.0], modal_overlap=[0.0]
         )
@@ -428,7 +430,7 @@ def test_frequency_band_count_mismatch_raises() -> None:
 
 
 def test_nonpositive_geometry_raises() -> None:
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'junction_length' must be a positive"):
         building.vibration_reduction_index([5.0], -2.0, 4.0, 4.0)
 
 

--- a/tests/building/measurement/test_flanking_transmission_report.py
+++ b/tests/building/measurement/test_flanking_transmission_report.py
@@ -343,9 +343,9 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError`` on every fiche."""
     out = str(tmp_path / "x.pdf")
     kij, dnf, lnf = _kij_result(), _dnf_result(), _lnf_result()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         kij.report(out, engine="weasyprint")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         dnf.report(out, engine="weasyprint")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         lnf.report(out, engine="weasyprint")

--- a/tests/building/measurement/test_floor_covering_improvement.py
+++ b/tests/building/measurement/test_floor_covering_improvement.py
@@ -96,14 +96,16 @@ def test_flat_improvement_shifts_delta_lw_one_for_one() -> None:
 
 def test_weighted_improvement_requires_16_bands() -> None:
     five_bands = np.zeros(5)
-    with pytest.raises(ValueError, match="16 one-third-octave"):
+    with pytest.raises(
+        ValueError, match=r"'delta_l' must give the 16 one-third-octave values"
+    ):
         building.weighted_impact_improvement(five_bands)
 
 
 def test_weighted_improvement_rejects_non_finite() -> None:
     bad = np.zeros(16)
     bad[0] = np.inf
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'delta_l' must contain only finite values"):
         building.weighted_impact_improvement(bad)
 
 
@@ -117,7 +119,7 @@ def test_acceleration_level_formula_1() -> None:
 
 
 def test_acceleration_level_rejects_nonpositive() -> None:
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'acceleration' must be positive"):
         building.acceleration_level(0.0)
     with pytest.raises(ValueError, match="'reference' must be positive"):
         building.acceleration_level(1e-3, reference=0.0)
@@ -258,11 +260,13 @@ def test_ci_delta_zero_improvement_is_zero() -> None:
 
 def test_ci_delta_validation() -> None:
     short = np.zeros(5)
-    with pytest.raises(ValueError, match="16 one-third-octave"):
+    with pytest.raises(
+        ValueError, match=r"'delta_l' must give the 16 one-third-octave values"
+    ):
         building.impact_improvement_adaptation_term(short)
     bad = np.zeros(16)
     bad[3] = np.nan
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'delta_l' must contain only finite values"):
         building.impact_improvement_adaptation_term(bad)
 
 

--- a/tests/building/measurement/test_heavy_impact.py
+++ b/tests/building/measurement/test_heavy_impact.py
@@ -255,7 +255,7 @@ def test_check_source_rejects_a_wrong_band_count() -> None:
 
 
 def test_unknown_source_name_is_rejected() -> None:
-    with pytest.raises(ValueError, match="source"):
+    with pytest.raises(ValueError, match=r"'source' must be one of"):
         building.heavy_impact_source_specification("tapping_machine")
 
 
@@ -430,7 +430,9 @@ def test_standardization_reproduces_a_published_25_band_example() -> None:
 
 
 def test_standardization_rejects_a_mismatched_reverberation_time() -> None:
-    with pytest.raises(ValueError, match="reverberation_time"):
+    with pytest.raises(
+        ValueError, match=r"'reverberation_time' must be a scalar or match 'level'"
+    ):
         building.standardized_maximum_impact_level([70.0, 65.0], 50.0, [1.0, 2.0, 3.0])
 
 
@@ -488,7 +490,10 @@ def test_octave_conversion_groups_consecutive_thirds() -> None:
 
 
 def test_octave_conversion_rejects_a_non_multiple_of_three() -> None:
-    with pytest.raises(ValueError, match="multiple of 3"):
+    with pytest.raises(
+        ValueError,
+        match=r"'level' must be a 1-D array whose length is a multiple of 3",
+    ):
         building.heavy_impact_octave_levels([60.0, 61.0, 62.0, 63.0])
 
 
@@ -619,7 +624,9 @@ def test_rating_rejects_an_unsupported_band_count() -> None:
 
 
 def test_rating_rejects_mismatched_frequencies() -> None:
-    with pytest.raises(ValueError, match="rating bands"):
+    with pytest.raises(
+        ValueError, match=r"'frequency' must be the ISO 717-2 Annex D rating bands"
+    ):
         building.a_weighted_maximum_impact_level(
             ISO717_2_TABLE_D4_LEVELS, [125.0, 250.0, 500.0, 1000.0]
         )

--- a/tests/building/measurement/test_insulation.py
+++ b/tests/building/measurement/test_insulation.py
@@ -496,11 +496,16 @@ def test_extended_18_band_100_5000_range() -> None:
 
 def test_extended_requires_core_bands() -> None:
 
-    with pytest.raises(ValueError, match="core"):
+    with pytest.raises(
+        ValueError, match=r"input must contain the \d+ core one-third-octave bands"
+    ):
         building.weighted_rating_extended(
             [40.0] * 10, [50, 63, 80, 100, 125, 160, 200, 250, 315, 400]
         )
-    with pytest.raises(ValueError, match="16 core"):
+    with pytest.raises(
+        ValueError,
+        match=r"Without 'frequencies' the input must be the \d+ core one-third-octave bands",
+    ):
         building.weighted_rating_extended([40.0] * 18)
 
 

--- a/tests/building/measurement/test_intensity_insulation.py
+++ b/tests/building/measurement/test_intensity_insulation.py
@@ -110,7 +110,9 @@ def test_ri_rating_none_off_band_count() -> None:
         [80.0] * 18, [40.0] * 18, measurement_area=10.0, area=10.0
     )
     assert r.rating is None
-    with pytest.raises(ValueError, match="16"):
+    with pytest.raises(
+        ValueError, match=r"No single-number rating is available to plot"
+    ):
         r.plot()
 
 
@@ -141,9 +143,9 @@ def test_kc_decreases_with_frequency() -> None:
 
 
 def test_kc_requires_both_room_parameters() -> None:
-    with pytest.raises(ValueError, match="both"):
+    with pytest.raises(ValueError, match=r"Supply both 'boundary_area' and 'volume'"):
         building.adaptation_term_kc([500.0], boundary_area=117.0)
-    with pytest.raises(ValueError, match="both"):
+    with pytest.raises(ValueError, match=r"Supply both 'boundary_area' and 'volume'"):
         building.adaptation_term_kc([500.0], volume=81.0)
 
 
@@ -164,7 +166,9 @@ def test_element_normalized_difference_formula_8() -> None:
         [80.0], [40.0], measurement_area=10.0, n=1
     )
     assert d.d_i_n_e[0] == pytest.approx(34.0)  # Sm = A0, N = 1
-    with pytest.warns(UserWarning, match="Formula \\(8\\)"):
+    with pytest.warns(
+        UserWarning, match=r"Formula \(8\) as printed subtracts 10 lg\(N\)"
+    ):
         d2 = building.intensity_element_normalized_difference(
             [80.0], [40.0], measurement_area=10.0, n=2
         )
@@ -174,7 +178,7 @@ def test_element_normalized_difference_formula_8() -> None:
 
 
 def test_element_normalized_rejects_bad_n() -> None:
-    with pytest.raises(ValueError, match="positive integer"):
+    with pytest.raises(ValueError, match=r"'n' must be a positive integer"):
         building.intensity_element_normalized_difference(
             [80.0], [40.0], measurement_area=10.0, n=0
         )
@@ -216,13 +220,15 @@ def test_combine_subareas_area_weighting() -> None:
 
 
 def test_combine_subareas_validation() -> None:
-    with pytest.raises(ValueError, match="two-dimensional"):
+    with pytest.raises(ValueError, match=r"'l_in' must be a two-dimensional"):
         building.combine_subareas([40.0, 42.0], [5.0])
     with pytest.raises(ValueError, match=r"'measurement_area'.*one value per subarea"):
         building.combine_subareas([[40.0, 42.0], [40.0, 42.0]], [5.0])
     with pytest.raises(ValueError, match=r"'measurement_area' must be a one-dim"):
         building.combine_subareas([[40.0], [42.0]], [[5.0], [5.0]])
-    with pytest.raises(ValueError, match="non-zero"):
+    with pytest.raises(
+        ValueError, match=r"'measurement_area' must contain non-zero, finite areas"
+    ):
         building.combine_subareas([[40.0], [42.0]], [5.0, 0.0])
 
 
@@ -243,9 +249,13 @@ def test_combine_subareas_negative_direction_rule() -> None:
 
 def test_combine_subareas_reverse_flow_dominating_raises() -> None:
     # Reverse energy equal to (or exceeding) the forward flow leaves no level.
-    with pytest.raises(ValueError, match="not positive"):
+    with pytest.raises(
+        ValueError, match=r"signed subarea energy sum of Formula \(11\) is not positive"
+    ):
         building.combine_subareas([[50.0], [50.0]], [5.0, -5.0])
-    with pytest.raises(ValueError, match="not positive"):
+    with pytest.raises(
+        ValueError, match=r"signed subarea energy sum of Formula \(11\) is not positive"
+    ):
         building.combine_subareas([[50.0], [53.0]], [5.0, -5.0])
 
 
@@ -255,11 +265,11 @@ def test_combine_subareas_reverse_flow_dominating_raises() -> None:
 
 
 def test_reduction_rejects_nonpositive_areas() -> None:
-    with pytest.raises(ValueError, match="measurement_area"):
+    with pytest.raises(ValueError, match=r"'measurement_area' must be positive"):
         building.intensity_sound_reduction(
             [80.0], [40.0], measurement_area=0.0, area=10.0
         )
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"'area' must be positive"):
         building.intensity_sound_reduction(
             [80.0], [40.0], measurement_area=10.0, area=-1.0
         )

--- a/tests/building/measurement/test_iso10140_report.py
+++ b/tests/building/measurement/test_iso10140_report.py
@@ -197,9 +197,9 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     out = str(tmp_path / "x.pdf")
     airborne = _airborne_result()
     impact = _impact_result()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         airborne.report(out, engine="weasyprint")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         impact.report(out, engine="weasyprint")
 
 
@@ -208,9 +208,9 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     out = str(tmp_path / "x.pdf")
     airborne = _airborne_result()
     impact = _impact_result()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         airborne.report(out, language="fr")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         impact.report(out, language="fr")
 
 
@@ -222,7 +222,10 @@ def test_missing_rating_rejected(tmp_path: Path) -> None:
     )
     assert result.rating is None
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="rating"):
+    with pytest.raises(
+        ValueError,
+        match=r"laboratory report needs the ISO 717 single-number rating",
+    ):
         result.report(out)
 
 
@@ -239,7 +242,9 @@ def test_rating_without_per_band_data_rejected(tmp_path: Path) -> None:
         rating=bare_rating,
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="per-band"):
+    with pytest.raises(
+        ValueError, match=r"report needs the ISO 717 per-band rating data"
+    ):
         result.report(out)
 
 

--- a/tests/building/measurement/test_iso15186_element_report.py
+++ b/tests/building/measurement/test_iso15186_element_report.py
@@ -167,7 +167,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = _element_result()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -175,7 +175,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     result = _element_result()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="fr")
 
 
@@ -187,7 +187,7 @@ def test_missing_rating_rejected(tmp_path: Path) -> None:
     )
     assert result.rating is None
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="rating"):
+    with pytest.raises(ValueError, match=r"element-normalized report needs the"):
         result.report(out)
 
 
@@ -211,7 +211,7 @@ def test_non_iso_band_count_rejected(tmp_path: Path) -> None:
     )
     result = IntensityElementNormalizedResult(d_i_n_e=curve, rating=rating)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="16 one-third-octave"):
+    with pytest.raises(ValueError, match=r"element-normalized report supports only"):
         result.report(out)
 
 
@@ -225,5 +225,5 @@ def test_rating_without_per_band_data_rejected(tmp_path: Path) -> None:
         rating=bare_rating,
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="per-band"):
+    with pytest.raises(ValueError, match=r"per-band rating data \('band_centers'"):
         result.report(out)

--- a/tests/building/measurement/test_iso15186_report.py
+++ b/tests/building/measurement/test_iso15186_report.py
@@ -213,7 +213,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = _intensity_result()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -221,7 +221,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     result = _intensity_result()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="fr")
 
 
@@ -233,7 +233,10 @@ def test_missing_rating_rejected(tmp_path: Path) -> None:
     )
     assert result.rating is None
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="rating"):
+    with pytest.raises(
+        ValueError,
+        match=r"The intensity report needs the ISO 717-1 single-number rating",
+    ):
         result.report(out)
 
 
@@ -269,7 +272,7 @@ def test_non_iso_band_count_rejected(tmp_path: Path) -> None:
         r_i=curve, r_i_modified=None, rating=rating, rating_modified=None
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="16 one-third-octave"):
+    with pytest.raises(ValueError, match="The intensity report supports only"):
         result.report(out)
 
 
@@ -285,7 +288,7 @@ def test_rating_without_per_band_data_rejected(tmp_path: Path) -> None:
         rating_modified=None,
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="per-band"):
+    with pytest.raises(ValueError, match=r"needs the ISO 717 per-band rating data"):
         result.report(out)
 
 
@@ -358,7 +361,11 @@ def test_clause8_fpi_wrong_band_count_rejected(tmp_path: Path) -> None:
     out = str(tmp_path / "x.pdf")
     fpi_5_bands = np.full(5, 4.0)
     residual_3_bands = np.full(3, 18.0)
-    with pytest.raises(ValueError, match="fpi"):
+    with pytest.raises(
+        ValueError, match=r"'fpi' must carry one value per reported band"
+    ):
         result.report(out, fpi=fpi_5_bands)
-    with pytest.raises(ValueError, match="residual_index"):
+    with pytest.raises(
+        ValueError, match=r"'residual_index' must carry one value per reported band"
+    ):
         result.report(out, residual_index=residual_3_bands)

--- a/tests/building/measurement/test_iso16251_report.py
+++ b/tests/building/measurement/test_iso16251_report.py
@@ -109,7 +109,7 @@ def test_report_with_metadata_one_page(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/building/measurement/test_iso16283_report.py
+++ b/tests/building/measurement/test_iso16283_report.py
@@ -206,7 +206,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _airborne_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -214,10 +214,10 @@ def test_unknown_quantity_rejected(tmp_path: Path) -> None:
     """An unknown field quantity raises ``ValueError``."""
     airborne = _airborne_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="quantity"):
+    with pytest.raises(ValueError, match=r"Unknown field quantity"):
         airborne.report(out, quantity="dn")
     impact = building.impact_insulation(_IMPACT_LN, _T_AT_T0)
-    with pytest.raises(ValueError, match="quantity"):
+    with pytest.raises(ValueError, match=r"Unknown field quantity"):
         impact.report(out, quantity="dnt")
 
 
@@ -225,7 +225,7 @@ def test_missing_r_prime_rejected(tmp_path: Path) -> None:
     """Requesting the R' fiche without area/volume raises ``ValueError``."""
     result = _airborne_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="r_prime"):
+    with pytest.raises(ValueError, match=r"result carries no 'r_prime' curve"):
         result.report(out, quantity="r_prime")
 
 
@@ -235,7 +235,9 @@ def test_non_core_band_count_rejected(tmp_path: Path) -> None:
         np.full(5, 90.0), np.full(5, 50.0), np.full(5, 0.5)
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="16 core"):
+    with pytest.raises(
+        ValueError, match=r"field report rates the 16 core one-third-octave bands"
+    ):
         result.report(out)
 
 
@@ -244,7 +246,9 @@ def test_verbose_needs_measurement_chain(tmp_path: Path) -> None:
     curve = np.asarray(_AIRBORNE_R, dtype=np.float64)
     bare = building.AirborneInsulationResult(d=curve, dnt=curve, r_prime=None)
     rejected = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="measurement chain"):
+    with pytest.raises(
+        ValueError, match=r"verbose=True needs the per-band measurement chain"
+    ):
         bare.report(rejected, verbose=True)
     # The non-verbose form still renders from the quantity alone.
     out = tmp_path / "bare.pdf"
@@ -260,5 +264,7 @@ def test_manual_impact_result_renders_without_chain(tmp_path: Path) -> None:
     bare.report(str(out))
     assert_one_page(str(out))
     rejected = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="measurement chain"):
+    with pytest.raises(
+        ValueError, match=r"verbose=True needs the per-band measurement chain"
+    ):
         bare.report(rejected, verbose=True)

--- a/tests/building/measurement/test_iso717_report.py
+++ b/tests/building/measurement/test_iso717_report.py
@@ -86,7 +86,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -175,7 +175,10 @@ def test_metadata_allows_non_positive_temperature() -> None:
 
 def test_metadata_rejects_out_of_range_humidity() -> None:
     """Relative humidity outside 0..100 % is rejected."""
-    with pytest.raises(ValueError, match="humidity"):
+    with pytest.raises(
+        ValueError,
+        match=r"ReportMetadata\.relative_humidity must be a relative humidity",
+    ):
         ReportMetadata(relative_humidity=150.0)
 
 
@@ -240,7 +243,9 @@ def test_impact_requirement_verdict_renders(tmp_path: Path) -> None:
 
 def test_metadata_rejects_negative_area() -> None:
     """``ReportMetadata`` rejects a non-positive numeric field."""
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(
+        ValueError, match=r"ReportMetadata\.area must be a finite, positive number"
+    ):
         ReportMetadata(area=-5.0)
 
 
@@ -305,7 +310,7 @@ def test_invalid_symbol_rejected(tmp_path: Path) -> None:
     """A malformed quantity symbol raises ``ValueError``."""
     result = building.weighted_rating(_AIRBORNE_R)
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="symbol"):
+    with pytest.raises(ValueError, match=r"Invalid ISO 717 quantity symbol"):
         result.report(out, symbol="not a symbol")
 
 
@@ -336,5 +341,5 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = building.weighted_rating(_AIRBORNE_R)
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/building/measurement/test_lab_insulation.py
+++ b/tests/building/measurement/test_lab_insulation.py
@@ -239,20 +239,20 @@ def test_airborne_band_count_mismatch() -> None:
 def test_airborne_t2_band_mismatch() -> None:
     l1, l2 = np.full(16, 80.0), np.full(16, 30.0)
     short_t2 = np.full(5, 0.8)
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(ValueError, match=r"'t2' must share the band count"):
         building.lab_airborne_insulation(l1, l2, short_t2, area=10.0, volume=50.0)
 
 
 @pytest.mark.parametrize(("area", "volume"), [(0.0, 50.0), (-1.0, 50.0)])
 def test_airborne_bad_area(area: float, volume: float) -> None:
     l1, l2, t2 = np.full(16, 80.0), np.full(16, 30.0), np.full(16, 0.8)
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"'area' must be positive"):
         building.lab_airborne_insulation(l1, l2, t2, area=area, volume=volume)
 
 
 def test_airborne_bad_volume() -> None:
     l1, l2, t2 = np.full(16, 80.0), np.full(16, 30.0), np.full(16, 0.8)
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(ValueError, match=r"'volume' must be positive"):
         building.lab_airborne_insulation(l1, l2, t2, area=10.0, volume=-5.0)
 
 
@@ -260,20 +260,20 @@ def test_airborne_bad_t2() -> None:
     l1, l2 = np.full(16, 80.0), np.full(16, 30.0)
     t2 = np.full(16, 0.8)
     t2[3] = 0.0
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'t2' must contain positive, finite values"):
         building.lab_airborne_insulation(l1, l2, t2, area=10.0, volume=50.0)
 
 
 def test_impact_t2_band_mismatch() -> None:
     li = np.full(16, 60.0)
     short_t2 = np.full(5, 0.8)
-    with pytest.raises(ValueError, match="band count"):
+    with pytest.raises(ValueError, match=r"'t2' must share the band count"):
         building.lab_impact_insulation(li, short_t2, volume=50.0)
 
 
 def test_impact_bad_volume() -> None:
     li, t2 = np.full(16, 60.0), np.full(16, 0.8)
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(ValueError, match=r"'volume' must be positive"):
         building.lab_impact_insulation(li, t2, volume=0.0)
 
 
@@ -373,7 +373,10 @@ def test_airborne_non_finite_band_is_refused(field: str) -> None:
     res = _airborne_result()
     bad = np.asarray(getattr(res, field), dtype=np.float64).copy()
     bad[3] = np.nan
-    with pytest.raises(ValueError, match=rf"'{field}' must contain only finite"):
+    with pytest.raises(
+        ValueError,
+        match=rf"LabAirborneInsulationResult: '{field}' must contain only finite",
+    ):
         dataclasses.replace(res, **{field: bad})
 
 
@@ -383,7 +386,10 @@ def test_impact_non_finite_band_is_refused(field: str) -> None:
     res = _impact_result()
     bad = np.asarray(getattr(res, field), dtype=np.float64).copy()
     bad[3] = np.nan
-    with pytest.raises(ValueError, match=rf"'{field}' must contain only finite"):
+    with pytest.raises(
+        ValueError,
+        match=rf"LabImpactInsulationResult: '{field}' must contain only finite",
+    ):
         dataclasses.replace(res, **{field: bad})
 
 
@@ -395,7 +401,9 @@ def test_plot_without_rating_raises() -> None:
         area=10.0,
         volume=50.0,
     )
-    with pytest.raises(ValueError, match="rating"):
+    with pytest.raises(
+        ValueError, match=r"No single-number rating is available to plot"
+    ):
         res.plot()
 
 

--- a/tests/building/measurement/test_structure_borne_power.py
+++ b/tests/building/measurement/test_structure_borne_power.py
@@ -78,11 +78,13 @@ def test_power_level_offset_is_minus_60() -> None:
 
 
 def test_power_level_rejects_bad_inputs() -> None:
-    with pytest.raises(ValueError, match="mass_per_area"):
+    with pytest.raises(ValueError, match=r"'mass_per_area' must be positive"):
         building.structure_borne_power_level(80.0, 1000.0, 0.0, 1.0, 0.01)
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"'area' must be positive"):
         building.structure_borne_power_level(80.0, 1000.0, 10.0, 0.0, 0.01)
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(
+        ValueError, match=r"'frequency' must contain positive, finite values"
+    ):
         building.structure_borne_power_level(80.0, 0.0, 10.0, 1.0, 0.01)
 
 
@@ -131,7 +133,9 @@ def test_reception_plate_total_level() -> None:
 
 
 def test_reception_plate_requires_eta_or_ts() -> None:
-    with pytest.raises(ValueError, match="loss_factor"):
+    with pytest.raises(
+        ValueError, match=r"either 'loss_factor' or 'reverberation_time'"
+    ):
         building.reception_plate_power(80.0, 1000.0, 25.0, 1.2)
 
 
@@ -253,7 +257,9 @@ def test_blocked_force_level_formula_15() -> None:
     # A complex plate mobility uses its real part (Formula 16).
     lfb_c = building.equivalent_blocked_force_level(61.7, 5.34e-6 + 2e-6j)
     assert float(lfb_c) == pytest.approx(float(lfb))
-    with pytest.raises(ValueError, match="positive real part"):
+    with pytest.raises(
+        ValueError, match="'plate_mobility' must be finite with a positive real part"
+    ):
         building.equivalent_blocked_force_level(61.7, -1e-6)
 
 
@@ -262,7 +268,7 @@ def test_characteristic_reception_plate_power_formula_17() -> None:
     lfb = building.equivalent_blocked_force_level(61.7, 5.34e-6)
     lwsn = building.characteristic_reception_plate_power(lfb)
     assert float(lwsn) == pytest.approx(61.7 + 10.0 * math.log10(5.0e-6 / 5.34e-6))
-    with pytest.raises(ValueError, match="characteristic_mobility"):
+    with pytest.raises(ValueError, match=r"'characteristic_mobility' must be positive"):
         building.characteristic_reception_plate_power(
             100.0, characteristic_mobility=0.0
         )
@@ -300,7 +306,9 @@ def test_free_velocity_level_formula_18_real_mobility() -> None:
     lvf = building.equivalent_free_velocity_level(70.0, y)
     assert float(lvf) == pytest.approx(expected)
     assert float(lvf) == pytest.approx(70.0 + 10.0 * math.log10(y) + 60.0)
-    with pytest.raises(ValueError, match="positive real part"):
+    with pytest.raises(
+        ValueError, match="'plate_mobility' must be finite with a positive real part"
+    ):
         building.equivalent_free_velocity_level(70.0, -1.0e-2)
 
 
@@ -354,9 +362,13 @@ def test_iso9611_mean_free_velocity_level() -> None:
 
 
 def test_power_level_rejects_nonpositive_loss_factor() -> None:
-    with pytest.raises(ValueError, match="loss_factor"):
+    with pytest.raises(
+        ValueError, match=r"'loss_factor' must contain positive, finite values"
+    ):
         building.structure_borne_power_level(80.0, 1000.0, 10.0, 1.0, 0.0)
-    with pytest.raises(ValueError, match="loss_factor"):
+    with pytest.raises(
+        ValueError, match=r"'loss_factor' must contain positive, finite values"
+    ):
         building.structure_borne_power_level(80.0, 1000.0, 10.0, 1.0, [0.01, -0.01])
 
 

--- a/tests/building/measurement/test_structure_borne_power_report.py
+++ b/tests/building/measurement/test_structure_borne_power_report.py
@@ -208,7 +208,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -216,5 +216,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/building/measurement/test_survey_insulation.py
+++ b/tests/building/measurement/test_survey_insulation.py
@@ -30,9 +30,9 @@ def test_reverberation_index_formula_3() -> None:
 
 
 def test_reverberation_index_rejects_nonpositive() -> None:
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'t' must contain positive values"):
         building.reverberation_index([0.5, 0.0])
-    with pytest.raises(ValueError, match="t0"):
+    with pytest.raises(ValueError, match=r"'t0' must be positive"):
         building.reverberation_index([0.5], t0=0.0)
 
 
@@ -173,19 +173,25 @@ def test_service_equipment_banded() -> None:
 
 
 def test_service_equipment_requires_three_positions() -> None:
-    with pytest.raises(ValueError, match="exactly three"):
+    with pytest.raises(
+        ValueError,
+        match=r"'measurements' must give exactly three measurement positions",
+    ):
         building.survey_service_equipment_level([35.0, 30.0], 3.0)
 
 
 def test_service_equipment_index_shape_mismatch_raises() -> None:
-    with pytest.raises(ValueError, match="match the shape"):
+    with pytest.raises(ValueError, match=r"'reverberation_index' must match the shape"):
         # Scalar average but a per-band k.
         building.survey_service_equipment_level([35.0, 30.0, 32.0], [3.0, 2.0])
 
 
 def test_service_equipment_scalar_measurements_raises_cleanly() -> None:
     # A 0-d input must give a clean ValueError, not an IndexError.
-    with pytest.raises(ValueError, match="exactly three"):
+    with pytest.raises(
+        ValueError,
+        match=r"'measurements' must give exactly three measurement positions",
+    ):
         building.survey_service_equipment_level(35.0, 3.0)  # type: ignore[arg-type]
 
 
@@ -197,7 +203,9 @@ def test_service_equipment_scalar_measurements_raises_cleanly() -> None:
 def test_index_band_count_must_match_levels() -> None:
     source, receiving = np.full(_OCTAVE, 80.0), np.full(_OCTAVE, 45.0)
     short_index = np.zeros(3)
-    with pytest.raises(ValueError, match="one value per band"):
+    with pytest.raises(
+        ValueError, match=r"'reverberation_index' must give one value per band"
+    ):
         building.survey_airborne_insulation(source, receiving, short_index)
 
 
@@ -207,7 +215,9 @@ def test_rating_none_off_band_count() -> None:
         np.full(4, 80.0), np.full(4, 45.0), np.zeros(4)
     )
     assert res.rating is None
-    with pytest.raises(ValueError, match="5 octave"):
+    with pytest.raises(
+        ValueError, match=r"No single-number rating is available to plot"
+    ):
         res.plot()
 
 
@@ -357,14 +367,16 @@ def test_estimate_feeds_survey_functions() -> None:
 
 
 def test_estimate_rejects_bad_inputs() -> None:
-    with pytest.raises(ValueError, match="at most 150"):
+    with pytest.raises(ValueError, match=r"'volume' must be at most"):
         building.estimate_reverberation_index(200.0, "a")
     # The error names the actual volume range, not an internal index.
     with pytest.raises(ValueError, match=r"60 <= V <= 150"):
         building.estimate_reverberation_index(100.0, "kitchen")  # only V < 35
-    with pytest.raises(ValueError, match="not tabulated"):
+    with pytest.raises(
+        ValueError, match=r"'room' .* is not tabulated for the volume range"
+    ):
         building.estimate_reverberation_index(10.0, "z")
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'volume' must be positive"):
         building.estimate_reverberation_index(0.0, "a")
 
 

--- a/tests/building/measurement/test_survey_insulation_report.py
+++ b/tests/building/measurement/test_survey_insulation_report.py
@@ -215,11 +215,11 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError`` on every survey fiche."""
     out = str(tmp_path / "x.pdf")
     airborne, impact, facade = _airborne(), _impact(), _facade()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         airborne.report(out, engine="weasyprint")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         impact.report(out, engine="weasyprint")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         facade.report(out, engine="weasyprint")
 
 
@@ -227,7 +227,7 @@ def test_unknown_airborne_quantity_rejected(tmp_path: Path) -> None:
     """An unknown airborne quantity raises ``ValueError``."""
     airborne = _airborne()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="quantity"):
+    with pytest.raises(ValueError, match=r"Unknown survey quantity"):
         airborne.report(out, quantity="dn")
 
 
@@ -237,7 +237,10 @@ def test_missing_r_prime_rating_rejected(tmp_path: Path) -> None:
         np.full(_OCTAVE, 80.0), np.full(_OCTAVE, 45.0), _K0
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="rating"):
+    with pytest.raises(
+        ValueError,
+        match=r"survey airborne report needs the ISO 717-1 single-number rating",
+    ):
         result.report(out, quantity="r_prime")
 
 
@@ -252,5 +255,7 @@ def test_missing_rating_off_band_count_rejected(tmp_path: Path) -> None:
     )
     out = str(tmp_path / "x.pdf")
     for result in (airborne, impact, facade):
-        with pytest.raises(ValueError, match="rating"):
+        with pytest.raises(
+            ValueError, match=r"report needs the ISO 717-\d single-number rating"
+        ):
             result.report(out)

--- a/tests/building/prediction/test_aperture_transmission.py
+++ b/tests/building/prediction/test_aperture_transmission.py
@@ -93,7 +93,7 @@ def test_slit_resonances_are_half_wavelength_spaced() -> None:
 def test_slit_resonance_rejects_wide_shallow_slit() -> None:
     # A very wide, shallow slit drives the effective depth d + 2e non-positive;
     # the resonance is undefined and must raise rather than return NaN.
-    with pytest.raises(ValueError, match="too wide"):
+    with pytest.raises(ValueError, match=r"slit too wide relative to its depth"):
         building.slit_resonance_frequencies(0.001, 0.2, orders=1)
 
 
@@ -143,9 +143,9 @@ def test_circular_aperture_thin_hole_reduction_positive_at_low_f() -> None:
 # Validation.
 # ---------------------------------------------------------------------------
 def test_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="field"):
+    with pytest.raises(ValueError, match=r"'field' must be one of"):
         building.slit_transmission_coefficient([500.0], 0.002, 0.1, field="oblique")
-    with pytest.raises(ValueError, match="width"):
+    with pytest.raises(ValueError, match=r"'width' must be positive"):
         building.slit_transmission_coefficient([500.0], -0.002, 0.1)
-    with pytest.raises(ValueError, match="tau"):
+    with pytest.raises(ValueError, match=r"'tau' must be positive"):
         building.transmission_loss_from_coefficient([-1.0])

--- a/tests/building/prediction/test_ceiling_plenum.py
+++ b/tests/building/prediction/test_ceiling_plenum.py
@@ -336,12 +336,16 @@ def test_clause_5_2_rounding_breaks_ties_upward_not_to_even() -> None:
 
 
 def test_rating_rejects_a_wrong_band_count() -> None:
-    with pytest.raises(ValueError, match="16 one-third-octave values"):
+    with pytest.raises(
+        ValueError, match=r"'attenuation' must hold \d+ one-third-octave"
+    ):
         building.ceiling_attenuation_class([30.0] * 15)
 
 
 def test_rating_rejects_mismatched_frequencies() -> None:
-    with pytest.raises(ValueError, match="contour bands"):
+    with pytest.raises(
+        ValueError, match=r"'frequency' must be the 16 ASTM E413 contour bands"
+    ):
         building.ceiling_attenuation_class(
             [30.0] * 16, [100.0 * (i + 1) for i in range(16)]
         )
@@ -357,7 +361,7 @@ def test_rating_result_rejects_a_short_deficiency_column() -> None:
     """
     res = building.ceiling_attenuation_class([30.0] * 16)
     short = res.deficiencies[:-1]
-    with pytest.raises(ValueError, match="'deficiencies'"):
+    with pytest.raises(ValueError, match=r"'deficiencies' \(15\)"):
         dataclasses.replace(res, deficiencies=short)
 
 
@@ -580,7 +584,7 @@ def test_intertek_2019_normalization_reproduces_the_report_column() -> None:
 
 
 def test_normalization_rejects_a_non_positive_absorption() -> None:
-    with pytest.raises(ValueError, match="absorption_area"):
+    with pytest.raises(ValueError, match=r"'absorption_area' must be positive"):
         building.normalized_ceiling_attenuation([90.0], [50.0], 0.0)
 
 
@@ -757,7 +761,7 @@ def test_undamped_transmission_factor_above_unity_is_rejected() -> None:
     tau = eps**2 LR/(4h) = 8,3 here, i.e. Rcl = -9,2 dB. Failing loudly beats
     reporting a negative sound reduction index.
     """
-    with pytest.raises(ValueError, match="above unity"):
+    with pytest.raises(ValueError, match=r"transmission factor reaches .+ above unity"):
         building.plenum_flanking_reduction_index(
             [0.0], [0.0], ceiling_length=5.0, plenum_height=0.6
         )
@@ -867,7 +871,10 @@ def test_power_split_must_be_a_fraction(name: str) -> None:
 
 
 def test_attenuation_coefficients_must_come_in_pairs() -> None:
-    with pytest.raises(ValueError, match="together"):
+    with pytest.raises(
+        ValueError,
+        match=r"'attenuation_source' and 'attenuation_receiving' must be given together",
+    ):
         building.plenum_flanking_reduction_index(
             [30.0],
             [30.0],
@@ -884,7 +891,7 @@ def test_partition_reference_shifts_by_the_room_aspect_ratio() -> None:
 
 
 def test_plenum_model_rejects_a_non_positive_height() -> None:
-    with pytest.raises(ValueError, match="plenum_height"):
+    with pytest.raises(ValueError, match=r"'plenum_height' must be positive"):
         building.plenum_flanking_reduction_index(
             [30.0], [30.0], ceiling_length=4.75, plenum_height=0.0
         )
@@ -953,5 +960,5 @@ def test_plenum_result_rejects_a_ceiling_evaluated_in_one_band() -> None:
         plenum_height=0.43,
     )
     one_band = res.reduction_index_source[:1]
-    with pytest.raises(ValueError, match="'reduction_index_source'"):
+    with pytest.raises(ValueError, match=r"'reduction_index_source' \(1\)"):
         dataclasses.replace(res, reduction_index_source=one_band)

--- a/tests/building/prediction/test_detailed_model.py
+++ b/tests/building/prediction/test_detailed_model.py
@@ -580,7 +580,11 @@ def test_impact_prediction_without_a_direct_path_sums_the_flanking_paths() -> No
     assert [p.label for p in result.paths] == ["Ff1", "Ff2"]
     assert result.l_prime_n == pytest.approx(50.0 + 10.0 * np.log10(2.0))
     assert result.fractions == pytest.approx(0.5)
-    with pytest.raises(ValueError, match="direct_level"):
+    with pytest.raises(
+        ValueError,
+        match=r"'detailed_impact_prediction' needs a 'direct_level', "
+        r"at least one flanking path",
+    ):
         building.detailed_impact_prediction(BANDS)
 
 
@@ -872,7 +876,7 @@ def test_perimeter_absorption_rejects_mismatched_lengths() -> None:
 
 def test_flanking_path_rejects_an_unknown_kind(situ: dict) -> None:
     """Only the three Annex-defined flanking paths exist."""
-    with pytest.raises(ValueError, match="kind"):
+    with pytest.raises(ValueError, match=r"'kind' must be one of"):
         building.airborne_flanking_path(
             label="x",
             kind="Dd",
@@ -887,7 +891,7 @@ def test_flanking_path_rejects_an_unknown_kind(situ: dict) -> None:
 def test_band_count_mismatch_is_reported(situ: dict) -> None:
     """A path built on a different band set cannot be combined."""
     too_short = np.zeros(5)
-    with pytest.raises(ValueError, match="one value per band"):
+    with pytest.raises(ValueError, match="'direct_index' must have one value per band"):
         building.detailed_airborne_prediction(BANDS, direct_index=too_short)
 
 

--- a/tests/building/prediction/test_detailed_model_report.py
+++ b/tests/building/prediction/test_detailed_model_report.py
@@ -179,7 +179,7 @@ def test_detailed_fiche_rejects_an_unrated_spectrum(tmp_path: Path) -> None:
     )
     assert partial.rating is None
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="ISO 717"):
+    with pytest.raises(ValueError, match=r"needs the ISO 717 single-number rating"):
         partial.report(out)
 
 
@@ -187,7 +187,7 @@ def test_detailed_fiche_rejects_an_unknown_engine(tmp_path: Path) -> None:
     """Only the reportlab back end exists."""
     result = _annex_g_impact()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/building/prediction/test_facade.py
+++ b/tests/building/prediction/test_facade.py
@@ -242,9 +242,11 @@ def test_facade_shape_level_difference_does_not_apply() -> None:
         building.facade_shape_level_difference("gallery_5", line_of_sight=1.0)
     with pytest.raises(ValueError, match="Unknown facade shape"):
         building.facade_shape_level_difference("igloo")
-    with pytest.raises(ValueError, match="absorption"):
+    with pytest.raises(ValueError, match=r"'absorption' must be an αw"):
         building.facade_shape_level_difference("balcony_6", absorption=1.5)
-    with pytest.raises(ValueError, match="line_of_sight"):
+    with pytest.raises(
+        ValueError, match=r"'line_of_sight' must be a non-negative height"
+    ):
         building.facade_shape_level_difference("balcony_6", line_of_sight=-1.0)
 
 
@@ -343,7 +345,10 @@ def test_outdoor_level_scalar_broadcast() -> None:
 
 
 def test_outdoor_level_incompatible_shapes_raise() -> None:
-    with pytest.raises(ValueError, match="broadcast-compatible"):
+    with pytest.raises(
+        ValueError,
+        match=r"'l_w' and 'attenuation' must have broadcast-compatible shapes",
+    ):
         building.outdoor_level([60.0, 60.0, 60.0], [0.0, 0.0])
 
 
@@ -361,16 +366,16 @@ def test_far_field_point_source() -> None:
 
 def test_element_requires_exactly_one_quantity() -> None:
     element = building.FacadeElement(name="x", area=1.0)
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(ValueError, match=r"Element 'x': give exactly one of"):
         element.tau(10.0, 1)
     element = building.FacadeElement(name="x", area=1.0, r=[40.0], dn_e=[30.0])
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(ValueError, match=r"Element 'x': give exactly one of"):
         element.tau(10.0, 1)
 
 
 def test_area_element_requires_positive_area() -> None:
     element = building.FacadeElement(name="x", r=[40.0])
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"Element 'x': 'area' must be positive"):
         element.tau(10.0, 1)
 
 
@@ -419,7 +424,7 @@ def test_scalar_broadcasts_to_band_count() -> None:
 
 def test_non_finite_input_rejected() -> None:
     element = building.FacadeElement(name="x", area=1.0, r=[np.nan])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'x \(r\)' must contain only finite"):
         element.tau(10.0, 1)
 
 
@@ -429,7 +434,7 @@ def test_duplicate_element_names_raise() -> None:
         building.FacadeElement(name="glass", area=5.0, r=[40.0]),
         building.FacadeElement(name="glass", area=5.0, r=[30.0]),
     ]
-    with pytest.raises(ValueError, match="unique"):
+    with pytest.raises(ValueError, match=r"Façade element names must be unique"):
         building.facade_sound_reduction(elements, area=10.0, volume=50.0)
 
 
@@ -490,16 +495,20 @@ def test_lp_in_length_must_match_bands() -> None:
 
 def test_tau_rejects_non_positive_total_area() -> None:
     element = building.FacadeElement(name="x", area=1.0, r=[40.0])
-    with pytest.raises(ValueError, match="total_area"):
+    with pytest.raises(
+        ValueError, match=r"'total_area' \(façade area S\) must be positive"
+    ):
         element.tau(0.0, 1)
 
 
 def test_positive_area_and_volume_required() -> None:
     elements = [building.FacadeElement(name="a", area=5.0, r=[40.0])]
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(ValueError, match=r"'volume' must be positive"):
         building.facade_sound_reduction(elements, area=10.0, volume=0.0)
     elements = [building.FacadeElement(name="a", area=5.0, r=[40.0])]
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(
+        ValueError, match=r"'area' \(total façade area S\) must be positive"
+    ):
         building.facade_sound_reduction(elements, area=0.0, volume=50.0)
 
 
@@ -532,7 +541,7 @@ def test_facade_prediction_unread_spectrum_must_match_bands() -> None:
     """
     res = _annex_f_result()
     one_too_many = np.append(res.r_45, 99.0)
-    with pytest.raises(ValueError, match="'r_45'"):
+    with pytest.raises(ValueError, match=rf"'r_45' \({one_too_many.size}\)"):
         dataclasses.replace(res, r_45=one_too_many)
 
 
@@ -547,7 +556,7 @@ def test_radiated_power_frequencies_must_match_bands() -> None:
     """
     res = _annex_g_side1_with_door()
     one_too_many = np.insert(res.frequencies, 0, 31.5)
-    with pytest.raises(ValueError, match="'frequencies'"):
+    with pytest.raises(ValueError, match=rf"'frequencies' \({one_too_many.size}\)"):
         dataclasses.replace(res, frequencies=one_too_many)
 
 

--- a/tests/building/prediction/test_installed_structure_borne.py
+++ b/tests/building/prediction/test_installed_structure_borne.py
@@ -81,7 +81,7 @@ def test_path_level_hand_value() -> None:
 
 
 def test_path_level_rejects_bad_area() -> None:
-    with pytest.raises(ValueError, match="element_area"):
+    with pytest.raises(ValueError, match=r"'element_area' must be positive"):
         building.structure_borne_pressure_level_path(69.0, 5.0, 50.0, 0.0)
 
 
@@ -123,7 +123,9 @@ def test_prediction_bundle() -> None:
 
 
 def test_prediction_requires_paths() -> None:
-    with pytest.raises(ValueError, match="paths"):
+    with pytest.raises(
+        ValueError, match=r"'paths' must contain at least one transmission path"
+    ):
         building.installed_source_prediction(80.0, 10.0, [])
 
 
@@ -144,7 +146,9 @@ def test_prediction_band_count_mismatch() -> None:
             "element_area": 12.0,
         }
     ]
-    with pytest.raises(ValueError, match="flanking_reduction_index"):
+    with pytest.raises(
+        ValueError, match=r"path 0: 'flanking_reduction_index' has \d+ bands"
+    ):
         building.installed_source_prediction(power_level, coupling, short_path)
 
 
@@ -179,7 +183,7 @@ def test_prediction_scalar_source_band_mismatch_across_paths() -> None:
             "element_area": 10.0,
         }
     ]
-    with pytest.raises(ValueError, match="adjustment_term"):
+    with pytest.raises(ValueError, match=r"path 0: 'adjustment_term' has \d+ bands"):
         building.installed_source_prediction(80.0, 10.0, mismatched_path)
 
 
@@ -376,17 +380,21 @@ def test_annex_i3_cistern_full_chain_table_i9() -> None:
 
 def test_coupling_terms_validate_mobilities() -> None:
     """Re{Y_i} <= 0 or Y_s = 0 raise instead of yielding NaN/inf silently."""
-    with pytest.raises(ValueError, match="positive real part"):
+    receiver_real = r"'receiver_mobility' must be finite with a positive real part"
+    source_non_zero = r"'source_mobility' must be finite and non-zero"
+    with pytest.raises(ValueError, match=receiver_real):
         building.coupling_term(1e-4 + 0j, -1e-5 + 0j)
-    with pytest.raises(ValueError, match="positive real part"):
+    with pytest.raises(ValueError, match=receiver_real):
         building.coupling_term(1e-4 + 0j, 1e-5j)  # purely imaginary receiver
-    with pytest.raises(ValueError, match="finite and non-zero"):
+    with pytest.raises(ValueError, match=source_non_zero):
         building.coupling_term(0.0, 1e-5 + 0j)
-    with pytest.raises(ValueError, match="positive real part"):
+    with pytest.raises(ValueError, match=receiver_real):
         building.coupling_term_force_source(1e-4 + 0j, 0.0 + 0j)
-    with pytest.raises(ValueError, match="finite and non-zero"):
+    with pytest.raises(ValueError, match=source_non_zero):
         building.coupling_term_velocity_source(0.0, 1e4 + 0j)
-    with pytest.raises(ValueError, match="receiver_mobility"):
+    with pytest.raises(
+        ValueError, match=r"'receiver_mobility' must be finite and non-zero"
+    ):
         building.installed_power_from_reception_plate([60.0], 0.0)
 
 
@@ -401,7 +409,7 @@ def test_prediction_frequencies_length_mismatch() -> None:
         }
     ]
     short_frequencies = np.array([500.0, 1000.0])  # 2 vs 3 bands
-    with pytest.raises(ValueError, match="frequencies carries 2"):
+    with pytest.raises(ValueError, match=r"frequencies carries \d+ values"):
         building.installed_source_prediction(
             power_level, coupling, paths, frequencies=short_frequencies
         )
@@ -445,7 +453,8 @@ def test_a_per_band_quantity_off_the_band_axis_is_refused(
     result = _annex_i_prediction()
     values = np.asarray(getattr(result, field_name))
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    count = 5 if trim else 7  # the six-band fixture, one short or one long
+    with pytest.raises(ValueError, match=rf"'{field_name}' \({count}\)"):
         dataclasses.replace(result, **{field_name: wrong})
 
 

--- a/tests/building/prediction/test_installed_structure_borne_report.py
+++ b/tests/building/prediction/test_installed_structure_borne_report.py
@@ -231,7 +231,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -239,7 +239,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")
 
 

--- a/tests/building/prediction/test_installed_structure_borne_tables.py
+++ b/tests/building/prediction/test_installed_structure_borne_tables.py
@@ -194,13 +194,18 @@ def test_table_d1_rejects_a_quantity_that_does_not_describe_the_row(
 
 
 def test_table_d1_names_the_missing_describing_quantity() -> None:
-    with pytest.raises(ValueError, match="missing longitudinal_velocity"):
+    with pytest.raises(
+        ValueError, match=r"Table D\.1 row 'plate' .* missing longitudinal_velocity"
+    ):
         building.typical_element_mobility("plate", density=2300.0, thickness=0.14)
 
 
 def test_frequency_independent_rows_reject_a_frequency() -> None:
     """Two of the six expressions carry no f; passing one is an error."""
-    with pytest.raises(ValueError, match="frequency-independent"):
+    with pytest.raises(
+        ValueError,
+        match=r"Table D\.1 row 'plate' is frequency-independent; do not pass 'frequency'",
+    ):
         building.typical_element_mobility(
             "plate",
             frequency=125.0,
@@ -216,7 +221,7 @@ def test_frequency_dependent_rows_require_a_frequency() -> None:
 
 
 def test_unknown_row_is_rejected() -> None:
-    with pytest.raises(ValueError, match="structure"):
+    with pytest.raises(ValueError, match=r"'structure' must be one of"):
         building.typical_element_mobility("slab", density=1.0)
 
 
@@ -406,5 +411,5 @@ def test_clause_f1_kij_floor() -> None:
 
 
 def test_multi_junction_adjustment_rejects_zero_junctions() -> None:
-    with pytest.raises(ValueError, match="at least 1"):
+    with pytest.raises(ValueError, match=r"'junctions' must be at least"):
         building.multi_junction_adjustment(0)

--- a/tests/building/prediction/test_masonry_cavity_wall.py
+++ b/tests/building/prediction/test_masonry_cavity_wall.py
@@ -191,7 +191,9 @@ def test_resonance_grows_as_the_square_root_of_the_tie_stiffness() -> None:
 
 
 def test_negative_tie_stiffness_is_rejected() -> None:
-    with pytest.raises(ValueError, match="tie_stiffness_per_area"):
+    with pytest.raises(
+        ValueError, match=r"'tie_stiffness_per_area' must be non-negative"
+    ):
         building.mass_spring_mass_resonance(
             140.0, 140.0, 0.075, tie_stiffness_per_area=-1.0
         )
@@ -362,7 +364,7 @@ def test_coupling_is_proportional_to_the_tie_density() -> None:
 
 
 def test_coupling_rejects_a_non_positive_tie_density() -> None:
-    with pytest.raises(ValueError, match="ties_per_area"):
+    with pytest.raises(ValueError, match=r"'ties_per_area' must be positive"):
         building.wall_tie_coupling_loss_factor(
             [100.0], 150.0, 170.0, 1.0e5, 1.2e5, ties_per_area=0.0
         )

--- a/tests/building/prediction/test_orthotropic_panels.py
+++ b/tests/building/prediction/test_orthotropic_panels.py
@@ -409,7 +409,13 @@ def test_heckl_construction_is_continuous_at_its_four_knots() -> None:
 
 
 def test_heckl_needs_a_wide_coincidence_range() -> None:
-    with pytest.raises(ValueError, match="four times"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"'critical_frequency_upper' above four times "
+            r"'critical_frequency_lower'"
+        ),
+    ):
         building.orthotropic_transmission_loss(
             BANDS,
             FIG627_MASS,
@@ -616,7 +622,10 @@ def test_orthotropic_plot_shades_the_coincidence_range() -> None:
 
 
 def test_orthotropic_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="must exceed"):
+    with pytest.raises(
+        ValueError,
+        match=r"'critical_frequency_upper' must exceed 'critical_frequency_lower'",
+    ):
         building.orthotropic_transmission_loss(
             BANDS,
             FIG627_MASS,
@@ -625,16 +634,16 @@ def test_orthotropic_rejects_bad_input() -> None:
         )
     with pytest.raises(ValueError, match="'method' must be one of"):
         _fig627(BANDS, method="heckle")
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'mass_per_area' must be positive"):
         building.orthotropic_transmission_loss(
             BANDS,
             -1.0,
             critical_frequency_lower=FIG627_FC1,
             critical_frequency_upper=FIG627_FC2,
         )
-    with pytest.raises(ValueError, match="limiting_angle"):
+    with pytest.raises(ValueError, match=r"'limiting_angle' must lie in"):
         _fig627(BANDS, limiting_angle=95.0)
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"'area' must be positive"):
         _fig627(BANDS, area=0.0)
 
 
@@ -647,18 +656,18 @@ def test_orthotropic_validates_every_argument_on_both_routes(method: str) -> Non
     one route while raising on the other is a trap for the caller, so all three
     are validated before the method branch.
     """
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"'area' must be positive"):
         _fig627(BANDS, method=method, area=-5.0)
-    with pytest.raises(ValueError, match="limiting_angle"):
+    with pytest.raises(ValueError, match=r"'limiting_angle' must lie in"):
         _fig627(BANDS, method=method, limiting_angle=170.0)
-    with pytest.raises(ValueError, match="loss_factor"):
+    with pytest.raises(ValueError, match=r"'loss_factor' must be positive"):
         _fig627(BANDS, method=method, loss_factor=-0.01)
 
 
 def test_orthotropic_helpers_reject_bad_input() -> None:
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'corrugation_amplitude' must be positive"):
         building.corrugated_plate_mass_factor(-0.01, 0.1)
-    with pytest.raises(ValueError, match="poisson_ratio"):
+    with pytest.raises(ValueError, match=r"'poisson_ratio' must lie in"):
         building.corrugated_plate_stiffness(
             1e-3, 0.01, 0.1, youngs_modulus=2.1e11, poisson_ratio=1.5
         )
@@ -673,5 +682,5 @@ def test_orthotropic_helpers_reject_bad_input() -> None:
             bending_stiffness_z=1.0,
             bending_stiffness_xz=1.0,
         )
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'bending_stiffness_1' must be positive"):
         building.orthotropic_critical_frequencies(7.8, 0.0, 1.0)

--- a/tests/building/prediction/test_panel_transmission.py
+++ b/tests/building/prediction/test_panel_transmission.py
@@ -144,7 +144,9 @@ def test_single_panel_from_bending_stiffness() -> None:
 
 
 def test_single_panel_requires_fc_or_stiffness() -> None:
-    with pytest.raises(ValueError, match="critical_frequency"):
+    with pytest.raises(
+        ValueError, match=r"provide 'critical_frequency' or 'bending_stiffness'"
+    ):
         building.single_panel_transmission_loss(BANDS, 15.0)
 
 
@@ -220,7 +222,7 @@ def test_double_wall_degenerate_f0_above_fl_is_partitioned() -> None:
 
 
 def test_double_wall_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="gap"):
+    with pytest.raises(ValueError, match=r"'gap' must be positive"):
         building.double_wall_transmission_loss(BANDS, 10.0, 10.0, -0.1)
 
 
@@ -575,16 +577,18 @@ def test_plateau_rejects_a_height_that_underflows_point_a() -> None:
 
 def test_plateau_rejects_bad_frequency_axis() -> None:
 
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'frequency' must be positive"):
         building.plateau_transmission_loss(
             [100.0, -1.0], material="brick", thickness_mm=110.0
         )
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'frequency' must be a non-empty"):
         building.plateau_transmission_loss([], material="brick", thickness_mm=110.0)
 
 
 def test_negative_field_correction_rejected() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"'field_correction' must be finite and non-negative"
+    ):
         building.mass_law_transmission_loss(500.0, 15.0, field_correction=-1.0)
 
 

--- a/tests/building/prediction/test_resilient_layers.py
+++ b/tests/building/prediction/test_resilient_layers.py
@@ -1244,54 +1244,69 @@ def test_octave_bandwidth_factor() -> None:
 @pytest.mark.parametrize(
     ("call", "match"),
     [
-        (lambda: building.hammer_impact_velocity(-1.0), "drop_height"),
+        (
+            lambda: building.hammer_impact_velocity(-1.0),
+            "'drop_height' must be positive",
+        ),
         (
             lambda: building.plate_contact_stiffness(1e9, poisson_ratio=1.5),
-            "poisson_ratio",
+            "'poisson_ratio' must lie in",
         ),
-        (lambda: building.covering_contact_stiffness(1e9, 0.0), "thickness"),
+        (
+            lambda: building.covering_contact_stiffness(1e9, 0.0),
+            "'thickness' must be positive",
+        ),
         (
             lambda: building.tapping_force_spectrum([100.0], 1e6, 1e3, band="half"),
-            "band",
+            "'band' must be one of",
         ),
-        (lambda: building.force_pulse([-1.0], 1e6, 1e3), "time"),
-        (lambda: building.combined_dynamic_stiffness([]), "layers"),
+        (
+            lambda: building.force_pulse([-1.0], 1e6, 1e3),
+            "'time' must contain only finite",
+        ),
+        (
+            lambda: building.combined_dynamic_stiffness([]),
+            "'layers' must be a non-empty",
+        ),
         (
             lambda: building.weighted_floating_floor_improvement(
                 1.0, 1e6, floor="cork"
             ),
-            "floor",
+            "'floor' must be one of",
         ),
-        (lambda: building.lining_improvement(100.0, system="cork"), "system"),
+        (
+            lambda: building.lining_improvement(100.0, system="cork"),
+            "'system' must be one of",
+        ),
         (
             lambda: building.lining_resonance_frequency(50.0, 10.0),
-            "exactly one",
+            "Give exactly one of 'dynamic_stiffness'",
         ),
         (
             lambda: building.lining_resonance_frequency(
                 50.0, 10.0, dynamic_stiffness=1e6, cavity_depth=0.05
             ),
-            "exactly one",
+            "Give exactly one of 'dynamic_stiffness'",
         ),
         (
             lambda: building.floating_floor_improvement_spectrum(
                 [100.0], resonance_frequency=50.0, model="cremer_hammer"
             ),
-            "limiting_frequency",
+            "'limiting_frequency' is required by model=",
         ),
         (
             lambda: building.floating_floor_improvement_spectrum(
                 [100.0], resonance_frequency=50.0, model="ver"
             ),
-            "model",
+            "'model' must be one of",
         ),
         (
             lambda: building.weighted_lining_improvement(100.0, float("nan")),
-            "base_rating",
+            "'base_rating' must be finite",
         ),
         (
             lambda: building.lining_improvement_in_situ(float("inf"), 100.0, 50.0),
-            "finite",
+            "'base_rating_in_situ' must be finite",
         ),
     ],
 )

--- a/tests/building/prediction/test_simplified_model.py
+++ b/tests/building/prediction/test_simplified_model.py
@@ -144,7 +144,7 @@ def test_kij_lightweight_double_homogeneous_e7() -> None:
         building.junction_vibration_reduction(
             "lightweight_double_homogeneous", "double_leaf", 0.5
         )
-    with pytest.raises(ValueError, match="< 1/3"):
+    with pytest.raises(ValueError, match=r"mass_ratio = m'⊥,i/m'i < 1/3"):
         building.junction_vibration_reduction(
             "lightweight_double_homogeneous", "double_leaf", 5.0
         )
@@ -185,7 +185,7 @@ def test_kij_corner_and_thickness_change_e9() -> None:
     assert building.junction_vibration_reduction(
         "thickness_change", "through", 1.0
     ) == pytest.approx(-5.0)
-    with pytest.raises(ValueError, match="single path"):
+    with pytest.raises(ValueError, match=r"A 'corner' junction has the single path"):
         building.junction_vibration_reduction("corner", "through", 10.0)
     with pytest.raises(ValueError, match="single in-line path"):
         building.junction_vibration_reduction("thickness_change", "corner", 3.0)
@@ -672,9 +672,13 @@ def test_standardized_level_difference_annex_h3_closure() -> None:
 
 def test_equivalent_impact_level_warns_outside_envelope() -> None:
     # Annex B covers 100-600 kg/m2; outside it the closed form extrapolates.
-    with pytest.warns(UserWarning, match="100-600"):
+    with pytest.warns(
+        UserWarning, match=r"mass_per_area = .* lies outside the .* envelope"
+    ):
         building.equivalent_impact_level(50.0)
-    with pytest.warns(UserWarning, match="extrapolation"):
+    with pytest.warns(
+        UserWarning, match=r"mass_per_area = .* lies outside the .* envelope"
+    ):
         building.equivalent_impact_level(800.0)
     # Inside the envelope no warning is emitted.
     with warnings.catch_warnings():

--- a/tests/building/prediction/test_simplified_model_report.py
+++ b/tests/building/prediction/test_simplified_model_report.py
@@ -378,7 +378,10 @@ def test_facade_report_requires_single_number_ratings(tmp_path: Path) -> None:
         volume=50.0,
     )
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="single-number"):
+    with pytest.raises(
+        ValueError,
+        match=r"facade prediction report needs the ISO 717-1 single-number ratings",
+    ):
         result.report(out)
 
 
@@ -386,7 +389,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = _annex_h3_airborne()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -394,5 +397,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` (shared validation path)."""
     out = str(tmp_path / "x.pdf")
     result = _annex_e3_impact()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="fr")

--- a/tests/building/prediction/test_wall_linings.py
+++ b/tests/building/prediction/test_wall_linings.py
@@ -254,7 +254,10 @@ def test_table_d1_1600_hz_overlap_takes_the_conservative_value() -> None:
 @pytest.mark.parametrize("resonance", [20.0, 6000.0])
 def test_table_d1_rejects_untabulated_resonances(resonance: float) -> None:
     """Table D.1 covers 30 Hz to 5 000 Hz only."""
-    with pytest.raises(ValueError, match="Table D.1"):
+    with pytest.raises(
+        ValueError,
+        match=r"'resonance_frequency' must lie in .* Table D\.1 is not tabulated",
+    ):
         building.weighted_lining_improvement(resonance, 45.0)
 
 
@@ -437,9 +440,12 @@ def test_in_situ_transfer_formula_d8() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"system": "studs", "glued_area": 40.0}, "glued exterior systems"),
-        ({"glued_area": 100.1}, "glued_area"),
-        ({"glued_area": 0.0}, "glued_area"),
+        (
+            {"system": "studs", "glued_area": 40.0},
+            r"'glued_area' applies to the glued exterior systems",
+        ),
+        ({"glued_area": 100.1}, r"'glued_area' is a percentage and cannot exceed"),
+        ({"glued_area": 0.0}, r"'glued_area' must be positive"),
     ],
 )
 def test_glued_area_guards(kwargs: dict[str, object], match: str) -> None:

--- a/tests/building/regulation/test_spanish_building_code.py
+++ b/tests/building/regulation/test_spanish_building_code.py
@@ -297,9 +297,9 @@ def test_d2m_nt_a_defaults_to_pink_noise() -> None:
 
 def test_facade_helpers_reject_each_other_s_spectra() -> None:
     """Neither helper accepts a spectrum its formula does not cover."""
-    with pytest.raises(ValueError, match="d2m_nt_a"):
+    with pytest.raises(ValueError, match=r"Formula \(A\.6\) evaluates 'D2m,nT,Atr'"):
         hr.d2m_nt_atr(_D2M_NT, spectrum="railway")
-    with pytest.raises(ValueError, match="d2m_nt_atr"):
+    with pytest.raises(ValueError, match=r"Formula \(A\.5\) evaluates 'D2m,nT,A'"):
         hr.d2m_nt_a(_D2M_NT, spectrum="traffic")
 
 
@@ -592,7 +592,7 @@ def test_party_wall_requirement_clause_2_1_1_c() -> None:
     assert (per_leaf.quantity, per_leaf.limit) == ("D2m,nT,Atr", 40.0)
     combined = hr.db_hr_party_wall_requirement("DnT,A")
     assert (combined.quantity, combined.limit) == ("DnT,A", 50.0)
-    with pytest.raises(ValueError, match="quantity"):
+    with pytest.raises(ValueError, match=r"'quantity' must be"):
         hr.db_hr_party_wall_requirement("RA")
 
 
@@ -670,18 +670,20 @@ def test_assessment_aggregates_every_check() -> None:
 # --------------------------------------------------------------------------- #
 def test_global_index_validation() -> None:
     """Wrong band counts, unknown spectra and non-finite values are rejected."""
-    with pytest.raises(ValueError, match="spectrum"):
+    with pytest.raises(ValueError, match=r"'spectrum' must be one of"):
         hr.db_hr_global_index(_R_PRIME, "white")
-    with pytest.raises(ValueError, match="eighteen"):
+    with pytest.raises(
+        ValueError, match=r"Without 'frequencies' the input must be the eighteen DB-HR"
+    ):
         hr.db_hr_global_index(_R_PRIME[:10])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'band_values' must contain finite"):
         hr.db_hr_global_index([math.nan, *_R_PRIME[1:]])
     two_dimensional = np.zeros((2, 18))
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'band_values' must be one-dimensional"):
         hr.db_hr_global_index(two_dimensional)
     with pytest.raises(ValueError, match=r"'frequencies'.*same shape"):
         hr.db_hr_global_index(_R_PRIME, frequencies=[100.0, 125.0])
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'frequencies' must contain positive"):
         hr.db_hr_global_index(_R_PRIME, frequencies=[0.0, *hr.DB_HR_FREQUENCIES[1:]])
 
 
@@ -703,7 +705,7 @@ def test_global_index_rejects_a_spectrum_of_another_band_set() -> None:
     """
     index = hr.ra(_R_PRIME)
     one_band_too_many = np.append(index.spectrum_levels, 99.9)
-    with pytest.raises(ValueError, match="'spectrum_levels'"):
+    with pytest.raises(ValueError, match=r"'spectrum_levels' \(19\)"):
         dataclasses.replace(index, spectrum_levels=one_band_too_many)
 
 
@@ -793,23 +795,27 @@ def test_a_check_on_an_undetermined_value_is_refused() -> None:
     requirement = hr.DbHrRequirement(
         "DnT,A", 50.0, "min", "dBA", 0, "DB-HR 2.1", "between dwellings"
     )
-    with pytest.raises(ValueError, match="'value' must be finite"):
+    with pytest.raises(ValueError, match=r"DbHrCheck: 'value' must be finite"):
         hr.DbHrCheck(requirement, math.nan, 45.0, -5.0, complies=False)
 
 
 def test_requirement_lookup_validation() -> None:
     """Unknown uses, rooms and room-pair combinations are rejected."""
-    with pytest.raises(ValueError, match="Unknown"):
+    with pytest.raises(
+        ValueError, match=r"Unknown \(building_use, room_type\) combination"
+    ):
         hr.db_hr_facade_requirement(62.0, "industrial", "bedrooms")
-    with pytest.raises(ValueError, match="dominant_noise"):
+    with pytest.raises(ValueError, match=r"'dominant_noise' must be"):
         hr.db_hr_facade_requirement(
             62.0, "residential", "bedrooms", dominant_noise="sea"
         )
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'ld' must be finite"):
         hr.db_hr_facade_requirement(math.nan, "residential", "bedrooms")
-    with pytest.raises(ValueError, match="Unknown"):
+    with pytest.raises(
+        ValueError, match=r"Unknown \(receiving_room, source_room\) combination"
+    ):
         hr.db_hr_airborne_requirement("protected", "outdoors")
-    with pytest.raises(ValueError, match="room_use"):
+    with pytest.raises(ValueError, match=r"'room_use' must be"):
         hr.db_hr_reverberation_requirement("swimming_pool")
 
 
@@ -819,7 +825,7 @@ def test_requirement_direction_is_validated() -> None:
     ``check_db_hr_requirement`` branches on "min" and treats anything else as
     "max", so the dataclass rejects any other spelling at construction.
     """
-    with pytest.raises(ValueError, match="direction"):
+    with pytest.raises(ValueError, match=r"'direction' must be"):
         hr.DbHrRequirement("D2m,nT,Atr", 32.0, "minimum", "dBA", 0, "ref", "desc")
     assert hr.DbHrRequirement("T", 0.7, "max", "s", 1, "ref", "desc").direction == "max"
 
@@ -840,12 +846,12 @@ def test_result_does_not_alias_the_caller_s_array() -> None:
 
 def test_window_size_and_assessment_validation() -> None:
     """A window needs a positive area and an assessment at least one check."""
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'area' must be a positive"):
         hr.window_size_correction(0.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'area' must be a positive"):
         hr.window_size_correction(-2.0)
     with pytest.raises(ValueError, match="At least one"):
         hr.assess_db_hr([])
     impact_requirement = hr.db_hr_impact_requirement("protected", "other_unit")
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'value' must be finite"):
         hr.check_db_hr_requirement(math.nan, impact_requirement)

--- a/tests/electroacoustics/test_distortion.py
+++ b/tests/electroacoustics/test_distortion.py
@@ -412,7 +412,7 @@ def test_difference_frequency_rejects_bad_args() -> None:
     tone = _tone(1000.0)
     with pytest.raises(ValueError, match="'f1' must be lower than 'f2'"):
         electroacoustics.difference_frequency_distortion(tone, FS, f1=2000.0, f2=1000.0)
-    with pytest.raises(ValueError, match="'order' must be"):
+    with pytest.raises(ValueError, match="'order' must be 2"):
         electroacoustics.difference_frequency_distortion(
             tone, FS, f1=1000.0, f2=2000.0, order=4
         )
@@ -513,7 +513,7 @@ def test_rejects_bad_fs_and_kind() -> None:
     tone = _tone(1000.0)
     with pytest.raises(ValueError, match="'fs' must be a positive"):
         electroacoustics.thd(tone, 0.0)
-    with pytest.raises(ValueError, match="'kind' must be"):
+    with pytest.raises(ValueError, match="'kind' must be 'F'"):
         electroacoustics.thd(tone, FS, 1000.0, kind="X")  # type: ignore[arg-type]
 
 
@@ -577,7 +577,9 @@ def test_itu_r_468_weighting_table_values() -> None:
     assert grid[int(np.argmax(curve))] == pytest.approx(6300.0, rel=1e-3)
     # DC blocks completely; negative/non-finite frequencies are rejected.
     assert electroacoustics.itu_r_468_weighting([0.0])[0] == -np.inf
-    with pytest.raises(ValueError, match="'frequencies' must be"):
+    with pytest.raises(
+        ValueError, match="'frequencies' must be finite and non-negative"
+    ):
         electroacoustics.itu_r_468_weighting([-100.0])
 
 
@@ -602,7 +604,7 @@ def test_weighted_thd_468_emphasises_6khz_products() -> None:
     assert w468 == pytest.approx(0.01 * 10.0 ** (12.2 / 20.0), rel=0.02)
     w_a = electroacoustics.weighted_thd(x, FS, 100.0, weighting="A")
     assert w468 / w_a == pytest.approx(10.0 ** (12.2 / 20.0), rel=0.05)
-    with pytest.raises(ValueError, match="'weighting' must be"):
+    with pytest.raises(ValueError, match="'weighting' must be '468'"):
         electroacoustics.weighted_thd(x, FS, 100.0, weighting="B")  # type: ignore[arg-type]
 
 
@@ -630,7 +632,10 @@ def test_thd_raises_when_no_harmonic_below_nyquist() -> None:
     # A 20 kHz fundamental at fs = 48 kHz has its 2nd harmonic above
     # Nyquist: the THD is undefined and must raise, not return 0.
     tone_hf = _tone(20000.0)
-    with pytest.raises(ValueError, match="Nyquist"):
+    with pytest.raises(
+        ValueError,
+        match=r"No harmonic of the fundamental lies below the Nyquist frequency",
+    ):
         electroacoustics.thd(tone_hf, FS, 20000.0)
 
 

--- a/tests/electroacoustics/test_electroacoustics_plot_i18n.py
+++ b/tests/electroacoustics/test_electroacoustics_plot_i18n.py
@@ -194,7 +194,7 @@ def test_loudspeaker_characteristics_es() -> None:
         "Nivel de presión acústica [dB]"
     )
     plt.close("all")
-    with pytest.raises(ValueError, match="unknown quantity"):
+    with pytest.raises(ValueError, match=r"unknown quantity"):
         res.plot(quantity="bogus")
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
@@ -219,7 +219,7 @@ def test_microphone_characteristics_es() -> None:
         "Nivel de presión acústica [dB]"
     )
     plt.close("all")
-    with pytest.raises(ValueError, match="unknown quantity"):
+    with pytest.raises(ValueError, match=r"unknown quantity"):
         res.plot(quantity="bogus")
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")

--- a/tests/electroacoustics/test_electroacoustics_signal_overloads.py
+++ b/tests/electroacoustics/test_electroacoustics_signal_overloads.py
@@ -133,7 +133,9 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
 def test_a_bare_array_still_requires_fs(
     func: Callable[..., object], record: np.ndarray, kwargs: dict[str, float]
 ) -> None:
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(
+        ValueError, match=r"fs is required when 'signal' is a bare array"
+    ):
         func(record, **kwargs)
 
 
@@ -145,7 +147,7 @@ def test_a_multichannel_signal_is_refused_by_name(
 ) -> None:
     """These metrics are defined on one record, and say so."""
     block = Signal(np.stack([record, record]), FS)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'signal' must be one-dimensional"):
         func(block, **kwargs)
 
 
@@ -201,7 +203,7 @@ def test_two_signals_at_different_rates_are_refused(
     func: Callable[..., object], kwargs: dict[str, float]
 ) -> None:
     first, second = Signal(_HARMONIC, FS), Signal(_MODULATION, FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(ValueError, match=r"are Signals recorded at different rates"):
         func(first, second, **kwargs)
 
 
@@ -209,7 +211,7 @@ def test_two_signals_at_different_rates_are_refused(
 def test_a_pair_of_bare_arrays_still_requires_fs(
     func: Callable[..., object], kwargs: dict[str, float]
 ) -> None:
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(ValueError, match=r"fs is required when 'x' is a bare array"):
         func(_HARMONIC, _MODULATION, **kwargs)
 
 
@@ -272,7 +274,9 @@ def test_swept_sine_refuses_a_conflicting_rate() -> None:
 
 
 def test_swept_sine_still_requires_fs_for_a_bare_array() -> None:
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(
+        ValueError, match=r"fs is required when 'recorded' is a bare array"
+    ):
         swept_sine_distortion(_RECORDED, **_SWEEP_KWARGS)
 
 

--- a/tests/electroacoustics/test_frequency_response.py
+++ b/tests/electroacoustics/test_frequency_response.py
@@ -107,7 +107,7 @@ def test_response_curves_must_share_one_frequency_axis() -> None:
     """
     x, y, _, _ = _known_system()
     good = electroacoustics.transfer_function(x, y, FS)
-    per_frequency = "one value per frequency"
+    per_frequency = "must each carry one value per frequency"
     for field in ("frequencies", "response", "magnitude_db", "phase", "coherence"):
         curve = getattr(good, field)
         for value in (curve[:-1], np.append(curve, curve[-1])):
@@ -122,7 +122,7 @@ def test_rejects_mismatched_lengths() -> None:
     """Both entry points name themselves, not the validator they share."""
     x = np.zeros(1000)
     shorter_y = np.zeros(500)
-    per_sample = r"'x'.*'y'.*one value per sample"
+    per_sample = r"'x'.*'y'.*must each carry one value per sample"
     with pytest.raises(ValueError, match=rf"transfer_function: {per_sample}"):
         electroacoustics.transfer_function(x, shorter_y, FS)
     with pytest.raises(ValueError, match=rf"coherence: {per_sample}"):
@@ -146,7 +146,7 @@ def test_high_overlap_does_not_crash() -> None:
 
 def test_rejects_bad_nperseg() -> None:
     x = np.zeros(1000)
-    with pytest.raises(ValueError, match="'nperseg'"):
+    with pytest.raises(ValueError, match="'nperseg' must be between"):
         electroacoustics.transfer_function(x, x, FS, nperseg=5000)
 
 
@@ -168,7 +168,7 @@ def test_rejects_nperseg_beyond_float_range() -> None:
     # Used to escape as OverflowError out of math.isfinite(); an integer is
     # finite by construction, so it reaches the range check and its name.
     x = np.zeros(1000)
-    with pytest.raises(ValueError, match="'nperseg' must be between 32"):
+    with pytest.raises(ValueError, match="'nperseg' must be between"):
         electroacoustics.transfer_function(x, x, FS, nperseg=10**10000)
 
 

--- a/tests/electroacoustics/test_loudspeaker.py
+++ b/tests/electroacoustics/test_loudspeaker.py
@@ -192,12 +192,15 @@ def test_minimum_impedance_without_rated_range_misses_out_of_band_dip() -> None:
 
 def test_rated_impedance_must_be_positive() -> None:
     f, spl = _flat_response()
-    with pytest.raises(ValueError, match="rated_impedance"):
+    with pytest.raises(ValueError, match=r"'rated_impedance' must be positive"):
         electroacoustics.loudspeaker_characteristics(f, spl, 0.0)
 
 
 def test_mismatched_response_lengths_rejected() -> None:
-    with pytest.raises(ValueError, match="equal length"):
+    with pytest.raises(
+        ValueError,
+        match=r"'on-axis response' frequencies and values must be 1-D and equal length",
+    ):
         electroacoustics.loudspeaker_characteristics(
             [100.0, 200.0, 400.0], [90.0, 90.0], _R
         )
@@ -373,13 +376,15 @@ def test_plot_rejects_unknown_quantity_and_missing_data() -> None:
     matplotlib.use("Agg")
 
     result = _example_result()
-    with pytest.raises(ValueError, match="unknown quantity"):
+    with pytest.raises(ValueError, match=r"unknown quantity 'bogus'"):
         result.plot(quantity="bogus")
     f, spl = _flat_response()
     bare = electroacoustics.loudspeaker_characteristics(
         f, spl, _R, sensitivity_band=(200.0, 4000.0)
     )
-    with pytest.raises(ValueError, match="no impedance"):
+    with pytest.raises(
+        ValueError, match=r"this result carries no impedance curve to plot"
+    ):
         bare.plot(quantity="impedance")
 
 
@@ -404,7 +409,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 
@@ -412,7 +417,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         result.report(out, language="xx")
 
 
@@ -506,7 +511,10 @@ def test_a_non_finite_response_axis_no_longer_reaches_the_fiche(
     axis = np.array(result.frequencies, dtype=float)
     axis[10] = float("nan")
     out = tmp_path / "non_finite_axis.pdf"
-    with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
+    with pytest.raises(
+        ValueError,
+        match=r"LoudspeakerCharacteristics: 'frequencies' must contain only finite",
+    ):
         dataclasses.replace(result, frequencies=axis)
     assert not out.exists()
 

--- a/tests/electroacoustics/test_microphone.py
+++ b/tests/electroacoustics/test_microphone.py
@@ -309,12 +309,15 @@ def test_distortion_below_limit_gives_no_max_spl() -> None:
 
 def test_sensitivity_must_be_positive() -> None:
     f, rel = _flat_response()
-    with pytest.raises(ValueError, match="sensitivity_mv_per_pa"):
+    with pytest.raises(ValueError, match=r"'sensitivity_mv_per_pa' must be positive"):
         electroacoustics.microphone_characteristics(f, rel, 0.0)
 
 
 def test_mismatched_response_lengths_rejected() -> None:
-    with pytest.raises(ValueError, match="equal length"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequency response' frequencies and values must be 1-D and equal length",
+    ):
         electroacoustics.microphone_characteristics(
             [100.0, 200.0, 400.0], [0.0, 0.0], _M_MV
         )
@@ -322,7 +325,10 @@ def test_mismatched_response_lengths_rejected() -> None:
 
 def test_reference_frequency_outside_band_rejected() -> None:
     f, rel = _flat_response()
-    with pytest.raises(ValueError, match="reference_frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"'reference_frequency' must lie within the measured frequency band",
+    ):
         electroacoustics.microphone_characteristics(
             f, rel, _M_MV, reference_frequency=30000.0
         )
@@ -333,14 +339,20 @@ def test_noise_voltage_and_stated_level_conflict() -> None:
     conflicting_noise = electroacoustics.MicrophoneNoise(
         voltage=1e-6, equivalent_level_db=14.0
     )
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(
+        ValueError,
+        match=r"either 'noise\.voltage' or 'noise\.equivalent_level_db', not both",
+    ):
         electroacoustics.microphone_characteristics(
             f, rel, _M_MV, noise=conflicting_noise
         )
 
 
 def test_nonpositive_frequencies_rejected() -> None:
-    with pytest.raises(ValueError, match="positive and finite"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequency response' frequencies must be positive and finite",
+    ):
         electroacoustics.microphone_characteristics(
             [0.0, 100.0, 1000.0], [0.0, 0.0, 0.0], _M_MV
         )
@@ -349,7 +361,9 @@ def test_nonpositive_frequencies_rejected() -> None:
 def test_empty_distortion_rejected() -> None:
     f, rel = _flat_response()
     empty_distortion = electroacoustics.MicrophoneOverload(distortion=([], []))
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(
+        ValueError, match="'distortion' needs at least two frequency points"
+    ):
         electroacoustics.microphone_characteristics(
             f, rel, _M_MV, overload=empty_distortion
         )
@@ -358,14 +372,16 @@ def test_empty_distortion_rejected() -> None:
 def test_empty_noise_spectrum_rejected() -> None:
     f, rel = _flat_response()
     empty_spectrum = electroacoustics.MicrophoneNoise(spectrum=([], []))
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(
+        ValueError, match=r"'noise\.spectrum' needs at least two frequency points"
+    ):
         electroacoustics.microphone_characteristics(f, rel, _M_MV, noise=empty_spectrum)
 
 
 def test_empty_polar_rejected() -> None:
     f, rel = _flat_response()
     empty_polar = electroacoustics.MicrophoneDirectivity(polar=([], []))
-    with pytest.raises(ValueError, match="at least two angle points"):
+    with pytest.raises(ValueError, match="'polar' needs at least two angle points"):
         electroacoustics.microphone_characteristics(
             f, rel, _M_MV, directivity=empty_polar
         )
@@ -555,7 +571,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -563,7 +579,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     result = _example_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="xx")
 
 
@@ -617,7 +633,10 @@ def test_a_non_finite_response_axis_no_longer_reaches_the_fiche(
     axis = np.array(result.frequencies, dtype=float)
     axis[10] = float("nan")
     out = tmp_path / "non_finite_axis.pdf"
-    with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
+    with pytest.raises(
+        ValueError,
+        match=r"MicrophoneCharacteristics: 'frequencies' must contain only finite",
+    ):
         dataclasses.replace(result, frequencies=axis)
     assert not out.exists()
 

--- a/tests/electroacoustics/test_sound_reinforcement.py
+++ b/tests/electroacoustics/test_sound_reinforcement.py
@@ -26,6 +26,7 @@ special cases with ``N_m = 1``.
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import pytest
@@ -184,7 +185,7 @@ def test_loop_gain_is_the_sum_of_its_parts() -> None:
 
 def test_result_is_frozen() -> None:
     result = electroacoustics.feedback_stability(-6.0, 74.0, 80.0)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         result.open_loop_gain = 0.0  # type: ignore[misc]
 
 
@@ -251,11 +252,15 @@ def test_open_microphone_validation(bad: float) -> None:
 
 
 def test_validation_errors() -> None:
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'open_loop_gain' must be finite"):
         electroacoustics.feedback_stability(math.nan, 74.0, 80.0)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"Levels and the directivity index must be finite"
+    ):
         electroacoustics.feedback_stability(-6.0, math.inf, 80.0)
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"'stability_margin' must be finite and non-negative"
+    ):
         electroacoustics.feedback_stability(-6.0, 74.0, 80.0, stability_margin=-1.0)
     with pytest.raises(ValueError, match="integer of at least 1"):
         electroacoustics.feedback_stability(-6.0, 74.0, 80.0, open_microphones=0)

--- a/tests/electroacoustics/test_swept_sine.py
+++ b/tests/electroacoustics/test_swept_sine.py
@@ -90,19 +90,23 @@ def test_synchronized_sweep_starts_at_zero_phase() -> None:
 
 
 def test_synchronized_sweep_band_and_duration_validation() -> None:
-    with pytest.raises(ValueError, match="f2"):
+    with pytest.raises(ValueError, match=r"'f2' must be greater than 'f1'"):
         ph.electroacoustics.synchronized_sweep_signal(FS, 100.0, 50.0, SECONDS)
-    with pytest.raises(ValueError, match="Nyquist"):
+    with pytest.raises(ValueError, match=r"'f2' must not exceed the Nyquist frequency"):
         ph.electroacoustics.synchronized_sweep_signal(FS, 100.0, 30000.0, SECONDS)
-    with pytest.raises(ValueError, match="synchronize"):
+    with pytest.raises(
+        ValueError, match=r"'seconds' is too short to synchronize the sweep"
+    ):
         ph.electroacoustics.synchronized_sweep_signal(FS, 1.0, 1000.0, 0.5)
-    with pytest.raises(ValueError, match="fade"):
+    with pytest.raises(ValueError, match=r"fade must be in"):
         ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS, fade=0.7)
 
 
 def test_synchronized_sweep_rejects_bad_amplitude() -> None:
     for bad in (0.0, -1.0, float("inf")):
-        with pytest.raises(ValueError, match="amplitude"):
+        with pytest.raises(
+            ValueError, match=r"'amplitude' must be a positive, finite number"
+        ):
             ph.electroacoustics.synchronized_sweep_signal(
                 FS, F1, F2, SECONDS, amplitude=bad
             )
@@ -112,7 +116,10 @@ def test_empty_thd_grid_raises_actionably() -> None:
     """f1 above fs/4: every order-2 product would exceed Nyquist."""
     f1, f2, seconds = 13000.0, 20000.0, 0.5
     x = ph.electroacoustics.synchronized_sweep_signal(FS, f1, f2, seconds)
-    with pytest.raises(ValueError, match="order-2 product"):
+    with pytest.raises(
+        ValueError,
+        match=r"no excitation-frequency bin has a measurable order-2 product",
+    ):
         ph.electroacoustics.swept_sine_distortion(
             x, FS, f1=f1, f2=f2, seconds=seconds, n_harmonics=2
         )
@@ -309,32 +316,41 @@ def test_validation_errors() -> None:
     x = ph.electroacoustics.synchronized_sweep_signal(FS, F1, F2, SECONDS)
     rec = _polynomial_recording(x)
     two_dimensional = rec.reshape(2, -1)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'recorded' must be one-dimensional"):
         ph.electroacoustics.swept_sine_distortion(
             two_dimensional, FS, f1=F1, f2=F2, seconds=SECONDS
         )
     not_finite = np.full(rec.size, np.nan)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'recorded' must be finite"):
         ph.electroacoustics.swept_sine_distortion(
             not_finite, FS, f1=F1, f2=F2, seconds=SECONDS
         )
-    with pytest.raises(ValueError, match="method"):
+    with pytest.raises(ValueError, match=r"'method' must be 'synchronized'"):
         ph.electroacoustics.swept_sine_distortion(
             rec, FS, f1=F1, f2=F2, seconds=SECONDS, method="nope"
         )  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="n_harmonics"):
+    with pytest.raises(ValueError, match=r"'n_harmonics' must be at least"):
         ph.electroacoustics.swept_sine_distortion(
             rec, FS, f1=F1, f2=F2, seconds=SECONDS, n_harmonics=1
         )
-    with pytest.raises(ValueError, match="whole sweep"):
+    with pytest.raises(
+        ValueError, match=r"'recorded' has \d+ samples but the sweep lasts"
+    ):
         ph.electroacoustics.swept_sine_distortion(
             rec[: rec.size // 2], FS, f1=F1, f2=F2, seconds=SECONDS
         )
-    with pytest.raises(ValueError, match="overlap"):
+    with pytest.raises(
+        ValueError,
+        match=r"'ir_length' \(\d+\) exceeds the \d+-sample spacing between orders",
+    ):
         ph.electroacoustics.swept_sine_distortion(
             rec, FS, f1=F1, f2=F2, seconds=SECONDS, ir_length=1 << 16
         )
-    with pytest.raises(ValueError, match="Lengthen the sweep"):
+    # "Lengthen the sweep" alone also matches the too-short-to-synchronize
+    # refusal above, which ends with the same advice.
+    with pytest.raises(
+        ValueError, match=r"the harmonic windows would be \d+ samples long"
+    ):
         # So many orders that the two closest arrivals are < 16 samples
         # apart and no usable window exists.
         ph.electroacoustics.swept_sine_distortion(
@@ -352,7 +368,10 @@ def test_farina_rejects_orders_beyond_the_sweep_ratio() -> None:
     fs, f1, f2, seconds = 48000, 1000.0, 2000.0, 1.0
     x = ph.room.sweep_signal(fs, f1, f2, seconds)
     rec = np.concatenate([x, np.zeros(4096)])
-    with pytest.raises(ValueError, match="anticausal"):
+    with pytest.raises(
+        ValueError,
+        match=r"method='farina' can only separate orders up to the sweep frequency ratio",
+    ):
         ph.electroacoustics.swept_sine_distortion(
             rec,
             fs,

--- a/tests/psychoacoustics/loudness/test_contours.py
+++ b/tests/psychoacoustics/loudness/test_contours.py
@@ -84,9 +84,13 @@ def test_roundtrip() -> None:
 
 def test_validity_limits() -> None:
     """Clause 4.1: 20-90 phon; above 80 phon only 20 Hz - 4 kHz remains."""
-    with pytest.raises(ValueError, match="phon"):
+    with pytest.raises(
+        ValueError, match=r"ISO 226:2023 Formula \(1\) is specified for .* phon"
+    ):
         psychoacoustics.equal_loudness_contour(19.0)
-    with pytest.raises(ValueError, match="phon"):
+    with pytest.raises(
+        ValueError, match=r"ISO 226:2023 Formula \(1\) is specified for .* phon"
+    ):
         psychoacoustics.equal_loudness_contour(91.0)
     freqs80, _ = psychoacoustics.equal_loudness_contour(80.0)
     freqs81, _ = psychoacoustics.equal_loudness_contour(81.0)
@@ -98,7 +102,10 @@ def test_untabulated_frequency_raises() -> None:
     """Table 1 defines parameters only at the 29 preferred frequencies; the
     standard specifies no interpolation between them.
     """
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"ISO 226:2023 Table 1 defines parameters only at the .* frequencies",
+    ):
         psychoacoustics.loudness_level(60.0, 440.0)
 
 
@@ -164,12 +171,17 @@ def test_contours_frequency_subset() -> None:
 
 
 def test_contours_rejects_untabulated_frequency() -> None:
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"ISO 226:2023 Table 1 defines parameters only at the .* frequencies",
+    ):
         psychoacoustics.equal_loudness_contours(frequencies=(440.0,))
 
 
 def test_contours_rejects_out_of_range_phon() -> None:
-    with pytest.raises(ValueError, match="phon"):
+    with pytest.raises(
+        ValueError, match=r"ISO 226:2023 Formula \(1\) is specified for .* phon"
+    ):
         psychoacoustics.equal_loudness_contours(phons=(10.0,))
 
 

--- a/tests/psychoacoustics/loudness/test_moore_glasberg.py
+++ b/tests/psychoacoustics/loudness/test_moore_glasberg.py
@@ -429,7 +429,9 @@ def test_a_result_refuses_a_centre_frequency_per_filter_missing() -> None:
     """
     result = psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, 60.0)])
     one_filter_short = result.centre_frequencies[1:]
-    with pytest.raises(ValueError, match="'centre_frequencies'"):
+    with pytest.raises(
+        ValueError, match=rf"'centre_frequencies' \({one_filter_short.size}\)"
+    ):
         dataclasses.replace(result, centre_frequencies=one_filter_short)
 
 
@@ -443,7 +445,7 @@ def test_a_result_refuses_a_centre_frequency_column_of_pairs() -> None:
     """
     result = psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, 60.0)])
     pairs = np.column_stack([result.centre_frequencies, result.centre_frequencies])
-    with pytest.raises(ValueError, match="'centre_frequencies'"):
+    with pytest.raises(ValueError, match="'centre_frequencies' must have one axis"):
         dataclasses.replace(result, centre_frequencies=pairs)
 
 

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -181,9 +181,13 @@ def test_stationary_time_skip() -> None:
     # ~1 % residual vs the from-onset tone: that one still contains the
     # broadband onset click the skip removes.
     assert n_skip == pytest.approx(n_steady, rel=0.02)
-    with pytest.raises(ValueError, match="time_skip"):
+    with pytest.raises(
+        ValueError, match=r"'time_skip' must be a non-negative, finite time"
+    ):
         psychoacoustics.loudness_zwicker(x, FS, stationary=True, time_skip=-0.1)
-    with pytest.raises(ValueError, match="time_skip"):
+    with pytest.raises(
+        ValueError, match=r"'time_skip' must leave at least one sample of signal"
+    ):
         psychoacoustics.loudness_zwicker(x, FS, stationary=True, time_skip=2.0)
 
 
@@ -415,7 +419,9 @@ def test_trace_that_disagrees_with_its_time_axis_is_refused() -> None:
         res.loudness_vs_time[:-1],
         np.append(res.loudness_vs_time, res.loudness_vs_time[-1]),
     ):
-        with pytest.raises(ValueError, match="'loudness_vs_time'"):
+        with pytest.raises(
+            ValueError, match=r"'loudness_vs_time' \(\d+\) must each carry one value"
+        ):
             dataclasses.replace(res, loudness_vs_time=trace)
 
 
@@ -503,24 +509,29 @@ def test_annex_b5_technical_signals(num: int) -> None:
 
 def test_invalid_inputs() -> None:
     ten_bands = np.zeros(10)
-    with pytest.raises(ValueError, match="28"):
+    with pytest.raises(
+        ValueError,
+        match=r"'levels' must contain exactly 28 one-third-octave band levels",
+    ):
         psychoacoustics.loudness_zwicker_from_spectrum(ten_bands)
     levels = np.full(28, 60.0)
-    with pytest.raises(ValueError, match="field"):
+    with pytest.raises(ValueError, match=r"'field' must be 'free' or 'diffuse'"):
         psychoacoustics.loudness_zwicker_from_spectrum(levels, field="reverberant")
     x = np.ones(1000)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive sampling rate"):
         psychoacoustics.loudness_zwicker(x, 0)
 
 
 def test_non_finite_inputs_rejected() -> None:
     levels = np.full(28, 60.0)
     levels[5] = np.nan
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'levels' must contain only finite values"):
         psychoacoustics.loudness_zwicker_from_spectrum(levels)
     x = np.ones(1000)
     x[3] = np.inf
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"Input signal 'x' must contain only finite values"
+    ):
         psychoacoustics.loudness_zwicker(x, FS)
 
 
@@ -529,7 +540,7 @@ def test_pathological_resampling_ratio_rejected() -> None:
     reject instead of hanging.
     """
     x = np.ones(1000)
-    with pytest.raises(ValueError, match="resampl"):
+    with pytest.raises(ValueError, match=r"needs an impractical resampling ratio"):
         psychoacoustics.loudness_zwicker(x, 44101)
 
 
@@ -546,7 +557,9 @@ def test_minimal_length_validation() -> None:
     of crashing on an empty percentile buffer.
     """
     too_short = np.ones(48)
-    with pytest.raises(ValueError, match="too short"):
+    with pytest.raises(
+        ValueError, match=r"Input signal is too short for the time-varying method"
+    ):
         psychoacoustics.loudness_zwicker(too_short, FS)
     res = psychoacoustics.loudness_zwicker(
         np.ones(96 * 4), FS

--- a/tests/psychoacoustics/quality/test_fluctuation_strength.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength.py
@@ -68,13 +68,15 @@ def test_am_noise_clamped_at_zero() -> None:
 
 @pytest.mark.parametrize("bad_m", [-0.1, 1.1, math.nan])
 def test_am_noise_rejects_bad_modulation(bad_m: float) -> None:
-    with pytest.raises(ValueError, match="modulation_factor"):
+    with pytest.raises(ValueError, match=r"'modulation_factor' must be in"):
         psychoacoustics.fluctuation_strength_am_noise(60.0, bad_m, 4.0)
 
 
 @pytest.mark.parametrize("bad_f", [0.0, -1.0, math.inf])
 def test_am_noise_rejects_bad_frequency(bad_f: float) -> None:
-    with pytest.raises(ValueError, match="mod_frequency"):
+    with pytest.raises(
+        ValueError, match=r"'mod_frequency' must be positive and finite"
+    ):
         psychoacoustics.fluctuation_strength_am_noise(60.0, 1.0, bad_f)
 
 
@@ -247,7 +249,9 @@ def test_a_specific_curve_off_the_filter_axis_is_refused(
     """
     curve = reference_result.specific
     wrong = curve[:-1] if trim else np.append(curve, curve[-1])
-    with pytest.raises(ValueError, match="'specific'"):
+    # The guard names both fields whichever one was made wrong, so the count
+    # is what says which. It is the test's own: 47 filters, one added or cut.
+    with pytest.raises(ValueError, match=rf"'specific' \({wrong.size}\)"):
         dataclasses.replace(reference_result, specific=wrong)
 
 
@@ -260,7 +264,7 @@ def test_a_bark_axis_off_the_filter_axis_is_refused(
     and their two counts rather than picking a culprit.
     """
     short_axis = reference_result.bark_axis[:-1]
-    with pytest.raises(ValueError, match="'bark_axis'"):
+    with pytest.raises(ValueError, match=rf"'bark_axis' \({short_axis.size}\)"):
         dataclasses.replace(reference_result, bark_axis=short_axis)
 
 

--- a/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
@@ -312,7 +312,9 @@ def test_a_trace_off_its_time_axis_is_refused(
     """
     trace = ref_calibration.fluctuation_strength_vs_time
     wrong = trace[:-1] if trim else np.append(trace, trace[-1])
-    with pytest.raises(ValueError, match="'fluctuation_strength_vs_time'"):
+    with pytest.raises(
+        ValueError, match=rf"'fluctuation_strength_vs_time' \({wrong.size}\)"
+    ):
         dataclasses.replace(ref_calibration, fluctuation_strength_vs_time=wrong)
 
 
@@ -351,7 +353,9 @@ def test_a_specific_table_that_lost_its_band_axis_is_refused(
     caller-supplied ``ax`` never reaches the heatmap at all.
     """
     flat = ref_calibration.specific_fluctuation_strength_vs_time.mean(axis=1)
-    with pytest.raises(ValueError, match="'specific_fluctuation_strength_vs_time'"):
+    with pytest.raises(
+        ValueError, match="'specific_fluctuation_strength_vs_time' must have 2 axes"
+    ):
         dataclasses.replace(ref_calibration, specific_fluctuation_strength_vs_time=flat)
 
 
@@ -372,7 +376,7 @@ def test_a_band_axis_off_the_filter_bank_is_refused(
     all were well.
     """
     column = np.asarray(getattr(ref_calibration, field))
-    with pytest.raises(ValueError, match=f"'{field}'"):
+    with pytest.raises(ValueError, match=rf"'{field}' \({column.size - 1}\)"):
         dataclasses.replace(ref_calibration, **{field: column[:-1]})
 
 
@@ -386,7 +390,7 @@ def test_a_time_axis_with_a_second_axis_is_refused(
     fill underneath is what stops, with ``'x' is not 1-dimensional`` -- naming
     matplotlib's own parameter, not the field that carried the extra axis.
     """
-    with pytest.raises(ValueError, match="'time'"):
+    with pytest.raises(ValueError, match="'time' must have one axis"):
         dataclasses.replace(ref_calibration, time=ref_calibration.time[:, None])
 
 

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -155,14 +155,17 @@ def test_a_time_grid_that_does_not_match_its_curves_is_refused(
     figure is drawn, and a caller who supplies an ``ax`` never draws that
     panel at all.
     """
-    with pytest.raises(ValueError, match="'time'"):
-        dataclasses.replace(ref_calibration, time=ref_calibration.time[:-1])
-    trace = ref_calibration.roughness_vs_time
-    with pytest.raises(ValueError, match="'roughness_vs_time'"):
-        dataclasses.replace(ref_calibration, roughness_vs_time=np.append(trace, 0.0))
-    heat = ref_calibration.specific_roughness_vs_time
-    with pytest.raises(ValueError, match="'specific_roughness_vs_time'"):
-        dataclasses.replace(ref_calibration, specific_roughness_vs_time=heat[:-1])
+    short_grid = ref_calibration.time[:-1]
+    with pytest.raises(ValueError, match=rf"'time' \({short_grid.size}\)"):
+        dataclasses.replace(ref_calibration, time=short_grid)
+    long_trace = np.append(ref_calibration.roughness_vs_time, 0.0)
+    with pytest.raises(ValueError, match=rf"'roughness_vs_time' \({long_trace.size}\)"):
+        dataclasses.replace(ref_calibration, roughness_vs_time=long_trace)
+    heat = ref_calibration.specific_roughness_vs_time[:-1]
+    with pytest.raises(
+        ValueError, match=rf"'specific_roughness_vs_time' \({len(heat)}\)"
+    ):
+        dataclasses.replace(ref_calibration, specific_roughness_vs_time=heat)
 
 
 def test_a_band_axis_shorter_than_the_bands_is_refused(
@@ -175,14 +178,24 @@ def test_a_band_axis_shorter_than_the_bands_is_refused(
     roughness is drawn by no panel of the built-in figure and reaches the
     documented ``plot(res.bark, res.specific_roughness)`` snippet intact.
     """
-    with pytest.raises(ValueError, match="'bark'"):
+    with pytest.raises(
+        ValueError,
+        match=r"EcmaRoughness: 'bark'.*one value per auditory band",
+    ):
         dataclasses.replace(ref_calibration, bark=ref_calibration.bark[:-1])
-    with pytest.raises(ValueError, match="'specific_roughness'"):
+    with pytest.raises(
+        ValueError,
+        match=r"EcmaRoughness: .*'specific_roughness'.*one value per auditory band",
+    ):
         dataclasses.replace(
             ref_calibration,
             specific_roughness=ref_calibration.specific_roughness[:-1],
         )
-    with pytest.raises(ValueError, match="'specific_roughness_vs_time"):
+    with pytest.raises(
+        ValueError,
+        match=r"EcmaRoughness: .*'specific_roughness_vs_time \(axis 1\)'"
+        r".*one value per auditory band",
+    ):
         dataclasses.replace(
             ref_calibration,
             specific_roughness_vs_time=ref_calibration.specific_roughness_vs_time[

--- a/tests/psychoacoustics/quality/test_sharpness.py
+++ b/tests/psychoacoustics/quality/test_sharpness.py
@@ -155,7 +155,7 @@ def test_annex_b_variants() -> None:
     s_a = sharpness_din_from_specific(spec, method="aures")
     s_b = sharpness_din_from_specific(spec, method="bismarck")
     assert s_a != s_b
-    with pytest.raises(ValueError, match="method"):
+    with pytest.raises(ValueError, match=r"method must be 'din'"):
         sharpness_din_from_specific(spec, method="zwicker")
 
 

--- a/tests/psychoacoustics/quality/test_tonality.py
+++ b/tests/psychoacoustics/quality/test_tonality.py
@@ -168,25 +168,27 @@ def test_invalid_inputs() -> None:
     one_second = np.ones(1000)
     two_channel = np.ones((2, FS))
     too_short = np.ones(100)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be positive"):
         psychoacoustics.tone_to_noise_ratio(one_second, 0)
-    with pytest.raises(ValueError, match="1D"):
+    with pytest.raises(ValueError, match=r"prominence_ratio expects a 1D signal"):
         psychoacoustics.prominence_ratio(two_channel, FS)
-    with pytest.raises(ValueError, match="too short"):
+    with pytest.raises(
+        ValueError, match=r"Signal too short for the requested .* Hz resolution"
+    ):
         psychoacoustics.tone_to_noise_ratio(too_short, FS)
 
 
 def test_invalid_resolution_and_tone_freq() -> None:
     x = np.ones(FS)
-    with pytest.raises(ValueError, match="resolution_hz"):
+    with pytest.raises(ValueError, match=r"'resolution_hz' must be positive"):
         psychoacoustics.tone_to_noise_ratio(x, FS, resolution_hz=0.0)
-    with pytest.raises(ValueError, match="tone_freq"):
+    with pytest.raises(ValueError, match=r"'tone_freq' must be positive"):
         psychoacoustics.prominence_ratio(x, FS, tone_freq=-100.0)
 
 
 def test_too_coarse_resolution_raises() -> None:
     x = np.ones(FS)
-    with pytest.raises(ValueError, match="too coarse"):
+    with pytest.raises(ValueError, match=r"resolution_hz=.* is too coarse for fs="):
         psychoacoustics.tone_to_noise_ratio(x, FS, resolution_hz=FS / 4.0)
 
 
@@ -195,9 +197,10 @@ def test_coarse_resolution_warns_at_low_frequency() -> None:
     half-width, biasing the ratio; the function warns (it does not raise).
     """
     x = _tone_in_noise(250.0, 0.2, 0.02)
-    with pytest.warns(UserWarning, match="bins"):
+    coarse = r"Frequency resolution .* is coarse for the tone at"
+    with pytest.warns(UserWarning, match=coarse):
         psychoacoustics.tone_to_noise_ratio(x, FS, tone_freq=250.0, resolution_hz=4.0)
-    with pytest.warns(UserWarning, match="bins"):
+    with pytest.warns(UserWarning, match=coarse):
         psychoacoustics.prominence_ratio(x, FS, tone_freq=250.0, resolution_hz=4.0)
 
 
@@ -216,11 +219,12 @@ def test_numeric_noise_power_warns() -> None:
     """Silence and DC produce formally finite TNR/PR values with no meaning;
     the function warns that the band power is at numeric-noise level.
     """
+    numeric_noise = r"critical-band power is at numeric-noise level"
     silence = np.zeros(FS * 2)
-    with pytest.warns(UserWarning, match="numeric-noise"):
+    with pytest.warns(UserWarning, match=numeric_noise):
         psychoacoustics.tone_to_noise_ratio(silence, FS, tone_freq=1000.0)
     dc = np.full(FS * 2, 0.5)
-    with pytest.warns(UserWarning, match="numeric-noise"):
+    with pytest.warns(UserWarning, match=numeric_noise):
         psychoacoustics.prominence_ratio(dc, FS, tone_freq=1000.0)
 
 

--- a/tests/psychoacoustics/quality/test_tonality_ecma.py
+++ b/tests/psychoacoustics/quality/test_tonality_ecma.py
@@ -213,9 +213,9 @@ def test_loudness_and_tonality_share_the_tonal_split(
 def test_band_range_rejects_out_of_range_edges() -> None:
     # Formulae 56/57 preconditions: 16 Hz < f_L, f_H < 20 kHz, f_L < f_H.
     x = _tone(1000.0, 40.0, seconds=0.5)
-    with pytest.raises(ValueError, match="16 Hz"):
+    with pytest.raises(ValueError, match=r"'f_low' must exceed"):
         psychoacoustics.tonality_ecma(x, FS, f_low=10.0)
-    with pytest.raises(ValueError, match="20 kHz"):
+    with pytest.raises(ValueError, match=r"'f_high' must be below"):
         psychoacoustics.tonality_ecma(x, FS, f_high=25000.0)
     with pytest.raises(ValueError, match="below 'f_high'"):
         psychoacoustics.tonality_ecma(x, FS, f_low=2000.0, f_high=500.0)

--- a/tests/psychoacoustics/quality/test_tone_audibility.py
+++ b/tests/psychoacoustics/quality/test_tone_audibility.py
@@ -212,7 +212,9 @@ def test_single_line_tone_audibility_flip_regression() -> None:
 
 def test_mean_narrowband_level_empty_critical_band_raises() -> None:
     # Lines far below the critical band of a 1 kHz tone (≈922-1085 Hz).
-    with pytest.raises(ValueError, match="critical band"):
+    with pytest.raises(
+        ValueError, match=r"No spectral lines fall in the critical band"
+    ):
         psychoacoustics.mean_narrowband_level(
             [50.0, 51.0, 52.0], [100.0, 110.0, 120.0], 1000.0
         )
@@ -245,7 +247,7 @@ def test_mean_narrowband_level_rejects_length_mismatch() -> None:
 
 
 def test_mean_narrowband_level_rejects_unsorted_frequencies() -> None:
-    with pytest.raises(ValueError, match="increasing"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be strictly increasing"):
         psychoacoustics.mean_narrowband_level(
             [50.0, 51.0, 52.0], [100.0, 99.0, 101.0], 100.0
         )
@@ -503,7 +505,9 @@ def test_separation_frequency_grows_either_side_of_reference() -> None:
 
 
 def test_separation_frequency_rejects_bad_frequency() -> None:
-    with pytest.raises(ValueError, match="tone_frequency"):
+    with pytest.raises(
+        ValueError, match=r"'tone_frequency' must be a positive, finite number"
+    ):
         psychoacoustics.two_tone_separation_frequency(0.0)
 
 
@@ -704,7 +708,9 @@ def test_assess_tones_rejects_empty() -> None:
 
 
 def test_assess_tones_rejects_non_positive_frequency() -> None:
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"'tone_frequencies' must be positive and finite"
+    ):
         psychoacoustics.assess_tones([0.0], [60.0], [50.0], 2.7)
 
 
@@ -951,7 +957,7 @@ def test_uncertainty_constants_and_validation() -> None:
     assert COVERAGE_FACTOR_90 == 1.645
     with pytest.raises(ValueError, match="at least one line"):
         psychoacoustics.audibility_uncertainty([], [50.0], 137.3, 2.7)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"Line levels must be finite"):
         psychoacoustics.audibility_uncertainty([60.0, np.nan], [50.0], 137.3, 2.7)
     with pytest.raises(
         ValueError,

--- a/tests/psychoacoustics/test_iso1996_tone_report.py
+++ b/tests/psychoacoustics/test_iso1996_tone_report.py
@@ -55,7 +55,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 
@@ -63,7 +63,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         result.report(out, language="xx")
 
 

--- a/tests/psychoacoustics/test_iso532_report.py
+++ b/tests/psychoacoustics/test_iso532_report.py
@@ -84,7 +84,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -209,5 +209,5 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
+++ b/tests/psychoacoustics/test_psychoacoustics_signal_overloads.py
@@ -245,7 +245,7 @@ def test_a_non_positive_explicit_factor_is_refused() -> None:
     signal and reported an annoyance of 0.0.
     """
     for bad in (0.0, -1.0):
-        with pytest.raises(ValueError, match="calibration_factor"):
+        with pytest.raises(ValueError, match=r"'calibration_factor' must be positive"):
             psychoacoustic_annoyance_from_signal(_TONE, FS, calibration_factor=bad)
 
 

--- a/tests/speech/test_objective_intelligibility.py
+++ b/tests/speech/test_objective_intelligibility.py
@@ -124,20 +124,20 @@ def test_input_validation() -> None:
 
     with pytest.raises(ValueError, match=r"stoi: 'clean'.*'degraded'.*same shape"):
         speech.stoi(x, shorter, FS)
-    with pytest.raises(ValueError, match="1-D"):
+    with pytest.raises(ValueError, match=r"'clean' and 'degraded' must be 1-D"):
         speech.stoi(two_d, two_d, FS)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive sample rate"):
         speech.stoi(x, x, 0)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'clean' and 'degraded' must be finite"):
         speech.stoi(x, with_nan, FS)
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'clean' and 'degraded' must be non-empty"):
         speech.stoi(empty, empty, FS)
 
 
 def test_too_short_signal_raises() -> None:
     # Under ~0.4 s of active speech there are fewer than 30 frames to segment.
     short = _speech_like(7, seconds=0.2)
-    with pytest.raises(ValueError, match="30"):
+    with pytest.raises(ValueError, match=r"Too few short-time frames to score"):
         speech.stoi(short, short, FS)
 
 

--- a/tests/speech/test_sii.py
+++ b/tests/speech/test_sii.py
@@ -312,13 +312,22 @@ def test_custom_speech_spectrum_accepted() -> None:
 
 def test_invalid_inputs_raise() -> None:
     short_threshold = np.zeros(5)
-    with pytest.raises(ValueError, match="18"):
+    with pytest.raises(
+        ValueError,
+        match=r"'speech_spectrum' must be a 1-D vector of 18 one-third-octave band values",
+    ):
         sii.speech_intelligibility_index([1.0, 2.0, 3.0])
-    with pytest.raises(ValueError, match="18"):
+    with pytest.raises(
+        ValueError,
+        match=r"'noise_spectrum' must be a 1-D vector of 18 one-third-octave band values",
+    ):
         sii.speech_intelligibility_index("normal", noise_spectrum=[1.0, 2.0])
-    with pytest.raises(ValueError, match="18"):
+    with pytest.raises(
+        ValueError,
+        match=r"'threshold' must be a 1-D vector of 18 one-third-octave band values",
+    ):
         sii.speech_intelligibility_index("normal", threshold=short_threshold)
-    with pytest.raises(ValueError, match="vocal_effort"):
+    with pytest.raises(ValueError, match=r"Unknown vocal_effort"):
         sii.standard_speech_spectrum("whisper")
 
 
@@ -357,7 +366,7 @@ def test_a_non_finite_band_vector_is_refused_by_parameter_name(name: str) -> Non
         "threshold": None,
     }
     arguments[name] = corrupt
-    with pytest.raises(ValueError, match=f"{name!r} must contain only finite"):
+    with pytest.raises(ValueError, match=rf"^{name!r} must contain only finite"):
         sii.speech_intelligibility_index(**arguments)  # type: ignore[arg-type]
 
 
@@ -415,7 +424,9 @@ def test_a_non_finite_band_quantity_is_refused_by_field_name(name: str) -> None:
     result = sii.speech_intelligibility_index("normal")
     corrupt = np.asarray(getattr(result, name), dtype=np.float64).copy()
     corrupt[9] = np.nan
-    with pytest.raises(ValueError, match=f"'{name}' must contain only finite"):
+    with pytest.raises(
+        ValueError, match=f"SIIResult: '{name}' must contain only finite"
+    ):
         dataclasses.replace(result, **{name: corrupt})
 
 
@@ -442,7 +453,9 @@ def test_a_non_finite_procedure_column_is_refused_by_field_name(name: str) -> No
     procedure = sii.sii_procedure("octave")
     corrupt = np.asarray(getattr(procedure, name), dtype=np.float64).copy()
     corrupt[0] = np.inf
-    with pytest.raises(ValueError, match=f"'{name}' must contain only finite"):
+    with pytest.raises(
+        ValueError, match=f"SIIProcedure: '{name}' must contain only finite"
+    ):
         dataclasses.replace(procedure, **{name: corrupt})
 
 
@@ -491,9 +504,9 @@ def test_standard_speech_spectra_single_effort() -> None:
 
 
 def test_standard_speech_spectra_rejects_unknown_and_empty() -> None:
-    with pytest.raises(ValueError, match="vocal_effort"):
+    with pytest.raises(ValueError, match=r"Unknown vocal_effort"):
         sii.standard_speech_spectra("whisper")
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"'vocal_efforts' cannot be empty"):
         sii.standard_speech_spectra([])
 
 
@@ -920,7 +933,10 @@ def test_speech_intelligibility_index_checks_band_count_per_method() -> None:
         sii.speech_intelligibility_index(
             twentyone_bands, eighteen_band_noise, method="critical-band"
         )
-    with pytest.raises(ValueError, match="band_importance"):
+    with pytest.raises(
+        ValueError,
+        match=r"'band_importance' must be a 1-D vector of 6 octave band values",
+    ):
         sii.speech_intelligibility_index(
             six_bands, method="octave", band_importance=short_importance
         )

--- a/tests/speech/test_sii_report.py
+++ b/tests/speech/test_sii_report.py
@@ -306,7 +306,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _example_c2()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -314,5 +314,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _example_c2()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/speech/test_speech_signal_overloads.py
+++ b/tests/speech/test_speech_signal_overloads.py
@@ -120,7 +120,9 @@ def test_stoi_takes_the_rate_from_either_side() -> None:
 def test_stoi_refuses_two_signals_at_different_rates() -> None:
     clean = Signal(_CLEAN, STOI_FS)
     degraded = Signal(_DEGRADED, STOI_FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError, match=r"'clean' and 'degraded' are Signals recorded at different"
+    ):
         stoi(clean, degraded)
 
 
@@ -170,7 +172,9 @@ def test_a_reference_at_another_rate_is_refused() -> None:
     """
     measured = Signal(_STIPA, FS)
     half = Signal(stipa_signal(FS // 2, seconds=18.0, seed=2), FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError, match=r"'x' and 'reference' are Signals recorded at different"
+    ):
         stipa(measured, reference=half)
 
 

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -258,7 +258,9 @@ def test_stipa_short_recording_warns(stipa_18s_seed1234: np.ndarray) -> None:
     practice recommends 15 s to 25 s).
     """
     short = speech.stipa_signal(FS, seconds=5.0, seed=1234)
-    with pytest.warns(UserWarning, match="15"):
+    with pytest.warns(
+        UserWarning, match=r"STIPA recording is .* shorter than the recommended"
+    ):
         speech.stipa(short, FS)
     # No warning at the recommended length.
     with warnings.catch_warnings():
@@ -339,27 +341,33 @@ def test_invalid_inputs_raise() -> None:
     two_dimensional_ir = np.zeros((2, 1000))
     silent_ir = np.zeros(FS // 4)
 
-    with pytest.raises(ValueError, match="1D"):
+    with pytest.raises(
+        ValueError, match=r"sti_from_impulse_response expects a 1D impulse response"
+    ):
         speech.sti_from_impulse_response(two_dimensional_ir, FS)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"Sample rate 'fs' must be positive"):
         speech.sti_from_impulse_response(ir, -1)
     with pytest.raises(ValueError, match="8 kHz octave band"):
         speech.sti_from_impulse_response(ir, 16000)
-    with pytest.raises(ValueError, match="silent"):
+    with pytest.raises(ValueError, match=r"Impulse response 'ir' is silent"):
         speech.sti_from_impulse_response(silent_ir, FS)
-    with pytest.raises(ValueError, match="7 octave-band values"):
+    with pytest.raises(
+        ValueError, match=r"'level' must contain exactly .* octave-band values"
+    ):
         speech.sti_from_impulse_response(ir, FS, level=[60.0, 60.0, 60.0])
-    with pytest.raises(ValueError, match="scalar or a vector"):
+    with pytest.raises(ValueError, match="'snr' must be a scalar or a vector"):
         speech.sti_from_impulse_response(ir, FS, snr=[10.0, 10.0])
     with pytest.raises(ValueError, match="requires the speech octave-band levels"):
         speech.sti_from_impulse_response(ir, FS, ambient=[40.0] * 7)
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(
+        ValueError, match=r"Provide either 'snr' or 'ambient' noise levels, not both"
+    ):
         speech.sti_from_impulse_response(
             ir, FS, snr=10.0, level=[60.0] * 7, ambient=[40.0] * 7
         )
 
     two_dimensional_signal = np.zeros((2, FS))
-    with pytest.raises(ValueError, match="1D"):
+    with pytest.raises(ValueError, match=r"stipa expects a 1D signal"):
         speech.stipa(two_dimensional_signal, FS)
     half_second_clip = speech.stipa_signal(FS, seconds=18.0, seed=3)[: FS // 2]
     # The 0.5 s clip also triggers the (correct) sub-15 s STIPA warning;
@@ -368,7 +376,10 @@ def test_invalid_inputs_raise() -> None:
     # two blocks stay nested rather than combined.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        with pytest.raises(ValueError, match="too short"):
+        with pytest.raises(
+            ValueError,
+            match=r"Signal too short for STIPA: it must contain at least one full period",
+        ):
             speech.stipa(half_second_clip, FS)
     with pytest.warns(STIWarning) as tone_warnings:  # noqa: PT031 - the warns block records the whole STIWarning family while running
         # A pure tone leaves other octave bands empty: those bands read
@@ -388,21 +399,25 @@ def test_invalid_inputs_raise() -> None:
     assert np.any(res_tone.mtf == 0.0)
     assert np.all(res_tone.mtf[3] < 0.01)
 
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'seconds' must be positive"):
         speech.stipa_signal(FS, seconds=0.0)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(
+        ValueError, match=r"Sample rate 'fs' must be .* half-octave carrier"
+    ):
         speech.stipa_signal(8000)
 
     wrong_shape_mtf = np.full((3, 14), 0.5)
     negative_mtf = _uniform_mtf(-0.1)
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'mtf' must have shape"):
         _sti_from_mtf(wrong_shape_mtf)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"Modulation transfer values must be finite"):
         _sti_from_mtf(negative_mtf)
 
 
 def test_mtf_above_1_3_warns_and_truncates() -> None:
-    with pytest.warns(UserWarning, match="1.3"):
+    with pytest.warns(
+        UserWarning, match=r"Modulation transfer values above .* detected"
+    ):
         result = _sti_from_mtf(_uniform_mtf(1.4))
     assert result.sti == 1.0
 
@@ -501,7 +516,7 @@ def test_an_sti_result_refuses_an_mti_off_the_band_axis() -> None:
         band_levels=np.full(7, 60.0),
         rating="B",
     )
-    with pytest.raises(ValueError, match="'mti'"):
+    with pytest.raises(ValueError, match=r"'mti' \(6\)"):
         dataclasses.replace(result, mti=result.mti[:-1])
 
 
@@ -544,5 +559,5 @@ def test_an_sti_result_refuses_a_bare_number_for_a_band_column() -> None:
     ir = np.zeros(FS // 2)
     ir[100] = 1.0
     result = speech.sti_from_impulse_response(ir, FS)
-    with pytest.raises(ValueError, match="'mti'"):
+    with pytest.raises(ValueError, match="'mti' must have one axis; got 0"):
         dataclasses.replace(result, mti=0.75)

--- a/tests/speech/test_sti.py
+++ b/tests/speech/test_sti.py
@@ -415,10 +415,11 @@ def test_invalid_inputs_raise() -> None:
 
 
 def test_mtf_above_1_3_warns_and_truncates() -> None:
+    over_unity = _uniform_mtf(1.4)
     with pytest.warns(
         UserWarning, match=r"Modulation transfer values above .* detected"
     ):
-        result = _sti_from_mtf(_uniform_mtf(1.4))
+        result = _sti_from_mtf(over_unity)
     assert result.sti == 1.0
 
 

--- a/tests/speech/test_sti_report.py
+++ b/tests/speech/test_sti_report.py
@@ -223,7 +223,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _uniform_result(0.5)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -231,5 +231,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _uniform_result(0.5)
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/test_animation_fingerprint.py
+++ b/tests/test_animation_fingerprint.py
@@ -315,7 +315,7 @@ def _fake_batch(monkeypatch: pytest.MonkeyPatch, fails: str | None) -> list[list
     if fails is None:
         registry.generate_animations("images", variants=True)
     else:
-        with pytest.raises(RuntimeError, match="the encoder died"):
+        with pytest.raises(RuntimeError, match=r"^the encoder died$"):
             registry.generate_animations("images", variants=True)
     return stamped
 
@@ -394,7 +394,9 @@ def _fake_parallel_batch(
     if fails is None:
         registry._generate_animations_parallel("images", clips, jobs=1)
     else:
-        with pytest.raises(RuntimeError, match="the encoder died"):
+        with pytest.raises(
+            RuntimeError, match=r"(?s)animation generation failed.*the encoder died"
+        ):
             registry._generate_animations_parallel("images", clips, jobs=1)
     return stamped
 

--- a/tests/test_api_docs_generator.py
+++ b/tests/test_api_docs_generator.py
@@ -48,7 +48,11 @@ def test_no_duplicate_module_assignment() -> None:
 
 
 def test_unmapped_module_raises_helpful_keyerror() -> None:
-    with pytest.raises(KeyError, match="not mapped"):
+    with pytest.raises(
+        KeyError,
+        match=r"module 'phonometry\.does_not_exist' is not mapped to any"
+        r" API-reference section",
+    ):
         api_taxonomy.module_section("phonometry.does_not_exist")
 
 

--- a/tests/test_device_geometry_plots.py
+++ b/tests/test_device_geometry_plots.py
@@ -69,7 +69,7 @@ def test_silencer_hand_built_refuses() -> None:
     import dataclasses
 
     bare = dataclasses.replace(result, geometry=None)
-    with pytest.raises(ValueError, match="does not retain"):
+    with pytest.raises(ValueError, match="does not retain its geometry"):
         bare.plot_geometry()
 
 
@@ -174,14 +174,17 @@ def test_silencer_chain_without_a_duct_refuses_to_draw() -> None:
 def test_silencer_free_function_validation() -> None:
     with pytest.raises(ValueError, match="Unknown silencer kind"):
         pm.noise_control.plot_silencer_geometry("muffler")
-    with pytest.raises(ValueError, match="chamber_area"):
+    with pytest.raises(ValueError, match=r"'chamber_area' must exceed 'pipe_area'"):
         pm.noise_control.plot_silencer_geometry(
             "expansion chamber",
             length=0.3,
             chamber_area=0.004,
             pipe_area=0.005,
         )
-    with pytest.raises(ValueError, match="must not exceed"):
+    with pytest.raises(
+        ValueError,
+        match=r"'inlet_extension' \+ 'outlet_extension' must not exceed",
+    ):
         pm.noise_control.plot_silencer_geometry(
             "extended-tube chamber",
             length=0.1,
@@ -190,7 +193,9 @@ def test_silencer_free_function_validation() -> None:
             inlet_extension=0.08,
             outlet_extension=0.08,
         )
-    with pytest.raises(ValueError, match="needs"):
+    with pytest.raises(
+        ValueError, match=r"A Helmholtz resonator drawing needs 'neck_area'"
+    ):
         pm.noise_control.plot_silencer_geometry("Helmholtz resonator", duct_area=0.01)
 
 
@@ -303,7 +308,10 @@ def test_barrier_result_retains_geometry_and_draws() -> None:
 
 
 def test_barrier_free_function_validation() -> None:
-    with pytest.raises(ValueError, match="receiver_distance"):
+    with pytest.raises(
+        ValueError,
+        match=r"'receiver_distance' must be greater than 'barrier_distance'",
+    ):
         pm.environment.plot_barrier_geometry(
             source_height=1.5,
             barrier_distance=5.0,
@@ -350,9 +358,9 @@ def test_microphone_positions_hemisphere_and_sphere() -> None:
     ax = pm.emission.plot_microphone_positions(sphere)
     assert ax.name == "3d"
     bad = np.zeros((3, 2))
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'positions' must have shape \(N, 3\)"):
         pm.emission.plot_microphone_positions(bad)
-    with pytest.raises(ValueError, match="radius"):
+    with pytest.raises(ValueError, match=r"'radius' must be positive when given"):
         pm.emission.plot_microphone_positions(pos, radius=-1.0)
 
 
@@ -370,9 +378,9 @@ def test_aperture_results_retain_geometry_and_draw() -> None:
 
 
 def test_aperture_validation() -> None:
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(ValueError, match=r"Give exactly one of 'width' or 'radius'"):
         pm.building.plot_aperture_geometry(0.1)
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(ValueError, match=r"Give exactly one of 'width' or 'radius'"):
         pm.building.plot_aperture_geometry(0.1, width=0.003, radius=0.005)
     with pytest.raises(ValueError, match="'depth' must be positive"):
         pm.building.plot_aperture_geometry(0.0, width=0.003)
@@ -395,7 +403,7 @@ def test_aperture_geometry_refuses_a_nan_hole_radius() -> None:
     """The refusal names ``radius``, the parameter the caller passed, not
     the doubled opening the drawing works in.
     """
-    with pytest.raises(ValueError, match="'radius' must be positive"):
+    with pytest.raises(ValueError, match=r"'radius' must be positive\."):
         pm.building.plot_aperture_geometry(0.1, radius=float("nan"))
 
 
@@ -453,9 +461,9 @@ def test_piston_geometry_with_and_without_lobe() -> None:
     without = pm.electroacoustics.radiating_piston(0.1, np.array([500.0]))
     ax = without.plot_geometry()
     assert ax.get_legend() is None
-    with pytest.raises(ValueError, match="radius"):
+    with pytest.raises(ValueError, match=r"'radius' must be positive\."):
         pm.electroacoustics.plot_piston_geometry(0.0)
-    with pytest.raises(ValueError, match="together"):
+    with pytest.raises(ValueError, match=r"Give 'angles' and 'directivity' together"):
         pm.electroacoustics.plot_piston_geometry(0.1, angles=angles)
     with pytest.raises(ValueError, match=r"'directivity'.*same shape"):
         pm.electroacoustics.plot_piston_geometry(
@@ -491,7 +499,7 @@ def test_plenum_geometry_draws_and_validates() -> None:
     assert ax.get_aspect() == 1.0
     with pytest.raises(ValueError, match="'exit_area' must be positive"):
         pm.noise_control.plot_plenum_geometry(0.0, 1.2, 6.0)
-    with pytest.raises(ValueError, match="angle"):
+    with pytest.raises(ValueError, match=r"'angle' must be in \[0, pi/2\)"):
         pm.noise_control.plot_plenum_geometry(0.09, 1.2, 6.0, angle=2.0)
 
 
@@ -533,7 +541,7 @@ def test_fdtd_domain_preview() -> None:
     labels = [t.get_text() for t in ax.get_legend().get_texts()]
     assert len(labels) == 5
     bad_probes = np.zeros((2, 3))
-    with pytest.raises(ValueError, match="probes"):
+    with pytest.raises(ValueError, match=r"'probes' must have shape \(N, 2\)"):
         sim.plot_geometry(probes=bad_probes)
     # A plain rigid box keeps the record empty and still draws.
     plain = FDTD2D(343.0, 0.05, shape=(10, 10))

--- a/tests/test_diagram_canvas_math.py
+++ b/tests/test_diagram_canvas_math.py
@@ -208,7 +208,7 @@ def test_math_and_prose_escape_metacharacters_in_the_comment() -> None:
 
 
 def test_unbalanced_markup_raises() -> None:
-    with pytest.raises(ValueError, match="unbalanced"):
+    with pytest.raises(ValueError, match=r"unbalanced \$ markup in 'broken \$L_p'"):
         _element("broken $L_p")
 
 
@@ -219,7 +219,7 @@ def test_multicharacter_script_without_braces_raises() -> None:
         _element("cut-off $f_max$ of the array")
     assert "'_max'" in str(excinfo.value)
     assert "'cut-off $f_max$ of the array'" in str(excinfo.value)
-    with pytest.raises(ValueError, match="ambiguous script"):
+    with pytest.raises(ValueError, match=r"ambiguous script '_ref' in '\$p_ref\$'"):
         _element("$p_ref$")
     # An opening bracket right after the script character is the same trap,
     # but braces around the whole tail would swallow the argument into the
@@ -302,13 +302,15 @@ def test_nested_script_raises() -> None:
         _element("$L_{p_1}$")
     assert "nested script" in str(excinfo.value)
     assert "'$L_{p_1}$'" in str(excinfo.value)
-    with pytest.raises(ValueError, match="nested script"):
+    with pytest.raises(ValueError, match=r"nested script '\^2' inside a script"):
         _element("$a_{b^2}$")
 
 
 def test_empty_script_payload_raises() -> None:
     for broken in ("$L_$", "$L^$", "$L_{}$"):
-        with pytest.raises(ValueError, match="empty script"):
+        with pytest.raises(
+            ValueError, match=rf"empty script .* in {re.escape(repr(broken))}"
+        ):
             _element(broken)
 
 
@@ -392,9 +394,9 @@ def test_fit_gate_raises_on_overflow_and_passes_the_boundary() -> None:
     svg.text(900 - width + 0.4, 100, "overhang", anchor="start")
     assert svg.parts
     # Just past it: the gate names the string and the measured span.
-    with pytest.raises(ValueError, match=r"spans .* on a 900 px sheet"):
+    with pytest.raises(ValueError, match=r"label .* spans .* px sheet"):
         svg.text(900 - width + 0.6, 100, "overhang", anchor="start")
-    with pytest.raises(ValueError, match="900 px sheet"):
+    with pytest.raises(ValueError, match=r"label .* spans .* px sheet"):
         svg.text(-1, 130, "left overhang", anchor="start")
 
 

--- a/tests/test_diagram_outline.py
+++ b/tests/test_diagram_outline.py
@@ -202,9 +202,11 @@ def test_bold_call_styles_math_variables_bolditalic() -> None:
 
 
 def test_mono_or_whole_string_italic_with_math_is_refused() -> None:
-    with pytest.raises(ValueError, match="mono"):
+    with pytest.raises(ValueError, match=r"mono cannot carry composed mathematics"):
         _label_runs("$L_p$", mono=True)
-    with pytest.raises(ValueError, match="italic"):
+    with pytest.raises(
+        ValueError, match=r"whole-string italic cannot carry composed mathematics"
+    ):
         _label_runs("$L_p$", italic=True)
 
 

--- a/tests/test_errors_and_edge_cases.py
+++ b/tests/test_errors_and_edge_cases.py
@@ -35,7 +35,7 @@ def test_octave_filter_bank_invalid_init() -> None:
     with pytest.raises(ValueError, match="list of two frequencies"):
         filters.OctaveFilterBank(fs=48000, limits=[1000])
 
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="Limit frequencies must be positive"):
         filters.OctaveFilterBank(fs=48000, limits=[-10, 1000])
 
     with pytest.raises(ValueError, match="less than the upper limit"):
@@ -60,9 +60,7 @@ def test_weighting_filter_invalid() -> None:
     """
     rng = np.random.default_rng(42)
     x = rng.standard_normal(1000)
-    with pytest.raises(
-        ValueError, match="must be 'A', 'B', 'C', 'D', 'G', 'AU' or 'Z'"
-    ):
+    with pytest.raises(ValueError, match="Weighting curve must be 'A'"):
         filters.weighting_filter(x, 48000, curve="E")
 
 
@@ -277,7 +275,7 @@ def test_calculate_level_invalid_mode() -> None:
 
     signal = np.array([1.0])
 
-    with pytest.raises(ValueError, match="Invalid mode\\. Use 'rms' or 'peak'\\."):
+    with pytest.raises(ValueError, match=r"Invalid mode\. Use 'rms'"):
         bank._calculate_level(signal, "invalid_mode")
 
 

--- a/tests/test_fdtd2d.py
+++ b/tests/test_fdtd2d.py
@@ -96,7 +96,7 @@ def test_scalar_c_requires_shape() -> None:
 def test_source_outside_the_grid_is_rejected() -> None:
     sim = fdtd2d.FDTD2D(343.0, 0.05, shape=(10, 10))
     pulse = fdtd2d.GaussianPulse(ix=99, iy=0, width=1e-4)
-    with pytest.raises(ValueError, match="outside the grid"):
+    with pytest.raises(ValueError, match="source position lies outside the grid"):
         sim.add_source(pulse)
 
 
@@ -189,8 +189,8 @@ def test_cw_source_rejects_invalid_parameters(
     ("kwargs", "match"),
     [
         ({"steps": -1}, "steps must be non-negative"),
-        ({"steps": 1, "record_every": 0}, "record_every"),
-        ({"steps": 1, "record_every": 1, "decimate": 0}, "decimate"),
+        ({"steps": 1, "record_every": 0}, "record_every must be >= 1"),
+        ({"steps": 1, "record_every": 1, "decimate": 0}, "decimate must be >= 1"),
     ],
 )
 def test_run_rejects_invalid_recording_controls(

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -376,60 +376,69 @@ def test_job_round_trip_subsampled_frames() -> None:
 def test_build_job_validation() -> None:
     """build_job rejects inconsistent sampling and non-integer widths."""
     ok: dict[str, Any] = {"shape": (_NY, _NX), "steps": 100, "sample_steps": [50]}
-    with pytest.raises(ValueError, match="cfl"):
+    with pytest.raises(ValueError, match=r"cfl must lie in \(0, 1\)"):
         fdtd_gpu_remote.build_job(343.0, _DX, cfl=1.5, **ok)
-    with pytest.raises(ValueError, match="damping"):
+    with pytest.raises(ValueError, match=r"damping must be non-negative and finite"):
         fdtd_gpu_remote.build_job(343.0, _DX, damping=-1.0, **ok)
     bad_damping = np.zeros((_NY + 1, _NX))
-    with pytest.raises(ValueError, match="damping"):
+    with pytest.raises(
+        ValueError, match=r"damping map shape .* does not match the grid"
+    ):
         fdtd_gpu_remote.build_job(343.0, _DX, damping=bad_damping, **ok)
-    with pytest.raises(ValueError, match="impedance sides"):
+    with pytest.raises(ValueError, match=r"unknown impedance sides"):
         fdtd_gpu_remote.build_job(343.0, _DX, edge_impedance={"front": 413.0}, **ok)
-    with pytest.raises(ValueError, match="absorbing"):
+    with pytest.raises(
+        ValueError,
+        match=r"side 'top' cannot be both absorbing and an impedance boundary",
+    ):
         fdtd_gpu_remote.build_job(
             343.0, _DX, sponge_width=10, edge_impedance={"top": 413.0}, **ok
         )
     bad_profile = {"top": np.ones(_NX + 2)}
-    with pytest.raises(ValueError, match="impedance"):
+    with pytest.raises(
+        ValueError, match=r"impedance for side 'top' must be a scalar or a 1D array"
+    ):
         fdtd_gpu_remote.build_job(343.0, _DX, edge_impedance=bad_profile, **ok)
     bad_mask_shape = np.zeros((_NY + 1, _NX), np.bool_)
-    with pytest.raises(ValueError, match="obstacle_mask"):
+    with pytest.raises(ValueError, match=r"obstacle_mask must match the grid shape"):
         fdtd_gpu_remote.build_job(343.0, _DX, obstacle_mask=bad_mask_shape, **ok)
     bad_mask_dtype = np.zeros((_NY, _NX), np.int64)
-    with pytest.raises(ValueError, match="obstacle_mask"):
+    with pytest.raises(ValueError, match=r"obstacle_mask must be a boolean array"):
         fdtd_gpu_remote.build_job(343.0, _DX, obstacle_mask=bad_mask_dtype, **ok)
-    with pytest.raises(ValueError, match="sample_steps"):
+    with pytest.raises(ValueError, match=r"sample_steps must lie within \[0, steps\]"):
         fdtd_gpu_remote.build_job(
             343.0, _DX, shape=(_NY, _NX), steps=100, sample_steps=[50, 150]
         )
-    with pytest.raises(ValueError, match="sample_steps"):
+    with pytest.raises(ValueError, match=r"sample_steps must lie within \[0, steps\]"):
         fdtd_gpu_remote.build_job(
             343.0, _DX, shape=(_NY, _NX), steps=100, sample_steps=[-1, 50]
         )
-    with pytest.raises(ValueError, match="sample_stride"):
+    with pytest.raises(ValueError, match=r"sample_stride must be >= 1"):
         fdtd_gpu_remote.build_job(343.0, _DX, sample_stride=0, **ok)
-    with pytest.raises(ValueError, match="sample_stride"):
+    with pytest.raises(ValueError, match=r"sample_stride must be an integer"):
         fdtd_gpu_remote.build_job(343.0, _DX, sample_stride=2.0, **ok)
-    with pytest.raises(ValueError, match="sample_dtype"):
+    with pytest.raises(ValueError, match=r"sample_dtype must be"):
         fdtd_gpu_remote.build_job(343.0, _DX, sample_dtype="int16", **ok)
-    with pytest.raises(ValueError, match="sponge_width"):
+    with pytest.raises(ValueError, match=r"sponge_width must be an integer"):
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=True, **ok)
-    with pytest.raises(ValueError, match="sponge_width"):
+    with pytest.raises(ValueError, match=r"sponge_width must be an integer"):
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=3.5, **ok)
-    with pytest.raises(ValueError, match="sponge_width"):
+    with pytest.raises(ValueError, match=r"sponge_width must be an integer"):
         fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), sponge_width=2.5)
     too_wide = min(_NY, _NX)
     with pytest.raises(ValueError, match="smallest grid side"):
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=too_wide, **ok)
-    with pytest.raises(ValueError, match="sponge_reflection"):
+    with pytest.raises(
+        ValueError, match=r"sponge_reflection must lie strictly between"
+    ):
         fdtd_gpu_remote.build_job(
             343.0, _DX, sponge_width=4, sponge_reflection=1.5, **ok
         )
     bad_scale_length = np.ones(_NX + 1)
-    with pytest.raises(ValueError, match="init_scale_x"):
+    with pytest.raises(ValueError, match=r"init_scale_x must be a 1D array of length"):
         fdtd_gpu_remote.build_job(343.0, _DX, init_scale_x=bad_scale_length, **ok)
     bad_scale_nan = np.full(_NX, np.nan)
-    with pytest.raises(ValueError, match="init_scale_x"):
+    with pytest.raises(ValueError, match=r"init_scale_x must be finite everywhere"):
         fdtd_gpu_remote.build_job(343.0, _DX, init_scale_x=bad_scale_nan, **ok)
 
 

--- a/tests/test_internal_validation.py
+++ b/tests/test_internal_validation.py
@@ -106,7 +106,7 @@ def test_a_nested_list_cannot_smuggle_an_extra_axis_past_a_one_axis_pin() -> Non
     rank sees it.
     """
     result = _Result(first=[[60.0, 1.0], [61.0, 1.0]])
-    with pytest.raises(ValueError, match="'first'"):
+    with pytest.raises(ValueError, match="'first' must have one axis; got 2"):
         require_ranks(result, first=1)
 
 
@@ -144,7 +144,7 @@ def test_a_lone_number_beside_a_spectrum_is_still_refused() -> None:
     against a missing one.
     """
     result = _Result(first=np.float64(1.0), second=np.zeros(4))
-    with pytest.raises(ValueError, match="'first'"):
+    with pytest.raises(ValueError, match="'first' must have one axis; got 0"):
         require_ranks(result, first=1, second=1)
 
 
@@ -163,7 +163,7 @@ def test_same_shape_refuses_two_grids_that_agree_on_one_axis_only() -> None:
     """
     result = _Result(first=np.zeros((3, 2)), second=np.zeros((3, 4)))
     require_same_length(result, "first", "second")
-    with pytest.raises(ValueError, match="'second'"):
+    with pytest.raises(ValueError, match="'second'.* must all have the same shape"):
         require_same_shape(result, "first", "second", quantity="cell")
 
 
@@ -193,7 +193,7 @@ def test_the_message_names_the_result_the_fields_and_the_counts() -> None:
     and neither names the field or the type it came from.
     """
     result = _Result(first=np.zeros(16), second=np.zeros(17))
-    with pytest.raises(ValueError, match="'first'") as caught:
+    with pytest.raises(ValueError, match=r"'first' \(16\)") as caught:
         require_same_length(result, "first", "second", axis="band")
     message = str(caught.value)
     assert "_Result" in message
@@ -209,7 +209,9 @@ def test_equal_shapes_names_the_entry_point_and_every_shape() -> None:
     the shape. The owner is the name the caller typed, not the private
     validator it happened to reach.
     """
-    with pytest.raises(ValueError, match="'y'") as caught:
+    with pytest.raises(
+        ValueError, match="'y'.* must all have the same shape"
+    ) as caught:
         require_equal_shapes("coherence", {"x": (3, 2), "y": (3, 4)}, "sample")
     message = str(caught.value)
     assert "coherence:" in message
@@ -224,7 +226,7 @@ def test_equal_shapes_is_quiet_when_they_agree() -> None:
 def test_equal_shapes_sees_what_a_count_cannot() -> None:
     """Two grids of the same height agree on every count a length check reads."""
     require_equal_shapes("f", {"a": (3,), "b": (3,)})
-    with pytest.raises(ValueError, match="'b'"):
+    with pytest.raises(ValueError, match="'b'.* must all have the same shape"):
         require_equal_shapes("f", {"a": (3, 2), "b": (3, 4)})
 
 

--- a/tests/test_mutually_required_groups.py
+++ b/tests/test_mutually_required_groups.py
@@ -59,7 +59,9 @@ OCTAVES = np.array([125.0, 250.0, 500.0, 1000.0])
 def test_lining_resonance_takes_one_formula_not_both() -> None:
     """D.1 and D.2 are two constructions, not two ways to say one number."""
     for kwargs in ({}, {"dynamic_stiffness": 1e7, "cavity_depth": 0.05}):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(
+            ValueError, match=r"exactly one of 'dynamic_stiffness'.*or 'cavity_depth'"
+        ):
             lining_resonance_frequency(100.0, 10.0, **kwargs)  # type: ignore[call-overload]
     assert lining_resonance_frequency(100.0, 10.0, dynamic_stiffness=1e7) > 0.0
     assert lining_resonance_frequency(100.0, 10.0, cavity_depth=0.05) > 0.0
@@ -68,7 +70,9 @@ def test_lining_resonance_takes_one_formula_not_both() -> None:
 def test_ground_effect_takes_one_ground_description() -> None:
     both = {"flow_resistivity": 200e3, "impedance": np.ones(4, dtype=complex)}
     for kwargs in ({}, both):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(
+            ValueError, match=r"exactly one of 'impedance' or 'flow_resistivity'"
+        ):
             ground_effect(  # type: ignore[call-overload]
                 OCTAVES, 1.0, 1.5, 10.0, **kwargs
             )
@@ -76,13 +80,15 @@ def test_ground_effect_takes_one_ground_description() -> None:
 
 def test_gaussian_residual_takes_one_percentile() -> None:
     for kwargs in ({}, {"l90": 45.0, "l95": 44.0}):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(ValueError, match=r"exactly one of 'l90' or 'l95'"):
             gaussian_residual_level(50.0, **kwargs)  # type: ignore[call-overload]
 
 
 def test_diffuser_polar_takes_one_description() -> None:
     for kwargs in ({}, {"depths": BANDS, "reflection": BANDS}):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(
+            ValueError, match=r"exactly one of 'depths' or 'reflection'"
+        ):
             predict_diffuser_polar_response(0.1, 500.0, **kwargs)  # type: ignore[call-overload]
 
 
@@ -93,9 +99,9 @@ def test_diffuser_polar_takes_one_description() -> None:
 
 def test_airborne_insulation_wants_area_and_volume_together() -> None:
     l1, l2, t2 = np.full(16, 80.0), np.full(16, 40.0), np.full(16, 0.5)
-    with pytest.raises(ValueError, match="together"):
+    with pytest.raises(ValueError, match=r"'area' and 'volume' must be given together"):
         airborne_insulation(l1, l2, t2, area=10.0)  # type: ignore[call-overload]
-    with pytest.raises(ValueError, match="together"):
+    with pytest.raises(ValueError, match=r"'area' and 'volume' must be given together"):
         airborne_insulation(l1, l2, t2, volume=50.0)  # type: ignore[call-overload]
 
 
@@ -108,21 +114,24 @@ def test_survey_insulation_area_needs_volume() -> None:
 
 def test_adaptation_term_wants_both_or_neither() -> None:
     """Neither is not an error here: it selects the Formula (B.2) approximation."""
-    with pytest.raises(ValueError, match="both"):
+    with pytest.raises(ValueError, match=r"both 'boundary_area' and 'volume'"):
         adaptation_term_kc(OCTAVES, boundary_area=50.0)  # type: ignore[call-overload]
     assert adaptation_term_kc(OCTAVES).shape == OCTAVES.shape
 
 
 def test_plenum_attenuations_travel_together() -> None:
     r = np.full(4, 30.0)
-    with pytest.raises(ValueError, match="together"):
+    with pytest.raises(
+        ValueError,
+        match=r"'attenuation_source' and 'attenuation_receiving' must be given together",
+    ):
         plenum_flanking_reduction_index(  # type: ignore[call-overload]
             r, r, ceiling_length=3.0, plenum_height=1.0, attenuation_source=r
         )
 
 
 def test_plateau_needs_a_complete_construction() -> None:
-    with pytest.raises(ValueError, match="mass_per_area"):
+    with pytest.raises(ValueError, match=r"plateau construction needs 'mass_per_area'"):
         plateau_transmission_loss(OCTAVES, mass_per_area=20.0)  # type: ignore[call-overload]
 
 
@@ -146,7 +155,9 @@ def test_floating_floor_pair_is_not_dropped_in_silence() -> None:
 
 
 def test_cremer_hammer_needs_its_limiting_frequency() -> None:
-    with pytest.raises(ValueError, match="limiting_frequency"):
+    with pytest.raises(
+        ValueError, match=r"'limiting_frequency' is required by model='cremer_hammer'"
+    ):
         floating_floor_improvement_spectrum(  # type: ignore[call-overload]
             BANDS, resonance_frequency=52.8, model="cremer_hammer"
         )
@@ -182,7 +193,9 @@ def test_sti_snr_and_ambient_are_two_ways_of_saying_one_thing() -> None:
     ir = np.zeros(4096)
     ir[0] = 1.0
     level, ambient = np.full(7, 60.0), np.full(7, 30.0)
-    with pytest.raises(ValueError, match="not both"):
+    with pytest.raises(
+        ValueError, match=r"either 'snr' or 'ambient' noise levels, not both"
+    ):
         sti_from_impulse_response(  # type: ignore[call-overload]
             ir, 48000, 15.0, level, ambient
         )
@@ -190,7 +203,7 @@ def test_sti_snr_and_ambient_are_two_ways_of_saying_one_thing() -> None:
 
 def test_shock_exposure_and_measurement_times_travel_together() -> None:
     a = np.random.default_rng(0).standard_normal(4096)
-    with pytest.raises(ValueError, match="both"):
+    with pytest.raises(ValueError, match=r"both exposure_time and measurement_time"):
         multiple_shock_assessment(  # type: ignore[call-overload]
             a,
             1000.0,
@@ -210,7 +223,9 @@ def test_source_room_refuses_itself_at_construction() -> None:
     the call means the complaint arrives at the line that built the object.
     """
     for kwargs in ({}, {"level": 80.0, "power_level": 90.0}):
-        with pytest.raises(ValueError, match="exactly one"):
+        with pytest.raises(
+            ValueError, match=r"exactly one of 'level'.*or 'power_level'"
+        ):
             SourceRoom(**kwargs)
     with pytest.raises(ValueError, match="'room_constant' is required"):
         SourceRoom(power_level=90.0)

--- a/tests/test_removed_names.py
+++ b/tests/test_removed_names.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import re
 import sys
 
 import numpy as np
@@ -114,7 +115,11 @@ def test_the_canonical_names_the_3_1_aliases_pointed_at_are_all_here() -> None:
 
 def test_the_plot_renderers_moved_out_of_the_deprecated_module() -> None:
     """``phonometry._plotting`` was the 3.2 re-export; ``_plot`` is the home."""
-    with pytest.raises(ModuleNotFoundError):
+    # Naming the module matters: a module that came back carrying a broken
+    # optional import would raise ModuleNotFoundError too, about something else.
+    with pytest.raises(
+        ModuleNotFoundError, match=r"No module named 'phonometry\._plotting'"
+    ):
         importlib.import_module("phonometry._plotting")
     assert callable(importlib.import_module("phonometry._plot.room").plot_excitation)
 
@@ -137,7 +142,9 @@ _REMOVED_FLAT_MODULE_PATHS = [
 
 @pytest.mark.parametrize("path", _REMOVED_FLAT_MODULE_PATHS)
 def test_removed_flat_module_path_raises(path: str) -> None:
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(
+        ModuleNotFoundError, match=rf"No module named '(?:{_import_chain(path)})'"
+    ):
         importlib.import_module(path)
     assert path not in sys.modules
     # The names these modules held never moved; the package that owns each of
@@ -169,9 +176,27 @@ _REMOVED_4_0_MODULE_PATHS = [
 ]
 
 
+def _import_chain(path: str) -> str:
+    """``a.b.c`` -> a regex alternation of ``a.b.c``, ``a.b`` and ``a``.
+
+    Python reports the FIRST missing ancestor, not the path asked for: with
+    ``phonometry.environmental`` removed too, importing its ``cnossos_road``
+    submodule reports the parent. Either is a correct refusal of this path, and
+    naming the chain still excludes the failure worth catching, which is some
+    unrelated third-party import going missing underneath a module that came
+    back.
+    """
+    parts = path.split(".")
+    return "|".join(
+        re.escape(".".join(parts[: i + 1])) for i in reversed(range(len(parts)))
+    )
+
+
 @pytest.mark.parametrize("path", _REMOVED_4_0_MODULE_PATHS)
 def test_removed_4_0_module_path_raises(path: str) -> None:
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(
+        ModuleNotFoundError, match=rf"No module named '(?:{_import_chain(path)})'"
+    ):
         importlib.import_module(path)
     assert path not in sys.modules
 
@@ -185,13 +210,15 @@ def test_a_removed_path_is_not_served_by_its_parent_package() -> None:
     ``AttributeError``. Three exception types for one removal, which is why the
     CHANGELOG names them separately.
     """
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(
+        ModuleNotFoundError, match=r"No module named 'phonometry\.hearing\.sti'"
+    ):
         importlib.import_module("phonometry.hearing.sti")
-    with pytest.raises(ImportError):
+    with pytest.raises(ImportError, match=r"cannot import name 'sti'"):
         from phonometry.hearing import sti  # noqa: F401
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError, match=r"has no attribute 'sti'"):
         _ = ph.hearing.sti
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError, match=r"has no attribute 'environmental'"):
         _ = ph.environmental
 
 

--- a/tests/test_secondary_geometry_plots.py
+++ b/tests/test_secondary_geometry_plots.py
@@ -45,7 +45,7 @@ def test_facade_result_retains_elements_and_draws() -> None:
     )
     assert res.elements == tuple(elements)
     assert res.plot_geometry() is not None
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match=r"'elements' must contain at least one"):
         pm.building.plot_facade_elements([])
 
 
@@ -112,7 +112,7 @@ def test_double_wall_result_retains_geometry_and_draws() -> None:
     single = pm.building.single_panel_transmission_loss(
         FREQ, 10.0, critical_frequency=1200.0
     )
-    with pytest.raises(ValueError, match="does not retain"):
+    with pytest.raises(ValueError, match="does not retain its double-wall geometry"):
         single.plot_geometry()
     with pytest.raises(ValueError, match="'mass1' must be positive"):
         pm.building.plot_double_wall_geometry(0.0, 8.8, 0.1)
@@ -155,24 +155,24 @@ def test_junction_result_retains_thicknesses_and_draws() -> None:
     assert res.plot_geometry() is not None
     for junction in ("L", "T1", "T2", "X"):
         assert pm.building.plot_junction_geometry(junction, 0.14, 0.2) is not None
-    with pytest.raises(ValueError, match="junction"):
+    with pytest.raises(ValueError, match=r"'junction' must be"):
         pm.building.plot_junction_geometry("Y", 0.14, 0.2)
 
 
 def test_junction_geometry_rejects_nan_thickness() -> None:
     """A NaN thickness would draw collapsed plates under a 'nan mm' label."""
-    with pytest.raises(ValueError, match="thickness1"):
+    with pytest.raises(ValueError, match=r"'thickness1' must be positive"):
         pm.building.plot_junction_geometry("L", float("nan"), 0.1)
 
 
 def test_junction_geometry_rejects_nan_second_thickness() -> None:
-    with pytest.raises(ValueError, match="thickness2"):
+    with pytest.raises(ValueError, match=r"'thickness2' must be positive"):
         pm.building.plot_junction_geometry("L", 0.14, float("nan"))
 
 
 def test_insitu_setup_defaults_and_retention() -> None:
     assert pm.materials.plot_insitu_geometry() is not None
-    with pytest.raises(ValueError, match="mic_height"):
+    with pytest.raises(ValueError, match=r"'source_height' must exceed 'mic_height'"):
         pm.materials.plot_insitu_geometry(source_height=0.2, mic_height=0.25)
     fs = 48000
     impulse = np.zeros(2048)
@@ -202,7 +202,7 @@ def test_goniometer_microphone_count() -> None:
     ax = pm.materials.plot_goniometer_geometry()
     counts = [len(c.get_offsets()) for c in ax.collections]
     assert 37 in counts
-    with pytest.raises(ValueError, match="angular_step"):
+    with pytest.raises(ValueError, match=r"'angular_step' must be in"):
         pm.materials.plot_goniometer_geometry(angular_step=0.0)
 
 
@@ -215,12 +215,12 @@ def test_plate_geometry_from_result() -> None:
 
 def test_plate_geometry_rejects_nan_length() -> None:
     """A NaN length would draw no plate under a 'nan m' dimension label."""
-    with pytest.raises(ValueError, match="length_x"):
+    with pytest.raises(ValueError, match=r"'length_x' must be positive"):
         pm.vibration.plot_plate_geometry(float("nan"), 1.2)
 
 
 def test_plate_geometry_rejects_nan_width() -> None:
-    with pytest.raises(ValueError, match="length_y"):
+    with pytest.raises(ValueError, match=r"'length_y' must be positive"):
         pm.vibration.plot_plate_geometry(1.2, float("nan"))
 
 
@@ -232,7 +232,7 @@ def test_open_plan_result_retains_positions_and_draws() -> None:
     )
     assert res.positions_m is not None
     assert res.plot_geometry() is not None
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(ValueError, match="'positions' needs at least two"):
         pm.room.plot_open_plan_geometry([3.0])
 
 
@@ -295,7 +295,7 @@ def test_intensity_result_retains_spacing_and_draws() -> None:
     assert res.spacing == pytest.approx(0.012)
     assert res.plot_geometry() is not None
     assert pm.emission.plot_pp_probe_geometry() is not None
-    with pytest.raises(ValueError, match="spacing"):
+    with pytest.raises(ValueError, match=r"'spacing' must be positive"):
         pm.emission.plot_pp_probe_geometry(0.0)
 
 

--- a/tests/test_signal_contract_exemptions.py
+++ b/tests/test_signal_contract_exemptions.py
@@ -124,9 +124,11 @@ def test_the_two_microphone_probe_takes_the_rate_from_either_side() -> None:
     assert_same(sound_intensity(Signal(p1, FS), p2, spacing=0.012), reference)
     assert_same(sound_intensity(p1, Signal(p2, FS), spacing=0.012), reference)
     first, second = Signal(p1, FS), Signal(p2, FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError, match="'p1' and 'p2' are Signals recorded at different rates"
+    ):
         sound_intensity(first, second, spacing=0.012)
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(ValueError, match=r"fs is required when 'p1' is a bare array"):
         sound_intensity(p1, p2, spacing=0.012)
 
 
@@ -235,9 +237,9 @@ def test_a_full_scale_reading_still_resolves_the_rate(
     """Exempt from the calibration, not from the rate: it still takes one."""
     sig = Signal(_RECORD, FS)
     assert_same(func(sig, **kwargs), func(_RECORD, FS, **kwargs))
-    with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
+    with pytest.raises(ValueError, match=r"fs=\d+ conflicts with the Signal's own fs"):
         func(sig, FS + 1, **kwargs)
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(ValueError, match=r"fs is required when 'x' is a bare array"):
         func(_RECORD, **kwargs)
 
 
@@ -274,9 +276,13 @@ def test_a_non_pressure_record_still_resolves_the_rate(
     """An acceleration is not a pressure, and it still needs a sample rate."""
     sig = Signal(_RECORD, FS)
     assert_same(func(sig, **kwargs), func(_RECORD, FS, **kwargs))
-    with pytest.raises(ValueError, match="conflicts with the Signal's own"):
+    with pytest.raises(
+        ValueError, match=r"(fs|sample_rate)=\d+ conflicts with the Signal's own fs"
+    ):
         func(sig, FS + 1, **kwargs)
-    with pytest.raises(ValueError, match="is required"):
+    with pytest.raises(
+        ValueError, match=r"(fs|sample_rate) is required when '\w+' is a bare array"
+    ):
         func(_RECORD, **kwargs)
 
 
@@ -310,7 +316,7 @@ def test_the_calibrator_take_gets_its_validation_from_the_object() -> None:
         warnings.simplefilter("error")
         unvalidated = sensitivity(short)
     assert from_object == pytest.approx(unvalidated)
-    with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
+    with pytest.raises(ValueError, match=r"fs=\d+ conflicts with the Signal's own fs"):
         sensitivity(take, fs=FS + 1)
 
 


### PR DESCRIPTION
A `pytest.raises` pattern of one or two words passes against any message containing those words. `match="fs"` matches anything mentioning fs. `match="finite"` passes whichever of two fields refused.

That is not a hole I reasoned my way to. A `match="positive"` was still passing by substring luck against a message that had since been improved to name `'length_x'`, so the test had quietly stopped pinning what its own name claimed, and three sites in one file carrying that same word turned out to guard three different fields.

This is the first of three parts, split only to keep each reviewable. The three together carry 1174 tightened patterns across the suite.

## How each pattern was derived

From the message the code actually raises, captured by instrumenting `pytest.raises` in a plugin that records the real exception at every site. Never from the test name, which is the thing being checked rather than evidence about it.

## What a pattern keeps, and what it must not

It keeps the identifier and enough predicate to name the rule, and nothing else.

It does not keep an enumeration of allowed values, a numeric bound the library chose, a shape, the repr of the value the test itself passed, or numpy's own wording. Those pass today and fail the day the message legitimately improves, which is this defect inverted. Where the enumeration *is* the whole predicate, the pattern keeps the identifier and the first value: the list grows at the end, so the opening survives growth and still breaks if that value is withdrawn, which is a premise change a test should notice.

Where a shared guard names every field at once, the pattern keeps the count as well. That number is not the library's and cannot drift: the test chose it when it built four bands and truncated one column to three, and it is the only thing that says which field was made wrong.

## What was deliberately left alone

83 sites. `"Unknown language"` names its rule without quoting a field, and widening it to the whole message would be churn. Pinning is worth exactly what it disambiguates.

## Also here

Seven error messages carried a comma decimal inside English prose, four of them the same absolute zero, against eleven that use a point. One writes `0,5` where another message writes `0.5` for the same quantity. No test pinned them, and prose citing a standard's own notation keeps its separator and was left alone.


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated numerous pytest exception matchers to use more specific, descriptive regex patterns.</li>
<li>Refined error message validation across aircraft, building, electroacoustics, psychoacoustics, and speech test suites.</li>
<li>Improved test robustness by ensuring exceptions are raised for the correct reasons rather than generic substring matches.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation tests across aircraft, building, electroacoustics, psychoacoustics, speech, simulation, and plotting features.
  * Assertions now verify precise, parameter-specific error and warning messages, including invalid values, dimensions, ranges, and required inputs.
  * Improved checks for frozen-result behavior, removed module paths, report configuration errors, and signal-rate conflicts.
  * Added coverage for several additional invalid-input scenarios without changing expected application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->