### PR TITLE
Make a refusal test pin the refusal it is named for (3 of 3)

### DIFF
--- a/tests/broadcast/test_program_loudness.py
+++ b/tests/broadcast/test_program_loudness.py
@@ -11,7 +11,7 @@ the EBU and cannot be synthesized, so they are not reproduced here.
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import FrozenInstanceError, replace
 
 import numpy as np
 import pytest
@@ -144,10 +144,10 @@ def test_k_weighting_rejects_low_rate_and_empty() -> None:
     # Below 16 kHz the bilinear warping breaks the +/-0.1 LU tolerance (the
     # 997 Hz anchor drifts to about -2.89 LKFS at 8 kHz), so such rates raise.
     for fs in (4000.0, 8000.0):
-        with pytest.raises(ValueError, match="fs >= 16000"):
+        with pytest.raises(ValueError, match=r"K-weighting redesign requires fs"):
             k_weighting_coefficients(fs)
     empty = np.empty(0)
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' cannot be empty"):
         k_weighting(empty, FS)
 
 
@@ -181,11 +181,11 @@ def test_k_weighting_response_default_grid() -> None:
 
 
 def test_k_weighting_response_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="fs >= 16000"):
+    with pytest.raises(ValueError, match=r"K-weighting redesign requires fs"):
         k_weighting_response(8000.0)
-    with pytest.raises(ValueError, match="positive integer"):
+    with pytest.raises(ValueError, match=r"n must be a positive integer"):
         k_weighting_response(48000.0, n=0)
-    with pytest.raises(ValueError, match="cannot be empty"):
+    with pytest.raises(ValueError, match=r"'frequencies' cannot be empty"):
         k_weighting_response(48000.0, frequencies=[])
     with pytest.raises(ValueError, match=r"\(0, fs/2\]"):
         k_weighting_response(48000.0, frequencies=[30000.0])
@@ -195,7 +195,9 @@ def test_k_weighting_response_rejects_curve_off_the_grid() -> None:
     """A curve of another length is refused where the response is built."""
     res = k_weighting_response(48000.0, n=64)
     short = res.shelf_db[:-1]
-    with pytest.raises(ValueError, match="'shelf_db'"):
+    with pytest.raises(
+        ValueError, match=r"'shelf_db' \(63\).*must each carry one value"
+    ):
         replace(res, shelf_db=short)
 
 
@@ -424,12 +426,12 @@ def test_true_peak_defaults_and_validation() -> None:
     x = _sine(-6.0, 0.5)
     # Explicit 4x equals the default at 48 kHz.
     assert true_peak_level(x, FS) == true_peak_level(x, FS, oversample=4)
-    with pytest.raises(ValueError, match="oversample"):
+    with pytest.raises(ValueError, match=r"oversample must be an integer"):
         true_peak_level(x, FS, oversample=0)
-    with pytest.raises(ValueError, match="oversample"):
+    with pytest.raises(ValueError, match=r"oversample must be an integer"):
         true_peak_level(x, FS, oversample=True)  # type: ignore[arg-type]
     empty = np.empty(0)
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' cannot be empty"):
         true_peak_level(empty, FS)
     # Silence: -inf dBTP, no runtime warnings leak.
     assert true_peak_level(np.zeros(1000), FS) == float("-inf")
@@ -510,9 +512,13 @@ def test_annex3_table4_channel_weight(
 def test_channel_weight_arrays_and_validation() -> None:
     w = channel_weight([0.0, 90.0, 135.0], [0.0, 0.0, 0.0])
     np.testing.assert_allclose(w, [1.0, 1.41, 1.0])
-    with pytest.raises(ValueError, match="azimuth"):
+    with pytest.raises(
+        ValueError, match=r"azimuth must be within .+ and elevation within"
+    ):
         channel_weight(400.0)
-    with pytest.raises(ValueError, match="azimuth"):
+    with pytest.raises(
+        ValueError, match=r"azimuth must be within .+ and elevation within"
+    ):
         channel_weight(0.0, 95.0)
 
 
@@ -535,7 +541,7 @@ def test_default_weights_and_errors() -> None:
         integrated_loudness(x, FS)
     with pytest.raises(ValueError, match="one entry per channel"):
         integrated_loudness(x, FS, weights=[1.0, 1.0])
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"channel weights must be non-negative"):
         integrated_loudness(x, FS, weights=[1.0, -1.0, 1.0])
     # Explicit Annex 3 weights on a 3-channel bed work. Each channel holds
     # half the power of its peak level, so three coherent channels at
@@ -591,7 +597,7 @@ def test_result_fields_and_series_geometry() -> None:
     assert res.lra_low <= res.lra_high
     assert res.loudness_range == pytest.approx(res.lra_high - res.lra_low)
     # A frozen result: attributes cannot be reassigned.
-    with pytest.raises(AttributeError):
+    with pytest.raises(FrozenInstanceError):
         res.integrated = 0.0  # type: ignore[misc]
 
 
@@ -606,7 +612,9 @@ def test_result_rejects_weights_that_miss_a_channel() -> None:
     res = program_loudness(x, FS)
     assert res.true_peak_per_channel.shape == res.channel_weights.shape
     short = res.channel_weights[:-1]
-    with pytest.raises(ValueError, match="'channel_weights'"):
+    with pytest.raises(
+        ValueError, match=r"'channel_weights' \(4\).*must each carry one value"
+    ):
         replace(res, channel_weights=short)
 
 
@@ -619,9 +627,13 @@ def test_result_rejects_a_maximum_its_own_series_denies() -> None:
     """
     res = program_loudness(_steps(((-23.0, 10.0),)), FS)
     assert res.max_momentary == pytest.approx(float(np.max(res.momentary)))
-    with pytest.raises(ValueError, match="'max_momentary'"):
+    with pytest.raises(
+        ValueError, match=r"'max_momentary' must be the maximum of 'momentary'"
+    ):
         replace(res, max_momentary=0.0)
-    with pytest.raises(ValueError, match="'max_short_term'"):
+    with pytest.raises(
+        ValueError, match=r"'max_short_term' must be the maximum of 'short_term'"
+    ):
         replace(res, max_short_term=0.0)
 
 
@@ -629,7 +641,10 @@ def test_result_rejects_a_maximum_over_an_empty_series() -> None:
     """An excerpt too short to fill one window holds no maximum at all."""
     res = program_loudness(_stereo(_sine(-23.0, 0.2)), FS)
     assert res.momentary.size == 0
-    with pytest.raises(ValueError, match="'max_momentary'"):
+    with pytest.raises(
+        ValueError,
+        match=r"'max_momentary' must be the maximum of 'momentary'.*'momentary' is empty",
+    ):
         replace(res, max_momentary=-23.0)
 
 
@@ -681,32 +696,36 @@ def test_other_sample_rates_agree_with_48k() -> None:
 def test_program_loudness_validation() -> None:
     empty = np.empty((2, 0))
     tone = _stereo(_sine(-23.0, 1.0))
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' cannot be empty"):
         program_loudness(empty, FS)
-    with pytest.raises(ValueError, match="momentary_step"):
+    with pytest.raises(ValueError, match=r"'momentary_step' must be positive"):
         program_loudness(tone, FS, momentary_step=0.0)
-    with pytest.raises(ValueError, match="short_term_step"):
+    with pytest.raises(ValueError, match=r"'short_term_step' must be positive"):
         program_loudness(tone, FS, short_term_step=-1.0)
     # A NaN-poisoned programme must not silently measure as digital silence.
     poisoned = _stereo(_sine(-23.0, 1.0))
     poisoned[0, 100] = np.nan
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' must be finite"):
         program_loudness(poisoned, FS)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' must be finite"):
         integrated_loudness(poisoned, FS)
 
 
 def test_update_rate_and_weight_validation() -> None:
     tone = _stereo(_sine(-23.0, 1.0))
-    with pytest.raises(ValueError, match="10 Hz"):
+    with pytest.raises(
+        ValueError, match=r"momentary_step and short_term_step.*meter update rate"
+    ):
         program_loudness(tone, FS, momentary_step=0.2)
-    with pytest.raises(ValueError, match="10 Hz"):
+    with pytest.raises(
+        ValueError, match=r"momentary_step and short_term_step.*meter update rate"
+    ):
         program_loudness(tone, FS, short_term_step=0.5)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"channel weights must be finite"):
         program_loudness(tone, FS, weights=[1.0, np.nan])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"azimuth and elevation must be finite"):
         channel_weight(np.nan)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"azimuth and elevation must be finite"):
         channel_weight(30.0, np.inf)
 
 

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -76,7 +76,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     result = _case1_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         result.report(out, engine="weasyprint")
 
 
@@ -192,7 +192,7 @@ def test_unknown_tolerance_rejected(tmp_path: Path) -> None:
     """An unknown tolerance rule raises ``ValueError``."""
     result = _case1_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="tolerance"):
+    with pytest.raises(ValueError, match=r"Unknown tolerance rule"):
         result.report(out, tolerance="broadcast")
 
 
@@ -300,5 +300,5 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     result = _case1_result()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/emission/test_emission_result_plots.py
+++ b/tests/emission/test_emission_result_plots.py
@@ -102,5 +102,5 @@ def test_intensity_without_band_data_raises() -> None:
     p1 = RNG.standard_normal(FS)
     res = ph.emission.sound_intensity(p1, np.roll(p1, 1), FS, spacing=0.012)
     assert res.frequency is None
-    with pytest.raises(ValueError, match="per-band"):
+    with pytest.raises(ValueError, match=r"plot\(\) needs per-band intensity data"):
         res.plot()

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -248,23 +248,23 @@ def test_validation_errors() -> None:
         ValueError, match=r"sound_intensity: 'p1'.*'p2'.*one value per sample"
     ):
         emission.sound_intensity(good, good[:-1], FS, spacing=SPACING)
-    with pytest.raises(ValueError, match="spacing"):
+    with pytest.raises(ValueError, match=r"Microphone 'spacing' must be positive"):
         emission.sound_intensity(good, good, FS, spacing=0.0)
-    with pytest.raises(ValueError, match="spacing"):
+    with pytest.raises(ValueError, match=r"Microphone 'spacing' must be positive"):
         emission.sound_intensity(good, good, FS, spacing=-0.01)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"Sample rate 'fs' must be positive"):
         emission.sound_intensity(good, good, 0, spacing=SPACING)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"Sample rate 'fs' must be positive"):
         emission.sound_intensity(good, good, -48000, spacing=SPACING)
-    with pytest.raises(ValueError, match="rho"):
+    with pytest.raises(ValueError, match=r"Air density 'rho' must be positive"):
         emission.sound_intensity(good, good, FS, spacing=SPACING, rho=0.0)
-    with pytest.raises(ValueError, match="'c'"):
+    with pytest.raises(ValueError, match=r"'c' must be positive"):
         emission.sound_intensity(good, good, FS, spacing=SPACING, c=-1.0)
-    with pytest.raises(ValueError, match="fraction"):
+    with pytest.raises(ValueError, match=r"'fraction' must be"):
         emission.sound_intensity(good, good, FS, spacing=SPACING, fraction=2)
-    with pytest.raises(ValueError, match="limits"):
+    with pytest.raises(ValueError, match=r"'limits' must be"):
         emission.sound_intensity(good, good, FS, spacing=SPACING, limits=[100.0])
-    with pytest.raises(ValueError, match="limits"):
+    with pytest.raises(ValueError, match=r"'limits' must be"):
         emission.sound_intensity(
             good, good, FS, spacing=SPACING, limits=[1000.0, 100.0]
         )
@@ -275,9 +275,11 @@ def test_validation_errors() -> None:
             good, good, FS, spacing=SPACING, limits=[float("nan"), 1000.0]
         )
     two_dimensional = np.zeros((2, 100))
-    with pytest.raises(ValueError, match="1D"):
+    with pytest.raises(
+        ValueError, match=r"sound_intensity expects 1D pressure signals"
+    ):
         emission.sound_intensity(two_dimensional, two_dimensional, FS, spacing=SPACING)
-    with pytest.raises(ValueError, match="too short"):
+    with pytest.raises(ValueError, match=r"Signals too short for a spectral estimate"):
         emission.sound_intensity(good[:8], good[:8], FS, spacing=SPACING)
 
 
@@ -314,7 +316,11 @@ def test_field_indicators_validation() -> None:
         emission.field_indicators([90.0, 91.0], [1e-3])
     with pytest.raises(ValueError, match="two measurement positions"):
         emission.field_indicators([90.0], [1e-3])
-    with pytest.raises(ValueError, match="not positive"):
+    with pytest.raises(
+        ValueError,
+        match=r"algebraic mean normal intensity over the measurement surface "
+        r"is not positive",
+    ):
         emission.field_indicators([90.0, 90.0], [1e-3, -2e-3])
     three_band_lp = np.full((4, 3), 90.0)
     three_band_in = np.full((4, 3), 1e-3)
@@ -359,7 +365,11 @@ def test_field_indicators_per_band_matches_per_column_scalars() -> None:
     # ISO 9614-1 A.2.3 test conditions and raises, exactly as the scalar path.
     bad = i_n.copy()
     bad[:, 1] = -1.0e-5
-    with pytest.raises(ValueError, match="not positive"):
+    with pytest.raises(
+        ValueError,
+        match=r"algebraic mean normal intensity over the measurement surface "
+        r"is not positive",
+    ):
         emission.field_indicators(lp, bad, freqs)
 
 
@@ -394,7 +404,7 @@ def test_field_indicators_plot_draws_indicators_and_ld() -> None:
         ind.plot(language="xx")
     # The scalar (single-band) result has nothing per band to draw.
     single = emission.field_indicators(lp[:, 0], i_n[:, 0])
-    with pytest.raises(ValueError, match="per-band"):
+    with pytest.raises(ValueError, match=r"plot\(\) needs per-band indicators"):
         single.plot()
     plt.close("all")
 
@@ -407,7 +417,7 @@ def test_dynamic_capability_index() -> None:
     assert emission.dynamic_capability_index(
         18.0, bias_error_factor=7.0
     ) == pytest.approx(11.0)
-    with pytest.raises(ValueError, match="bias_error_factor"):
+    with pytest.raises(ValueError, match=r"'bias_error_factor' must be positive"):
         emission.dynamic_capability_index(18.0, bias_error_factor=0.0)
 
 
@@ -480,15 +490,23 @@ def test_f1_validation() -> None:
     three_dimensional = np.zeros((2, 2, 2))
     with pytest.raises(ValueError, match="1D .samples,. or 2D"):
         emission.temporal_variability_indicator(three_dimensional)
-    with pytest.raises(ValueError, match="not positive"):
+    with pytest.raises(
+        ValueError,
+        match=r"algebraic mean of the short-time normal intensity samples "
+        r"is not positive",
+    ):
         emission.temporal_variability_indicator([1.0e-5, -3.0e-5])
     # A NaN or infinite sample would otherwise slip past the positivity test
     # and turn the indicator into a silent NaN.
     with_nan = [1.0e-5, float("nan"), 1.2e-5]
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"normal intensity samples must all be finite"
+    ):
         emission.temporal_variability_indicator(with_nan)
     with_inf = [1.0e-5, float("inf"), 1.2e-5]
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"normal intensity samples must all be finite"
+    ):
         emission.temporal_variability_indicator(with_inf)
 
 
@@ -582,7 +600,7 @@ def test_field_is_stationary_against_the_table_b3_limit() -> None:
     varying = emission.field_indicators(lp, i_n, temporal_intensity=[1.0e-5, 5.0e-5])
     assert varying.field_is_stationary() is False
     without_f1 = emission.field_indicators(lp, i_n)
-    with pytest.raises(ValueError, match="no F1"):
+    with pytest.raises(ValueError, match=r"This result carries no F1"):
         without_f1.field_is_stationary()
 
 
@@ -643,7 +661,7 @@ def test_an_f1_off_the_band_axis_is_refused(kind: str) -> None:
         "short": f1[:-1],
         "long": np.append(f1, f1[-1]),
     }[kind]
-    with pytest.raises(ValueError, match="'f1'"):
+    with pytest.raises(ValueError, match=r"'f1'.*must each carry one value per band"):
         dataclasses.replace(result, f1=wrong)
 
 
@@ -669,7 +687,9 @@ def test_an_intensity_band_quantity_off_the_band_axis_is_refused(
     )
     values = np.asarray(getattr(result, field_name))
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    with pytest.raises(
+        ValueError, match=rf"'{field_name}'.*must each carry one value per band"
+    ):
         dataclasses.replace(result, **{field_name: wrong})
 
 

--- a/tests/emission/test_intensity_compliance.py
+++ b/tests/emission/test_intensity_compliance.py
@@ -112,14 +112,14 @@ def test_table2_accepts_exact_base_ten_band_centres() -> None:
 
 def test_frequency_outside_table_is_rejected() -> None:
     """A frequency that is not a tabulated band raises, it is not snapped."""
-    with pytest.raises(ValueError, match="Table 2 band"):
+    with pytest.raises(ValueError, match=r"is not an IEC 61043 Table 2 band"):
         emission.residual_index_limits("instrument", frequencies=[700.0])
-    with pytest.raises(ValueError, match="Table 2 band"):
+    with pytest.raises(ValueError, match=r"is not an IEC 61043 Table 2 band"):
         emission.residual_index_limits("instrument", frequencies=[8000.0])
 
 
 def test_unknown_device_is_rejected() -> None:
-    with pytest.raises(ValueError, match="probe"):
+    with pytest.raises(ValueError, match=r"'device' must be 'probe'"):
         emission.residual_index_limits("analyser")
 
 
@@ -158,7 +158,9 @@ def test_note1_rule_matches_the_table_values_at_50_mm() -> None:
 
 
 def test_non_positive_spacing_is_rejected() -> None:
-    with pytest.raises(ValueError, match="spacing"):
+    with pytest.raises(
+        ValueError, match=r"'spacing' must be a positive, finite distance"
+    ):
         emission.residual_index_limits("probe", spacing=0.0)
 
 
@@ -179,7 +181,9 @@ def test_instrument_class_from_components(
 
 
 def test_instrument_class_rejects_class_2x() -> None:
-    with pytest.raises(ValueError, match="2X"):
+    with pytest.raises(
+        ValueError, match=r"'probe_class' and 'processor_class' must be 1"
+    ):
         emission.instrument_class_from_components(1, 3)
 
 
@@ -321,9 +325,11 @@ def test_mismatched_lengths_and_repeats_are_rejected() -> None:
         ),
     ):
         emission.verify_intensity_class([20.0, 20.0], [1000.0])
-    with pytest.raises(ValueError, match="repeats"):
+    with pytest.raises(
+        ValueError, match=r"'frequencies' repeats an IEC 61043 Table 2 band"
+    ):
         emission.verify_intensity_class([20.0, 20.0], [1000.0, 1000.0])
-    with pytest.raises(ValueError, match="At least one"):
+    with pytest.raises(ValueError, match="At least one measurement band is required"):
         emission.verify_intensity_class([], [])
 
 
@@ -364,9 +370,9 @@ def test_result_rejects_an_unknown_class() -> None:
     result = emission.intensity_class_compliance(
         _table_column("probe", 1), _BANDS, device="probe"
     )
-    with pytest.raises(ValueError, match="must be 1 or 2"):
+    with pytest.raises(ValueError, match="'device_class' must be 1"):
         result.binding_margin(0)
-    with pytest.raises(ValueError, match="must be 1 or 2"):
+    with pytest.raises(ValueError, match="'device_class' must be 1"):
         result.failing_bands(3)
 
 
@@ -418,13 +424,17 @@ def test_index_follows_note1_when_the_spacer_changes() -> None:
 
 
 def test_phase_conversion_rejects_invalid_inputs() -> None:
-    with pytest.raises(ValueError, match="phase_mismatch"):
+    with pytest.raises(
+        ValueError, match=r"'phase_mismatch' must be finite and positive"
+    ):
         emission.residual_index_from_phase_mismatch(0.0, 1000.0, 0.025)
-    with pytest.raises(ValueError, match="spacing"):
+    with pytest.raises(
+        ValueError, match=r"'spacing' must be a positive, finite distance"
+    ):
         emission.phase_mismatch_from_residual_index(20.0, 1000.0, -0.01)
-    with pytest.raises(ValueError, match="'c'"):
+    with pytest.raises(ValueError, match=r"'c' must be a positive, finite speed"):
         emission.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025, c=0.0)
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency' must be finite and positive"):
         emission.phase_mismatch_from_residual_index(20.0, 0.0, 0.025)
 
 
@@ -452,7 +462,7 @@ def test_an_instrument_verdict_refuses_per_band_entries_that_disagree() -> None:
         device="instrument",
         spacing=0.025,
     )
-    with pytest.raises(ValueError, match="'bands'"):
+    with pytest.raises(ValueError, match=r"'bands' \(3\)"):
         dataclasses.replace(result, bands=result.bands[:-1])
 
 
@@ -498,7 +508,7 @@ def test_a_non_finite_band_of_the_verdict_is_refused(field_name: str) -> None:
     )
     values = np.asarray(getattr(result, field_name), dtype=float).copy()
     values[1] = float("nan")
-    with pytest.raises(ValueError, match=f"'{field_name}' must be finite"):
+    with pytest.raises(ValueError, match=rf"'{field_name}' must be finite\."):
         dataclasses.replace(result, **{field_name: values})
 
 

--- a/tests/emission/test_iso3741_report.py
+++ b/tests/emission/test_iso3741_report.py
@@ -298,7 +298,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -306,5 +306,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/emission/test_iso3744_report.py
+++ b/tests/emission/test_iso3744_report.py
@@ -275,7 +275,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -283,5 +283,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/emission/test_iso4871_report.py
+++ b/tests/emission/test_iso4871_report.py
@@ -166,19 +166,34 @@ def test_dual_number_verification_uses_separately_rounded_values() -> None:
 
 def test_emission_pressure_pair_must_be_given_together() -> None:
     """A lone emission-pressure level (no uncertainty) is rejected."""
-    with pytest.raises(ValueError, match="given together"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"emission_pressure_level and emission_pressure_uncertainty"
+            r" must be given together"
+        ),
+    ):
         emission.OperatingModeDeclaration("m", 88.0, 2.0, emission_pressure_level=78.0)
 
 
 def test_negative_uncertainty_is_rejected() -> None:
     """The uncertainty K must be finite and non-negative."""
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"OperatingModeDeclaration\.sound_power_uncertainty"
+            r" must be finite and non-negative"
+        ),
+    ):
         emission.OperatingModeDeclaration("m", 88.0, -1.0)
 
 
 def test_non_finite_level_is_rejected() -> None:
     """A non-finite sound power level is rejected."""
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError,
+        match=r"OperatingModeDeclaration\.sound_power_level must be finite",
+    ):
         emission.OperatingModeDeclaration("m", math.nan, 2.0)
 
 
@@ -191,7 +206,7 @@ def test_declaration_requires_at_least_one_mode() -> None:
 def test_unknown_form_is_rejected() -> None:
     """An unknown declaration form is rejected."""
     modes = _annex_b_modes()
-    with pytest.raises(ValueError, match="dual-number"):
+    with pytest.raises(ValueError, match=r"NoiseEmissionDeclaration\.form must be"):
         emission.NoiseEmissionDeclaration(modes, form="triple")  # type: ignore[arg-type]
 
 
@@ -346,14 +361,14 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     pytest.importorskip("reportlab")
     decl = _annex_b_declaration()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         decl.report(out, engine="weasyprint")
 
 
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     decl = _annex_b_declaration()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         decl.report(str(tmp_path / "bad.pdf"), language="xx")
 
 

--- a/tests/emission/test_iso7849_report.py
+++ b/tests/emission/test_iso7849_report.py
@@ -273,7 +273,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _engineering_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -281,5 +281,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _engineering_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/emission/test_iso9614_3_report.py
+++ b/tests/emission/test_iso9614_3_report.py
@@ -723,14 +723,14 @@ def test_per_band_residual_index_is_ranged_in_the_strip(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _determination()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(str(tmp_path / "x.pdf"), engine="weasyprint")
 
 
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _determination()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(str(tmp_path / "bad.pdf"), language="xx")
 
 
@@ -738,7 +738,10 @@ def test_indicators_over_other_bands_rejected(tmp_path: Path) -> None:
     """Indicators measured over a different band set are refused, not printed."""
     res = _determination()
     other, _criteria = _qualification(np.full(3, 2.0), _FREQS[:3])
-    with pytest.raises(ValueError, match="indicators"):
+    with pytest.raises(
+        ValueError,
+        match=r"'indicators\.f_pi_unsigned' must span the \d+ bands of the determination",
+    ):
         res.report(str(tmp_path / "mismatch.pdf"), indicators=other)
 
 
@@ -746,12 +749,17 @@ def test_criteria_over_other_bands_rejected(tmp_path: Path) -> None:
     """Criteria evaluated over a different band set are refused too."""
     res = _determination()
     _indicators, other = _qualification(np.full(3, 2.0), _FREQS[:3])
-    with pytest.raises(ValueError, match="criteria"):
+    with pytest.raises(
+        ValueError,
+        match=r"'criteria\.criterion_1' must span the \d+ bands of the determination",
+    ):
         res.report(str(tmp_path / "mismatch.pdf"), criteria=other)
 
 
 def test_residual_index_over_other_bands_rejected(tmp_path: Path) -> None:
     """A per-band residual index must span the determination's bands."""
     res = _determination()
-    with pytest.raises(ValueError, match="residual_index"):
+    with pytest.raises(
+        ValueError, match=r"'residual_index' must be a scalar or span the \d+ bands"
+    ):
         res.report(str(tmp_path / "mismatch.pdf"), residual_index=[15.0, 15.0])

