### PR TITLE
Let a band with no reading draw as no bar, not as a measured zero

### DIFF
--- a/scripts/figures/materials.py
+++ b/scripts/figures/materials.py
@@ -2450,9 +2450,17 @@ def generate_insitu_absorption(output_dir: str) -> None:
     freqs = result.frequencies
     positions = np.arange(freqs.size, dtype=float)
     _fig, ax = plt.subplots(figsize=(10, 6.3))
+    # No nan_to_num here. ISO 13472-1 leaves a band undetermined when the
+    # separated impulse responses give it no usable energy, and the producer
+    # says so with a NaN; zeroing it would draw a full-height gap as a
+    # measured alpha of zero, which reads as perfect reflection, the opposite
+    # of no reading at all. Matplotlib draws no bar for a NaN height, which is
+    # what the result's own .plot() does before marking the position with an
+    # em dash. This spectrum has no undetermined band today, so the figure is
+    # unchanged; the difference only shows on data that does.
     ax.bar(
         positions,
-        np.nan_to_num(result.absorption),
+        np.asarray(result.absorption, dtype=float),
         width=0.7,
         color=COLOR_PRIMARY,
         edgecolor=COLOR_FG,


### PR DESCRIPTION
The in-situ absorption figure passed its spectrum through `nan_to_num` before drawing it.

ISO 13472-1 leaves a band undetermined when the separated impulse responses give it no usable energy, and the producer says so with a NaN. Zeroing it drew a full-height gap as an alpha of exactly zero: not an absent reading but a claim of perfect reflection, in the ordinary colour, indistinguishable from a measured band.

## The other two ways the tree already gets this right

The renderer this script bypasses draws no bar and marks the position with an em dash.

The library's other bar charts keep `nan_to_num` but pair it with `_hatch_invalid`, so a flagged band's zero height reads as a marker rather than a value, muted and hatched. One of them goes further and excludes the flagged positions entirely, drawing a full-height hatched span instead and citing ISO 9614-3 9.2 for it.

The figure script had neither, which is what made it the only real instance. I swept every `nan_to_num` in the tree rather than fixing the one I was told about: five others, and all five are either downstream of a construction guard that already refuses a non-finite value, paired with hatching, or a named geometric substitution rather than a plotted measurement.

## Effect on the figure

None. The spectrum drawn here carries no undetermined band, so it regenerates byte for byte identical, which I checked by regenerating and comparing. The difference only appears on data that does.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Modified the absorption plot generation in scripts/figures/materials.py to remove np.nan_to_num.</li>
<li>Changed the absorption data conversion to use np.asarray instead of np.nan_to_num to allow Matplotlib to correctly handle NaN values by not drawing bars for them, preventing misleading zero-absorption readings.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated absorption plots to preserve unavailable measurements as gaps instead of displaying them as zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->