### PR TITLE
State that auto review is on, and let the bots commit unread

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,8 +12,15 @@ reviews:
   # default left exactly the part that most needs reading unreviewed and
   # answered with a note about checking this file.
   auto_review:
+    enabled: true
     base_branches:
       - ".*"
+    # A bot commit carries no reviewable intent: dependabot bumps a pin and
+    # github-actions stamps a generated artifact, and neither is a decision
+    # anyone needs read back to them.
+    ignore_usernames:
+      - "github-actions[bot]"
+      - "dependabot[bot]"
   path_instructions:
     - path: "docs/**"
       instructions: >-


### PR DESCRIPTION
`enabled: true` is the default, so it is a statement rather than a switch. It earns its line because `base_branches` right below it only means anything while auto review is on, and reading the pair should not require knowing which defaults apply.

`ignore_usernames` is new behaviour, for the two accounts that commit here without deciding anything: dependabot bumps a pin and github-actions stamps a generated artifact. Twelve of the last four hundred commits are dependabot's.

Nothing else moves. `base_branches: [".*"]` has been in place since #616, so stacked pull requests were already being reviewed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enabled auto-review functionality in .coderabbit.yaml.</li>
<li>Configured the bot to ignore commits from 'github-actions[bot]' and 'dependabot[bot]' to reduce noise in reviews.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review settings to enable reviews explicitly.
  * Excluded routine commits from selected automation accounts from automated review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->