--- a/tests/emission/test_iso9614_report.py
+++ b/tests/emission/test_iso9614_report.py
@@ -296,7 +296,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -304,5 +304,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _uniform_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -149,22 +149,38 @@ def test_k2_no_room_data_is_free_field_zero() -> None:
 
 def test_k2_reverberation_time_without_volume_raises() -> None:
     """Half-specified room (T without V) must not silently give K2 = 0."""
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(
+        ValueError,
+        match=r"reverberation_time and volume must be given together.*"
+        r"'volume' is missing",
+    ):
         emission.environmental_correction(40.0, reverberation_time=1.2)
 
 
 def test_k2_volume_without_reverberation_time_raises() -> None:
-    with pytest.raises(ValueError, match="reverberation_time"):
+    with pytest.raises(
+        ValueError,
+        match=r"reverberation_time and volume must be given together.*"
+        r"'reverberation_time' is missing",
+    ):
         emission.environmental_correction(40.0, volume=300.0)
 
 
 def test_k2_mean_absorption_without_room_surface_raises() -> None:
-    with pytest.raises(ValueError, match="room_surface"):
+    with pytest.raises(
+        ValueError,
+        match=r"mean_absorption_coefficient and room_surface must be given together.*"
+        r"'room_surface' is missing",
+    ):
         emission.environmental_correction(50.0, mean_absorption_coefficient=0.2)
 
 
 def test_k2_room_surface_without_mean_absorption_raises() -> None:
-    with pytest.raises(ValueError, match="mean_absorption_coefficient"):
+    with pytest.raises(
+        ValueError,
+        match=r"mean_absorption_coefficient and room_surface must be given together.*"
+        r"'mean_absorption_coefficient' is missing",
+    ):
         emission.environmental_correction(50.0, room_surface=500.0)
 
 
@@ -172,7 +188,11 @@ def test_partial_room_data_raises_via_sound_power_pressure() -> None:
     """The partial-pair guard is enforced through sound_power_pressure too."""
     levels = np.full((10, 1), 90.0)
     half_specified_room = emission.RoomEnvironment(reverberation_time=1.2)
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(
+        ValueError,
+        match=r"reverberation_time and volume must be given together.*"
+        r"'volume' is missing",
+    ):
         emission.sound_power_pressure(
             levels,
             "hemisphere",
@@ -361,7 +381,9 @@ def test_background_levels_single_spectrum_broadcasts() -> None:
 def test_background_levels_wrong_length_raises() -> None:
     levels = np.tile(np.array([90.0, 92.0, 95.0]), (10, 1))
     background_two_bands = np.array([70.0, 71.0])
-    with pytest.raises(ValueError, match="background_levels"):
+    with pytest.raises(
+        ValueError, match=r"'background_levels' must match 'levels_positions' shape"
+    ):
         emission.sound_power_pressure(
             levels, "hemisphere", radius=2.0, background_levels=background_two_bands
         )
@@ -453,7 +475,10 @@ def test_sound_power_level_a_single_band_equals_level() -> None:
 def test_too_few_positions_raises() -> None:
     """Engineering hemisphere needs >= 10 positions (ISO 3744 clause 8.1.1)."""
     five_positions = np.full((5, 1), 60.0)
-    with pytest.raises(ValueError, match="microphone positions"):
+    with pytest.raises(
+        ValueError,
+        match=r"engineering hemisphere.*requires at least \d+ microphone positions",
+    ):
         emission.sound_power_pressure(five_positions, "hemisphere", radius=2.0)
 
 
@@ -634,7 +659,9 @@ def test_a_per_band_quantity_off_the_band_axis_is_refused(trim: bool) -> None:
     result = _ten_position_determination()
     values = np.asarray(result.sound_power_level)
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match="'sound_power_level'"):
+    with pytest.raises(
+        ValueError, match=r"'sound_power_level'.*must each carry one value per band"
+    ):
         dataclasses.replace(result, sound_power_level=wrong)
 
 

--- a/tests/emission/test_sound_power_intensity.py
+++ b/tests/emission/test_sound_power_intensity.py
@@ -439,7 +439,10 @@ def test_a_weighted_total_omits_band_failing_criterion_2_engineering() -> None:
         [np.full(4, 1.0e-3), np.array([5.0e-3, -1.0e-3, 1.0e-3, -1.0e-3])]
     )
     lp = np.full((4, 2), 92.0)  # FpI ~ 2 dB in both bands: criterion 1 passes
-    with pytest.warns(emission.SoundPowerWarning, match="criterion 2"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"criterion 2 is not satisfied and the engineering grade is not achieved",
+    ):
         res = emission.sound_power_intensity(
             intensity,
             areas,
@@ -481,7 +484,10 @@ def test_a_weighting_screening_unavailable_warns_and_sums_all() -> None:
     """
     areas = np.ones(4)
     intensity = np.column_stack([np.full(4, 1.0e-3), np.full(4, 5.0e-4)])
-    with pytest.warns(emission.SoundPowerWarning, match="10.6 b"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"A-weighted total sums every determinable band",
+    ):
         res = emission.sound_power_intensity(
             intensity, areas, frequencies=np.array([500.0, 1000.0])
         )
@@ -588,7 +594,8 @@ def test_a_per_band_quantity_off_the_band_axis_is_refused(
     result = _five_band_determination()
     values = np.asarray(getattr(result, field_name))
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    count = 4 if trim else 6  # the five-band fixture, one short or one long
+    with pytest.raises(ValueError, match=rf"'{field_name}' \({count}\)"):
         dataclasses.replace(result, **{field_name: wrong})
 
 
@@ -597,7 +604,10 @@ def test_a_per_segment_quantity_off_the_segment_axis_is_refused() -> None:
     import dataclasses
 
     result = _five_band_determination()
-    with pytest.raises(ValueError, match="measurement segment"):
+    with pytest.raises(
+        ValueError,
+        match=r"'repeatability' \(3\)",
+    ):
         dataclasses.replace(result, repeatability=result.repeatability[:-1])
 
 

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -92,7 +92,10 @@ def test_precision_positions_invalid_surface_raises() -> None:
 
 def test_precision_positions_requires_a_radius() -> None:
     """Keyword-only and required, so Python enforces it before the body runs."""
-    with pytest.raises(TypeError, match="required keyword-only argument"):
+    with pytest.raises(
+        TypeError,
+        match=r"precision_positions\(\).*required keyword-only argument: 'radius'",
+    ):
         precision_positions("sphere")  # type: ignore[call-arg]
     with pytest.raises(ValueError, match="A positive 'radius' is required"):
         precision_positions("sphere", radius=0.0)
@@ -361,7 +364,10 @@ def test_anechoic_invalid_surface_raises() -> None:
 
 def test_anechoic_requires_a_radius() -> None:
     levels = np.full((40, 1), 70.0)
-    with pytest.raises(TypeError, match="required keyword-only argument"):
+    with pytest.raises(
+        TypeError,
+        match=r"sound_power_anechoic\(\).*required keyword-only argument: 'radius'",
+    ):
         sound_power_anechoic(levels, "sphere")  # type: ignore[call-arg]
     with pytest.raises(ValueError, match="A positive 'radius' is required"):
         sound_power_anechoic(levels, "sphere", radius=0.0)
@@ -401,7 +407,10 @@ def test_a_per_band_column_off_the_band_axis_is_refused(trim: bool) -> None:
     result = _forty_position_determination()
     values = result.uncertainty_bands
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match="'uncertainty_bands'"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'uncertainty_bands' \({wrong.size}\) must each carry one value per band",
+    ):
         dataclasses.replace(result, uncertainty_bands=wrong)
 
 
@@ -851,7 +860,10 @@ def test_a_determination_column_off_the_band_axis_is_refused(
     result = _four_band_determination()
     values = np.asarray(getattr(result, field_name))
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'{field_name}' \({wrong.size}\).*must each carry one value per band",
+    ):
         dataclasses.replace(result, **{field_name: wrong})
 
 
@@ -887,7 +899,9 @@ def test_a_field_indicator_off_the_band_axis_is_refused() -> None:
 
     indicators = _four_band_indicators()
     one_band_fs = indicators.fs[:1]
-    with pytest.raises(ValueError, match="'fs'"):
+    with pytest.raises(
+        ValueError, match=r"'fs' \(1\) must each carry one value per band"
+    ):
         dataclasses.replace(indicators, fs=one_band_fs)
 
 
@@ -922,7 +936,9 @@ def test_criterion_5_off_the_band_axis_is_refused() -> None:
     )
     assert criteria.criterion_5 is not None
     one_band_criterion_5 = criteria.criterion_5[:1]
-    with pytest.raises(ValueError, match="'criterion_5'"):
+    with pytest.raises(
+        ValueError, match=r"'criterion_5' \(1\) must each carry one value per band"
+    ):
         dataclasses.replace(criteria, criterion_5=one_band_criterion_5)
 
 

--- a/tests/emission/test_sound_power_reverberation.py
+++ b/tests/emission/test_sound_power_reverberation.py
@@ -152,7 +152,10 @@ def test_comparison_fewer_than_six_positions_warns() -> None:
     levels = np.array([[80.0], [80.1], [79.9]])  # 3 positions, tight spread
     lp_rss = np.array([70.0])
     lw_ref = np.array([90.0])
-    with pytest.warns(emission.SoundPowerWarning, match="microphone position"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"microphone position\(s\) were supplied; an unqualified reverberation room requires",
+    ):
         emission.sound_power_comparison(levels, lp_rss, lw_ref)
 
 
@@ -161,7 +164,10 @@ def test_comparison_interposition_std_above_criterion_warns() -> None:
     levels = np.array([[70.0], [80.0], [72.0], [78.0], [71.0], [79.0]])
     lp_rss = np.array([70.0])
     lw_ref = np.array([90.0])
-    with pytest.warns(emission.SoundPowerWarning, match="standard deviation"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"Inter-position standard deviation exceeds the ISO 3741 sM criterion",
+    ):
         emission.sound_power_comparison(levels, lp_rss, lw_ref)
 
 
@@ -239,7 +245,10 @@ def test_background_correction_is_per_position_eq14_to_16() -> None:
     t60 = np.array([1.5])
     levels = np.array([[70.0], [68.0], [66.0], [72.0], [71.0], [69.0]])
     background = np.array([[58.0], [60.0], [59.0], [60.0], [62.0], [58.0]])
-    with pytest.warns(emission.SoundPowerWarning, match="9.1.2"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"Background margin below the ISO 3741 criterion",
+    ):
         res = emission.sound_power_reverberation(
             levels,
             t60,
@@ -288,7 +297,10 @@ def test_background_shape_mismatch_raises() -> None:
     t60 = np.array([1.5])
     levels = np.full((6, 1), 80.0)
     mismatched_background = np.full((3, 1), 60.0)  # 3 rows against 6 positions
-    with pytest.raises(ValueError, match="background_levels"):
+    with pytest.raises(
+        ValueError,
+        match=r"'background_levels' must match the per-position 'levels' shape",
+    ):
         emission.sound_power_reverberation(
             levels,
             t60,
@@ -375,7 +387,9 @@ def test_a_weighted_total_from_bands() -> None:
 # --------------------------------------------------------------------------
 def test_invalid_volume_raises() -> None:
     lp, t60, freqs = np.array([80.0]), np.array([1.5]), np.array([1000.0])
-    with pytest.raises(ValueError, match="'volume' and 'surface_area'"):
+    with pytest.raises(
+        ValueError, match=r"'volume' and 'surface_area' must be positive"
+    ):
         emission.sound_power_reverberation(lp, t60, -1.0, 210.0, freqs)
 
 
@@ -392,7 +406,9 @@ def test_mismatched_shapes_raise() -> None:
 @pytest.mark.parametrize("theta", [-273.0, -300.0, np.inf, np.nan])
 def test_direct_method_invalid_temperature_raises(theta: float) -> None:
     lp, t60, freqs = np.array([80.0]), np.array([1.5]), np.array([1000.0])
-    with pytest.raises(ValueError, match="temperature"):
+    with pytest.raises(
+        ValueError, match=r"'temperature' must be finite and greater than"
+    ):
         emission.sound_power_reverberation(
             lp,
             t60,
@@ -406,7 +422,9 @@ def test_direct_method_invalid_temperature_raises(theta: float) -> None:
 @pytest.mark.parametrize("ps", [0.0, -1.0, np.inf, np.nan])
 def test_direct_method_invalid_pressure_raises(ps: float) -> None:
     lp, t60, freqs = np.array([80.0]), np.array([1.5]), np.array([1000.0])
-    with pytest.raises(ValueError, match="static_pressure"):
+    with pytest.raises(
+        ValueError, match=r"'static_pressure' must be finite and positive"
+    ):
         emission.sound_power_reverberation(
             lp,
             t60,
@@ -419,13 +437,17 @@ def test_direct_method_invalid_pressure_raises(ps: float) -> None:
 
 def test_comparison_method_invalid_temperature_raises() -> None:
     levels, levels_ref, lw_ref = (np.array([80.0]), np.array([70.0]), np.array([90.0]))
-    with pytest.raises(ValueError, match="temperature"):
+    with pytest.raises(
+        ValueError, match=r"'temperature' must be finite and greater than"
+    ):
         emission.sound_power_comparison(levels, levels_ref, lw_ref, temperature=-300.0)
 
 
 def test_comparison_method_invalid_pressure_raises() -> None:
     levels, levels_ref, lw_ref = (np.array([80.0]), np.array([70.0]), np.array([90.0]))
-    with pytest.raises(ValueError, match="static_pressure"):
+    with pytest.raises(
+        ValueError, match=r"'static_pressure' must be finite and positive"
+    ):
         emission.sound_power_comparison(levels, levels_ref, lw_ref, static_pressure=0.0)
 
 
@@ -437,7 +459,10 @@ def test_volume_below_table1_minimum_warns() -> None:
     freqs = np.array([100.0, 500.0])
     t60 = np.array([1.5, 1.5])
     lp = np.array([80.0, 80.0])
-    with pytest.warns(emission.SoundPowerWarning, match="Table 1"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"Room volume .+ is below the ISO 3741 Table 1 minimum",
+    ):
         emission.sound_power_reverberation(lp, t60, 150.0, 210.0, freqs)
 
 
@@ -456,7 +481,10 @@ def test_fewer_than_six_positions_warns() -> None:
     freqs = np.array([1000.0])
     t60 = np.array([1.5])
     levels = np.array([[80.0], [80.1], [79.9]])  # 3 positions, tight spread
-    with pytest.warns(emission.SoundPowerWarning, match="microphone position"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"microphone position\(s\) were supplied; an unqualified reverberation room requires",
+    ):
         emission.sound_power_reverberation(levels, t60, 200.0, 210.0, freqs)
 
 
@@ -466,7 +494,10 @@ def test_interposition_std_above_criterion_warns() -> None:
     t60 = np.array([1.5])
     # Six positions with a large spread -> sM > 1,5 dB.
     levels = np.array([[70.0], [80.0], [72.0], [78.0], [71.0], [79.0]])
-    with pytest.warns(emission.SoundPowerWarning, match="standard deviation"):
+    with pytest.warns(
+        emission.SoundPowerWarning,
+        match=r"Inter-position standard deviation exceeds the ISO 3741 sM criterion",
+    ):
         emission.sound_power_reverberation(levels, t60, 200.0, 210.0, freqs)
 
 
@@ -495,7 +526,7 @@ def test_comparison_wrong_frequency_length_raises_clean_error() -> None:
     lw_ref = np.array([90.0, 91.0, 92.0])
     background = np.array([50.0, 51.0, 52.0])
     short_freqs = np.array([1000.0, 2000.0])  # wrong length (2 != 3)
-    with pytest.raises(ValueError, match="length must match"):
+    with pytest.raises(ValueError, match=r"'frequencies' length must match"):
         emission.sound_power_comparison(
             levels,
             levels_ref,

--- a/tests/emission/test_vibration_sound_power.py
+++ b/tests/emission/test_vibration_sound_power.py
@@ -43,7 +43,7 @@ def test_calibration_matches_hand_formula() -> None:
 
 
 def test_calibration_rejects_non_positive_frequency() -> None:
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency' must be positive"):
         emission.velocity_level_from_acceleration(9.81, 0.0)
 
 
@@ -103,7 +103,7 @@ def test_upper_limit_is_largest() -> None:
 
 
 def test_power_level_rejects_bad_area() -> None:
-    with pytest.raises(ValueError, match="area"):
+    with pytest.raises(ValueError, match=r"'area' must be positive"):
         emission.radiated_sound_power_level(80.0, 0.0)
 
 
@@ -208,7 +208,8 @@ def test_a_vibration_band_quantity_off_the_band_axis_is_refused(
     result = _four_band_determination()
     values = np.asarray(getattr(result, field_name))
     wrong = values[:-1] if trim else np.append(values, values[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    count = 3 if trim else 5  # the four-band fixture, one short or one long
+    with pytest.raises(ValueError, match=rf"'{field_name}' \({count}\)"):
         dataclasses.replace(result, **{field_name: wrong})
 
 
@@ -224,7 +225,7 @@ def test_a_stray_single_frequency_is_refused() -> None:
 
     result = _four_band_determination()
     one_band = np.asarray(result.frequencies)[2:3]
-    with pytest.raises(ValueError, match="'frequencies'"):
+    with pytest.raises(ValueError, match=r"'frequencies' \(1\)"):
         dataclasses.replace(result, frequencies=one_band)
 
 
@@ -250,7 +251,10 @@ def test_a_non_finite_band_quantity_is_refused(field_name: str) -> None:
     result = _four_band_determination()
     values = np.asarray(getattr(result, field_name), dtype=float).copy()
     values[1] = float("nan")
-    with pytest.raises(ValueError, match=f"VibrationSoundPowerResult: '{field_name}'"):
+    with pytest.raises(
+        ValueError,
+        match=f"VibrationSoundPowerResult: '{field_name}' must contain only finite",
+    ):
         dataclasses.replace(result, **{field_name: values})
 
 

--- a/tests/hearing/test_exposure_result_plots.py
+++ b/tests/hearing/test_exposure_result_plots.py
@@ -50,5 +50,5 @@ def test_exposure_plot_without_tasks_raises() -> None:
     levels = np.full(5, 80.0)
     res = ph.hearing.job_based_exposure(levels, 6.0)
     assert not res.tasks
-    with pytest.raises(ValueError, match="per-task"):
+    with pytest.raises(ValueError, match=r"plot\(\) needs per-task contributions"):
         res.plot()

--- a/tests/hearing/test_hearing.py
+++ b/tests/hearing/test_hearing.py
@@ -93,13 +93,15 @@ def test_subset_by_frequency() -> None:
 
 
 def test_invalid_inputs_raise() -> None:
-    with pytest.raises(ValueError, match="at least 18"):
+    with pytest.raises(ValueError, match=r"age must be at least \d+ years"):
         h.age_threshold(10, "male")
     with pytest.raises(ValueError, match="sex must be"):
         h.age_threshold(40, "other")
-    with pytest.raises(ValueError, match="fractile"):
+    with pytest.raises(ValueError, match=r"fractile must be in"):
         h.age_threshold(40, "male", fractile=1.0)
-    with pytest.raises(ValueError, match="audiometric frequency"):
+    with pytest.raises(
+        ValueError, match=r"frequency .* is not an ISO 7029 audiometric frequency"
+    ):
         h.age_threshold(40, "male", frequencies=[777.0])
     with pytest.raises(ValueError, match="field must be"):
         h.reference_threshold("random")
@@ -119,7 +121,10 @@ def test_a_spectrum_off_the_frequency_axis_is_refused(case: str) -> None:
         "long": np.append(result.threshold, result.threshold[-1]),
         "own-database": result.threshold[8:9],  # 4000 Hz alone
     }[case]
-    with pytest.raises(ValueError, match="'threshold'"):
+    with pytest.raises(
+        ValueError,
+        match=r"'threshold'.*must each carry one value per audiometric frequency",
+    ):
         dataclasses.replace(result, threshold=wrong)
 
 

--- a/tests/hearing/test_iso9612_report.py
+++ b/tests/hearing/test_iso9612_report.py
@@ -282,7 +282,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _two_task_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -290,5 +290,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _two_task_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/hearing/test_noise_induced_hearing_loss.py
+++ b/tests/hearing/test_noise_induced_hearing_loss.py
@@ -169,11 +169,11 @@ def test_frequency_subset() -> None:
 def test_invalid_inputs_raise() -> None:
     with pytest.raises(ValueError, match="years must be positive"):
         m.nipts(90.0, 0.0)
-    with pytest.raises(ValueError, match="fractile"):
+    with pytest.raises(ValueError, match=r"fractile must be in \(0, 1\)"):
         m.nipts(90.0, 20.0, 1.5)
     with pytest.raises(ValueError, match="not an ISO 1999"):
         m.nipts(90.0, 20.0, frequencies=[1234.0])
-    with pytest.raises(ValueError, match="at least 18"):
+    with pytest.raises(ValueError, match=r"age must be at least 18 years"):
         m.htlan(10, "male", 90.0, 20.0)
 
 
@@ -212,14 +212,23 @@ def test_combine_age_and_noise_matches_htlan() -> None:
 
 def test_outside_validated_domain_warns() -> None:
     """Conditions beyond the standard's stated ranges warn (but still compute)."""
-    with pytest.warns(m.NoiseInducedHearingLossWarning, match="1-40 year"):
+    with pytest.warns(
+        m.NoiseInducedHearingLossWarning,
+        match=r"exposure duration .* is outside the 1-40 year range",
+    ):
         m.nipts(90.0, 60.0, 0.5)
-    with pytest.warns(m.NoiseInducedHearingLossWarning, match="tails"):
+    with pytest.warns(
+        m.NoiseInducedHearingLossWarning,
+        match=r"fractile .* lies in the distribution tails",
+    ):
         m.nipts(90.0, 20.0, 0.99)
     with pytest.warns(m.NoiseInducedHearingLossWarning, match="exceeds the 100 dB"):
         m.nipts(130.0, 20.0, 0.5)
     # The htlan noise component inherits the same guards.
-    with pytest.warns(m.NoiseInducedHearingLossWarning, match="1-40 year"):
+    with pytest.warns(
+        m.NoiseInducedHearingLossWarning,
+        match=r"exposure duration .* is outside the 1-40 year range",
+    ):
         m.htlan(60, "male", 90.0, 60.0, 0.5)
 
 
@@ -243,7 +252,7 @@ def test_nipts_rejects_a_fractile_spectrum_of_another_length() -> None:
     """
     result = m.nipts(95.0, 20.0)
     on_another_grid = np.append(result.value, [12.0, 9.0])
-    with pytest.raises(ValueError, match="'value'"):
+    with pytest.raises(ValueError, match=rf"'value' \({on_another_grid.size}\)"):
         dataclasses.replace(result, value=on_another_grid)
 
 
@@ -256,7 +265,7 @@ def test_htlan_rejects_a_component_of_another_length() -> None:
     """
     result = m.htlan(60, "male", 95.0, 20.0, 0.5)
     one_frequency_short = result.nipts[:-1]
-    with pytest.raises(ValueError, match="'nipts'"):
+    with pytest.raises(ValueError, match=rf"'nipts' \({one_frequency_short.size}\)"):
         dataclasses.replace(result, nipts=one_frequency_short)
 
 
@@ -283,7 +292,10 @@ def test_nipts_rejects_nan_exposure_level() -> None:
 
 def test_nipts_rejects_nan_years() -> None:
     with (
-        pytest.warns(m.NoiseInducedHearingLossWarning, match="outside the 1-40"),
+        pytest.warns(
+            m.NoiseInducedHearingLossWarning,
+            match=r"exposure duration .* is outside the 1-40 year range",
+        ),
         pytest.raises(ValueError, match="'years' must be finite"),
     ):
         m.nipts(l_ex=85.0, years=float("nan"))

--- a/tests/hearing/test_noise_induced_hearing_loss_report.py
+++ b/tests/hearing/test_noise_induced_hearing_loss_report.py
@@ -240,7 +240,7 @@ def test_nipts_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = nipts(90.0, 20.0, 0.9)
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         res.report(out, engine="weasyprint")
 
 
@@ -248,5 +248,5 @@ def test_htlan_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = htlan(60, "male", 95.0, 30.0, 0.5)
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         res.report(out, language="xx")

--- a/tests/hearing/test_occupational_exposure.py
+++ b/tests/hearing/test_occupational_exposure.py
@@ -11,6 +11,7 @@ Table 1) anchor the remaining behaviour.
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import pytest
@@ -318,7 +319,7 @@ def test_task_rejects_nonpositive_duration() -> None:
 
 
 def test_task_rejects_empty_samples() -> None:
-    with pytest.raises(ValueError, match="sample"):
+    with pytest.raises(ValueError, match=r"A Task needs at least one Lp,A,eqT sample"):
         Task(samples=(), duration_hours=8.0)
 
 
@@ -337,7 +338,7 @@ def test_task_rejects_nan_duration() -> None:
 
 
 def test_job_based_rejects_nonpositive_sample_duration() -> None:
-    with pytest.raises(ValueError, match="sample_duration_hours"):
+    with pytest.raises(ValueError, match=r"'sample_duration_hours' must be positive"):
         job_based_exposure(
             [80.0, 82.0, 81.0], 8.0, n_workers=6, sample_duration_hours=0.0
         )
