### PR TITLE
Make a refusal test pin the refusal it is named for (2 of 3)

### DIFF
--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -1455,7 +1455,7 @@ def sound_power_intensity_precision(
         msg = "All 'areas' must be positive."
         raise ValueError(msg)
     if temperature <= _ABS_ZERO_C:
-        msg = "'temperature' must be above -273,15 degrees Celsius."
+        msg = "'temperature' must be above -273.15 degrees Celsius."
         raise ValueError(msg)
     if barometric_pressure <= 0.0:
         msg = "'barometric_pressure' must be positive (Pa)."

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -143,7 +143,7 @@ def _validate(
         msg = "'frequencies' must be positive."
         raise ValueError(msg)
     if temperature <= -_KELVIN:
-        msg = "'temperature' must be above absolute zero (-273,15 degC)."
+        msg = "'temperature' must be above absolute zero (-273.15 degC)."
         raise ValueError(msg)
     if not 0.0 <= relative_humidity <= _MAX_RELATIVE_HUMIDITY_PERCENT:
         msg = "'relative_humidity' must be within [0, 100] %."

--- a/src/phonometry/materials/absorbers/biot.py
+++ b/src/phonometry/materials/absorbers/biot.py
@@ -139,7 +139,7 @@ def _require_poisson_ratio(value: float) -> float:
     """Validate a Poisson coefficient of an isotropic frame."""
     nu = float(value)
     if not -1.0 < nu < _POISSON_INCOMPRESSIBLE_LIMIT:
-        msg = "'poisson_ratio' must satisfy -1 < nu < 0,5."
+        msg = "'poisson_ratio' must satisfy -1 < nu < 0.5."
         raise ValueError(msg)
     return nu
 

--- a/src/phonometry/materials/absorbers/four_microphone.py
+++ b/src/phonometry/materials/absorbers/four_microphone.py
@@ -102,7 +102,7 @@ def speed_of_sound_astm(temperature: ArrayLike) -> Real:
     """
     t = np.asarray(temperature, dtype=np.float64)
     if np.any(t <= -_ASTM_T0):
-        msg = "'temperature' must exceed -273,15 degC."
+        msg = "'temperature' must exceed -273.15 degC."
         raise ValueError(msg)
     return np.asarray(_ASTM_C_CONST * np.sqrt(_ASTM_T0 + t), dtype=np.float64)
 
@@ -122,7 +122,7 @@ def air_density_astm(
     t = np.asarray(temperature, dtype=np.float64)
     p = np.asarray(atmospheric_pressure, dtype=np.float64)
     if np.any(t <= -_ASTM_T0):
-        msg = "'temperature' must exceed -273,15 degC."
+        msg = "'temperature' must exceed -273.15 degC."
         raise ValueError(msg)
     if np.any(p <= 0.0):
         msg = "'atmospheric_pressure' must be positive (kPa)."

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -162,7 +162,7 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
     # NaN is named alongside the bound: a NaN temperature would otherwise
     # propagate through Eq. (6) into every derived quantity.
     if math.isnan(temperature) or temperature <= -_KELVIN:
-        msg = "'temperature' must be above absolute zero (-273,15 degC)."
+        msg = "'temperature' must be above absolute zero (-273.15 degC)."
         raise ValueError(msg)
     lo, hi = _EQ6_TEMPERATURE_RANGE
     if not lo <= temperature <= hi:

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -197,7 +197,7 @@ def speed_of_sound(temperature: ArrayLike) -> Real:
     t = np.asarray(temperature, dtype=np.float64)
     kelvin = _T0 + t
     if np.any(kelvin <= 0.0):
-        msg = "'temperature' must exceed -273,15 degC."
+        msg = "'temperature' must exceed -273.15 degC."
         raise ValueError(msg)
     return np.asarray(_C_REF * np.sqrt(kelvin / _T_REF_K), dtype=np.float64)
 

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -516,6 +516,20 @@ def test_intensity_non_finite_area_raises() -> None:
         sound_power_intensity_precision(intensity, areas_with_nan)
 
 
+def test_intensity_temperature_below_absolute_zero_raises() -> None:
+    """Eq. 10 normalizes with 296,15/(273,15 + theta), an absolute temperature.
+
+    At absolute zero that denominator vanishes and below it the whole ratio
+    turns negative, so the logarithm of Eq. 10 would be handed an infinity or
+    a negative number and LW0 would be reported as a level when it is a NaN.
+    The reading is refused instead.
+    """
+    intensity = np.full((2,), 1e-5)
+    areas = np.array([1.0, 1.0])
+    with pytest.raises(ValueError, match="'temperature' must be above"):
+        sound_power_intensity_precision(intensity, areas, temperature=-300.0)
+
+
 def test_intensity_single_segment_2d_input_not_transposed() -> None:
     # A genuine (1, N) single-segment, N-band array must NOT be read as N
     # segments, even when N equals a plausible segment count. One area -> one

--- a/tests/environment/assessment/test_impulse_prominence.py
+++ b/tests/environment/assessment/test_impulse_prominence.py
@@ -81,11 +81,15 @@ def test_rating_level_energy_average() -> None:
 
 
 def test_invalid_inputs_raise() -> None:
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"onset_rate and level_difference must be positive"
+    ):
         nt.predicted_prominence(0.0, 10.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"onset_rate and level_difference must be positive"
+    ):
         nt.predicted_prominence(100.0, -1.0)
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match="at least one impulse is required"):
         nt.impulse_prominence([], [])
     with pytest.raises(
         ValueError,
@@ -97,9 +101,11 @@ def test_invalid_inputs_raise() -> None:
         match=r"rating_level: 'laeq' .*'adjustment' .*'durations' .*same shape",
     ):
         nt.rating_level([70.0, 60.0], [0.0], [30.0, 30.0], 60.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"reference_time and durations must be positive"
+    ):
         nt.rating_level([70.0], [0.0], [30.0], 0.0)
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match="at least one sub-interval is required"):
         nt.rating_level([], [], [], 60.0)
 
 
@@ -119,7 +125,10 @@ def test_onset_rate_gate_zeroes_non_qualifying_impulses() -> None:
     (clause 4.5): a 5 dB/s level rise (P = 5.30 for LD = 40 dB) must not
     yield KI > 0.
     """
-    with pytest.warns(nt.ImpulseProminenceWarning, match="10 dB/s"):
+    with pytest.warns(
+        nt.ImpulseProminenceWarning,
+        match=r"onset rates .*do not qualify as impulses",
+    ):
         res = nt.impulse_prominence([5.0], [40.0])
     assert res.qualifies.tolist() == [False]
     assert res.per_impulse[0] == pytest.approx(5.303, abs=2e-3)
@@ -154,7 +163,9 @@ def test_assessment_period_defaults_and_validates() -> None:
     assert other.prominence == pytest.approx(default.prominence)
 
     for bad in (0.0, -5.0, float("nan"), float("inf")):
-        with pytest.raises(ValueError, match="assessment_period_min"):
+        with pytest.raises(
+            ValueError, match=r"assessment_period_min must be positive and finite"
+        ):
             nt.impulse_prominence([1200.0], [32.0], assessment_period_min=bad)
 
 
@@ -175,7 +186,9 @@ def test_per_impulse_columns_that_disagree_are_refused(trim: bool) -> None:
     )
     values = np.asarray(result.qualifies)
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match="per impulse"):
+    with pytest.raises(
+        ValueError, match=r"'qualifies' \(\d+\) must each carry one value per impulse"
+    ):
         dataclasses.replace(result, qualifies=wrong)
 
 

--- a/tests/environment/assessment/test_impulse_prominence_report.py
+++ b/tests/environment/assessment/test_impulse_prominence_report.py
@@ -64,7 +64,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -72,7 +72,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="xx")
 
 

--- a/tests/environment/assessment/test_impulsive_sound.py
+++ b/tests/environment/assessment/test_impulsive_sound.py
@@ -261,7 +261,7 @@ def test_level_history_interval_within_range() -> None:
 
 def test_rejects_sample_interval_outside_range() -> None:
     sig = _tone(1000.0, 0.5, 1.0)
-    with pytest.raises(ValueError, match="10-25 ms"):
+    with pytest.raises(ValueError, match=r"dt must be within"):
         iso.sound_pressure_level_history(sig, FS, dt=0.05)
 
 
@@ -273,12 +273,12 @@ def test_rejects_non_positive_fs() -> None:
 
 def test_rejects_empty_signal() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError, match="must not be empty"):
+    with pytest.raises(ValueError, match="signal must not be empty"):
         iso.sound_pressure_level_history(empty, FS)
 
 
 def test_detect_onsets_rejects_short_input() -> None:
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(ValueError, match="at least two level samples are required"):
         iso.detect_onsets([40.0], DT)
 
 

--- a/tests/environment/assessment/test_measurement.py
+++ b/tests/environment/assessment/test_measurement.py
@@ -139,7 +139,10 @@ def test_residual_correction_formula16() -> None:
 
 
 def test_residual_correction_unreliable_warns() -> None:
-    with pytest.warns(EnvironmentalMeasurementWarning, match="upper bound"):
+    with pytest.warns(
+        EnvironmentalMeasurementWarning,
+        match=r"Use reportable_upper_bound, not corrected_level",
+    ):
         res = environment.residual_sound_correction(50.0, 48.0)  # margin 2 dB <= 3
     assert not res.reliable
     # 10.4: with a margin <= 3 dB no correction is allowed; the reportable
@@ -155,7 +158,9 @@ def test_residual_correction_reports_measured_as_bound() -> None:
 
 
 def test_residual_not_below_raises() -> None:
-    with pytest.raises(ValueError, match="below"):
+    with pytest.raises(
+        ValueError, match=r"'residual_level' must be below 'measured_level'"
+    ):
         environment.residual_sound_correction(50.0, 50.0)
 
 
@@ -171,18 +176,18 @@ def test_gaussian_residual_i1_i2() -> None:
 
 
 def test_gaussian_residual_needs_one_percentile() -> None:
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(ValueError, match=r"Supply exactly one of 'l90' or 'l95'"):
         environment.gaussian_residual_level(50.0, l90=40.0, l95=38.0)
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(ValueError, match=r"Supply exactly one of 'l90' or 'l95'"):
         environment.gaussian_residual_level(50.0)
 
 
 def test_gaussian_residual_rejects_inverted_percentiles() -> None:
     # L90 > L50 is impossible (exceedance ordering): almost certainly swapped
     # arguments; the squared spread would otherwise hide the mistake.
-    with pytest.raises(ValueError, match="swapped"):
+    with pytest.raises(ValueError, match=r"'l90' exceeds 'l50'.*look swapped"):
         environment.gaussian_residual_level(40.0, l90=50.0)
-    with pytest.raises(ValueError, match="swapped"):
+    with pytest.raises(ValueError, match=r"'l95' exceeds 'l50'.*look swapped"):
         environment.gaussian_residual_level(40.0, l95=41.0)
 
 
@@ -215,7 +220,7 @@ def test_combined_uncertainty_accepts_pairs() -> None:
 
 
 def test_expanded_uncertainty_bad_confidence() -> None:
-    with pytest.raises(ValueError, match="confidence"):
+    with pytest.raises(ValueError, match=r"'confidence' must be one of"):
         environment.expanded_uncertainty(1.0, confidence=0.90)
 
 
@@ -250,14 +255,19 @@ def test_repeated_measurements_spread_levels() -> None:
     (3.944 dB for [50, 60, 70]) while the Note 2 approximation inflates to
     12.183 dB and triggers the spread warning.
     """
-    with pytest.warns(EnvironmentalMeasurementWarning, match="Formula \\(20\\)"):
+    with pytest.warns(
+        EnvironmentalMeasurementWarning,
+        match=r"Formula \(20\) approximation \(approximate_uncertainty\)",
+    ):
         res = environment.uncertainty_from_repeated_measurements([50.0, 60.0, 70.0])
     assert res.standard_uncertainty == pytest.approx(3.944, abs=2e-3)
     assert res.approximate_uncertainty == pytest.approx(12.183, abs=2e-3)
 
 
 def test_repeated_measurements_needs_two() -> None:
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(
+        ValueError, match="'levels' must be a 1-D array of at least two"
+    ):
         environment.uncertainty_from_repeated_measurements([58.0])
 
 

--- a/tests/environment/assessment/test_rating.py
+++ b/tests/environment/assessment/test_rating.py
@@ -54,7 +54,7 @@ def test_lden_custom_periods() -> None:
 
 
 def test_lden_periods_must_sum_24() -> None:
-    with pytest.raises(ValueError, match="24"):
+    with pytest.raises(ValueError, match=r"Period durations must sum to 24 h"):
         environment.lden(60, 55, 50, hours=(12, 4, 9))
 
 
@@ -86,9 +86,11 @@ def test_composite_generalizes_lden() -> None:
 
 
 def test_composite_validation() -> None:
-    with pytest.raises(ValueError, match="24"):
+    with pytest.raises(ValueError, match=r"Period durations must sum to 24 h"):
         environment.composite_rating_level([(60.0, 10.0, 0.0)])
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"Every period duration must be a positive, finite number"
+    ):
         environment.composite_rating_level([(60.0, -1.0, 0.0), (50.0, 25.0, 0.0)])
 
 
@@ -96,12 +98,14 @@ def test_composite_accepts_generator_and_rejects_empty() -> None:
     periods = [(60.0, 12, 0.0), (55.0, 4, 5.0), (50.0, 8, 10.0)]
     from_gen = environment.composite_rating_level(p for p in periods)
     assert from_gen == pytest.approx(environment.composite_rating_level(periods))
-    with pytest.raises(ValueError, match="one period"):
+    with pytest.raises(ValueError, match=r"At least one period is required"):
         environment.composite_rating_level([])
 
 
 def test_composite_rejects_non_finite_hours() -> None:
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"Every period duration must be a positive, finite number"
+    ):
         environment.composite_rating_level(
             [(60.0, float("nan"), 0.0), (50.0, 12.0, 0.0)]
         )

--- a/tests/environment/assessment/test_rd1367_report.py
+++ b/tests/environment/assessment/test_rd1367_report.py
@@ -76,7 +76,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="xx")
 
 

--- a/tests/environment/assessment/test_spain.py
+++ b/tests/environment/assessment/test_spain.py
@@ -492,7 +492,7 @@ def test_new_activity_without_annual_information_is_refused() -> None:
     is an error rather than a silently omitted check.
     """
     periods, limits = _example_periods(), rd.activity_limits("a")
-    with pytest.raises(ValueError, match="annual index"):
+    with pytest.raises(ValueError, match=r"annual index LK,x is required"):
         rd.assess_activity(periods, limits)
 
 
@@ -538,13 +538,13 @@ def test_assess_activity_reports_only_the_periods_supplied() -> None:
 # --------------------------------------------------------------------------- #
 def test_noise_phase_validation() -> None:
     """A phase needs a positive duration, a finite level and non-negative corrections."""
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'hours' must be a positive, finite number"):
         rd.NoisePhase(0.0, 50.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'hours' must be a positive, finite number"):
         rd.NoisePhase(-1.0, 50.0)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'laeq' must be finite"):
         rd.NoisePhase(1.0, math.nan)
-    with pytest.raises(ValueError, match="0, 3 or 6"):
+    with pytest.raises(ValueError, match=r"'kt' must be 0"):
         rd.NoisePhase(1.0, 50.0, kt=-3.0)
 
 
@@ -558,9 +558,9 @@ def test_corrections_are_graded_zero_three_or_six() -> None:
     for step in rd.RD1367_CORRECTION_VALUES:
         assert rd.total_correction(step, step, 0.0) == min(2 * step, 9.0)
     for bad in (1.0, 4.5, 7.0, -3.0):
-        with pytest.raises(ValueError, match="0, 3 or 6"):
+        with pytest.raises(ValueError, match=r"'kt' must be 0"):
             rd.total_correction(bad)
-        with pytest.raises(ValueError, match="0, 3 or 6"):
+        with pytest.raises(ValueError, match=r"'kf' must be 0"):
             rd.corrected_level(50.0, kf=bad)
 
 
@@ -594,28 +594,34 @@ def test_tonal_correction_validation() -> None:
         rd.tonal_correction([60.0, 60.0], [100.0, 125.0, 160.0])
     with pytest.raises(ValueError, match="At least three"):
         rd.tonal_correction([60.0, 60.0], [100.0, 125.0])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'levels' must contain finite values"):
         rd.tonal_correction([60.0, math.nan, 60.0], [100.0, 125.0, 160.0])
-    with pytest.raises(ValueError, match="strictly ascending"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be strictly ascending"):
         rd.tonal_correction([60.0, 60.0, 60.0], [160.0, 125.0, 100.0])
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"'frequencies' must contain positive, finite values"
+    ):
         rd.tonal_correction([60.0, 60.0, 60.0], [0.0, 125.0, 160.0])
     two_dimensional = np.zeros((2, 3))
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(
+        ValueError, match=r"'levels' and 'frequencies' must be one-dimensional"
+    ):
         rd.tonal_correction(two_dimensional, two_dimensional)
 
 
 def test_limit_lookup_validation() -> None:
     """Unknown area types, room combinations and periods are rejected."""
-    with pytest.raises(ValueError, match="area_type"):
+    with pytest.raises(ValueError, match=r"'area_type' must be one of"):
         rd.activity_limits("z")
-    with pytest.raises(ValueError, match="building_use"):
+    with pytest.raises(ValueError, match=r"'building_use' must be one of"):
         rd.vibration_quality_objective("industrial")
-    with pytest.raises(ValueError, match="Unknown"):
+    with pytest.raises(
+        ValueError, match=r"Unknown \(building_use, room_type\) combination"
+    ):
         rd.indoor_quality_objectives("residential", "classrooms")
-    with pytest.raises(ValueError, match="urbanisation"):
+    with pytest.raises(ValueError, match=r"'urbanisation' must be 'existing'"):
         rd.outdoor_quality_objectives("a", urbanisation="future")
-    with pytest.raises(ValueError, match="period"):
+    with pytest.raises(ValueError, match=r"'period' must be one of"):
         rd.activity_limits("a")["afternoon"]
 
 
@@ -628,23 +634,34 @@ def test_assess_activity_validation() -> None:
     with pytest.raises(ValueError, match="no noise phases"):
         rd.assess_activity(empty_day, limits)
     afternoon = {"afternoon": [rd.NoisePhase(1.0, 50.0)]}
-    with pytest.raises(ValueError, match="evaluation period"):
+    with pytest.raises(
+        ValueError, match=r"None of the supplied keys is an evaluation period"
+    ):
         rd.assess_activity(afternoon, limits)
     day = {"day": [rd.NoisePhase(12.0, 50.0)]}
-    with pytest.raises(ValueError, match="operating_days"):
+    with pytest.raises(
+        ValueError,
+        match=r"'operating_days' must be a positive integer no larger than 'year_days'",
+    ):
         rd.assess_activity(day, limits, operating_days=400)
-    with pytest.raises(ValueError, match="year_days"):
+    with pytest.raises(
+        ValueError, match=r"'year_days' must be a positive whole number"
+    ):
         rd.assess_activity(day, limits, operating_days=10, year_days=0)
     # 'year_days' is validated even when it is the only annual input given,
     # and a fractional count of days is rejected rather than truncated.
-    with pytest.raises(ValueError, match="year_days"):
+    with pytest.raises(
+        ValueError, match=r"'year_days' must be a positive whole number"
+    ):
         rd.assess_activity(
             day,
             limits,
             long_term_levels={"day": 50.0},
             year_days=365.5,  # type: ignore[arg-type]
         )
-    with pytest.raises(ValueError, match="whole number"):
+    with pytest.raises(
+        ValueError, match=r"'operating_days' must be a whole number of days"
+    ):
         rd.assess_activity(
             day,
             limits,
@@ -707,19 +724,21 @@ def test_an_assessment_over_no_period_is_refused() -> None:
 
 def test_long_term_level_validation() -> None:
     """The annual average needs at least one finite level and matching weights."""
-    with pytest.raises(ValueError, match="At least one"):
+    with pytest.raises(ValueError, match="At least one daily level"):
         rd.long_term_corrected_level([])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'daily_levels' must contain finite values"):
         rd.long_term_corrected_level([math.nan])
     with pytest.raises(ValueError, match=r"'daily_levels' .*'weights' .*same shape"):
         rd.long_term_corrected_level([50.0, 50.0], weights=[1.0])
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(
+        ValueError, match=r"'weights' must contain positive, finite values"
+    ):
         rd.long_term_corrected_level([50.0], weights=[0.0])
 
 
 def test_round_reported_level_rejects_non_finite() -> None:
     """Rounding a non-finite level is an error rather than a silent NaN."""
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'value' must be finite"):
         rd.round_reported_level(math.inf)
 
 
@@ -732,5 +751,5 @@ def test_a_tonal_correction_refuses_per_band_columns_that_disagree() -> None:
 
     frequencies = np.array([100.0, 125.0, 160.0, 200.0, 250.0])
     result = rd.tonal_correction(np.array([50.0, 62.0, 51.0, 50.0, 49.0]), frequencies)
-    with pytest.raises(ValueError, match="'levels'"):
+    with pytest.raises(ValueError, match=r"'levels' \(4\)"):
         dataclasses.replace(result, levels=result.levels[:-1])

--- a/tests/environment/propagation/test_ground_barriers.py
+++ b/tests/environment/propagation/test_ground_barriers.py
@@ -160,7 +160,9 @@ def test_ground_effect_result_is_frozen_and_has_plot() -> None:
     ],
 )
 def test_ground_effect_requires_exactly_one_impedance_source(kwargs: dict) -> None:
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(
+        ValueError, match=r"exactly one of 'impedance' or 'flow_resistivity'"
+    ):
         environment.ground_effect(_BANDS, 1.0, 1.0, 20.0, **kwargs)
 
 
@@ -174,12 +176,12 @@ def test_ground_effect_rejects_bad_geometry() -> None:
 def test_ground_effect_rejects_non_finite_impedance() -> None:
     # An infinite Z is not the hard-ground limit (that is a large finite Z); it
     # would give inf/inf = NaN in Rp, so it is rejected outright.
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'impedance' must be finite"):
         environment.ground_effect(_BANDS, 1.0, 1.0, 20.0, impedance=np.inf)
     inf_z = complex(np.inf, 0.0)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'impedance' must be finite"):
         environment.spherical_reflection_coefficient(_BANDS, inf_z, 1.0, 1.5, 50.0)
