### PR TITLE
Refuse at the door what used to arrive as a NaN

### DIFF
--- a/src/phonometry/_internal/utils.py
+++ b/src/phonometry/_internal/utils.py
@@ -8,8 +8,10 @@ from typing import TYPE_CHECKING, cast
 import numpy as np
 from scipy import signal
 
+from .validation import _as_float64
+
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from numpy.typing import ArrayLike
 
 # Rank of the cached SOS filter state ``zi`` as ``_sos_initial_state`` lays
 # it out: (n_sections, 2) for 1-D input, (n_sections, n_channels, 2) for 2-D.
@@ -17,17 +19,56 @@ _ZI_NDIM_MONO = 2
 _ZI_NDIM_MULTICHANNEL = 3
 
 
-def _typesignal(x: Sequence[float] | np.ndarray) -> np.ndarray:
+def _typesignal(x: ArrayLike, *, name: str = "x") -> np.ndarray:
     """Ensure signal is a float64 numpy array.
 
     Integer inputs (e.g. int16 audio from ``scipy.io.wavfile.read``) are
     converted to float64 to prevent silent overflow when the signal is
     squared internally. Float64 arrays are passed through without copying.
 
+    Every entry point that consumes a recording resolves its samples here or
+    through :func:`phonometry.io._resolve.resolve_samples`, which is why the
+    three refusals below live in one place rather than in each of them.
+
+    ``np.asarray`` on its own says too little and admits too much. A string
+    or a ragged list of lists comes back in numpy's own words, naming no
+    parameter, and a dict, a complex number or a plain object comes back as
+    a ``TypeError``, which is not the exception these entry points document;
+    both are re-raised as a ``ValueError`` that says which argument was
+    wrong, exactly as :func:`~phonometry._internal.validation._as_float64`
+    does for the result fields one layer up.
+
+    ``None`` it does not refuse at all. ``None`` converts, to a ``NaN``
+    array of one sample, so a call that lost its signal on the way in came
+    back with a whole spectrum of ``NaN`` and refused nothing. It is not a
+    ``Signal``, not a sequence of floats and not an array, which is what
+    ``ArrayLike`` above says and what every caller's own annotation says.
+
+    A non-finite sample is refused for the same reason one layer further
+    down: a single ``NaN`` survives every filter and poisons every band
+    computed from it, and it arrives by two routes that are the same value
+    afterwards -- a ``None`` sitting inside the sequence, and a ``NaN`` the
+    caller passed. The entry points that refused it by hand did so each in
+    its own words, and only some of them refused it at all; the check
+    belongs where every one of them passes, and they now share this one.
+
     :param x: Input signal.
+    :param name: Parameter name used in the error messages.
     :return: Numpy float64 array.
+    :raises ValueError: if *x* is ``None``, cannot be read as numbers, or
+        carries a ``NaN`` or an infinity.
     """
-    return np.atleast_1d(np.asarray(x, dtype=np.float64))
+    if x is None:
+        msg = f"'{name}' must be a signal, not None."
+        raise ValueError(msg)
+    samples = np.atleast_1d(_as_float64(x, name))
+    if not np.all(np.isfinite(samples)):
+        msg = (
+            f"'{name}' must contain only finite samples; a None inside the "
+            "sequence arrives as a NaN and is refused the same way."
+        )
+        raise ValueError(msg)
+    return samples
 
 
 def _resample_to_length(y: np.ndarray, factor: int, target_length: int) -> np.ndarray:

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -56,7 +56,6 @@ if TYPE_CHECKING:
 
 from .._internal.peaks import inter_sample_peak
 from .._internal.types import as_float_or_array