@@ -434,7 +435,7 @@ def test_a_task_result_without_its_task_contributions_is_refused() -> None:
 
 def test_result_dataclasses_are_frozen() -> None:
     result = job_based_exposure([80.0, 82.0, 81.0, 83.0, 80.0], 8.0)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         result.lex_8h = 0.0  # type: ignore[misc]
     tc = TaskContribution(
         label="x",
@@ -451,7 +452,7 @@ def test_result_dataclasses_are_frozen() -> None:
         u2=0.7,
         u3=1.0,
     )
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         tc.u1a = 1.0  # type: ignore[misc]
     assert isinstance(result, ExposureResult)
 

--- a/tests/metrology/test_calibration_validation.py
+++ b/tests/metrology/test_calibration_validation.py
@@ -43,7 +43,9 @@ def test_stable_tone_no_warning() -> None:
 
 def test_unstable_tone_warns() -> None:
     """5% AM -> ~0.4 dB fluctuation, far beyond the 0.10 dB class 1 limit."""
-    with pytest.warns(metrology.CalibrationWarning, match="fluctuation"):
+    with pytest.warns(
+        metrology.CalibrationWarning, match=r"Calibration tone level fluctuation is"
+    ):
         metrology.sensitivity(_cal_tone(am_depth=0.05), fs=FS)
 
 
@@ -60,7 +62,9 @@ def test_validation_needs_fs_and_is_skipped_without_it() -> None:
     on the `validate` row instead of only three lines above it.
     """
     unstable = _cal_tone(am_depth=0.05)
-    with pytest.warns(metrology.CalibrationWarning, match="fluctuation"):
+    with pytest.warns(
+        metrology.CalibrationWarning, match=r"Calibration tone level fluctuation is"
+    ):
         with_fs = metrology.sensitivity(unstable, fs=FS, validate=True)
     with _assert_no_calibration_warning():
         without_fs = metrology.sensitivity(unstable, validate=True)
@@ -76,7 +80,7 @@ def test_custom_fluctuation_limit() -> None:
 
 def test_empty_reference_raises() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Reference signal is empty"):
         metrology.sensitivity(empty, fs=FS)
 
 
@@ -97,7 +101,9 @@ def test_default_limit_follows_iec_60942_2017_table2() -> None:
     within the 0.20 dB limit for a 31.5-63 Hz nominal frequency (Table 2).
     """
     x = _cal_tone(am_depth=0.015)
-    with pytest.warns(metrology.CalibrationWarning, match="Table 2"):
+    with pytest.warns(
+        metrology.CalibrationWarning, match=r"Calibration tone level fluctuation is"
+    ):
         metrology.sensitivity(x, fs=FS)
     with _assert_no_calibration_warning():
         metrology.sensitivity(x, fs=FS, frequency=50.0)
@@ -110,7 +116,9 @@ def test_asymmetric_fluctuation_uses_max_min_vs_mean() -> None:
     # 200 ms one-sided level dip of ~0.2 dB in the settled region
     i0, i1 = int(3.0 * FS), int(3.2 * FS)
     dip[i0:i1] = 10 ** (-0.2 / 20)
-    with pytest.warns(metrology.CalibrationWarning, match="fluctuation"):
+    with pytest.warns(
+        metrology.CalibrationWarning, match=r"Calibration tone level fluctuation is"
+    ):
         metrology.sensitivity(x * dip, fs=FS)
 
 
@@ -170,8 +178,12 @@ def test_sensitivity_rejects_non_finite_samples() -> None:
 
     sig = np.sin(2 * np.pi * 1000.0 * np.arange(4800) / 48000.0)
     sig[100] = np.nan
-    with pytest.raises(ValueError, match="non-finite"):
+    with pytest.raises(
+        ValueError, match=r"Reference signal contains non-finite samples"
+    ):
         metrology.sensitivity(sig, fs=48000)
     sig[100] = np.inf
-    with pytest.raises(ValueError, match="non-finite"):
+    with pytest.raises(
+        ValueError, match=r"Reference signal contains non-finite samples"
+    ):
         metrology.sensitivity(sig, fs=48000)

--- a/tests/metrology/test_data_qualification.py
+++ b/tests/metrology/test_data_qualification.py
@@ -178,18 +178,18 @@ def test_runs_test_discards_median_ties() -> None:
 
 def test_trend_test_validation() -> None:
     short = [1.0] * 9
-    with pytest.raises(ValueError, match="at least 10"):
+    with pytest.raises(ValueError, match=r"'values' must hold at least"):
         ph.metrology.trend_test(short)
     two_dim = np.ones((5, 4))
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'values' must be one-dimensional"):
         ph.metrology.trend_test(two_dim)
     with_nan = np.r_[np.arange(19.0), np.nan]
     with pytest.raises(ValueError, match="'values' must be finite"):
         ph.metrology.trend_test(with_nan)
     good = list(range(12))
-    with pytest.raises(ValueError, match="method"):
+    with pytest.raises(ValueError, match=r"'method' must be one of"):
         ph.metrology.trend_test(good, method="chi2")
-    with pytest.raises(ValueError, match="alpha"):
+    with pytest.raises(ValueError, match=r"'alpha' must be inside"):
         ph.metrology.trend_test(good, alpha=1.5)
     constant = np.ones(12)
     with pytest.raises(ValueError, match="distinct from the median"):
@@ -297,13 +297,13 @@ def test_stationarity_trailing_samples_are_discarded() -> None:
 def test_stationarity_validation() -> None:
     rng = np.random.default_rng(7)
     x = rng.standard_normal(2048)
-    with pytest.raises(ValueError, match="statistic"):
+    with pytest.raises(ValueError, match=r"'statistic' must be one of"):
         ph.metrology.stationarity_test(x, FS, statistic="kurtosis")
-    with pytest.raises(ValueError, match="n_segments"):
+    with pytest.raises(ValueError, match=r"'n_segments' must be between"):
         ph.metrology.stationarity_test(x, FS, n_segments=5)
-    with pytest.raises(ValueError, match="n_segments"):
+    with pytest.raises(ValueError, match=r"'n_segments' must be between"):
         ph.metrology.stationarity_test(x, FS, n_segments=4096)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.metrology.stationarity_test(x, 0.0)
 
 
@@ -398,10 +398,10 @@ def test_level_crossing_default_levels_and_validation() -> None:
     assert res.levels[0] == pytest.approx(-3.0 * res.sigma)
     assert res.levels[-1] == pytest.approx(3.0 * res.sigma)
     constant = np.ones(4096)
-    with pytest.raises(ValueError, match="constant"):
+    with pytest.raises(ValueError, match=r"'x' must not be constant"):
         ph.metrology.level_crossing_rate(constant, FS)
     empty_levels: list[float] = []
-    with pytest.raises(ValueError, match="levels"):
+    with pytest.raises(ValueError, match=r"'levels' must be a non-empty"):
         ph.metrology.level_crossing_rate(x, FS, levels=empty_levels)
     nan_levels = [0.0, np.nan]
     with pytest.raises(ValueError, match="'levels' must be finite"):
@@ -497,7 +497,7 @@ def test_peak_statistics_validation_and_fields() -> None:
     assert np.all(np.diff(res.peak_values) >= 0.0)  # sorted
     assert res.duration == pytest.approx((x.size - 1) / FS)
     constant = np.zeros(4096)
-    with pytest.raises(ValueError, match="constant"):
+    with pytest.raises(ValueError, match=r"'x' must not be constant"):
         ph.metrology.peak_statistics(constant, FS)
 
 
@@ -699,6 +699,6 @@ def test_plots_render_and_return_axes() -> None:
 def test_peak_plot_without_maxima_raises() -> None:
     ramp_result = ph.metrology.peak_statistics(np.linspace(0.0, 1.0, 4096) ** 2, FS)
     assert ramp_result.peak_values.size == 0
-    with pytest.raises(ValueError, match="maxima"):
+    with pytest.raises(ValueError, match=r"has no local maxima to plot"):
         ramp_result.plot()
     plt.close("all")

--- a/tests/metrology/test_metrology_result_plots.py
+++ b/tests/metrology/test_metrology_result_plots.py
@@ -51,5 +51,7 @@ def test_monte_carlo_plot_without_samples_raises() -> None:
         lambda a, b, c: a + b + c, _MC_QUANTITIES, trials=200, seed=7
     )
     assert res.samples is None
-    with pytest.raises(ValueError, match="keep_samples"):
+    with pytest.raises(
+        ValueError, match=r"plot\(\) needs the Monte Carlo output samples"
+    ):
         res.plot()

--- a/tests/metrology/test_uncertainty.py
+++ b/tests/metrology/test_uncertainty.py
@@ -163,15 +163,15 @@ def test_monte_carlo_triangular_tiny_uncertainty() -> None:
 
 
 def test_invalid_inputs_raise() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"'uncertainty' must be non-negative"):
         u.Quantity(0.0, -1.0)
-    with pytest.raises(ValueError, match="distribution"):
+    with pytest.raises(ValueError, match=r"distribution must be one of"):
         u.Quantity(0.0, 1.0, "weird")
     with pytest.raises(ValueError, match="dof must be positive"):
         u.Quantity(0.0, 1.0, dof=0.0)
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match="at least one input quantity is required"):
         u.combine_uncertainty(lambda: 0.0, [])
-    with pytest.raises(ValueError, match="coverage"):
+    with pytest.raises(ValueError, match=r"coverage must be in \(0, 1\)"):
         u.coverage_factor(1.5)
     pair = [u.Quantity(0, 1)] * 2
     wrong_shape = np.eye(3)
@@ -179,23 +179,23 @@ def test_invalid_inputs_raise() -> None:
     non_unit_diagonal = np.array([[1.0, 0.0], [0.0, 0.9]])
     # Symmetric, unit diagonal, but indefinite (|r| > 1).
     indefinite = np.array([[1.0, 1.5], [1.5, 1.0]])
-    with pytest.raises(ValueError, match="shape"):
+    with pytest.raises(ValueError, match=r"correlation must have shape"):
         u.combine_uncertainty(_add4, pair, correlation=wrong_shape)
-    with pytest.raises(ValueError, match="symmetric"):
+    with pytest.raises(ValueError, match=r"correlation matrix must be symmetric"):
         u.combine_uncertainty(_add2, pair, correlation=asymmetric)
-    with pytest.raises(ValueError, match="diagonal"):
+    with pytest.raises(ValueError, match=r"correlation matrix diagonal must be 1\.0"):
         u.combine_uncertainty(_add2, pair, correlation=non_unit_diagonal)
     with pytest.raises(ValueError, match="positive semi-definite"):
         u.combine_uncertainty(_add2, pair, correlation=indefinite)
     quantities = [u.Quantity(0, 1)]
-    with pytest.raises(ValueError, match="trials"):
+    with pytest.raises(ValueError, match=r"trials must be at least 2"):
         u.monte_carlo(_add4, quantities, trials=0)
-    with pytest.raises(ValueError, match="at least 2"):
+    with pytest.raises(ValueError, match=r"trials must be at least 2"):
         # trials=1 used to return NaN (ddof=1) with a raw numpy warning.
         u.monte_carlo(_add4, quantities, trials=1)
-    with pytest.raises(ValueError, match="coverage"):
+    with pytest.raises(ValueError, match=r"coverage must be in \(0, 1\)"):
         u.monte_carlo(_add4, quantities, coverage=2.0)
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(ValueError, match="at least one input quantity is required"):
         u.monte_carlo(_add4, [])
 
 
@@ -223,7 +223,10 @@ def test_correlated_budget_requires_explicit_coverage_factor() -> None:
     """
     qs = [u.Quantity(10.0, 0.1, dof=5), u.Quantity(10.0, 0.1, dof=5)]
     r = np.array([[1.0, 0.999], [0.999, 1.0]])
-    with pytest.warns(u.UncertaintyWarning, match="Welch-Satterthwaite"):
+    with pytest.warns(
+        u.UncertaintyWarning,
+        match=r"Welch-Satterthwaite.*is defined for independent inputs",
+    ):
         result = u.combine_uncertainty(lambda a, b: a - b, qs, correlation=r)
     assert math.isnan(result.effective_dof)
     # uc = sqrt(2*(1-r)) * 0.1 ~ 0.00447; sane (was ~1e149 via the
@@ -231,7 +234,13 @@ def test_correlated_budget_requires_explicit_coverage_factor() -> None:
     assert result.combined_uncertainty == pytest.approx(
         0.1 * math.sqrt(2.0 * (1.0 - 0.999)), rel=1e-6
     )
-    with pytest.raises(ValueError, match="coverage_factor_override"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"effective degrees of freedom are undefined for a correlated budget"
+            r".*pass an explicit coverage_factor_override"
+        ),
+    ):
         result.expanded(0.95)
     k, big = result.expanded(coverage_factor_override=2.0)
     assert k == 2.0
@@ -483,7 +492,10 @@ def test_undefined_effective_dof_is_not_a_non_finite_number() -> None:
     must keep asking for an explicit coverage factor there.
     """
     pair = [u.Quantity(0.0, 1.0, dof=5), u.Quantity(0.0, 1.0, dof=5)]
-    with pytest.warns(u.UncertaintyWarning, match="Welch-Satterthwaite"):
+    with pytest.warns(
+        u.UncertaintyWarning,
+        match=r"Welch-Satterthwaite.*is defined for independent inputs",
+    ):
         correlated = u.combine_uncertainty(
             _add2, pair, correlation=np.array([[1.0, 0.5], [0.5, 1.0]])
         )
@@ -546,5 +558,8 @@ def test_monte_carlo_rejects_model_with_non_finite_output() -> None:
         return np.where(x < 0.0, np.nan, 0.0)
 
     inputs = [u.Quantity(0.0, 1.0, name="x")]
-    with pytest.raises(ValueError, match=r"'model' returned a non-finite output"):
+    with pytest.raises(
+        ValueError,
+        match=r"'model' returned a non-finite output for \d+ of \d+ trials",
+    ):
         u.monte_carlo(partial_model, inputs, trials=2000, seed=1)

--- a/tests/noise_control/test_duct_modes.py
+++ b/tests/noise_control/test_duct_modes.py
@@ -106,12 +106,17 @@ def test_plane_wave_limit_accepts_area_and_rectangle() -> None:
 
 
 def test_plane_wave_limit_requires_a_cross_section() -> None:
-    with pytest.raises(ValueError, match="diameter"):
+    with pytest.raises(
+        ValueError, match=r"give 'diameter', or both 'width' and 'height', or 'area'"
+    ):
         duct_modes.plane_wave_limit()
 
 
 def test_warn_above_plane_wave_limit() -> None:
-    with pytest.warns(duct_modes.PlaneWaveWarning, match="264 Hz"):
+    with pytest.warns(
+        duct_modes.PlaneWaveWarning,
+        match=r"test duct: .* above the first duct cut-on frequency",
+    ):
         mask = duct_modes.warn_above_plane_wave_limit(
             [125.0, 250.0, 500.0, 1000.0], 263.6, "test duct"
         )
@@ -128,11 +133,17 @@ def test_no_warning_below_the_limit() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"diameter": 0.0}, "diameter"),
-        ({"diameter": 0.2, "flow_velocity": -1.0}, "flow_velocity"),
-        ({"diameter": 0.2, "flow_velocity": 400.0}, "subsonic"),
-        ({"diameter": 0.2, "count": 0}, "count"),
-        ({"diameter": 0.2, "count": 13}, "count"),
+        ({"diameter": 0.0}, r"'diameter' must be positive"),
+        (
+            {"diameter": 0.2, "flow_velocity": -1.0},
+            r"'flow_velocity' must be non-negative",
+        ),
+        (
+            {"diameter": 0.2, "flow_velocity": 400.0},
+            r"'flow_velocity' must be subsonic",
+        ),
+        ({"diameter": 0.2, "count": 0}, r"'count' must be between"),
+        ({"diameter": 0.2, "count": 13}, r"'count' must be between"),
     ],
 )
 def test_circular_validation(kwargs: dict[str, float], match: str) -> None:
@@ -143,10 +154,13 @@ def test_circular_validation(kwargs: dict[str, float], match: str) -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"width": 0.0, "height": 0.4}, "width"),
-        ({"width": 0.65, "height": -0.4}, "height"),
-        ({"width": 0.65, "height": 0.4, "count": 0}, "count"),
-        ({"width": 0.65, "height": 0.4, "flow_velocity": 400.0}, "subsonic"),
+        ({"width": 0.0, "height": 0.4}, r"'width' must be positive"),
+        ({"width": 0.65, "height": -0.4}, r"'height' must be positive"),
+        ({"width": 0.65, "height": 0.4, "count": 0}, r"'count' must be at least"),
+        (
+            {"width": 0.65, "height": 0.4, "flow_velocity": 400.0},
+            r"'flow_velocity' must be subsonic",
+        ),
     ],
 )
 def test_rectangular_validation(kwargs: dict[str, float], match: str) -> None:
@@ -178,7 +192,7 @@ def test_plot_draws_both_ladders_and_shades_the_plane_wave_band() -> None:
 def test_plot_language_is_validated() -> None:
     pytest.importorskip("matplotlib")
     res = duct_modes.rectangular_duct_cut_on(0.65, 0.4)
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         res.plot(language="xx")
 
 

--- a/tests/noise_control/test_duct_path.py
+++ b/tests/noise_control/test_duct_path.py
@@ -339,7 +339,9 @@ def test_rc_criterion_family() -> None:
 
 
 def test_section_declares_the_plane_wave_limit() -> None:
-    with pytest.warns(PlaneWaveWarning, match="Supply"):
+    with pytest.warns(
+        PlaneWaveWarning, match=r"Supply: .* above the first duct cut-on frequency"
+    ):
         duct_path(
             OCTAVE_BANDS,
             FAN_LW,
@@ -359,11 +361,20 @@ def test_no_section_means_no_validity_warning() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"frequencies": [], "source_level": []}, "frequencies"),
-        ({"criterion": "NR"}, "criterion"),
-        ({"target": float("nan")}, "target"),
-        ({"source_level": [1.0, 2.0]}, "source_level"),
-        ({"room_effect": [1.0, 2.0]}, "room_effect"),
+        (
+            {"frequencies": [], "source_level": []},
+            r"'frequencies' must be a non-empty 1-D array",
+        ),
+        ({"criterion": "NR"}, r"'criterion' must be one of"),
+        ({"target": float("nan")}, r"'target' must be a finite criterion value"),
+        (
+            {"source_level": [1.0, 2.0]},
+            r"'source_level' must be a scalar or have one value per band",
+        ),
+        (
+            {"room_effect": [1.0, 2.0]},
+            r"'room_effect' must be a scalar or have one value per band",
+        ),
     ],
 )
 def test_duct_path_validation(kwargs: dict[str, object], match: str) -> None:
@@ -378,18 +389,22 @@ def test_duct_path_validation(kwargs: dict[str, object], match: str) -> None:
 
 
 def test_elements_must_be_duct_elements() -> None:
-    with pytest.raises(TypeError, match="DuctElement"):
+    with pytest.raises(TypeError, match=r"'elements' must hold DuctElement entries"):
         duct_path(OCTAVE_BANDS, FAN_LW, ["not an element"])  # type: ignore[list-item]
 
 
 def test_element_spectrum_must_be_finite() -> None:
     elements = [DuctElement("Duct", [1, 2, 3, 4, 5, 6, 7, np.nan])]
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"'elements\[0\]\.attenuation' must be finite"
+    ):
         duct_path(OCTAVE_BANDS, FAN_LW, elements)
 
 
 def test_combine_requires_at_least_one_path() -> None:
-    with pytest.raises(ValueError, match="at least one"):
+    with pytest.raises(
+        ValueError, match=r"'paths' must hold at least one DuctPathResult"
+    ):
         combine_duct_paths([])
 
 
@@ -430,7 +445,10 @@ def test_a_stage_row_off_the_band_axis_is_refused(field_name: str, trim: bool) -
     # The stage itself carries no guard, so it is built outside the block:
     # what is under test is the sheet refusing to hold it.
     stages = (dataclasses.replace(stage, **{field_name: wrong}), *result.stages[1:])
-    with pytest.raises(ValueError, match=f"'stages\\[0\\]\\.{field_name}'"):
+    with pytest.raises(
+        ValueError,
+        match=f"'stages\\[0\\]\\.{field_name}'.*must each carry one value per band",
+    ):
         dataclasses.replace(result, stages=stages)
 
 
@@ -467,7 +485,9 @@ def test_a_room_effect_off_the_band_axis_is_refused() -> None:
     """The room effect is applied band by band, so it must have the bands."""
     result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
     one_band_short = np.zeros(len(OCTAVE_BANDS) - 1)
-    with pytest.raises(ValueError, match="'room_effect'"):
+    with pytest.raises(
+        ValueError, match=r"'room_effect'.*must each carry one value per band"
+    ):
         dataclasses.replace(result, room_effect=one_band_short)
 
 