-    with pytest.raises(ValueError, match="non-zero"):
+    with pytest.raises(ValueError, match=r"'impedance' must be non-zero"):
         environment.ground_effect(_BANDS, 1.0, 1.0, 20.0, impedance=0.0)
 
 
@@ -419,7 +421,8 @@ def test_a_barrier_series_off_the_frequency_axis_is_refused(
     res = environment.barrier_insertion_loss(_BANDS, 1.0, 50.0, 4.0, 100.0, 1.5)
     values = np.asarray(getattr(res, field_name))
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    count = 7 if trim else 9  # the eight-band fixture, one short or one long
+    with pytest.raises(ValueError, match=rf"'{field_name}' \({count}\)"):
         dataclasses.replace(res, **{field_name: wrong})
 
 
@@ -468,7 +471,10 @@ def test_a_barrier_loss_covering_no_frequency_is_refused() -> None:
 
 
 def test_barrier_rejects_bad_geometry() -> None:
-    with pytest.raises(ValueError, match="must exceed"):
+    with pytest.raises(
+        ValueError,
+        match=r"'barrier_height' must exceed the source and receiver heights",
+    ):
         # barrier not taller than source/receiver -> no shadow.
         environment.barrier_insertion_loss(_BANDS, 2.0, 50.0, 1.5, 100.0, 1.0)
     with pytest.raises(ValueError, match="exceed 'barrier_distance'"):
@@ -484,22 +490,25 @@ def test_barrier_rejects_bad_geometry() -> None:
             method="kurze_anderson",
             ground_flow_resistivity=2e5,
         )
-    with pytest.raises(ValueError, match="unknown method"):
+    with pytest.raises(ValueError, match=r"unknown method 'utd'"):
         environment.barrier_insertion_loss(
             _BANDS, 1.0, 50.0, 4.0, 100.0, 1.5, method="utd"
         )  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="barrier_distance \\+ thickness"):
+    with pytest.raises(
+        ValueError,
+        match=r"'receiver_distance' must exceed 'barrier_distance \+ thickness'",
+    ):
         # A thick barrier whose far edge lies at/beyond the receiver.
         environment.barrier_insertion_loss(
             _BANDS, 1.0, 50.0, 4.0, 100.0, 1.5, method="exact", thickness=60.0
         )
-    with pytest.raises(ValueError, match="speed_of_sound"):
+    with pytest.raises(ValueError, match=r"'speed_of_sound' must be positive"):
         environment.barrier_insertion_loss(
             _BANDS, 1.0, 50.0, 4.0, 100.0, 1.5, speed_of_sound=0.0
         )
     for bad in (float("nan"), float("inf"), -1.0):
         # thickness NaN/inf/<=0 are all rejected (NaN slips past a bare <= 0).
-        with pytest.raises(ValueError, match="thickness"):
+        with pytest.raises(ValueError, match=r"'thickness' must be positive"):
             environment.barrier_insertion_loss(
                 _BANDS,
                 1.0,

--- a/tests/environment/propagation/test_outdoor_propagation.py
+++ b/tests/environment/propagation/test_outdoor_propagation.py
@@ -54,7 +54,7 @@ class TestGeometricDivergence:
         assert delta == pytest.approx(6.0206, abs=1e-3)
 
     def test_non_positive_raises(self) -> None:
-        with pytest.raises(ValueError, match="positive"):
+        with pytest.raises(ValueError, match=r"'distance' must be positive"):
             environment.geometric_divergence(0.0)
 
 
@@ -159,9 +159,9 @@ class TestGroundGeneral:
         assert porous[3] > hard[3]
 
     def test_invalid_ground_factor_raises(self) -> None:
-        with pytest.raises(ValueError, match=r"ground_source"):
+        with pytest.raises(ValueError, match=r"'ground_source' must be within"):
             environment.ground_attenuation(100.0, 1.0, 1.0, BANDS, 1.5, 0.0, 0.0)
-        with pytest.raises(ValueError, match=r"ground_middle"):
+        with pytest.raises(ValueError, match=r"'ground_middle' must be within"):
             environment.ground_attenuation(100.0, 1.0, 1.0, BANDS, 0.0, -0.1, 0.0)
 
     def test_default_projected_distance(self) -> None:
@@ -387,7 +387,7 @@ class TestOutdoorPropagation:
         assert gain[-2] > gain[0]
 
     def test_invalid_distance_raises(self) -> None:
-        with pytest.raises(ValueError, match="positive"):
+        with pytest.raises(ValueError, match=r"'distance' must be positive"):
             environment.outdoor_propagation_attenuation(-1.0, 1.0, 1.0)
 
 
@@ -448,28 +448,30 @@ class TestPredictedReceiverLevel:
 
 class TestInputValidation:
     def test_barrier_rejects_zero_edge_separation(self) -> None:
-        with pytest.raises(ValueError, match="edge_separation"):
+        with pytest.raises(ValueError, match=r"'edge_separation' must be positive"):
             environment.Barrier(
                 source_to_edge=50.0, edge_to_receiver=50.0, edge_separation=0.0
             )
 
     def test_barrier_rejects_negative_edge_distance(self) -> None:
-        with pytest.raises(ValueError, match="non-negative"):
+        with pytest.raises(
+            ValueError, match=r"Barrier edge distances must be non-negative"
+        ):
             environment.Barrier(source_to_edge=-1.0, edge_to_receiver=50.0)
 
     def test_ground_attenuation_rejects_nonpositive_frequency(self) -> None:
         with_zero = np.array([0.0, 500.0])
-        with pytest.raises(ValueError, match="frequencies"):
+        with pytest.raises(ValueError, match=r"'frequencies' must be positive"):
             environment.ground_attenuation(200.0, 2.0, 2.0, with_zero, 1.0, 1.0, 1.0)
 
     def test_ground_attenuation_rejects_nonpositive_distance(self) -> None:
-        with pytest.raises(ValueError, match="distance"):
+        with pytest.raises(ValueError, match=r"'distance' must be positive"):
             environment.ground_attenuation(0.0, 2.0, 2.0, BANDS, 1.0, 1.0, 1.0)
 
     def test_barrier_attenuation_rejects_nonpositive_frequency(self) -> None:
         barrier = environment.Barrier(source_to_edge=50.0, edge_to_receiver=50.0)
         with_negative = np.array([-1.0, 500.0])
-        with pytest.raises(ValueError, match="frequencies"):
+        with pytest.raises(ValueError, match=r"'frequencies' must be positive"):
             environment.barrier_attenuation(barrier, 90.0, with_negative)
 
 

--- a/tests/environment/propagation/test_outdoor_propagation_report.py
+++ b/tests/environment/propagation/test_outdoor_propagation_report.py
@@ -292,11 +292,11 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError`` for both fiches."""
     attenuation = _attenuation()
     out_a = str(tmp_path / "a.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         attenuation.report(out_a, engine="weasyprint")
     barrier = _barrier()
     out_b = str(tmp_path / "b.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         barrier.report(out_b, engine="weasyprint")
 
 
@@ -304,9 +304,9 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unsupported language raises ``ValueError`` for both fiches."""
     attenuation = _attenuation()
     out_a = str(tmp_path / "a.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         attenuation.report(out_a, language="fr")
     barrier = _barrier()
     out_b = str(tmp_path / "b.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         barrier.report(out_b, language="fr")

--- a/tests/environment/sources/test_cnossos_rail.py
+++ b/tests/environment/sources/test_cnossos_rail.py
@@ -622,10 +622,14 @@ def test_vehicle_and_track_descriptors_round_trip() -> None:
 
 def test_descriptor_rejects_bad_codes() -> None:
     for code in ("", "a4", "z4cn", "a4xn", "a4cz"):
-        with pytest.raises(ValueError, match="Table \\[2.3.a\\]"):
+        with pytest.raises(
+            ValueError, match=r"is not a Table \[2\.3\.a\] vehicle descriptor"
+        ):
             VehicleDescriptor.from_code(code)
     for code in ("BMSNN", "BMSNNNN", "ZMSNNN"):
-        with pytest.raises(ValueError, match="Table \\[2.3.b\\]"):
+        with pytest.raises(
+            ValueError, match=r"is not a Table \[2\.3\.b\] track descriptor"
+        ):
             TrackDescriptor.from_code(code)
 
 
@@ -845,11 +849,13 @@ def test_invalid_inputs() -> None:
         railway_source_power(standing, track)
     with pytest.raises(ValueError, match="non-negative number per hour"):
         railway_source_power(negative_flow, track)
-    with pytest.raises(ValueError, match="positive period"):
+    with pytest.raises(ValueError, match=r"'reference_time' must be a positive period"):
         railway_source_power(running, track, reference_time=0.0)
-    with pytest.raises(ValueError, match="positive number of metres"):
+    with pytest.raises(
+        ValueError, match=r"'length' must be a positive number of metres"
+    ):
         railway_source_power(running, zero_length)
-    with pytest.raises(ValueError, match="height"):
+    with pytest.raises(ValueError, match=r"'height' must be 1"):
         vertical_directivity(10.0, height=3)
     with pytest.raises(ValueError, match="Unknown brake type"):
         wheel_roughness("z")
@@ -871,7 +877,9 @@ def test_invalid_inputs() -> None:
         total_effective_roughness(short_roughness, roughness, roughness)
     with pytest.raises(ValueError, match="positive number of axles"):
         rolling_sound_power(roughness, roughness, 0)
-    with pytest.raises(ValueError, match="non-negative number of m"):
+    with pytest.raises(
+        ValueError, match=r"'joint_density' must be a non-negative number"
+    ):
         impact_roughness(roughness, -1.0)
     with pytest.raises(
         ValueError,
@@ -886,7 +894,9 @@ def test_invalid_inputs() -> None:
         roughness_to_frequency([1.0, 2.0], [1.0, 0.0], 50.0)
     with pytest.raises(ValueError, match="'frequencies' must all be positive"):
         roughness_to_frequency([1.0, 2.0], [1.0, 2.0], 50.0, frequencies=[0.0])
-    with pytest.raises(ValueError, match="positive number of metres"):
+    with pytest.raises(
+        ValueError, match=r"'radius' must be a positive number of metres"
+    ):
         curve_squeal_excess(0.0)
 
 
@@ -911,7 +921,9 @@ def test_a_component_on_the_octave_grid_is_refused() -> None:
     result = _emission_result()
     octave = np.full(result.frequencies.size, 90.0)
     components = {**result.components, "bridge": (octave, octave)}
-    with pytest.raises(ValueError, match=r"'components\['bridge'\]\[0\]'"):
+    with pytest.raises(
+        ValueError, match=rf"'components\['bridge'\]\[0\]' \({octave.size}\)"
+    ):
         dataclasses.replace(result, components=components)
 
 

--- a/tests/environment/sources/test_cnossos_road.py
+++ b/tests/environment/sources/test_cnossos_road.py
@@ -659,9 +659,9 @@ def test_unknown_category_and_surface_are_rejected() -> None:
 
 
 def test_invalid_inputs_are_rejected() -> None:
-    with pytest.raises(ValueError, match="positive number of km/h"):
+    with pytest.raises(ValueError, match="'speed' must be a positive number of km/h"):
         road_rolling_noise("1", 0.0)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'temperature' must be a finite number"):
         road_rolling_noise("1", 50.0, temperature=float("nan"))
     with pytest.raises(ValueError, match="at least one vehicle category"):
         road_source_power([])
@@ -672,10 +672,12 @@ def test_invalid_inputs_are_rejected() -> None:
     with pytest.raises(ValueError, match="at most one flow per vehicle category"):
         road_source_power(repeated)
     negative = RoadTraffic(RoadVehicleCategory.LIGHT, -1.0, 50.0)
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"'flow_rate' must be a non-negative number"):
         road_source_power(negative)
     power = np.array([90.0])
-    with pytest.raises(ValueError, match="positive number of metres"):
+    with pytest.raises(
+        ValueError, match="'length' must be a positive number of metres"
+    ):
         line_source_segment_power(power, 0.0)
 
 
@@ -753,13 +755,14 @@ def test_incomplete_database_is_rejected_as_an_invalid_input() -> None:
         temperature_k={"1": ROAD_COEFFICIENTS.temperature_k["1"]},
     )
     assert road_rolling_noise("1", 70.0, coefficients=partial).shape == (8,)
+    unknown = r"coefficient database has no category '3'"
     for call in (road_rolling_noise, road_propulsion_noise):
-        with pytest.raises(ValueError, match="no category '3'"):
+        with pytest.raises(ValueError, match=unknown):
             call("3", 70.0, coefficients=partial)
-    with pytest.raises(ValueError, match="no category '3'"):
+    with pytest.raises(ValueError, match=unknown):
         road_vehicle_sound_power("3", 70.0, coefficients=partial)
     heavy = RoadTraffic(RoadVehicleCategory.HEAVY, 100.0, 70.0)
-    with pytest.raises(ValueError, match="no category '3'"):
+    with pytest.raises(ValueError, match=unknown):
         road_source_power(heavy, coefficients=partial)
 
 
@@ -786,13 +789,17 @@ def test_studded_tyre_inputs_are_range_checked() -> None:
     (2.2.8) takes a negative argument, which would silently return NaN.
     """
     for fraction in (-0.1, 1.5):
-        with pytest.raises(ValueError, match="fraction in "):
+        with pytest.raises(
+            ValueError, match=r"'studded_fraction' must be a fraction in"
+        ):
             road_rolling_noise("1", 60.0, studded_fraction=fraction, studded_months=3.0)
     for months in (-1.0, 13.0):
-        with pytest.raises(ValueError, match="months in "):
+        with pytest.raises(
+            ValueError, match=r"'studded_months' must be a number of months in"
+        ):
             road_rolling_noise("1", 60.0, studded_fraction=0.5, studded_months=months)
     # The check runs for every category, not only the one it can affect.
-    with pytest.raises(ValueError, match="fraction in "):
+    with pytest.raises(ValueError, match=r"'studded_fraction' must be a fraction in"):
         road_rolling_noise("3", 60.0, studded_fraction=2.0)
     # The two extremes themselves are valid.
     assert road_rolling_noise(

--- a/tests/environment/sources/test_wind_turbine.py
+++ b/tests/environment/sources/test_wind_turbine.py
@@ -115,7 +115,9 @@ def test_tonal_audibility_flat_spectrum_not_audible() -> None:
     # The flat spectrum's argmax candidate sits at the first line, whose
     # critical band extends below the supplied range: the truncation warning
     # fires alongside the (correct) no-identified-tone outcome.
-    with pytest.warns(WindTurbineNoiseWarning, match="critical band"):
+    with pytest.warns(
+        WindTurbineNoiseWarning, match=r"does not cover the whole critical band"
+    ):
         res = wind_turbine_tonality(levels, freqs)
     assert res.is_audible is False
     assert res.has_identified_tone is False
@@ -144,7 +146,7 @@ def test_tonal_audibility_rejects_mismatched_spectrum() -> None:
 
 def test_tonal_audibility_rejects_non_monotonic_frequencies() -> None:
     # A non-increasing frequency axis is not a valid narrowband spectrum.
-    with pytest.raises(ValueError, match="strictly increasing"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be strictly increasing"):
         wind_turbine_tonality([30.0, 30.0, 30.0], [100.0, 98.0, 104.0])
 
 
@@ -152,7 +154,7 @@ def test_tonal_audibility_rejects_non_uniform_spacing() -> None:
     # Formulae 30-34 assume a uniform frequency resolution df. A near-miss axis
     # (2, 2, 2.4 Hz) that a loose 25 % tolerance would accept — but which biases
     # df and the ENBW/masking level — must be rejected by the tight tolerance.
-    with pytest.raises(ValueError, match="uniformly spaced"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be uniformly spaced"):
         wind_turbine_tonality([30.0, 30.0, 30.0, 30.0], [100.0, 102.0, 104.0, 106.4])
 
 
@@ -228,7 +230,9 @@ def test_truncated_critical_band_warns() -> None:
     freqs = np.arange(460.0, 540.0 + df, df)  # narrower than CBW(500) = 117 Hz
     levels = np.full(freqs.size, 30.0)
     levels[int(np.argmin(np.abs(freqs - 500.0)))] = 60.0
-    with pytest.warns(WindTurbineNoiseWarning, match="critical band"):
+    with pytest.warns(
+        WindTurbineNoiseWarning, match=r"does not cover the whole critical band"
+    ):
         wind_turbine_tonality(levels, freqs, tone_frequency=500.0)
 
 
@@ -237,7 +241,7 @@ def test_candidate_below_20hz_rejected() -> None:
     freqs = np.arange(1.0, 200.0 + df, df)
     levels = np.full(freqs.size, 30.0)
     levels[int(np.argmin(np.abs(freqs - 10.0)))] = 60.0
-    with pytest.raises(ValueError, match="below 20 Hz"):
+    with pytest.raises(ValueError, match=r"The candidate tone lies below 20 Hz"):
         wind_turbine_tonality(levels, freqs, tone_frequency=10.0)
 
 
@@ -283,5 +287,5 @@ def test_slant_distance_vertical_axis() -> None:
     assert slant_distance(h, d, rotor_axis="vertical") == pytest.approx(
         np.hypot(h, h + d)
     )
-    with pytest.raises(ValueError, match="rotor_axis"):
+    with pytest.raises(ValueError, match=r"'rotor_axis' must be"):
         slant_distance(h, d, rotor_axis="diagonal")

--- a/tests/environment/sources/test_wind_turbine_tonality_report.py
+++ b/tests/environment/sources/test_wind_turbine_tonality_report.py
@@ -68,7 +68,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -76,7 +76,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(out, language="xx")
 
 

--- a/tests/environment/test_environment_plot_i18n.py
+++ b/tests/environment/test_environment_plot_i18n.py
@@ -41,7 +41,7 @@ def test_plot_spanish_labels() -> None:
 
 def test_plot_unknown_language_raises() -> None:
     result = _result()
-    with pytest.raises(ValueError, match="Unknown language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         result.plot(language="xx")
     plt.close("all")
 

--- a/tests/filters/test_compliance.py
+++ b/tests/filters/test_compliance.py
@@ -128,11 +128,13 @@ def test_coarse_grid_breakpoints_evaluated_exactly() -> None:
 def test_invalid_inputs_raise() -> None:
     bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[500, 2000])
     band_centre = np.array([1.0])
-    with pytest.raises(ValueError, match="num_points"):
+    with pytest.raises(ValueError, match=r"'num_points' must be at least"):
         filters.verify_filter_class(bank, num_points=4)
-    with pytest.raises(ValueError, match="filter_class"):
+    with pytest.raises(
+        ValueError, match=r"filter_class must be one of .* for edition '2014'"
+    ):
         class_limits(1.0, 3, band_centre)
-    with pytest.raises(ValueError, match="fraction"):
+    with pytest.raises(ValueError, match=r"'fraction' must be positive"):
         class_limits(-1.0, 1, band_centre)
 
 
@@ -233,14 +235,18 @@ def test_range_limited_flag_reports_unverifiable_stopband() -> None:
 
 def test_1995_rejects_out_of_range_class_and_bad_edition() -> None:
     band_centre = np.array([1.0])
-    with pytest.raises(ValueError, match="filter_class"):
+    with pytest.raises(
+        ValueError, match=r"filter_class must be one of .* for edition '1995'"
+    ):
         class_limits(1.0, 3, band_centre, edition="1995")
-    with pytest.raises(ValueError, match="filter_class"):
+    with pytest.raises(
+        ValueError, match=r"filter_class must be one of .* for edition '2014'"
+    ):
         class_limits(1.0, 0, band_centre)  # class 0 invalid for 2014
-    with pytest.raises(ValueError, match="edition"):
+    with pytest.raises(ValueError, match=r"edition must be '2014'"):
         class_limits(1.0, 1, band_centre, edition="2020")
     bank = filters.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[500, 2000])
-    with pytest.raises(ValueError, match="edition"):
+    with pytest.raises(ValueError, match=r"edition must be '2014'"):
         filters.verify_filter_class(bank, edition="2020")
 
 
@@ -275,8 +281,11 @@ def test_a_filter_verdict_refuses_per_band_entries_that_disagree() -> None:
     result = filters.filter_class_compliance(
         OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
     )
-    with pytest.raises(ValueError, match="'bands'"):
-        dataclasses.replace(result, bands=result.bands[:-1])
+    short = result.bands[:-1]
+    # Every field of the result is named whichever one is short, so the count
+    # is the only part that says it was 'bands'. This test set that count.
+    with pytest.raises(ValueError, match=rf"'bands' \({len(short)}\)"):
+        dataclasses.replace(result, bands=short)
 
 
 def test_a_filter_verdict_refuses_a_class_its_bands_carry_no_margins_for() -> None:
@@ -291,7 +300,9 @@ def test_a_filter_verdict_refuses_a_class_its_bands_carry_no_margins_for() -> No
     result = filters.filter_class_compliance(
         OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
     )
-    with pytest.raises(ValueError, match="'overall_class' must be one of"):
+    # 'got 0' is what separates this from the non-integer case below, which
+    # the library refuses with the same sentence.
+    with pytest.raises(ValueError, match=r"'overall_class' must be one of .*; got 0\."):
         dataclasses.replace(result, overall_class=0)
 
 
@@ -306,7 +317,7 @@ def test_a_filter_verdict_refuses_an_edition_that_disagrees_with_its_bands() -> 
     result = filters.filter_class_compliance(
         OctaveFilterBank(fs=48000, fraction=1, order=4, limits=[500, 16000])
     )
-    with pytest.raises(ValueError, match="'edition'"):
+    with pytest.raises(ValueError, match=r"'edition' \('1995'\) defines classes"):
         dataclasses.replace(result, edition="1995")
 
 
@@ -425,7 +436,8 @@ def test_a_filter_verdict_refuses_a_class_its_bands_do_not_derive() -> None:
     # ``_verify_band`` emits for a filter just outside the tighter corridor.
     bands[1].update({"class": 2, "margin_class1_db": -0.35})
     with pytest.raises(
-        ValueError, match=r"'overall_class' must be the class the bands derive"
+        ValueError,
+        match=r"'overall_class' must be the class the bands derive.*band states 2",
     ):
         dataclasses.replace(result, bands=bands, overall_class=1)
 
@@ -449,7 +461,8 @@ def test_a_filter_verdict_refuses_a_class_over_a_band_that_meets_none() -> None:
     # The producer's own pairing of that band list is accepted.
     assert dataclasses.replace(result, bands=bands, overall_class=None) is not None
     with pytest.raises(
-        ValueError, match=r"'overall_class' must be the class the bands derive"
+        ValueError,
+        match=r"'overall_class' must be the class the bands derive.*band states None",
     ):
         dataclasses.replace(result, bands=bands, overall_class=1)
 
@@ -473,7 +486,9 @@ def test_a_filter_verdict_refuses_a_class_that_is_no_designation() -> None:
     )
     bands = tuple(copy.deepcopy(band) for band in result.bands)
     bands[1]["class"] = 1.0
-    with pytest.raises(ValueError, match=r"'overall_class' must be one of"):
+    with pytest.raises(
+        ValueError, match=r"'overall_class' must be one of .*; got 1\.0"
+    ):
         dataclasses.replace(result, overall_class=1.0)
     with pytest.raises(ValueError, match=r"'bands' must state a 'class' of"):
         dataclasses.replace(result, bands=bands)

--- a/tests/filters/test_design.py
+++ b/tests/filters/test_design.py
@@ -180,10 +180,10 @@ def test_cheby2_low_attenuation_raises() -> None:
     """attenuation <= 3.01 dB has no -3 dB point: must raise, not produce NaN."""
     from phonometry.filters.design import _cheby2_transition_ratio
 
-    with pytest.raises(ValueError, match="3.01"):
+    with pytest.raises(ValueError, match=r"cheby2 'attenuation' must be greater than"):
         _cheby2_transition_ratio(order=6, attenuation=3.0)
     low_attenuation = filters.FilterDesign(filter_type="cheby2", attenuation=2.0)
-    with pytest.raises(ValueError, match="3.01"):
+    with pytest.raises(ValueError, match=r"cheby2 'attenuation' must be greater than"):
         filters.OctaveFilterBank(fs=48000, fraction=3, design=low_attenuation)
 
 

--- a/tests/filters/test_g_weighting.py
+++ b/tests/filters/test_g_weighting.py
@@ -109,7 +109,7 @@ def test_g_stateful_holds_its_reference_at_low_fs() -> None:
 
 
 def test_invalid_curve_message_mentions_g() -> None:
-    with pytest.raises(ValueError, match="G"):
+    with pytest.raises(ValueError, match=r"Weighting curve must be .*'G'"):
         filters.WeightingFilter(FS, "Q")
 
 

--- a/tests/filters/test_iec61260_report.py
+++ b/tests/filters/test_iec61260_report.py
@@ -106,7 +106,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
         _class1_bank()
     )  # hoisted out of raises (S5778)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -137,7 +137,9 @@ def test_required_class_missing_from_edition_rejected(tmp_path: Path) -> None:
     result = filters.filter_class_compliance(_class1_bank())
     out = str(tmp_path / "class0.pdf")
     meta = ReportMetadata(required_class=0)
-    with pytest.raises(ValueError, match="edition"):
+    with pytest.raises(
+        ValueError, match=r"required_class=0 does not exist in the .* edition"
+    ):
         result.report(out, metadata=meta)
 
 
@@ -205,9 +207,9 @@ def test_empty_bands_result_is_graceful() -> None:
         num_points=2048,
     )
     assert empty.available_classes() == []
-    with pytest.raises(ValueError, match="no bands"):
+    with pytest.raises(ValueError, match=r"has no bands, so it has no reference class"):
         empty.reference_class()
-    with pytest.raises(ValueError, match="no bands"):
+    with pytest.raises(ValueError, match=r"has no bands, so it has no reference class"):
         empty.report("/dev/null")
 
 
@@ -236,5 +238,5 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = filters.filter_class_compliance(_class1_bank())
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/filters/test_parametric_eq.py
+++ b/tests/filters/test_parametric_eq.py
@@ -458,46 +458,48 @@ def test_every_type_designs_and_is_stable(filter_type: str) -> None:
 
 
 def test_rejects_unknown_type_and_bad_frequencies() -> None:
-    with pytest.raises(ValueError, match="filter_type"):
+    with pytest.raises(ValueError, match=r"Unknown filter_type 'bell'"):
         ph.filters.EQSection("bell", 1000.0)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'f0' must be positive"):
         ph.filters.EQSection("peaking", 0.0)
     at_nyquist = ph.filters.EQSection("peaking", FS / 2, gain_db=3.0)
-    with pytest.raises(ValueError, match="Nyquist"):
+    with pytest.raises(
+        ValueError, match=r"f0 = .* must sit below the Nyquist frequency"
+    ):
         ph.filters.ParametricEQ(FS, at_nyquist)
     section = ph.filters.EQSection("peaking", 1000.0, gain_db=3.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'fs' must be positive"):
         ph.filters.ParametricEQ(0, section)
 
 
 def test_rejects_conflicting_or_misplaced_parameters() -> None:
-    with pytest.raises(ValueError, match="only one"):
+    with pytest.raises(ValueError, match=r"Give only one of 'q', 'bw' and 'slope'"):
         ph.filters.EQSection("peaking", 1000.0, gain_db=3.0, q=1.0, bw=1.0)
-    with pytest.raises(ValueError, match="slope"):
+    with pytest.raises(ValueError, match=r"'slope' applies to the shelving types"):
         ph.filters.EQSection("peaking", 1000.0, gain_db=3.0, slope=1.0)
-    with pytest.raises(ValueError, match="bw"):
+    with pytest.raises(ValueError, match=r"'bw' applies to"):
         ph.filters.EQSection("lowshelf", 1000.0, gain_db=3.0, bw=1.0)
-    with pytest.raises(ValueError, match="gain_db"):
+    with pytest.raises(ValueError, match=r"'gain_db' applies to"):
         ph.filters.EQSection("notch", 1000.0, gain_db=3.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'q' must be positive"):
         ph.filters.EQSection("peaking", 1000.0, gain_db=3.0, q=-1.0)
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match="at least one EQSection"):
         ph.filters.ParametricEQ(FS, [])
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    ("kwargs", "offender"),
     [
-        {"f0": float("nan"), "gain_db": 3.0},
-        {"f0": float("inf"), "gain_db": 3.0},
-        {"f0": 1000.0, "gain_db": float("nan")},
-        {"f0": 1000.0, "gain_db": float("inf")},
-        {"f0": 1000.0, "gain_db": 3.0, "q": float("nan")},
-        {"f0": 1000.0, "gain_db": 3.0, "bw": float("inf")},
+        ({"f0": float("nan"), "gain_db": 3.0}, "f0"),
+        ({"f0": float("inf"), "gain_db": 3.0}, "f0"),
+        ({"f0": 1000.0, "gain_db": float("nan")}, "gain_db"),
+        ({"f0": 1000.0, "gain_db": float("inf")}, "gain_db"),
+        ({"f0": 1000.0, "gain_db": 3.0, "q": float("nan")}, "q"),
+        ({"f0": 1000.0, "gain_db": 3.0, "bw": float("inf")}, "bw"),
     ],
 )
-def test_rejects_non_finite_parameters(kwargs: dict) -> None:
-    with pytest.raises(ValueError, match="finite"):
+def test_rejects_non_finite_parameters(kwargs: dict, offender: str) -> None:
+    with pytest.raises(ValueError, match=rf"'{offender}' must be finite"):
         ph.filters.EQSection("peaking", **kwargs)
 
 
@@ -512,7 +514,9 @@ def test_extreme_finite_gain_raises_value_error(
     # 10^(gain_db/40) overflows for huge positive gains and underflows to
     # zero (then divides by zero in the designers) for huge negative ones;
     # both used to leak raw OverflowError/ZeroDivisionError.
-    with pytest.raises(ValueError, match="representable"):
+    with pytest.raises(
+        ValueError, match=r"'gain_db' = .* is outside the representable range"
+    ):
         ph.filters.EQSection(filter_type, 1000.0, gain_db=gain_db, **kwargs)
 
 
@@ -520,7 +524,7 @@ def test_shelf_slope_beyond_gain_bound_raises_informatively() -> None:
     # A = 10^(9/40): the alpha recipe is real only below
     # (A + 1/A)/(A + 1/A - 2) = 8.2869...; beyond it the raw math would
     # fail with a bare "math domain error".
-    with pytest.raises(ValueError, match="too steep"):
+    with pytest.raises(ValueError, match=r"Shelf slope 'slope' = .* is too steep"):
         ph.filters.EQSection("lowshelf", 1000.0, gain_db=9.0, slope=12.0)
     # Just below the bound the design succeeds and is strictly stable.
     section = ph.filters.EQSection("lowshelf", 1000.0, gain_db=9.0, slope=8.0)
@@ -534,7 +538,7 @@ def test_bw_overflow_near_nyquist_raises_value_error() -> None:
     # The w0/sin(w0) warping factor diverges towards Nyquist: this bw/f0
     # pair used to escape as a raw OverflowError from math.sinh.
     section = ph.filters.EQSection("notch", 23999.0, bw=1.0)
-    with pytest.raises(ValueError, match="too wide"):
+    with pytest.raises(ValueError, match=r"Bandwidth 'bw' = .* is too wide"):
         ph.filters.ParametricEQ(FS, section)
 
 
@@ -565,13 +569,13 @@ def test_response_grid_validation() -> None:
     eq = ph.filters.ParametricEQ(
         FS, ph.filters.EQSection("peaking", 1000.0, gain_db=3.0)
     )
-    with pytest.raises(ValueError, match="n_points"):
+    with pytest.raises(ValueError, match=r"'n_points' must be at least"):
         eq.response(n_points=1)
-    with pytest.raises(ValueError, match="f_min"):
+    with pytest.raises(ValueError, match=r"Need 0 < f_min < f_max <= fs/2"):
         eq.response(f_min=0.0)
-    with pytest.raises(ValueError, match="f_min"):
+    with pytest.raises(ValueError, match=r"Need 0 < f_min < f_max <= fs/2"):
         eq.response(f_min=100.0, f_max=50.0)
-    with pytest.raises(ValueError, match="f_min"):
+    with pytest.raises(ValueError, match=r"Need 0 < f_min < f_max <= fs/2"):
         eq.response(f_max=FS)
 
 
@@ -579,7 +583,7 @@ def test_response_rejects_cascade_short_of_its_sections() -> None:
     """Two rows of curves for three sections is not a response."""
     res = ph.filters.ParametricEQ(FS, _three_sections()).response(n_points=128)
     short = res.section_magnitude_db[:2]
-    with pytest.raises(ValueError, match="'section_magnitude_db'"):
+    with pytest.raises(ValueError, match=r"'section_magnitude_db' \(2\)"):
         dataclasses.replace(res, section_magnitude_db=short)
 
 
@@ -587,7 +591,7 @@ def test_response_rejects_cascade_taller_than_its_sections() -> None:
     """The silent direction: the plot loops over ``sections`` and drops the rest."""
     res = ph.filters.ParametricEQ(FS, _three_sections()).response(n_points=128)
     tall = np.vstack([res.section_magnitude_db, res.section_magnitude_db[:1]])
-    with pytest.raises(ValueError, match="'section_magnitude_db'"):
+    with pytest.raises(ValueError, match=r"'section_magnitude_db' \(4\)"):
         dataclasses.replace(res, section_magnitude_db=tall)
 
 
@@ -603,7 +607,7 @@ def test_response_rejects_sos_block_short_of_its_sections() -> None:
     """The cascade that leaves here to be filtered with must be the drawn one."""
     res = ph.filters.ParametricEQ(FS, _three_sections()).response(n_points=128)
     short_sos = res.sos[:2]
-    with pytest.raises(ValueError, match="'sos'"):
+    with pytest.raises(ValueError, match=r"'sos' \(2\)"):
         dataclasses.replace(res, sos=short_sos)
 
 
@@ -639,6 +643,6 @@ def test_plot_rejects_unknown_language() -> None:
     res = ph.filters.ParametricEQ(
         FS, ph.filters.EQSection("peaking", 1000.0, gain_db=3.0)
     ).response(n_points=64)
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         res.plot(language="xx")
     plt.close("all")

--- a/tests/filters/test_parametric_filters.py
+++ b/tests/filters/test_parametric_filters.py
@@ -334,12 +334,14 @@ def test_time_weighting_initial_state_invalid() -> None:
     fs = 1000
     x = np.ones(fs)
 
-    with pytest.raises(ValueError, match="initial_state"):
+    with pytest.raises(ValueError, match=r"initial_state must be None"):
         filters.time_weighting(x, fs, mode="fast", initial_state="invalid")
 
     two_channels = np.ones((2, 10))
     mismatched_state = np.ones(3)
-    with pytest.raises(ValueError, match="broadcastable"):
+    with pytest.raises(
+        ValueError, match=r"initial_state must be scalar or broadcastable"
+    ):
         filters.time_weighting(
             two_channels, fs, mode="fast", initial_state=mismatched_state
         )
@@ -348,7 +350,7 @@ def test_time_weighting_initial_state_invalid() -> None:
 def test_time_weighting_initial_state_first_rejects_empty_input() -> None:
     """Verify initial_state='first' requires at least one sample."""
     empty = np.array([])
-    with pytest.raises(ValueError, match="initial_state"):
+    with pytest.raises(ValueError, match=r"initial_state must be None"):
         filters.time_weighting(empty, 1000, mode="fast", initial_state="first")
 
 
@@ -536,7 +538,9 @@ def test_a_weighting_48k_hf_accuracy_locked() -> None:
 
 def test_high_accuracy_incompatible_with_stateful() -> None:
     """high_accuracy resampling would break block continuity: must raise."""
-    with pytest.raises(ValueError, match="high_accuracy"):
+    with pytest.raises(
+        ValueError, match=r"high_accuracy is not compatible with stateful"
+    ):
         filters.WeightingFilter(48000, "A", stateful=True, high_accuracy=True)
 
 

--- a/tests/filters/test_signal_overloads.py
+++ b/tests/filters/test_signal_overloads.py
@@ -72,7 +72,7 @@ def test_a_conflicting_rate_is_refused_a_matching_one_is_not(
     func: Callable[..., object], kwargs: dict[str, float | EQSection]
 ) -> None:
     sig = Signal(_tone(), FS)
-    with pytest.raises(ValueError, match="conflicts with the Signal's own fs"):
+    with pytest.raises(ValueError, match=r"fs=\d+ conflicts with the Signal's own fs"):
         func(sig, FS + 1, **kwargs)
     # The same number twice is agreement, not a conflict. Outside the block:
     # this call must succeed, and inside it a failure would read as a pass.
@@ -93,7 +93,7 @@ def test_a_bare_array_still_requires_fs(
     func: Callable[..., object], kwargs: dict[str, float | EQSection]
 ) -> None:
     x = _tone()
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(ValueError, match="fs is required when 'x' is a bare array"):
         func(x, **kwargs)
 
 
@@ -248,16 +248,21 @@ def test_the_arguments_behind_fs_are_keyword_only_and_required() -> None:
     """
     sig = Signal(_tone(), FS)
     section = EQSection("peaking", 1000.0, 3.0, 1.0)
-    with pytest.raises(TypeError, match="required keyword-only argument"):
+    with pytest.raises(
+        TypeError, match=r"linkwitz_riley\(\).*required keyword-only argument: 'freq'"
+    ):
         linkwitz_riley(sig)  # type: ignore[call-arg]
-    with pytest.raises(TypeError, match="required keyword-only argument"):
+    with pytest.raises(
+        TypeError,
+        match=r"parametric_eq\(\).*required keyword-only argument: 'sections'",
+    ):
         parametric_eq(sig)  # type: ignore[call-arg]
     # Required is only half of it: the slot behind fs used to accept a
     # positional value, and a call that still passes one must not be read as
     # something else (an order, a second section) rather than refused.
-    with pytest.raises(TypeError, match="positional arguments"):
+    with pytest.raises(TypeError, match=r"linkwitz_riley\(\).*positional arguments"):
         linkwitz_riley(sig, FS, 800.0)  # type: ignore[call-arg]
-    with pytest.raises(TypeError, match="positional arguments"):
+    with pytest.raises(TypeError, match=r"parametric_eq\(\).*positional arguments"):
         parametric_eq(sig, FS, section)  # type: ignore[call-arg]
 
 

--- a/tests/filters/test_spectrogram.py
+++ b/tests/filters/test_spectrogram.py
@@ -54,7 +54,9 @@ def test_spectrogram_rejects_stateful() -> None:
         block_processing=filters.BlockProcessing(stateful=True),
     )
     silence = np.zeros(FS)
-    with pytest.raises(ValueError, match="stateful"):
+    with pytest.raises(
+        ValueError, match=r"spectrogram\(\) is not supported on stateful banks"
+    ):
         bank.spectrogram(silence)
 
 
@@ -64,9 +66,11 @@ def test_spectrogram_invalid_params_raise() -> None:
     # exactly the one call whose exception is under test
     one_second = np.zeros(FS)
     shorter_than_the_window = np.zeros(1000)
-    with pytest.raises(ValueError, match="overlap"):
+    with pytest.raises(ValueError, match=r"overlap must be in \[0, 1\)"):
         bank.spectrogram(one_second, overlap=1.0)
-    with pytest.raises(ValueError, match="window_time"):
+    with pytest.raises(
+        ValueError, match=r"window_time must be positive and shorter than the signal"
+    ):
         bank.spectrogram(shorter_than_the_window, window_time=1.0)
 
 

--- a/tests/filters/test_stateful_octave_filter_bank.py
+++ b/tests/filters/test_stateful_octave_filter_bank.py
@@ -98,7 +98,10 @@ def test_stateful_steady_ic_initialization() -> None:
     # expected here: assert it rather than leak it to the run summary.
     from phonometry.filters.core import FilterBankWarning
 
-    with pytest.warns(FilterBankWarning, match="Detrending"):
+    with pytest.warns(
+        FilterBankWarning,
+        match=r"Detrending is not recommended during block processing",
+    ):
         bank.filter(test_signal)
 
     # Check that zi is a list of numpy arrays with the expected shape
@@ -167,5 +170,7 @@ def test_detrend_stateful_warning() -> None:
         design=FilterDesign(resample=False),
         block_processing=BlockProcessing(stateful=True),
     )
