### PR TITLE
Close the three refusals that could not say what they refused

### DIFF
--- a/src/phonometry/electroacoustics/sound_reinforcement.py
+++ b/src/phonometry/electroacoustics/sound_reinforcement.py
@@ -135,15 +135,21 @@ def feedback_loop_gain(
         :data:`CARDIOID_RELATIVE_DIRECTIVITY` for a cardioid).
     :return: The feedback-loop gain :math:`G_\mathrm{S}`, dB.
     """
-    values = (
-        float(level_loudspeaker_at_microphone),
-        float(level_loudspeaker_at_listener),
-        float(microphone_directivity),
+    named = (
+        ("level_loudspeaker_at_microphone", float(level_loudspeaker_at_microphone)),
+        ("level_loudspeaker_at_listener", float(level_loudspeaker_at_listener)),
+        ("microphone_directivity", float(microphone_directivity)),
     )
-    if not all(math.isfinite(v) for v in values):
-        msg = "Levels and the directivity index must be finite."
-        raise ValueError(msg)
-    l_hm, l_hl, d_m = values
+    # Named one at a time. The three used to share a message that said
+    # "Levels and the directivity index must be finite", which is true and
+    # useless: a reader cannot tell which of the three arrived non-finite,
+    # and the two levels are measured separately, so the answer decides
+    # where to look.
+    for name, value in named:
+        if not math.isfinite(value):
+            msg = f"'{name}' must be finite; got {value!r}."
+            raise ValueError(msg)
+    l_hm, l_hl, d_m = (value for _, value in named)
     return l_hm - l_hl + d_m
 
 

--- a/src/phonometry/io/_resolve.py
+++ b/src/phonometry/io/_resolve.py
@@ -240,7 +240,9 @@ def resolve_samples(
     :param name: Name of the signal parameter, for the error messages.
     :return: The samples, float64.
     :raises ValueError: If *x* is ``None``, cannot be read as numbers, or
-        carries a non-finite sample.
+        carries a non-finite sample; or, for a calibrated Signal, if the
+        factor overflows the samples it scales, which neither of them is
+        answerable for on its own.
     """
     samples = _typesignal(x, name=name)
     if calibrate and isinstance(x, Signal) and x.calibration_factor is not None:

--- a/src/phonometry/io/_resolve.py
+++ b/src/phonometry/io/_resolve.py
@@ -181,6 +181,44 @@ def resolve_calibration(x: SignalInput, calibration_factor: float | None) -> flo
     return 1.0
 
 
+def _scaled(samples: np.ndarray, factor: float, name: str) -> np.ndarray:
+    """Scale *samples* by *factor*, refusing a product that leaves the doubles.
+
+    Both operands are finite by the time they reach here: the samples were
+    checked and :class:`~phonometry.io.Signal` requires a positive finite
+    factor. Their product need not be, and it used to leave as an ``inf``
+    that nothing had refused, since the finiteness check runs before the
+    multiplication and cannot see past it.
+
+    The overflow is caught in the multiplication itself rather than by
+    measuring the result, so this costs no second pass over the recording:
+    numpy already detects it and ``errstate`` only decides what to do about
+    it. Nothing legitimate reaches it. The loudest quantity acoustics
+    measures is a blast overpressure of a few bar, and a double holds
+    something like ten to the three hundred and two times that, so a product
+    that overflows is a calibration chain built wrong rather than a scale
+    that will not fit.
+
+    :param samples: The validated samples.
+    :param factor: The calibration factor, positive and finite.
+    :param name: Name of the signal parameter, for the error message.
+    :return: The scaled samples.
+    :raises ValueError: If the product overflows to infinity.
+    """
+    try:
+        with np.errstate(over="raise"):
+            return samples * factor
+    except FloatingPointError:
+        peak = float(np.max(np.abs(samples)))
+        msg = (
+            f"'{name}': the calibration factor overflows the samples it "
+            f"scales; {factor!r} times a peak of {peak!r} leaves the range a "
+            "double can hold. Both are finite on their own, so check the "
+            "chain rather than either end of it."
+        )
+        raise ValueError(msg) from None
+
+
 def resolve_samples(
     x: SignalInput, *, calibrate: bool = True, name: str = "x"
 ) -> np.ndarray:
@@ -206,11 +244,13 @@ def resolve_samples(
     """
     samples = _typesignal(x, name=name)
     if calibrate and isinstance(x, Signal) and x.calibration_factor is not None:
-        return samples * x.calibration_factor
+        return _scaled(samples, x.calibration_factor, name)
     return samples
 
 
-def apply_calibration(x: SignalInput, samples: np.ndarray) -> np.ndarray:
+def apply_calibration(
+    x: SignalInput, samples: np.ndarray, *, name: str = "x"
+) -> np.ndarray:
     """Scale already-validated samples to pascals, if *x* carried a factor.
 
     The two-step sibling of :func:`resolve_samples`, for the functions that
@@ -222,10 +262,12 @@ def apply_calibration(x: SignalInput, samples: np.ndarray) -> np.ndarray:
 
     :param x: The signal argument as the caller passed it.
     :param samples: The validated samples derived from it.
+    :param name: Name of the signal parameter, for the error message.
     :return: The samples, in pascals when the object knew how.
+    :raises ValueError: If the factor overflows the samples it scales.
     """
     if isinstance(x, Signal) and x.calibration_factor is not None:
-        return samples * x.calibration_factor
+        return _scaled(samples, x.calibration_factor, name)
     return samples
 
 

--- a/tests/electroacoustics/test_sound_reinforcement.py
+++ b/tests/electroacoustics/test_sound_reinforcement.py
@@ -28,10 +28,14 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from typing import TYPE_CHECKING
 
 import pytest
 
 from phonometry import electroacoustics
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 #: Long, printed p. 697: "the desired open-loop system gain might be of the
 #: order of -6 dB", typical of an auditorium or church.
@@ -255,7 +259,7 @@ def test_validation_errors() -> None:
     with pytest.raises(ValueError, match=r"'open_loop_gain' must be finite"):
         electroacoustics.feedback_stability(math.nan, 74.0, 80.0)
     with pytest.raises(
-        ValueError, match=r"Levels and the directivity index must be finite"
+        ValueError, match=r"'level_loudspeaker_at_microphone' must be finite"
     ):
         electroacoustics.feedback_stability(-6.0, math.inf, 80.0)
     with pytest.raises(
@@ -264,3 +268,38 @@ def test_validation_errors() -> None:
         electroacoustics.feedback_stability(-6.0, 74.0, 80.0, stability_margin=-1.0)
     with pytest.raises(ValueError, match="integer of at least 1"):
         electroacoustics.feedback_stability(-6.0, 74.0, 80.0, open_microphones=0)
+
+
+@pytest.mark.parametrize(
+    ("field", "call"),
+    [
+        (
+            "level_loudspeaker_at_microphone",
+            lambda bad: electroacoustics.feedback_stability(-6.0, bad, 80.0),
+        ),
+        (
+            "level_loudspeaker_at_listener",
+            lambda bad: electroacoustics.feedback_stability(-6.0, 74.0, bad),
+        ),
+        (
+            "microphone_directivity",
+            lambda bad: electroacoustics.feedback_stability(
+                -6.0, 74.0, 80.0, microphone_directivity=bad
+            ),
+        ),
+    ],
+)
+def test_the_loop_gain_names_which_of_its_three_terms_is_not_finite(
+    field: str, call: Callable[[float], object]
+) -> None:
+    """One message for three parameters could not say which had arrived bad.
+
+    The loop gain is a difference of two separately measured levels plus a
+    directivity index, so which one is non-finite decides where the caller
+    looks: at the microphone position, at the listener position, or at the
+    microphone's own pattern. The three used to share the sentence "Levels and
+    the directivity index must be finite", true of all of them and a help with
+    none.
+    """
+    with pytest.raises(ValueError, match=rf"'{field}' must be finite"):
+        call(math.nan)

--- a/tests/signal_contract.py
+++ b/tests/signal_contract.py
@@ -17,13 +17,21 @@ from typing import Any
 import numpy as np
 
 
-def assert_same(a: Any, b: Any, path: str = "") -> None:  # noqa: ANN401 - deep-compares results of any shape: dataclasses, dicts, sequences, arrays, scalars
+def assert_same(a: Any, b: Any, path: str = "result") -> None:  # noqa: ANN401 - deep-compares results of any shape: dataclasses, dicts, sequences, arrays, scalars
     """Assert two results are identical, walking result objects field by field.
+
+    Every failure names the field path it reached and, at a leaf, what the two
+    sides hold. The path used to start empty, so a mismatch at the top level
+    raised an ``AssertionError`` carrying no message at all, and the callers
+    that assert a difference IS expected could only write a bare
+    ``pytest.raises(AssertionError)``. That accepts any failure of the helper,
+    including a shape mismatch that has nothing to do with the contract the
+    test is named for, which is the one thing a refusal test must not do.
 
     :param a: The result of the call under test.
     :param b: The result of the reference call.
     :param path: Field path reached so far, for the failure message.
-    :raises AssertionError: On the first field that differs.
+    :raises AssertionError: On the first field that differs, naming the path.
     """
     if is_dataclass(a) and not isinstance(a, type):
         assert type(a) is type(b), path
@@ -44,6 +52,9 @@ def assert_same(a: Any, b: Any, path: str = "") -> None:  # noqa: ANN401 - deep-
         # equal_nan: a NaN in the same place is the same result. Several
         # of these carry one by design (an unqualified decay time, an empty
         # band), and without this the helper would reject a match.
-        assert np.array_equal(np.asarray(a), np.asarray(b), equal_nan=True), path
+        arr_a, arr_b = np.asarray(a), np.asarray(b)
+        assert np.array_equal(arr_a, arr_b, equal_nan=True), (
+            f"{path} differs: arrays of shape {arr_a.shape} and {arr_b.shape}"
+        )
         return
-    assert a == b, path
+    assert a == b, f"{path} differs: {a!r} != {b!r}"

--- a/tests/test_signal_contract_exemptions.py
+++ b/tests/test_signal_contract_exemptions.py
@@ -226,7 +226,7 @@ def test_a_full_scale_reading_never_sees_the_calibration(
     calibrated = func(Signal(_RECORD, FS, calibration_factor=CAL), **kwargs)
     assert_same(calibrated, func(_RECORD, FS, **kwargs))
     pre_scaled = func(CAL * _RECORD, FS, **kwargs)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match=r"result.*differs"):
         assert_same(calibrated, pre_scaled)
 
 
@@ -265,7 +265,7 @@ def test_a_non_pressure_record_never_sees_the_calibration(
     calibrated = func(Signal(_RECORD, FS, calibration_factor=CAL), **kwargs)
     assert_same(calibrated, func(_RECORD, FS, **kwargs))
     pre_scaled = func(CAL * _RECORD, FS, **kwargs)
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match=r"result.*differs"):
         assert_same(calibrated, pre_scaled)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -126,3 +126,52 @@ def test_resample_to_length_padding_and_trimming() -> None:
     y4 = _resample_to_length(x2, 1, 8)
     assert y4.shape == (2, 8)
     np.testing.assert_array_equal(y4, x2[:, :8])
+
+
+@pytest.mark.parametrize(
+    ("entry", "field"),
+    [("resolve_samples", "x"), ("apply_calibration", "ref_signal")],
+)
+def test_a_factor_that_overflows_its_samples_is_refused(entry: str, field: str) -> None:
+    """Two finite numbers whose product is not, and nothing saw it.
+
+    The samples are checked for finiteness before the calibration factor is
+    applied, and a check cannot see past the multiplication that follows it.
+    Both operands are finite by contract, the factor because
+    :class:`~phonometry.io.Signal` requires it, so the infinity was created
+    between them and left as a value.
+
+    The refusal names both, because neither is wrong on its own: a chain that
+    overflows is built wrong somewhere along it, and saying only "non-finite"
+    would send the reader to whichever end they looked at first.
+    """
+    from phonometry.io import Signal
+    from phonometry.io._resolve import apply_calibration, resolve_samples
+
+    samples = np.full(4, 1e300)
+    signal = Signal(samples, 48000, calibration_factor=1e10)
+    call = (
+        (lambda: resolve_samples(signal))
+        if entry == "resolve_samples"
+        else (lambda: apply_calibration(signal, samples, name=field))
+    )
+    with pytest.raises(
+        ValueError, match=rf"'{field}': the calibration factor overflows"
+    ):
+        call()
+
+
+def test_a_calibration_the_instruments_actually_use_is_untouched() -> None:
+    """The headroom is not close, and the guard must not pretend otherwise.
+
+    A double reaches about 1.8e308, and the loudest quantity acoustics
+    measures is a blast overpressure of a few bar. A full-scale sample scaled
+    to pascals by a factor of 1e5 lands at 5e4, which is 1e303 short of the
+    ceiling, so nothing an instrument produces comes near this refusal.
+    """
+    from phonometry.io import Signal
+    from phonometry.io._resolve import resolve_samples
+
+    scaled = resolve_samples(Signal(np.full(4, 0.5), 48000, calibration_factor=1e5))
+    assert np.all(np.isfinite(scaled))
+    assert float(np.max(scaled)) == pytest.approx(5.0e4)


### PR DESCRIPTION
Three refusals that fired correctly and could not say what they had refused.

## A comparison helper with no message

`assert_same` walks results field by field and names the field it reached, except at the top: the path started empty, so a mismatch there raised an `AssertionError` carrying nothing. The two tests that assert a difference *is* expected could then only write a bare `pytest.raises(AssertionError)`, which accepts any failure of the helper, including a shape mismatch unrelated to the contract they are named for. The path starts at `result` now, and a leaf says what the two sides hold.

## One sentence for three parameters

A feedback loop gain guarded three inputs with `Levels and the directivity index must be finite`: true of all of them and a help with none. The gain is a difference of two separately measured levels plus a directivity index, so which one arrived non-finite decides where the caller looks, at the microphone position, the listener position, or the microphone's own pattern. Each is named now, and the test that pinned the old sentence is parametrised over the three, which the old sentence made impossible.

## An infinity created between two finite numbers

The samples were checked for finiteness *before* the calibration factor scaled them, and a check cannot see past the multiplication that follows it. Both operands are finite by contract (`Signal` requires a positive finite factor), so the infinity was created between them and left as a value.

This one was left open in an earlier review for costing a second pass over every calibrated recording. It does not. numpy detects the overflow in the multiplication itself and `errstate` only decides what to do about it, so there is no extra pass at all. Measured over sixty seconds at 48 kHz: the plain multiply 3.03 ms, with `errstate` 2.88 ms, with a second `isfinite` pass 4.63 ms.

The headroom is also not close, which is why refusing is right rather than widening the type. A double reaches 1.8e308; the loudest quantity acoustics measures is a blast overpressure of a few bar, about 1e6 Pa. A product that overflows is a calibration chain built wrong, not a scale that will not fit. And a wider type would not have helped: `np.longdouble` is the same 64 bits as `double` under MSVC, so the fix would have been a silent no-op on the two Windows runners this repository tests on.

The guard is shared between `resolve_samples` and `apply_calibration`, its two-step sibling, which multiplied the same way; fixing one and not the other would have left exactly the inconsistency this work keeps closing.

Full suite green: 10146 passed, 16 skipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Improve refusal diagnostics and prevent calibration overflow from producing invalid sample values.

Bug Fixes:
- Improve validation errors so feedback-loop gain identifies the specific non-finite input.
- Reject calibration operations when scaling finite samples would overflow instead of returning infinite values.
- Make result comparison failures report the result path and differing values or shapes.

Enhancements:
- Share overflow-safe calibration handling between direct sample resolution and deferred calibration application.

Tests:
- Add coverage for parameter-specific feedback-loop validation, calibration overflow refusal, safe calibration, and descriptive comparison failures.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Improved error reporting in feedback_loop_gain by validating finiteness of each input parameter individually.</li>
<li>Introduced a _scaled helper function in io/_resolve.py to detect and raise errors on overflow during signal calibration.</li>
<li>Updated resolve_samples and apply_calibration to use the new _scaled function for safer calibration scaling.</li>
<li>Added unit tests to verify the new error handling and scaling logic.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation errors for non-finite sound reinforcement inputs by identifying the specific field.
  * Added clear errors when calibration causes numeric overflow, including the affected signal and calibration details.
  * Preserved valid high-magnitude calibration results without incorrectly rejecting finite values.

* **Tests**
  * Expanded coverage for field-specific validation, calibration overflow handling, and detailed assertion messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->