@@ -500,7 +520,7 @@ def test_a_single_number_where_a_spectrum_belongs_says_so(
     """
     result = _build(SUPPLY_ELEMENTS, SUPPLY_ROOM_EFFECT, "Supply")
     scalar_field = build(result)
-    with pytest.raises(ValueError, match=f"'{re.escape(what)}'"):
+    with pytest.raises(ValueError, match=f"'{re.escape(what)}' must have one axis"):
         dataclasses.replace(result, **scalar_field)
 
 

--- a/tests/noise_control/test_duct_path_report.py
+++ b/tests/noise_control/test_duct_path_report.py
@@ -254,14 +254,14 @@ def test_a_long_path_still_renders_on_one_page(tmp_path: Path, verbose: bool) ->
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     res = _supply()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
 def test_unknown_language_rejected(tmp_path: Path) -> None:
     res = _supply()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")
 
 
@@ -284,5 +284,5 @@ def test_plot_returns_axes() -> None:
 def test_plot_language_is_validated() -> None:
     pytest.importorskip("matplotlib")
     res = _supply()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.plot(language="xx")

--- a/tests/noise_control/test_enclosure_report.py
+++ b/tests/noise_control/test_enclosure_report.py
@@ -212,7 +212,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -220,5 +220,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/noise_control/test_enclosures.py
+++ b/tests/noise_control/test_enclosures.py
@@ -74,7 +74,10 @@ def test_callable_panel_r() -> None:
 
 
 def test_callable_requires_frequencies() -> None:
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequencies' is required when 'panel_transmission_loss' is a callable",
+    ):
         noise_control.enclosure_insertion_loss(lambda f: f, 6.0, 5.0, 0.3)
 
 
@@ -178,7 +181,10 @@ def test_required_transmission_loss_callable_and_result_shape() -> None:
 
     mpl.use("Agg")
     assert res.plot().get_ylabel()
-    with pytest.raises(ValueError, match="frequencies"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequencies' is required when 'insertion_loss' is a callable",
+    ):
         noise_control.enclosure_required_transmission_loss(lambda f: f, 6.0, 5.0, 0.3)
 
 
@@ -187,7 +193,7 @@ def test_validation() -> None:
         noise_control.enclosure_insertion_loss([20.0], -1.0, 5.0, 0.3)
     with pytest.raises(ValueError, match="'internal_absorption' must lie strictly in"):
         noise_control.enclosure_insertion_loss([20.0], 6.0, 5.0, 1.0)
-    with pytest.raises(ValueError, match="model"):
+    with pytest.raises(ValueError, match=r"'model' must be one of"):
         noise_control.enclosure_insertion_loss([20.0], 6.0, 5.0, 0.3, model="hansen")
 
 
@@ -203,7 +209,9 @@ def test_absorption_off_the_band_count_is_refused_by_name() -> None:
 def test_empty_absorption_is_refused() -> None:
     # An empty array passes every vacuous np.any/np.all test and used to
     # come back as an empty result instead of raising.
-    with pytest.raises(ValueError, match="'internal_absorption' must be a scalar"):
+    with pytest.raises(
+        ValueError, match="'internal_absorption' must be a scalar or a non-empty"
+    ):
         noise_control.enclosure_insertion_loss([20.0], 12.0, 20.0, [])
 
 

--- a/tests/noise_control/test_hvac_long.py
+++ b/tests/noise_control/test_hvac_long.py
@@ -106,9 +106,9 @@ def test_fan_casing_attenuation_table_13_8() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"fan_type": "turbine"}, "fan_type"),
-        ({"relative_efficiency": 0.0}, "relative_efficiency"),
-        ({"relative_efficiency": 101.0}, "100"),
+        ({"fan_type": "turbine"}, r"'fan_type' must be one of"),
+        ({"relative_efficiency": 0.0}, r"'relative_efficiency' must be positive"),
+        ({"relative_efficiency": 101.0}, r"'relative_efficiency' must not exceed"),
     ],
 )
 def test_fan_sound_power_validation(kwargs: dict[str, object], match: str) -> None:
@@ -117,7 +117,7 @@ def test_fan_sound_power_validation(kwargs: dict[str, object], match: str) -> No
 
 
 def test_blade_passing_frequency_validation() -> None:
-    with pytest.raises(ValueError, match="blades"):
+    with pytest.raises(ValueError, match=r"'blades' must be a positive integer"):
         hvac.blade_passing_frequency(1200.0, 0)
 
 
@@ -332,7 +332,7 @@ def test_end_reflection_methods_agree_within_a_few_decibels() -> None:
 
 
 def test_end_reflection_unknown_method() -> None:
-    with pytest.raises(ValueError, match="method"):
+    with pytest.raises(ValueError, match=r"'method' must be one of"):
         hvac.end_reflection_loss([125.0], 0.3, method="ashrae")
 
 
@@ -363,9 +363,9 @@ def test_split_loss_eq_14_17_with_area_mismatch() -> None:
 @pytest.mark.parametrize(
     ("args", "match"),
     [
-        ((0.0, [0.1]), "main_area"),
-        ((0.6, []), "branch_areas"),
-        ((0.6, [0.1, -0.2]), "positive"),
+        ((0.0, [0.1]), r"'main_area' must be positive"),
+        ((0.6, []), r"'branch_areas' must be a non-empty"),
+        ((0.6, [0.1, -0.2]), r"'branch_areas' must be positive"),
     ],
 )
 def test_split_loss_validation(args: tuple[object, ...], match: str) -> None:
@@ -374,7 +374,7 @@ def test_split_loss_validation(args: tuple[object, ...], match: str) -> None:
 
 
 def test_split_loss_branch_index_out_of_range() -> None:
-    with pytest.raises(ValueError, match="branch"):
+    with pytest.raises(ValueError, match=r"'branch' must index 'branch_areas'"):
         hvac.split_loss(0.6, [0.3, 0.3], branch=2)
 
 
@@ -403,7 +403,7 @@ def test_silencer_self_noise_velocity_exponent() -> None:
 
 
 def test_silencer_self_noise_requires_passages() -> None:
-    with pytest.raises(ValueError, match="passages"):
+    with pytest.raises(ValueError, match=r"'passages' must be a positive integer"):
         hvac.silencer_self_noise(None, 10.0, 0, 0.9)
 
 
@@ -449,9 +449,9 @@ def test_splitter_silencer_combines_by_eq_8_241() -> None:
 @pytest.mark.parametrize(
     ("args", "match"),
     [
-        ((None, 0.6, 1.5, [], 0.2), "airway_widths"),
-        ((None, 0.6, 1.5, [0.1, 0.0], 0.2), "positive"),
-        ((None, 0.6, 1.5, 0.1, 0.0), "splitter_thickness"),
+        ((None, 0.6, 1.5, [], 0.2), r"'airway_widths' must be a non-empty"),
+        ((None, 0.6, 1.5, [0.1, 0.0], 0.2), r"'airway_widths' must be positive"),
+        ((None, 0.6, 1.5, 0.1, 0.0), r"'splitter_thickness' must be positive"),
     ],
 )
 def test_splitter_silencer_validation(args: tuple[object, ...], match: str) -> None:
@@ -560,11 +560,11 @@ def test_diffuser_sound_power_counts_identical_devices() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"face_area": 0.0}, "face_area"),
-        ({"volume_flow": 0.0}, "volume_flow"),
-        ({"pressure_drop": -1.0}, "pressure_drop"),
-        ({"shape": "slot"}, "shape"),
-        ({"count": 0}, "count"),
+        ({"face_area": 0.0}, r"'face_area' must be positive"),
+        ({"volume_flow": 0.0}, r"'volume_flow' must be positive"),
+        ({"pressure_drop": -1.0}, r"'pressure_drop' must be positive"),
+        ({"shape": "slot"}, r"'shape' must be one of"),
+        ({"count": 0}, r"'count' must be a positive integer"),
         ({"count": 1.5}, "'count' must be a positive integer"),
     ],
 )
@@ -598,9 +598,9 @@ def test_air_terminal_velocity_limit_ashrae_table_9(
 
 
 def test_air_terminal_velocity_limit_validation() -> None:
-    with pytest.raises(ValueError, match="design_criterion"):
+    with pytest.raises(ValueError, match=r"'design_criterion' must be one of"):
         hvac.air_terminal_velocity_limit(20)
-    with pytest.raises(ValueError, match="opening"):
+    with pytest.raises(ValueError, match=r"'opening' must be one of"):
         hvac.air_terminal_velocity_limit(30, opening="exhaust")
 
 
@@ -635,9 +635,9 @@ def test_air_terminal_damper_correction_ashrae_table_10(
 
 
 def test_air_terminal_damper_correction_validation() -> None:
-    with pytest.raises(ValueError, match="pressure_ratio"):
+    with pytest.raises(ValueError, match=r"'pressure_ratio' must be positive"):
         hvac.air_terminal_damper_correction(0.0)
-    with pytest.raises(ValueError, match="location"):
+    with pytest.raises(ValueError, match=r"'location' must be one of"):
         hvac.air_terminal_damper_correction(3.0, location="fan")
 
 
@@ -664,9 +664,11 @@ def test_room_effect_accepts_a_per_band_room_constant() -> None:
 
 
 def test_room_effect_validation() -> None:
-    with pytest.raises(ValueError, match="distance"):
+    with pytest.raises(ValueError, match=r"'distance' must be positive"):
         hvac.room_effect(0.0, 50.0)
-    with pytest.raises(ValueError, match="room_constant"):
+    with pytest.raises(
+        ValueError, match=r"'room_constant' must be positive and finite"
+    ):
         hvac.room_effect(3.0, 0.0)
 
 

--- a/tests/noise_control/test_hvac_report.py
+++ b/tests/noise_control/test_hvac_report.py
@@ -237,7 +237,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -245,5 +245,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/noise_control/test_room_to_room.py
+++ b/tests/noise_control/test_room_to_room.py
@@ -178,7 +178,7 @@ def test_rc_criterion_family() -> None:
     assert result.criterion_curve is not None
     # The six bands of this chain are short of the 31.5 Hz to 4 kHz span
     # clause D.4 asks for, which the rating reports as a warning.
-    with pytest.warns(UserWarning, match="D.4"):
+    with pytest.warns(UserWarning, match=r"clause D\.4 rates a spectrum that includes"):
         assert result.rating.__class__.__name__ == "RCResult"
 
 
@@ -204,46 +204,59 @@ def test_source_description_is_exclusive() -> None:
     all still raises, because the empty default is built here and rejects
     itself for the same reason.
     """
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(
+        ValueError, match=r"give exactly one of 'level'.*or 'power_level'"
+    ):
         noise_control.room_to_room_transmission(_BANDS, 40.0, 20.0, _ABSORPTION)
-    with pytest.raises(ValueError, match="exactly one"):
+    with pytest.raises(
+        ValueError, match=r"give exactly one of 'level'.*or 'power_level'"
+    ):
         noise_control.SourceRoom(level=90.0, power_level=100.0)
-    with pytest.raises(ValueError, match="room_constant"):
+    with pytest.raises(
+        ValueError, match=r"'room_constant' is required with 'power_level'"
+    ):
         noise_control.SourceRoom(power_level=100.0)
 
 
 def test_validation() -> None:
     """Malformed bands, spectra, areas, absorption and options are rejected."""
     source = noise_control.SourceRoom(level=90.0)
-    with pytest.raises(ValueError, match="non-empty 1-D"):
+    with pytest.raises(
+        ValueError, match=r"'frequencies' must be a non-empty 1-D array"
+    ):
         noise_control.room_to_room_transmission([], 40.0, 20.0, 20.0, source=source)
-    with pytest.raises(ValueError, match="one value per band"):
+    with pytest.raises(
+        ValueError,
+        match=r"'transmission_loss' must be a scalar or have one value per band",
+    ):
         noise_control.room_to_room_transmission(
             _BANDS, [40.0, 41.0], 20.0, _ABSORPTION, source=source
         )
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'transmission_loss' must be finite"):
         noise_control.room_to_room_transmission(
             _BANDS, _NAN_SPECTRUM, 20.0, _ABSORPTION, source=source
         )
-    with pytest.raises(ValueError, match="partition_area"):
+    with pytest.raises(ValueError, match=r"'partition_area' must be positive"):
         noise_control.room_to_room_transmission(
             _BANDS, 40.0, 0.0, _ABSORPTION, source=source
         )
-    with pytest.raises(ValueError, match="receiving_absorption"):
+    with pytest.raises(ValueError, match=r"'receiving_absorption' must be positive"):
         noise_control.room_to_room_transmission(
             _BANDS, 40.0, 20.0, _NO_ABSORPTION, source=source
         )
     negative_flanking = noise_control.DesignCriterion(flanking_penalty=-1.0)
-    with pytest.raises(ValueError, match="flanking_penalty"):
+    with pytest.raises(
+        ValueError, match=r"'criterion\.flanking_penalty' must be non-negative"
+    ):
         _chain(criterion=negative_flanking)
     unknown_family = noise_control.DesignCriterion(family="NR")
-    with pytest.raises(ValueError, match="criterion"):
+    with pytest.raises(ValueError, match=r"'criterion' must be one of"):
         _chain(criterion=unknown_family)
     unknown_model = noise_control.SourceRoom(level=_SOURCE, model="constant_energy")
-    with pytest.raises(ValueError, match="model"):
+    with pytest.raises(ValueError, match=r"'source\.model' must be one of"):
         _chain(source=unknown_model)
     nan_target = noise_control.DesignCriterion(target=_NAN)
-    with pytest.raises(ValueError, match="target"):
+    with pytest.raises(ValueError, match=r"'target' must be a finite criterion value"):
         _chain(criterion=nan_target)
 
 
@@ -281,7 +294,10 @@ def test_a_spectrum_off_the_band_axis_is_refused(field_name: str, trim: bool) ->
     result = _powered_chain()
     row = np.asarray(getattr(result, field_name))
     wrong = row[:-1] if trim else np.append(row, row[-1])
-    with pytest.raises(ValueError, match=f"'{field_name}'"):
+    # The guard names every field of the result, so the identifier alone would
+    # match whichever row was short. The count is the test's own: it is what
+    # this test made wrong, and it is the only thing that says so.
+    with pytest.raises(ValueError, match=rf"'{field_name}' \({wrong.size}\)"):
         dataclasses.replace(result, **{field_name: wrong})
 
 
@@ -308,7 +324,7 @@ def test_a_single_absorption_number_is_refused() -> None:
         criterion=noise_control.DesignCriterion(target=45.0),
     )
     one_number = float(graded[0])
-    with pytest.raises(ValueError, match="'receiving_absorption'"):
+    with pytest.raises(ValueError, match=r"'receiving_absorption' must have one axis"):
         dataclasses.replace(result, receiving_absorption=one_number)
 
 

--- a/tests/noise_control/test_silencer_report.py
+++ b/tests/noise_control/test_silencer_report.py
@@ -176,7 +176,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         res.report(out, engine="weasyprint")
 
 
@@ -184,5 +184,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -244,6 +244,11 @@ def test_extended_tube_straight_section_excludes_the_extensions() -> None:
     assert not np.allclose(result.transmission_loss, by_hand(length), atol=1.0)
 
 
+_OVERLAPPING_EXTENSIONS = (
+    r"the inlet and outlet extensions cannot together exceed the chamber length"
+)
+
+
 def test_extended_tube_extensions_may_meet_but_not_overlap() -> None:
     # Extensions that meet leave no straight section: the cascade degenerates
     # to the two annular branches shunting the same plane, which is finite and
@@ -263,7 +268,7 @@ def test_extended_tube_extensions_may_meet_but_not_overlap() -> None:
         outlet_area=0.01,
     )
     assert meeting.transmission_loss == pytest.approx(by_hand, abs=1e-9)
-    with pytest.raises(ValueError, match="negative length"):
+    with pytest.raises(ValueError, match=_OVERLAPPING_EXTENSIONS):
         sl.extended_tube_chamber(
             f, 0.5, 0.04, 0.01, inlet_extension=0.3, outlet_extension=0.3
         )
@@ -281,7 +286,7 @@ def test_extensions_that_meet_only_in_decimal_are_still_accepted() -> None:
     assert np.all(np.isfinite(meeting.transmission_loss))
     # An overlap far below any drawn dimension, and far above the arithmetic,
     # is still an overlap.
-    with pytest.raises(ValueError, match="negative length"):
+    with pytest.raises(ValueError, match=_OVERLAPPING_EXTENSIONS):
         sl.extended_tube_chamber(
             f, 0.3, 0.04, 0.01, inlet_extension=0.1, outlet_extension=0.2 + 1e-6
         )
@@ -314,11 +319,11 @@ def test_insertion_loss_impedance_off_the_grid_is_refused() -> None:
 
 
 def test_validation() -> None:
-    with pytest.raises(ValueError, match="'frequencies' must be positive"):
+    with pytest.raises(ValueError, match="'frequencies' must be positive and finite"):
         sl.expansion_chamber([0.0], 0.3, 0.04, 0.01)
     with pytest.raises(ValueError, match="'chamber_area' must be positive"):
         sl.expansion_chamber([100.0], 0.3, -0.04, 0.01)
-    with pytest.raises(ValueError, match="must exceed"):
+    with pytest.raises(ValueError, match=r"'chamber_area' must exceed 'pipe_area'"):
         sl.extended_tube_chamber([100.0], 0.3, 0.01, 0.02)
 
 

--- a/tests/room/test_crowd_noise.py
+++ b/tests/room/test_crowd_noise.py
@@ -225,7 +225,7 @@ def test_fewer_absorption_areas_than_level_rows_is_refused() -> None:
     which covers the plot and every other reader at once.
     """
     result = room.crowd_noise([20.0, 90.0, 190.0])
-    with pytest.raises(ValueError, match="'absorption_areas'"):
+    with pytest.raises(ValueError, match=r"'absorption_areas' \(2\)"):
         dataclasses.replace(result, absorption_areas=result.absorption_areas[:-1])
 
 
@@ -238,7 +238,7 @@ def test_fewer_talkers_than_level_columns_is_refused() -> None:
     """
     result = room.crowd_noise([20.0, 90.0, 190.0])
     short_axis = result.talkers[:-1]
-    with pytest.raises(ValueError, match="'talkers'"):
+    with pytest.raises(ValueError, match="'talkers'.* one value per talker count"):
         dataclasses.replace(result, talkers=short_axis)
 
 
@@ -327,18 +327,33 @@ def test_a_variant_that_restates_itself_is_accepted() -> None:
 @pytest.mark.parametrize(
     ("call", "match"),
     [
-        (lambda: room.crowd_noise_level(0, 20.0), "at least 1"),
-        (lambda: room.crowd_noise_level(1, 0.0), "positive and finite"),
-        (lambda: room.speech_direct_level(0.0), "positive and finite"),
+        (lambda: room.crowd_noise_level(0, 20.0), "'talkers' must be at least 1"),
+        (
+            lambda: room.crowd_noise_level(1, 0.0),
+            "'absorption_area' must be positive and finite",
+        ),
+        (
+            lambda: room.speech_direct_level(0.0),
+            "'distance' must be positive and finite",
+        ),
         (
             lambda: room.speech_direct_level(1.0, directivity=0.0),
-            "directivity",
+            "'directivity' must be positive",
         ),
-        (lambda: room.speech_to_noise_ratio(1.0, -1.0), "positive and finite"),
-        (lambda: room.absorption_per_table(1.0, math.nan), "finite"),
-        (lambda: room.crowd_noise([]), "non-empty"),
-        (lambda: room.crowd_noise(20.0, talkers=[0.5]), "at least 1"),
-        (lambda: room.crowd_noise(-1.0), "positive and finite"),
+        (
+            lambda: room.speech_to_noise_ratio(1.0, -1.0),
+            "'absorption_per_table' must be positive and finite",
+        ),
+        (
+            lambda: room.absorption_per_table(1.0, math.nan),
+            "'speech_to_noise' must be finite",
+        ),
+        (lambda: room.crowd_noise([]), "'absorption_areas' must be a non-empty"),
+        (lambda: room.crowd_noise(20.0, talkers=[0.5]), "'talkers' must be at least 1"),
+        (
+            lambda: room.crowd_noise(-1.0),
+            "'absorption_areas' must be positive and finite",
+        ),
     ],
 )
 def test_validation_errors(call: object, match: str) -> None:

--- a/tests/room/test_enclosed_space_absorption.py
+++ b/tests/room/test_enclosed_space_absorption.py
@@ -143,7 +143,7 @@ def test_air_condition_none_neglects_air() -> None:
 def test_invalid_inputs_raise() -> None:
     with pytest.raises(ValueError, match="'volume' must be positive"):
         m.object_fraction([1.0], 0.0)
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"object volumes must be non-negative"):
         m.hard_object_absorption([-1.0])
     with pytest.raises(ValueError, match="absorption_area must be positive"):
         m.reverberation_time(0.0, 30.0)
@@ -159,7 +159,7 @@ def test_invalid_inputs_raise() -> None:
 
 def test_physical_range_validation() -> None:
     # Object volumes cannot be negative nor exceed the room volume.
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"object volumes must be non-negative"):
         m.object_fraction([-1.0], 30.0)
     with pytest.raises(ValueError, match="cannot exceed the room volume"):
         m.object_fraction([40.0], 30.0)
@@ -169,13 +169,17 @@ def test_physical_range_validation() -> None:
     with pytest.raises(ValueError, match=r"range \[0, 1\)"):
         m.reverberation_time(2.0, 30.0, object_fraction=1.0)
     # Negative attenuation, absorption coefficients, object areas or air area.
-    with pytest.raises(ValueError, match="must be non-negative"):
+    with pytest.raises(
+        ValueError, match=r"the attenuation coefficient m must be non-negative"
+    ):
         m.air_absorption_area(-1e-3, 100.0)
-    with pytest.raises(ValueError, match="absorption coefficients"):
+    with pytest.raises(
+        ValueError, match=r"absorption coefficients must be non-negative"
+    ):
         m.equivalent_absorption_area([(10.0, -0.1)])
     with pytest.raises(ValueError, match="object absorption areas"):
         m.equivalent_absorption_area([(10.0, 0.1)], objects=[-1.0])
-    with pytest.raises(ValueError, match="air_area"):
+    with pytest.raises(ValueError, match=r"air_area must be non-negative"):
         m.equivalent_absorption_area([(10.0, 0.1)], air_area=-0.5)
 
 
@@ -236,7 +240,10 @@ def test_a_non_finite_quantity_is_refused(field_name: str) -> None:
         if np.ndim(value) == 0
         else np.concatenate([[float("nan")], np.asarray(value)[1:]])
     )
-    with pytest.raises(ValueError, match=f"'{field_name}' must "):
+    predicate = (
+        "must be finite" if np.ndim(value) == 0 else "must contain only finite values"
+    )
+    with pytest.raises(ValueError, match=f"'{field_name}' {predicate}"):
         dataclasses.replace(result, **{field_name: bad})
 
 
@@ -254,7 +261,10 @@ def test_a_non_finite_absorption_area_is_refused_where_the_time_is_computed() ->
 
 def test_air_condition_requires_standard_bands() -> None:
     # The built-in Table 1 profiles cover the standard octave bands only.