-    with pytest.warns(UserWarning, match="block processing"):
+    with pytest.warns(
+        UserWarning, match=r"Detrending is not recommended during block processing"
+    ):
         bank.filter(signal, detrend=True)

--- a/tests/filters/test_stateful_weighting_filter.py
+++ b/tests/filters/test_stateful_weighting_filter.py
@@ -128,9 +128,9 @@ def test_stateful_weighting_invalid_fs_raises() -> None:
     """Non-positive sample rates must be rejected at construction."""
     from phonometry import filters
 
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         filters.WeightingFilter(fs=0, stateful=True)
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         filters.WeightingFilter(fs=-48000, stateful=True)
 
 
@@ -138,7 +138,9 @@ def test_stateful_weighting_high_accuracy_raises() -> None:
     """high_accuracy resampling is incompatible with block processing."""
     from phonometry import filters
 
-    with pytest.raises(ValueError, match="not compatible with stateful"):
+    with pytest.raises(
+        ValueError, match="high_accuracy is not compatible with stateful"
+    ):
         filters.WeightingFilter(fs=48000, stateful=True, high_accuracy=True)
 
 

--- a/tests/filters/test_weighting_class_verifier.py
+++ b/tests/filters/test_weighting_class_verifier.py
@@ -232,7 +232,7 @@ def test_sweep_result_reported_for_compliant_filter() -> None:
     assert set(between) == {"worst_freq", "margin_class1_db", "margin_class2_db"}
     assert between["margin_class1_db"] >= 0.0
     wf = filters.WeightingFilter(48000, "A")
-    with pytest.raises(ValueError, match="sweep_points"):
+    with pytest.raises(ValueError, match=r"'sweep_points' must be at least"):
         filters.verify_weighting_class(wf, sweep_points=8)
 
 

--- a/tests/filters/test_zero_phase.py
+++ b/tests/filters/test_zero_phase.py
@@ -51,7 +51,9 @@ def test_zero_phase_rejects_stateful() -> None:
         block_processing=filters.BlockProcessing(stateful=True),
     )
     silence = np.zeros(FS)
-    with pytest.raises(ValueError, match="zero_phase"):
+    with pytest.raises(
+        ValueError, match=r"zero_phase is not compatible with stateful processing"
+    ):
         bank.filter(silence, zero_phase=True)
 
 