-from .._internal.utils import _typesignal
 from .._internal.validation import (
     check_engine,
     require_positive,
@@ -246,7 +245,7 @@ def k_weighting(x: SignalInput, fs: float | None = None) -> np.ndarray:
     :return: The K-weighted signal, same shape as the input.
     """
     fs = resolve_fs(x, fs)
-    x_proc = _typesignal(resolve_samples(x, calibrate=False))
+    x_proc = resolve_samples(x, calibrate=False)
     if x_proc.shape[-1] == 0:
         raise ValueError(_EMPTY_SIGNAL)
     (b1, a1), (b2, a2) = k_weighting_coefficients(fs)
@@ -621,7 +620,7 @@ def true_peak_level(
     ):
         msg = "oversample must be an integer >= 1."
         raise ValueError(msg)
-    x_proc = _typesignal(resolve_samples(x, calibrate=False))
+    x_proc = resolve_samples(x, calibrate=False)
     if x_proc.shape[-1] == 0:
         raise ValueError(_EMPTY_SIGNAL)
     peak = inter_sample_peak(x_proc, int(oversample))
@@ -675,18 +674,16 @@ def integrated_loudness(
 def _prepare_signal(
     x: SignalInput, weights: ArrayLike | None
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Coerce to 2D float64, reject empty/non-finite input, resolve weights.
+    """Coerce to 2D float64, reject an empty signal, resolve weights.
 
     A NaN or infinity anywhere in the signal would poison every gating
-    block, empty the gate and silently read as digital silence (-inf), so
-    non-finite input is rejected up front.
+    block, empty the gate and silently read as digital silence (-inf). The
+    refusal is :func:`~phonometry.io._resolve.resolve_samples`', one layer
+    down, where every entry point on the contract gets the same one.
     """
-    x_proc = np.atleast_2d(_typesignal(resolve_samples(x, calibrate=False)))
+    x_proc = np.atleast_2d(resolve_samples(x, calibrate=False))
     if x_proc.shape[-1] == 0:
         raise ValueError(_EMPTY_SIGNAL)
-    if not np.all(np.isfinite(x_proc)):
-        msg = "Input signal 'x' must be finite (no NaN/inf samples)."
-        raise ValueError(msg)
     return x_proc, _resolve_weights(x_proc.shape[0], weights)
 
 

--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -375,7 +375,9 @@ def impact_force_exposure_level(
     sample_rate = resolve_fs(force, sample_rate, name="force", rate="sample_rate")
     # calibrate=False: a Signal may carry a digital-to-pascal factor and
     # this record is a force in newtons. See phonometry.io._resolve.
-    f = require_finite_array(resolve_samples(force, calibrate=False), "force")
+    f = require_finite_array(
+        resolve_samples(force, calibrate=False, name="force"), "force"
+    )
     if f.size < _MIN_TRAPEZOID_SAMPLES:
         msg = "'force' must be a 1-D record of at least two samples."
         raise ValueError(msg)

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -660,8 +660,8 @@ def sound_intensity(
     :return: :class:`IntensityResult`.
     """
     fs = resolve_pair_fs(p1, p2, fs, names=("p1", "p2"))
-    x1 = apply_calibration(p1, _typesignal(np.asarray(p1)))
-    x2 = apply_calibration(p2, _typesignal(np.asarray(p2)))
+    x1 = apply_calibration(p1, _typesignal(p1, name="p1"))
+    x2 = apply_calibration(p2, _typesignal(p2, name="p2"))
     _validate_probe_signals(x1, x2)
     _validate_probe_medium(fs, spacing, rho, c)
     _validate_band_options(fraction, limits)

--- a/src/phonometry/environment/assessment/impulsive_sound.py
+++ b/src/phonometry/environment/assessment/impulsive_sound.py
@@ -681,7 +681,7 @@ def sound_pressure_level_history(
     from ...filters.weighting import time_weighting, weighting_filter
 
     fs = resolve_fs(signal, fs, name="signal")
-    x = np.asarray(resolve_samples(signal), dtype=np.float64).ravel()
+    x = np.asarray(resolve_samples(signal, name="signal"), dtype=np.float64).ravel()
     if not math.isfinite(fs) or fs <= 0.0:
         msg = "fs must be positive."
         raise ValueError(msg)
@@ -928,7 +928,7 @@ def impulsive_sound_adjustment(
     :raises ValueError: for invalid ``fs``, ``dt`` or an empty signal.
     """
     fs = resolve_fs(signal, fs, name="signal")
-    x = np.asarray(resolve_samples(signal), dtype=np.float64).ravel()
+    x = np.asarray(resolve_samples(signal, name="signal"), dtype=np.float64).ravel()
     times, levels = sound_pressure_level_history(
         x,
         fs,

--- a/src/phonometry/io/_resolve.py
+++ b/src/phonometry/io/_resolve.py
@@ -26,6 +26,16 @@ The rules, identical everywhere:
   only a label for the result's time axis and the computation never reads
   it, which is :func:`resolve_optional_fs` and stays callable without
   one.
+- **Samples.** What is not a signal is refused here, by the name the
+  entry point gave it, and as a ``ValueError`` because that is what the
+  entry points document: ``None``, a string, a dict, a ragged list of
+  lists, and a ``NaN`` or an infinity among the samples. The last of
+  those is a refusal rather than a passing-on because a single
+  non-finite sample survives every filter and poisons every band
+  computed from it, so a call that lost one sample comes back with a
+  whole spectrum of ``NaN`` and nothing said. See
+  :func:`phonometry._internal.utils._typesignal`, which is where all of
+  it happens.
 - **Calibration.** A calibrated Signal presents its samples in pascals.
   One rule rather than a per-function taxonomy: it is what keeps every
   surface on this contract talking about the same signal, instead of one
@@ -171,25 +181,31 @@ def resolve_calibration(x: SignalInput, calibration_factor: float | None) -> flo
     return 1.0
 
 
-def resolve_samples(x: SignalInput, *, calibrate: bool = True) -> np.ndarray:
+def resolve_samples(
+    x: SignalInput, *, calibrate: bool = True, name: str = "x"
+) -> np.ndarray:
     """The float64 samples of the input, in pascals when it can know.
 
     A :class:`~phonometry.io.Signal` contributes its array view (1-D for
     one channel, ``(channels, samples)`` for several), so a mono Signal
-    yields the same result a mono array does; bare input passes through
-    :func:`_typesignal` untouched.
+    yields the same result a mono array does. Both forms go through
+    :func:`_typesignal`, which is where an input that is not a signal at
+    all -- ``None``, a string, a ragged list, a ``NaN`` sample -- is
+    refused by the name this call gives it; only the factor below tells
+    the two apart.
 
     :param x: The signal argument, a Signal or a bare array.
     :param calibrate: Whether a calibrated Signal's factor is applied.
         ``False`` for the functions that own the factor themselves (they
         pair this with :func:`resolve_calibration`) and for the
         documented exemptions in the module docstring.
+    :param name: Name of the signal parameter, for the error messages.
     :return: The samples, float64.
+    :raises ValueError: If *x* is ``None``, cannot be read as numbers, or
+        carries a non-finite sample.
     """
-    if not isinstance(x, Signal):
-        return _typesignal(x)
-    samples = _typesignal(np.asarray(x))
-    if calibrate and x.calibration_factor is not None:
+    samples = _typesignal(x, name=name)
+    if calibrate and isinstance(x, Signal) and x.calibration_factor is not None:
         return samples * x.calibration_factor
     return samples
 

--- a/src/phonometry/metrology/calibration.py
+++ b/src/phonometry/metrology/calibration.py
@@ -136,16 +136,11 @@ def sensitivity(
     # from a calibrator take, so scaling the samples by a factor the object
     # already carries would fold the old calibration into the new one.
     signal_arr = np.asarray(
-        resolve_samples(ref_signal, calibrate=False), dtype=np.float64
+        resolve_samples(ref_signal, calibrate=False, name="ref_signal"),
+        dtype=np.float64,
     )
     if signal_arr.size == 0:
         msg = "Reference signal is empty, cannot calibrate."
-        raise ValueError(msg)
-    if not np.all(np.isfinite(signal_arr)):
-        msg = (
-            "Reference signal contains non-finite samples (NaN/inf); they "
-            "would silently corrupt the calibration factor."
-        )
         raise ValueError(msg)
     if narrowband:
         if fs is None:

--- a/src/phonometry/psychoacoustics/loudness/ecma.py
+++ b/src/phonometry/psychoacoustics/loudness/ecma.py
@@ -739,13 +739,11 @@ def loudness_ecma(
         raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
-        signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
+        signal_in,
+        require_1d_signal(_typesignal(signal_in, name="signal_in")),
     )
     if x.size == 0:
         msg = "signal must not be empty"
-        raise ValueError(msg)
-    if not np.all(np.isfinite(x)):
-        msg = "'signal_in' must be finite."
         raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:

--- a/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness/moore_glasberg.py
@@ -1035,14 +1035,9 @@ def loudness_moore_glasberg(
     """
     _validate_conditions(field, presentation)
     fs = resolve_fs(x, fs)
-    pressure = apply_calibration(
-        x, require_1d_signal(_typesignal(np.asarray(x)), name="'x'")
-    )
+    pressure = apply_calibration(x, require_1d_signal(_typesignal(x), name="'x'"))
     if pressure.size == 0:
         msg = "Input signal 'x' cannot be empty."
-        raise ValueError(msg)
-    if not np.all(np.isfinite(pressure)):
-        msg = "Input signal 'x' must contain only finite values."
         raise ValueError(msg)
     if fs <= 0.0:
         msg = f"'fs' must be a positive sampling rate, got {fs!r}."

--- a/src/phonometry/psychoacoustics/loudness/zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness/zwicker.py
@@ -926,7 +926,7 @@ def loudness_zwicker(
         raise ValueError(msg)
     factor = resolve_calibration(x, calibration_factor)
     require_positive(factor, "calibration_factor")
-    pressure = _typesignal(np.asarray(x))
+    pressure = _typesignal(x)
     if pressure.ndim != 1:
         msg = (
             "loudness_zwicker() accepts single-channel signals only, got "
@@ -935,9 +935,6 @@ def loudness_zwicker(
         raise ValueError(msg)
     if pressure.size == 0:
         msg = "Input signal 'x' cannot be empty."
-        raise ValueError(msg)
-    if not np.all(np.isfinite(pressure)):
-        msg = "Input signal 'x' must contain only finite values."
         raise ValueError(msg)
     pressure = pressure * factor
 

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength_ecma.py
@@ -954,13 +954,11 @@ def fluctuation_strength_ecma(
         raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
-        signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
+        signal_in,
+        require_1d_signal(_typesignal(signal_in, name="signal_in")),
     )
     if x.size == 0:
         msg = "signal must not be empty"
-        raise ValueError(msg)
-    if not np.all(np.isfinite(x)):
-        msg = "'signal' must be finite."
         raise ValueError(msg)
     fs = require_positive(float(fs), "fs")
     if fs != _FS:

--- a/src/phonometry/psychoacoustics/quality/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/roughness_ecma.py
@@ -625,13 +625,11 @@ def roughness_ecma(
         raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
-        signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
+        signal_in,
+        require_1d_signal(_typesignal(signal_in, name="signal_in")),
     )
     if x.size == 0:
         msg = "signal must not be empty"
-        raise ValueError(msg)
-    if not np.all(np.isfinite(x)):
-        msg = "'signal_in' must be finite."
         raise ValueError(msg)
     fs = float(fs)
     if fs <= 0.0:

--- a/src/phonometry/psychoacoustics/quality/tonality.py
+++ b/src/phonometry/psychoacoustics/quality/tonality.py
@@ -329,7 +329,7 @@ def tone_to_noise_ratio(
     :return: :class:`ToneAssessment` with ``ratio_db`` = TNR in dB.
     """
     fs = resolve_fs(x, fs)
-    x_proc = apply_calibration(x, np.atleast_1d(_typesignal(np.asarray(x))))
+    x_proc = apply_calibration(x, _typesignal(x))
     if x_proc.ndim != 1:
         msg = "tone_to_noise_ratio expects a 1D signal."
         raise ValueError(msg)
@@ -458,7 +458,7 @@ def prominence_ratio(
     :return: :class:`ToneAssessment` with ``ratio_db`` = PR in dB.
     """
     fs = resolve_fs(x, fs)
-    x_proc = apply_calibration(x, np.atleast_1d(_typesignal(np.asarray(x))))
+    x_proc = apply_calibration(x, _typesignal(x))
     if x_proc.ndim != 1:
         msg = "prominence_ratio expects a 1D signal."
         raise ValueError(msg)

--- a/src/phonometry/psychoacoustics/quality/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/quality/tonality_ecma.py
@@ -299,7 +299,8 @@ def tonality_ecma(
         raise ValueError(msg)
     fs = resolve_fs(signal_in, fs, name="signal_in")
     x = apply_calibration(
-        signal_in, require_1d_signal(_typesignal(np.asarray(signal_in)))
+        signal_in,
+        require_1d_signal(_typesignal(signal_in, name="signal_in")),
     )
     if x.size == 0:
         msg = "signal must not be empty"

--- a/src/phonometry/room/acoustics.py
+++ b/src/phonometry/room/acoustics.py
@@ -473,7 +473,7 @@ def _band_parameters(x: np.ndarray, fs: int) -> tuple[float, ...]:
 
 
 def _validate_ir(ir: Signal | list[float] | np.ndarray, fs: int) -> np.ndarray:
-    x = _typesignal(np.asarray(ir))
+    x = _typesignal(ir, name="ir")
     if x.ndim != 1:
         msg = "The impulse response must be one-dimensional."
         raise ValueError(msg)

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -501,8 +501,8 @@ def impulse_response(
     fs = resolve_optional_pair_fs(
         recorded, reference, fs, names=("recorded", "reference")
     )
-    rec = apply_calibration(recorded, _typesignal(np.asarray(recorded)))
-    ref = _typesignal(np.asarray(reference))
+    rec = apply_calibration(recorded, _typesignal(recorded, name="recorded"))
+    ref = _typesignal(reference, name="reference")
     if rec.ndim != 1 or ref.ndim != 1:
         msg = "'recorded' and 'reference' must be one-dimensional."
         raise ValueError(msg)
@@ -617,8 +617,8 @@ def mls_impulse_response(
         a definitive aliasing diagnosis.
     """
     fs = resolve_optional_pair_fs(recorded, mls, fs, names=("recorded", "mls"))
-    rec = apply_calibration(recorded, _typesignal(np.asarray(recorded)))
-    seq = _typesignal(np.asarray(mls))
+    rec = apply_calibration(recorded, _typesignal(recorded, name="recorded"))
+    seq = _typesignal(mls, name="mls")
     if rec.ndim != 1 or seq.ndim != 1:
         msg = "'recorded' and 'mls' must be one-dimensional."
         raise ValueError(msg)
@@ -783,7 +783,7 @@ def golay_impulse_response(
     fs = resolve_optional_pair_fs(
         recorded_a, recorded_b, fs, names=("recorded_a", "recorded_b")
     )
-    code_a, code_b = (_typesignal(c) for c in pair)
+    code_a, code_b = (_typesignal(c, name="pair") for c in pair)
     if code_a.ndim != 1 or code_b.ndim != 1:
         msg = "both Golay codes must be one-dimensional."
         raise ValueError(msg)
@@ -799,7 +799,7 @@ def golay_impulse_response(
         ("recorded_a", recorded_a, code_a),
         ("recorded_b", recorded_b, code_b),
     ):
-        rec = apply_calibration(rec_in, _typesignal(np.asarray(rec_in)))
+        rec = apply_calibration(rec_in, _typesignal(rec_in, name=name))
         if rec.ndim != 1:
             msg = f"'{name}' must be one-dimensional."
             raise ValueError(msg)

--- a/src/phonometry/signals/inversion.py
+++ b/src/phonometry/signals/inversion.py
@@ -352,15 +352,12 @@ def _validated_response(
     response: SignalInput | TimedResponse,
 ) -> np.ndarray:
     """Validate the measured impulse response array."""
-    h = _typesignal(np.asarray(response, dtype=np.float64))
+    h = _typesignal(response, name="response")
     if h.ndim != 1:
         msg = "'response' must be one-dimensional."
         raise ValueError(msg)
     if h.size < _MIN_RESPONSE_SAMPLES:
         msg = f"'response' must have at least {_MIN_RESPONSE_SAMPLES} samples."
-        raise ValueError(msg)
-    if not np.all(np.isfinite(h)):
-        msg = "'response' must be finite."
         raise ValueError(msg)
     if isinstance(response, Signal):
         return apply_calibration(response, h)

--- a/src/phonometry/signals/miso.py
+++ b/src/phonometry/signals/miso.py
@@ -164,7 +164,7 @@ def _validate_inputs(
         # calibration is applied once, here, because the rows that come out
         # are bare arrays and would otherwise reach the estimate in digital
         # units.
-        rows = list(np.atleast_2d(resolve_samples(inputs)))
+        rows = list(np.atleast_2d(resolve_samples(inputs, name="inputs")))
     elif isinstance(inputs, np.ndarray) and inputs.ndim == 2:  # noqa: PLR2004
         rows = [np.ascontiguousarray(row, dtype=np.float64) for row in inputs]
     else:

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -519,7 +519,7 @@ def sti_from_impulse_response(
     :return: :class:`STIResult` with ``mtf`` of shape (7, 14).
     """
     fs = resolve_fs(ir, fs, name="ir")
-    ir_proc = apply_calibration(ir, _typesignal(np.asarray(ir)))
+    ir_proc = apply_calibration(ir, _typesignal(ir, name="ir"))
     if ir_proc.ndim != 1:
         msg = "sti_from_impulse_response expects a 1D impulse response."
         raise ValueError(msg)
@@ -720,7 +720,7 @@ def stipa(
         if reference is None
         else resolve_pair_fs(x, reference, fs, names=("x", "reference"))
     )
-    x_proc = apply_calibration(x, _typesignal(np.asarray(x)))
+    x_proc = apply_calibration(x, _typesignal(x))
     if x_proc.ndim != 1:
         msg = "stipa expects a 1D signal."
         raise ValueError(msg)
@@ -745,7 +745,9 @@ def stipa(
 
     mdr = _stipa_modulation_depths(_intensity_envelopes(x_proc, fs), fs)
     if reference is not None:
-        ref_proc = apply_calibration(reference, _typesignal(np.asarray(reference)))
+        ref_proc = apply_calibration(
+            reference, _typesignal(reference, name="reference")
+        )
         if ref_proc.ndim != 1:
             msg = "'reference' must be a 1D signal."
             raise ValueError(msg)

--- a/src/phonometry/vibration/human/exposure.py
+++ b/src/phonometry/vibration/human/exposure.py
@@ -629,7 +629,9 @@ def _weighted_signal(signal: SignalInput) -> Real:
     unit conversion nobody asked for. This is the exemption the contract
     describes for a quantity that is not a pressure.
     """
-    x = np.asarray(resolve_samples(signal, calibrate=False), dtype=np.float64)
+    x = np.asarray(
+        resolve_samples(signal, calibrate=False, name="signal"), dtype=np.float64
+    )
     if x.ndim != 1 or x.size == 0:
         msg = "'signal' must be a non-empty 1-D array."
         raise ValueError(msg)

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -195,19 +195,15 @@ def spinal_response(acceleration: SignalInput, fs: float | None = None) -> np.nd
     fs = require_positive(resolve_fs(acceleration, fs, name="acceleration"), "fs")
     # calibrate=False: a Signal may carry a digital-to-pascal factor, and
     # this is an acceleration in m/s2. See phonometry.io._resolve.
-    az = np.asarray(resolve_samples(acceleration, calibrate=False), dtype=np.float64)
+    az = np.asarray(
+        resolve_samples(acceleration, calibrate=False, name="acceleration"),
+        dtype=np.float64,
+    )
     if az.ndim != 1:
         msg = "acceleration must be a 1-D time series."
         raise ValueError(msg)
     if az.size == 0:
         msg = "acceleration must not be empty."
-        raise ValueError(msg)
-    # Refuse a corrupt record outright, as the STIPA and STOI entries do: a
-    # single NaN sample turns the whole IIR spinal response NaN, every NaN
-    # comparison then counts zero peaks, and the assessment reports R = 0.0
-    # (the safest possible verdict) with no trace of the corruption.
-    if not np.all(np.isfinite(az)):
-        msg = "acceleration must contain only finite values."
         raise ValueError(msg)
     spectrum = np.fft.rfft(az)
     freq = np.fft.rfftfreq(az.size, d=1.0 / fs)

--- a/tests/broadcast/test_program_loudness.py
+++ b/tests/broadcast/test_program_loudness.py
@@ -705,9 +705,9 @@ def test_program_loudness_validation() -> None:
     # A NaN-poisoned programme must not silently measure as digital silence.
     poisoned = _stereo(_sine(-23.0, 1.0))
     poisoned[0, 100] = np.nan
-    with pytest.raises(ValueError, match=r"Input signal 'x' must be finite"):
+    with pytest.raises(ValueError, match=r"'x' must contain only finite samples"):
         program_loudness(poisoned, FS)
-    with pytest.raises(ValueError, match=r"Input signal 'x' must be finite"):
+    with pytest.raises(ValueError, match=r"'x' must contain only finite samples"):
         integrated_loudness(poisoned, FS)
 
 

--- a/tests/emission/test_intensity.py
+++ b/tests/emission/test_intensity.py
@@ -751,11 +751,18 @@ def test_a_non_finite_broadband_total_is_refused(field_name: str) -> None:
         dataclasses.replace(result, **{field_name: float("nan")})
 
 
-def test_a_nan_sample_is_refused_at_the_result_instead_of_titling_the_figure() -> None:
-    """The same guard catches the producer path: NaN in, refusal out."""
+def test_a_nan_sample_is_refused_at_the_probe_instead_of_titling_the_figure() -> None:
+    """The producer path refuses it first, and says which probe carried it.
+
+    The result guard above would still catch a NaN total, and it is what
+    stood between this producer and a figure titled ``nan dB``. The sample
+    no longer reaches it: the resolver refuses a non-finite sample as the
+    signal comes in, which names ``p1`` rather than the derived total the
+    caller never passed and cannot go looking for.
+    """
     p1, p2 = _plane_wave_pair(delay_s=SPACING / C)
     p1[10] = np.nan
-    with pytest.raises(ValueError, match="'total_intensity' must be finite"):
+    with pytest.raises(ValueError, match="'p1' must contain only finite samples"):
         emission.sound_intensity(p1, p2, FS, spacing=SPACING, rho=RHO, c=C, fraction=3)
 
 

--- a/tests/metrology/test_calibration_validation.py
+++ b/tests/metrology/test_calibration_validation.py
@@ -179,11 +179,11 @@ def test_sensitivity_rejects_non_finite_samples() -> None:
     sig = np.sin(2 * np.pi * 1000.0 * np.arange(4800) / 48000.0)
     sig[100] = np.nan
     with pytest.raises(
-        ValueError, match=r"Reference signal contains non-finite samples"
+        ValueError, match=r"'ref_signal' must contain only finite samples"
     ):
         metrology.sensitivity(sig, fs=48000)
     sig[100] = np.inf
     with pytest.raises(
-        ValueError, match=r"Reference signal contains non-finite samples"
+        ValueError, match=r"'ref_signal' must contain only finite samples"
     ):
         metrology.sensitivity(sig, fs=48000)

--- a/tests/psychoacoustics/loudness/test_ecma.py
+++ b/tests/psychoacoustics/loudness/test_ecma.py
@@ -167,7 +167,9 @@ def test_non_finite_signal_raises() -> None:
     # poison index (NaN fails the half-wave rectification comparison).
     tone = _tone(1000.0, 40.0, seconds=0.5)
     tone[100] = np.nan
-    with pytest.raises(ValueError, match="'signal_in' must be finite"):
+    with pytest.raises(
+        ValueError, match="'signal_in' must contain only finite samples"
+    ):
         psychoacoustics.loudness_ecma(tone, FS)
 
 

--- a/tests/psychoacoustics/loudness/test_zwicker.py
+++ b/tests/psychoacoustics/loudness/test_zwicker.py
@@ -529,9 +529,7 @@ def test_non_finite_inputs_rejected() -> None:
         psychoacoustics.loudness_zwicker_from_spectrum(levels)
     x = np.ones(1000)
     x[3] = np.inf
-    with pytest.raises(
-        ValueError, match=r"Input signal 'x' must contain only finite values"
-    ):
+    with pytest.raises(ValueError, match=r"'x' must contain only finite samples"):
         psychoacoustics.loudness_zwicker(x, FS)
 
 

--- a/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/quality/test_fluctuation_strength_ecma.py
@@ -416,7 +416,9 @@ def test_invalid_fs_raises(bad_fs: float) -> None:
 def test_non_finite_signal_raises() -> None:
     sig = _tone(1000.0, 60.0, 1.0)
     sig[100] = np.nan
-    with pytest.raises(ValueError, match="'signal' must be finite"):
+    with pytest.raises(
+        ValueError, match="'signal_in' must contain only finite samples"
+    ):
         psychoacoustics.fluctuation_strength_ecma(sig, FS)
 
 

--- a/tests/psychoacoustics/quality/test_roughness_ecma.py
+++ b/tests/psychoacoustics/quality/test_roughness_ecma.py
@@ -243,10 +243,14 @@ def test_non_finite_signal_raises() -> None:
     # washes out in the envelope stages and the result looks like silence).
     tone = _tone(1000.0, 60.0, 0.5)
     tone[100] = np.nan
-    with pytest.raises(ValueError, match="'signal_in' must be finite"):
+    with pytest.raises(
+        ValueError, match="'signal_in' must contain only finite samples"
+    ):
         psychoacoustics.roughness_ecma(tone, FS)
     tone[100] = np.inf
-    with pytest.raises(ValueError, match="'signal_in' must be finite"):
+    with pytest.raises(
+        ValueError, match="'signal_in' must contain only finite samples"
+    ):
         psychoacoustics.roughness_ecma(tone, FS)
 
 

--- a/tests/signals/test_inversion.py
+++ b/tests/signals/test_inversion.py
@@ -181,7 +181,9 @@ def test_rejects_bad_inputs() -> None:
     with pytest.raises(ValueError, match=r"'response' must be one-dimensional"):
         signals.regularized_inverse_filter(two_dim, FS, f_range=(200.0, 4000.0))
     with_nan = np.array([1.0, np.nan])
-    with pytest.raises(ValueError, match=r"'response' must be finite"):
+    with pytest.raises(
+        ValueError, match=r"'response' must contain only finite samples"
+    ):
         signals.regularized_inverse_filter(with_nan, FS, f_range=(200.0, 4000.0))
     all_zero = np.zeros(64)
     with pytest.raises(ValueError, match=r"'response' must not be identically zero"):

--- a/tests/signals/test_signal_theory_limits.py
+++ b/tests/signals/test_signal_theory_limits.py
@@ -112,14 +112,12 @@ def test_multichannel_mismatched_lengths() -> None:
     fs = 8000
     # Numpy arrays must have rectangular shape, so we test with a list of lists of different lengths
     x = [[1.0, 2.0, 3.0], [1.0, 2.0]]
-    # This should probably raise an error or handle it via numpy's default behavior
-    # The TypeError arm never fired and is gone: a tuple arm that cannot happen
-    # only widens what the block accepts. The wording below is NUMPY's, not
-    # ours, which is the one case where pinning a foreign message is the lesser
-    # evil: nothing here refuses the ragged input itself. If the library ever
-    # validates it and raises its own ValueError, this test should fail and be
-    # rewritten around that message, because its premise will have changed.
-    with pytest.raises(ValueError, match=r"setting an array element with a sequence"):
+    # The premise this test was written on has changed, exactly as its previous
+    # note said it should. It used to pin NUMPY's wording, "setting an array
+    # element with a sequence", because nothing here refused the ragged input
+    # itself and a foreign message was the lesser evil. The resolver now
+    # refuses it, and names the parameter that carried it.
+    with pytest.raises(ValueError, match=r"'x' must be numeric"):
         # type ignore because list of lists of floats is technically not what we hint, but what user might pass
         filters.octave_filter(x, fs)  # type: ignore
 

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -132,24 +132,29 @@ def test_nan_handling() -> None:
     """Test the behavior when the input signal contains NaN values.
 
     **Purpose:**
-    Determine if NaNs in the input propagate to the output.
+    Determine what a NaN in the input does to the output.
 
     **Verification:**
     - Create a signal with a single NaN value.
     - Process it through the filter bank.
 
     **Expectation:**
-    - Digital filters (IIR/SOS) inherently propagate NaNs because the output depends on previous inputs.
-    - The output SPL array should contain NaNs, confirming standard signal processing behavior.
+    - Refused, by the name of the parameter that carried it.
+    - This test used to assert the opposite: that the NaN propagated, on the
+      grounds that an IIR filter inherently propagates one. It does, which is
+      exactly why the propagation is not something to hand a caller. One
+      poisoned sample in 4800 came back as eight bands of NaN with nothing
+      said, so a measurement with a single dropout read as a whole ruined
+      spectrum and there was no way to tell it from a broken instrument.
+      The refusal is the resolver's, so every entry point on it answers alike.
     """
     fs = 48000
     rng = np.random.default_rng(42)
     x = rng.standard_normal(4800)
     x[100] = np.nan
 
-    spl, _ = filters.octave_filter(x, fs)
-    # Expect NaNs in SPL
-    assert np.isnan(spl).any()
+    with pytest.raises(ValueError, match=r"'x' must contain only finite samples"):
+        filters.octave_filter(x, fs)
 
 
 def test_silence() -> None:

--- a/tests/test_errors_and_edge_cases.py
+++ b/tests/test_errors_and_edge_cases.py
@@ -331,6 +331,46 @@ def test_octave_filter_rejects_malformed_limits_on_the_plotting_path() -> None:
         )
 
 
+def test_octave_filter_refuses_a_missing_signal_instead_of_answering_nan() -> None:
+    """Verify that a lost signal is refused rather than measured.
+
+    **Purpose:**
+    A caller whose signal never arrived must be told so, not handed a reading.
+
+    **Verification:**
+    - Call the filter bank with None where the signal goes.
+
+    **Expectation:**
+    - A `ValueError` naming `'x'`. None used to convert to a one-sample NaN
+      array, so this call returned eight bands of NaN and refused nothing.
+    """
+    with pytest.raises(ValueError, match="'x' must be a signal, not None"):
+        filters.octave_filter(None, 48000)  # type: ignore[arg-type]
+
+
+def test_a_refusal_names_the_parameter_of_the_entry_point_that_was_called() -> None:
+    """Verify the parameter named in the message is one the caller can find.
+
+    **Purpose:**
+    The resolver sits under every entry point that consumes a recording, so a
+    message hard-coded to `'x'` would name an argument that most of them do
+    not have.
+
+    **Verification:**
+    - Reach the same refusal through `sensitivity`, whose signal parameter is
+      called `ref_signal`.
+
+    **Expectation:**
+    - The message names `'ref_signal'`, not `'x'`.
+    """
+    poisoned = np.sin(2 * np.pi * 1000.0 * np.arange(4800) / 48000.0)
+    poisoned[100] = np.nan
+    with pytest.raises(
+        ValueError, match="'ref_signal' must contain only finite samples"
+    ):
+        metrology.sensitivity(poisoned, fs=48000)
+
+
 def test_process_bands_without_level_calculation() -> None:
     """Verify internal band processing can skip level calculation."""
     bank = filters.OctaveFilterBank(48000)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,10 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
 """Tests for internal utility helpers."""
 
+from typing import Any
+
 import numpy as np
+import pytest
 
 from phonometry._internal.utils import _resample_to_length, _typesignal
 
@@ -18,6 +21,88 @@ def test_typesignal_preserves_float64_without_copy() -> None:
     """float64 arrays pass through unchanged (no copy)."""
     x = np.array([1.0, 2.0])
     assert _typesignal(x) is x
+
+
+def test_typesignal_refuses_none_as_the_whole_signal() -> None:
+    """None is not a signal, and converts to a NaN array rather than raising."""
+    with pytest.raises(ValueError, match=r"'x' must be a signal, not None"):
+        _typesignal(None)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        pytest.param("hello", id="string"),
+        pytest.param({"a": 1.0}, id="dict"),
+        pytest.param(object(), id="object"),
+        pytest.param(1 + 2j, id="complex"),
+        pytest.param([[1.0, 2.0], [3.0]], id="ragged"),
+    ],
+)
+def test_typesignal_refuses_what_is_not_numeric_by_name(bad: Any) -> None:  # noqa: ANN401 - the point is that anything at all may arrive here
+    """What numpy cannot read as numbers is refused naming the parameter.
+
+    Numpy answers a string or a ragged list in its own words and an object or
+    a dict with a TypeError, which is not the exception the entry points
+    document.
+    """
+    with pytest.raises(ValueError, match=r"'x' must be numeric"):
+        _typesignal(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        pytest.param([1.0, np.nan, 3.0], id="nan"),
+        pytest.param([1.0, np.inf, 3.0], id="inf"),
+        pytest.param([1.0, None, 3.0], id="none-inside-the-sequence"),
+    ],
+)
+def test_typesignal_refuses_a_non_finite_sample(bad: Any) -> None:  # noqa: ANN401 - a list carrying a None is not a Sequence[float]
+    """One poisoned sample is refused, whichever of the two routes it came by.
+
+    A None inside the sequence and a NaN the caller passed are the same value
+    after conversion, so the message speaks for both.
+    """
+    with pytest.raises(ValueError, match=r"'x' must contain only finite samples"):
+        _typesignal(bad)
+
+
+def test_typesignal_names_the_parameter_it_was_given() -> None:
+    """The name is the caller's, so a refusal names an argument that exists."""
+    with pytest.raises(ValueError, match=r"'reference' must be numeric"):
+        _typesignal("hello", name="reference")
+
+
+@pytest.mark.parametrize(
+    ("legal", "shape"),
+    [
+        pytest.param([], (0,), id="empty"),
+        pytest.param([1.0], (1,), id="single-sample"),
+        pytest.param(np.zeros(16), (16,), id="silent-buffer-of-exact-zeros"),
+        pytest.param(np.arange(8, dtype=np.int16), (8,), id="integer-array"),
+        pytest.param(np.zeros((2, 8)), (2, 8), id="two-dimensional"),
+        pytest.param(
+            np.ma.masked_array([1.0, 2.0, 3.0], mask=[0, 1, 0]), (3,), id="masked"
+        ),
+        pytest.param(np.asfortranarray(np.zeros((2, 8))), (2, 8), id="fortran-ordered"),
+        pytest.param(np.zeros(16)[::2], (8,), id="non-contiguous-slice"),
+    ],
+)
+def test_typesignal_still_accepts_every_legal_shape_of_signal(
+    legal: Any,  # noqa: ANN401 - the parametrization is over unrelated array-likes
+    shape: tuple[int, ...],
+) -> None:
+    """The refusals must not have narrowed what a signal is allowed to be.
+
+    A resolver under twenty-nine entry points refuses for all of them at once,
+    so an empty record, one sample, a silence of exact zeros, an int16 take
+    straight off a WAV, a (channels, samples) block, a masked array, a
+    Fortran-ordered block and a strided view all have to survive it.
+    """
+    out = _typesignal(legal)
+    assert out.shape == shape
+    assert out.dtype == np.float64
 
 
 def test_resample_to_length_padding_and_trimming() -> None:

--- a/tests/vibration/human/test_multiple_shock_vibration.py
+++ b/tests/vibration/human/test_multiple_shock_vibration.py
@@ -265,7 +265,9 @@ def test_a_corrupt_seat_record_is_refused_where_it_enters(bad: float) -> None:
     az = np.zeros(2560)
     az[::400] = 60.0
     az[50] = bad
-    with pytest.raises(ValueError, match="acceleration must contain only finite"):
+    with pytest.raises(
+        ValueError, match="'acceleration' must contain only finite samples"
+    ):
         v.multiple_shock_assessment(
             az, 256.0, start_age=20, years=20, days_per_year=120, sex="male"
         )


### PR DESCRIPTION
Every entry point that takes a signal resolves it through one line, `_typesignal`, and that line let three things past.

`filters.octave_filter(None, 8000)` returned eight bands of NaN and refused nothing. A `None` inside a list became a NaN sample, and one poisoned sample in a few thousand came back as a whole ruined spectrum with nothing said, which a caller cannot tell from a broken instrument. Anything else numpy could not convert escaped in numpy's own words, or as a `TypeError` where the entry points document a `ValueError`.

## Why this is a defect and not a policy choice

The tree already refused a non-finite sample nearly everywhere. `signals.envelope_spectrum` and `signals.time_delay` answer `'x' must be finite.`; `metrology.sensitivity` answers in its own words. The filter family and broadcast were the outliers. The resolver now says it once for all of them, and the message names the parameter that carried the value: `'ref_signal'` where that is its name, not a generic `'x'`.

## The part that was in doubt, and what settled it

A `None` inside a sequence and a NaN the caller passed are the same array after conversion, so closing the first means refusing non-finite samples generally. That is a real behavioural change under 29 entry points, so it was decided by running the suite rather than by argument.

It broke twelve tests, and not one was a caller with a legitimate NaN-bearing signal:

- ten already refused such a sample and only disagreed about the wording, each saying in its own docstring why it must die ("must raise, not silently report 0.0 asper"; "reports R = 0.0, the safest possible verdict, with no trace of the corruption")
- one carried a written instruction for exactly this change, saying that if the library ever validated the input itself the test should fail and be rewritten around the new message
- the last asserted that a NaN *propagates* through the filter bank: the defect recorded as expected behaviour. It does propagate, which is exactly why it is not something to hand back. That test is rewritten rather than deleted, and its docstring now records what it used to claim and why it changed.

## Two things found along the way

Eleven call sites wrapped the resolver as `_typesignal(np.asarray(x))`. The outer conversion turned the `None` into a NaN before either new guard could see it, so without dropping those wrappers the naming would have been cosmetic at eleven of the entry points.

Nine per-entry-point guards became unreachable once the resolver refuses first. They are removed rather than left as dead `raise` lines that would show up as uncovered.

## What changes for a caller who was not passing garbage

Nothing. Empty signals, a single sample, exact-zero silence, integer arrays, calibrated and uncalibrated `Signal`s, 2-D `(channels, samples)`, masked, Fortran-ordered and non-contiguous arrays were all probed and all still work, with a calibrated `Signal` still bit-identical to the equivalent pre-scaled bare call.

One case does change: a masked array whose masked slot hides a NaN is refused now. The mask never survived `np.asarray`, so that NaN was already reaching the computation and poisoning it silently; the refusal surfaces a bug rather than creating one.

Full suite green: 10140 passed, 16 skipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Centralized signal validation logic in `_typesignal` to handle `None`, non-finite values, and type conversion consistently.</li>
<li>Removed redundant signal validation calls across multiple modules, relying on `resolve_samples` or the updated `_typesignal`.</li>
<li>Improved error messaging for invalid signal inputs by providing parameter names and specific reasons for rejection.</li>
<li>Updated type annotations to use `ArrayLike` for signal inputs.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signal inputs are now consistently validated across measurement, acoustics, psychoacoustics, vibration, and filtering features.
  * Missing, non-numeric, ragged, NaN, and infinite-valued inputs are rejected with clear errors.
  * Validation errors now identify the specific input parameter involved.
  * Array-like signal inputs are converted consistently while preserving supported signal shapes.
* **Improvements**
  * Calibration handling is more consistent for recorded signals and signal objects.
  * Empty-input and dimensionality checks remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->