-    with pytest.raises(ValueError, match="OCTAVE_BANDS"):
+    with pytest.raises(
+        ValueError,
+        match=r"air_condition profiles cover the standard OCTAVE_BANDS only",
+    ):
         m.enclosed_space_reverberation(
             [(20.0, 0.5)],
             50.0,

--- a/tests/room/test_enclosed_space_absorption_report.py
+++ b/tests/room/test_enclosed_space_absorption_report.py
@@ -101,7 +101,7 @@ def test_no_metadata_still_renders(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 

--- a/tests/room/test_golay.py
+++ b/tests/room/test_golay.py
@@ -69,7 +69,7 @@ def test_golay_pair_is_bipolar() -> None:
 
 @pytest.mark.parametrize("order", [0, -3, 23])
 def test_golay_pair_rejects_bad_order(order: int) -> None:
-    with pytest.raises(ValueError, match="order"):
+    with pytest.raises(ValueError, match=r"order must be between"):
         room.golay_pair(order)
 
 
@@ -141,7 +141,10 @@ def test_alias_warning_when_ir_longer_than_period() -> None:
     pair = room.golay_pair(6)
     rec_a = _periodic_response(pair[0], b, a, periods=1)
     rec_b = _periodic_response(pair[1], b, a, periods=1)
-    with pytest.warns(ImpulseResponseWarning, match="Golay"):
+    with pytest.warns(
+        ImpulseResponseWarning,
+        match=r"Recovered Golay impulse response still has energy near the end",
+    ):
         room.golay_impulse_response(rec_a, rec_b, pair)
 
 
@@ -152,13 +155,17 @@ def test_input_validation() -> None:
     empty = np.zeros(0)
     truncated_pair = (pair[0], pair[1][:8])
     two_dim = np.zeros((2, 16))
-    with pytest.raises(ValueError, match="multiple"):
+    with pytest.raises(
+        ValueError, match=r"'recorded_a' length must be a positive multiple"
+    ):
         room.golay_impulse_response(non_multiple, valid, pair)
-    with pytest.raises(ValueError, match="multiple"):
+    with pytest.raises(
+        ValueError, match=r"'recorded_b' length must be a positive multiple"
+    ):
         room.golay_impulse_response(valid, empty, pair)
-    with pytest.raises(ValueError, match="equal-length"):
+    with pytest.raises(ValueError, match=r"'pair' must hold two equal-length codes"):
         room.golay_impulse_response(valid, valid, truncated_pair)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'recorded_a' must be one-dimensional"):
         room.golay_impulse_response(two_dim, valid, pair)
 
 

--- a/tests/room/test_image_source.py
+++ b/tests/room/test_image_source.py
@@ -375,7 +375,9 @@ def test_source_outside_room_rejected() -> None:
 
 
 def test_absorption_above_one_rejected() -> None:
-    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+    with pytest.raises(
+        ValueError, match=r"absorption coefficients must lie in \[0, 1\]"
+    ):
         room.image_source_rir(
             (5.0, 4.0, 3.0),
             (1.0, 2.0, 1.5),
@@ -388,7 +390,9 @@ def test_absorption_above_one_rejected() -> None:
 
 def test_absorption_band_count_mismatch_rejected() -> None:
     alpha = np.full((6, 4), 0.2)  # 4 bands vs 3 frequencies
-    with pytest.raises(ValueError, match="bands but the result has"):
+    with pytest.raises(
+        ValueError, match=r"'absorption' has \d+ bands but the result has"
+    ):
         room.image_source_rir(
             (5.0, 4.0, 3.0),
             (1.0, 1.0, 1.0),
@@ -401,7 +405,9 @@ def test_absorption_band_count_mismatch_rejected() -> None:
 
 
 def test_coincident_source_receiver_rejected() -> None:
-    with pytest.raises(ValueError, match="coincide"):
+    with pytest.raises(
+        ValueError, match=r"source and receiver coincide; the direct path has zero"
+    ):
         room.image_source_rir(
             (5.0, 4.0, 3.0),
             (2.0, 2.0, 1.5),
@@ -417,7 +423,7 @@ def test_bad_dimension_and_fs() -> None:
         room.image_source_rir(
             (0.0, 4.0, 3.0), (1.0, 2.0, 1.5), (3.0, 2.0, 1.5), 0.2, fs=16000
         )
-    with pytest.raises(ValueError, match="Sample rate 'fs'"):
+    with pytest.raises(ValueError, match="Sample rate 'fs' must be positive"):
         room.image_source_rir(
             (5.0, 4.0, 3.0), (1.0, 2.0, 1.5), (3.0, 2.0, 1.5), 0.2, fs=0
         )
@@ -528,9 +534,16 @@ def test_a_reflection_table_of_two_lengths_is_refused() -> None:
         (5.0, 4.0, 3.0), (1.0, 1.0, 1.5), (3.0, 2.5, 1.2), 0.2, fs=8000, max_order=2
     )
     for amplitudes in (res.amplitudes[:-1], np.append(res.amplitudes, 1e-3)):
-        with pytest.raises(ValueError, match="'amplitudes'"):
+        with pytest.raises(
+            ValueError,
+            match=rf"'amplitudes' \({amplitudes.size}\) must each carry one value "
+            r"per image",
+        ):
             dataclasses.replace(res, amplitudes=amplitudes)
-    with pytest.raises(ValueError, match="'times'"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'times' \({res.times.size - 1}\).*must each carry one value per image",
+    ):
         dataclasses.replace(res, times=res.times[1:])
     banded = room.image_source_rir(
         (5.0, 4.0, 3.0),
@@ -563,11 +576,22 @@ def test_band_labels_must_match_the_bands_they_label() -> None:
         frequencies=[125.0, 250.0, 500.0, 1000.0],
     )
     for frequencies in ([125.0, 250.0, 500.0], [125.0, 250.0, 500.0, 1000.0, 2000.0]):
-        with pytest.raises(ValueError, match="'frequencies'"):
+        with pytest.raises(
+            ValueError,
+            match=rf"'frequencies' \({len(frequencies)}\).*must each carry one value "
+            r"per band",
+        ):
             dataclasses.replace(res, frequencies=np.asarray(frequencies))
-    with pytest.raises(ValueError, match="'ir'"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'ir' \({res.ir.shape[0] - 1}\).*must each carry one value per band",
+    ):
         dataclasses.replace(res, ir=res.ir[:-1])
-    with pytest.raises(ValueError, match="'amplitudes'"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'amplitudes' \({res.amplitudes.shape[0] - 1}\) must each carry one "
+        r"value per band",
+    ):
         dataclasses.replace(res, amplitudes=res.amplitudes[:-1])
     # A scalar frequency is the one band it names, not a missing axis.
     single = room.image_source_rir(
@@ -594,9 +618,12 @@ def test_a_point_missing_a_coordinate_is_refused() -> None:
     res = room.image_source_rir(
         (5.0, 4.0, 3.0), (1.0, 1.0, 1.5), (3.0, 2.5, 1.2), 0.2, fs=8000, max_order=2
     )
-    with pytest.raises(ValueError, match="'source'"):
+    with pytest.raises(ValueError, match=r"'source' \(2\).*must each carry one value"):
         dataclasses.replace(res, source=(1.0, 1.0))
-    with pytest.raises(ValueError, match="'image_positions"):
+    with pytest.raises(
+        ValueError,
+        match=r"'image_positions \(axis 1\)' \(2\) must each carry one value",
+    ):
         dataclasses.replace(res, image_positions=res.image_positions[:, :2])
 
 

--- a/tests/room/test_impulse_response.py
+++ b/tests/room/test_impulse_response.py
@@ -126,7 +126,9 @@ def test_farina_rejects_zero_padded_reference() -> None:
     # Pad the reference to the recording length, as one would for spectral.
     n = y.size + x.size - 1
     x_padded = np.concatenate([x, np.zeros(n - x.size)])
-    with pytest.raises(ValueError, match="zero-pad|unpadded|spectral"):
+    with pytest.raises(
+        ValueError, match=r"method='farina' requires the unpadded excitation sweep"
+    ):
         room.impulse_response(y, x_padded, FS, method="farina", f_range=(f1, f2))
     # The unpadded sweep still works unchanged.
     ir = room.impulse_response(
@@ -272,7 +274,9 @@ def test_mls_short_period_aliasing_warns() -> None:
     for i in range(h.size):
         hh[i % length] += h[i]  # circular wrap into one period
     y = np.real(np.fft.ifft(np.fft.fft(a) * np.fft.fft(hh)))
-    with pytest.warns(UserWarning, match="aliases"):
+    with pytest.warns(
+        UserWarning, match=r"likely longer than one period and aliases circularly"
+    ):
         room.mls_impulse_response(y, a)
 
 
@@ -343,7 +347,7 @@ def test_invalid_arguments() -> None:
         room.sweep_signal(FS, 100.0, 100.0, 1.0)  # f1 == f2
     with pytest.raises(ValueError, match="f2 must be greater than f1"):
         room.sweep_signal(FS, 100.0, 50.0, 1.0)  # f1 > f2
-    with pytest.raises(ValueError, match="must not exceed the Nyquist frequency"):
+    with pytest.raises(ValueError, match="f2 must not exceed the Nyquist frequency"):
         room.sweep_signal(FS, 20.0, 30000.0, 1.0)  # f2 > Nyquist
     with pytest.raises(ValueError, match="order must be one of"):
         room.mls_signal(1)  # order too small
@@ -352,7 +356,7 @@ def test_invalid_arguments() -> None:
     ten = np.zeros(10)
     with pytest.raises(ValueError, match="unknown method"):
         room.impulse_response(ten, ten, FS, method="bogus")
-    with pytest.raises(ValueError, match="requires f_range"):
+    with pytest.raises(ValueError, match=r"method='farina' requires f_range"):
         room.impulse_response(ten, ten, FS, method="farina")  # no f_range
     seq = room.mls_signal(4)
     with pytest.raises(
@@ -542,10 +546,10 @@ def test_plot_excitation_short_and_empty_guards() -> None:
 
     # Empty inputs raise a clear error rather than a cryptic reduction failure.
     empty = np.array([])
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"excitation signal is empty"):
         room.plot_excitation(empty, FS, kind="mls")
     empty_result = room.ImpulseResponseResult(ir=empty, fs=FS, method="spectral")
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"impulse response is empty"):
         empty_result.plot()
 
 

--- a/tests/room/test_iso3382_3_report.py
+++ b/tests/room/test_iso3382_3_report.py
@@ -131,7 +131,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -139,7 +139,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")
 
 

--- a/tests/room/test_iso3382_report.py
+++ b/tests/room/test_iso3382_report.py
@@ -136,7 +136,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -144,7 +144,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ``ValueError``."""
     res = _result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")
 
 
@@ -427,7 +427,10 @@ def test_spanish_report_renders_translated_fiche(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------
 def test_room_volume_must_be_positive() -> None:
     """A non-positive room volume raises ``ValueError``."""
-    with pytest.raises(ValueError, match="room_volume"):
+    with pytest.raises(
+        ValueError,
+        match=r"ReportMetadata\.room_volume must be a finite, positive number",
+    ):
         ReportMetadata(room_volume=0.0)
 
 
@@ -437,7 +440,9 @@ def test_position_counts_must_be_positive_integers(
     field: str, bad: int | float
 ) -> None:
     """A position count must be a positive integer (bools and floats rejected)."""
-    with pytest.raises(ValueError, match=field):
+    with pytest.raises(
+        ValueError, match=rf"ReportMetadata\.{field} must be a positive integer"
+    ):
         ReportMetadata(**{field: bad})
 
 

--- a/tests/room/test_modes.py
+++ b/tests/room/test_modes.py
@@ -200,7 +200,9 @@ def test_enumeration_refuses_an_unreasonable_lattice() -> None:
     up to 20 kHz is hundreds of millions of triples. That regime is exactly
     where Equations (8.45) and (8.46) are accurate, so the error says so.
     """
-    with pytest.raises(ValueError, match="room_mode_count"):
+    with pytest.raises(
+        ValueError, match=r"order triples, above the .+ limit\. Lower 'max_frequency'"
+    ):
         room.room_modes(LONG_ROOM, max_frequency=20000.0)
     # The smooth count answers the same question there without enumerating.
     assert float(room.room_mode_count(20000.0, LONG_ROOM)) > 8e7
@@ -209,16 +211,22 @@ def test_enumeration_refuses_an_unreasonable_lattice() -> None:
 def test_result_is_a_frozen_dataclass() -> None:
     result = room.room_modes(LONG_ROOM, max_frequency=30.0)
     assert isinstance(result, room.RoomModesResult)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         result.speed_of_sound = 340.0  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"dimensions": (7.0, 5.0)}, "three room dimensions"),
-        ({"dimensions": (7.0, 5.0, 0.0)}, "positive and finite"),
-        ({"dimensions": (7.0, 5.0, math.nan)}, "positive and finite"),
+        (
+            {"dimensions": (7.0, 5.0)},
+            "'dimensions' must hold the three room dimensions",
+        ),
+        ({"dimensions": (7.0, 5.0, 0.0)}, "'dimensions' must be positive and finite"),
+        (
+            {"dimensions": (7.0, 5.0, math.nan)},
+            "'dimensions' must be positive and finite",
+        ),
     ],
 )
 def test_dimension_validation(kwargs: dict[str, object], match: str) -> None:
@@ -262,16 +270,16 @@ def test_other_validation_errors() -> None:
         room.room_modes(LONG_ROOM, speed_of_sound=-1.0)
     with pytest.raises(ValueError, match="'reverberation_time' must be positive"):
         room.room_modes(LONG_ROOM, reverberation_time=0.0)
-    with pytest.raises(ValueError, match="non-negative integers"):
+    with pytest.raises(ValueError, match="'orders' must be non-negative integers"):
         room.room_mode_frequency((1, -1, 0), LONG_ROOM)
-    with pytest.raises(ValueError, match="non-negative integers"):
+    with pytest.raises(ValueError, match="'orders' must be non-negative integers"):
         room.room_mode_frequency((1.5, 0, 0), LONG_ROOM)
     two_dimensional = np.zeros((2, 4))
-    with pytest.raises(ValueError, match="triple"):
+    with pytest.raises(ValueError, match=r"'orders' must be a triple \(nx, ny, nz\)"):
         room.room_mode_frequency(two_dimensional, LONG_ROOM)
-    with pytest.raises(ValueError, match="non-negative and finite"):
+    with pytest.raises(ValueError, match="'frequency' must be non-negative and finite"):
         room.room_mode_count(-1.0, LONG_ROOM)
-    with pytest.raises(ValueError, match="non-negative and finite"):
+    with pytest.raises(ValueError, match="'frequency' must be non-negative and finite"):
         room.room_modal_density(math.inf, LONG_ROOM)
 
 

--- a/tests/room/test_noise_criteria.py
+++ b/tests/room/test_noise_criteria.py
@@ -126,7 +126,7 @@ def test_nc_marginal_cases_on_the_family_edges() -> None:
 
 
 def test_nc_out_of_range_curve_raises() -> None:
-    with pytest.raises(ValueError, match="tabulated range"):
+    with pytest.raises(ValueError, match=r"NC index .* is outside the tabulated range"):
         rn.nc_curve(80.0)
 
 
@@ -225,7 +225,10 @@ def test_subset_by_frequency() -> None:
 
 def test_rc_requires_mid_frequency_bands() -> None:
     # Without 500/1000/2000 Hz the RC rating cannot be computed.
-    with pytest.raises(ValueError, match="mid-frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"octave bands are required to compute the mid-frequency average",
+    ):
         rn.room_criterion([50.0, 45.0], [63.0, 125.0])
 
 
@@ -239,9 +242,11 @@ def test_invalid_inputs_raise() -> None:
     with pytest.raises(ValueError, match="not one of"):
         rn.noise_criterion([50.0], [777.0])
     two_dimensional = np.zeros((2, 10))
-    with pytest.raises(ValueError, match="1-D vector"):
+    with pytest.raises(
+        ValueError, match=r"levels must be a 1-D vector of octave-band levels"
+    ):
         rn.noise_criterion(two_dimensional)
-    with pytest.raises(ValueError, match="no valid"):
+    with pytest.raises(ValueError, match=r"no valid octave-band levels were supplied"):
         rn.noise_criterion([], [])
 
 
@@ -326,7 +331,7 @@ def test_an_nc_rating_refuses_levels_off_the_band_axis(trim: bool) -> None:
     result = rn.noise_criterion([50.0, 45.0, 40.0, 38.0, 35.0, 32.0, 30.0, 28.0], bands)
     levels = np.asarray(result.levels)
     wrong = levels[:-1] if trim else np.append(levels, levels[-1])
-    with pytest.raises(ValueError, match="'levels'"):
+    with pytest.raises(ValueError, match=rf"NCResult: .*'levels' \({wrong.size}\)"):
         dataclasses.replace(result, levels=wrong)
 
 
@@ -363,7 +368,10 @@ def test_an_rc_rating_refuses_the_unimplemented_rv_tag() -> None:
     tag and would have boxed ``RC-nn(RV)`` over "Spectral quality: neutral".
     """
     result = rn.room_criterion(rn.rc_curve(35.0))
-    with pytest.raises(ValueError, match="classification 'RV'"):
+    with pytest.raises(
+        ValueError,
+        match=r"classification 'RV'.*requires the Table 6 criterion test",
+    ):
         dataclasses.replace(result, classification="RV")
 
 
@@ -378,9 +386,12 @@ def test_an_rc_rating_refuses_an_unknown_spectral_tag() -> None:
 @pytest.mark.parametrize(
     ("field", "message"),
     [
-        ("rating", "'rating' must be finite"),
-        ("lmf", "'lmf' must be finite"),
-        ("reference_curve", "'reference_curve' must contain only finite values"),
+        ("rating", "RCResult: 'rating' must be finite"),
+        ("lmf", "RCResult: 'lmf' must be finite"),
+        (
+            "reference_curve",
+            "RCResult: 'reference_curve' must contain only finite values",
+        ),
     ],
 )
 def test_an_rc_rating_refuses_a_non_finite_rating_average_or_curve(
@@ -474,7 +485,7 @@ def test_an_nc_rating_outside_the_family_keeps_its_flag() -> None:
     over[2] += 1.0  # 63 Hz, 1 dB above the highest tabulated curve
     result = rn.noise_criterion(over)
     assert result.out_of_range == "above"
-    with pytest.raises(ValueError, match="'rating' must be finite"):
+    with pytest.raises(ValueError, match="NCResult: 'rating' must be finite"):
         dataclasses.replace(result, out_of_range=None)
 
 

--- a/tests/room/test_open_plan.py
+++ b/tests/room/test_open_plan.py
@@ -95,7 +95,9 @@ def test_too_few_positions_raises() -> None:
     r = np.array([2.0, 4.0, 8.0])
     lp = 70.0 - 6.0 * np.log2(r)
     sti = np.array([0.6, 0.4, 0.2])
-    with pytest.raises(ValueError, match="at least 4"):
+    with pytest.raises(
+        ValueError, match=r"ISO 3382-3 requires at least \d+ measurement positions"
+    ):
         room.open_plan_metrics(r, lp, sti)
 
 
@@ -145,7 +147,9 @@ def test_nan_in_positions_raises() -> None:
     r = np.array([2.0, 4.0, np.nan, 16.0])
     lp = np.array([70.0, 64.0, 58.0, 46.0])
     sti = np.array([0.6, 0.5, 0.4, 0.3])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"positions_m, spl_a_speech and sti_values must be finite"
+    ):
         room.open_plan_metrics(r, lp, sti)
 
 
@@ -154,7 +158,9 @@ def test_nan_in_spl_raises() -> None:
     r = np.array([2.0, 4.0, 8.0, 16.0])
     lp = np.array([70.0, np.nan, 58.0, 46.0])
     sti = np.array([0.6, 0.5, 0.4, 0.3])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"positions_m, spl_a_speech and sti_values must be finite"
+    ):
         room.open_plan_metrics(r, lp, sti)
 
 
@@ -163,5 +169,7 @@ def test_inf_in_sti_raises() -> None:
     r = np.array([2.0, 4.0, 8.0, 16.0])
     lp = np.array([70.0, 64.0, 58.0, 46.0])
     sti = np.array([0.6, np.inf, 0.4, 0.3])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(
+        ValueError, match=r"positions_m, spl_a_speech and sti_values must be finite"
+    ):
         room.open_plan_metrics(r, lp, sti)

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -261,8 +261,10 @@ def test_a_non_finite_room_is_refused(field: str, bad: float) -> None:
     """
     good = room.reverberation_time_models(DIMS, (0.2, 0.15, 0.3), frequencies=1000.0)
     value = getattr(good, field)
-    replacement = bad if np.ndim(value) == 0 else np.full_like(np.asarray(value), bad)
-    with pytest.raises(ValueError, match=f"'{field}' must "):
+    per_band = np.ndim(value) != 0
+    replacement = np.full_like(np.asarray(value), bad) if per_band else bad
+    rule = "must contain only finite" if per_band else "must be finite"
+    with pytest.raises(ValueError, match=f"'{field}' {rule}"):
         dataclasses.replace(good, **{field: replacement})
 
 
@@ -312,12 +314,15 @@ def test_empty_surfaces_raise() -> None:
         room.millington_sette_reverberation_time,
     ],
 )
-@pytest.mark.parametrize("bad", [-0.1, math.nan, math.inf])
+@pytest.mark.parametrize(
+    ("bad", "rule"),
+    [(-0.1, "non-negative"), (math.nan, "finite"), (math.inf, "finite")],
+)
 def test_negative_and_non_finite_alpha_rejected_by_surface_models(
-    model: _SurfaceModel, bad: float
+    model: _SurfaceModel, bad: float, rule: str
 ) -> None:
     """Negative and non-finite coefficients are rejected by every model."""
-    with pytest.raises(ValueError, match="absorption coefficients must be"):
+    with pytest.raises(ValueError, match=f"absorption coefficients must be {rule}"):
         model(VOLUME, [(10.0, bad)])
 
 
@@ -325,11 +330,14 @@ def test_negative_and_non_finite_alpha_rejected_by_surface_models(
     "model",
     [room.fitzroy_reverberation_time, room.arau_puchades_reverberation_time],
 )
-@pytest.mark.parametrize("bad", [-0.1, math.nan, math.inf])
+@pytest.mark.parametrize(
+    ("bad", "rule"),
+    [(-0.1, "non-negative"), (math.nan, "finite"), (math.inf, "finite")],
+)
 def test_negative_and_non_finite_alpha_rejected_by_axial_models(
-    model: _AxialModel, bad: float
+    model: _AxialModel, bad: float, rule: str
 ) -> None:
-    with pytest.raises(ValueError, match="absorption coefficients must be"):
+    with pytest.raises(ValueError, match=f"absorption coefficients must be {rule}"):
         model(DIMS, (bad, 0.2, 0.2))
 
 
@@ -349,7 +357,9 @@ def test_alpha_above_unit_error_bound_rejected_by_surface_models(
     (The axial models reject 20.0 too, but through their stricter below-1
     wall-pair-mean check, exercised in the axial rejection test below.)
     """
-    with pytest.raises(ValueError, match="unit error"):
+    with pytest.raises(
+        ValueError, match=r"absorption coefficients above .* look like a unit error"
+    ):
         model(VOLUME, [(10.0, 20.0)])
 
 
@@ -357,7 +367,9 @@ def test_sabine_accepts_the_documented_upper_bound() -> None:
     """The bound is inclusive: alpha exactly 2.0 computes, 2.0 + eps raises."""
     t = room.sabine_reverberation_time(VOLUME, [(SURFACE, 2.0)])
     assert t == pytest.approx(_K * VOLUME / (SURFACE * 2.0), abs=1e-9)
-    with pytest.raises(ValueError, match="unit error"):
+    with pytest.raises(
+        ValueError, match=r"absorption coefficients above .* look like a unit error"
+    ):
         room.sabine_reverberation_time(VOLUME, [(SURFACE, 2.0000001)])
 
 
@@ -422,24 +434,28 @@ def test_mean_absorption_accepts_iso354_alphas_above_one() -> None:
 
 
 def test_perfectly_reflecting_room_raises() -> None:
-    with pytest.raises(ValueError, match="non-positive"):
+    with pytest.raises(ValueError, match=r"the total absorption is non-positive"):
         room.sabine_reverberation_time(VOLUME, [(10.0, 0.0)])
 
 
 def test_non_positive_volume_raises() -> None:
-    with pytest.raises(ValueError, match="volume"):
+    with pytest.raises(ValueError, match=r"'volume' must be positive"):
         room.sabine_reverberation_time(0.0, UNIFORM_SURFACES)
 
 
 def test_negative_air_attenuation_raises() -> None:
-    with pytest.raises(ValueError, match="air_attenuation"):
+    with pytest.raises(
+        ValueError, match=r"'air_attenuation' must be finite and non-negative"
+    ):
         room.sabine_reverberation_time(VOLUME, UNIFORM_SURFACES, air_attenuation=-1.0)
 
 
 @pytest.mark.parametrize("bad", [math.nan, math.inf])
 def test_non_finite_air_attenuation_raises(bad: float) -> None:
     """NaN used to slip through the old m < 0 comparison and return NaN."""
-    with pytest.raises(ValueError, match="air_attenuation"):
+    with pytest.raises(
+        ValueError, match=r"'air_attenuation' must be finite and non-negative"
+    ):
         room.sabine_reverberation_time(VOLUME, UNIFORM_SURFACES, air_attenuation=bad)
 
 
@@ -456,13 +472,19 @@ def test_bad_absorptions_length_raises() -> None:
 def test_mismatched_surface_band_counts_raise() -> None:
     """Per-band coefficients with different band counts get a clear error."""
     surfaces = [(40.0, [0.1, 0.2, 0.3]), (40.0, [0.1, 0.2])]
-    with pytest.raises(ValueError, match="incompatible shapes"):
+    with pytest.raises(
+        ValueError,
+        match=r"per-band surface absorption coefficients have incompatible shapes",
+    ):
         room.eyring_reverberation_time(VOLUME, surfaces)
 
 
 def test_mismatched_axis_band_counts_raise() -> None:
     """A 6-band x-pair against a 4-band y-pair is reported, not a raw NumPy error."""
-    with pytest.raises(ValueError, match="incompatible shapes"):
+    with pytest.raises(
+        ValueError,
+        match=r"per-band axis absorptions and air attenuation have incompatible shapes",
+    ):
         room.arau_puchades_reverberation_time(
             DIMS, ([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [0.1, 0.2, 0.3, 0.4], 0.2)
         )
@@ -471,7 +493,10 @@ def test_mismatched_axis_band_counts_raise() -> None:
 def test_mismatched_air_band_count_raises() -> None:
     """Air attenuation with a different band count than the surfaces is caught."""
     surfaces = [(158.0, [0.2, 0.3, 0.4])]
-    with pytest.raises(ValueError, match="incompatible shapes"):
+    with pytest.raises(
+        ValueError,
+        match=r"per-band absorption and air attenuation have incompatible shapes",
+    ):
         room.sabine_reverberation_time(VOLUME, surfaces, air_attenuation=[0.001, 0.002])
 
 

--- a/tests/room/test_reverberation_prediction_report.py
+++ b/tests/room/test_reverberation_prediction_report.py
@@ -94,7 +94,7 @@ def test_no_metadata_still_renders(tmp_path: Path) -> None:
 def test_unknown_engine_rejected(tmp_path: Path) -> None:
     res = _result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         res.report(out, engine="weasyprint")
 
 

--- a/tests/room/test_room_noise_report.py
+++ b/tests/room/test_room_noise_report.py
@@ -153,7 +153,7 @@ def test_unknown_engine_rejected(
     """An unknown rendering engine raises ``ValueError``."""
     out = str(tmp_path / "x.pdf")
     result = factory()
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine 'weasyprint'"):
         result.report(out, engine="weasyprint")
 
 
@@ -164,7 +164,7 @@ def test_unknown_language_rejected(
     """An unknown fiche language raises ``ValueError``."""
     out = str(tmp_path / "bad.pdf")
     result = factory()
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language 'xx'"):
         result.report(out, language="xx")
 
 
@@ -357,7 +357,9 @@ def test_rc_result_refuses_a_reference_curve_of_another_length() -> None:
     from dataclasses import replace
 
     result = _rc_result()
-    with pytest.raises(ValueError, match="'reference_curve'"):
+    with pytest.raises(
+        ValueError, match=r"'reference_curve'.*must each carry one value per band"
+    ):
         replace(result, reference_curve=result.reference_curve[:-1])
 
 

--- a/tests/room/test_room_result_plots.py
+++ b/tests/room/test_room_result_plots.py
@@ -152,5 +152,7 @@ def test_open_plan_plot_without_regression_raises() -> None:
     bare = ph.room.OpenPlanResult(
         d2s=float("nan"), lp_as_4m=float("nan"), rd=float("nan"), rp=float("nan")
     )
-    with pytest.raises(ValueError, match="regression"):
+    with pytest.raises(
+        ValueError, match=r"plot\(\) needs the spatial-decay regression"
+    ):
         bare.plot()

--- a/tests/room/test_room_signal_overloads.py
+++ b/tests/room/test_room_signal_overloads.py
@@ -235,7 +235,10 @@ def test_golay_reads_the_second_recording_too() -> None:
 def test_two_recordings_at_different_rates_are_refused() -> None:
     """Golay takes two recordings, and they have to be the same measurement."""
     first, second = Signal(_GOLAY_A, FS), Signal(_GOLAY_B, FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError,
+        match=r"'recorded_a' and 'recorded_b' are Signals recorded at different rates",
+    ):
         golay_impulse_response(first, second, pair=_PAIR)
 
 

--- a/tests/room/test_shaped_sweep.py
+++ b/tests/room/test_shaped_sweep.py
@@ -171,19 +171,19 @@ def test_shaped_sweep_deconvolves_a_known_system() -> None:
 # Validation
 # --------------------------------------------------------------------------
 def test_rejects_bad_inputs() -> None:
-    with pytest.raises(ValueError, match="f1"):
+    with pytest.raises(ValueError, match=r"f1 must be positive"):
         room.shaped_sweep_signal(FS, 0.0, 5000.0, 1.0)
-    with pytest.raises(ValueError, match="f2"):
+    with pytest.raises(ValueError, match=r"f2 must be greater than f1"):
         room.shaped_sweep_signal(FS, 500.0, 100.0, 1.0)
-    with pytest.raises(ValueError, match="Nyquist"):
+    with pytest.raises(ValueError, match=r"f2 must not exceed the Nyquist"):
         room.shaped_sweep_signal(FS, 50.0, 30000.0, 1.0)
-    with pytest.raises(ValueError, match="seconds"):
+    with pytest.raises(ValueError, match=r"seconds must be positive"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 0.0)
-    with pytest.raises(ValueError, match="amplitude"):
+    with pytest.raises(ValueError, match=r"amplitude must be positive"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, amplitude=0.0)
-    with pytest.raises(ValueError, match="fade"):
+    with pytest.raises(ValueError, match=r"fade must be in"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, fade=0.7)
-    with pytest.raises(ValueError, match="start_delay"):
+    with pytest.raises(ValueError, match=r"start_delay must be positive"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, start_delay=0.0)
     with pytest.raises(ValueError, match="unknown named target"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target="blue")
@@ -196,10 +196,12 @@ def test_rejects_bad_inputs() -> None:
     with pytest.raises(ValueError, match=r"array target.*at least 2 points"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=too_short)
     decreasing = (np.array([200.0, 100.0]), np.array([0.0, 0.0]))
-    with pytest.raises(ValueError, match="increasing"):
+    with pytest.raises(
+        ValueError, match=r"target frequencies must be positive and increasing"
+    ):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=decreasing)
     non_finite = (np.array([100.0, 200.0]), np.array([0.0, np.inf]))
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"target magnitudes must be finite"):
         room.shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=non_finite)
 
 

--- a/tests/room/test_steady_field.py
+++ b/tests/room/test_steady_field.py
@@ -34,9 +34,9 @@ def test_room_constant_per_band() -> None:
 
 
 def test_room_constant_domain() -> None:
-    with pytest.raises(ValueError, match="strictly in"):
+    with pytest.raises(ValueError, match=r"'mean_absorption' must lie strictly in"):
         room.room_constant(100.0, 1.0)
-    with pytest.raises(ValueError, match="strictly in"):
+    with pytest.raises(ValueError, match=r"'mean_absorption' must lie strictly in"):
         room.room_constant(100.0, 0.0)
     with pytest.raises(ValueError, match="'surface_area' must be positive"):
         room.room_constant(-1.0, 0.2)
@@ -160,7 +160,7 @@ def test_steady_field_validation() -> None:
         room.steady_state_spl(90.0, -1.0, 25.0)
     with pytest.raises(ValueError, match="'room_constant' must be positive"):
         room.steady_state_spl(90.0, 1.0, -25.0)
-    with pytest.raises(ValueError, match="source_model"):
+    with pytest.raises(ValueError, match=r"'source_model' must be one of"):
         room.steady_state_spl(90.0, 1.0, 25.0, source_model="constant_intensity")
     with pytest.raises(ValueError, match="'reverberation_time' must be positive"):
         room.schroeder_frequency(-1.0, 200.0)

--- a/tests/signals/test_cepstrum.py
+++ b/tests/signals/test_cepstrum.py
@@ -149,7 +149,7 @@ def test_complex_cepstrum_round_trip_is_exact() -> None:
 
 def test_only_the_complex_cepstrum_inverts() -> None:
     res = ph.signals.cepstrum(_impulse_echo(), FS, kind="power")
-    with pytest.raises(ValueError, match="invertible"):
+    with pytest.raises(ValueError, match=r"Only the complex cepstrum is invertible"):
         res.invert()
 
 
@@ -232,9 +232,9 @@ def test_echo_detection_search_band_is_respected() -> None:
 
 def test_echo_detection_rejects_bad_band() -> None:
     x = _impulse_echo()
-    with pytest.raises(ValueError, match="search band"):
+    with pytest.raises(ValueError, match=r"quefrency search band must satisfy"):
         ph.signals.echo_detection(x, FS, min_quefrency=0.1, max_quefrency=0.05)
-    with pytest.raises(ValueError, match="search band"):
+    with pytest.raises(ValueError, match=r"quefrency search band must satisfy"):
         ph.signals.echo_detection(x, FS, max_quefrency=1.0)
 
 
@@ -275,11 +275,11 @@ def test_lifter_modes_are_exactly_complementary() -> None:
 
 def test_lifter_validates_inputs() -> None:
     x = _impulse_echo()
-    with pytest.raises(ValueError, match="mode"):
+    with pytest.raises(ValueError, match=r"'mode' must be 'lowpass'"):
         ph.signals.lifter(x, FS, cutoff=0.01, mode="bandpass")
-    with pytest.raises(ValueError, match="cutoff"):
+    with pytest.raises(ValueError, match=r"'cutoff' must resolve to"):
         ph.signals.lifter(x, FS, cutoff=10.0)  # beyond nfft/2
-    with pytest.raises(ValueError, match="cutoff"):
+    with pytest.raises(ValueError, match=r"'cutoff' must resolve to"):
         ph.signals.lifter(x, FS, cutoff=1e-9)  # below one sample
 
 
@@ -290,25 +290,25 @@ def test_lifter_validates_inputs() -> None:
 
 def test_cepstrum_validates_inputs() -> None:
     x = _impulse_echo()
-    with pytest.raises(ValueError, match="kind"):
+    with pytest.raises(ValueError, match=r"'kind' must be one of"):
         ph.signals.cepstrum(x, FS, kind="cheese")
-    with pytest.raises(ValueError, match="nfft"):
+    with pytest.raises(ValueError, match=r"'nfft' must be at least the record length"):
         ph.signals.cepstrum(x, FS, nfft=N - 2)
-    with pytest.raises(ValueError, match="even"):
+    with pytest.raises(ValueError, match=r"'nfft' must be even"):
         ph.signals.cepstrum(x, FS, nfft=N + 1)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.cepstrum(x, 0.0)
     silence = np.zeros(N)
-    with pytest.raises(ValueError, match="identically zero"):
+    with pytest.raises(ValueError, match=r"'x' must not be identically zero"):
         ph.signals.cepstrum(silence, FS)
 
 
 def test_results_are_frozen() -> None:
     res = ph.signals.cepstrum(_impulse_echo(), FS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.kind = "real"  # type: ignore[misc]
     echo = ph.signals.echo_detection(_impulse_echo(), FS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         echo.delay = 0.0  # type: ignore[misc]
 
 
@@ -486,6 +486,6 @@ def test_lifter_plot_two_panels_and_external_ax() -> None:
 
 def test_plot_rejects_unknown_language() -> None:
     res = ph.signals.cepstrum(_impulse_echo(), FS)
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.plot(language="xx")
     plt.close("all")

--- a/tests/signals/test_correlation.py
+++ b/tests/signals/test_correlation.py
@@ -170,11 +170,11 @@ def test_correlation_random_error_reproduces_example_8_5() -> None:
 
 def test_correlation_random_error_validation() -> None:
     assert ph.signals.correlation_random_error(0.0, 100.0, 5.0) == np.inf
-    with pytest.raises(ValueError, match="coefficient"):
+    with pytest.raises(ValueError, match=r"'coefficient' must be in"):
         ph.signals.correlation_random_error(1.5, 100.0, 5.0)
-    with pytest.raises(ValueError, match="signal_bandwidth"):
+    with pytest.raises(ValueError, match=r"'signal_bandwidth' must be a positive"):
         ph.signals.correlation_random_error(0.5, 0.0, 5.0)
-    with pytest.raises(ValueError, match="duration"):
+    with pytest.raises(ValueError, match=r"'duration' must be a positive"):
         ph.signals.correlation_random_error(0.5, 100.0, -1.0)
 
 
@@ -317,7 +317,7 @@ def test_ml_weighting_requires_averaged_coherence() -> None:
     """
     x = _white(23, n=2048)
     y = np.roll(x, 5)
-    with pytest.raises(ValueError, match="averaged coherence"):
+    with pytest.raises(ValueError, match=r"'ml' weighting needs an averaged coherence"):
         ph.signals.time_delay(x, y, FS, method="gcc", weighting="ml", nperseg=2048)
 
 
@@ -325,9 +325,9 @@ def test_time_delay_rejects_constant_records() -> None:
     flat = np.zeros(4096)
     x = _white(24, n=4096)
     for method in ("direct", "gcc", "phase"):
-        with pytest.raises(ValueError, match="constant"):
+        with pytest.raises(ValueError, match=r"'x' and 'y' must not be constant"):
             ph.signals.time_delay(flat, x, FS, method=method)  # type: ignore[arg-type]
-        with pytest.raises(ValueError, match="constant"):
+        with pytest.raises(ValueError, match=r"'x' and 'y' must not be constant"):
             ph.signals.time_delay(x, flat, FS, method=method)  # type: ignore[arg-type]
 
 
@@ -494,16 +494,18 @@ def test_correlation_rejects_invalid_inputs() -> None:
         ValueError, match=r"correlation: 'x'.*'y'.*one value per sample"
     ):
         ph.signals.correlation(x, x[:-1], FS)