--- a/tests/io/test_io_bext_write.py
+++ b/tests/io/test_io_bext_write.py
@@ -230,22 +230,22 @@ def test_loudness_encoding_reproduces_the_tech3285_worked_examples(
 
 def test_oversize_fields_raise_instead_of_truncating(tmp_path: Path) -> None:
     long_originator = replace(fresh_metadata(), originator="x" * 33)
-    with pytest.raises(ValueError, match="Originator"):
+    with pytest.raises(ValueError, match=r"bext Originator is \d+ bytes"):
         write(tmp_path / "x.wav", np.zeros(4), FS, bext=long_originator)
     long_umid = replace(fresh_metadata(), umid=bytes(65))
-    with pytest.raises(ValueError, match="UMID"):
+    with pytest.raises(ValueError, match=r"bext UMID is \d+ bytes"):
         write(tmp_path / "x.wav", np.zeros(4), FS, bext=long_umid)
 
 
 def test_version_gating_is_enforced_on_write(tmp_path: Path) -> None:
     umid_on_v0 = replace(fresh_metadata(), version=0, umid=bytes(64))
-    with pytest.raises(ValueError, match="version >= 1"):
+    with pytest.raises(ValueError, match=r"bext version \d+ has no UMID field"):
         write(tmp_path / "x.wav", np.zeros(4), FS, bext=umid_on_v0)
     loudness_on_v1 = replace(fresh_metadata(), version=1, loudness_value=-23.0)
-    with pytest.raises(ValueError, match="version >= 2"):
+    with pytest.raises(ValueError, match=r"bext version \d+ has no loudness fields"):
         write(tmp_path / "x.wav", np.zeros(4), FS, bext=loudness_on_v1)
 
 
 def test_unknown_bext_argument_is_refused(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="unknown bext"):
+    with pytest.raises(ValueError, match=r"unknown bext 'auto'"):
         write(tmp_path / "x.wav", np.zeros(4), FS, bext="auto")

--- a/tests/io/test_io_blocks.py
+++ b/tests/io/test_io_blocks.py
@@ -133,17 +133,24 @@ def test_lossy_sources_warn_when_streaming_begins(tmp_path: Path) -> None:
     path = tmp_path / "note.mp3"
     sf.write(str(path), x, FS)
     blocks = iter(read_blocks(path, 1024))
-    with pytest.warns(LossyCompressionWarning, match="not metrologically"):
+    with pytest.warns(
+        LossyCompressionWarning,
+        match=r"is a lossy format.*not metrologically defensible",
+    ):
         next(blocks)
 
 
 def test_invalid_geometry_is_refused(tmp_path: Path) -> None:
     path = _write(tmp_path, pcm_wav(np.zeros(8, dtype=np.int64), bits=16))
-    with pytest.raises(ValueError, match="block_size"):
+    with pytest.raises(ValueError, match=r"block_size must be at least"):
         read_blocks(path, 0)
-    with pytest.raises(ValueError, match="overlap"):
+    with pytest.raises(
+        ValueError, match=r"overlap must satisfy 0 <= overlap < block_size"
+    ):
         read_blocks(path, 4, overlap=4)
-    with pytest.raises(ValueError, match="overlap"):
+    with pytest.raises(
+        ValueError, match=r"overlap must satisfy 0 <= overlap < block_size"
+    ):
         read_blocks(path, 4, overlap=-1)
 
 
@@ -157,7 +164,7 @@ def test_a_truncated_data_chunk_fails_mid_stream(tmp_path: Path) -> None:
     path = _write(tmp_path, image)
     blocks = read_blocks(path, 8)
     next(blocks)  # frames 0-8 exist
-    with pytest.raises(ValueError, match="bytes short"):
+    with pytest.raises(ValueError, match=r"data chunk ends \d+ bytes short of frame"):
         list(blocks)
 
 

--- a/tests/io/test_io_chunks.py
+++ b/tests/io/test_io_chunks.py
@@ -188,7 +188,9 @@ def test_bext_unset_loudness_sentinel_reads_as_none(tmp_path: Path) -> None:
 def test_bext_shorter_than_fixed_part_is_rejected(tmp_path: Path) -> None:
     image = pcm_wav(TONE, extra_chunks=chunk(b"bext", bytes(100)))
     path = _write(tmp_path, image)
-    with pytest.raises(ValueError, match="602"):
+    with pytest.raises(
+        ValueError, match=r"bext chunk is .* bytes; the EBU Tech 3285 fixed part is 602"
+    ):
         parse_wav_chunks(path)
 
 
@@ -311,7 +313,10 @@ def test_rf64_sentinel_without_ds64_is_rejected(tmp_path: Path) -> None:
         fourcc=b"RF64",
     )
     path = _write(tmp_path, image)
-    with pytest.raises(ValueError, match="ds64"):
+    with pytest.raises(
+        ValueError,
+        match=r"RF64 data chunk defers its size to a ds64 chunk that never appeared",
+    ):
         parse_wav_chunks(path)
 
 

--- a/tests/io/test_io_convert.py
+++ b/tests/io/test_io_convert.py
@@ -146,7 +146,9 @@ def test_explicit_narrowing_reports_the_accumulated_clipping(
     src = tmp_path / "hot.wav"
     write(src, x, FS, subtype="DOUBLE")
     dst = tmp_path / "narrow.wav"
-    with pytest.warns(ClippingWarning, match="10 of 1000"):
+    with pytest.warns(
+        ClippingWarning, match=r"10 of 1000 samples exceed the full-scale range"
+    ):
         convert(src, dst, subtype="PCM_16", block_size=100)
     assert np.asarray(read(dst)).max() == 32767 / 32768
 
@@ -159,7 +161,10 @@ def test_lossy_source_converts_with_the_metrology_warning(
     src = tmp_path / "note.mp3"
     sf.write(str(src), x, FS)
     dst = tmp_path / "expanded.wav"
-    with pytest.warns(LossyCompressionWarning, match="not metrologically"):
+    with pytest.warns(
+        LossyCompressionWarning,
+        match=r"is a lossy format.*not metrologically defensible",
+    ):
         result = convert(src, dst)
     # The decoder hands floats; the default keeps them as FLOAT.
     assert result.format_name == "IEEE float"
@@ -178,14 +183,14 @@ def test_lossy_targets_are_refused_before_reading_anything(
     for name in ("y.mp3", "y.ogg", "y.opus", "y.m4a"):
         with pytest.raises(ValueError, match="outside this API by policy"):
             convert(tmp_path / "never-read.wav", tmp_path / name)
-    with pytest.raises(ValueError, match="unsupported target"):
+    with pytest.raises(ValueError, match=r"unsupported target '\.xyz'"):
         convert(tmp_path / "never-read.wav", tmp_path / "y.xyz")
 
 
 def test_same_file_is_refused(tmp_path: Path) -> None:
     src = tmp_path / "self.wav"
     write(src, np.zeros(8), FS)
-    with pytest.raises(ValueError, match="same file"):
+    with pytest.raises(ValueError, match=r"source and destination are the same file"):
         convert(src, src)
 
 

--- a/tests/io/test_io_flac.py
+++ b/tests/io/test_io_flac.py
@@ -74,17 +74,19 @@ def test_int16_codes_pass_through_flac_bit_exact(tmp_path: Path) -> None:
 
 @needs_soundfile
 def test_flac_refuses_what_it_cannot_hold(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="24 bits"):
+    with pytest.raises(ValueError, match=r"FLAC stores integers up to 24 bits"):
         write(tmp_path / "x.flac", np.zeros(4, dtype=np.int32), FS)
     for subtype in ("PCM_32", "FLOAT", "DOUBLE"):
-        with pytest.raises(ValueError, match="24 bits"):
+        with pytest.raises(ValueError, match=r"FLAC holds integer PCM up to 24 bits"):
             write(tmp_path / "x.flac", np.zeros(4), FS, subtype=subtype)
 
 
 @needs_soundfile
 def test_flac_clipping_is_saturated_and_announced(tmp_path: Path) -> None:
     path = tmp_path / "hot.flac"
-    with pytest.warns(ClippingWarning, match="1 of 2"):
+    with pytest.warns(
+        ClippingWarning, match=r"1 of 2 samples exceed the full-scale range"
+    ):
         write(path, np.array([1.5, -0.5]), FS, subtype="PCM_16")
     assert np.asarray(read(path)).tolist() == [32767 / 32768, -0.5]
 

--- a/tests/io/test_io_read.py
+++ b/tests/io/test_io_read.py
@@ -266,7 +266,9 @@ def test_truncated_data_is_refused_at_every_depth(tmp_path: Path) -> None:
         )
         path = _write(tmp_path, image, f"trunc{bits}.wav")
         assert info(path).frames == 100
-        with pytest.raises(ValueError, match="truncated recording"):
+        with pytest.raises(
+            ValueError, match=r"refusing to read a truncated recording as if it were"
+        ):
             read(path)
 
 
@@ -391,7 +393,9 @@ def test_info_answers_a_giant_rf64_from_its_headers_alone(
     assert bext.max_short_term_loudness == pytest.approx(-21.10)
 
     # The proof that no sample was touched: touching them is impossible.
-    with pytest.raises(ValueError, match="truncated recording"):
+    with pytest.raises(
+        ValueError, match=r"refusing to read a truncated recording as if it were"
+    ):
         read(path)
 
 
@@ -429,9 +433,13 @@ def test_missing_audio_extra_is_named_in_the_error(
 
     mp3 = tmp_path / "note.mp3"
     mp3.write_bytes(b"ID3\x04\x00\x00\x00\x00\x00\x00" + bytes(64))
-    with pytest.raises(ImportError, match=r"pip install phonometry\[audio\]"):
+    with pytest.raises(
+        ImportError, match=r"Reading MPEG audio \(MP3\) requires python-soundfile"
+    ):
         read(mp3)
-    with pytest.raises(ImportError, match="MPEG audio"):
+    with pytest.raises(
+        ImportError, match=r"Reading MPEG audio \(MP3\) requires python-soundfile"
+    ):
         info(mp3)
 
     # A compressed WAV is recognised on the base install (the walker reads
@@ -442,7 +450,9 @@ def test_missing_audio_extra_is_named_in_the_error(
         chunk(b"data", bytes(4)),
     )
     compressed = _write(tmp_path, alaw, "compressed.wav")
-    with pytest.raises(ImportError, match=r"phonometry\[audio\]"):
+    with pytest.raises(
+        ImportError, match=r"Reading WAV A-law requires python-soundfile"
+    ):
         read(compressed)
     # info() on the same file needs no extra at all: headers are base work.
     described = info(_write(tmp_path, alaw, "compressed2.wav"))
@@ -461,7 +471,9 @@ def test_mp3_read_warns_and_stamps_lossy(tmp_path: Path) -> None:
     x = 0.4 * np.sin(2 * np.pi * 1000 * np.arange(FS // 2) / FS)
     path = tmp_path / "note.mp3"
     sf.write(str(path), x, FS)
-    with pytest.warns(LossyCompressionWarning, match="not metrologically defensible"):
+    with pytest.warns(
+        LossyCompressionWarning, match=r"MPEG audio \(MP3\).* is a lossy format"
+    ):
         sig = read(path)
     assert sig.fs == FS
     assert sig.source is not None
@@ -499,7 +511,9 @@ def test_compressed_wav_keeps_the_walker_metadata(tmp_path: Path) -> None:
     struct.pack_into("<I", raw, 4, len(raw) - 8)
     path.write_bytes(bytes(raw))
 
-    with pytest.warns(LossyCompressionWarning, match="ALAW"):
+    with pytest.warns(
+        LossyCompressionWarning, match=r"WAV A-law \(ALAW\) is a lossy format"
+    ):
         sig = read(path)
     assert sig.provenance is not None
     assert sig.provenance.originator == "logger"

--- a/tests/io/test_io_sidecar.py
+++ b/tests/io/test_io_sidecar.py
@@ -103,7 +103,7 @@ def test_foreign_json_at_the_reserved_name_is_refused(tmp_path: Path) -> None:
     audio = tmp_path / "meas.wav"
     write(audio, np.zeros(8), FS)
     sidecar_path(audio).write_text('{"unrelated": true}')
-    with pytest.raises(ValueError, match="phonometry-calibration"):
+    with pytest.raises(ValueError, match=r"not a 'phonometry-calibration' sidecar"):
         read(audio)
 
 
@@ -114,7 +114,10 @@ def test_newer_schema_versions_are_refused_by_name(tmp_path: Path) -> None:
     payload = json.loads(target.read_text())
     payload["schema_version"] = SIDECAR_VERSION + 1
     target.write_text(json.dumps(payload))
-    with pytest.raises(ValueError, match="upgrade phonometry"):
+    with pytest.raises(
+        ValueError,
+        match=r"sidecar schema version .* is newer than the version .* this phonometry",
+    ):
         read_sidecar(audio)
 
 
@@ -132,7 +135,10 @@ def test_malformed_fields_are_refused(tmp_path: Path) -> None:
     }
     for corruption, message in (
         ({"calibration_factor": "loud"}, "must be a number"),
-        ({"calibration_factor": -1.0}, "finite and positive"),
+        (
+            {"calibration_factor": -1.0},
+            "calibration_factor must be finite and positive",
+        ),
         ({"channel_labels": [1, 2]}, "array of strings"),
         ({"reference_spl": "94"}, "must be a number"),
     ):
@@ -145,17 +151,23 @@ def test_malformed_fields_are_refused(tmp_path: Path) -> None:
 
 
 def test_the_dataclass_itself_rejects_a_nonpositive_factor() -> None:
-    with pytest.raises(ValueError, match="finite and positive"):
+    with pytest.raises(
+        ValueError, match=r"calibration_factor must be finite and positive"
+    ):
         CalibrationSidecar(calibration_factor=0.0)
 
 
 def test_write_sidecar_true_requires_a_calibrated_signal(
     tmp_path: Path,
 ) -> None:
-    with pytest.raises(ValueError, match="calibration_factor"):
+    with pytest.raises(
+        ValueError, match=r"sidecar=True needs a Signal with a calibration_factor"
+    ):
         write(tmp_path / "x.wav", np.zeros(8), FS, sidecar=True)
     uncalibrated = Signal(data=np.zeros(8), fs=FS)
-    with pytest.raises(ValueError, match="calibration_factor"):
+    with pytest.raises(
+        ValueError, match=r"sidecar=True needs a Signal with a calibration_factor"
+    ):
         write(tmp_path / "x.wav", uncalibrated, sidecar=True)
 
 

--- a/tests/io/test_io_signal.py
+++ b/tests/io/test_io_signal.py
@@ -120,11 +120,13 @@ def test_invalid_construction_is_rejected() -> None:
         match=r"Signal: .*'channel_labels' .* must each carry one value per channel",
     ):
         Signal(data=np.zeros((2, 10)), fs=FS, channel_labels=("FL",))
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"fs must be a positive finite number"):
         Signal(data=tone, fs=0)
-    with pytest.raises(ValueError, match="calibration_factor"):
+    with pytest.raises(
+        ValueError, match=r"calibration_factor must be a positive finite number"
+    ):
         Signal(data=tone, fs=FS, calibration_factor=0.0)
-    with pytest.raises(ValueError, match="1-D or"):
+    with pytest.raises(ValueError, match=r"data must be 1-D or \(channels, samples\)"):
         Signal(data=np.zeros((2, 2, 2)), fs=FS)
 
 
@@ -192,5 +194,5 @@ def test_plot_spanish_labels() -> None:
 
 def test_plot_rejects_unknown_language() -> None:
     sig = Signal(data=_tone(), fs=FS)
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'fr'"):
         sig.plot(language="fr")

--- a/tests/io/test_io_signal_structure.py
+++ b/tests/io/test_io_signal_structure.py
@@ -96,9 +96,9 @@ def test_crop_defaults_to_the_records_own_edges() -> None:
 def test_crop_refuses_an_empty_or_backwards_span() -> None:
     """A zero-length span, a reversed one and a negative start all raise."""
     whole = _stereo()
-    with pytest.raises(ValueError, match="greater than"):
+    with pytest.raises(ValueError, match=r"'tmax'.*must be greater than 'tmin'"):
         whole.crop(0.5, 0.5)
-    with pytest.raises(ValueError, match="greater than"):
+    with pytest.raises(ValueError, match=r"'tmax'.*must be greater than 'tmin'"):
         whole.crop(0.75, 0.25)
     with pytest.raises(ValueError, match="must not be negative"):
         whole.crop(-1.0, 0.5)

--- a/tests/io/test_io_write.py
+++ b/tests/io/test_io_write.py
@@ -92,12 +92,12 @@ def test_signal_input_supplies_fs_and_refuses_a_conflicting_one(
     path = tmp_path / "fromsignal.wav"
     write(path, sig)
     assert read(path).fs == 44100
-    with pytest.raises(ValueError, match="conflicts"):
+    with pytest.raises(ValueError, match=r"conflicts with the Signal's own fs"):
         write(path, sig, FS)
 
 
 def test_bare_array_requires_fs(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="fs is required"):
+    with pytest.raises(ValueError, match=r"fs is required when writing a bare array"):
         write(tmp_path / "nofs.wav", np.zeros(8))
 
 
@@ -145,7 +145,9 @@ def test_integer_input_passes_codes_through_bit_exact(
 
 
 def test_integer_input_refuses_a_conflicting_subtype(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="pass-through"):
+    with pytest.raises(
+        ValueError, match=r"integer int16 input is a bit-exact pass-through of PCM_16"
+    ):
         write(tmp_path / "c.wav", np.zeros(4, dtype=np.int16), FS, subtype="PCM_32")
 
 
@@ -237,14 +239,19 @@ def test_tpdf_dither_renders_the_mean_code_unbiased(tmp_path: Path) -> None:
 
 def test_dither_is_refused_outside_pcm16(tmp_path: Path) -> None:
     for subtype in ("PCM_24", "PCM_32", "FLOAT", "DOUBLE"):
-        with pytest.raises(ValueError, match="PCM_16"):
+        with pytest.raises(
+            ValueError,
+            match=r"dither='tpdf' applies only when quantising to PCM_16",
+        ):
             write(tmp_path / "d.wav", np.zeros(4), FS, subtype=subtype, dither="tpdf")
-    with pytest.raises(ValueError, match="dither"):
+    with pytest.raises(ValueError, match=r"unknown dither 'rectangular'"):
         write(tmp_path / "d.wav", np.zeros(4), FS, dither="rectangular")
     # rng exists to seed the dither; alone it would promise a
     # reproducibility nothing delivers.
     silence = np.zeros(4)
-    with pytest.raises(ValueError, match="rng"):
+    with pytest.raises(
+        ValueError, match=r"rng seeds the TPDF dither noise and does nothing without it"
+    ):
         write(tmp_path / "d.wav", silence, FS, rng=7)
 
 
@@ -255,7 +262,10 @@ def test_dither_is_refused_outside_pcm16(tmp_path: Path) -> None:
 
 def test_lossy_and_unknown_targets_are_refused(tmp_path: Path) -> None:
     for name in ("copy.mp3", "copy.ogg", "copy.opus", "copy.xyz"):
-        with pytest.raises(ValueError, match="WAV family"):
+        with pytest.raises(
+            ValueError,
+            match=r"unsupported target '\.\w+'; the writer produces the WAV family",
+        ):
             write(tmp_path / name, np.zeros(4), FS)
 
 
@@ -330,7 +340,10 @@ def test_streamed_count_mismatch_without_an_estimate_still_raises(
 ) -> None:
     """The exact-count contract keeps refusing a short or long stream."""
     path = tmp_path / "mismatch.wav"
-    with pytest.raises(ValueError, match="inconsistent"):
+    with pytest.raises(
+        ValueError,
+        match=r"the block stream carried 10 frames but the header promised 12",
+    ):
         write_wav_stream(path, [np.zeros((1, 10))], FS, 1, "FLOAT", 12)
 
 

--- a/tests/materials/absorbers/test_absorption_rating.py
+++ b/tests/materials/absorbers/test_absorption_rating.py
@@ -20,6 +20,8 @@ Validation strategy: the standard's own numbers, not self-consistency.
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 from reference_data import (
@@ -267,7 +269,7 @@ def test_curve_needing_shift_from_reference() -> None:
 def test_result_is_frozen() -> None:
     res = weighted_absorption(_ANNEX_A1_ALPHA_P)
     assert isinstance(res, AbsorptionRatingResult)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.alpha_w = 0.0  # type: ignore[misc]
 
 
@@ -293,7 +295,10 @@ def test_an_octave_curve_off_the_rating_axis_is_refused(field_name: str) -> None
 
     res = weighted_absorption(_ANNEX_A1_ALPHA_P)
     short = np.asarray(getattr(res, field_name), dtype=float)[:-1]
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'{field_name}'.*must each carry one value per octave band",
+    ):
         dataclasses.replace(res, **{field_name: short})
 
 
@@ -303,7 +308,10 @@ def test_a_single_value_reference_curve_is_refused() -> None:
 
     res = weighted_absorption(_ANNEX_A1_ALPHA_P)
     one_value = np.array([res.shifted_reference[1]])
-    with pytest.raises(ValueError, match="'shifted_reference'"):
+    with pytest.raises(
+        ValueError,
+        match=r"'shifted_reference' \(1\).*must each carry one value per octave band",
+    ):
         dataclasses.replace(res, shifted_reference=one_value)
 
 
@@ -429,15 +437,15 @@ def test_from_third_octave_rejects_wrong_length() -> None:
 def test_weighted_absorption_rejects_multidimensional_input() -> None:
     # A wrongly-shaped (3, 5) array must not be silently flattened (CodeRabbit).
     two_dimensional = np.zeros((3, 5))
-    with pytest.raises(ValueError, match="1-D"):
+    with pytest.raises(ValueError, match=r"alpha_p must be 1-D"):
         weighted_absorption(two_dimensional)
 
 
 def test_weighted_absorption_rejects_non_finite() -> None:
     # NaN/inf must fail fast with a clear message, not a cryptic downstream error.
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"alpha_p values must all be finite"):
         weighted_absorption([0.35, float("nan"), 0.65, 0.60, 0.55])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"alpha_p values must all be finite"):
         weighted_absorption(
             {250: 0.35, 500: float("inf"), 1000: 0.65, 2000: 0.60, 4000: 0.55}
         )

--- a/tests/materials/absorbers/test_absorption_uncertainty.py
+++ b/tests/materials/absorbers/test_absorption_uncertainty.py
@@ -180,12 +180,12 @@ def test_unknown_condition_raises() -> None:
 
 
 def test_negative_rating_raises() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"'dl_alpha' must be a non-negative, finite"):
         materials.single_number_rating_uncertainty(-1.0)
 
 
 def test_non_finite_raises() -> None:
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'alpha' must contain only finite"):
         materials.sound_absorption_coefficient_uncertainty([np.nan], [1000])
 
 
@@ -204,7 +204,7 @@ def test_spectra_of_unequal_length_are_refused(field: str) -> None:
         ref.ISO12999_2_TABLE4_ALPHA_S, ref.ISO12999_2_TABLE4_FREQ
     )
     one_short = getattr(res, field)[:-1]
-    with pytest.raises(ValueError, match=f"'{field}'"):
+    with pytest.raises(ValueError, match=rf"'{field}' \({len(one_short)}\)"):
         dataclasses.replace(res, **{field: one_short})
 
 
@@ -230,7 +230,7 @@ def test_single_number_carries_a_value_without_a_spectrum() -> None:
 # ---------------------------------------------------------------------------
 def test_plot_single_number_raises() -> None:
     res = materials.weighted_coefficient_uncertainty(0.7)
-    with pytest.raises(ValueError, match="single-number"):
+    with pytest.raises(ValueError, match=r"plot\(\) needs a per-band result"):
         res.plot()
 
 

--- a/tests/materials/absorbers/test_airflow_resistance.py
+++ b/tests/materials/absorbers/test_airflow_resistance.py
@@ -167,7 +167,9 @@ def test_a_non_finite_determination_quantity_is_refused(field_name: str) -> None
 
     u = np.array([0.5e-3, 1.0e-3, 2.0e-3, 4.0e-3])
     result = static_airflow_resistance(u, 12000.0 * u, 0.008, 0.05)
-    with pytest.raises(ValueError, match=f"StaticAirflowResult: '{field_name}'"):
+    with pytest.raises(
+        ValueError, match=f"StaticAirflowResult: '{field_name}' must be finite"
+    ):
         dataclasses.replace(result, **{field_name: float("nan")})
 
 
@@ -227,7 +229,10 @@ def test_static_velocity_above_limit_warns() -> None:
     # Highest velocity 20 mm/s exceeds the 15 mm/s clause-7.5 limit.
     u = np.array([0.5e-3, 5.0e-3, 20.0e-3])
     dp = 12000.0 * u
-    with pytest.warns(AirflowResistanceWarning, match="15"):
+    with pytest.warns(
+        AirflowResistanceWarning,
+        match=r"Highest linear airflow velocity .* exceeds the .* limit of ISO 9053-1",
+    ):
         static_airflow_resistance(u, dp, 0.008)
 
 
@@ -302,7 +307,10 @@ def test_alternating_formula_matches_hand_computation() -> None:
 
 def test_alternating_validity_term_warns() -> None:
     # (h_t/h_s)*10**((L_ps-L_pt)/20) = 0.5 * 1.0 = 0.5, not < 0.3 (Formula 3).
-    with pytest.warns(AirflowResistanceWarning, match="Formula \\(3\\)"):
+    with pytest.warns(
+        AirflowResistanceWarning,
+        match=r"Validity term .* is not below .* Formula \(3\)",
+    ):
         alternating_airflow_resistance(
             70.0,
             70.0,
@@ -315,7 +323,10 @@ def test_alternating_validity_term_warns() -> None:
 
 def test_alternating_background_margin_warns() -> None:
     # L_ps - L_pb = 5 dB, not > 10 dB (Formula 4).
-    with pytest.warns(AirflowResistanceWarning, match="Formula \\(4\\)"):
+    with pytest.warns(
+        AirflowResistanceWarning,
+        match=r"Specimen-to-background margin .* is not above .* Formula \(4\)",
+    ):
         alternating_airflow_resistance(
             60.0,
             80.0,
@@ -328,7 +339,10 @@ def test_alternating_background_margin_warns() -> None:
 
 
 def test_alternating_frequency_out_of_range_warns() -> None:
-    with pytest.warns(AirflowResistanceWarning, match="6.2"):
+    with pytest.warns(
+        AirflowResistanceWarning,
+        match=r"Piston frequency .* is outside the ISO 9053-2:2020 clause 6\.2 range",
+    ):
         alternating_airflow_resistance(
             60.0,
             80.0,

--- a/tests/materials/absorbers/test_biot.py
+++ b/tests/materials/absorbers/test_biot.py
@@ -1170,6 +1170,24 @@ def test_biot_waves_rejects_bad_input() -> None:
         materials.biot_waves(medium, **kwargs, poisson_ratio=0.5)
 
 
+@pytest.mark.parametrize("nu", [-1.5, -1.0, 0.5, 0.6])
+def test_frame_bulk_modulus_rejects_a_poisson_ratio_off_the_stability_range(
+    nu: float,
+) -> None:
+    """Both ends of the isotropic range are closed, for opposite reasons.
+
+    Eq. (6.29) reads ``Kb = 2 N (nu + 1)/(3(1 - 2 nu))``. At the upper end the
+    denominator vanishes and ``Kb`` diverges: the incompressible-solid limit.
+    At the lower end the numerator vanishes and ``Kb`` collapses to zero, a
+    frame that carries shear but no compression at all. Neither is a
+    thermodynamically stable elastic solid, so the value at either bound is
+    refused rather than returned as a modulus.
+    """
+    n_mod = 3.0e5 * (1.0 + 0.07j)
+    with pytest.raises(ValueError, match=r"'poisson_ratio' must satisfy"):
+        materials.frame_bulk_modulus(n_mod, nu)
+
+
 def test_layer_rejects_a_medium_on_another_grid() -> None:
     frequency = np.geomspace(100.0, 1000.0, 8)
     other = _glass_wool_medium(np.geomspace(100.0, 1000.0, 9))

--- a/tests/materials/absorbers/test_biot.py
+++ b/tests/materials/absorbers/test_biot.py
@@ -844,9 +844,11 @@ def test_an_unresolvable_stack_is_refused_instead_of_exhausting_memory() -> None
         materials.PorousLayer(400.0, _dense_medium(frequency)),
         _dense_poroelastic(frequency, 0.05),
     ]
-    with pytest.raises(ValueError, match="nepers"):
+    with pytest.raises(ValueError, match=r"PoroelasticLayer attenuates by \d+ nepers"):
         materials.layered_absorber(frequency, [floppy])
-    with pytest.raises(ValueError, match="nepers"):
+    with pytest.raises(
+        ValueError, match=r"the fluid layers of the stack attenuate by \d+ nepers"
+    ):
         materials.layered_absorber(frequency, deaf_run)
 
 
@@ -1148,19 +1150,23 @@ def test_biot_waves_rejects_bad_input() -> None:
         "frame_density": TABLE_6_1_FRAME_DENSITY,
         "shear_modulus": TABLE_6_1_SHEAR_MODULUS,
     }
-    with pytest.raises(ValueError, match="must not exceed 1"):
+    with pytest.raises(ValueError, match=r"'porosity' must not exceed"):
         materials.biot_waves(medium, **{**kwargs, "porosity": 1.5})
-    with pytest.raises(ValueError, match="must be >= 1"):
+    with pytest.raises(ValueError, match=r"'tortuosity' must be >="):
         materials.biot_waves(medium, **{**kwargs, "tortuosity": 0.5})
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'frame_density' must be positive"):
         materials.biot_waves(medium, **{**kwargs, "frame_density": 0.0})
-    with pytest.raises(ValueError, match="positive real part"):
+    with pytest.raises(
+        ValueError, match=r"'shear_modulus' must have a positive real part"
+    ):
         materials.biot_waves(medium, **{**kwargs, "shear_modulus": -1.0})
-    with pytest.raises(ValueError, match="non-negative imaginary part"):
+    with pytest.raises(
+        ValueError, match=r"'shear_modulus' must have a non-negative imaginary part"
+    ):
         materials.biot_waves(medium, **{**kwargs, "shear_modulus": 1.0 - 1.0j})
-    with pytest.raises(ValueError, match="must be finite"):
+    with pytest.raises(ValueError, match=r"'shear_modulus' must be finite"):
         materials.biot_waves(medium, **{**kwargs, "shear_modulus": complex("nan")})
-    with pytest.raises(ValueError, match="-1 < nu < 0,5"):
+    with pytest.raises(ValueError, match=r"'poisson_ratio' must satisfy"):
         materials.biot_waves(medium, **kwargs, poisson_ratio=0.5)
 
 
@@ -1175,18 +1181,21 @@ def test_layer_rejects_a_medium_on_another_grid() -> None:
         TABLE_6_1_FRAME_DENSITY,
         TABLE_6_1_SHEAR_MODULUS,
     )
-    with pytest.raises(ValueError, match="different frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"PoroelasticLayer\.medium was evaluated on a different frequency vector",
+    ):
         materials.layered_absorber(frequency, [layer])
 
 
 def test_surface_impedance_and_transfer_matrix_reject_bad_thickness() -> None:
     frequency = np.geomspace(100.0, 1000.0, 4)
     waves = _glass_wool_waves(frequency)
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'thickness' must be positive"):
         materials.biot_surface_impedance(waves, 0.0)
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'thickness' must be positive"):
         materials.poroelastic_transfer_matrix(waves, -0.01)
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'thickness' must be positive"):
         materials.frame_quarter_wave_resonance(
             0.0, shear_modulus=1.0, poisson_ratio=0.0, frame_density=30.0
         )

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -104,6 +104,18 @@ def test_air_property_domain_errors() -> None:
         air_density_iso(293.0, -1.0)
 
 
+def test_air_density_astm_rejects_temperature_below_absolute_zero() -> None:
+    """ASTM Eq. (5) scales the reference density by 273,15/(273,15 + T).
+
+    Below absolute zero that ratio is negative, so rho would come back
+    negative and carry the sign into every rho c the four-microphone
+    reduction builds on. The temperature is refused at the door, exactly as
+    ``speed_of_sound_astm`` refuses it above.
+    """
+    with pytest.raises(ValueError, match="'temperature' must exceed"):
+        air_density_astm(-300.0, 101.325)
+
+
 def test_air_density_mismatched_arrays_raise() -> None:
     # Two arrays of different lengths must be refused by name, not left to
     # numpy's two-shapes broadcast error.

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -19,6 +19,8 @@ physics identities:
 
 from __future__ import annotations
 
+import dataclasses
+
 import numpy as np
 import pytest
 
@@ -267,7 +269,7 @@ def test_result_is_frozen() -> None:
         speed_of_sound=C0,
         characteristic_impedance=RC,
     )