-    with pytest.raises(ValueError, match="normalization"):
+    with pytest.raises(ValueError, match=r"'normalization' must be"):
         ph.signals.correlation(x, fs=FS, normalization="raw")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="max_lag"):
+    with pytest.raises(
+        ValueError, match=r"'max_lag' must be at least one sample and shorter"
+    ):
         ph.signals.correlation(x, fs=FS, max_lag=10.0)
-    with pytest.raises(ValueError, match="max_lag"):
+    with pytest.raises(ValueError, match=r"'max_lag' must be a positive"):
         ph.signals.correlation(x, fs=FS, max_lag=-1.0)
-    with pytest.raises(ValueError, match="'fs'"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive"):
         ph.signals.correlation(x, fs=0.0)
     res = ph.signals.correlation(x, fs=FS)
-    with pytest.raises(ValueError, match="signal_bandwidth"):
+    with pytest.raises(ValueError, match=r"'signal_bandwidth' must be a positive"):
         res.random_error(0.0)
 
 
@@ -530,19 +532,25 @@ def test_time_delay_rejects_invalid_inputs() -> None:
     y = np.roll(x, 5)
     with pytest.raises(ValueError, match=r"time_delay: 'x'.*'y'.*one value per sample"):
         ph.signals.time_delay(x, y[:-1], FS)
-    with pytest.raises(ValueError, match="method"):
+    with pytest.raises(ValueError, match=r"'method' must be 'gcc'"):
         ph.signals.time_delay(x, y, FS, method="fft")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="weighting"):
+    with pytest.raises(ValueError, match=r"'weighting' must be 'none'"):
         ph.signals.time_delay(x, y, FS, weighting="eckart")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="interpolation"):
+    with pytest.raises(ValueError, match=r"'interpolation' must be"):
         ph.signals.time_delay(x, y, FS, interpolation="cubic")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="upsample"):
+    with pytest.raises(ValueError, match=r"'upsample' must be a positive integer"):
         ph.signals.time_delay(x, y, FS, upsample=0)
-    with pytest.raises(ValueError, match="max_delay"):
+    with pytest.raises(
+        ValueError,
+        match=r"'max_delay' must be at least one sample and shorter than half",
+    ):
         ph.signals.time_delay(x, y, FS, method="gcc", nperseg=256, max_delay=1.0)
-    with pytest.raises(ValueError, match="max_delay"):
+    with pytest.raises(
+        ValueError,
+        match=r"'max_delay' must be at least one sample and shorter than the record",
+    ):
         ph.signals.time_delay(x, y, FS, method="direct", max_delay=x.size / FS)
-    with pytest.raises(ValueError, match="signal_bandwidth"):
+    with pytest.raises(ValueError, match=r"'signal_bandwidth' must be a positive"):
         ph.signals.time_delay(x, y, FS, signal_bandwidth=-100.0)
 
 
@@ -553,9 +561,9 @@ def test_ir_utilities_reject_invalid_inputs() -> None:
         match=r"align_impulse_responses: 'ir'.*'reference'.*one value per sample",
     ):
         ph.signals.align_impulse_responses(ir, ir[:-1], FS)
-    with pytest.raises(ValueError, match="upsample"):
+    with pytest.raises(ValueError, match=r"'upsample' must be a positive integer"):
         ph.signals.impulse_response_delay(ir, FS, upsample=-2)
-    with pytest.raises(ValueError, match="'fs'"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive"):
         ph.signals.impulse_response_delay(ir, 0.0)
 
 
@@ -592,10 +600,10 @@ def test_alignment_rejects_records_of_different_lengths() -> None:
 def test_results_are_frozen() -> None:
     x = _white(18, n=4096)
     res = ph.signals.correlation(x, fs=FS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.values = res.values * 2.0  # type: ignore[misc]
     tde = ph.signals.time_delay(x, np.roll(x, 5), FS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         tde.delay = 0.0  # type: ignore[misc]
 
 

--- a/tests/signals/test_envelope.py
+++ b/tests/signals/test_envelope.py
@@ -152,15 +152,17 @@ def test_envelope_rejects_invalid_inputs() -> None:
     x, _ = _am(1000.0, 10.0, 0.5)
     two_dimensional = np.stack([x, x])
     non_finite = np.full(4096, np.nan)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         ph.signals.envelope(two_dimensional, FS)
-    with pytest.raises(ValueError, match="'fs'"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.envelope(x, 0.0)
-    with pytest.raises(ValueError, match="decimation_factor"):
+    with pytest.raises(ValueError, match=r"'decimation_factor' must be a positive"):
         ph.signals.envelope(x, FS, decimation_factor=0)
-    with pytest.raises(ValueError, match="decimation_factor"):
+    with pytest.raises(
+        ValueError, match=r"'decimation_factor' must be smaller than the record length"
+    ):
         ph.signals.envelope(x, FS, decimation_factor=x.size)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'x' must be finite"):
         ph.signals.envelope(non_finite, FS)
 
 
@@ -176,7 +178,7 @@ def test_short_record_antialiased_decimation_is_supported() -> None:
 
 def test_result_is_frozen() -> None:
     res = ph.signals.envelope(_tone(1000.0), FS)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.envelope = res.envelope * 2.0  # type: ignore[misc]
 
 
@@ -362,24 +364,26 @@ def test_envelope_spectrum_bandpass_prefilter_isolates_the_carrier() -> None:
 def test_envelope_spectrum_band_validation() -> None:
     x = _am_signal()
     for band in ((0.0, 100.0), (200.0, 100.0), (100.0, FS / 2.0)):
-        with pytest.raises(ValueError, match="band"):
+        with pytest.raises(
+            ValueError, match=r"'band' must satisfy 0 < low < high < fs/2"
+        ):
             ph.signals.envelope_spectrum(x, FS, band=band)
     # Malformed shapes: not exactly two numeric edges.
     for bad in ((700.0,), (700.0, 900.0, 1300.0), (700.0, None)):
-        with pytest.raises(ValueError, match="pair"):
+        with pytest.raises(ValueError, match=r"'band' must be a pair of numeric"):
             ph.signals.envelope_spectrum(x, FS, band=bad)  # type: ignore[arg-type]
     # A record shorter than the zero-phase padding fails informatively.
-    with pytest.raises(ValueError, match="too short"):
+    with pytest.raises(ValueError, match=r"Signal too short for an envelope spectrum"):
         ph.signals.envelope_spectrum(x[:20], FS, band=(700.0, 1300.0))
 
 
 def test_envelope_spectrum_validates_inputs() -> None:
     x = _am_signal()
-    with pytest.raises(ValueError, match="kind"):
+    with pytest.raises(ValueError, match=r"'kind' must be 'magnitude' or 'squared'"):
         ph.signals.envelope_spectrum(x, FS, kind="log")
-    with pytest.raises(ValueError, match="nfft"):
+    with pytest.raises(ValueError, match=r"'nfft' must be at least the record length"):
         ph.signals.envelope_spectrum(x, FS, nfft=100)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.envelope_spectrum(x, -1.0)
 
 

--- a/tests/signals/test_estimate_overloads.py
+++ b/tests/signals/test_estimate_overloads.py
@@ -90,13 +90,16 @@ SOLO = [
 ]
 SOLO_IDS = [f.__name__ for f, _ in SOLO]
 
-# The pairwise ones: two records that must share a rate.
-PAIRS = [
-    (cross_spectral_density, {}),
-    (coherent_output_spectrum, {}),
-    (time_delay, {}),
-    (align_impulse_responses, {}),
+# The pairwise ones: two records that must share a rate. One shared guard
+# refuses every mismatched pair, so the third field is the only thing that
+# says which pair of arguments the call asked it to check.
+_PAIRS_WITH_ARGUMENT_NAMES = [
+    (cross_spectral_density, {}, ("x", "y")),
+    (coherent_output_spectrum, {}, ("x", "y")),
+    (time_delay, {}, ("x", "y")),
+    (align_impulse_responses, {}, ("ir", "reference")),
 ]
+PAIRS = [(func, kwargs) for func, kwargs, _ in _PAIRS_WITH_ARGUMENT_NAMES]
 PAIR_IDS = [f.__name__ for f, _ in PAIRS]
 
 
@@ -143,7 +146,7 @@ def test_a_multichannel_signal_is_refused_by_name(
     averaging -- would answer a question the caller did not ask.
     """
     block = Signal(np.stack([_record(0), _record(1)]), FS)
-    with pytest.raises(ValueError, match="must be one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         func(block, **kwargs)
 
 
@@ -179,14 +182,19 @@ def test_a_pair_takes_the_rate_from_either_side(
     assert_same(func(Signal(x, FS), Signal(y, FS), **kwargs), reference)
 
 
-@pytest.mark.parametrize(("func", "kwargs"), PAIRS, ids=PAIR_IDS)
+@pytest.mark.parametrize(
+    ("func", "kwargs", "names"), _PAIRS_WITH_ARGUMENT_NAMES, ids=PAIR_IDS
+)
 def test_two_signals_at_different_rates_are_refused(
-    func: Callable[..., object], kwargs: dict[str, float]
+    func: Callable[..., object], kwargs: dict[str, float], names: tuple[str, str]
 ) -> None:
     """Nothing here can say which rate is the truth, so neither is chosen."""
     x, y = _record(0), _record(1)
     first, second = Signal(x, FS), Signal(y, FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError,
+        match=rf"'{names[0]}' and '{names[1]}' are Signals recorded at different",
+    ):
         func(first, second, **kwargs)
 
 
@@ -230,7 +238,9 @@ def test_correlation_keeps_its_rate_optional_for_bare_arrays() -> None:
     assert_same(correlation(x, y), correlation(x, y, 1.0))
     assert_same(correlation(Signal(x, FS), y), correlation(x, y, FS))
     at_fs, at_half = Signal(x, FS), Signal(y, FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError, match=r"'x' and 'y' are Signals recorded at different"
+    ):
         correlation(at_fs, at_half)
 
 
@@ -257,7 +267,9 @@ def test_miso_refuses_an_output_recorded_at_another_rate() -> None:
     a, b, out = _record(0), _record(1), _record(2)
     block = Signal(np.stack([a, b]), FS)
     at_half = Signal(out, FS // 2)
-    with pytest.raises(ValueError, match="recorded at different rates"):
+    with pytest.raises(
+        ValueError, match=r"'inputs' and 'output' are Signals recorded at different"
+    ):
         miso_coherence(block, at_half)
 
 
@@ -274,9 +286,13 @@ def test_miso_refuses_two_inputs_recorded_at_different_rates() -> None:
     first, second = Signal(a, FS), Signal(b, FS // 2)
     at_fs, at_half = Signal(out, FS), Signal(out, FS // 2)
     assert first.data.shape == second.data.shape  # the length check is blind
-    with pytest.raises(ValueError, match="different rates"):
+    with pytest.raises(
+        ValueError, match=r"'inputs' holds Signals recorded at different rates"
+    ):
         miso_coherence([first, second], at_fs)
-    with pytest.raises(ValueError, match="different rates"):
+    with pytest.raises(
+        ValueError, match=r"'inputs' holds Signals recorded at different rates"
+    ):
         miso_coherence([second, first], at_half)
 
 
@@ -296,8 +312,16 @@ def test_the_arguments_behind_fs_are_keyword_only_and_required() -> None:
     need the value, and the reader would have to run it to find out.
     """
     sig = Signal(_record(), FS)
-    for call in (zoom_fft, lifter, time_synchronous_average, resample_signal):
-        with pytest.raises(TypeError, match="required keyword-only argument"):
+    for call, missing in (
+        (zoom_fft, r"'f_min'.*'f_max'"),
+        (lifter, r"'cutoff'"),
+        (time_synchronous_average, r"'period'"),
+        (resample_signal, r"'fs_new'"),
+    ):
+        with pytest.raises(
+            TypeError,
+            match=rf"{call.__name__}\(\).*required keyword-only arguments?: {missing}",
+        ):
             call(sig)  # type: ignore[call-arg]
 
 

--- a/tests/signals/test_inversion.py
+++ b/tests/signals/test_inversion.py
@@ -146,7 +146,7 @@ def test_fs_is_taken_from_a_result_object() -> None:
     assert isinstance(res, signals.InverseFilterResult)
     assert res.fs == FS
     bare = np.asarray(ir)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' is required"):
         signals.regularized_inverse_filter(bare, f_range=(200.0, 10000.0))
 
 
@@ -155,32 +155,36 @@ def test_fs_is_taken_from_a_result_object() -> None:
 # --------------------------------------------------------------------------
 def test_rejects_bad_inputs() -> None:
     h = _biquad_ir()
-    with pytest.raises(ValueError, match="f_range"):
+    with pytest.raises(ValueError, match=r"f_range\[0\] must be positive"):
         signals.regularized_inverse_filter(h, FS, f_range=(0.0, 4000.0))
-    with pytest.raises(ValueError, match="f_range"):
+    with pytest.raises(
+        ValueError, match=r"f_range\[1\] must be greater than f_range\[0\]"
+    ):
         signals.regularized_inverse_filter(h, FS, f_range=(4000.0, 200.0))
-    with pytest.raises(ValueError, match="Nyquist"):
+    with pytest.raises(
+        ValueError, match=r"f_range\[1\] must not exceed the Nyquist frequency"
+    ):
         signals.regularized_inverse_filter(h, FS, f_range=(200.0, 40000.0))
-    with pytest.raises(ValueError, match="regularization"):
+    with pytest.raises(ValueError, match=r"regularization levels must be positive"):
         signals.regularized_inverse_filter(
             h, FS, f_range=(200.0, 4000.0), regularization_inside=0.0
         )
-    with pytest.raises(ValueError, match="transition"):
+    with pytest.raises(ValueError, match=r"transition_octaves must be positive"):
         signals.regularized_inverse_filter(
             h, FS, f_range=(200.0, 4000.0), transition_octaves=-1.0
         )
-    with pytest.raises(ValueError, match="n_fft"):
+    with pytest.raises(ValueError, match=r"n_fft must be at least the response length"):
         signals.regularized_inverse_filter(h, FS, f_range=(200.0, 4000.0), n_fft=16)
-    with pytest.raises(ValueError, match="delay"):
+    with pytest.raises(ValueError, match=r"delay must be in \[0, n_fft\)"):
         signals.regularized_inverse_filter(h, FS, f_range=(200.0, 4000.0), delay=-1)
     two_dim = np.zeros((2, 8))
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'response' must be one-dimensional"):
         signals.regularized_inverse_filter(two_dim, FS, f_range=(200.0, 4000.0))
     with_nan = np.array([1.0, np.nan])
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'response' must be finite"):
         signals.regularized_inverse_filter(with_nan, FS, f_range=(200.0, 4000.0))
     all_zero = np.zeros(64)
-    with pytest.raises(ValueError, match="zero"):
+    with pytest.raises(ValueError, match=r"'response' must not be identically zero"):
         signals.regularized_inverse_filter(all_zero, FS, f_range=(200.0, 4000.0))
 
 
@@ -291,5 +295,5 @@ def test_apply_rejects_non_1d() -> None:
     h = _biquad_ir()
     res = signals.regularized_inverse_filter(h, FS, f_range=(500.0, 8000.0))
     two_dim = np.zeros((2, 4))
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         res.apply(two_dim)

--- a/tests/signals/test_levels.py
+++ b/tests/signals/test_levels.py
@@ -102,7 +102,9 @@ def test_ln_levels_weighting_a() -> None:
 def test_ln_levels_invalid_percentile_raises() -> None:
 
     tone = _tone(1000)
-    with pytest.raises(ValueError, match="between 0 and 100"):
+    with pytest.raises(
+        ValueError, match=r"Percentile values in 'n' must be between 0 and 100"
+    ):
         signals.ln_levels(tone, FS, n=(0,))
 
 
@@ -124,20 +126,20 @@ def test_leq_dbfs_ignores_calibration_factor() -> None:
 
 def test_leq_empty_signal_raises() -> None:
     empty = np.array([])
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' cannot be empty"):
         signals.leq(empty)
 
 
 def test_leq_nonpositive_calibration_raises() -> None:
     tone = _tone(1000)
-    with pytest.raises(ValueError, match="calibration_factor"):
+    with pytest.raises(ValueError, match=r"'calibration_factor' must be positive"):
         signals.leq(tone, calibration_factor=-1.0)
 
 
 def test_ln_levels_empty_signal_raises() -> None:
 
     empty = np.array([])
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"Input signal 'x' cannot be empty"):
         signals.ln_levels(empty, FS)
 
 
@@ -376,16 +378,16 @@ def test_sound_exposure_defaults_to_recording_duration() -> None:
 def test_sel_invalid_fs_raises() -> None:
 
     tone = _tone(1000)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"Sample rate 'fs' must be positive"):
         signals.sel(tone, 0)
 
 
 def test_sound_exposure_rejects_nonpositive_duration() -> None:
 
     tone = _tone_at_level(90.0)
-    with pytest.raises(ValueError, match="duration_hours"):
+    with pytest.raises(ValueError, match=r"'duration_hours' must be positive"):
         signals.sound_exposure(tone, FS, duration_hours=0)
-    with pytest.raises(ValueError, match="duration_hours"):
+    with pytest.raises(ValueError, match=r"'duration_hours' must be positive"):
         signals.lex_8h(tone, FS, duration_hours=-1.0)
 
 
@@ -532,9 +534,9 @@ def test_ln_levels_and_sel_accept_every_weighting_filter_curve(curve: str) -> No
 def test_ln_levels_and_sel_reject_an_unknown_weighting() -> None:
 
     x = _tone(1000)
-    with pytest.raises(ValueError, match="Weighting curve"):
+    with pytest.raises(ValueError, match=r"Weighting curve must be"):
         signals.ln_levels(x, FS, weighting="Q")
-    with pytest.raises(ValueError, match="Weighting curve"):
+    with pytest.raises(ValueError, match=r"Weighting curve must be"):
         signals.sel(x, FS, weighting="Q")
 
 

--- a/tests/signals/test_miso.py
+++ b/tests/signals/test_miso.py
@@ -426,7 +426,7 @@ def test_plot_on_given_axis_draws_spectra_panel() -> None:
 def test_rejects_single_input() -> None:
     x1 = _white(140, n=1 << 14)
     y = x1.copy()
-    with pytest.raises(ValueError, match="at least two"):
+    with pytest.raises(ValueError, match=r"'inputs' must hold at least two"):
         ph.signals.miso_coherence([x1], y, FS)
 
 
@@ -445,7 +445,7 @@ def test_rejects_bad_order() -> None:
     x1 = _white(180, n=1 << 14)
     x2 = _white(181, n=1 << 14)
     y = x1 + x2
-    with pytest.raises(ValueError, match="permutation"):
+    with pytest.raises(ValueError, match=r"'order' must be a permutation of range"):
         ph.signals.miso_coherence([x1, x2], y, FS, order=(0, 0))
 
 

--- a/tests/signals/test_multitaper.py
+++ b/tests/signals/test_multitaper.py
@@ -261,31 +261,39 @@ def test_multitaper_defaults_and_result_fields() -> None:
     assert np.allclose(np.sum(res.weights, axis=0), 1.0)
     assert res.random_error.shape == res.degrees_of_freedom.shape
     assert np.allclose(res.random_error, np.sqrt(2.0 / res.degrees_of_freedom))
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError, match=r"cannot assign to field 'psd'"):
         res.psd = res.psd * 2.0  # type: ignore[misc]
 
 
 def test_multitaper_rejects_invalid_inputs() -> None:
     x = _white(37, n=1024)
     two_dimensional = np.zeros((4, 256))
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         ph.signals.multitaper_psd(two_dimensional, FS)
-    with pytest.raises(ValueError, match="too short"):
+    with pytest.raises(ValueError, match=r"Signal too short for a spectral estimate"):
         ph.signals.multitaper_psd(x[:16], FS)
-    with pytest.raises(ValueError, match="positive, finite"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.multitaper_psd(x, -1.0)
-    with pytest.raises(ValueError, match="time_half_bandwidth"):
+    with pytest.raises(ValueError, match=r"'time_half_bandwidth' must be in"):
         ph.signals.multitaper_psd(x, FS, time_half_bandwidth=0.5)
-    with pytest.raises(ValueError, match="Shannon number"):
+    # One sentence covers both ends of the range, so the rejected value is the
+    # only thing that says which end this call was on.
+    with pytest.raises(
+        ValueError,
+        match=r"'n_tapers' must be between 1 and the Shannon number.*\(got 9\)",
+    ):
         ph.signals.multitaper_psd(x, FS, n_tapers=9)
-    with pytest.raises(ValueError, match="Shannon number"):
+    with pytest.raises(
+        ValueError,
+        match=r"'n_tapers' must be between 1 and the Shannon number.*\(got 0\)",
+    ):
         ph.signals.multitaper_psd(x, FS, n_tapers=0)
     silence = np.zeros(1024)
-    with pytest.raises(ValueError, match="identically zero"):
+    with pytest.raises(ValueError, match=r"'x' must not be identically zero"):
         ph.signals.multitaper_psd(silence, FS)
-    with pytest.raises(ValueError, match="scaling"):
+    with pytest.raises(ValueError, match=r"'scaling' must be"):
         ph.signals.multitaper_psd(x, FS, scaling="bogus")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="confidence"):
+    with pytest.raises(ValueError, match=r"'confidence' must be in"):
         ph.signals.multitaper_psd(x, FS, confidence=1.5)
 
 
@@ -350,7 +358,11 @@ def test_multitaper_eigenvalues_and_weights_must_share_the_taper_axis() -> None:
         ("weights", np.vstack([good.weights, good.weights[:1]])),
     )
     for field, value in cases:
-        with pytest.raises(ValueError, match=rf"'{field}'.*{per_taper}"):
+        # Both fields are named whichever one was made wrong, so the count is
+        # what identifies it, and the count is the one this test chose.
+        with pytest.raises(
+            ValueError, match=rf"'{field}' \({len(value)}\).*{per_taper}"
+        ):
             dataclasses.replace(good, **{field: value})
 
 

--- a/tests/signals/test_parametrized_signals.py
+++ b/tests/signals/test_parametrized_signals.py
@@ -289,7 +289,7 @@ def test_time_weighting_class_multichannel_state() -> None:
 
 def test_time_weighting_class_invalid_params() -> None:
 
-    with pytest.raises(ValueError, match="must be positive"):
+    with pytest.raises(ValueError, match=r"'fs' must be positive"):
         filters.TimeWeighting(0)
     with pytest.raises(ValueError, match="Invalid time weighting mode"):
         filters.TimeWeighting(48000, mode="banana")

--- a/tests/signals/test_phase.py
+++ b/tests/signals/test_phase.py
@@ -214,22 +214,24 @@ def test_phase_referenced_to_dc() -> None:
 def test_validation_errors() -> None:
     good = _biquad_response()
     two_dimensional = good.reshape(1, -1)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'response' must be one-dimensional"):
         ph.signals.minimum_phase(two_dimensional)
     too_short = good[:4]
-    with pytest.raises(ValueError, match="at least"):
+    with pytest.raises(
+        ValueError, match=r"'response' must have at least .* frequency bins"
+    ):
         ph.signals.minimum_phase(too_short)
     not_finite = np.full(64, np.nan + 0j)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'response' must be finite"):
         ph.signals.minimum_phase(not_finite)
     all_zero = np.zeros(64)
-    with pytest.raises(ValueError, match="identically zero"):
+    with pytest.raises(ValueError, match=r"'response' must not be identically zero"):
         ph.signals.minimum_phase(all_zero)
-    with pytest.raises(ValueError, match="oversample"):
+    with pytest.raises(ValueError, match=r"'oversample' must be a positive integer"):
         ph.signals.minimum_phase(good, oversample=0)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.group_delay(good, -1.0)
-    with pytest.raises(ValueError, match="fs"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.phase_decomposition(good, 0.0)
 
 

--- a/tests/signals/test_signal_theory_limits.py
+++ b/tests/signals/test_signal_theory_limits.py
@@ -113,7 +113,13 @@ def test_multichannel_mismatched_lengths() -> None:
     # Numpy arrays must have rectangular shape, so we test with a list of lists of different lengths
     x = [[1.0, 2.0, 3.0], [1.0, 2.0]]
     # This should probably raise an error or handle it via numpy's default behavior
-    with pytest.raises((ValueError, TypeError)):
+    # The TypeError arm never fired and is gone: a tuple arm that cannot happen
+    # only widens what the block accepts. The wording below is NUMPY's, not
+    # ours, which is the one case where pinning a foreign message is the lesser
+    # evil: nothing here refuses the ragged input itself. If the library ever
+    # validates it and raises its own ValueError, this test should fail and be
+    # rewritten around that message, because its premise will have changed.
+    with pytest.raises(ValueError, match=r"setting an array element with a sequence"):
         # type ignore because list of lists of floats is technically not what we hint, but what user might pass
         filters.octave_filter(x, fs)  # type: ignore
 

--- a/tests/signals/test_signal_toolbox.py
+++ b/tests/signals/test_signal_toolbox.py
@@ -124,7 +124,9 @@ def test_tone_burst_incommensurate_frequency_warns() -> None:
     only for commensurate f/fs; otherwise a warning quantifies the
     residual step at the gate edge.
     """
-    with pytest.warns(ph.PhonometryWarning, match="incommensurate") as record:
+    with pytest.warns(
+        ph.PhonometryWarning, match=r"'frequency' .* is incommensurate with fs"
+    ) as record:
         res = ph.signals.tone_burst(FS, 997.0, 10)
     assert res.burst_samples == 481
     # The warning quantifies the exact span and the residual step at the
@@ -145,7 +147,9 @@ def test_tone_burst_invalid_config_raises_before_warning() -> None:
 
     with _warnings.catch_warnings():
         _warnings.simplefilter("error", ph.PhonometryWarning)
-        with pytest.raises(ValueError, match="repetition_rate"):
+        with pytest.raises(
+            ValueError, match=r"'repetition_rate' is required when 'repetitions' > 1"
+        ):
             ph.signals.tone_burst(FS, 997.0, 10, repetitions=2)
 
 
@@ -165,17 +169,25 @@ def test_tone_burst_result_is_frozen() -> None:
 
 
 def test_tone_burst_invalid_inputs() -> None:
-    with pytest.raises(ValueError, match="positive integer"):
+    with pytest.raises(ValueError, match=r"'cycles' must be a positive integer"):
         ph.signals.tone_burst(FS, 5000.0, 0)
-    with pytest.raises(ValueError, match="Nyquist"):
+    with pytest.raises(ValueError, match=r"'frequency' must be below the Nyquist rate"):
         ph.signals.tone_burst(FS, 24000.0, 10)
-    with pytest.raises(ValueError, match="repetition_rate"):
+    with pytest.raises(
+        ValueError, match=r"'repetition_rate' is required when 'repetitions' > 1"
+    ):
         ph.signals.tone_burst(FS, 5000.0, 25, repetitions=2)
-    with pytest.raises(ValueError, match="does not fit"):
+    with pytest.raises(
+        ValueError, match=r"The burst does not fit in one repetition period"
+    ):
         ph.signals.tone_burst(FS, 5000.0, 25, repetition_rate=300.0)
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"'pre_silence' must be a non-negative, finite number"
+    ):
         ph.signals.tone_burst(FS, 5000.0, 25, pre_silence=-1.0)
-    with pytest.raises(ValueError, match="positive, finite"):
+    with pytest.raises(
+        ValueError, match=r"'amplitude' must be a positive, finite number"
+    ):
         ph.signals.tone_burst(FS, 5000.0, 25, amplitude=0.0)
 
 
@@ -201,7 +213,9 @@ def test_tone_burst_gate_must_lie_on_the_record_it_gates() -> None:
         ("signal", np.column_stack([res.signal] * 2), one_axis),
     )
     for field, value, fragment in cases:
-        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+        with pytest.raises(
+            ValueError, match=rf"ToneBurstResult: .*'{field}'.*{fragment}"
+        ):
             dataclasses.replace(res, **{field: value})
 
 
@@ -292,18 +306,18 @@ def test_identity_ratio_returns_copy_without_filtering() -> None:
 def test_irrational_ratio_raises() -> None:
     x = ph.signals.noise_signal(FS, 0.05, seed=4)
     fs_irrational = FS * np.sqrt(2.0)
-    with pytest.raises(ValueError, match="rational"):
+    with pytest.raises(ValueError, match=r"'fs_new'/'fs' = .* is not a rational ratio"):
         ph.signals.resample_signal(x, FS, fs_new=fs_irrational)
 
 
 def test_resample_invalid_parameters() -> None:
     x = ph.signals.noise_signal(FS, 0.05, seed=4)
     two_dimensional = np.zeros((4, 4))
-    with pytest.raises(ValueError, match="at least 30"):
+    with pytest.raises(ValueError, match=r"'stopband_attenuation_db' must be at least"):
         ph.signals.resample_signal(x, FS, fs_new=32000.0, stopband_attenuation_db=10.0)
-    with pytest.raises(ValueError, match="transition_width"):
+    with pytest.raises(ValueError, match=r"'transition_width' must be in"):
         ph.signals.resample_signal(x, FS, fs_new=32000.0, transition_width=0.9)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         ph.signals.resample_signal(two_dimensional, FS, fs_new=32000.0)
 
 
@@ -326,7 +340,9 @@ def test_resampled_record_and_taps_must_each_be_flat() -> None:
         ("signal", np.column_stack([res.signal] * 2), one_axis),
     )
     for field, value, fragment in cases:
-        with pytest.raises(ValueError, match=rf"'{field}'.*{fragment}"):
+        with pytest.raises(
+            ValueError, match=rf"ResampledSignalResult: .*'{field}'.*{fragment}"
+        ):
             dataclasses.replace(res, **{field: value})
 
 
@@ -429,11 +445,13 @@ def test_fractional_delay_invalid_inputs() -> None:
     x = ph.signals.noise_signal(FS, 0.05, seed=11)
     full_length = float(x.size)
     two_dimensional = np.zeros((2, 8))
-    with pytest.raises(ValueError, match="mode"):
+    with pytest.raises(ValueError, match=r"'mode' must be 'linear'"):
         ph.signals.fractional_delay(x, 1.0, mode="wrap")  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="magnitude"):
+    with pytest.raises(
+        ValueError, match=r"'delay' magnitude must be smaller than the record length"
+    ):
         ph.signals.fractional_delay(x, full_length)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'delay' must be a finite number"):
         ph.signals.fractional_delay(x, np.nan)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         ph.signals.fractional_delay(two_dimensional, 1.0)

--- a/tests/signals/test_signals.py
+++ b/tests/signals/test_signals.py
@@ -78,11 +78,15 @@ def test_white_is_gaussian_like() -> None:
 
 
 def test_rejects_invalid_arguments() -> None:
-    with pytest.raises(ValueError, match="'fs'"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.noise_signal(0.0, 1.0)
-    with pytest.raises(ValueError, match="'seconds'"):
+    with pytest.raises(
+        ValueError, match=r"'seconds' must be a positive, finite number"
+    ):
         ph.signals.noise_signal(FS, -1.0)
-    with pytest.raises(ValueError, match="16 samples"):
+    with pytest.raises(
+        ValueError, match=r"'fs'\*'seconds' must give at least .* samples"
+    ):
         ph.signals.noise_signal(FS, 1e-5)
     with pytest.raises(ValueError, match="'color'"):
         ph.signals.noise_signal(FS, 1.0, color="brown")  # type: ignore[arg-type]

--- a/tests/signals/test_spectra.py
+++ b/tests/signals/test_spectra.py
@@ -181,9 +181,13 @@ def test_confidence_interval_widens_at_higher_confidence() -> None:
 def test_resolution_bias_error_closed_form() -> None:
     # Eq. 8.141: εb = -(Be/Br)²/3; quarter-bandwidth analysis -> -1/48.
     assert ph.signals.resolution_bias_error(1.0, 4.0) == pytest.approx(-1.0 / 48.0)
-    with pytest.raises(ValueError, match="resolution_bandwidth"):
+    with pytest.raises(
+        ValueError, match=r"'resolution_bandwidth' must be a positive, finite number"
+    ):
         ph.signals.resolution_bias_error(0.0, 4.0)
-    with pytest.raises(ValueError, match="half_power_bandwidth"):
+    with pytest.raises(
+        ValueError, match=r"'half_power_bandwidth' must be a positive, finite number"
+    ):
         ph.signals.resolution_bias_error(1.0, -1.0)
 
 
@@ -411,17 +415,29 @@ def test_smoothing_zero_frequency_point_is_copied() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
-        ({"frequencies": [[1.0, 2.0]], "values": [1.0, 2.0]}, "one-dimensional"),
+        (
+            {"frequencies": [[1.0, 2.0]], "values": [1.0, 2.0]},
+            r"'frequencies' and 'values' must be one-dimensional",
+        ),
         (
             {"frequencies": [1.0, 2.0], "values": [1.0]},
             r"'frequencies'.*'values'.*one value per frequency",
         ),
-        ({"frequencies": [1.0], "values": [1.0]}, "two frequency points"),
-        ({"frequencies": [2.0, 1.0], "values": [1.0, 1.0]}, "increasing"),
-        ({"frequencies": [1.0, np.nan], "values": [1.0, 1.0]}, "finite"),
+        (
+            {"frequencies": [1.0], "values": [1.0]},
+            r"At least two frequency points are required",
+        ),
+        (
+            {"frequencies": [2.0, 1.0], "values": [1.0, 1.0]},
+            r"'frequencies' must be strictly increasing",
+        ),
+        (
+            {"frequencies": [1.0, np.nan], "values": [1.0, 1.0]},
+            r"'frequencies' and 'values' must be finite",
+        ),
         (
             {"frequencies": [1.0, 2.0], "values": [1.0, -1.0]},
-            "non-negative",
+            r"'values' must be non-negative in the power domain",
         ),
         (
             {
@@ -429,15 +445,15 @@ def test_smoothing_zero_frequency_point_is_copied() -> None:
                 "values": [1.0, -1.0],
                 "domain": "amplitude",
             },
-            "non-negative",
+            r"'values' must be non-negative in the amplitude domain",
         ),
         (
             {"frequencies": [1.0, 2.0], "values": [1.0, 1.0], "fraction": 0.0},
-            "fraction",
+            r"'fraction' must be a positive, finite number",
         ),
         (
             {"frequencies": [1.0, 2.0], "values": [1.0, 1.0], "domain": "bad"},
-            "domain",
+            r"'domain' must be",
         ),
     ],
 )
@@ -455,23 +471,27 @@ def test_psd_rejects_invalid_inputs() -> None:
     x = _white(12)
     two_dimensional = np.stack([x, x])
     non_finite = np.full(4096, np.nan)
-    with pytest.raises(ValueError, match="one-dimensional"):
+    with pytest.raises(ValueError, match=r"'x' must be one-dimensional"):
         ph.signals.power_spectral_density(two_dimensional, FS)
-    with pytest.raises(ValueError, match="too short"):
+    with pytest.raises(ValueError, match=r"Signal too short for a spectral estimate"):
         ph.signals.power_spectral_density(x[:16], FS)
-    with pytest.raises(ValueError, match="finite"):
+    with pytest.raises(ValueError, match=r"'x' must be finite"):
         ph.signals.power_spectral_density(non_finite, FS)
-    with pytest.raises(ValueError, match="'fs'"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite number"):
         ph.signals.power_spectral_density(x, 0.0)
-    with pytest.raises(ValueError, match="nperseg"):
+    with pytest.raises(
+        ValueError, match=r"'nperseg' must be between .* and the signal length"
+    ):
         ph.signals.power_spectral_density(x, FS, nperseg=16)
-    with pytest.raises(ValueError, match="nperseg"):
+    with pytest.raises(
+        ValueError, match=r"'nperseg' must be between .* and the signal length"
+    ):
         ph.signals.power_spectral_density(x, FS, nperseg=x.size + 1)
-    with pytest.raises(ValueError, match="overlap"):
+    with pytest.raises(ValueError, match=r"'overlap' must be in"):
         ph.signals.power_spectral_density(x, FS, overlap=1.0)
-    with pytest.raises(ValueError, match="confidence"):
+    with pytest.raises(ValueError, match=r"'confidence' must be in"):
         ph.signals.power_spectral_density(x, FS, confidence=1.0)
-    with pytest.raises(ValueError, match="scaling"):
+    with pytest.raises(ValueError, match=r"'scaling' must be"):
         ph.signals.power_spectral_density(x, FS, scaling="power")  # type: ignore[arg-type]
 
 
@@ -585,7 +605,7 @@ def test_default_nperseg_targets_4hz_resolution() -> None:
 
 def test_results_are_frozen() -> None:
     res = ph.signals.power_spectral_density(_white(15), FS, nperseg=1024)
-    with pytest.raises(AttributeError):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         res.psd = res.psd * 2.0  # type: ignore[misc]
 
 

--- a/tests/signals/test_synchronous_average.py
+++ b/tests/signals/test_synchronous_average.py
@@ -271,7 +271,9 @@ def test_default_n_averages_uses_whole_record() -> None:
 
 def test_requested_n_averages_over_available_raises() -> None:
     signal = _repeat(_periodic(PERIOD, M, (1.0,)), 5)
-    with pytest.raises(ValueError, match="exceeds"):
+    with pytest.raises(
+        ValueError, match=r"'n_averages' = .* exceeds the .* whole periods available"
+    ):
         ph.signals.time_synchronous_average(signal, FS, period=PERIOD, n_averages=6)
 
 
@@ -345,9 +347,9 @@ def test_average_curves_must_run_over_their_own_axis() -> None:
 
 def test_comb_filter_response_validation() -> None:
     one = np.array([1.0])
-    with pytest.raises(ValueError, match="positive integer"):
+    with pytest.raises(ValueError, match=r"'n_averages' must be a positive integer"):
         comb_filter_response(one, PERIOD, 0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'period' must be a positive, finite number"):
         comb_filter_response(one, -1.0, 2)
 
 
@@ -356,9 +358,15 @@ def test_comb_filter_response_rejects_overflowing_order() -> None:
     # instead of the documented bounded response.
     huge_frequency = np.array([1e308])
     large_frequency = np.array([1e307])
-    with pytest.raises(ValueError, match="overflows"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequencies' \* 'period' .* overflows the floating-point range",
+    ):
         comb_filter_response(huge_frequency, 1e308, 3)
-    with pytest.raises(ValueError, match="overflows"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequencies' \* 'period' .* overflows the floating-point range",
+    ):
         comb_filter_response(large_frequency, 100.0, 2**40)
 
 

--- a/tests/signals/test_time_frequency.py
+++ b/tests/signals/test_time_frequency.py
@@ -120,22 +120,24 @@ class TestSpectrogramCalibration:
 class TestSpectrogramValidation:
     def test_rejects_bad_overlap(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="overlap"):
+        with pytest.raises(ValueError, match=r"'overlap' must be in \[0, 1\)"):
             signals.spectrogram(x, 1000.0, overlap=1.0)
 
     def test_rejects_bad_scaling(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="scaling"):
+        with pytest.raises(ValueError, match=r"'scaling' must be 'density'"):
             signals.spectrogram(x, 1000.0, scaling="amplitude")  # type: ignore[arg-type]
 
     def test_rejects_short_signal(self) -> None:
         x = np.ones(8)
-        with pytest.raises(ValueError, match="too short"):
+        with pytest.raises(ValueError, match=r"Signal too short for a spectrogram"):
             signals.spectrogram(x, 1000.0)
 
     def test_rejects_bad_nperseg(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="nperseg"):
+        with pytest.raises(
+            ValueError, match=r"'nperseg' must be between .* and the signal length"
+        ):
             signals.spectrogram(x, 1000.0, nperseg=2048)
 
 
@@ -286,27 +288,33 @@ class TestZoomFFTExactness:
 class TestZoomFFTValidation:
     def test_rejects_inverted_band(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="zoom band"):
+        with pytest.raises(
+            ValueError, match=r"The zoom band must satisfy 0 <= f_min < f_max <= fs/2"
+        ):
             signals.zoom_fft(x, 1000.0, f_min=300.0, f_max=200.0)
 
     def test_rejects_band_above_nyquist(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="zoom band"):
+        with pytest.raises(
+            ValueError, match=r"The zoom band must satisfy 0 <= f_min < f_max <= fs/2"
+        ):
             signals.zoom_fft(x, 1000.0, f_min=100.0, f_max=600.0)
 
     def test_rejects_negative_f_min(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="zoom band"):
+        with pytest.raises(
+            ValueError, match=r"The zoom band must satisfy 0 <= f_min < f_max <= fs/2"
+        ):
             signals.zoom_fft(x, 1000.0, f_min=-10.0, f_max=200.0)
 
     def test_rejects_single_point_grid(self) -> None:
         x = np.ones(1024)
-        with pytest.raises(ValueError, match="n_points"):
+        with pytest.raises(ValueError, match=r"'n_points' must be at least 2"):
             signals.zoom_fft(x, 1000.0, f_min=100.0, f_max=200.0, n_points=1)
 
     def test_rejects_short_signal(self) -> None:
         x = np.ones(8)
-        with pytest.raises(ValueError, match="too short"):
+        with pytest.raises(ValueError, match=r"Signal too short for a zoom FFT"):
             signals.zoom_fft(x, 1000.0, f_min=100.0, f_max=200.0)
 
     def test_spectral_quantities_must_sit_on_the_zoom_grid(self) -> None:

--- a/tests/signals/test_window_metrics.py
+++ b/tests/signals/test_window_metrics.py
@@ -135,7 +135,7 @@ def test_window_metrics_result_is_frozen() -> None:
 def test_window_metrics_invalid_inputs() -> None:
     with pytest.raises(ValueError, match="Unknown window"):
         ph.signals.window_metrics("not-a-window", N)
-    with pytest.raises(ValueError, match="at least 16"):
+    with pytest.raises(ValueError, match=r"'n' must be at least \d+ samples"):
         ph.signals.window_metrics("hann", 8)
 
 

--- a/tests/vibration/human/test_human_vibration.py
+++ b/tests/vibration/human/test_human_vibration.py
@@ -193,7 +193,7 @@ def test_unknown_weighting_raises() -> None:
 
 
 def test_frequency_weighting_rejects_empty() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'frequencies' must be a non-empty"):
         hv.frequency_weighting("Wk", [])
 
 
@@ -221,9 +221,9 @@ def test_apply_weighting_scales_sine_by_magnitude() -> None:
 
 def test_apply_weighting_validates() -> None:
     two_dimensional = np.zeros((2, 2))
-    with pytest.raises(ValueError, match="1-D"):
+    with pytest.raises(ValueError, match=r"'signal' must be a non-empty 1-D array"):
         hv.apply_weighting(two_dimensional, 1000.0, name="Wk")
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'fs' must be a positive, finite"):
         hv.apply_weighting([1.0, 2.0], 0.0, name="Wk")
 
 
@@ -309,9 +309,9 @@ def test_running_rms_of_constant_power_signal() -> None:
 
 
 def test_running_rms_validation() -> None:
-    with pytest.raises(ValueError, match="method"):
+    with pytest.raises(ValueError, match=r"'method' must be 'linear'"):
         hv.running_rms([1.0, 2.0], 100.0, method="bogus")
-    with pytest.raises(ValueError, match="integration_time"):
+    with pytest.raises(ValueError, match=r"'integration_time' must be positive"):
         hv.running_rms([1.0, 2.0], 100.0, integration_time=0.0)
 
 
@@ -323,7 +323,7 @@ def test_crest_factor_warns_above_nine() -> None:
     # A lone spike gives crest = 10 / (10/sqrt(200)) = sqrt(200) ~ 14.1 > 9.
     x = np.zeros(200)
     x[0] = 10.0
-    with pytest.warns(hv.HumanVibrationWarning, match="exceeds 9"):
+    with pytest.warns(hv.HumanVibrationWarning, match=r"Crest factor .* exceeds"):
         cf = hv.crest_factor(x)
     assert cf > 9.0
 
@@ -360,9 +360,13 @@ def test_wbv_exposure_basis_z_axis_dominates_and_differs_from_vector_total() -> 
 
 
 def test_wbv_exposure_basis_rejects_negative_or_nonfinite() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"axis r\.m\.s\. accelerations must be non-negative"
+    ):
         hv.wbv_exposure_basis(-0.1, 0.2, 0.3)
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"axis r\.m\.s\. accelerations must be non-negative"
+    ):
         hv.wbv_exposure_basis(0.1, math.nan, 0.3)
 
 
@@ -416,7 +420,7 @@ def test_energy_equivalent_acceleration() -> None:
 
 
 def test_energy_equivalent_rejects_negative_duration() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"^'durations_s' must be non-negative"):
         hv.energy_equivalent_acceleration([1.0, 2.0], [1.0, -1.0])
 
 
@@ -459,7 +463,7 @@ def test_exposure_assessment_wbv_a8_and_vdv() -> None:
 def test_exposure_assessment_invalid() -> None:
     with pytest.raises(ValueError, match="kind must be 'hav' or 'wbv'"):
         hv.exposure_assessment(1.0, kind="hav", metric="vdv")
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(ValueError, match=r"'value' must be finite and non-negative"):
         hv.exposure_assessment(-1.0, kind="hav")
 
 
@@ -511,17 +515,17 @@ def test_all_nonpositive_frequencies_return_zero_response() -> None:
 
 
 def test_apply_weighting_rejects_empty_signal() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'signal' must be a non-empty"):
         hv.apply_weighting([], 1000.0, name="Wk")
 
 
 def test_running_rms_rejects_empty_signal() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'signal' must be a non-empty"):
         hv.running_rms([], 1000.0)
 
 
 def test_vibration_total_value_validates() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'components' must be a non-empty"):
         hv.vibration_total_value([])
     with pytest.raises(
         ValueError, match=r"vibration_total_value: 'components' .*'k' .*same shape"
@@ -530,12 +534,15 @@ def test_vibration_total_value_validates() -> None:
 
 
 def test_daily_exposure_rejects_negative() -> None:
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError,
+        match=r"'total_value' and 'duration_s' must be finite and non-negative",
+    ):
         hv.daily_exposure(-1.0, 3600.0)
 
 
 def test_combine_partial_exposures_rejects_empty() -> None:
-    with pytest.raises(ValueError, match="non-empty"):
+    with pytest.raises(ValueError, match=r"'partials' must be a non-empty"):
         hv.combine_partial_exposures([])
 
 
@@ -544,7 +551,9 @@ def test_hav_daily_exposure_validates() -> None:
         ValueError, match=r"hav_daily_exposure: 'total_values' .*'durations_s' .*shape"
     ):
         hv.hav_daily_exposure([2.0, 3.0], [3600.0])
-    with pytest.raises(ValueError, match="non-negative"):
+    with pytest.raises(
+        ValueError, match=r"'total_values' and 'durations_s' must be non-negative"
+    ):
         hv.hav_daily_exposure([2.0, -3.0], [3600.0, 3600.0])
 
 
@@ -558,12 +567,12 @@ def test_energy_equivalent_rejects_length_mismatch() -> None:
 
 
 def test_energy_equivalent_rejects_zero_total_duration() -> None:
-    with pytest.raises(ValueError, match="total duration"):
+    with pytest.raises(ValueError, match=r"total duration must be positive"):
         hv.energy_equivalent_acceleration([1.0, 2.0], [0.0, 0.0])
 
 
 def test_hav_vwf_lifetime_rejects_nonpositive() -> None:
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'a8' must be a positive daily exposure"):
         hv.hav_vwf_lifetime_years(0.0)
 
 

--- a/tests/vibration/human/test_human_vibration_report.py
+++ b/tests/vibration/human/test_human_vibration_report.py
@@ -276,7 +276,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _annex_e3_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -284,7 +284,7 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _annex_e3_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")
 
 

--- a/tests/vibration/human/test_multiple_shock_report.py
+++ b/tests/vibration/human/test_multiple_shock_report.py
@@ -213,7 +213,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _annex_c_male()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -221,5 +221,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _annex_c_male()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/vibration/human/test_multiple_shock_vibration.py
+++ b/tests/vibration/human/test_multiple_shock_vibration.py
@@ -211,16 +211,16 @@ def test_multiple_shock_assessment_end_to_end() -> None:
 def test_invalid_inputs_raise() -> None:
     with pytest.raises(ValueError, match="'fs' must be positive"):
         v.spinal_response([1.0, 2.0], 0.0)
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(ValueError, match=r"acceleration must not be empty"):
         v.spinal_response([], 256.0)
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match=r"'measurement_time' must be positive"):
         v.daily_dose(50.0, 8.0, 0.0)
     with pytest.raises(
         ValueError,
         match=r"daily_dose_multi: 'doses'.*must all have the same shape",
     ):
         v.daily_dose_multi([1.0, 2.0], [1.0], [1.0, 2.0])
-    with pytest.raises(ValueError, match="years must be"):
+    with pytest.raises(ValueError, match="years must be a positive integer"):
         v.injury_risk(1.0, start_age=20, years=0, days_per_year=120)
     with pytest.raises(ValueError, match="'sex' must be"):
         v.injury_probability(1.0, sex="other")
@@ -237,7 +237,9 @@ def test_invalid_inputs_raise() -> None:
 
 def test_injury_risk_rejects_exhausted_strength() -> None:
     # By ~age 125 the male ultimate strength minus static stress goes negative.
-    with pytest.raises(ValueError, match="non-positive"):
+    with pytest.raises(
+        ValueError, match=r"ultimate strength minus static stress is non-positive"
+    ):
         v.injury_risk(1.0, start_age=20, years=120, days_per_year=120, sex="male")
 
 

--- a/tests/vibration/machinery/test_diagnostics.py
+++ b/tests/vibration/machinery/test_diagnostics.py
@@ -339,7 +339,10 @@ class TestValidation:
             bearing_fault_frequencies(**{**_P85, **kwargs})  # type: ignore[arg-type]
 
     def test_bearing_rejects_element_larger_than_pitch(self) -> None:
-        with pytest.raises(ValueError, match="smaller than"):
+        with pytest.raises(
+            ValueError,
+            match=r"'element_diameter' must be smaller than 'pitch_diameter'",
+        ):
             bearing_fault_frequencies(2000.0, 15, 40.0, 34.0)
 
     @pytest.mark.parametrize(
@@ -375,7 +378,9 @@ class TestValidation:
 
     def test_motor_rejects_supply_below_shaft_rate(self) -> None:
         """A shaft turning at or above synchronous speed is not an induction motor."""
-        with pytest.raises(ValueError, match="synchronous"):
+        with pytest.raises(
+            ValueError, match=r"the shaft rate must stay below the synchronous speed"
+        ):
             induction_motor_frequencies(3600.0, 4, 52, supply_frequency=60.0)
 
     @pytest.mark.parametrize(
@@ -393,21 +398,23 @@ class TestValidation:
 
     def test_unknown_line_name(self) -> None:
         res = bearing_fault_frequencies(**_P85)  # type: ignore[arg-type]
-        with pytest.raises(KeyError, match="BPFO"):
+        with pytest.raises(KeyError, match=r"no fault line named 'not-a-line'"):
             _ = res["not-a-line"]
 
     def test_within_rejects_inverted_span(self) -> None:
         res = bearing_fault_frequencies(**_P85)  # type: ignore[arg-type]
-        with pytest.raises(ValueError, match="greater than"):
+        with pytest.raises(ValueError, match=r"'high' must be greater than 'low'"):
             res.within(500.0, 100.0)
 
     def test_harmonics_rejects_zero_count(self) -> None:
         res = bearing_fault_frequencies(**_P85)  # type: ignore[arg-type]
-        with pytest.raises(ValueError, match="positive integer"):
+        with pytest.raises(ValueError, match=r"'count' must be a positive integer"):
             res.harmonics("BPFO", 0)
 
     def test_combine_rejects_no_results(self) -> None:
-        with pytest.raises(ValueError, match="at least one"):
+        with pytest.raises(
+            ValueError, match="'combine_fault_lines' needs at least one result"
+        ):
             combine_fault_lines()
 
     def test_combine_rejects_mismatched_shaft_rates(self) -> None:

--- a/tests/vibration/structural/test_experimental_sea.py
+++ b/tests/vibration/structural/test_experimental_sea.py
@@ -369,7 +369,10 @@ class TestValidation:
     """Invalid measurements are rejected rather than silently inverted."""
 
     def test_receiver_richer_in_modal_energy_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="modal energy"):
+        with pytest.raises(
+            ValueError,
+            match=r"driven subsystem must hold more modal energy than the receiver",
+        ):
             power_injection_clf(500.0, 1.0, 2.0, 4.4e-3, 2.4e-3, 1.0, 1.0)
 
     @pytest.mark.parametrize("bad", [0.0, -1.0])
@@ -378,7 +381,10 @@ class TestValidation:
             power_injection_clf(500.0, bad, 0.1, 4.4e-3, 2.4e-3, 1.0, 1.0)
 
     def test_band_length_mismatch(self) -> None:
-        with pytest.raises(ValueError, match="frequency bands"):
+        with pytest.raises(
+            ValueError,
+            match=r"'energy1' must be a scalar or match the \d+ frequency bands",
+        ):
             power_injection_clf(
                 [125.0, 250.0], [1.0, 0.9, 0.8], 0.1, 4.4e-3, 2.4e-3, 1.0, 1.0
             )
@@ -408,7 +414,7 @@ class TestValidation:
         """Two tests with proportional energy distributions are singular."""
         energies = np.array([[[1.0], [2.0]], [[0.5], [1.0]]])
         powers = np.ones((2, 1))
-        with pytest.raises(ValueError, match="singular"):
+        with pytest.raises(ValueError, match=r"measured energy matrix is singular"):
             power_injection_matrix(_ONE_BAND, energies, powers)
 
     def test_unknown_band(self) -> None:

--- a/tests/vibration/structural/test_mechanical_mobility.py
+++ b/tests/vibration/structural/test_mechanical_mobility.py
@@ -138,9 +138,17 @@ def test_unknown_frf_raises() -> None:
 
 def test_zero_value_reciprocal_conversion_raises() -> None:
     # A dead channel cannot be converted through a force-per-motion reciprocal.
-    with pytest.raises(ValueError, match="dead channel"):
+    with pytest.raises(
+        ValueError,
+        match=r"'value' contains zeros \(dead channel\); converting 'mobility' to "
+        r"'impedance'",
+    ):
         vibration.convert_frf(0.0, 100.0, "mobility", "impedance")
-    with pytest.raises(ValueError, match="dead channel"):
+    with pytest.raises(
+        ValueError,
+        match=r"'value' contains zeros \(dead channel\); converting 'impedance' to "
+        r"'mobility'",
+    ):
         vibration.convert_frf([1e-3, 0.0], 100.0, "impedance", "mobility")
     # Motion-per-force to motion-per-force tolerates zeros (0 maps to 0).
     out = vibration.convert_frf(0.0, 100.0, "mobility", "accelerance")
@@ -148,11 +156,14 @@ def test_zero_value_reciprocal_conversion_raises() -> None:
 
 
 def test_non_positive_frequency_raises() -> None:
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequency' must be positive \(mobility conversions divide by omega\)",
+    ):
         vibration.convert_frf(1.0, 0.0, "receptance", "mobility")
-    with pytest.raises(ValueError, match="mass"):
+    with pytest.raises(ValueError, match=r"'mass' must be positive"):
         vibration.sdof_receptance(100.0, 0.0, K, C)
-    with pytest.raises(ValueError, match="damping"):
+    with pytest.raises(ValueError, match=r"'damping' must be non-negative"):
         vibration.sdof_receptance(100.0, M, K, -1.0)
 
 
@@ -197,18 +208,21 @@ def test_rigid_mass_calibration_accepts_complex_frf() -> None:
 
 
 def test_rigid_mass_calibration_validation() -> None:
-    with pytest.raises(ValueError, match="quantity"):
+    with pytest.raises(ValueError, match=r"'quantity' must be 'accelerance'"):
         vibration.rigid_mass_calibration_check(
             [0.1], [100.0], 10.0, quantity="receptance"
         )
-    with pytest.raises(ValueError, match="mass"):
+    with pytest.raises(ValueError, match=r"'mass' must be positive"):
         vibration.rigid_mass_calibration_check([0.1], [100.0], 0.0)
     with pytest.raises(
         ValueError,
         match=r"rigid_mass_calibration_check: 'frf'.*'frequencies'.*same shape",
     ):
         vibration.rigid_mass_calibration_check([0.1, 0.1], [100.0], 10.0)
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(
+        ValueError,
+        match=r"'frequency' must be positive \(mobility conversions divide by omega\)",
+    ):
         vibration.rigid_mass_calibration_check([0.1], [0.0], 10.0)
 
 
@@ -225,7 +239,9 @@ def test_a_tolerance_mask_short_of_its_frequencies_is_refused() -> None:
     f = np.geomspace(20.0, 2000.0, 12)
     res = vibration.rigid_mass_calibration_check(np.full(12, 0.1), f, mass=10.0)
     short = res.within_tolerance[:8]
-    with pytest.raises(ValueError, match="'within_tolerance'"):
+    with pytest.raises(
+        ValueError, match=r"'within_tolerance' \(8\).*must each carry one value"
+    ):
         dataclasses.replace(res, within_tolerance=short)
 
 
@@ -251,11 +267,11 @@ def test_random_error_scales_with_averages() -> None:
 
 
 def test_random_error_validation() -> None:
-    with pytest.raises(ValueError, match="n_averages"):
+    with pytest.raises(ValueError, match=r"'n_averages' must be at least 1"):
         vibration.random_error_percent(0.8, 0)
-    with pytest.raises(ValueError, match="coherence"):
+    with pytest.raises(ValueError, match=r"'coherence' must lie in \(0, 1\]"):
         vibration.random_error_percent(0.0, 10)
-    with pytest.raises(ValueError, match="coherence"):
+    with pytest.raises(ValueError, match=r"'coherence' must lie in \(0, 1\]"):
         vibration.random_error_percent(1.2, 10)
 
 
@@ -285,7 +301,9 @@ def test_a_mobility_short_of_its_frequencies_is_refused() -> None:
     """
     res = vibration.sdof_mobility_result(np.linspace(1.0, 50.0, 40), M, K, C)
     short = res.mobility[:-1]
-    with pytest.raises(ValueError, match="'mobility'"):
+    with pytest.raises(
+        ValueError, match=r"'mobility' \(39\).*must each carry one value"
+    ):
         dataclasses.replace(res, mobility=short)
 
 
@@ -314,7 +332,10 @@ def test_a_non_finite_frf_value_is_refused(field_name: str, bad: complex) -> Non
     res = vibration.sdof_mobility_result(np.linspace(1.0, 50.0, 40), M, K, C)
     values = np.asarray(getattr(res, field_name)).copy()
     values[20] = bad
-    with pytest.raises(ValueError, match=f"MobilityResult: '{field_name}'"):
+    with pytest.raises(
+        ValueError,
+        match=f"MobilityResult: '{field_name}' must contain only finite values",
+    ):
         dataclasses.replace(res, **{field_name: values})
 
 

--- a/tests/vibration/structural/test_mobility_report.py
+++ b/tests/vibration/structural/test_mobility_report.py
@@ -132,7 +132,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _driving_point_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -140,5 +140,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _driving_point_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")

--- a/tests/vibration/structural/test_point_mobility.py
+++ b/tests/vibration/structural/test_point_mobility.py
@@ -165,9 +165,9 @@ def test_plate_bending_wave_speed() -> None:
 # Validation.
 # ---------------------------------------------------------------------------
 def test_rejects_non_positive() -> None:
-    with pytest.raises(ValueError, match="bending_stiffness"):
+    with pytest.raises(ValueError, match=r"'bending_stiffness' must be positive"):
         vibration.infinite_plate_impedance(-1.0, M2)
-    with pytest.raises(ValueError, match="location"):
+    with pytest.raises(ValueError, match=r"'location' must be"):
         vibration.infinite_plate_impedance(BP, M2, location="corner")
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency' must be positive"):
         vibration.infinite_beam_mobility(0.0, B_BEAM, M1)

--- a/tests/vibration/structural/test_radiation_efficiency.py
+++ b/tests/vibration/structural/test_radiation_efficiency.py
@@ -91,9 +91,9 @@ def test_clamped_boundary_radiates_more() -> None:
 # Validation.
 # ---------------------------------------------------------------------------
 def test_rejects_bad_input() -> None:
-    with pytest.raises(ValueError, match="boundary"):
+    with pytest.raises(ValueError, match=r"'boundary' must be one of"):
         vibration.radiation_efficiency([500.0], LX, LY, 2000.0, boundary="pinned")
-    with pytest.raises(ValueError, match="critical_frequency"):
+    with pytest.raises(ValueError, match=r"'critical_frequency' must be positive"):
         vibration.radiation_efficiency([500.0], LX, LY, -1.0)
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency' must be positive"):
         vibration.radiation_efficiency([-1.0], LX, LY, 2000.0)

--- a/tests/vibration/structural/test_transfer_stiffness.py
+++ b/tests/vibration/structural/test_transfer_stiffness.py
@@ -44,15 +44,15 @@ def test_level_custom_reference() -> None:
 
 
 def test_level_rejects_non_positive_reference() -> None:
-    with pytest.raises(ValueError, match="reference"):
+    with pytest.raises(ValueError, match=r"'reference' must be positive"):
         vibration.transfer_stiffness_level(1e6, reference=0.0)
 
 
 def test_level_rejects_zero_stiffness() -> None:
     # A dead channel (|k| = 0) has no level; -inf must not propagate silently.
-    with pytest.raises(ValueError, match="zero"):
+    with pytest.raises(ValueError, match=r"'stiffness' contains zero magnitudes"):
         vibration.transfer_stiffness_level(0.0)
-    with pytest.raises(ValueError, match="dead-channel"):
+    with pytest.raises(ValueError, match=r"'stiffness' contains zero magnitudes"):
         vibration.transfer_stiffness_level([1e6, 0.0 + 0.0j])
 
 
@@ -79,9 +79,13 @@ def test_loss_factor_is_tan_phase() -> None:
 
 def test_loss_factor_rejects_purely_imaginary_stiffness() -> None:
     # Re(k) = 0 -> eta = Im/Re is undefined, not inf.
-    with pytest.raises(ValueError, match="purely imaginary"):
+    with pytest.raises(
+        ValueError, match=r"'stiffness' contains purely imaginary values"
+    ):
         vibration.loss_factor(1j * 1e6)
-    with pytest.raises(ValueError, match="purely imaginary"):
+    with pytest.raises(
+        ValueError, match=r"'stiffness' contains purely imaginary values"
+    ):
         vibration.loss_factor([1e6 + 1e4j, 0.0 + 5e5j])
 
 
@@ -101,7 +105,7 @@ def test_direct_method_preserves_phase() -> None:
 
 def test_direct_method_rejects_zero_displacement() -> None:
     # A dead u1 channel must raise, not return an infinite stiffness.
-    with pytest.raises(ValueError, match="input_displacement"):
+    with pytest.raises(ValueError, match=r"'input_displacement' contains zeros"):
         vibration.transfer_stiffness_direct(5.0 + 0j, 0.0 + 0j)
     with pytest.raises(ValueError, match="dead input channel"):
         vibration.transfer_stiffness_direct([5.0, 4.0], [1e-6, 0.0])
@@ -137,9 +141,9 @@ def test_indirect_recovers_kelvin_voigt_at_high_frequency() -> None:
 
 
 def test_indirect_rejects_bad_inputs() -> None:
-    with pytest.raises(ValueError, match="frequency"):
+    with pytest.raises(ValueError, match=r"'frequency' must be positive"):
         vibration.transfer_stiffness_indirect(0.0, 0.01 + 0j, 10.0)
-    with pytest.raises(ValueError, match="blocking_mass"):
+    with pytest.raises(ValueError, match=r"'blocking_mass' must be positive"):
         vibration.transfer_stiffness_indirect(500.0, 0.01 + 0j, 0.0)
 
 
@@ -148,7 +152,9 @@ def test_indirect_rejects_bad_inputs() -> None:
 # ---------------------------------------------------------------------------
 def test_indirect_warns_above_transmissibility_limit() -> None:
     # |T| = 0.5 violates Inequality (2) (DeltaL1,2 < 20 dB): a warning fires.
-    with pytest.warns(PhonometryWarning, match="Inequality"):
+    with pytest.warns(
+        PhonometryWarning, match=r"ISO 10846-3 Inequality \(2\) is violated"
+    ):
         vibration.transfer_stiffness_indirect(50.0, 0.5 + 0j, 10.0)
 
 
@@ -163,7 +169,9 @@ def test_indirect_silent_within_transmissibility_limit() -> None:
 def test_result_helper_warns_above_transmissibility_limit() -> None:
     f = np.array([100.0, 200.0])
     t = np.array([0.5 + 0j, 0.02 + 0j])
-    with pytest.warns(PhonometryWarning, match="ISO 10846-3"):
+    with pytest.warns(
+        PhonometryWarning, match=r"ISO 10846-3 Inequality \(2\) is violated"
+    ):
         vibration.indirect_transfer_stiffness_result(f, t, blocking_mass=8.0)
 
 
@@ -237,7 +245,7 @@ def test_blocking_force_ratio_complex_and_validation() -> None:
     assert complex(vibration.blocking_force_ratio(k22, kt)) == pytest.approx(
         1.0 / (1.0 + k22 / kt)
     )
-    with pytest.raises(ValueError, match="termination_stiffness"):
+    with pytest.raises(ValueError, match=r"'termination_stiffness' must be non-zero"):
         vibration.blocking_force_ratio(1e5, 0.0)
 
 
@@ -283,7 +291,9 @@ def test_plot_returns_axes() -> None:
     t = vibration.base_transmissibility(f, 5.0, 1e6, 200.0)
     # The synthetic curve exceeds |T| = 0.1 near resonance, so the
     # ISO 10846-3 validity advisory is expected, as in the tests above.
-    with pytest.warns(PhonometryWarning, match="ISO 10846-3"):
+    with pytest.warns(
+        PhonometryWarning, match=r"ISO 10846-3 Inequality \(2\) is violated"
+    ):
         res = vibration.indirect_transfer_stiffness_result(f, t, blocking_mass=5.0)
     assert res.plot() is not None
 
@@ -321,7 +331,7 @@ def test_a_stiffness_short_of_its_frequencies_is_refused() -> None:
     t = np.array([0.05, 0.02, 0.008]) * np.exp(1j * 0.1)
     res = vibration.indirect_transfer_stiffness_result(f, t, blocking_mass=8.0)
     short = res.transfer_stiffness[:-1]
-    with pytest.raises(ValueError, match="'transfer_stiffness'"):
+    with pytest.raises(ValueError, match=rf"'transfer_stiffness' \({short.size}\)"):
         dataclasses.replace(res, transfer_stiffness=short)
 
 
@@ -334,7 +344,7 @@ def test_a_lone_frequency_beside_a_spectrum_is_refused() -> None:
     """
     res = vibration.indirect_transfer_stiffness_result(500.0, 0.01, blocking_mass=8.0)
     spectrum = np.full(3, complex(res.transfer_stiffness))
-    with pytest.raises(ValueError, match="'frequencies'"):
+    with pytest.raises(ValueError, match="'frequencies' must have one axis"):
         dataclasses.replace(res, transfer_stiffness=spectrum)
 
 

--- a/tests/vibration/structural/test_transfer_stiffness_report.py
+++ b/tests/vibration/structural/test_transfer_stiffness_report.py
@@ -201,7 +201,7 @@ def test_unknown_engine_rejected(tmp_path: Path) -> None:
     """An unknown rendering engine raises ValueError."""
     res = _direct_result()
     out = str(tmp_path / "x.pdf")
-    with pytest.raises(ValueError, match="engine"):
+    with pytest.raises(ValueError, match=r"Unknown report engine"):
         res.report(out, engine="weasyprint")
 
 
@@ -209,5 +209,5 @@ def test_unknown_language_rejected(tmp_path: Path) -> None:
     """An unknown fiche language raises ValueError."""
     res = _direct_result()
     out = str(tmp_path / "bad.pdf")
-    with pytest.raises(ValueError, match="language"):
+    with pytest.raises(ValueError, match=r"Unknown language"):
         res.report(out, language="xx")


### PR DESCRIPTION
Third of three, and it carries the part a census could not have found.

#637 and #638 close the patterns that are visibly too short. This one closes the ones that quote an identifier and still fail to pin the refusal, which no list of "short patterns" would ever flag.

## The class

The shared validation raises three rules per result type that all name the same field: the per-band counts, the axis, and the value. A pattern of the field alone matches all three, so a test named for the finiteness guard passes identically on the None guard. Measured, not argued: in one file the pattern built as `f"StaticAirflowResult: '{field}'"` matches both `must be finite.` and `must not be None.`, and the test is named for the first.

Two sites in another file each carried `'rating' must be finite` and each matched the *other* class's message, so neither pinned the class its own test name claims. Both passed. Both had always passed.

## How they were found

By capturing the message every `pytest.raises` site actually raises and cross-matching each pattern against every distinct message the corpus can produce, with messages that state the same rule from two call sites counted as one rule.

A pattern is never ambiguous inside its own file. It is ambiguous against everything the library can say, which is why this needed a corpus-wide instrument rather than a reading.

## What came out

266 sites separated. As many again were examined and left alone, most of them one rule stated from two call sites, which reads as a collision and is not one.

Two rounds of independent verification followed, and both found the same direction of error: patterns tightened *past* usefulness, carrying a citation, a library-chosen count, or the repr of the value the test passed. One had kept the count the library chose and dropped the one the test built, which is exactly backwards. Those were relaxed to the shortest form that still selects one rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation tests across broadcast, emission, hearing, metrology, noise control, room, signals, and vibration features.
  * Error and warning checks now verify precise, field-specific messages, including invalid inputs, report settings, plotting requirements, and array dimensions.
  * Updated immutable-result checks to expect the appropriate frozen-instance error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->