-    with pytest.raises((AttributeError, TypeError)):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.reflection = np.array([0.0])  # type: ignore[misc]
 
 
@@ -341,9 +343,9 @@ def test_plane_wave_range_square_alias() -> None:
 
 
 def test_plane_wave_range_invalid_shape() -> None:
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'shape' must be"):
         plane_wave_frequency_range(0.03, C0, diameter=0.05, shape="oval")
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"'shape' must be"):
         plane_wave_frequency_range_astm(0.03, C0, diameter=0.05, shape="oval")
 
 
@@ -369,7 +371,7 @@ def test_hydraulic_diameter_values() -> None:
     assert hydraulic_diameter(0.08, 0.04) == pytest.approx(
         4.0 * (0.08 * 0.04) / (2.0 * (0.08 + 0.04))
     )
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'width' and 'height' must be positive"):
         hydraulic_diameter(0.0, 0.05)
 
 
@@ -619,7 +621,10 @@ def test_two_load_warns_on_singular_load_pair() -> None:
     f = np.array([500.0, 1000.0])
     k = np.asarray(tube_wavenumber(f, C0)).real.astype(np.complex128)
     load = (1.0 + 0j, 0.9 + 0j, 0.8 + 0j, 0.7 + 0j)
-    with pytest.warns(ImpedanceTubeWarning, match="near-singular"):
+    with pytest.warns(
+        ImpedanceTubeWarning,
+        match=r"transfer_matrix_two_load: the solve denominator is near-singular",
+    ):
         transfer_matrix_two_load(
             load,
             load,
@@ -779,6 +784,9 @@ def test_one_load_recovers_symmetric_specimen() -> None:
     assert np.allclose(rec.t11, rec.t22)
 
 
+_OUTSIDE_ASTM_RANGE = r"Wavenumbers outside the ASTM E2611-19 plane-wave working range"
+
+
 def test_astm_solvers_warn_outside_plane_wave_range() -> None:
     # With the tube diameter given, frequencies past the 6.2.4.1 cut-on
     # (0,586 c/d for this 10 cm circular tube ~ 2011 Hz) must be flagged.
@@ -787,7 +795,7 @@ def test_astm_solvers_warn_outside_plane_wave_range() -> None:
     tm = air_layer_transfer_matrix(k, THICKNESS, RC)
     load_a = _synth_four_mics(tm, np.asarray(k), 1.0 + 0.0j, 0.3 + 0.0j)
     load_b = _synth_four_mics(tm, np.asarray(k), 1.0 + 0.0j, -0.5 + 0.2j)
-    with pytest.warns(ImpedanceTubeWarning, match="ASTM E2611-19"):
+    with pytest.warns(ImpedanceTubeWarning, match=_OUTSIDE_ASTM_RANGE):
         transfer_matrix_two_load(
             load_a,
             load_b,
@@ -797,7 +805,7 @@ def test_astm_solvers_warn_outside_plane_wave_range() -> None:
             diameter=0.10,
             **GEOM,
         )
-    with pytest.warns(ImpedanceTubeWarning, match="ASTM E2611-19"):
+    with pytest.warns(ImpedanceTubeWarning, match=_OUTSIDE_ASTM_RANGE):
         transfer_matrix_one_load(
             load_a,
             thickness=THICKNESS,
@@ -806,7 +814,7 @@ def test_astm_solvers_warn_outside_plane_wave_range() -> None:
             diameter=0.10,
             **GEOM,
         )
-    with pytest.warns(ImpedanceTubeWarning, match="ASTM E2611-19"):
+    with pytest.warns(ImpedanceTubeWarning, match=_OUTSIDE_ASTM_RANGE):
         wave_decomposition(
             *load_a,
             wavenumber=k,
@@ -822,7 +830,7 @@ def test_astm_solvers_warn_below_lower_bound() -> None:
     k = np.asarray(tube_wavenumber(f, C0)).real.astype(np.complex128)
     tm = air_layer_transfer_matrix(k, THICKNESS, RC)
     load = _synth_four_mics(tm, np.asarray(k), 1.0 + 0.0j, 0.3 + 0.0j)
-    with pytest.warns(ImpedanceTubeWarning, match="ASTM E2611-19"):
+    with pytest.warns(ImpedanceTubeWarning, match=_OUTSIDE_ASTM_RANGE):
         wave_decomposition(*load, wavenumber=k, diameter=0.10, **GEOM)
 
 
@@ -895,7 +903,10 @@ def test_transfer_matrix_retains_measurement_context() -> None:
     bare = air_layer_transfer_matrix(k, THICKNESS, RC)
     assert bare.frequency is None
     assert bare.air_characteristic_impedance is None
-    with pytest.raises(ValueError, match="hand-built"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequency' and 'characteristic_impedance' must be supplied",
+    ):
         bare.plot()
 
 

--- a/tests/materials/absorbers/test_iso10534_report.py
+++ b/tests/materials/absorbers/test_iso10534_report.py
@@ -121,7 +121,7 @@ def test_report_with_metadata_one_page(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/materials/absorbers/test_iso11654_report.py
+++ b/tests/materials/absorbers/test_iso11654_report.py
@@ -83,7 +83,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = weighted_absorption(_A1_ALPHA_P)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 
@@ -172,7 +172,10 @@ def test_third_octave_arrays_must_hold_three_bands_per_octave(bands: int) -> Non
     import dataclasses
 
     result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
-    with pytest.raises(ValueError, match="'3 x band_centers'"):
+    with pytest.raises(
+        ValueError,
+        match=r"'3 x band_centers'.*must each carry one value per one-third-octave band",
+    ):
         dataclasses.replace(
             result,
             third_octave_alpha_s=np.full(bands, 0.5),
@@ -303,5 +306,5 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/materials/absorbers/test_iso354_report.py
+++ b/tests/materials/absorbers/test_iso354_report.py
@@ -156,7 +156,7 @@ def test_report_with_metadata_one_page(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/materials/absorbers/test_iso9053_report.py
+++ b/tests/materials/absorbers/test_iso9053_report.py
@@ -150,7 +150,7 @@ def test_no_thickness_omits_resistivity(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/materials/absorbers/test_limp_frame.py
+++ b/tests/materials/absorbers/test_limp_frame.py
@@ -88,9 +88,9 @@ def test_decoupling_frequency_scaling() -> None:
 
 
 def test_decoupling_frequency_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'flow_resistivity' must be positive"):
         materials.decoupling_frequency(-1.0, porosity=0.98, frame_density=30.0)
-    with pytest.raises(ValueError, match="must not exceed 1"):
+    with pytest.raises(ValueError, match="'porosity' must not exceed 1"):
         materials.decoupling_frequency(25.0e3, porosity=1.5, frame_density=30.0)
 
 
@@ -261,9 +261,9 @@ def test_limp_frame_plot_smoke() -> None:
 
 def test_limp_frame_rejects_bad_input() -> None:
     rigid = _rigid(np.array([100.0]))
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match="'frame_density' must be positive"):
         materials.limp_frame(rigid, -1.0)
-    with pytest.raises(ValueError, match="must not exceed 1"):
+    with pytest.raises(ValueError, match="'porosity' must not exceed 1"):
         materials.limp_frame(rigid, 30.0, porosity=1.2)
 
 
@@ -288,7 +288,7 @@ def test_limp_frame_criteria_match_the_printed_thresholds() -> None:
 
 
 def test_limp_frame_applicable_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"'frame_bulk_modulus' must be non-negative"):
         materials.limp_frame_applicable(-1.0)
     with pytest.raises(ValueError, match="'criterion' must be one of"):
         materials.limp_frame_applicable(1.0e3, criterion="panneton")

--- a/tests/materials/absorbers/test_porous.py
+++ b/tests/materials/absorbers/test_porous.py
@@ -125,9 +125,15 @@ class TestDelanyBazley:
         assert np.min(zs.real) < 0.0
 
     def test_warns_outside_validity(self) -> None:
-        with pytest.warns(PorousAbsorberWarning, match="fit range"):
+        with pytest.warns(
+            PorousAbsorberWarning,
+            match=r"Delany-Bazley:.*outside the published fit range",
+        ):
             delany_bazley(np.array([10.0]), 50000.0)
-        with pytest.warns(PorousAbsorberWarning, match="fit range"):
+        with pytest.warns(
+            PorousAbsorberWarning,
+            match=r"Delany-Bazley:.*outside the published fit range",
+        ):
             delany_bazley(np.array([20000.0]), 1000.0)
 
     def test_presets_and_custom_coefficients(self) -> None:
@@ -145,9 +151,11 @@ class TestDelanyBazley:
 
     def test_rejects_bad_inputs(self) -> None:
         f = np.array([100.0])
-        with pytest.raises(ValueError, match="preset"):
+        with pytest.raises(ValueError, match=r"unknown coefficient preset"):
             delany_bazley(f, 10000.0, coefficients="nope")
-        with pytest.raises(ValueError, match="8 values"):
+        with pytest.raises(
+            ValueError, match=r"'coefficients' must provide exactly 8 values"
+        ):
             delany_bazley(f, 10000.0, coefficients=(1.0, 2.0))
         with pytest.raises(ValueError, match="'flow_resistivity' must be positive"):
             delany_bazley(f, -1.0)
@@ -285,7 +293,7 @@ class TestJohnsonChampouxAllard:
 
     def test_rejects_bad_parameters(self) -> None:
         f = np.array([100.0])
-        with pytest.raises(ValueError, match="porosity"):
+        with pytest.raises(ValueError, match=r"'porosity' must not exceed 1"):
             johnson_champoux_allard(
                 f,
                 1e4,
@@ -294,7 +302,7 @@ class TestJohnsonChampouxAllard:
                 viscous_length=1e-4,
                 thermal_length=2e-4,
             )
-        with pytest.raises(ValueError, match="tortuosity"):
+        with pytest.raises(ValueError, match=r"'tortuosity' must be >= 1"):
             johnson_champoux_allard(
                 f,
                 1e4,
@@ -504,13 +512,18 @@ class TestLayeredAbsorber:
         layers = [PorousLayer(0.05, med)]
         with pytest.raises(ValueError, match="at least one layer"):
             layered_absorber(f, [])
-        with pytest.raises(ValueError, match="angle"):
+        with pytest.raises(ValueError, match=r"'angle' must satisfy 0 <= angle < pi/2"):
             layered_absorber(f, layers, angle=np.pi / 2.0)
-        with pytest.raises(ValueError, match="termination"):
+        with pytest.raises(
+            ValueError, match=r"'termination' must be .*complex impedance"
+        ):
             layered_absorber(f, layers, termination="soft")
         other = miki(_grid(100.0, 200.0, 7), 20000.0)
         mismatched = [PorousLayer(0.05, other)]
-        with pytest.raises(ValueError, match="frequency vector"):
+        with pytest.raises(
+            ValueError,
+            match=r"PorousLayer\.medium was evaluated on a different frequency vector",
+        ):
             layered_absorber(f, mismatched)
 
 
@@ -721,14 +734,20 @@ class TestResonantSheets:
         """
         f = np.array([1000.0])
         layers = [AirLayer(0.05)]
-        with pytest.raises(ValueError, match="angle"):
+        with pytest.raises(ValueError, match=r"'angle' must satisfy 0 <= angle < pi/2"):
             layered_absorber(f, layers, angle=np.pi / 2.0 - 1e-9)
 
     def test_termination_array_length_mismatch_rejected(self) -> None:
         f = np.array([500.0, 1000.0])
         layers = [AirLayer(0.05)]
         termination = np.array([800.0 + 0j] * 3)
-        with pytest.raises(ValueError, match="termination"):
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"'termination' impedance array must be scalar or match the "
+                r"shape of 'frequency'"
+            ),
+        ):
             layered_absorber(f, layers, termination=termination)
 
     def test_perforated_plate_open_area_one_is_nearly_transparent(self) -> None:
@@ -823,10 +842,14 @@ class TestRandomIncidence:
         f = np.array([500.0])
         med = miki(f, 15000.0)
         layers = [PorousLayer(0.05, med)]
-        with pytest.raises(ValueError, match="angle_limit"):
+        with pytest.raises(
+            ValueError, match=r"'angle_limit' must satisfy 0 < angle_limit <= pi/2"
+        ):
             diffuse_field_absorption(f, layers, angle_limit=2.0)
-        with pytest.raises(ValueError, match="quadrature_points"):
+        with pytest.raises(ValueError, match=r"'quadrature_points' must be at least 2"):
             diffuse_field_absorption(f, layers, quadrature_points=1)
         negative_real = np.array([-1.0 + 0.5j])
-        with pytest.raises(ValueError, match="real part"):
+        with pytest.raises(
+            ValueError, match=r"'normalized_impedance' must have a positive real part"
+        ):
             statistical_absorption(negative_real)

--- a/tests/materials/diffusers/test_diffuser_design.py
+++ b/tests/materials/diffusers/test_diffuser_design.py
@@ -202,53 +202,59 @@ def test_polar_response_plot_returns_polar_axes() -> None:
 
 # --- Input-validation guards --------------------------------------------------
 def test_prime_must_be_odd_prime() -> None:
-    with pytest.raises(ValueError, match="odd prime"):
+    with pytest.raises(ValueError, match=r"'prime' must be an odd prime"):
         quadratic_residue_sequence(8)
-    with pytest.raises(ValueError, match="prime"):
+    with pytest.raises(ValueError, match=r"'prime' must be prime"):
         quadratic_residue_sequence(9)
 
 
 def test_requires_exactly_one_of_depths_or_reflection() -> None:
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(
+        ValueError, match=r"Provide exactly one of 'depths' or 'reflection'"
+    ):
         predict_diffuser_polar_response(0.10, 1000.0)
     depths = np.zeros(7)
     reflection = np.ones(7)
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(
+        ValueError, match=r"Provide exactly one of 'depths' or 'reflection'"
+    ):
         predict_diffuser_polar_response(
             0.10, 1000.0, depths=depths, reflection=reflection
         )
 
 
 def test_depths_need_at_least_two_wells() -> None:
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(ValueError, match=r"'depths'.*at least two"):
         predict_diffuser_polar_response(0.10, 1000.0, depths=[0.05])
 
 
 def test_negative_depth_rejected() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"'depths' values must be finite and non-negative"
+    ):
         predict_diffuser_polar_response(0.10, 1000.0, depths=[0.05, -0.01, 0.02])
 
 
 def test_non_positive_geometry_rejected() -> None:
     depths = qrd_well_depths(7, 500.0)
-    with pytest.raises(ValueError, match="well_width"):
+    with pytest.raises(ValueError, match=r"'well_width' must be a positive, finite"):
         predict_diffuser_polar_response(0.0, 1000.0, depths=depths)
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency' must be a positive, finite"):
         predict_diffuser_polar_response(0.10, 0.0, depths=depths)
-    with pytest.raises(ValueError, match="periods"):
+    with pytest.raises(ValueError, match=r"'periods' must be an integer"):
         predict_diffuser_polar_response(0.10, 1000.0, depths=depths, periods=0)
 
 
 def test_spectrum_requires_depths() -> None:
     """Keyword-only and required: the signature says so on its own now."""
-    with pytest.raises(TypeError, match="required keyword-only argument"):
+    with pytest.raises(TypeError, match=r"required keyword-only argument: 'depths'"):
         predicted_diffusion_spectrum(0.10, [500.0])  # type: ignore[call-arg]
 
 
 def test_spectrum_reserved_reflection_argument() -> None:
     depths = np.zeros(7)
     reserved = object()
-    with pytest.raises(ValueError, match="reflection_of"):
+    with pytest.raises(ValueError, match=r"'reflection_of' is reserved .*must be None"):
         predicted_diffusion_spectrum(
             0.10, [500.0], depths=depths, reflection_of=reserved
         )

--- a/tests/materials/diffusers/test_iso17497_report.py
+++ b/tests/materials/diffusers/test_iso17497_report.py
@@ -205,7 +205,7 @@ def test_scattering_verbose_shows_alpha_spec_one_page(tmp_path: Path) -> None:
 def test_scattering_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _scattering()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -293,7 +293,7 @@ def test_diffusion_verbose_shows_normalized_one_page(tmp_path: Path) -> None:
 def test_diffusion_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _diffusion_spectrum()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -340,7 +340,7 @@ def test_polar_displays_coefficient_and_angles(tmp_path: Path) -> None:
 def test_polar_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _polar()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/materials/diffusers/test_metadiffuser.py
+++ b/tests/materials/diffusers/test_metadiffuser.py
@@ -215,13 +215,17 @@ def test_panel_validation() -> None:
     with pytest.raises(ValueError, match="at least two wells"):
         metadiffuser_reflection(f, [ABSORBER], depth=0.03, period=0.10)
     not_a_well = [ABSORBER, 0.01]
-    with pytest.raises(TypeError, match="MetadiffuserWell"):
+    with pytest.raises(
+        TypeError, match=r"wells\[1\] must be a MetadiffuserWell or None"
+    ):
         metadiffuser_reflection(f, not_a_well, depth=0.03, period=0.10)
     too_tall = [ABSORBER, _well(110.0, 5.0, 20.0, 4.0, 20.0)]
     with pytest.raises(ValueError, match="smaller than the period"):
         metadiffuser_reflection(f, too_tall, depth=0.03, period=0.10)
     empty_band = np.array([])
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(
+        ValueError, match=r"'frequencies' must be a non-empty 1-D sequence"
+    ):
         metadiffuser_diffusion_spectrum(
             empty_band, [ABSORBER, None], depth=0.03, period=0.10
         )
@@ -241,7 +245,7 @@ def test_square_resonator_geometry_and_validation() -> None:
         resonator_geometry="square",
     )
     assert result.reflection.shape == (2, 2)
-    with pytest.raises(ValueError, match="geometry"):
+    with pytest.raises(ValueError, match=r"'resonator_geometry' must be one of"):
         metadiffuser_reflection(
             f,
             [ABSORBER, None],
@@ -275,6 +279,6 @@ def test_result_plots_render_and_validate() -> None:
         absorption=result.absorption,
         well_absorption=result.well_absorption,
     )
-    with pytest.raises(ValueError, match="retain"):
+    with pytest.raises(ValueError, match=r"This result does not retain its geometry"):
         bare.plot_geometry()
     plt.close("all")

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -548,7 +548,7 @@ def test_diffusion_coefficient_rejects_zero_energy() -> None:
 
 
 def test_base_plate_checker_rejects_wrong_length() -> None:
-    with pytest.raises(ValueError, match="values for bands"):
+    with pytest.raises(ValueError, match=r"scattering must have \d+ values for bands"):
         check_base_plate_scattering([0.1, 0.2, 0.3])
 
 
@@ -611,7 +611,10 @@ def test_scattering_result_rejects_an_empty_spectrum() -> None:
     write when there is no band to take a range from.
     """
     empty = np.array([])
-    with pytest.raises(ValueError, match=r"ScatteringResult: 'frequencies'"):
+    with pytest.raises(
+        ValueError,
+        match=r"ScatteringResult: 'frequencies' must carry at least one band",
+    ):
         ScatteringResult(
             frequencies=empty,
             scattering=empty,
@@ -633,7 +636,9 @@ def test_scattering_result_rejects_a_non_finite_coefficient() -> None:
 
 def test_scattering_result_rejects_a_non_finite_band_centre() -> None:
     """A NaN band centre crashes the header's round(freqs.min()) anonymously."""
-    with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
+    with pytest.raises(
+        ValueError, match=r"ScatteringResult: 'frequencies' must contain only finite"
+    ):
         ScatteringResult(
             frequencies=np.array([250.0, np.nan, 1000.0]),
             scattering=np.array([0.1, 0.3, 0.5]),
@@ -803,7 +808,10 @@ def test_diffusion_spectrum_rejects_an_empty_spectrum() -> None:
     "0 Hz to 0 Hz".
     """
     empty = np.array([])
-    with pytest.raises(ValueError, match=r"DiffusionSpectrum: 'frequencies'"):
+    with pytest.raises(
+        ValueError,
+        match=r"DiffusionSpectrum: 'frequencies' must carry at least one band",
+    ):
         DiffusionSpectrum(frequencies=empty, diffusion=empty)
 
 
@@ -826,7 +834,9 @@ def test_diffusion_spectrum_rejects_a_non_finite_band_centre() -> None:
     The bare "cannot convert float NaN to integer" names neither the field nor
     the result, so the band axis is pinned where it is built.
     """
-    with pytest.raises(ValueError, match=r"'frequencies' must contain only finite"):
+    with pytest.raises(
+        ValueError, match=r"DiffusionSpectrum: 'frequencies' must contain only finite"
+    ):
         DiffusionSpectrum(
             frequencies=np.array([250.0, np.nan, 1000.0]),
             diffusion=np.array([0.2, 0.4, 0.7]),

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -470,6 +470,17 @@ def test_random_incidence_two_dimensional_weighting() -> None:
 # ---------------------------------------------------------------------------
 # Input-validation guards.
 # ---------------------------------------------------------------------------
+def test_speed_of_sound_rejects_temperature_below_absolute_zero() -> None:
+    """Eq. (2) takes the square root of (273,15 + t)/293,15.
+
+    Below absolute zero the radicand is negative and numpy's real square root
+    hands back a NaN, which would then travel silently into the Sabine
+    Eqs. (1)/(4) that consume c. The temperature is refused first.
+    """
+    with pytest.raises(ValueError, match="'temperature' must exceed"):
+        speed_of_sound(-300.0)
+
+
 def test_diffusion_requires_two_receivers() -> None:
     with pytest.raises(ValueError, match="'levels' needs at least two receivers"):
         directional_diffusion_coefficient([80.0])

--- a/tests/materials/resilient/test_dynamic_stiffness.py
+++ b/tests/materials/resilient/test_dynamic_stiffness.py
@@ -64,9 +64,9 @@ def test_enclosed_gas_true_atmosphere() -> None:
 
 
 def test_enclosed_gas_bad_porosity_raises() -> None:
-    with pytest.raises(ValueError, match="porosity"):
+    with pytest.raises(ValueError, match=r"'porosity' must be in the range"):
         materials.enclosed_gas_stiffness(0.02, 0.0)
-    with pytest.raises(ValueError, match="porosity"):
+    with pytest.raises(ValueError, match=r"'porosity' must be in the range"):
         materials.enclosed_gas_stiffness(0.02, 1.5)
 
 
@@ -105,7 +105,10 @@ def test_intermediate_resistivity_adds_gas() -> None:
 
 
 def test_low_resistivity_negligible_gas_warns_and_uses_apparent() -> None:
-    with pytest.warns(DynamicStiffnessWarning, match="disregarded"):
+    with pytest.warns(
+        DynamicStiffnessWarning,
+        match=r"s' is taken as s't with the enclosed-gas term disregarded",
+    ):
         s = materials.installed_dynamic_stiffness(
             20e6, 5.0, gas_stiffness=1e6
         )  # 5 % of s't
@@ -113,7 +116,10 @@ def test_low_resistivity_negligible_gas_warns_and_uses_apparent() -> None:
 
 
 def test_low_resistivity_significant_gas_is_unresolvable() -> None:
-    with pytest.warns(DynamicStiffnessWarning, match="cannot resolve"):
+    with pytest.warns(
+        DynamicStiffnessWarning,
+        match=r"non-negligible enclosed-gas stiffness, EN 29052-1 cannot resolve",
+    ):
         s = materials.installed_dynamic_stiffness(
             20e6, 5.0, gas_stiffness=5e6
         )  # 25 % of s't
@@ -146,7 +152,10 @@ def test_chain_high_resistivity_ignores_gas() -> None:
 
 
 def test_chain_requires_gas_inputs_below_100() -> None:
-    with pytest.raises(ValueError, match="thickness.*porosity"):
+    with pytest.raises(
+        ValueError,
+        match=r"'thickness' and 'porosity' are required for the enclosed-gas term",
+    ):
         materials.floating_floor_resonance(25.0, 200.0, 100.0, airflow_resistivity=50.0)
 
 
@@ -154,13 +163,13 @@ def test_chain_requires_gas_inputs_below_100() -> None:
 # Validation
 # ---------------------------------------------------------------------------
 def test_non_positive_inputs_raise() -> None:
-    with pytest.raises(ValueError, match="resonant_frequency"):
+    with pytest.raises(ValueError, match=r"'resonant_frequency' must be positive"):
         materials.apparent_dynamic_stiffness(0.0, 200.0)
-    with pytest.raises(ValueError, match="total_mass_per_area"):
+    with pytest.raises(ValueError, match=r"'total_mass_per_area' must be positive"):
         materials.apparent_dynamic_stiffness(25.0, 0.0)
-    with pytest.raises(ValueError, match="mass_per_area"):
+    with pytest.raises(ValueError, match=r"'mass_per_area' must be positive"):
         materials.natural_frequency(10e6, 0.0)
-    with pytest.raises(ValueError, match="airflow_resistivity"):
+    with pytest.raises(ValueError, match=r"'airflow_resistivity' must be positive"):
         materials.installed_dynamic_stiffness(20e6, 0.0)
 
 

--- a/tests/materials/resilient/test_iso9052_report.py
+++ b/tests/materials/resilient/test_iso9052_report.py
@@ -165,7 +165,7 @@ def test_high_resistivity_omits_gas_term(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     result = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 

--- a/tests/materials/test_geometry_plots.py
+++ b/tests/materials/test_geometry_plots.py
@@ -119,7 +119,7 @@ def test_layered_result_retains_layers_and_draws() -> None:
         absorption=res.absorption,
         transfer_matrix=res.transfer_matrix,
     )
-    with pytest.raises(ValueError, match="does not retain"):
+    with pytest.raises(ValueError, match=r"does not retain its layers"):
         bare.plot_geometry()
 
 
@@ -159,7 +159,7 @@ def test_diffuser_response_retains_wells_and_draws() -> None:
         reflection=np.exp(-2j * np.pi * np.arange(7) / 7),
     )
     assert explicit.depths is None
-    with pytest.raises(ValueError, match="does not retain"):
+    with pytest.raises(ValueError, match=r"does not retain its well geometry"):
         explicit.plot_geometry()
 
 
@@ -191,7 +191,7 @@ def test_transfer_matrix_geometry_paths() -> None:
     f = np.array([500.0, 1000.0])
     k = 2.0 * np.pi * f / 343.2
     hand_built = m.air_layer_transfer_matrix(k, 0.05, 413.0)
-    with pytest.raises(ValueError, match="does not retain"):
+    with pytest.raises(ValueError, match=r"does not retain its tube geometry"):
         hand_built.plot_geometry()
 
 
@@ -214,13 +214,13 @@ def test_impedance_tube_sample_patch_is_to_scale() -> None:
 
 
 def test_qrd_geometry_validation() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'depths' must be a non-empty 1-D sequence"):
         m.plot_qrd_geometry([], 0.12)
-    with pytest.raises(ValueError, match="'depths' must be non-negative"):
+    with pytest.raises(ValueError, match=r"'depths' must be non-negative"):
         m.plot_qrd_geometry([-0.01], 0.12)
-    with pytest.raises(ValueError, match="well_width"):
+    with pytest.raises(ValueError, match=r"'well_width' must be positive"):
         m.plot_qrd_geometry([0.05], 0.0)
-    with pytest.raises(ValueError, match="periods"):
+    with pytest.raises(ValueError, match=r"'periods' must be >="):
         m.plot_qrd_geometry([0.05], 0.12, periods=0)
 
 
@@ -234,7 +234,10 @@ def test_qrd_geometry_refuses_a_nan_well_depth() -> None:
 
 
 def test_transmission_tube_validation() -> None:
-    with pytest.raises(ValueError, match="must exceed"):
+    with pytest.raises(
+        ValueError,
+        match=r"'l2' is measured from the front face and must exceed 'thickness'",
+    ):
         m.plot_transmission_tube_geometry(
             l1=0.1, s1=0.03, l2=0.04, s2=0.03, thickness=0.05
         )
@@ -242,7 +245,7 @@ def test_transmission_tube_validation() -> None:
         m.plot_transmission_tube_geometry(
             l1=0.1, s1=0.0, l2=0.15, s2=0.03, thickness=0.05
         )
-    with pytest.raises(ValueError, match="diameter"):
+    with pytest.raises(ValueError, match=r"'diameter' must be positive"):
         m.plot_transmission_tube_geometry(
             l1=0.1, s1=0.03, l2=0.15, s2=0.03, thickness=0.05, diameter=-1.0
         )
@@ -306,9 +309,9 @@ def test_slit_absorber_geometry_refuses_a_nan_lattice_step() -> None:
 def test_impedance_tube_validation() -> None:
     with pytest.raises(ValueError, match="'x1' must exceed 'spacing'"):
         m.plot_impedance_tube_geometry(spacing=0.05, x1=0.04)
-    with pytest.raises(ValueError, match="diameter"):
+    with pytest.raises(ValueError, match=r"'diameter' must be positive"):
         m.plot_impedance_tube_geometry(spacing=0.05, x1=0.15, diameter=-0.1)
-    with pytest.raises(ValueError, match="sample_thickness"):
+    with pytest.raises(ValueError, match=r"'sample_thickness' must be positive"):
         m.plot_impedance_tube_geometry(spacing=0.05, x1=0.15, sample_thickness=0.0)
     with pytest.raises(ValueError, match="Unknown language"):
         m.plot_impedance_tube_geometry(spacing=0.05, x1=0.15, language="de")
@@ -320,16 +323,18 @@ def test_slit_geometry_validation() -> None:
         m.plot_slit_absorber_geometry(
             resonator, slit_height=0.0, lattice_step=0.015, period=0.02
         )
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(
+        ValueError, match=r"'resonators' must contain at least one resonator"
+    ):
         m.plot_slit_absorber_geometry(
             [], slit_height=0.002, lattice_step=0.015, period=0.02
         )
 
 
 def test_absorber_stack_validation() -> None:
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match=r"'layers' must contain at least one layer"):
         m.plot_absorber_stack([])
-    with pytest.raises(TypeError, match="Unsupported layer"):
+    with pytest.raises(TypeError, match=r"Unsupported layer type"):
         m.plot_absorber_stack([object()])
 
 

--- a/tests/materials/test_materials_result_plots.py
+++ b/tests/materials/test_materials_result_plots.py
@@ -90,7 +90,7 @@ def test_transfer_matrix_plot_spanish_and_bad_language() -> None:
     assert "ASTM E2611" in ax.get_title()
     assert "matriz de transferencia" in ax.get_title()
     plt.close("all")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         tm.plot(f, rho_c, language="fr")
 
 

--- a/tests/simulation/test_elastic_fdtd.py
+++ b/tests/simulation/test_elastic_fdtd.py
@@ -557,13 +557,13 @@ def test_source_validation() -> None:
         iy=1,  # type: ignore[arg-type]
         waveform=lambda t: 0.0,
     )
-    with pytest.raises(ValueError, match="outside the grid"):
+    with pytest.raises(ValueError, match="source position lies outside the grid"):
         sim.add_source(explosion_off_grid)
-    with pytest.raises(ValueError, match="outside the grid"):
+    with pytest.raises(ValueError, match="source position lies outside the grid"):
         sim.add_source(force_off_grid)
-    with pytest.raises(ValueError, match="inside an obstacle"):
+    with pytest.raises(ValueError, match="source position lies inside an obstacle"):
         sim.add_source(explosion_in_obstacle)
-    with pytest.raises(ValueError, match="inside an obstacle"):
+    with pytest.raises(ValueError, match="source position lies inside an obstacle"):
         sim.add_source(force_in_obstacle)
     with pytest.raises(ValueError, match="source ix must be an integer"):
         sim.add_source(explosion_bad_ix)
@@ -584,17 +584,29 @@ def test_source_validation() -> None:
             {"recording": ElasticRecording(snapshot_field="txx")},
             "snapshot_field must be one of",
         ),
-        ({"recording": ElasticRecording(snapshot_every=0)}, "snapshot_every"),
-        ({"recording": ElasticRecording(probes=[(99, 0)])}, "outside the grid"),
+        (
+            {"recording": ElasticRecording(snapshot_every=0)},
+            "snapshot_every must be >= 1",
+        ),
+        (
+            {"recording": ElasticRecording(probes=[(99, 0)])},
+            r"probe .* lies outside the grid",
+        ),
         (
             {"boundaries": ElasticBoundaries({"north": "free"})},
             "unknown boundary sides",
         ),
-        ({"boundaries": ElasticBoundaries("anechoic")}, "must be one of"),
-        ({"boundaries": ElasticBoundaries({"left": "open"})}, "must be one of"),
+        (
+            {"boundaries": ElasticBoundaries("anechoic")},
+            r"boundary for side .* must be one of",
+        ),
+        (
+            {"boundaries": ElasticBoundaries({"left": "open"})},
+            r"boundary for side .* must be one of",
+        ),
         (
             {"boundaries": ElasticBoundaries("absorbing", absorbing_layer_cells=0)},
-            "absorbing_layer_cells",
+            "absorbing_layer_cells must be >= 1",
         ),
     ],
 )
@@ -718,7 +730,7 @@ def test_orthogonal_free_sides_pin_both_corner_stresses() -> None:
 
 def test_collocated_rejects_unknown_field() -> None:
     sim = ElasticFDTD2D(6000.0, 3000.0, 0.01, rho=2700.0, shape=(10, 10))
-    with pytest.raises(ValueError, match="field must be one of"):
+    with pytest.raises(ValueError, match=r"\bfield must be one of"):
         sim.collocated("txy")
 
 
@@ -783,7 +795,9 @@ def test_plot_localizes_labels(small_result: ElasticFDTDResult) -> None:
 
 def test_plot_rejects_unknown_kind_and_missing_snapshots() -> None:
     res = _small_run(recording=replace(_SMALL_RECORDING, snapshot_every=None))
-    with pytest.raises(ValueError, match="kind"):
+    with pytest.raises(ValueError, match=r"kind must be 'probes'"):
         res.plot(kind="field")
-    with pytest.raises(ValueError, match="no snapshots"):
+    with pytest.raises(
+        ValueError, match=r"holds no snapshots; rerun .* with snapshot_every"
+    ):
         res.plot(kind="snapshot")

--- a/tests/simulation/test_elastic_fluid_solid.py
+++ b/tests/simulation/test_elastic_fluid_solid.py
@@ -546,7 +546,7 @@ def test_from_regions_and_material_validation() -> None:
         )
     with pytest.raises(ValueError, match="at least 2 x 2"):
         ElasticFDTD2D.from_regions((1, 10), 0.01, background=WATER)
-    with pytest.raises(ValueError, match="must be an integer"):
+    with pytest.raises(ValueError, match=r"shape\[0\] must be an integer"):
         ElasticFDTD2D.from_regions(
             (10.5, 10),
             0.01,  # type: ignore[arg-type]

--- a/tests/simulation/test_fdtd.py
+++ b/tests/simulation/test_fdtd.py
@@ -377,14 +377,14 @@ def test_obstacle_mask_validation() -> None:
     open_source = GaussianPulse(ix=1, iy=1, width=1e-4)
     with pytest.raises(ValueError, match="match the grid shape"):
         FDTD2D(C0, 0.05, shape=(10, 12), obstacle_mask=mask)
-    with pytest.raises(ValueError, match="boolean"):
+    with pytest.raises(ValueError, match=r"obstacle_mask must be a boolean array"):
         FDTD2D(C0, 0.05, shape=(10, 10), obstacle_mask=float_mask)
-    with pytest.raises(ValueError, match="open cells"):
+    with pytest.raises(ValueError, match=r"obstacle_mask must leave open cells"):
         FDTD2D(C0, 0.05, shape=(10, 10), obstacle_mask=full_mask)
     sim = FDTD2D(C0, 0.05, shape=(10, 10), obstacle_mask=mask)
-    with pytest.raises(ValueError, match="inside an obstacle"):
+    with pytest.raises(ValueError, match="source position lies inside an obstacle"):
         sim.add_source(masked_source)
-    with pytest.raises(ValueError, match="inside an obstacle"):
+    with pytest.raises(ValueError, match=r"probe .* lies inside an obstacle"):
         fdtd_simulation(
             C0,
             0.05,
@@ -403,8 +403,8 @@ def test_obstacle_mask_validation() -> None:
     ("boundaries", "match"),
     [
         ({"north": "rigid"}, "unknown boundary sides"),
-        ({"left": "open"}, "must be one of"),
-        ("anechoic", "must be one of"),
+        ({"left": "open"}, r"boundary for side .* must be one of"),
+        ("anechoic", r"boundary for side .* must be one of"),
     ],
 )
 def test_boundary_spec_rejects_unknown_values(
@@ -436,7 +436,10 @@ def test_edge_impedance_validation(
 
 
 def test_side_cannot_be_absorbing_and_impedance() -> None:
-    with pytest.raises(ValueError, match="both absorbing"):
+    with pytest.raises(
+        ValueError,
+        match=r"side 'left' cannot be both absorbing and an impedance boundary",
+    ):
         FDTD2D(
             C0,
             0.05,
@@ -518,7 +521,9 @@ def test_unstable_or_invalid_cfl_is_rejected(cfl: float) -> None:
     # dt = cfl * dx / (c sqrt(2)); cfl is the Courant number CN of
     # Eq. (4.13) and the explicit scheme requires CN <= 1 (Eq. 4.14).
     sources = [GaussianPulse(ix=5, iy=5, width=1e-4)]
-    with pytest.raises(ValueError, match="cfl"):
+    with pytest.raises(
+        ValueError, match=r"cfl must lie in.*the leapfrog scheme is unstable"
+    ):
         fdtd_simulation(C0, 0.05, 1e-3, shape=(20, 20), cfl=cfl, sources=sources)
 
 
@@ -595,9 +600,9 @@ def test_two_runs_are_bit_identical() -> None:
         ({"sources": []}, "at least one source"),
         ({"duration": 0.0}, "duration must be positive"),
         ({"duration": 1e-9}, "at least one time step"),
-        ({"snapshot_every": 0}, "snapshot_every"),
+        ({"snapshot_every": 0}, "snapshot_every must be >= 1"),
         ({"snapshot_every": 2.5}, "snapshot_every must be an integer"),
-        ({"probes": [(99, 0)]}, "outside the grid"),
+        ({"probes": [(99, 0)]}, r"probe .* lies outside the grid"),
         ({"probes": [(2.5, 3)]}, "probe ix must be an integer"),
         ({"probes": [(2, 3.5)]}, "probe iy must be an integer"),
         # A malformed entry used to be reported by the interpreter's
@@ -606,7 +611,7 @@ def test_two_runs_are_bit_identical() -> None:
         ({"probes": [5]}, r"probes must hold \(ix, iy\) index pairs"),
         (
             {"boundaries": "absorbing", "absorbing_layer_cells": 0},
-            "absorbing_layer_cells",
+            "absorbing_layer_cells must be >= 1",
         ),
         (
             {"boundaries": "absorbing", "absorbing_layer_cells": 2.5},
@@ -681,13 +686,13 @@ def test_result_rejects_rasters_recorded_on_another_grid(
     assert small_result.snapshots is not None
     assert small_result.obstacle_mask is not None
     fewer_rows = small_result.snapshots[:, 5:-5, :]
-    with pytest.raises(ValueError, match=r"'snapshots \(axis 1\)'"):
+    with pytest.raises(ValueError, match=r"'snapshots \(axis 1\)' \(20\)"):
         replace(small_result, snapshots=fewer_rows)
     fewer_columns = small_result.snapshots[:, :, 5:-5]
     with pytest.raises(ValueError, match=r"'snapshots \(axis 2\)'"):
         replace(small_result, snapshots=fewer_columns)
     cropped_mask = small_result.obstacle_mask[5:-5, :]
-    with pytest.raises(ValueError, match="'obstacle_mask'"):
+    with pytest.raises(ValueError, match=r"'obstacle_mask' \(20\)"):
         replace(small_result, obstacle_mask=cropped_mask)
 
 
@@ -740,7 +745,7 @@ def test_plot_rejects_unknown_kind_and_missing_snapshots() -> None:
         sources=[GaussianPulse(ix=5, iy=5, width=1e-4)],
         probes=[(10, 10)],
     )
-    with pytest.raises(ValueError, match="kind"):
+    with pytest.raises(ValueError, match=r"kind must be 'probes'"):
         res.plot(kind="field")
-    with pytest.raises(ValueError, match="no snapshots"):
+    with pytest.raises(ValueError, match=r"the result holds no snapshots"):
         res.plot(kind="snapshot")

--- a/tests/simulation/test_fdtd_ntff.py
+++ b/tests/simulation/test_fdtd_ntff.py
@@ -485,14 +485,18 @@ def test_contour_probe_validation() -> None:
         sim.add_contour_probe(5, 49, 5, 10, frequencies=[F0])
     with pytest.raises(ValueError, match="open cell on both sides"):
         sim.add_contour_probe(10, 5, 5, 10, frequencies=[F0])
-    with pytest.raises(ValueError, match="positive finite"):
+    with pytest.raises(
+        ValueError, match=r"frequencies must be a non-empty 1D sequence of positive"
+    ):
         sim.add_contour_probe(5, 10, 5, 10, frequencies=[])
-    with pytest.raises(ValueError, match="positive finite"):
+    with pytest.raises(
+        ValueError, match=r"frequencies must be a non-empty 1D sequence of positive"
+    ):
         sim.add_contour_probe(5, 10, 5, 10, frequencies=[0.0])
     probe = sim.add_contour_probe(5, 10, 5, 10, frequencies=[F0])
-    with pytest.raises(ValueError, match="not tracked"):
+    with pytest.raises(ValueError, match=r"frequency .* is not tracked by this probe"):
         probe.phasors(999.0)
-    with pytest.raises(ValueError, match="no samples"):
+    with pytest.raises(ValueError, match=r"no samples accumulated yet"):
         probe.phasors(F0)
 
 
@@ -500,7 +504,7 @@ def test_contour_probe_rejects_touching_obstacles() -> None:
     mask = np.zeros((40, 50), dtype=bool)
     mask[18:22, 20:30] = True
     sim = FDTD2D(C0, 0.01, shape=(40, 50), obstacle_mask=mask)
-    with pytest.raises(ValueError, match="touch obstacle"):
+    with pytest.raises(ValueError, match=r"contour faces touch obstacle cells"):
         sim.add_contour_probe(20, 35, 10, 30, frequencies=[F0])
     sim.add_contour_probe(15, 35, 10, 30, frequencies=[F0])
 
@@ -523,15 +527,17 @@ def test_far_field_input_validation() -> None:
     sim.run(4)
     phasors = probe.phasors(F0)
     not_phasors = np.zeros(4)
-    with pytest.raises(TypeError, match="ContourPhasors"):
+    with pytest.raises(TypeError, match=r"contour must be a ContourPhasors"):
         far_field_from_contour(not_phasors, [0.0])  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="angles"):
+    with pytest.raises(
+        ValueError, match=r"angles must be a non-empty 1D sequence of finite"
+    ):
         far_field_from_contour(phasors, [])
-    with pytest.raises(ValueError, match="does not clear"):
+    with pytest.raises(ValueError, match=r"does not clear the contour"):
         far_field_from_contour(phasors, [0.0], distance=0.01)
-    with pytest.raises(ValueError, match="distance"):
+    with pytest.raises(ValueError, match=r"distance must be positive and finite"):
         far_field_from_contour(phasors, [0.0], distance=-1.0)
-    with pytest.raises(ValueError, match="speed_of_sound"):
+    with pytest.raises(ValueError, match=r"speed_of_sound must be positive and finite"):
         far_field_from_contour(phasors, [0.0], speed_of_sound=0.0)
 
 
@@ -545,7 +551,9 @@ def test_contour_phasors_subtract_mismatch() -> None:
     harmonic = p1.phasors(2.0 * F0)
     longer = p2.phasors(F0)
     shifted = p3.phasors(F0)
-    with pytest.raises(ValueError, match="different frequencies"):
+    with pytest.raises(
+        ValueError, match=r"cannot subtract phasors at different frequencies"
+    ):
         base.subtract(harmonic)
     with pytest.raises(
         ValueError,
@@ -555,7 +563,9 @@ def test_contour_phasors_subtract_mismatch() -> None:
         base.subtract(longer)
     # Same sample count, one cell along: only the coordinates disagree.
     assert shifted.positions.shape == base.positions.shape
-    with pytest.raises(ValueError, match="different contours"):
+    with pytest.raises(
+        ValueError, match=r"cannot subtract phasors sampled on different contours"
+    ):
         base.subtract(shifted)
 
 

--- a/tests/simulation/test_fdtd_plane_wave.py
+++ b/tests/simulation/test_fdtd_plane_wave.py
@@ -71,7 +71,7 @@ def test_packet_stays_plane_and_supports_carrier() -> None:
 
 def test_packet_validation() -> None:
     sim = FDTD2D(C0, DX, shape=(20, 20))
-    with pytest.raises(ValueError, match="direction"):
+    with pytest.raises(ValueError, match=r"'direction' must be"):
         sim.add_plane_wave("north", center=0.1, width=0.02)
     with pytest.raises(ValueError, match="'width' must be positive"):
         sim.add_plane_wave("down", center=0.1, width=0.0)
@@ -143,10 +143,10 @@ def test_plane_source_steady_state_is_plane_and_one_way() -> None:
 def test_plane_source_validation_and_geometry_preview() -> None:
     sim = FDTD2D(C0, DX, shape=(40, 40))
     bad_direction = PlaneWaveSource("sideways", lambda t: 0.0)
-    with pytest.raises(ValueError, match="direction"):
+    with pytest.raises(ValueError, match=r"'direction' must be"):
         sim.add_source(bad_direction)
     bad_offset = PlaneWaveSource("down", lambda t: 0.0, offset=40)
-    with pytest.raises(ValueError, match="offset"):
+    with pytest.raises(ValueError, match=r"plane-wave offset lies outside the grid"):
         sim.add_source(bad_offset)
     sim.add_source(PlaneWaveSource("left", lambda t: 0.0, offset=2))
     assert len(sim._plane_sources) == 1
@@ -155,5 +155,7 @@ def test_plane_source_validation_and_geometry_preview() -> None:
     mask[5, 10:20] = True
     blocked = FDTD2D(C0, DX, shape=(40, 40), obstacle_mask=mask)
     on_obstacle = PlaneWaveSource("down", lambda t: 0.0, offset=5)
-    with pytest.raises(ValueError, match="obstacle"):
+    with pytest.raises(
+        ValueError, match=r"plane-wave injection line crosses an obstacle"
+    ):
         blocked.add_source(on_obstacle)

--- a/tests/underwater/bioacoustics/test_audiograms.py
+++ b/tests/underwater/bioacoustics/test_audiograms.py
@@ -170,7 +170,7 @@ def test_orca_audiogram_supports_the_figure_of_merit_of_example_11_4_6() -> None
 
 @pytest.mark.parametrize("frequency", [400.0, 90e3])
 def test_orca_audiogram_rejects_frequencies_outside_the_fit(frequency: float) -> None:
-    with pytest.raises(ValueError, match="500-80000 Hz"):
+    with pytest.raises(ValueError, match=r"'frequency_hz' must lie within"):
         orca_audiogram(frequency)
 
 
@@ -179,14 +179,22 @@ def test_orca_audiogram_rejects_frequencies_outside_the_fit(frequency: float) ->
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("frequency", [[], [0.0], [-1.0], [np.nan]])
-def test_invalid_frequencies_raise(frequency: list[float]) -> None:
-    with pytest.raises(ValueError, match="frequency_hz"):
+@pytest.mark.parametrize(
+    ("frequency", "message"),
+    [
+        ([], r"'frequency_hz' must be finite and non-empty"),
+        ([0.0], r"'frequency_hz' must be strictly positive"),
+        ([-1.0], r"'frequency_hz' must be strictly positive"),
+        ([np.nan], r"'frequency_hz' must be finite and non-empty"),
+    ],
+)
+def test_invalid_frequencies_raise(frequency: list[float], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
         group_audiogram(frequency, "HF")
 
 
 def test_unknown_group_raises() -> None:
-    with pytest.raises(ValueError, match="group"):
+    with pytest.raises(ValueError, match=r"'group' must be one of"):
         group_audiogram(1e3, "dolphin")
 
 
@@ -200,7 +208,7 @@ def test_an_audiogram_curve_with_an_extra_axis_is_refused(field: str) -> None:
     """
     res = group_audiogram(np.logspace(2.0, 5.0, 40), "HF")
     column = np.column_stack([getattr(res, field)] * 2)
-    with pytest.raises(ValueError, match=f"'{field}'"):
+    with pytest.raises(ValueError, match=f"'{field}' must have one axis"):
         dataclasses.replace(res, **{field: column})
 
 
@@ -208,7 +216,7 @@ def test_a_threshold_that_outruns_its_frequencies_is_refused() -> None:
     """One threshold too many would leave the last point with no frequency."""
     res = group_audiogram(np.logspace(2.0, 5.0, 40), "HF")
     longer = np.append(res.threshold, res.threshold[-1])
-    with pytest.raises(ValueError, match="'threshold'"):
+    with pytest.raises(ValueError, match=r"'threshold' \(41\)"):
         dataclasses.replace(res, threshold=longer)
 
 

--- a/tests/underwater/bioacoustics/test_weighting.py
+++ b/tests/underwater/bioacoustics/test_weighting.py
@@ -467,20 +467,27 @@ def test_default_guidance_is_the_current_one() -> None:
 def test_group_codes_are_not_portable_between_versions() -> None:
     """NMFS 2018 has MF, NMFS 2024 does not; NMFS 2024 has VHF, NMFS 2018 does not."""
     assert "MF" in hearing_groups("nmfs-2018")
-    with pytest.raises(ValueError, match="not portable"):
+    with pytest.raises(
+        ValueError, match=r"'group' must be one of .*for guidance 'nmfs-2024'"
+    ):
         auditory_weighting(1000.0, "MF", guidance="nmfs-2024")
-    with pytest.raises(ValueError, match="not portable"):
+    with pytest.raises(
+        ValueError, match=r"'group' must be one of .*for guidance 'nmfs-2018'"
+    ):
         auditory_weighting(1000.0, "VHF", guidance="nmfs-2018")
 
 
 def test_unknown_guidance_raises() -> None:
-    with pytest.raises(ValueError, match="guidance"):
+    with pytest.raises(ValueError, match=r"'guidance' must be one of"):
         auditory_weighting(1000.0, "LF", guidance="nmfs-2007")
 
 
 @pytest.mark.parametrize("frequency", [[], [0.0], [np.nan]])
 def test_invalid_frequencies_raise(frequency: list[float]) -> None:
-    with pytest.raises(ValueError, match="frequency_hz"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequency_hz' must be (finite and non-empty|strictly positive)",
+    ):
         auditory_weighting(frequency, "LF")
 
 
@@ -490,9 +497,9 @@ def test_mismatched_band_spectrum_raises() -> None:
 
 
 def test_non_finite_band_spectrum_raises() -> None:
-    with pytest.raises(ValueError, match="band_sel"):
+    with pytest.raises(ValueError, match=r"'band_sel' must be finite"):
         weighted_exposure([100.0, 200.0], [170.0, np.nan], "LF")
-    with pytest.raises(ValueError, match="band_sel"):
+    with pytest.raises(ValueError, match=r"'band_sel' must be finite"):
         weighted_exposure([100.0, 200.0], [170.0, np.inf], "LF")
 
 
@@ -519,13 +526,15 @@ def test_the_result_does_not_alias_the_caller_arrays() -> None:
 
 @pytest.mark.parametrize("n_events", [0, 1.5, -3])
 def test_invalid_event_count_raises(n_events: float) -> None:
-    with pytest.raises(ValueError, match="n_events"):
+    with pytest.raises(
+        ValueError, match=r"'n_events' must be a whole number of events"
+    ):
         weighted_exposure([1000.0], [170.0], "LF", n_events=n_events)  # type: ignore[arg-type]
 
 
 def test_non_finite_peak_spl_raises() -> None:
     not_a_number = float("nan")
-    with pytest.raises(ValueError, match="peak_spl"):
+    with pytest.raises(ValueError, match=r"'peak_spl' must be finite"):
         weighted_exposure([1000.0], [170.0], "LF", peak_spl=not_a_number)
 
 
@@ -543,7 +552,7 @@ def test_a_curve_that_does_not_run_over_the_frequencies_is_refused() -> None:
     legend row repeated once per curve.
     """
     good = auditory_weighting(np.logspace(1.0, 5.0, 64), "LF")
-    per_frequency = "one value per frequency"
+    per_frequency = "must each carry one value per frequency"
     one_axis = "must have one axis"
     cases = (
         ("frequencies", good.frequencies[:-1], per_frequency),
@@ -581,7 +590,7 @@ def test_an_exposure_row_that_does_not_run_over_the_bands_is_refused() -> None:
     the only reader that would object, is ever drawn.
     """
     good = weighted_exposure([125.0, 250.0, 500.0, 1000.0], [180.0] * 4, "LF")
-    per_band = "one value per band"
+    per_band = "must each carry one value per band"
     one_axis = "must have one axis"
     cases = (
         ("band_sel", good.band_sel[:-1], per_band),
@@ -628,7 +637,9 @@ def test_a_non_finite_peak_level_is_refused_at_construction() -> None:
     and it reaches the margin as a subtraction that quietly answers ``NaN``.
     """
     good = weighted_exposure([1000.0], [100.0], "VHF", impulsive=True, peak_spl=210.0)
-    with pytest.raises(ValueError, match=r"'peak_spl' must be finite"):
+    with pytest.raises(
+        ValueError, match=r"WeightedExposureResult: 'peak_spl' must be finite"
+    ):
         dataclasses.replace(good, peak_spl=float("nan"))
 
 

--- a/tests/underwater/propagation/test_bathymetry.py
+++ b/tests/underwater/propagation/test_bathymetry.py
@@ -646,7 +646,7 @@ def test_eigenrays_declines_a_sloping_trace() -> None:
         n_steps=401,
         bathymetry=([0.0, 2000.0], [200.0, 150.0]),
     )
-    with pytest.raises(ValueError, match="sloping bottom|Snell"):
+    with pytest.raises(ValueError, match=r"'trace' was made over a sloping bottom"):
         eigenrays(trace, receiver_range=1500.0, receiver_depth=80.0)
 
 
@@ -670,13 +670,21 @@ def test_the_seabed_pair_and_a_slope_are_rejected_together() -> None:
 def test_invalid_bathymetry_is_rejected() -> None:
     """Each way a polyline can be malformed has its own message."""
     good = {"source_depth": 60.0, "launch_angles_deg": [10.0], "max_range": 1000.0}
-    with pytest.raises(ValueError, match="pair"):
+    with pytest.raises(
+        ValueError,
+        match=r"'bathymetry' must be a \(ranges_m, depths_m\) pair of arrays",
+    ):
         ray_trace([0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, 1000.0],))  # type: ignore[arg-type]
     with pytest.raises(ValueError, match=r"ray_trace: 'bathymetry ranges'.*same shape"):
         ray_trace([0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, 1000.0], [200.0]))
-    with pytest.raises(ValueError, match="at least two points"):
+    with pytest.raises(
+        ValueError,
+        match=r"the two halves of 'bathymetry' must carry at least two points",
+    ):
         ray_trace([0.0, 200.0], [_C, _C], **good, bathymetry=([0.0], [200.0]))
-    with pytest.raises(ValueError, match="strictly increasing"):
+    with pytest.raises(
+        ValueError, match=r"the bathymetry ranges must be strictly increasing"
+    ):
         ray_trace(
             [0.0, 200.0],
             [_C, _C],
@@ -687,7 +695,9 @@ def test_invalid_bathymetry_is_rejected() -> None:
         ray_trace(
             [0.0, 200.0], [_C, _C], **good, bathymetry=([100.0, 1000.0], [200.0, 150.0])
         )
-    with pytest.raises(ValueError, match="strictly positive"):
+    with pytest.raises(
+        ValueError, match=r"the bathymetry depths must be strictly positive"
+    ):
         ray_trace(
             [0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, 1000.0], [200.0, 0.0])
         )
@@ -695,12 +705,14 @@ def test_invalid_bathymetry_is_rejected() -> None:
         ray_trace(
             [0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, 1000.0], [200.0, 250.0])
         )
-    with pytest.raises(ValueError, match="must be finite"):
+    with pytest.raises(ValueError, match=r"the bathymetry must be finite"):
         ray_trace(
             [0.0, 200.0], [_C, _C], **good, bathymetry=([0.0, np.nan], [200.0, 150.0])
         )
     # A source below the local water column at r = 0 is outside the medium.
-    with pytest.raises(ValueError, match="water column"):
+    with pytest.raises(
+        ValueError, match=r"'source_depth' must lie within the water column"
+    ):
         ray_trace(
             [0.0, 200.0],
             [_C, _C],

--- a/tests/underwater/propagation/test_closed_form.py
+++ b/tests/underwater/propagation/test_closed_form.py
@@ -45,7 +45,9 @@ def test_practical_spreading_matches_pieces() -> None:
 
 
 def test_practical_requires_transition_range() -> None:
-    with pytest.raises(ValueError, match="transition_range"):
+    with pytest.raises(
+        ValueError, match=r"'transition_range' is required for the 'practical' law"
+    ):
         spreading_loss([100.0], law="practical")
 
 
@@ -169,7 +171,7 @@ def test_ainslie_mccolm_depth_in_km() -> None:
 
 
 def test_unknown_absorption_model_rejected() -> None:
-    with pytest.raises(ValueError, match="model"):
+    with pytest.raises(ValueError, match=r"'model' must be one of"):
         seawater_absorption(1000.0, model="fisher-simmons")
 
 
@@ -194,7 +196,7 @@ def test_propagation_loss_is_spreading_plus_absorption() -> None:
 
 
 def test_propagation_loss_rejects_nonpositive_range() -> None:
-    with pytest.raises(ValueError, match="range_m"):
+    with pytest.raises(ValueError, match=r"'range_m' must be strictly positive"):
         propagation_loss([0.0, 100.0], 1000.0)
 
 

--- a/tests/underwater/propagation/test_eigenrays.py
+++ b/tests/underwater/propagation/test_eigenrays.py
@@ -279,7 +279,11 @@ def test_the_cap_keeps_the_earliest_arrivals_and_says_so() -> None:
     about the arrivals it keeps.
     """
     trace, full = _guide_arrivals()
-    with pytest.warns(PhonometryWarning, match="11 eigenrays.*6 earliest"):
+    with pytest.warns(
+        PhonometryWarning,
+        match=r"eigenrays connect the receiver within the traced fan"
+        r".*Raise 'max_arrivals'",
+    ):
         capped = eigenrays(
             trace,
             receiver_range=_GUIDE["r"],
@@ -481,20 +485,24 @@ def test_the_trace_records_the_profile_it_flew_through() -> None:
 
 def test_invalid_inputs_rejected() -> None:
     trace, _res = _guide_arrivals()
-    with pytest.raises(ValueError, match="receiver_depth"):
+    with pytest.raises(
+        ValueError, match=r"'receiver_depth' must lie strictly inside the water column"
+    ):
         eigenrays(trace, receiver_range=500.0, receiver_depth=0.0)
-    with pytest.raises(ValueError, match="receiver_range"):
+    with pytest.raises(
+        ValueError, match=r"'receiver_range' must not run past the traced fan"
+    ):
         eigenrays(trace, receiver_range=700.0, receiver_depth=46.0)
-    with pytest.raises(ValueError, match="receiver_range"):
+    with pytest.raises(ValueError, match=r"'receiver_range' must be positive"):
         eigenrays(trace, receiver_range=0.0, receiver_depth=46.0)
-    with pytest.raises(ValueError, match="max_arrivals"):
+    with pytest.raises(ValueError, match=r"'max_arrivals' must be at least"):
         eigenrays(trace, receiver_range=500.0, receiver_depth=46.0, max_arrivals=0)
-    with pytest.raises(ValueError, match="n_steps"):
+    with pytest.raises(ValueError, match=r"'n_steps' must be at least"):
         eigenrays(trace, receiver_range=500.0, receiver_depth=46.0, n_steps=1)
     slow = FluidSeabed(density=1800.0, sound_speed=-1700.0)
-    with pytest.raises(ValueError, match="sound_speed"):
+    with pytest.raises(ValueError, match=r"'sound_speed' must be positive"):
         eigenrays(trace, receiver_range=500.0, receiver_depth=46.0, bottom=slow)
-    with pytest.raises(ValueError, match="bottom"):
+    with pytest.raises(ValueError, match=r"'bottom' must be one of"):
         eigenrays(trace, receiver_range=500.0, receiver_depth=46.0, bottom="sandy")
     lone = ray_trace(
         [0.0, 100.0],

--- a/tests/underwater/propagation/test_gaussian_beams.py
+++ b/tests/underwater/propagation/test_gaussian_beams.py
@@ -858,11 +858,11 @@ def test_a_malformed_seabed_is_rejected() -> None:
     airy = FluidSeabed(density=-1.0, sound_speed=1700.0)
     still = FluidSeabed(density=1800.0, sound_speed=0.0)
     dry = FluidSeabed(density=1800.0, sound_speed=1700.0, water_density=0.0)
-    with pytest.raises(ValueError, match="density"):
+    with pytest.raises(ValueError, match=r"'density' must be positive"):
         gaussian_beams(200.0, *iso, source_depth=500.0, bottom=airy)
-    with pytest.raises(ValueError, match="sound_speed"):
+    with pytest.raises(ValueError, match=r"'sound_speed' must be positive"):
         gaussian_beams(200.0, *iso, source_depth=500.0, bottom=still)
-    with pytest.raises(ValueError, match="water_density"):
+    with pytest.raises(ValueError, match=r"'water_density' must be positive"):
         gaussian_beams(200.0, *iso, source_depth=500.0, bottom=dry)
 
 
@@ -1788,7 +1788,10 @@ def test_a_source_on_a_profile_kink_is_warned_about() -> None:
     c = np.array([1500.0, 1510.0, 1488.0, 1512.0])
     r = np.array([1000.0])
     fan = BeamFan(max_angle_deg=30.0, n_beams=9)
-    with pytest.warns(PhonometryWarning, match="gradient discontinuity"):
+    with pytest.warns(
+        PhonometryWarning,
+        match=r"'source_depth' sits on a gradient discontinuity of the profile",
+    ):
         gaussian_beams(
             200.0,
             z,
@@ -1844,7 +1847,10 @@ def test_a_beam_wider_than_a_quarter_of_the_channel_passes_in_silence() -> None:
 def test_a_step_that_cannot_follow_the_steepest_beam_is_warned_about() -> None:
     r = np.array([2000.0])
     steep_fan = BeamFan(max_angle_deg=85.0, n_beams=9)
-    with pytest.warns(PhonometryWarning, match="steepest beam"):
+    with pytest.warns(
+        PhonometryWarning,
+        match=r"one marching step carries the steepest beam of the fan",
+    ):
         gaussian_beams(
             200.0,
             [0.0, 400.0],
@@ -1904,27 +1910,31 @@ def test_every_warning_is_reported_against_the_line_that_caused_it() -> None:
 
 def test_invalid_inputs_rejected() -> None:
     iso = ([0.0, 1000.0], [_C, _C])
-    with pytest.raises(ValueError, match="source_depth"):
+    with pytest.raises(
+        ValueError, match=r"'source_depth' must lie within the water column"
+    ):
         gaussian_beams(200.0, *iso, source_depth=1200.0)
     vertical = BeamFan(max_angle_deg=90.0)
-    with pytest.raises(ValueError, match="max_angle_deg"):
+    with pytest.raises(ValueError, match=r"'max_angle_deg' must lie in"):
         gaussian_beams(200.0, *iso, source_depth=500.0, fan=vertical)
-    with pytest.raises(ValueError, match="bottom"):
+    with pytest.raises(ValueError, match=r"'bottom' must be one of"):
         gaussian_beams(200.0, *iso, source_depth=500.0, bottom="sandy")
-    with pytest.raises(ValueError, match="range_step"):
+    with pytest.raises(ValueError, match=r"'range_step' must not exceed 'max_range'"):
         gaussian_beams(
             200.0, *iso, source_depth=500.0, max_range=100.0, range_step=200.0
         )
     unpaired = BeamFan(n_beams=1)
-    with pytest.raises(ValueError, match="n_beams"):
+    with pytest.raises(ValueError, match=r"'n_beams' must be at least"):
         gaussian_beams(200.0, *iso, source_depth=500.0, fan=unpaired)
-    with pytest.raises(ValueError, match="ranges_m"):
+    with pytest.raises(ValueError, match=r"'ranges_m' must be finite"):
         gaussian_beams(200.0, *iso, source_depth=500.0, ranges_m=[-1.0])
-    with pytest.raises(ValueError, match="receiver_depths_m"):
+    with pytest.raises(ValueError, match=r"'receiver_depths_m' must be finite"):
         gaussian_beams(
             200.0, *iso, source_depth=500.0, ranges_m=[500.0], receiver_depths_m=[]
         )
-    with pytest.raises(ValueError, match="receiver_depths_m"):
+    with pytest.raises(
+        ValueError, match=r"'receiver_depths_m' must lie within the water column"
+    ):
         gaussian_beams(
             200.0,
             *iso,
@@ -1932,17 +1942,17 @@ def test_invalid_inputs_rejected() -> None:
             ranges_m=[500.0],
             receiver_depths_m=[1200.0],
         )  # below the seabed
-    with pytest.raises(ValueError, match="ranges_m"):
+    with pytest.raises(ValueError, match=r"'ranges_m' must not run past 'max_range'"):
         # Past the march there is no column to read a beam off, and answering
         # by extrapolating the last one would be a silent wrong answer.
         gaussian_beams(
             200.0, *iso, source_depth=500.0, max_range=1000.0, ranges_m=[2000.0]
         )
-    with pytest.raises(ValueError, match="n_depth_points"):
+    with pytest.raises(ValueError, match=r"'n_depth_points' must be at least"):
         gaussian_beams(
             200.0, *iso, source_depth=500.0, ranges_m=[500.0], n_depth_points=1
         )
-    with pytest.raises(ValueError, match="absorption"):
+    with pytest.raises(ValueError, match=r"'absorption' must name one of"):
         gaussian_beams(200.0, *iso, source_depth=500.0, absorption="mud")
 
 

--- a/tests/underwater/propagation/test_numerical.py
+++ b/tests/underwater/propagation/test_numerical.py
@@ -566,17 +566,21 @@ def test_parabolic_equation_tracks_normal_modes_trend() -> None:
 
 
 def test_invalid_inputs_rejected() -> None:
-    with pytest.raises(ValueError, match="depths"):
+    with pytest.raises(ValueError, match=r"'depths' must start at the surface"):
         normal_modes(
             20.0, [10.0, 20.0], [1500.0, 1500.0], source_depth=15.0, receiver_depth=15.0
         )  # does not start at z = 0
-    with pytest.raises(ValueError, match="bottom"):
+    with pytest.raises(ValueError, match=r"'bottom' must be one of"):
         normal_modes(20.0, *_ISO, source_depth=50.0, receiver_depth=50.0, bottom="soft")
-    with pytest.raises(ValueError, match="source_depth"):
+    with pytest.raises(
+        ValueError, match=r"'source_depth' must lie within the water column"
+    ):
         parabolic_equation(50.0, *_ISO, source_depth=150.0)
-    with pytest.raises(ValueError, match="launch_angles_deg"):
+    with pytest.raises(
+        ValueError, match=r"'launch_angles_deg' must be within .* degrees"
+    ):
         ray_trace(*_ISO, source_depth=50.0, launch_angles_deg=[90.0])  # not forward
-    with pytest.raises(ValueError, match="range_step"):
+    with pytest.raises(ValueError, match=r"'range_step' must not exceed 'max_range'"):
         parabolic_equation(
             50.0, *_ISO, source_depth=50.0, max_range=1000.0, range_step=2000.0
         )

--- a/tests/underwater/propagation/test_seabed_reflection.py
+++ b/tests/underwater/propagation/test_seabed_reflection.py
@@ -69,7 +69,7 @@ def test_total_reflection_below_critical_angle() -> None:
 
 def test_no_critical_angle_for_slow_bottom() -> None:
     # A slower bottom (mud, c2 < c1) has no critical angle.
-    with pytest.raises(ValueError, match="c2 > c1"):
+    with pytest.raises(ValueError, match=r"critical angle exists only when c2 > c1"):
         critical_angle(1500.0, 1450.0)
     res = bottom_reflection_loss(45.0, rho1=1000.0, c1=1500.0, rho2=1500.0, c2=1450.0)
     assert res.critical_angle is None
@@ -127,7 +127,7 @@ def test_exact_intromission_zero_gives_inf_loss_without_warning() -> None:
 
 
 def test_grazing_angle_out_of_range_rejected() -> None:
-    with pytest.raises(ValueError, match="grazing_angle"):
+    with pytest.raises(ValueError, match=r"'grazing_angle' must be within"):
         reflection_coefficient(120.0, **_WATER, **_SAND)
 
 

--- a/tests/underwater/propagation/test_sound_speed.py
+++ b/tests/underwater/propagation/test_sound_speed.py
@@ -204,12 +204,12 @@ def test_surface_speed_increases_with_temperature() -> None:
 
 
 def test_unknown_model_rejected() -> None:
-    with pytest.raises(ValueError, match="model"):
+    with pytest.raises(ValueError, match=r"'model' must be one of"):
         sea_water_sound_speed(10.0, 35.0, 100.0, model="wilson")
 
 
 def test_negative_depth_rejected() -> None:
-    with pytest.raises(ValueError, match="depth"):
+    with pytest.raises(ValueError, match=r"'depth' must be non-negative"):
         sea_water_sound_speed(10.0, 35.0, -5.0)
 
 
@@ -227,7 +227,7 @@ def test_profile_gradient_and_shape() -> None:
 
 
 def test_profile_requires_increasing_depths() -> None:
-    with pytest.raises(ValueError, match="increasing"):
+    with pytest.raises(ValueError, match=r"'depths' must be strictly increasing"):
         sound_speed_profile([0.0, 100.0, 50.0], 10.0, 35.0)
 
 

--- a/tests/underwater/propagation/test_weston_regimes.py
+++ b/tests/underwater/propagation/test_weston_regimes.py
@@ -374,21 +374,30 @@ def test_invalid_arguments_raise(kwargs: dict[str, object], message: str) -> Non
 
 @pytest.mark.parametrize("ranges", [[], [0.0], [np.nan]])
 def test_invalid_ranges_raise(ranges: list[float]) -> None:
-    with pytest.raises(ValueError, match="range_m"):
+    with pytest.raises(
+        ValueError, match=r"'range_m' must be (finite and non-empty|strictly positive)"
+    ):
         weston_propagation_loss(ranges, 250.0, 50.0)
 
 
 def test_mud_without_critical_angle_needs_an_explicit_one() -> None:
     with pytest.raises(ValueError, match="no critical angle"):
         weston_propagation_loss(1000.0, 250.0, 50.0, seabed="mud")
-    with pytest.raises(ValueError, match="critical angle"):
+    with pytest.raises(
+        ValueError, match=r"'effective_depth' needs a seabed with a critical angle"
+    ):
         effective_depth(50.0, 250.0, seabed="mud")
-    with pytest.raises(ValueError, match="critical angle"):
+    with pytest.raises(
+        ValueError,
+        match=r"'waveguide_cutoff_frequency' needs a seabed with a critical angle",
+    ):
         waveguide_cutoff_frequency(50.0, seabed="mud")
 
 
 def test_refracting_branch_requires_a_frequency() -> None:
-    with pytest.raises(ValueError, match="frequency_hz"):
+    with pytest.raises(
+        ValueError, match=r"'frequency_hz' is required for a refracting seabed"
+    ):
         reflection_loss_gradient("mud")
 
 
@@ -403,10 +412,13 @@ def test_refracting_branch_requires_a_sediment_gradient() -> None:
         loss_parameter=0.00165,
         sound_speed_gradient=0.0,
     )
-    with pytest.raises(ValueError, match="sound_speed_gradient"):
+    with pytest.raises(ValueError, match=r"needs a positive 'sound_speed_gradient'"):
         reflection_loss_gradient(flat, frequency_hz=250.0)
 
 
 def test_negative_attenuation_rejected() -> None:
-    with pytest.raises(ValueError, match="attenuation_db_per_wavelength"):
+    with pytest.raises(
+        ValueError,
+        match=r"'attenuation_db_per_wavelength' must be non-negative and finite",
+    ):
         loss_parameter(-1.0)

--- a/tests/underwater/sources/test_ambient_noise.py
+++ b/tests/underwater/sources/test_ambient_noise.py
@@ -109,16 +109,16 @@ def test_shipping_length_mismatch_rejected() -> None:
 
 
 def test_shipping_non_finite_rejected() -> None:
-    with pytest.raises(ValueError, match="shipping.*finite"):
+    with pytest.raises(ValueError, match=r"'shipping' must contain only finite"):
         ocean_ambient_noise(
             [100.0, 1000.0], wind_speed_knots=5.0, shipping=[80.0, np.nan]
         )
 
 
 def test_invalid_inputs_rejected() -> None:
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency_hz' must be strictly positive"):
         wind_noise_spectrum(-1.0, 5.0)
-    with pytest.raises(ValueError, match="wind_speed"):
+    with pytest.raises(ValueError, match=r"'wind_speed_knots' must be non-negative"):
         wind_noise_spectrum(1000.0, -1.0)
 
 

--- a/tests/underwater/sources/test_pile_driving_noise.py
+++ b/tests/underwater/sources/test_pile_driving_noise.py
@@ -255,11 +255,15 @@ def test_empty_bands_are_reported_as_minus_infinity() -> None:
 def test_strike_sel_spectrum_validates_its_arguments() -> None:
     x = _pulse(50.0, 0.2)
     silence = np.zeros(1024)
-    with pytest.raises(ValueError, match="fraction"):
+    with pytest.raises(ValueError, match=r"'fraction' must be 1"):
         underwater.strike_sel_spectrum(x, FS, fraction=6)
-    with pytest.raises(ValueError, match="limits"):
+    with pytest.raises(
+        ValueError, match=r"'limits' must be a finite, increasing, positive pair"
+    ):
         underwater.strike_sel_spectrum(x, FS, limits=(2000.0, 100.0))
-    with pytest.raises(ValueError, match="no energy"):
+    with pytest.raises(
+        ValueError, match=r"'pressure' has no energy inside the requested bands"
+    ):
         underwater.strike_sel_spectrum(silence, FS)
 
 

--- a/tests/underwater/sources/test_ship_radiated_noise.py
+++ b/tests/underwater/sources/test_ship_radiated_noise.py
@@ -49,9 +49,13 @@ def test_radiated_noise_level_closed_form() -> None:
 
 
 def test_radiated_noise_level_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="'rms_pressure'"):
+    with pytest.raises(
+        ValueError, match=r"'rms_pressure' must be a positive, finite number"
+    ):
         underwater.radiated_noise_level(0.0, 100.0)
-    with pytest.raises(ValueError, match="'distance'"):
+    with pytest.raises(
+        ValueError, match=r"'distance' must be a positive, finite number"
+    ):
         underwater.radiated_noise_level(1e-6, -1.0)
 
 
@@ -96,15 +100,15 @@ def test_hydrophone_depths() -> None:
 
 
 def test_hydrophone_depths_rejects_bad_angles() -> None:
-    with pytest.raises(ValueError, match="'angles'"):
+    with pytest.raises(ValueError, match=r"'angles' must be below"):
         underwater.hydrophone_depths(100.0, angles=(90.0,))
 
 
 def test_hydrophone_depths_rejects_non_finite_angles() -> None:
     # NaN/inf angles must be rejected, not silently yield NaN depths.
-    with pytest.raises(ValueError, match="'angles'"):
+    with pytest.raises(ValueError, match=r"'angles' must be finite"):
         underwater.hydrophone_depths(100.0, angles=(np.nan,))
-    with pytest.raises(ValueError, match="'angles'"):
+    with pytest.raises(ValueError, match=r"'angles' must be finite"):
         underwater.hydrophone_depths(100.0, angles=(np.inf,))
 
 

--- a/tests/underwater/sources/test_ship_traffic_noise.py
+++ b/tests/underwater/sources/test_ship_traffic_noise.py
@@ -139,9 +139,9 @@ def test_vessel_classes_exposed() -> None:
 
 
 def test_unknown_class_and_model_rejected() -> None:
-    with pytest.raises(ValueError, match="vessel_class"):
+    with pytest.raises(ValueError, match=r"'vessel_class' must be one of"):
         ship_source_spectrum(12.0, 100.0, vessel_class="submarine")
-    with pytest.raises(ValueError, match="model"):
+    with pytest.raises(ValueError, match=r"'model' must be one of"):
         ship_source_spectrum(12.0, 100.0, model="urick")
 
 

--- a/tests/underwater/test_ainslie_worked_examples.py
+++ b/tests/underwater/test_ainslie_worked_examples.py
@@ -295,8 +295,8 @@ def test_detection_range_from_curve_bridges_a_numerical_model() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "message"),
     [
-        ({"max_range": 0.5}, "max_range"),
-        ({"n_points": 1}, "n_points"),
+        ({"max_range": 0.5}, r"'max_range' must exceed"),
+        ({"n_points": 1}, r"'n_points' must be at least"),
     ],
 )
 def test_detection_range_validates_its_arguments(
@@ -311,7 +311,7 @@ def test_detection_range_from_curve_validates_its_arguments() -> None:
         detection_range_from_curve(60.0, [1.0, 2.0], [10.0])
     with pytest.raises(ValueError, match="range_m.*strictly increasing"):
         detection_range_from_curve(60.0, [2.0, 1.0], [10.0, 20.0])
-    with pytest.raises(ValueError, match="crossing"):
+    with pytest.raises(ValueError, match=r"'crossing' must be"):
         detection_range_from_curve(60.0, [1.0, 2.0], [10.0, 20.0], crossing="middle")
 
 


### PR DESCRIPTION
Second of three. Same work as #637, different packages, split only to keep each part reviewable.

The rule each pattern follows and the reason it exists are in #637. In short: a pattern keeps the identifier and enough predicate to name the rule, and leaves out anything that will drift, because a pattern pinning a bound fails the day the bound changes for a good reason.

Every pattern here was derived from the message the code actually raises, captured by instrumentation rather than read off a test name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decimal formatting in temperature and Poisson-ratio validation messages for consistent international notation.
  * Improved the clarity and specificity of validation errors and warnings across acoustic analysis, filtering, simulation, materials, underwater acoustics, and file handling.

* **Tests**
  * Updated validation checks to verify the complete, parameter-specific error and warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->