### PR TITLE
Draw "See also" as one box, and give the section an element to be

### DIFF
--- a/scripts/mirror_overviews.py
+++ b/scripts/mirror_overviews.py
@@ -146,7 +146,9 @@ def _rewrite_links(body: str, route: str) -> str:
 #: The component wrappers an overview may use, and the import lines that bring
 #: them in. The mirror is plain markdown for GitHub, which renders neither, so
 #: both are removed and the children are kept: a <ScopeClaim> holds nothing but
-#: the prose of one claim, so dropping the tag leaves the paragraph it wraps.
+#: the prose of one claim, so dropping the tag leaves the paragraph it wraps,
+#: and a <SeeAlso> holds the heading, the sentence that sometimes introduces it
+#: and the list of links, all of which the mirror wants.
 #: The claim's `label` is not recovered here — the overviews are the pages that
 #: carry no label, because every claim under "What this section does not cover"
 #: is on the same side of the boundary and the heading already says which.
@@ -156,7 +158,7 @@ def _rewrite_links(body: str, route: str) -> str:
 #: to the heading below it. Both were visible in the first generated mirror.
 _IMPORT = re.compile(r"^import\s+\w+\s+from\s+'[^']*';[ \t]*$\n?", re.MULTILINE)
 _COMPONENT = re.compile(
-    r"^</?(?:Scope|ScopeClaim)(?:\s[^>]*)?>[ \t]*$\n?", re.MULTILINE
+    r"^</?(?:Scope|ScopeClaim|SeeAlso)(?:\s[^>]*)?>[ \t]*$\n?", re.MULTILINE
 )
 _BLANK_RUN = re.compile(r"\n{3,}")
 

--- a/site/src/components/Scope.astro
+++ b/site/src/components/Scope.astro
@@ -9,10 +9,12 @@
  * any framing sentence that introduces the claims. Two reasons, and the
  * second is the important one:
  *
- *  - a heading emitted by a component is invisible to Starlight's table of
- *    contents, which is built from the markdown AST, so moving it in here
- *    would drop the section from "On this page" and lose its anchor (the
- *    same trap src/styles/see-also.css records);
+ *  - a heading RENDERED BY a component is invisible to Starlight's table of
+ *    contents, which is built from the markdown AST, so writing one in here
+ *    would drop the section from "On this page" and lose its anchor. Note
+ *    what this does not say: a heading that stays authored markdown keeps
+ *    both even when a component WRAPS it, which is how SeeAlso.astro bounds
+ *    its own section;
  *  - it makes the contract exact. EVERYTHING INSIDE THIS ELEMENT IS A
  *    CLAIM, AND NOTHING ELSE IS. That is what makes the corpus countable.
  *

--- a/site/src/components/SeeAlso.astro
+++ b/site/src/components/SeeAlso.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * The "See also" panel that closes a guide: its heading, the sentence that
+ * sometimes introduces it, and the list of links to related pages, drawn as
+ * ONE box.
+ *
+ * WHY THIS IS A COMPONENT AND NOT A STYLE RULE. The panel used to be painted
+ * in two halves by src/styles/see-also.css — the heading wrapper drew the top
+ * (border with no bottom side, top corners rounded) and a `+ ul` sibling
+ * selector drew the bottom. `+` is the ADJACENT sibling, so the bottom half
+ * appeared only where the list happened to follow the heading immediately. On
+ * the twenty-eight pages that open the section with a sentence the adjacent
+ * sibling is a <p>, nothing matched, and the reader met a box drawn around the
+ * title alone with its border hanging open and the links spilling out below.
+ *
+ * The rule could not be repaired in place. `+ :is(p, ul)` only moves the
+ * defect — the paragraph closes the box and the list falls outside instead —
+ * and CSS has no "until the next heading" combinator, `:has()` included, so
+ * nothing in a stylesheet can bracket a run of markdown siblings. An opening
+ * and a closing tag can, and they bound the section by construction: whatever
+ * an author puts between them is inside the box, and the question of what the
+ * box contains stops being a guess made by a selector.
+ *
+ * THE HEADING STAYS IN THE MARKDOWN, and unlike <Scope> it now sits INSIDE
+ * this element rather than above it. It has to stay authored markdown for the
+ * reason Scope.astro records: a heading RENDERED BY a component never reaches
+ * the table of contents, which Astro collects from the
+ * MDX syntax tree at compile time, and it would lose the id and hover anchor
+ * that Starlight's own pipeline gives it. Markdown inside this element is part
+ * of that syntax tree, so `## See also` keeps its "On this page" line, its
+ * `see-also` / `véase-también` id and its anchor link exactly as before.
+ *
+ * Injecting the entry afterwards, the way src/routeData.ts does for the
+ * bibliography, is not available here: the bibliography is always last, while
+ * seventy of the two hundred and forty-two pages carry further H2s after this
+ * section, so an appended entry would list "See also" below headings it comes
+ * before on the page.
+ *
+ * WHY <nav>. The panel is a list of links to other pages and nothing else,
+ * which is what the element is defined for, and naming it promotes it to a
+ * landmark a screen reader user can jump to — worth having at the foot of a
+ * guide that runs to several thousand words. The name comes from the visible
+ * heading through `aria-labelledby`, so the two cannot drift apart and nothing
+ * is restated: a bare <section> would need a role and a name to say what the
+ * <h2> inside it already says. Starlight names its own two table-of-contents
+ * navs the same way, off a heading id, so this is the site's existing pattern
+ * rather than a new one.
+ *
+ * The computed name comes out uppercased, "SEE ALSO" and "VÉASE TAMBIÉN",
+ * because the accessible-name calculation takes the RENDERED text and the
+ * label is set in caps by the stylesheet. That is measured, not assumed, and
+ * it is left alone deliberately: it is exactly how the heading itself has
+ * always been announced, and an `aria-label` in title case would buy nicer
+ * pronunciation by making the landmark's name disagree with the words on the
+ * screen.
+ *
+ * Styled by src/styles/see-also.css, which now keys on this element's class
+ * instead of on the heading's slug.
+ */
+
+/**
+ * The heading id per language, which is the slug Starlight derives from the
+ * section title and the anchor the rest of the site links to. Keyed here
+ * because `aria-labelledby` has to name an element this component does not
+ * render; the corpus titles every one of these sections with the same two
+ * words, which is the same assumption the stylesheet made before it.
+ */
+const HEADING_ID = { en: 'see-also', es: 'véase-también' } as const;
+
+const { lang } = Astro.locals.starlightRoute;
+const headingId = lang.startsWith('es') ? HEADING_ID.es : HEADING_ID.en;
+---
+
+<nav class="see-also" aria-labelledby={headingId}>
+	<slot />
+</nav>

--- a/site/src/content/docs/aircraft/aircraft-noise.mdx
+++ b/site/src/content/docs/aircraft/aircraft-noise.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../components/ReportPreview.astro';
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 import Video from '../../../components/Video.astro';
 
@@ -533,6 +534,8 @@ moved to [Airport noise](/phonometry/aircraft/airport-noise/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Airport noise (ECAC Doc 29)](/phonometry/aircraft/airport-noise/): the NPD
@@ -544,3 +547,5 @@ moved to [Airport noise](/phonometry/aircraft/airport-noise/).
   noise-power-distance tables for real types, which is where the certification
   data ends up for modelling work.
 - API reference: [`aircraft.certification`](/phonometry/reference/api/aeroacoustics/certification/) and [`aircraft.atmospheric_absorption`](/phonometry/reference/api/aeroacoustics/atmospheric-absorption/).
+
+</SeeAlso>

--- a/site/src/content/docs/aircraft/airport-noise.mdx
+++ b/site/src/content/docs/aircraft/airport-noise.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 import Video from '../../../components/Video.astro';
 
@@ -521,6 +522,8 @@ ground.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Aircraft noise: Effective Perceived Noise Level](/phonometry/aircraft/aircraft-noise/):
@@ -542,3 +545,5 @@ ground.
   from single events.
 - API reference:
   [`aircraft.airport_noise`](/phonometry/reference/api/aeroacoustics/airport-noise/).
+
+</SeeAlso>

--- a/site/src/content/docs/aircraft/anp-fleet.mdx
+++ b/site/src/content/docs/aircraft/anp-fleet.mdx
@@ -20,6 +20,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 
 [Airport Noise (ECAC Doc 29)](/phonometry/aircraft/airport-noise/) computes an
@@ -471,6 +472,8 @@ phonometry ships version 2.3 and does not update it.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -481,3 +484,5 @@ Pages elsewhere on the site that this section leans on:
   the certification metric, which is measured rather than tabulated.
 - API reference:
   [`aircraft.anp_fleet`](/phonometry/reference/api/aeroacoustics/anp-fleet/).
+
+</SeeAlso>

--- a/site/src/content/docs/aircraft/rotorcraft-noise.mdx
+++ b/site/src/content/docs/aircraft/rotorcraft-noise.mdx
@@ -50,6 +50,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 
 Helicopter noise is strongly directive, so the **ECAC Doc 32** method describes
@@ -1038,6 +1039,8 @@ flight-condition interpolation, which follows the NORAH2 guidance instead.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Aircraft noise: Effective Perceived Noise Level](/phonometry/aircraft/aircraft-noise/):
@@ -1050,3 +1053,5 @@ flight-condition interpolation, which follows the NORAH2 guidance instead.
   the ISO 9613-2 ground effect and the CNOSSOS ground classes this two-ray
   adjustment shares.
 - API reference: [`aircraft.rotorcraft_noise`](/phonometry/reference/api/aeroacoustics/rotorcraft-noise/).
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/buildings/design/detailed-prediction.mdx
@@ -34,6 +34,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The simplified model of
@@ -630,6 +631,8 @@ one-third octaves, or 125 Hz to 2000 Hz in octaves.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Predicting Sound Insulation (EN 12354)](/phonometry/buildings/design/insulation-prediction/): the
@@ -645,3 +648,5 @@ one-third octaves, or 125 Hz to 2000 Hz in octaves.
   the $s'$ behind the floating floor's resonance frequency.
 - API reference: [`building.prediction.detailed_model`](/phonometry/reference/api/building/detailed-model/).
 - Theory: [Sound insulation and absorption, predicted](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-predicted-en-12354-1-2-6-bies-cremer-hopkins): the direct and flanking path algebra the detailed model itemises.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/impact-improvement.mdx
+++ b/site/src/content/docs/buildings/design/impact-improvement.mdx
@@ -41,6 +41,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A soft floor covering does not block airborne sound; it cushions footsteps.
@@ -390,6 +391,8 @@ Foret et al. (2011) worked example.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Laboratory Insulation Measurement](/phonometry/buildings/insulation/insulation-lab/):
@@ -407,3 +410,5 @@ Foret et al. (2011) worked example.
 - [Theory](/phonometry/reference/theory/rooms-buildings/): the
   reference-curve derivation behind the weighted single numbers.
 - API reference: [`building.measurement.floor_covering_improvement`](/phonometry/reference/api/building/floor-covering-improvement/).
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/index.mdx
+++ b/site/src/content/docs/buildings/design/index.mdx
@@ -5,6 +5,7 @@ description: "Sound insulation before it is built: the EN/ISO 12354 flanking pre
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 The pages of the [Sound insulation](/phonometry/buildings/insulation/)
 section answer the question *what does this building achieve?* The pages here
@@ -142,6 +143,8 @@ measurement in [Sound insulation](/phonometry/buildings/insulation/).
   what that power becomes once the machine is mounted on a real element, and
   the level it produces in the receiving room.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -149,6 +152,8 @@ Pages elsewhere on the site that this section leans on:
 - [Dynamic stiffness of resilient materials (EN 29052-1)](/phonometry/materials/resilient/dynamic-stiffness/):
   the load-plate resonance measurement, the enclosed-gas term and the
   floating-floor natural frequency.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/buildings/design/installed-structure-borne.mdx
+++ b/site/src/content/docs/buildings/design/installed-structure-borne.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 **EN 12354-5:2009** predicts the sound pressure level in a receiving room caused
@@ -644,6 +645,8 @@ revision.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Structure-borne sound power of equipment (EN 15657)](/phonometry/buildings/design/structure-borne-power/):
@@ -658,3 +661,5 @@ revision.
   the airborne and impact members of the same prediction family.
 - API reference: [`building.prediction.installed_structure_borne`](/phonometry/reference/api/building/installed-structure-borne/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the mobility and radiation-efficiency theory the installed level is predicted from.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/insulation-prediction.mdx
+++ b/site/src/content/docs/buildings/design/insulation-prediction.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -626,6 +627,8 @@ spaces](/phonometry/buildings/rooms/enclosed-space-absorption/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Façade Sound Insulation](/phonometry/buildings/insulation/facade-insulation/): the
@@ -651,3 +654,5 @@ spaces](/phonometry/buildings/rooms/enclosed-space-absorption/).
   the $s'$ input to the EN 12354-2 floating-floor term.
 - API reference: [`building.prediction.simplified_model`](/phonometry/reference/api/building/simplified-model/) and [`building.prediction.facade`](/phonometry/reference/api/building/facade/).
 - Theory: [Sound insulation and absorption, predicted](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-predicted-en-12354-1-2-6-bies-cremer-hopkins): the EN 12354 path model and the transmission quantities it sums.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/panel-sound-insulation.mdx
+++ b/site/src/content/docs/buildings/design/panel-sound-insulation.mdx
@@ -64,6 +64,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -1001,6 +1002,8 @@ need the whole room-plate-cavity-plate-room chain.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Predicting Sound Insulation (EN 12354)](/phonometry/buildings/design/insulation-prediction/):
@@ -1013,3 +1016,5 @@ need the whole room-plate-cavity-plate-room chain.
   cavity-fill models a double wall consumes.
 - API reference: [`building.prediction.panel_transmission`](/phonometry/reference/api/building/panel-transmission/), [`building.prediction.masonry_cavity_wall`](/phonometry/reference/api/building/masonry-cavity-wall/), [`building.prediction.aperture_transmission`](/phonometry/reference/api/building/aperture-transmission/), [`vibration.structural.radiation_efficiency`](/phonometry/reference/api/vibration/radiation-efficiency/) and [`vibration.structural.point_mobility`](/phonometry/reference/api/vibration/point-mobility/).
 - Theory: [Sound insulation and absorption, predicted](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-predicted-en-12354-1-2-6-bies-cremer-hopkins): the mass law, the coincidence dip and the transmission coefficient the panel models return.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/resilient-layers.mdx
+++ b/site/src/content/docs/buildings/design/resilient-layers.mdx
@@ -40,6 +40,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A resilient layer is the cheapest way to buy impact sound insulation and the
@@ -543,6 +544,8 @@ these models.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Floor-Covering Impact Improvement (ISO 16251-1)](/phonometry/buildings/design/impact-improvement/):
@@ -558,3 +561,5 @@ these models.
   the lining resonance.
 - API reference: [`building.prediction.resilient_layers`](/phonometry/reference/api/building/resilient-layers/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the mass-spring picture behind an improvement index, and why a resilient layer is a mobility mismatch.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/design/structure-borne-power.mdx
+++ b/site/src/content/docs/buildings/design/structure-borne-power.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Building service equipment (pumps, fans, boilers, sanitary appliances)
@@ -518,7 +519,11 @@ of the standard is cited as the source-side counterpart, not implemented.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - API reference: [`building.measurement.structure_borne_power`](/phonometry/reference/api/building/structure-borne-power/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the point mobility, the source-receiver mismatch and the injected power they define.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/facade-insulation.mdx
+++ b/site/src/content/docs/buildings/insulation/facade-insulation.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A façade is the one element of a building that faces the noise everybody
@@ -738,6 +739,8 @@ appear: the implementation follows the formulas rather than the printed rows.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/):
@@ -760,3 +763,5 @@ appear: the implementation follows the formulas rather than the printed rows.
 - [Theory](/phonometry/reference/theory/rooms-buildings/): the reference-curve
   derivation behind the weighted single-number ratings.
 - API reference: [`building.prediction.facade`](/phonometry/reference/api/building/facade/) and [`building.measurement.insulation`](/phonometry/reference/api/building/insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/flanking-lab.mdx
+++ b/site/src/content/docs/buildings/insulation/flanking-lab.mdx
@@ -70,6 +70,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 EN 12354 predicts a building from its junctions, and ISO 10848 is how a
@@ -652,6 +653,8 @@ duct is an input here, not a prediction.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Predicting Sound Insulation (EN 12354)](/phonometry/buildings/design/insulation-prediction/):
@@ -671,3 +674,5 @@ duct is an input here, not a prediction.
 - API reference: [`building.measurement.flanking_transmission`](/phonometry/reference/api/building/flanking-transmission/)
   and [`building.prediction.ceiling_plenum`](/phonometry/reference/api/building/ceiling-plenum/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the mobility and radiation-efficiency theory behind a flanking path.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/heavy-impact-sources.mdx
+++ b/site/src/content/docs/buildings/insulation/heavy-impact-sources.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The ISO tapping machine is a *light* impact source. Its five 500 g hammers fall
@@ -460,6 +461,8 @@ of Formula (4).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/): the
@@ -472,3 +475,5 @@ of Formula (4).
   the improvement a soft covering gives against the light source.
 - API reference: [`building.measurement.heavy_impact`](/phonometry/reference/api/building/heavy-impact/).
 - Theory: [Sound insulation and absorption, measured](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-measured-iso-16283-iso-10140-iso-717-iso-354): the impact-level normalisations of ISO 10140 and ISO 717-2 that the rubber ball and bang machine feed.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/insulation-field.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-field.mdx
@@ -56,6 +56,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 This guide continues from the [Room Acoustics guide](/phonometry/buildings/rooms/room-acoustics/):
@@ -749,6 +750,8 @@ Intensity](/phonometry/buildings/insulation/insulation-intensity/)).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Insulation Ratings (ISO 717)](/phonometry/buildings/insulation/insulation-ratings/): the
@@ -775,6 +778,8 @@ Intensity](/phonometry/buildings/insulation/insulation-intensity/)).
 - [Theory](/phonometry/reference/theory/rooms-buildings/): the reference-curve derivation behind the
   weighted single-number ratings.
 - API reference: [`building.measurement.insulation`](/phonometry/reference/api/building/insulation/) and [`building.measurement.uncertainty`](/phonometry/reference/api/building/uncertainty/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/buildings/insulation/insulation-intensity.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-intensity.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A reverberation room reads transmitted sound power *indirectly*: the
@@ -518,6 +519,8 @@ apply unchanged to field data, but nothing checks how that data was acquired.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Laboratory Insulation Measurement](/phonometry/buildings/insulation/insulation-lab/):
@@ -532,3 +535,5 @@ apply unchanged to field data, but nothing checks how that data was acquired.
 - [Theory](/phonometry/reference/theory/rooms-buildings/): the
   reference-curve derivation behind the weighted single-number ratings.
 - API reference: [`building.measurement.intensity_insulation`](/phonometry/reference/api/building/intensity-insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/insulation-lab.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-lab.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 To rate a building element on its own (a wall type, a floating floor, a
@@ -564,6 +565,8 @@ floor-covering improvement (ISO 16251-1) and flanking transmission (ISO
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/):
@@ -586,3 +589,5 @@ floor-covering improvement (ISO 16251-1) and flanking transmission (ISO
   the absorption-area machinery of the receiving room.
 - API reference: [`building.measurement.lab_insulation`](/phonometry/reference/api/building/lab-insulation/).
 - Theory: [Sound insulation and absorption, measured](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-measured-iso-16283-iso-10140-iso-717-iso-354): the derivation of R and R′ and the normalisations that separate laboratory from field.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/insulation-ratings.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-ratings.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -614,6 +615,8 @@ Sources](/phonometry/buildings/insulation/heavy-impact-sources/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/):
@@ -634,6 +637,8 @@ Sources](/phonometry/buildings/insulation/heavy-impact-sources/).
 - [Theory](/phonometry/reference/theory/rooms-buildings/): the
   reference-curve derivation behind the weighted single-number ratings.
 - API reference: [`building.measurement.insulation`](/phonometry/reference/api/building/insulation/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/buildings/insulation/insulation-survey.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-survey.mdx
@@ -21,6 +21,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Not every question deserves a full engineering measurement. When a dispute
@@ -442,6 +443,8 @@ cycles for service equipment are also outside the library.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/):
@@ -459,3 +462,5 @@ cycles for service equipment are also outside the library.
 - [Theory](/phonometry/reference/theory/rooms-buildings/): the
   reference-curve derivation behind the weighted single-number ratings.
 - API reference: [`building.measurement.survey_insulation`](/phonometry/reference/api/building/survey-insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/low-frequency-procedure.mdx
+++ b/site/src/content/docs/buildings/insulation/low-frequency-procedure.mdx
@@ -41,6 +41,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Below 100 Hz a bedroom-sized room has too few modes for microphones in its
@@ -624,6 +625,8 @@ procedure by Clause 6.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/): the
@@ -641,3 +644,5 @@ procedure by Clause 6.
   [`building.measurement.low_frequency`](/phonometry/reference/api/building/low-frequency/)
   and
   [`building.measurement.insulation`](/phonometry/reference/api/building/insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/insulation/spanish-building-code.mdx
+++ b/site/src/content/docs/buildings/insulation/spanish-building-code.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The *Documento Básico HR* "Protección frente al ruido" of the Spanish building
@@ -371,6 +372,8 @@ scope as well.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Insulation Ratings (ISO 717)](/phonometry/buildings/insulation/insulation-ratings/): the reference-curve route with $R_\mathrm{w}$, $C$, $C_\mathrm{tr}$ and the enlarged-range terms that DB-HR calls simply $C$ and $C_\mathrm{tr}$.
@@ -380,6 +383,8 @@ scope as well.
 - [Field Insulation Measurement (ISO 16283)](/phonometry/buildings/insulation/insulation-field/): the band spectra of $R'$, $D_\mathrm{nT}$ and $L'_\mathrm{nT}$ that these global quantities summarise.
 - API reference: [`building.regulation.spain`](/phonometry/reference/api/building/spain/).
 - Theory: [Sound insulation and absorption, measured](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-measured-iso-16283-iso-10140-iso-717-iso-354): the quantities the code requires, derived from ISO 12354 and ISO 717 rather than from the code.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/buildings/rooms/enclosed-space-absorption.mdx
+++ b/site/src/content/docs/buildings/rooms/enclosed-space-absorption.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 **EN 12354-6:2003** predicts the **total equivalent sound absorption area** of a
@@ -581,6 +582,8 @@ target passed through `requirement` is drawn as a reference line only.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Reverberation-time prediction (Sabine, Eyring, Arau)](/phonometry/buildings/rooms/reverberation-prediction/):
@@ -602,3 +605,5 @@ target passed through `requirement` is drawn as a reference line only.
   `environment.propagation.air_absorption`.
 - API reference: [`room.enclosed_space_absorption`](/phonometry/reference/api/rooms/enclosed-space-absorption/).
 - Theory: [Sound insulation and absorption, predicted](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-predicted-en-12354-1-2-6-bies-cremer-hopkins): the equivalent-absorption-area definition the EN 12354-6 procedure computes.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/rooms/open-plan-acoustics.mdx
+++ b/site/src/content/docs/buildings/rooms/open-plan-acoustics.mdx
@@ -22,6 +22,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 An open-plan office is not a reverberation problem; it is a privacy
@@ -698,6 +699,8 @@ a given table sits.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Room Acoustics](/phonometry/buildings/rooms/room-acoustics/): the ISO 3382-1/2
@@ -714,3 +717,5 @@ a given table sits.
   derivations this page builds on.
 - API reference: [`room.open_plan`](/phonometry/reference/api/rooms/open-plan/).
 - Theory: [Impulse response and room-acoustic parameters](/phonometry/reference/theory/rooms-buildings/#impulse-response-and-room-acoustic-parameters-iso-18233-iso-3382-1-2-3): the decay and absorption theory the ISO 3382-3 distraction distance is measured against.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/rooms/reverberation-prediction.mdx
+++ b/site/src/content/docs/buildings/rooms/reverberation-prediction.mdx
@@ -98,6 +98,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -719,6 +720,8 @@ prediction.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Sound Absorption Measurement and Rating](/phonometry/materials/absorbers/absorption-measurement/):
@@ -733,3 +736,5 @@ prediction.
   applies.
 - API reference: [`room.reverberation_prediction`](/phonometry/reference/api/rooms/reverberation-prediction/) and [`environment.propagation.air_absorption`](/phonometry/reference/api/environment/air-absorption/).
 - Theory: [Sound insulation and absorption, predicted](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-predicted-en-12354-1-2-6-bies-cremer-hopkins): the diffuse-field assumption every Sabine-family formula makes, and where it stops holding.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/rooms/room-acoustics.mdx
+++ b/site/src/content/docs/buildings/rooms/room-acoustics.mdx
@@ -49,6 +49,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -663,6 +664,8 @@ Rating](/phonometry/materials/absorbers/absorption-measurement/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Measuring the Room Impulse Response](/phonometry/buildings/rooms/room-impulse-response/):
@@ -689,6 +692,8 @@ Rating](/phonometry/materials/absorbers/absorption-measurement/).
   definitions the ISO 3382 implementations are validated against.
 - API reference: [`room.acoustics`](/phonometry/reference/api/rooms/acoustics/).
 - Theory: [Impulse response and room-acoustic parameters](/phonometry/reference/theory/rooms-buildings/#impulse-response-and-room-acoustic-parameters-iso-18233-iso-3382-1-2-3): the decay model behind T20, T30 and EDT and the energy ratios the clarity and definition parameters are built from.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/buildings/rooms/room-image-sources.mdx
+++ b/site/src/content/docs/buildings/rooms/room-image-sources.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -946,6 +947,8 @@ ratios are discussed but not tabulated.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Room Acoustics](/phonometry/buildings/rooms/room-acoustics/): the *measured* impulse
@@ -967,3 +970,5 @@ ratios are discussed but not tabulated.
 - API reference: [`room.image_source`](/phonometry/reference/api/rooms/image-source/)
   and [`room.steady_field`](/phonometry/reference/api/rooms/steady-field/).
 - Theory: [Impulse response and room-acoustic parameters](/phonometry/reference/theory/rooms-buildings/#impulse-response-and-room-acoustic-parameters-iso-18233-iso-3382-1-2-3): the geometrical model behind the image method and its relation to the statistical one.
+
+</SeeAlso>

--- a/site/src/content/docs/buildings/rooms/room-impulse-response.mdx
+++ b/site/src/content/docs/buildings/rooms/room-impulse-response.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -735,6 +736,8 @@ measured or where.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Room Acoustics](/phonometry/buildings/rooms/room-acoustics/): the decay analysis
@@ -754,6 +757,8 @@ measured or where.
   integration the decay analysis applies to this IR.
 - API reference: [`room.impulse_response`](/phonometry/reference/api/rooms/impulse-response/).
 - Theory: [Impulse response and room-acoustic parameters](/phonometry/reference/theory/rooms-buildings/#impulse-response-and-room-acoustic-parameters-iso-18233-iso-3382-1-2-3): the Schroeder backward integration and the deconvolution the sweep method rests on.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/buildings/rooms/room-noise.mdx
+++ b/site/src/content/docs/buildings/rooms/room-noise.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Steady background noise in an occupied room (from ventilation, diffusers or
@@ -562,6 +563,8 @@ governs the job, before quoting a limit.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Room Acoustics](/phonometry/buildings/rooms/room-acoustics/): the ISO 3382
@@ -580,3 +583,5 @@ governs the job, before quoting a limit.
   when the source is next door rather than overhead.
 - API reference: [`room.noise_criteria`](/phonometry/reference/api/rooms/noise-criteria/).
 - Theory: [Room noise criteria (ANSI S12.2)](/phonometry/reference/theory/rooms-buildings/#room-noise-criteria-ansi-s122): how the NC, RC Mark II and NR families are constructed and what each was designed to penalise.
+
+</SeeAlso>

--- a/site/src/content/docs/devices/broadcast/index.mdx
+++ b/site/src/content/docs/devices/broadcast/index.mdx
@@ -5,6 +5,7 @@ description: "The two meters broadcasting standardised: the ITU-R BS.1770 K-weig
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 Broadcasting solved the loudness problem with a measurement rather than a
 compressor: one number per programme, gated so that silence does not dilute it,
@@ -66,6 +67,8 @@ anywhere in it.
   a reading dBqps, and the three fitted time scales those windows identify only
   to within a factor of 1.61 to 2.09.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -75,6 +78,8 @@ Pages elsewhere on the site that this section leans on:
   how loud something *sounds* rather than how a programme should be delivered.
 - [Frequency Weighting (A, C, Z)](/phonometry/signals/levels/weighting/): the
   weighting family K-weighting sits beside, and does not belong to.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/devices/broadcast/program-loudness.mdx
+++ b/site/src/content/docs/devices/broadcast/program-loudness.mdx
@@ -49,6 +49,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -748,6 +749,8 @@ outside it by construction; those live in [Loudness (ISO
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Loudness (ISO 532)](/phonometry/perception/psychoacoustics/loudness/): the
@@ -761,4 +764,6 @@ outside it by construction; those live in [Loudness (ISO
   the chain that carries the programme once it has been normalised.
 - [Broadcast](/phonometry/devices/broadcast/): the section overview.
 - API reference: [`broadcast`](/phonometry/reference/api/broadcast/program-loudness/).
+
+</SeeAlso>
 

--- a/site/src/content/docs/devices/broadcast/quasi-peak.mdx
+++ b/site/src/content/docs/devices/broadcast/quasi-peak.mdx
@@ -26,6 +26,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 **ITU-R BS.468-4** measures audio-frequency noise voltage in sound
@@ -350,6 +351,8 @@ the 600 Ω termination — are hardware and are not modelled. There is no
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Programme loudness & true peak](/phonometry/devices/broadcast/program-loudness/):
@@ -364,6 +367,8 @@ the 600 Ω termination — are hardware and are not modelled. There is no
   declaration.
 - [Broadcast](/phonometry/devices/broadcast/): the section overview.
 - API reference: [`broadcast.quasi_peak`](/phonometry/reference/api/broadcast/quasi-peak/).
+
+</SeeAlso>
 
 ## Standards
 

--- a/site/src/content/docs/devices/electroacoustics/electroacoustics.mdx
+++ b/site/src/content/docs/devices/electroacoustics/electroacoustics.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Two staples of audio-equipment characterisation, from a captured signal: how much
@@ -660,6 +661,8 @@ revision is not the one checked.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Loudspeaker Characterisation (IEC 60268-5)](/phonometry/devices/electroacoustics/loudspeakers/):
@@ -677,3 +680,5 @@ revision is not the one checked.
   the physical arrangement behind the $H_1$ estimate of section 5, with the
   reference tap and the two synchronous channels drawn.
 - API reference: [`electroacoustics.distortion`](/phonometry/reference/api/electroacoustics/distortion/), [`electroacoustics.intermodulation`](/phonometry/reference/api/electroacoustics/intermodulation/), [`electroacoustics.noise_measurements`](/phonometry/reference/api/electroacoustics/noise-measurements/) and [`electroacoustics.frequency_response`](/phonometry/reference/api/electroacoustics/frequency-response/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/electroacoustics/loudspeakers.mdx
+++ b/site/src/content/docs/devices/electroacoustics/loudspeakers.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -830,6 +831,8 @@ enters the design separately.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Electroacoustics](/phonometry/devices/electroacoustics/electroacoustics/): the IEC 60268-3
@@ -844,3 +847,5 @@ enters the design separately.
   descriptor, for when the question is how much acoustic power the source
   emits rather than how it responds on axis.
 - API reference: [`electroacoustics.piston`](/phonometry/reference/api/electroacoustics/piston/), [`electroacoustics.loudspeaker`](/phonometry/reference/api/electroacoustics/loudspeaker/) and [`electroacoustics.sound_reinforcement`](/phonometry/reference/api/electroacoustics/sound-reinforcement/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/electroacoustics/microphones.mdx
+++ b/site/src/content/docs/devices/electroacoustics/microphones.mdx
@@ -35,6 +35,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Every acoustic measurement in this documentation starts at a microphone, and
@@ -614,6 +615,8 @@ dBFS](/phonometry/signals/metrology/calibration/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Electroacoustics](/phonometry/devices/electroacoustics/electroacoustics/): the IEC 60268-3
@@ -627,3 +630,5 @@ dBFS](/phonometry/signals/metrology/calibration/).
 - [Build a sound level meter](/phonometry/signals/sound-level-meter/): the
   measurement chain a characterised microphone feeds.
 - API reference: [`electroacoustics.microphone`](/phonometry/reference/api/electroacoustics/microphone/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/electroacoustics/swept-sine-distortion.mdx
+++ b/site/src/content/docs/devices/electroacoustics/swept-sine-distortion.mdx
@@ -42,6 +42,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A single exponential sine sweep characterises the linear response and
@@ -538,6 +539,8 @@ the tail are the operator's to keep and to report.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Electroacoustics](/phonometry/devices/electroacoustics/electroacoustics/): the
@@ -550,3 +553,5 @@ the tail are the operator's to keep and to report.
   which is the linear half of the same recording.
 - API reference: [`electroacoustics.swept_sine`](/phonometry/reference/api/electroacoustics/swept-sine/)
   and [`signals.phase`](/phonometry/reference/api/signals/phase/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/emission/intensity.mdx
+++ b/site/src/content/docs/devices/emission/intensity.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -1014,6 +1015,8 @@ is grade it against Table 2. The before-use check of clause 14 and the ISO
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Sound Power by Intensity Scanning](/phonometry/devices/emission/sound-power-intensity/) — the ISO 9614-2/-3 routes that consume $\delta_{pI}$, the field indicators and the dynamic capability.
@@ -1023,3 +1026,5 @@ is grade it against Table 2. The before-use check of clause 14 and the ISO
 - [Theory: signal analysis](/phonometry/reference/theory/signal-analysis/) — the cross-spectral derivation behind $I(f) = -\mathrm{Im}\{G_{12}\}/(2\pi f \rho_0 \Delta r)$.
 - API reference: [`emission.intensity`](/phonometry/reference/api/power/intensity/).
 - Theory: [Sound intensity (IEC 61043)](/phonometry/reference/theory/signal-analysis/#sound-intensity-iec-61043): the finite-difference approximation behind a p-p probe and the errors it commits.
+
+</SeeAlso>

--- a/site/src/content/docs/devices/emission/sound-power-intensity.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-intensity.mdx
@@ -715,12 +715,13 @@ the clause 10 f) 2) omission of the bands the Annex C criteria reject.
 
 <ScopeClaim status="not-covered" label="Not covered">
 ISO 9614-1, the discrete fixed-point intensity method, is not one of the
-routes here: only its field indicators are reused, and the discrete-point
-power determination is not implemented at all; the [sound intensity
-guide](/phonometry/devices/emission/intensity/) covers the probe and the Annex
-A field indicators that both parts share. The probe's finite-difference bias
+routes here: it holds the probe still at each position instead of sweeping it,
+and both its power determination and the Annex A field indicators the two
+scanning parts reuse are in the [sound intensity
+guide](/phonometry/devices/emission/intensity/). The probe's
+finite-difference bias
 and the pressure-residual intensity index are measured properties of the
-instrument, covered in the same guide. Choosing among the six routes, and the
+instrument, covered in the same guide. Choosing among the seven routes, and the
 ISO 4871 declaration a result feeds, live in [Sound
 Power](/phonometry/devices/emission/sound-power/).
 </ScopeClaim>
@@ -730,7 +731,7 @@ Power](/phonometry/devices/emission/sound-power/).
 
 ## See also
 
-- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the five
+- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the seven
   determination routes, the accuracy grades and the ISO 4871 noise-emission
   declaration.
 - [Sound Intensity (p-p)](/phonometry/devices/emission/intensity/): the two-microphone

--- a/site/src/content/docs/devices/emission/sound-power-intensity.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-intensity.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -714,21 +715,22 @@ the clause 10 f) 2) omission of the bands the Annex C criteria reject.
 
 <ScopeClaim status="not-covered" label="Not covered">
 ISO 9614-1, the discrete fixed-point intensity method, is not one of the
-routes here: it holds the probe still at each position instead of sweeping it,
-and both its power determination and the Annex A field indicators the two
-scanning parts reuse are in the [sound intensity
-guide](/phonometry/devices/emission/intensity/). The probe's
-finite-difference bias
+routes here: only its field indicators are reused, and the discrete-point
+power determination is not implemented at all; the [sound intensity
+guide](/phonometry/devices/emission/intensity/) covers the probe and the Annex
+A field indicators that both parts share. The probe's finite-difference bias
 and the pressure-residual intensity index are measured properties of the
-instrument, covered in the same guide. Choosing among the seven routes, and the
+instrument, covered in the same guide. Choosing among the six routes, and the
 ISO 4871 declaration a result feeds, live in [Sound
 Power](/phonometry/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
-- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the seven
+- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the five
   determination routes, the accuracy grades and the ISO 4871 noise-emission
   declaration.
 - [Sound Intensity (p-p)](/phonometry/devices/emission/intensity/): the two-microphone
@@ -743,3 +745,5 @@ Power](/phonometry/devices/emission/sound-power/).
   field-indicator derivations.
 - API reference: [`emission.sound_power_intensity`](/phonometry/reference/api/power/sound-power-intensity/).
 - Theory: [Sound power determination](/phonometry/reference/theory/environment-transport/#sound-power-determination-iso-374437453746-iso-3741-iso-9614-123): the ISO 9614 scanning derivation and the field indicators that qualify it.
+
+</SeeAlso>

--- a/site/src/content/docs/devices/emission/sound-power-pressure.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-pressure.mdx
@@ -35,6 +35,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -842,15 +843,17 @@ above 500 m of altitude or below 10 °C (clause 8.2.5), is not applied either:
 `sound_power_pressure` takes no temperature or pressure argument. The $C_3$
 meteorological correction of ISO 3745 needs an air-absorption coefficient the
 caller supplies (`air_absorption_coefficient=`); this module does not compute
-it from ISO 9613-1 itself. Choosing among the seven routes, and the ISO 4871
+it from ISO 9613-1 itself. Choosing among the six routes, and the ISO 4871
 declaration a result feeds, live in [Sound
 Power](/phonometry/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
-- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the seven
+- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the five
   determination routes, the accuracy grades and the ISO 4871 noise-emission
   declaration.
 - [Sound Power in the Reverberation Room (ISO 3741)](/phonometry/devices/emission/sound-power-reverberation/):
@@ -867,3 +870,5 @@ Power](/phonometry/devices/emission/sound-power/).
   and $C_1$/$C_2$ derivations.
 - API reference: [`emission.sound_power`](/phonometry/reference/api/power/sound-power/).
 - Theory: [Sound power determination](/phonometry/reference/theory/environment-transport/#sound-power-determination-iso-374437453746-iso-3741-iso-9614-123): the enveloping-surface derivation of ISO 3744/3746 and the environmental correction it needs.
+
+</SeeAlso>

--- a/site/src/content/docs/devices/emission/sound-power-pressure.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-pressure.mdx
@@ -843,7 +843,7 @@ above 500 m of altitude or below 10 °C (clause 8.2.5), is not applied either:
 `sound_power_pressure` takes no temperature or pressure argument. The $C_3$
 meteorological correction of ISO 3745 needs an air-absorption coefficient the
 caller supplies (`air_absorption_coefficient=`); this module does not compute
-it from ISO 9613-1 itself. Choosing among the six routes, and the ISO 4871
+it from ISO 9613-1 itself. Choosing among the seven routes, and the ISO 4871
 declaration a result feeds, live in [Sound
 Power](/phonometry/devices/emission/sound-power/).
 </ScopeClaim>
@@ -853,7 +853,7 @@ Power](/phonometry/devices/emission/sound-power/).
 
 ## See also
 
-- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the five
+- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the seven
   determination routes, the accuracy grades and the ISO 4871 noise-emission
   declaration.
 - [Sound Power in the Reverberation Room (ISO 3741)](/phonometry/devices/emission/sound-power-reverberation/):

--- a/site/src/content/docs/devices/emission/sound-power-reverberation.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-reverberation.mdx
@@ -474,7 +474,7 @@ itself (Annex C/D, eigenfrequency counting or a reference-source comparison)
 is assumed, not performed; the library only warns on the coarse advisory
 criteria ISO 3741 states explicitly (the Table 1 minimum volume, the $V/S$
 reverberation floor, fewer than 6 positions, an inter-position spread above
-1.5 dB). Choosing among the six routes, and the ISO 4871 declaration a result
+1.5 dB). Choosing among the seven routes, and the ISO 4871 declaration a result
 feeds, live in [Sound Power](/phonometry/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
@@ -483,7 +483,7 @@ feeds, live in [Sound Power](/phonometry/devices/emission/sound-power/).
 
 ## See also
 
-- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the five
+- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the seven
   determination routes, the accuracy grades and the ISO 4871 noise-emission
   declaration.
 - [Sound Power by Pressure Methods (ISO 3744 / ISO 3746 / ISO 3745)](/phonometry/devices/emission/sound-power-pressure/):

--- a/site/src/content/docs/devices/emission/sound-power-reverberation.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-reverberation.mdx
@@ -21,6 +21,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -473,14 +474,16 @@ itself (Annex C/D, eigenfrequency counting or a reference-source comparison)
 is assumed, not performed; the library only warns on the coarse advisory
 criteria ISO 3741 states explicitly (the Table 1 minimum volume, the $V/S$
 reverberation floor, fewer than 6 positions, an inter-position spread above
-1.5 dB). Choosing among the seven routes, and the ISO 4871 declaration a result
+1.5 dB). Choosing among the six routes, and the ISO 4871 declaration a result
 feeds, live in [Sound Power](/phonometry/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
-- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the seven
+- [Sound Power](/phonometry/devices/emission/sound-power/): choosing among the five
   determination routes, the accuracy grades and the ISO 4871 noise-emission
   declaration.
 - [Sound Power by Pressure Methods (ISO 3744 / ISO 3746 / ISO 3745)](/phonometry/devices/emission/sound-power-pressure/):
@@ -495,3 +498,5 @@ feeds, live in [Sound Power](/phonometry/devices/emission/sound-power/).
   Waterhouse and $C_1$/$C_2$ derivations.
 - API reference: [`emission.sound_power_reverberation`](/phonometry/reference/api/power/sound-power-reverberation/).
 - Theory: [Sound power determination](/phonometry/reference/theory/environment-transport/#sound-power-determination-iso-374437453746-iso-3741-iso-9614-123): the ISO 3741 comparison and direct methods derived from the diffuse-field relation.
+
+</SeeAlso>

--- a/site/src/content/docs/devices/emission/sound-power.mdx
+++ b/site/src/content/docs/devices/emission/sound-power.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -446,6 +447,8 @@ $K = 1.645\,\sigma_\mathrm{R}$ case (Annex A.2.2) are stated, not derived.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Sound Power by Pressure Methods (ISO 3744 / ISO 3746 / ISO 3745)](/phonometry/devices/emission/sound-power-pressure/):
@@ -471,6 +474,8 @@ $K = 1.645\,\sigma_\mathrm{R}$ case (Annex A.2.2) are stated, not derived.
 - [Theory](/phonometry/reference/theory/environment-transport/): the Waterhouse, $K_1$/$K_2$ and $C_1$/$C_2$ derivations.
 - API reference: [`emission.sound_power`](/phonometry/reference/api/power/sound-power/), [`emission.sound_power_reverberation`](/phonometry/reference/api/power/sound-power-reverberation/) and [`emission.sound_power_intensity`](/phonometry/reference/api/power/sound-power-intensity/).
 - Theory: [Sound power determination](/phonometry/reference/theory/environment-transport/#sound-power-determination-iso-374437453746-iso-3741-iso-9614-123): the enveloping-surface, reverberation-room and intensity derivations behind the six acoustic routes.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/devices/emission/vibration-sound-power.mdx
+++ b/site/src/content/docs/devices/emission/vibration-sound-power.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -527,6 +528,8 @@ the probe and the field indicators behind it but computes no power.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Sound Power](/phonometry/devices/emission/sound-power/): the route chooser
@@ -546,3 +549,5 @@ the probe and the field indicators behind it but computes no power.
   the transducer practice behind a measured surface velocity.
 - API reference: [`emission.vibration_sound_power`](/phonometry/reference/api/power/vibration-sound-power/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the radiation efficiency that turns a surface velocity into a radiated power.
+
+</SeeAlso>

--- a/site/src/content/docs/devices/noise-control/duct-path.mdx
+++ b/site/src/content/docs/devices/noise-control/duct-path.mdx
@@ -43,6 +43,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -1119,6 +1120,8 @@ are usually one of them:
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Silencers](/phonometry/devices/noise-control/silencers/): the reactive four-pole
@@ -1135,3 +1138,5 @@ are usually one of them:
   [`noise_control.duct_path`](/phonometry/reference/api/noise_control/duct-path/),
   [`noise_control.duct_modes`](/phonometry/reference/api/noise_control/duct-modes/),
   [`noise_control.hvac`](/phonometry/reference/api/noise_control/hvac/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/devices/noise-control/noise-control.mdx
@@ -37,6 +37,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Three passive measures dominate applied noise control: a **silencer** in the
@@ -585,6 +586,8 @@ its enclosure or its slab is outside every model on the page.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Silencers](/phonometry/devices/noise-control/silencers/): the reactive four-pole
@@ -608,3 +611,5 @@ its enclosure or its slab is outside every model on the page.
 - API reference:
   [`noise_control.hvac`](/phonometry/reference/api/noise_control/hvac/) and
   [`noise_control.enclosures`](/phonometry/reference/api/noise_control/enclosures/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/noise-control/room-to-room.mdx
+++ b/site/src/content/docs/devices/noise-control/room-to-room.mdx
@@ -36,6 +36,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -602,6 +603,8 @@ closer to a surface than about half a wavelength.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Panel sound insulation](/phonometry/buildings/design/panel-sound-insulation/):
@@ -621,3 +624,5 @@ closer to a surface than about half a wavelength.
   the whole chain starts from.
 - API reference:
   [`noise_control.room_to_room`](/phonometry/reference/api/noise_control/room-to-room/).
+
+</SeeAlso>

--- a/site/src/content/docs/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/devices/noise-control/silencers.mdx
@@ -38,6 +38,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -933,6 +934,8 @@ the area jumps are not modelled, and the branch models are lossless unless a
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Duct-Borne Noise: Fan to Room](/phonometry/devices/noise-control/duct-path/): the
@@ -949,3 +952,5 @@ the area jumps are not modelled, and the branch models are lossless unless a
 - [Loudspeaker Characterisation (IEC 60268-5)](/phonometry/devices/electroacoustics/loudspeakers/):
   the radiating piston, the companion radiator model of a duct's open end.
 - API reference: [`noise_control.silencers`](/phonometry/reference/api/noise_control/silencers/).
+
+</SeeAlso>

--- a/site/src/content/docs/environment/assessment/environmental-levels.mdx
+++ b/site/src/content/docs/environment/assessment/environmental-levels.mdx
@@ -33,6 +33,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A community does not hear a single $L_\mathrm{Aeq}$: it hears a day whose evenings and
@@ -381,6 +382,8 @@ follows once you have applied them.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Integrated and Statistical Levels](/phonometry/signals/levels/levels/): the $L_\mathrm{eq}$/$L_\mathrm{Aeq}$, percentile and event levels the indicators of this page are assembled from.
@@ -391,6 +394,8 @@ follows once you have applied them.
 - [Occupational exposure (ISO 9612)](/phonometry/perception/hearing/occupational-exposure/): the workplace counterpart, from task samples to the daily exposure level with its uncertainty budget.
 - API reference: [`environment.assessment.measurement`](/phonometry/reference/api/environment/measurement/) and [`environment.assessment.rating`](/phonometry/reference/api/environment/rating/).
 - Theory: [Environmental descriptors (ISO 1996-1)](/phonometry/reference/theory/environment-transport/#environmental-descriptors-iso-1996-1): the ISO 1996-1 definitions of the rating level and the day-evening-night indicators, and what the adjustments do to them.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/environment/assessment/impulsive-sound.mdx
+++ b/site/src/content/docs/environment/assessment/impulsive-sound.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -416,7 +417,11 @@ function of their own.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - API reference: [`environment.assessment.impulsive_sound`](/phonometry/reference/api/environment/impulsive-sound/).
 - Theory: [Impulsive-sound prominence (NT ACOU 112)](/phonometry/reference/theory/environment-transport/#impulsive-sound-prominence-nt-acou-112): the NT ACOU 112 prominence derivation and the onset criterion it rests on.
+
+</SeeAlso>

--- a/site/src/content/docs/environment/assessment/index.mdx
+++ b/site/src/content/docs/environment/assessment/index.mdx
@@ -5,6 +5,7 @@ description: "Rating environmental noise once it has arrived: the ISO 1996-1 ind
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 Propagation says what arrives at the receiver. Assessment says what it counts
 as, which is a separate question with its own standards. It is a chain with
@@ -64,6 +65,8 @@ of both.
   the corrected level LKeq, the Kt/Kf/Ki corrections, the evaluation periods
   and noise phases, and the immission limit tables.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -76,6 +79,8 @@ Pages elsewhere on the site that this section leans on:
   tonal adjustment maps into decibels.
 - [Outdoor Sound Propagation](/phonometry/environment/propagation/outdoor-propagation/):
   the path that delivered the sound to the receiver being assessed.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/environment/assessment/spanish-noise-regulation.mdx
+++ b/site/src/content/docs/environment/assessment/spanish-noise-regulation.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Acoustic assessment in Spain does not stop at an $L_\mathrm{Aeq}$. Real Decreto
@@ -453,6 +454,8 @@ page starts where the sound level meter ends.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Environmental Levels (ISO 1996-1/-2)](/phonometry/environment/assessment/environmental-levels/): the $L_\mathrm{den}$ and $L_\mathrm{dn}$ indicators and the ISO 1996-2 adjustments the corrections of the regulation coexist with.
@@ -461,6 +464,8 @@ page starts where the sound level meter ends.
 - [Impulsive-sound prominence](/phonometry/environment/assessment/impulsive-sound/): the ISO/PAS 1996-3 impulsive adjustment, the relative of $K_\mathrm{i}$ that is not interchangeable with it.
 - API reference: [`environment.assessment.spain`](/phonometry/reference/api/environment/spain/).
 - Theory: [Environmental descriptors (ISO 1996-1)](/phonometry/reference/theory/environment-transport/#environmental-descriptors-iso-1996-1): the ISO 1996-1 indicators the national indices are built from.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/environment/propagation/atmospheric-refraction.mdx
+++ b/site/src/content/docs/environment/propagation/atmospheric-refraction.mdx
@@ -21,6 +21,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -516,6 +517,10 @@ $z = 0$; neither takes a terrain elevation profile.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - Theory: [Outdoor propagation](/phonometry/reference/theory/environment-transport/#outdoor-propagation-iso-9613-12): the meteorological assumptions ISO 9613-2 makes, which is what refraction takes apart.
+
+</SeeAlso>

--- a/site/src/content/docs/environment/propagation/ground-barriers.mdx
+++ b/site/src/content/docs/environment/propagation/ground-barriers.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -569,6 +570,8 @@ it is coherent and reciprocal but not a full boundary-element solution.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Outdoor Sound Propagation](/phonometry/environment/propagation/outdoor-propagation/): the octave-band ISO 9613-2 fits these models sit underneath, and the rule an obstacle has to satisfy to be a barrier at all.
@@ -576,3 +579,5 @@ it is coherent and reciprocal but not a full boundary-element solution.
 - [Porous absorbers](/phonometry/materials/absorbers/porous-absorbers/): the Delany-Bazley and Miki models behind `flow_resistivity`, and their fit range.
 - Theory: [Outdoor propagation](/phonometry/reference/theory/environment-transport/#outdoor-propagation-iso-9613-12): the ground and barrier terms of ISO 9613-2 in the context of the whole attenuation sum.
 - API reference: [`environment.propagation.ground_barriers`](/phonometry/reference/api/environment/ground-barriers/).
+
+</SeeAlso>

--- a/site/src/content/docs/environment/propagation/index.mdx
+++ b/site/src/content/docs/environment/propagation/index.mdx
@@ -5,6 +5,7 @@ description: "Sound on its way through open air: the ISO 9613 propagation model 
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 This section is the **path**: what happens to a sound between a source of known
 power and a receiver hundreds of metres away. Its three pages go from the
@@ -72,6 +73,8 @@ for a machine, and in [Aircraft noise](/phonometry/aircraft/) for aircraft.
   the refracting atmosphere itself: effective sound-speed profiles, curved rays
   with their shadow zones, and the Green's function parabolic equation.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -84,6 +87,8 @@ Pages elsewhere on the site that this section leans on:
 - [Impulsive-sound prominence (NT ACOU 112)](/phonometry/environment/assessment/impulsive-sound/),
   in [Assessment and regulation](/phonometry/environment/assessment/): the
   character adjustment applied to the level once it has arrived.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/environment/propagation/outdoor-propagation.mdx
+++ b/site/src/content/docs/environment/propagation/outdoor-propagation.mdx
@@ -59,6 +59,7 @@ references:
     note: "Only the clause 8.1.2.1 conversion m = alpha/(10 lg e) behind air_attenuation_m; the reverberation-room method itself is covered in the Room Acoustics guide."
 ---
 
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import Video from '../../../../components/Video.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import ReportPreview from '../../../../components/ReportPreview.astro';
@@ -883,6 +884,8 @@ Here too `result.plot()` previews the insertion-loss spectrum of the fiche;
 the [ground and barriers guide](/phonometry/environment/propagation/ground-barriers/) draws the
 same result against the exact half-plane and coherent-ground models.
 
+<SeeAlso>
+
 ## See also
 
 - [Spherical ground effect and advanced barriers](/phonometry/environment/propagation/ground-barriers/): the wave acoustics underneath the Table 3 ground fit and the Eq. (14) screening curve.
@@ -891,3 +894,5 @@ same result against the exact half-plane and coherent-ground models.
 - [Environmental noise levels](/phonometry/environment/assessment/environmental-levels/): what happens to the predicted level once it becomes an assessed one.
 - API reference: [`environment.propagation.outdoor_propagation`](/phonometry/reference/api/environment/outdoor-propagation/) and [`environment.propagation.air_absorption`](/phonometry/reference/api/environment/air-absorption/).
 - Theory: [Outdoor propagation](/phonometry/reference/theory/environment-transport/#outdoor-propagation-iso-9613-12): the ISO 9613-2 attenuation terms derived one by one, and the atmospheric absorption of Part 1.
+
+</SeeAlso>

--- a/site/src/content/docs/environment/sources/cnossos-rail-emission.mdx
+++ b/site/src/content/docs/environment/sources/cnossos-rail-emission.mdx
@@ -43,6 +43,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A road is one source line 5 cm above the pavement. A railway track is **two**,
@@ -637,6 +638,8 @@ loudspeakers, are treated by the industrial method.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - API reference: [`environment.sources.cnossos_rail`](/phonometry/reference/api/environment/cnossos-rail/).
@@ -644,3 +647,5 @@ loudspeakers, are treated by the industrial method.
   ISO 9613-2 chain that carries a source power to a receiver.
 - [Environmental noise levels](/phonometry/environment/assessment/environmental-levels/): the
   $L_\mathrm{den}$ and $L_\mathrm{night}$ indicators the resulting maps are drawn for.
+
+</SeeAlso>

--- a/site/src/content/docs/environment/sources/cnossos-road-emission.mdx
+++ b/site/src/content/docs/environment/sources/cnossos-road-emission.mdx
@@ -43,6 +43,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Every strategic noise map drawn in the European Union since 2021 starts from the
@@ -605,6 +606,8 @@ point sources is declared out of scope by the method itself.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - API reference: [`environment.sources.cnossos_road`](/phonometry/reference/api/environment/cnossos-road/).
@@ -612,3 +615,5 @@ point sources is declared out of scope by the method itself.
   ISO 9613-2 chain that carries a source power to a receiver.
 - [Environmental noise levels](/phonometry/environment/assessment/environmental-levels/): the
   $L_\mathrm{den}$ and $L_\mathrm{night}$ indicators the resulting maps are drawn for.
+
+</SeeAlso>

--- a/site/src/content/docs/environment/sources/index.mdx
+++ b/site/src/content/docs/environment/sources/index.mdx
@@ -5,6 +5,7 @@ description: "The source descriptors an environmental prediction starts from: CN
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 A propagation model does not accept a machine; it accepts a **source
 descriptor** with a fixed geometry. For traffic that means an incoherent source
@@ -68,6 +69,8 @@ page is independent of both.
   the IEC 61400-11 apparent sound power referred to the rotor centre, its
   wind-speed binning and the tonal-audibility chain, with the assessment fiche.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -76,6 +79,8 @@ Pages elsewhere on the site that this section leans on:
   the path model every descriptor here is built to feed.
 - [Sound power and intensity](/phonometry/devices/emission/): how a machine
   that is not a vehicle is characterised.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/environment/sources/wind-turbine-noise.mdx
+++ b/site/src/content/docs/environment/sources/wind-turbine-noise.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 IEC 61400-11 measures the acoustic emission of a wind turbine. This page covers
@@ -403,9 +404,13 @@ G-weighted infrasound level.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Environmental noise levels](/phonometry/environment/assessment/environmental-levels/): the ISO 1996-2 rating adjustment this page's $\Delta L_\mathrm{a}$ feeds.
 - [Tone audibility](/phonometry/perception/psychoacoustics/tone-audibility/): the same tonal-audibility idea outside the wind-turbine context.
 - [Outdoor Sound Propagation](/phonometry/environment/propagation/outdoor-propagation/): the chain that carries $L_{W\mathrm{A}}$ from the rotor to a dwelling.
 - API reference: [`environment.sources.wind_turbine`](/phonometry/reference/api/environment/wind-turbine/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/aircraft/aircraft-noise.mdx
+++ b/site/src/content/docs/es/aircraft/aircraft-noise.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -565,6 +566,8 @@ aeropuertos](/phonometry/es/aircraft/airport-noise/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ruido de aeropuertos (ECAC Doc 29)](/phonometry/es/aircraft/airport-noise/):
@@ -578,3 +581,5 @@ aeropuertos](/phonometry/es/aircraft/airport-noise/).
   nivel-potencia-distancia medidas para tipos reales, que es donde acaban los
   datos de certificación para el trabajo de modelado.
 - Referencia de la API: [`aircraft.certification`](/phonometry/es/reference/api/aeroacoustics/certification/) y [`aircraft.atmospheric_absorption`](/phonometry/es/reference/api/aeroacoustics/atmospheric-absorption/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/aircraft/airport-noise.mdx
+++ b/site/src/content/docs/es/aircraft/airport-noise.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -541,6 +542,8 @@ blando con hierba.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ruido de aeronaves: nivel efectivo de ruido percibido](/phonometry/es/aircraft/aircraft-noise/):
@@ -563,3 +566,5 @@ blando con hierba.
   acumula a partir de eventos únicos.
 - Referencia de la API:
   [`aircraft.airport_noise`](/phonometry/es/reference/api/aeroacoustics/airport-noise/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/aircraft/anp-fleet.mdx
+++ b/site/src/content/docs/es/aircraft/anp-fleet.mdx
@@ -20,6 +20,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 [Ruido de aeropuertos (ECAC Doc 29)](/phonometry/es/aircraft/airport-noise/)
@@ -485,6 +486,8 @@ phonometry distribuye la versión 2.3 y no la actualiza.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -496,3 +499,5 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   la métrica de certificación, que se mide en vez de tabularse.
 - Referencia de la API:
   [`aircraft.anp_fleet`](/phonometry/es/reference/api/aeroacoustics/anp-fleet/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/aircraft/rotorcraft-noise.mdx
+++ b/site/src/content/docs/es/aircraft/rotorcraft-noise.mdx
@@ -50,6 +50,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 El ruido de los helicópteros es muy directivo, así que el método de **ECAC
@@ -1072,6 +1073,8 @@ NORAH2.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ruido de aeronaves: nivel efectivo de ruido percibido](/phonometry/es/aircraft/aircraft-noise/):
@@ -1085,3 +1088,5 @@ NORAH2.
   el efecto de suelo de ISO 9613-2 y las clases de suelo CNOSSOS que comparte este
   ajuste de dos rayos.
 - Referencia de la API: [`aircraft.rotorcraft_noise`](/phonometry/es/reference/api/aeroacoustics/rotorcraft-noise/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
@@ -34,6 +34,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 El modelo simplificado de
@@ -667,6 +668,8 @@ necesita el espectro entero: de 100 Hz a 3150 Hz en tercios de octava, o de
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Predicción del aislamiento acústico (EN 12354)](/phonometry/es/buildings/design/insulation-prediction/):
@@ -683,3 +686,5 @@ necesita el espectro entero: de 100 Hz a 3150 Hz en tercios de octava, o de
   la $s'$ que hay detrás de la frecuencia de resonancia del suelo flotante.
 - Referencia de la API: [`building.prediction.detailed_model`](/phonometry/es/reference/api/building/detailed-model/).
 - Teoría: [Aislamiento acústico y absorción, predichos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-predichos-en-12354-1-2-6-bies-cremer-hopkins): el álgebra de trayectos directos y de flancos que el modelo detallado desglosa.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/impact-improvement.mdx
+++ b/site/src/content/docs/es/buildings/design/impact-improvement.mdx
@@ -41,6 +41,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Un revestimiento de suelo blando no bloquea el ruido aéreo; amortigua las
@@ -414,6 +415,8 @@ comparación del ejemplo resuelto de Foret et al. (2011).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en laboratorio](/phonometry/es/buildings/insulation/insulation-lab/):
@@ -431,3 +434,5 @@ comparación del ejemplo resuelto de Foret et al. (2011).
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/): la derivación
   de la curva de referencia tras los números únicos ponderados.
 - Referencia de la API: [`building.measurement.floor_covering_improvement`](/phonometry/es/reference/api/building/floor-covering-improvement/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/index.mdx
+++ b/site/src/content/docs/es/buildings/design/index.mdx
@@ -5,6 +5,7 @@ description: "El aislamiento acústico antes de construirlo: la predicción de f
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Las páginas de la sección de
 [Aislamiento acústico](/phonometry/es/buildings/insulation/)
@@ -154,6 +155,8 @@ construido se contrasta al final con la medición en campo de ISO 16283 en
   en qué se convierte esa potencia con la máquina montada sobre un elemento
   real, y el nivel que produce en el recinto receptor.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -161,6 +164,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
 - [Rigidez dinámica de materiales resilientes (EN 29052-1)](/phonometry/es/materials/resilient/dynamic-stiffness/):
   la medición por resonancia de placa de carga, el término del gas encerrado y
   la frecuencia natural del suelo flotante.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/buildings/design/installed-structure-borne.mdx
+++ b/site/src/content/docs/es/buildings/design/installed-structure-borne.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La **EN 12354-5:2009** predice el nivel de presión acústica en un recinto receptor
@@ -676,6 +677,8 @@ edición de 2009, no la revisión de 2023.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica estructural de equipos (EN 15657)](/phonometry/es/buildings/design/structure-borne-power/):
@@ -690,3 +693,5 @@ edición de 2009, no la revisión de 2023.
   los miembros aéreo y de impactos de la misma familia de predicción.
 - Referencia de la API: [`building.prediction.installed_structure_borne`](/phonometry/es/reference/api/building/installed-structure-borne/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la teoría de movilidad y eficiencia de radiación desde la que se predice el nivel instalado.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/insulation-prediction.mdx
+++ b/site/src/content/docs/es/buildings/design/insulation-prediction.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -656,6 +657,8 @@ recintos](/phonometry/es/buildings/rooms/enclosed-space-absorption/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Aislamiento acústico de fachadas](/phonometry/es/buildings/insulation/facade-insulation/):
@@ -684,3 +687,5 @@ recintos](/phonometry/es/buildings/rooms/enclosed-space-absorption/).
   la $s'$ que alimenta el término de suelo flotante de EN 12354-2.
 - Referencia de la API: [`building.prediction.simplified_model`](/phonometry/es/reference/api/building/simplified-model/) y [`building.prediction.facade`](/phonometry/es/reference/api/building/facade/).
 - Teoría: [Aislamiento acústico y absorción, predichos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-predichos-en-12354-1-2-6-bies-cremer-hopkins): el modelo de trayectos de EN 12354 y las magnitudes de transmisión que suma.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/panel-sound-insulation.mdx
+++ b/site/src/content/docs/es/buildings/design/panel-sound-insulation.mdx
@@ -64,6 +64,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -1032,6 +1033,8 @@ sala-placa-cámara-placa-sala.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Predicción del aislamiento (EN 12354)](/phonometry/es/buildings/design/insulation-prediction/):
@@ -1044,3 +1047,5 @@ sala-placa-cámara-placa-sala.
   modelos de relleno de cámara que consume una pared doble.
 - Referencia de la API: [`building.prediction.panel_transmission`](/phonometry/es/reference/api/building/panel-transmission/), [`building.prediction.masonry_cavity_wall`](/phonometry/es/reference/api/building/masonry-cavity-wall/), [`building.prediction.aperture_transmission`](/phonometry/es/reference/api/building/aperture-transmission/), [`vibration.structural.radiation_efficiency`](/phonometry/es/reference/api/vibration/radiation-efficiency/) y [`vibration.structural.point_mobility`](/phonometry/es/reference/api/vibration/point-mobility/).
 - Teoría: [Aislamiento acústico y absorción, predichos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-predichos-en-12354-1-2-6-bies-cremer-hopkins): la ley de masas, la caída del aislamiento en la coincidencia y el coeficiente de transmisión que devuelven los modelos de panel.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/resilient-layers.mdx
+++ b/site/src/content/docs/es/buildings/design/resilient-layers.mdx
@@ -40,6 +40,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una capa elástica es la forma más barata de comprar aislamiento a ruido de
@@ -556,6 +557,8 @@ caucho) no las cubre ninguno de estos modelos.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Mejora del aislamiento a impacto de suelos (ISO 16251-1)](/phonometry/es/buildings/design/impact-improvement/):
@@ -572,3 +575,5 @@ caucho) no las cubre ninguno de estos modelos.
   aéreo de la resonancia de la capa adicional.
 - Referencia de la API: [`building.prediction.resilient_layers`](/phonometry/es/reference/api/building/resilient-layers/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la imagen masa-muelle que hay detrás de un índice de mejora, y por qué una capa elástica es un desajuste de movilidad.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/design/structure-borne-power.mdx
+++ b/site/src/content/docs/es/buildings/design/structure-borne-power.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Los equipamientos del edificio (bombas, ventiladores, calderas, aparatos
@@ -550,7 +551,11 @@ homólogo del lado de la fuente, sin implementar.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - Referencia de la API: [`building.measurement.structure_borne_power`](/phonometry/es/reference/api/building/structure-borne-power/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la movilidad puntual, el desajuste fuente-receptor y la potencia inyectada que definen.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/facade-insulation.mdx
+++ b/site/src/content/docs/es/buildings/insulation/facade-insulation.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La fachada es el único elemento del edificio que da la cara al ruido del que
@@ -762,6 +763,8 @@ no las filas impresas.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/):
@@ -784,3 +787,5 @@ no las filas impresas.
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/): la derivación de
   la curva de referencia que sustenta los índices ponderados de un solo número.
 - Referencia de la API: [`building.prediction.facade`](/phonometry/es/reference/api/building/facade/) y [`building.measurement.insulation`](/phonometry/es/reference/api/building/insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/flanking-lab.mdx
+++ b/site/src/content/docs/es/buildings/insulation/flanking-lab.mdx
@@ -70,6 +70,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 EN 12354 predice un edificio a partir de sus uniones, e ISO 10848 es la trayectoria
@@ -684,6 +685,8 @@ $k'$ de un conducto revestido es aquí un dato de entrada, no una predicción.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Predicción del aislamiento acústico (EN 12354)](/phonometry/es/buildings/design/insulation-prediction/):
@@ -703,3 +706,5 @@ $k'$ de un conducto revestido es aquí un dato de entrada, no una predicción.
 - Referencia de la API: [`building.measurement.flanking_transmission`](/phonometry/es/reference/api/building/flanking-transmission/)
   y [`building.prediction.ceiling_plenum`](/phonometry/es/reference/api/building/ceiling-plenum/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la teoría de movilidad y eficiencia de radiación que hay detrás de un trayecto por flancos.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/heavy-impact-sources.mdx
+++ b/site/src/content/docs/es/buildings/insulation/heavy-impact-sources.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La máquina de impactos normalizada de ISO es una fuente de impacto *ligera*.
@@ -480,6 +481,8 @@ $T = T_0$ y en una reproducción publicada de 25 bandas de la Fórmula (4).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/):
@@ -493,3 +496,5 @@ $T = T_0$ y en una reproducción publicada de 25 bandas de la Fórmula (4).
   la mejora que aporta un revestimiento blando frente a la fuente ligera.
 - Referencia de la API: [`building.measurement.heavy_impact`](/phonometry/es/reference/api/building/heavy-impact/).
 - Teoría: [Aislamiento acústico y absorción, medidos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-medidos-iso-16283-iso-10140-iso-717-iso-354): las normalizaciones de nivel de impacto de ISO 10140 e ISO 717-2 que alimentan la pelota de caucho y la máquina de neumático.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/insulation-field.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-field.mdx
@@ -56,6 +56,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Esta guía continúa desde la [guía de Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/):
@@ -778,6 +779,8 @@ intensidad](/phonometry/es/buildings/insulation/insulation-intensity/)).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Índices globales de aislamiento (ISO 717)](/phonometry/es/buildings/insulation/insulation-ratings/):
@@ -807,6 +810,8 @@ intensidad](/phonometry/es/buildings/insulation/insulation-intensity/)).
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/): la derivación de la curva de referencia que sustenta
   los índices ponderados de un solo número.
 - Referencia de la API: [`building.measurement.insulation`](/phonometry/es/reference/api/building/insulation/) y [`building.measurement.uncertainty`](/phonometry/es/reference/api/building/uncertainty/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/buildings/insulation/insulation-intensity.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-intensity.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una cámara reverberante lee la potencia acústica transmitida de forma
@@ -541,6 +542,8 @@ cambios a datos de campo, pero nada comprueba cómo se adquirieron.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en laboratorio](/phonometry/es/buildings/insulation/insulation-lab/):
@@ -555,3 +558,5 @@ cambios a datos de campo, pero nada comprueba cómo se adquirieron.
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/): la derivación
   de la curva de referencia tras los índices globales ponderados.
 - Referencia de la API: [`building.measurement.intensity_insulation`](/phonometry/es/reference/api/building/intensity-insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/insulation-lab.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-lab.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Para valorar un elemento constructivo por sí mismo (un tipo de pared, un
@@ -579,6 +580,8 @@ por flancos (ISO 10848).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/):
@@ -601,3 +604,5 @@ por flancos (ISO 10848).
   que comparten la maquinaria de área de absorción del recinto receptor.
 - Referencia de la API: [`building.measurement.lab_insulation`](/phonometry/es/reference/api/building/lab-insulation/).
 - Teoría: [Aislamiento acústico y absorción, medidos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-medidos-iso-16283-iso-10140-iso-717-iso-354): la derivación de R y R′ y las normalizaciones que separan laboratorio de campo.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/insulation-ratings.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-ratings.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -635,6 +636,8 @@ blandas](/phonometry/es/buildings/insulation/heavy-impact-sources/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/):
@@ -656,6 +659,8 @@ blandas](/phonometry/es/buildings/insulation/heavy-impact-sources/).
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/): la derivación
   de la curva de referencia tras los índices globales ponderados.
 - Referencia de la API: [`building.measurement.insulation`](/phonometry/es/reference/api/building/insulation/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/buildings/insulation/insulation-survey.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-survey.mdx
@@ -21,6 +21,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 No toda pregunta merece una medición de ingeniería completa. Cuando una
@@ -462,6 +463,8 @@ de la biblioteca.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/):
@@ -480,3 +483,5 @@ de la biblioteca.
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/): la derivación
   de la curva de referencia tras los índices globales ponderados.
 - Referencia de la API: [`building.measurement.survey_insulation`](/phonometry/es/reference/api/building/survey-insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/low-frequency-procedure.mdx
+++ b/site/src/content/docs/es/buildings/insulation/low-frequency-procedure.mdx
@@ -41,6 +41,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Por debajo de 100 Hz un recinto del tamaño de un dormitorio tiene demasiado
@@ -650,6 +651,8 @@ procedimiento por su apartado 6.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/):
@@ -670,3 +673,5 @@ procedimiento por su apartado 6.
   [`building.measurement.low_frequency`](/phonometry/es/reference/api/building/low-frequency/)
   y
   [`building.measurement.insulation`](/phonometry/es/reference/api/building/insulation/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/insulation/spanish-building-code.mdx
+++ b/site/src/content/docs/es/buildings/insulation/spanish-building-code.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 El Documento Básico HR «Protección frente al ruido» del Código Técnico de la
@@ -385,6 +386,8 @@ apartado 6.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Índices globales de aislamiento (ISO 717)](/phonometry/es/buildings/insulation/insulation-ratings/): la vía de curva de referencia con $R_\mathrm{w}$, $C$, $C_\mathrm{tr}$ y los términos de rango ampliado que el DB HR llama simplemente $C$ y $C_\mathrm{tr}$.
@@ -394,6 +397,8 @@ apartado 6.
 - [Medición del aislamiento en campo (ISO 16283)](/phonometry/es/buildings/insulation/insulation-field/): los espectros por bandas de $R'$, $D_\mathrm{nT}$ y $L'_\mathrm{nT}$ que estas magnitudes globales resumen.
 - Referencia de la API: [`building.regulation.spain`](/phonometry/es/reference/api/building/spain/).
 - Teoría: [Aislamiento acústico y absorción, medidos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-medidos-iso-16283-iso-10140-iso-717-iso-354): las magnitudes que exige el código, derivadas de ISO 12354 e ISO 717 y no del propio código.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/buildings/rooms/enclosed-space-absorption.mdx
+++ b/site/src/content/docs/es/buildings/rooms/enclosed-space-absorption.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 **EN 12354-6:2003** predice el **área de absorción acústica equivalente total** de
@@ -604,6 +605,8 @@ EN 12354-6 da una estimación de campo difuso, y un objetivo pasado por
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Predicción del tiempo de reverberación (Sabine, Arau)](/phonometry/es/buildings/rooms/reverberation-prediction/):
@@ -626,3 +629,5 @@ EN 12354-6 da una estimación de campo difuso, y un objetivo pasado por
   cubren, mediante `environment.propagation.air_absorption`.
 - Referencia de la API: [`room.enclosed_space_absorption`](/phonometry/es/reference/api/rooms/enclosed-space-absorption/).
 - Teoría: [Aislamiento acústico y absorción, predichos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-predichos-en-12354-1-2-6-bies-cremer-hopkins): la definición de área de absorción equivalente que calcula el procedimiento de EN 12354-6.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/rooms/open-plan-acoustics.mdx
+++ b/site/src/content/docs/es/buildings/rooms/open-plan-acoustics.mdx
@@ -22,6 +22,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una oficina diáfana no es un problema de reverberación; es un problema de
@@ -717,6 +718,8 @@ absorción local ni de dónde está cada mesa dentro de la sala.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): los parámetros
@@ -733,3 +736,5 @@ absorción local ni de dónde está cada mesa dentro de la sala.
   derivaciones de acústica de salas en las que se apoya esta página.
 - Referencia de la API: [`room.open_plan`](/phonometry/es/reference/api/rooms/open-plan/).
 - Teoría: [Respuesta al impulso y parámetros de acústica de salas](/phonometry/es/reference/theory/rooms-buildings/#respuesta-al-impulso-y-parámetros-de-acústica-de-salas-iso-18233-iso-3382-1-2-3): la teoría de decaimiento y absorción frente a la que se mide la distancia de distracción de ISO 3382-3.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/rooms/reverberation-prediction.mdx
+++ b/site/src/content/docs/es/buildings/rooms/reverberation-prediction.mdx
@@ -98,6 +98,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -752,6 +753,8 @@ predicción estadística.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medida y clasificación de la absorción sonora](/phonometry/es/materials/absorbers/absorption-measurement/):
@@ -766,3 +769,5 @@ predicción estadística.
   estas cinco fórmulas.
 - Referencia de la API: [`room.reverberation_prediction`](/phonometry/es/reference/api/rooms/reverberation-prediction/) y [`environment.propagation.air_absorption`](/phonometry/es/reference/api/environment/air-absorption/).
 - Teoría: [Aislamiento acústico y absorción, predichos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-predichos-en-12354-1-2-6-bies-cremer-hopkins): la hipótesis de campo difuso que supone toda fórmula de la familia Sabine, y dónde deja de cumplirse.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/rooms/room-acoustics.mdx
+++ b/site/src/content/docs/es/buildings/rooms/room-acoustics.mdx
@@ -49,6 +49,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -686,6 +687,8 @@ sonora](/phonometry/es/materials/absorbers/absorption-measurement/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición de la respuesta al impulso](/phonometry/es/buildings/rooms/room-impulse-response/):
@@ -715,6 +718,8 @@ sonora](/phonometry/es/materials/absorbers/absorption-measurement/).
   definiciones de parámetros frente a los que se validan las implementaciones de ISO 3382.
 - Referencia de la API: [`room.acoustics`](/phonometry/es/reference/api/rooms/acoustics/).
 - Teoría: [Respuesta al impulso y parámetros de acústica de salas](/phonometry/es/reference/theory/rooms-buildings/#respuesta-al-impulso-y-parámetros-de-acústica-de-salas-iso-18233-iso-3382-1-2-3): el modelo de decaimiento que hay detrás de T20, T30 y EDT y las relaciones de energía con las que se construyen los parámetros de claridad y definición.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/buildings/rooms/room-image-sources.mdx
+++ b/site/src/content/docs/es/buildings/rooms/room-image-sources.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -973,6 +974,8 @@ de Bolt se comentan pero no se tabulan.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): la respuesta al
@@ -996,3 +999,5 @@ de Bolt se comentan pero no se tabulan.
 - Referencia de la API: [`room.image_source`](/phonometry/es/reference/api/rooms/image-source/)
   y [`room.steady_field`](/phonometry/es/reference/api/rooms/steady-field/).
 - Teoría: [Respuesta al impulso y parámetros de acústica de salas](/phonometry/es/reference/theory/rooms-buildings/#respuesta-al-impulso-y-parámetros-de-acústica-de-salas-iso-18233-iso-3382-1-2-3): el modelo geométrico que hay detrás del método de las imágenes y su relación con el estadístico.
+
+</SeeAlso>

--- a/site/src/content/docs/es/buildings/rooms/room-impulse-response.mdx
+++ b/site/src/content/docs/es/buildings/rooms/room-impulse-response.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -759,6 +760,8 @@ posiciones se midieron ni dónde.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): el análisis
@@ -780,6 +783,8 @@ posiciones se midieron ni dónde.
   de Schroeder que el análisis del decaimiento aplica a esta RI.
 - Referencia de la API: [`room.impulse_response`](/phonometry/es/reference/api/rooms/impulse-response/).
 - Teoría: [Respuesta al impulso y parámetros de acústica de salas](/phonometry/es/reference/theory/rooms-buildings/#respuesta-al-impulso-y-parámetros-de-acústica-de-salas-iso-18233-iso-3382-1-2-3): la integración inversa de Schroeder y la deconvolución en la que se apoya el método del barrido.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/buildings/rooms/room-noise.mdx
+++ b/site/src/content/docs/es/buildings/rooms/room-noise.mdx
@@ -42,6 +42,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 El ruido de fondo estacionario de una sala ocupada (de la ventilación, los
@@ -580,6 +581,8 @@ del cliente que rija el encargo, antes de citar un límite.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): los
@@ -600,3 +603,5 @@ del cliente que rija el encargo, antes de citar un límite.
   cuando la fuente está en el local de al lado y no encima.
 - Referencia de la API: [`room.noise_criteria`](/phonometry/es/reference/api/rooms/noise-criteria/).
 - Teoría: [Criterios de ruido de salas (ANSI S12.2)](/phonometry/es/reference/theory/rooms-buildings/#criterios-de-ruido-de-salas-ansi-s122): cómo se construyen las familias NC, RC Mark II y NR y qué buscaba penalizar cada una.
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/broadcast/index.mdx
+++ b/site/src/content/docs/es/devices/broadcast/index.mdx
@@ -5,6 +5,7 @@ description: "Los dos medidores que normalizó la radiodifusión: la cadena con 
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 La radiodifusión resolvió el problema de la sonoridad con una medición, no con
 un compresor: un número por programa, con puerta para que el silencio no lo
@@ -69,6 +70,8 @@ tonales, sin ninguna constante de tiempo impresa en todo el documento.
   apartado 2.6 que convierte una lectura en dBqps y las tres escalas de tiempo
   ajustadas que esas ventanas identifican solo dentro de un factor de 1,61 a 2,09.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -79,6 +82,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
 - [Ponderación frecuencial (A, C, Z)](/phonometry/es/signals/levels/weighting/):
   la familia de ponderaciones junto a la que se sitúa la ponderación K, sin
   pertenecer a ella.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/devices/broadcast/program-loudness.mdx
+++ b/site/src/content/docs/es/devices/broadcast/program-loudness.mdx
@@ -49,6 +49,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -770,6 +771,8 @@ binaural quedan fuera por construcción; eso vive en [Sonoridad (ISO
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Sonoridad (ISO 532)](/phonometry/es/perception/psychoacoustics/loudness/): los modelos
@@ -785,3 +788,5 @@ binaural quedan fuera por construcción; eso vive en [Sonoridad (ISO
   la cadena que transporta el programa una vez normalizado.
 - [Radiodifusión](/phonometry/es/devices/broadcast/): el resumen de la sección.
 - Referencia de la API: [`broadcast`](/phonometry/es/reference/api/broadcast/program-loudness/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/broadcast/quasi-peak.mdx
+++ b/site/src/content/docs/es/devices/broadcast/quasi-peak.mdx
@@ -26,6 +26,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La **Rec. UIT-R BS.468-4** mide el nivel de tensión de ruido de audiofrecuencia
@@ -360,6 +361,8 @@ no se modelan. No hay ficha `.report()`, por lo que dice el apartado 6.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Sonoridad de programa y pico verdadero](/phonometry/es/devices/broadcast/program-loudness/):
@@ -376,6 +379,8 @@ no se modelan. No hay ficha `.report()`, por lo que dice el apartado 6.
   siendo una declaración.
 - [Radiodifusión](/phonometry/es/devices/broadcast/): el resumen de la sección.
 - Referencia de la API: [`broadcast.quasi_peak`](/phonometry/es/reference/api/broadcast/quasi-peak/).
+
+</SeeAlso>
 
 ## Normas
 

--- a/site/src/content/docs/es/devices/electroacoustics/electroacoustics.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/electroacoustics.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Dos pilares de la caracterización de equipos de audio, a partir de una señal
@@ -694,6 +695,8 @@ AES17-2020 no es la comprobada.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Caracterización de altavoces (IEC 60268-5)](/phonometry/es/devices/electroacoustics/loudspeakers/):
@@ -712,3 +715,5 @@ AES17-2020 no es la comprobada.
   la disposición física detrás de la estimación de $H_1$ de la sección 5, con la
   toma de referencia y los dos canales sincronizados dibujados.
 - Referencia de la API: [`electroacoustics.distortion`](/phonometry/es/reference/api/electroacoustics/distortion/), [`electroacoustics.intermodulation`](/phonometry/es/reference/api/electroacoustics/intermodulation/), [`electroacoustics.noise_measurements`](/phonometry/es/reference/api/electroacoustics/noise-measurements/) y [`electroacoustics.frequency_response`](/phonometry/es/reference/api/electroacoustics/frequency-response/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/electroacoustics/loudspeakers.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/loudspeakers.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -868,6 +869,8 @@ directo-reverberante entra en el diseño por separado.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Electroacústica](/phonometry/es/devices/electroacoustics/electroacoustics/): el conjunto de
@@ -884,3 +887,5 @@ directo-reverberante entra en el diseño por separado.
   potencia radiada, para cuando la pregunta es cuánta potencia acústica emite
   la fuente y no cómo responde en el eje.
 - Referencia de la API: [`electroacoustics.piston`](/phonometry/es/reference/api/electroacoustics/piston/), [`electroacoustics.loudspeaker`](/phonometry/es/reference/api/electroacoustics/loudspeaker/) y [`electroacoustics.sound_reinforcement`](/phonometry/es/reference/api/electroacoustics/sound-reinforcement/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/electroacoustics/microphones.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/microphones.mdx
@@ -35,6 +35,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Toda medición acústica de esta documentación empieza en un micrófono, e
@@ -645,6 +646,8 @@ dBFS](/phonometry/es/signals/metrology/calibration/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Electroacústica](/phonometry/es/devices/electroacoustics/electroacoustics/): el conjunto de
@@ -660,3 +663,5 @@ dBFS](/phonometry/es/signals/metrology/calibration/).
 - [Montar un sonómetro](/phonometry/es/signals/sound-level-meter/): la cadena
   de medición que alimenta un micrófono caracterizado.
 - Referencia de la API: [`electroacoustics.microphone`](/phonometry/es/reference/api/electroacoustics/microphone/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/electroacoustics/swept-sine-distortion.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/swept-sine-distortion.mdx
@@ -42,6 +42,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Un solo barrido sinusoidal exponencial caracteriza a la vez la respuesta
@@ -555,6 +556,8 @@ cola quedan a cargo de quien opera, que además tiene que informar de ellos.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Electroacústica](/phonometry/es/devices/electroacoustics/electroacoustics/): el
@@ -568,3 +571,5 @@ cola quedan a cargo de quien opera, que además tiene que informar de ellos.
   `impulse_response`, que es la mitad lineal de la misma grabación.
 - Referencia de la API: [`electroacoustics.swept_sine`](/phonometry/es/reference/api/electroacoustics/swept-sine/)
   y [`signals.phase`](/phonometry/es/reference/api/signals/phase/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/emission/intensity.mdx
+++ b/site/src/content/docs/es/devices/emission/intensity.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -1059,6 +1060,8 @@ sonda de ISO 9614-2 son igualmente procedimientos, no funciones.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica por barrido de intensidad](/phonometry/es/devices/emission/sound-power-intensity/) — las vías de ISO 9614-2/-3 que consumen $\delta_{pI}$, los indicadores de campo y la capacidad dinámica.
@@ -1068,3 +1071,5 @@ sonda de ISO 9614-2 son igualmente procedimientos, no funciones.
 - [Teoría: análisis de señal](/phonometry/es/reference/theory/signal-analysis/) — la derivación por espectro cruzado que hay detrás de $I(f) = -\mathrm{Im}\{G_{12}\}/(2\pi f \rho_0 \Delta r)$.
 - Referencia de la API: [`emission.intensity`](/phonometry/es/reference/api/power/intensity/).
 - Teoría: [Intensidad acústica (IEC 61043)](/phonometry/es/reference/theory/signal-analysis/#intensidad-acústica-iec-61043): la aproximación en diferencias finitas que hay detrás de una sonda p-p y los errores que comete.
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/emission/sound-power-intensity.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-intensity.mdx
@@ -753,14 +753,13 @@ que rechazan los criterios del Anexo C.
 
 <ScopeClaim status="not-covered" label="No cubierto">
 ISO 9614-1, el método de intensidad de puntos fijos discretos, no es una de
-las vías de aquí: solo se reutilizan sus indicadores de campo, y la
-determinación de potencia por puntos discretos no está implementada en
-absoluto; la [guía de intensidad
-acústica](/phonometry/es/devices/emission/intensity/) cubre la sonda y los
-indicadores de campo del Anexo A que ambas partes comparten. El sesgo por
+las vías de aquí: mantiene la sonda quieta en cada posición en vez de
+barrerla, y tanto su determinación de potencia como los indicadores de campo
+del Anexo A que reutilizan las dos partes de barrido están en la [guía de
+intensidad acústica](/phonometry/es/devices/emission/intensity/). El sesgo por
 diferencias finitas de la sonda y el índice de intensidad residual de presión
 son propiedades medidas del instrumento, cubiertas en la misma guía. La
-elección entre las seis vías, y la declaración ISO 4871 que un resultado
+elección entre las siete vías, y la declaración ISO 4871 que un resultado
 alimenta, viven en [Potencia
 acústica](/phonometry/es/devices/emission/sound-power/).
 </ScopeClaim>
@@ -771,7 +770,7 @@ acústica](/phonometry/es/devices/emission/sound-power/).
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): la elección entre
-  las cinco vías de determinación, los grados de precisión y la declaración
+  las siete vías de determinación, los grados de precisión y la declaración
   de emisión sonora de ISO 4871.
 - [Intensidad acústica (p-p)](/phonometry/es/devices/emission/intensity/): la sonda de
   dos micrófonos, su sesgo por diferencias finitas, los indicadores de campo

--- a/site/src/content/docs/es/devices/emission/sound-power-intensity.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-intensity.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -752,22 +753,25 @@ que rechazan los criterios del Anexo C.
 
 <ScopeClaim status="not-covered" label="No cubierto">
 ISO 9614-1, el método de intensidad de puntos fijos discretos, no es una de
-las vías de aquí: mantiene la sonda quieta en cada posición en vez de
-barrerla, y tanto su determinación de potencia como los indicadores de campo
-del Anexo A que reutilizan las dos partes de barrido están en la [guía de
-intensidad acústica](/phonometry/es/devices/emission/intensity/). El sesgo por
+las vías de aquí: solo se reutilizan sus indicadores de campo, y la
+determinación de potencia por puntos discretos no está implementada en
+absoluto; la [guía de intensidad
+acústica](/phonometry/es/devices/emission/intensity/) cubre la sonda y los
+indicadores de campo del Anexo A que ambas partes comparten. El sesgo por
 diferencias finitas de la sonda y el índice de intensidad residual de presión
 son propiedades medidas del instrumento, cubiertas en la misma guía. La
-elección entre las siete vías, y la declaración ISO 4871 que un resultado
+elección entre las seis vías, y la declaración ISO 4871 que un resultado
 alimenta, viven en [Potencia
 acústica](/phonometry/es/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): la elección entre
-  las siete vías de determinación, los grados de precisión y la declaración
+  las cinco vías de determinación, los grados de precisión y la declaración
   de emisión sonora de ISO 4871.
 - [Intensidad acústica (p-p)](/phonometry/es/devices/emission/intensity/): la sonda de
   dos micrófonos, su sesgo por diferencias finitas, los indicadores de campo
@@ -783,3 +787,5 @@ acústica](/phonometry/es/devices/emission/sound-power/).
   derivaciones de los indicadores de campo.
 - Referencia de la API: [`emission.sound_power_intensity`](/phonometry/es/reference/api/power/sound-power-intensity/).
 - Teoría: [Determinación de la potencia acústica](/phonometry/es/reference/theory/environment-transport/#determinación-de-la-potencia-acústica-iso-374437453746-iso-3741-iso-9614-123): la derivación del barrido de la ISO 9614 y los indicadores de campo que la cualifican.
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/emission/sound-power-pressure.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-pressure.mdx
@@ -878,7 +878,7 @@ altitud o por debajo de 10 °C (apartado 8.2.5): `sound_power_pressure` no
 admite argumento de temperatura ni de presión. La corrección meteorológica
 $C_3$ de ISO 3745 necesita un coeficiente de absorción del aire que aporta
 quien llama (`air_absorption_coefficient=`); este módulo no lo calcula a
-partir de ISO 9613-1. La elección entre las seis vías, y la declaración ISO
+partir de ISO 9613-1. La elección entre las siete vías, y la declaración ISO
 4871 que un resultado alimenta, viven en [Potencia
 acústica](/phonometry/es/devices/emission/sound-power/).
 </ScopeClaim>
@@ -889,7 +889,7 @@ acústica](/phonometry/es/devices/emission/sound-power/).
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): la elección entre
-  las cinco vías de determinación, los grados de precisión y la declaración
+  las siete vías de determinación, los grados de precisión y la declaración
   de emisión sonora de ISO 4871.
 - [Potencia acústica en cámara reverberante (ISO 3741)](/phonometry/es/devices/emission/sound-power-reverberation/):
   la alternativa de precisión en campo difuso cuando la fuente puede viajar

--- a/site/src/content/docs/es/devices/emission/sound-power-pressure.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-pressure.mdx
@@ -35,6 +35,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -877,16 +878,18 @@ altitud o por debajo de 10 °C (apartado 8.2.5): `sound_power_pressure` no
 admite argumento de temperatura ni de presión. La corrección meteorológica
 $C_3$ de ISO 3745 necesita un coeficiente de absorción del aire que aporta
 quien llama (`air_absorption_coefficient=`); este módulo no lo calcula a
-partir de ISO 9613-1. La elección entre las siete vías, y la declaración ISO
+partir de ISO 9613-1. La elección entre las seis vías, y la declaración ISO
 4871 que un resultado alimenta, viven en [Potencia
 acústica](/phonometry/es/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): la elección entre
-  las siete vías de determinación, los grados de precisión y la declaración
+  las cinco vías de determinación, los grados de precisión y la declaración
   de emisión sonora de ISO 4871.
 - [Potencia acústica en cámara reverberante (ISO 3741)](/phonometry/es/devices/emission/sound-power-reverberation/):
   la alternativa de precisión en campo difuso cuando la fuente puede viajar
@@ -902,3 +905,5 @@ acústica](/phonometry/es/devices/emission/sound-power/).
   derivaciones de $K_1$/$K_2$ y $C_1$/$C_2$.
 - Referencia de la API: [`emission.sound_power`](/phonometry/es/reference/api/power/sound-power/).
 - Teoría: [Determinación de la potencia acústica](/phonometry/es/reference/theory/environment-transport/#determinación-de-la-potencia-acústica-iso-374437453746-iso-3741-iso-9614-123): la derivación de la superficie envolvente de la ISO 3744/3746 y la corrección ambiental que necesita.
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/emission/sound-power-reverberation.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-reverberation.mdx
@@ -498,7 +498,7 @@ fuente de referencia) se da por supuesta, no se ejecuta; la biblioteca solo
 avisa de los criterios orientativos que ISO 3741 declara explícitamente (el
 volumen mínimo de la Tabla 1, el suelo de reverberación $V/S$, menos de 6
 posiciones, una dispersión entre posiciones superior a 1,5 dB). La elección
-entre las seis vías, y la declaración ISO 4871 que un resultado alimenta,
+entre las siete vías, y la declaración ISO 4871 que un resultado alimenta,
 viven en [Potencia acústica](/phonometry/es/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
@@ -508,7 +508,7 @@ viven en [Potencia acústica](/phonometry/es/devices/emission/sound-power/).
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): la elección entre
-  las cinco vías de determinación, los grados de precisión y la declaración
+  las siete vías de determinación, los grados de precisión y la declaración
   de emisión sonora de ISO 4871.
 - [Potencia acústica por métodos de presión (ISO 3744 / ISO 3746 / ISO 3745)](/phonometry/es/devices/emission/sound-power-pressure/):
   la superficie envolvente in situ y la malla anecoica de precisión.

--- a/site/src/content/docs/es/devices/emission/sound-power-reverberation.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-reverberation.mdx
@@ -21,6 +21,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -497,15 +498,17 @@ fuente de referencia) se da por supuesta, no se ejecuta; la biblioteca solo
 avisa de los criterios orientativos que ISO 3741 declara explícitamente (el
 volumen mínimo de la Tabla 1, el suelo de reverberación $V/S$, menos de 6
 posiciones, una dispersión entre posiciones superior a 1,5 dB). La elección
-entre las siete vías, y la declaración ISO 4871 que un resultado alimenta,
+entre las seis vías, y la declaración ISO 4871 que un resultado alimenta,
 viven en [Potencia acústica](/phonometry/es/devices/emission/sound-power/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): la elección entre
-  las siete vías de determinación, los grados de precisión y la declaración
+  las cinco vías de determinación, los grados de precisión y la declaración
   de emisión sonora de ISO 4871.
 - [Potencia acústica por métodos de presión (ISO 3744 / ISO 3746 / ISO 3745)](/phonometry/es/devices/emission/sound-power-pressure/):
   la superficie envolvente in situ y la malla anecoica de precisión.
@@ -519,3 +522,5 @@ viven en [Potencia acústica](/phonometry/es/devices/emission/sound-power/).
   derivaciones de Waterhouse y $C_1$/$C_2$.
 - Referencia de la API: [`emission.sound_power_reverberation`](/phonometry/es/reference/api/power/sound-power-reverberation/).
 - Teoría: [Determinación de la potencia acústica](/phonometry/es/reference/theory/environment-transport/#determinación-de-la-potencia-acústica-iso-374437453746-iso-3741-iso-9614-123): los métodos de comparación y directo de la ISO 3741, deducidos de la relación de campo difuso.
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/emission/sound-power.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -470,6 +471,8 @@ enuncia, no se deriva.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica por métodos de presión (ISO 3744 / ISO 3746 / ISO 3745)](/phonometry/es/devices/emission/sound-power-pressure/):
@@ -498,6 +501,8 @@ enuncia, no se deriva.
   $C_1$/$C_2$.
 - Referencia de la API: [`emission.sound_power`](/phonometry/es/reference/api/power/sound-power/), [`emission.sound_power_reverberation`](/phonometry/es/reference/api/power/sound-power-reverberation/) y [`emission.sound_power_intensity`](/phonometry/es/reference/api/power/sound-power-intensity/).
 - Teoría: [Determinación de la potencia acústica](/phonometry/es/reference/theory/environment-transport/#determinación-de-la-potencia-acústica-iso-374437453746-iso-3741-iso-9614-123): las derivaciones de superficie envolvente, cámara reverberante e intensidad que hay detrás de las seis vías acústicas.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/devices/emission/vibration-sound-power.mdx
+++ b/site/src/content/docs/es/devices/emission/vibration-sound-power.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -553,6 +554,8 @@ ninguna potencia.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Potencia acústica](/phonometry/es/devices/emission/sound-power/): el selector
@@ -575,3 +578,5 @@ ninguna potencia.
   medida.
 - Referencia de la API: [`emission.vibration_sound_power`](/phonometry/es/reference/api/power/vibration-sound-power/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la eficiencia de radiación que convierte una velocidad superficial en potencia radiada.
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/noise-control/duct-path.mdx
+++ b/site/src/content/docs/es/devices/noise-control/duct-path.mdx
@@ -43,6 +43,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -1176,6 +1177,8 @@ cumple y un local que no suelan ser uno de ellos:
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Silenciadores](/phonometry/es/devices/noise-control/silencers/): los elementos reactivos
@@ -1195,3 +1198,5 @@ cumple y un local que no suelan ser uno de ellos:
   [`noise_control.duct_path`](/phonometry/es/reference/api/noise_control/duct-path/),
   [`noise_control.duct_modes`](/phonometry/es/reference/api/noise_control/duct-modes/),
   [`noise_control.hvac`](/phonometry/es/reference/api/noise_control/hvac/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/es/devices/noise-control/noise-control.mdx
@@ -37,6 +37,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Tres medidas pasivas dominan el control de ruido aplicado: un **silenciador** en
@@ -607,6 +608,8 @@ cerramiento o a su solera queda fuera de todos los modelos de la página.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Silenciadores](/phonometry/es/devices/noise-control/silencers/): los elementos reactivos
@@ -631,3 +634,5 @@ cerramiento o a su solera queda fuera de todos los modelos de la página.
 - Referencia de la API:
   [`noise_control.hvac`](/phonometry/es/reference/api/noise_control/hvac/) y
   [`noise_control.enclosures`](/phonometry/es/reference/api/noise_control/enclosures/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/noise-control/room-to-room.mdx
+++ b/site/src/content/docs/es/devices/noise-control/room-to-room.mdx
@@ -36,6 +36,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -622,6 +623,8 @@ superficie que media longitud de onda.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Aislamiento acústico de paneles](/phonometry/es/buildings/design/panel-sound-insulation/):
@@ -642,3 +645,5 @@ superficie que media longitud de onda.
   la máquina con la que arranca toda la cadena.
 - Referencia de la API:
   [`noise_control.room_to_room`](/phonometry/es/reference/api/noise_control/room-to-room/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/es/devices/noise-control/silencers.mdx
@@ -38,6 +38,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -984,6 +985,8 @@ de rama no tienen pérdidas salvo que se dé una `resistance`.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ruido por conductos: del ventilador a la sala](/phonometry/es/devices/noise-control/duct-path/):
@@ -1004,3 +1007,5 @@ de rama no tienen pérdidas salvo que se dé una `resistance`.
   abierto de un conducto.
 - Referencia de la API:
   [`noise_control.silencers`](/phonometry/es/reference/api/noise_control/silencers/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/assessment/environmental-levels.mdx
+++ b/site/src/content/docs/es/environment/assessment/environmental-levels.mdx
@@ -33,6 +33,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una comunidad no oye un único $L_\mathrm{Aeq}$: oye un día cuyas tardes y noches pesan
@@ -391,6 +392,8 @@ implementados, solo la aritmética que sigue una vez aplicados.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles integrados y estadísticos](/phonometry/es/signals/levels/levels/): los niveles $L_\mathrm{eq}$/$L_\mathrm{Aeq}$, percentiles y de suceso con los que se componen los indicadores de esta página.
@@ -401,6 +404,8 @@ implementados, solo la aritmética que sigue una vez aplicados.
 - [Exposición laboral (ISO 9612)](/phonometry/es/perception/hearing/occupational-exposure/): la contraparte en el puesto de trabajo, de las muestras por tarea al nivel de exposición diario con su balance de incertidumbre.
 - Referencia de la API: [`environment.assessment.measurement`](/phonometry/es/reference/api/environment/measurement/) y [`environment.assessment.rating`](/phonometry/es/reference/api/environment/rating/).
 - Teoría: [Descriptores ambientales (ISO 1996-1)](/phonometry/es/reference/theory/environment-transport/#descriptores-ambientales-iso-1996-1): las definiciones de ISO 1996-1 del nivel de evaluación y de los indicadores día-tarde-noche, y qué les hacen las correcciones.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/environment/assessment/impulsive-sound.mdx
+++ b/site/src/content/docs/es/environment/assessment/impulsive-sound.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -427,7 +428,11 @@ juicio del evaluador que sustituye esta medición, no como una función propia.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - Referencia de la API: [`environment.assessment.impulsive_sound`](/phonometry/es/reference/api/environment/impulsive-sound/).
 - Teoría: [Prominencia de sonidos impulsivos (NT ACOU 112)](/phonometry/es/reference/theory/environment-transport/#prominencia-de-sonidos-impulsivos-nt-acou-112): la derivación de la prominencia de NT ACOU 112 y el criterio de arranque en que se apoya.
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/assessment/index.mdx
+++ b/site/src/content/docs/es/environment/assessment/index.mdx
@@ -5,6 +5,7 @@ description: "Evaluar el ruido ambiental una vez ha llegado: los indicadores y e
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 La propagación dice qué llega al receptor. La evaluación dice cómo se
 contabiliza, que es otra pregunta con sus propias normas. Es una cadena de tres
@@ -66,6 +67,8 @@ nacional de ambas.
   el nivel corregido LKeq, las correcciones Kt/Kf/Ki, los periodos de
   evaluación y las fases de ruido, y las tablas de límites de inmisión.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -78,6 +81,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   decibelios el ajuste tonal de ISO 1996-2.
 - [Propagación del sonido en exteriores](/phonometry/es/environment/propagation/outdoor-propagation/):
   el camino que ha llevado el sonido hasta el receptor que se evalúa.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/environment/assessment/spanish-noise-regulation.mdx
+++ b/site/src/content/docs/es/environment/assessment/spanish-noise-regulation.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La evaluación acústica en España no termina en un $L_\mathrm{Aeq}$. El Real Decreto
@@ -461,6 +462,8 @@ el sonómetro.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles ambientales (ISO 1996-1/-2)](/phonometry/es/environment/assessment/environmental-levels/): los indicadores $L_\mathrm{den}$ y $L_\mathrm{dn}$ y los ajustes de ISO 1996-2 con los que conviven las correcciones del reglamento.
@@ -469,6 +472,8 @@ el sonómetro.
 - [Prominencia de sonidos impulsivos](/phonometry/es/environment/assessment/impulsive-sound/): el ajuste por impulsividad de ISO/PAS 1996-3, el pariente del $K_\mathrm{i}$ que no es intercambiable con él.
 - Referencia de la API: [`environment.assessment.spain`](/phonometry/es/reference/api/environment/spain/).
 - Teoría: [Descriptores ambientales (ISO 1996-1)](/phonometry/es/reference/theory/environment-transport/#descriptores-ambientales-iso-1996-1): los indicadores de ISO 1996-1 sobre los que se construyen los índices nacionales.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/environment/propagation/atmospheric-refraction.mdx
+++ b/site/src/content/docs/es/environment/propagation/atmospheric-refraction.mdx
@@ -21,6 +21,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -541,6 +542,10 @@ admite un perfil de elevación del terreno.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - Teoría: [Propagación en exteriores](/phonometry/es/reference/theory/environment-transport/#propagación-en-exteriores-iso-9613-12): las hipótesis meteorológicas que hace ISO 9613-2, que es justo lo que la refracción desmonta.
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/propagation/ground-barriers.mdx
+++ b/site/src/content/docs/es/environment/propagation/ground-barriers.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -592,6 +593,8 @@ por elementos de contorno.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Propagación del sonido en exteriores](/phonometry/es/environment/propagation/outdoor-propagation/): los ajustes por bandas de octava de ISO 9613-2 bajo los que se sitúan estos modelos, y la regla que un obstáculo tiene que cumplir para ser barrera siquiera.
@@ -599,3 +602,5 @@ por elementos de contorno.
 - [Absorbentes porosos](/phonometry/es/materials/absorbers/porous-absorbers/): los modelos de Delany-Bazley y de Miki que hay detrás de `flow_resistivity`, y su rango de ajuste.
 - Teoría: [Propagación en exteriores](/phonometry/es/reference/theory/environment-transport/#propagación-en-exteriores-iso-9613-12): los términos de suelo y de barrera de ISO 9613-2 en el contexto de toda la suma de atenuaciones.
 - Referencia de la API: [`environment.propagation.ground_barriers`](/phonometry/es/reference/api/environment/ground-barriers/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/propagation/index.mdx
+++ b/site/src/content/docs/es/environment/propagation/index.mdx
@@ -5,6 +5,7 @@ description: "El sonido en su camino por el aire libre: el modelo de propagació
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Esta sección es el **camino**: lo que le pasa a un sonido entre una fuente de
 potencia conocida y un receptor a cientos de metros. Sus tres páginas van del
@@ -79,6 +80,8 @@ máquina, y en [Ruido de aeronaves](/phonometry/es/aircraft/) para las aeronaves
   rayos curvados con sus zonas de sombra, y la ecuación parabólica de función
   de Green.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -91,6 +94,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
 - [Prominencia de sonidos impulsivos (NT ACOU 112)](/phonometry/es/environment/assessment/impulsive-sound/),
   en [Evaluación y normativa](/phonometry/es/environment/assessment/): el
   ajuste por carácter que se aplica al nivel una vez ha llegado.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/environment/propagation/outdoor-propagation.mdx
+++ b/site/src/content/docs/es/environment/propagation/outdoor-propagation.mdx
@@ -59,6 +59,7 @@ references:
     note: "Solo la conversión m = alfa/(10 lg e) del apartado 8.1.2.1 en que se basa air_attenuation_m; el método en cámara reverberante se trata en la guía de Acústica de salas."
 ---
 
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import Video from '../../../../../components/Video.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import ReportPreview from '../../../../../components/ReportPreview.astro';
@@ -927,6 +928,8 @@ de la ficha; la [guía de suelo y barreras](/phonometry/es/environment/propagati
 dibuja el mismo resultado frente a los modelos de semiplano exacto y suelo
 coherente.
 
+<SeeAlso>
+
 ## Véase también
 
 - [Efecto suelo esférico y barreras avanzadas](/phonometry/es/environment/propagation/ground-barriers/): la acústica ondulatoria que hay debajo del ajuste de suelo de la Tabla 3 y de la curva de apantallamiento de la Ec. (14).
@@ -935,3 +938,5 @@ coherente.
 - [Niveles ambientales](/phonometry/es/environment/assessment/environmental-levels/): qué le pasa al nivel predicho cuando pasa a ser un nivel evaluado.
 - Referencia de la API: [`environment.propagation.outdoor_propagation`](/phonometry/es/reference/api/environment/outdoor-propagation/) y [`environment.propagation.air_absorption`](/phonometry/es/reference/api/environment/air-absorption/).
 - Teoría: [Propagación en exteriores](/phonometry/es/reference/theory/environment-transport/#propagación-en-exteriores-iso-9613-12): los términos de atenuación de ISO 9613-2 derivados uno a uno, y la absorción atmosférica de la Parte 1.
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/sources/cnossos-rail-emission.mdx
+++ b/site/src/content/docs/es/environment/sources/cnossos-rail-emission.mdx
@@ -43,6 +43,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una carretera es una única línea fuente a 5 cm del pavimento. Una vía férrea son
@@ -659,6 +660,8 @@ estaciones y megafonía, se tratan por el método industrial.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - Referencia de la API: [`environment.sources.cnossos_rail`](/phonometry/es/reference/api/environment/cnossos-rail/).
@@ -667,3 +670,5 @@ estaciones y megafonía, se tratan por el método industrial.
 - [Niveles de ruido ambiental](/phonometry/es/environment/assessment/environmental-levels/): los
   indicadores $L_\mathrm{den}$ y $L_\mathrm{night}$ para los que se trazan los mapas
   resultantes.
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/sources/cnossos-road-emission.mdx
+++ b/site/src/content/docs/es/environment/sources/cnossos-road-emission.mdx
@@ -43,6 +43,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Todo mapa estratégico de ruido trazado en la Unión Europea desde 2021 parte de
@@ -627,6 +628,8 @@ fuentes puntuales lo declara fuera de alcance el propio método.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - Referencia de la API: [`environment.sources.cnossos_road`](/phonometry/es/reference/api/environment/cnossos-road/).
@@ -635,3 +638,5 @@ fuentes puntuales lo declara fuera de alcance el propio método.
 - [Niveles de ruido ambiental](/phonometry/es/environment/assessment/environmental-levels/): los
   indicadores $L_\mathrm{den}$ y $L_\mathrm{night}$ para los que se trazan los mapas
   resultantes.
+
+</SeeAlso>

--- a/site/src/content/docs/es/environment/sources/index.mdx
+++ b/site/src/content/docs/es/environment/sources/index.mdx
@@ -5,6 +5,7 @@ description: "Los descriptores de fuente de los que parte una predicción ambien
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Un modelo de propagación no admite una máquina; admite un **descriptor de
 fuente** con una geometría fijada. Para el tráfico eso significa una línea
@@ -75,6 +76,8 @@ ferrocarril reutiliza. La de aerogeneradores es independiente de ambas.
   su clasificación por velocidad de viento y la cadena de audibilidad tonal,
   con la ficha de evaluación.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -83,6 +86,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   el modelo de camino al que está hecho para alimentar todo descriptor de aquí.
 - [Potencia acústica e intensidad](/phonometry/es/devices/emission/): cómo se
   caracteriza una máquina que no es un vehículo.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/environment/sources/wind-turbine-noise.mdx
+++ b/site/src/content/docs/es/environment/sources/wind-turbine-noise.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La IEC 61400-11 mide la emisión acústica de un aerogenerador. Esta página cubre
@@ -423,9 +424,13 @@ para el nivel de infrasonido con ponderación G.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles ambientales](/phonometry/es/environment/assessment/environmental-levels/): el ajuste del nivel de evaluación de ISO 1996-2 que alimenta el $\Delta L_\mathrm{a}$ de esta página.
 - [Audibilidad de tonos](/phonometry/es/perception/psychoacoustics/tone-audibility/): la misma idea de audibilidad tonal fuera del contexto de los aerogeneradores.
 - [Propagación del sonido en exteriores](/phonometry/es/environment/propagation/outdoor-propagation/): la cadena que lleva el $L_{W\mathrm{A}}$ del rotor hasta una vivienda.
 - Referencia de la API: [`environment.sources.wind_turbine`](/phonometry/es/reference/api/environment/wind-turbine/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/io/audio-files.mdx
+++ b/site/src/content/docs/es/io/audio-files.mdx
@@ -43,6 +43,7 @@ references:
     note: "Por qué el dither opcional es triangular de un LSB, por qué se ofrece solo al cuantizar a 16 bits, y por qué es opcional para datos que van a análisis numérico."
 ---
 
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Un WAV de medición solo es interpretable junto a tres cosas que las muestras
@@ -539,6 +540,8 @@ incluidos los de 24 bits, el multicanal EXTENSIBLE y los RF64 de más de
 comprimidas de escucha — y empaqueta libsndfile bajo LGPL, que la
 instalación base evita a propósito.
 
+<SeeAlso>
+
 ## Véase también
 
 - [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/): de dónde sale el factor de sensibilidad, y la disciplina de campo a su alrededor.
@@ -547,3 +550,5 @@ instalación base evita a propósito.
 - [Sonoridad de programa](/phonometry/es/devices/broadcast/program-loudness/): la implementación de la BS.1770 tras `bext="loudness"`.
 - [Construye un sonómetro](/phonometry/es/signals/sound-level-meter/): la cadena completa en la que entran y de la que salen los archivos de esta página.
 - Referencia de la API: [`phonometry.io`](/phonometry/es/reference/api/io/io/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/absorbers/absorption-measurement.mdx
+++ b/site/src/content/docs/es/materials/absorbers/absorption-measurement.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -979,6 +980,8 @@ está.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Tubo de impedancia](/phonometry/es/materials/absorbers/impedance-tube/): la absorción,
@@ -1001,3 +1004,5 @@ está.
   la norma de incertidumbre hermana del aislamiento acústico, ISO 12999-1.
 - Referencia de la API: [`materials.absorbers.sound_absorption`](/phonometry/es/reference/api/materials/sound-absorption/), [`materials.absorbers.rating`](/phonometry/es/reference/api/materials/rating/) y [`materials.absorbers.uncertainty`](/phonometry/es/reference/api/materials/uncertainty/).
 - Teoría: [Caracterización de materiales acústicos](/phonometry/es/reference/theory/materials-surfaces/#caracterización-de-materiales-acústicos-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): la diferencia de decaimiento de ISO 354, la valoración ISO 11654 y de dónde salen los coeficientes prácticos.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/absorbers/airflow-resistance.mdx
+++ b/site/src/content/docs/es/materials/absorbers/airflow-resistance.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Empuja aire despacio a través de un absorbente poroso y el material devuelve
@@ -612,6 +613,8 @@ número único, así que la ficha no lleva ninguno de los dos.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Absorbentes porosos y multicapa](/phonometry/es/materials/absorbers/porous-absorbers/):
@@ -625,3 +628,5 @@ número único, así que la ficha no lleva ninguno de los dos.
   terminado.
 - Referencia de la API: [`materials.absorbers.airflow_resistance`](/phonometry/es/reference/api/materials/airflow-resistance/).
 - Teoría: [Caracterización de materiales acústicos](/phonometry/es/reference/theory/materials-surfaces/#caracterización-de-materiales-acústicos-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): las definiciones de resistencia y resistividad de ISO 9053 y el régimen de flujo que suponen.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/absorbers/impedance-tube.mdx
+++ b/site/src/content/docs/es/materials/absorbers/impedance-tube.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -1030,6 +1031,8 @@ sonora](/phonometry/es/materials/absorbers/absorption-measurement/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medida y clasificación de la absorción sonora](/phonometry/es/materials/absorbers/absorption-measurement/):
@@ -1048,3 +1051,5 @@ sonora](/phonometry/es/materials/absorbers/absorption-measurement/).
   micrófonos previa a la función de transferencia con dos micrófonos.
 - Referencia de la API: [`materials.absorbers.impedance_tube`](/phonometry/es/reference/api/materials/impedance-tube/).
 - Teoría: [Caracterización de materiales acústicos](/phonometry/es/reference/theory/materials-surfaces/#caracterización-de-materiales-acústicos-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): la derivación por función de transferencia de ISO 10534-2 y la extensión con cuatro micrófonos de ASTM E2611.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/absorbers/metamaterial-absorbers.mdx
+++ b/site/src/content/docs/es/materials/absorbers/metamaterial-absorbers.mdx
@@ -63,6 +63,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -667,6 +668,8 @@ es el tema de
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Absorbentes porosos y multicapa](/phonometry/es/materials/absorbers/porous-absorbers/):
@@ -684,3 +687,5 @@ es el tema de
   granel.
 - Referencia de la API: [`materials.absorbers.slow_sound`](/phonometry/es/reference/api/materials/slow-sound/).
 - Teoría: [Caracterización de materiales acústicos](/phonometry/es/reference/theory/materials-surfaces/#caracterización-de-materiales-acústicos-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): las definiciones de impedancia superficial y de absorción con las que se evalúan los modelos de resonador.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/absorbers/porous-absorbers.mdx
+++ b/site/src/content/docs/es/materials/absorbers/porous-absorbers.mdx
@@ -92,6 +92,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 A partir de la **resistividad al flujo** de un material poroso (la magnitud
@@ -1335,6 +1336,8 @@ absorbente de ranura con resonador de Helmholtz de acoplamiento crítico
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Resistencia al flujo de aire](/phonometry/es/materials/absorbers/airflow-resistance/),
@@ -1349,3 +1352,5 @@ absorbente de ranura con resonador de Helmholtz de acoplamiento crítico
   que llevan la absorción perfecta al régimen de sublongitud de onda
   profunda.
 - Teoría: [Caracterización de materiales acústicos](/phonometry/es/reference/theory/materials-surfaces/#caracterización-de-materiales-acústicos-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): las magnitudes de caracterización que estos modelos empíricos y fenomenológicos toman como entrada.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/diffusers/diffusers.mdx
+++ b/site/src/content/docs/es/materials/diffusers/diffusers.mdx
@@ -56,6 +56,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -1242,6 +1243,8 @@ metadifusores](/phonometry/es/materials/diffusers/metadiffusers/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Metadifusores](/phonometry/es/materials/diffusers/metadiffusers/): la versión en
@@ -1259,3 +1262,5 @@ metadifusores](/phonometry/es/materials/diffusers/metadiffusers/).
   tono puro consumen las relaciones de atenuación del aire de ISO 17497-1.
 - Referencia de la API: [`materials.diffusers.scattering_diffusion`](/phonometry/es/reference/api/materials/scattering-diffusion/) y [`materials.diffusers.design`](/phonometry/es/reference/api/materials/design/).
 - Teoría: [Dispersión superficial y difusión](/phonometry/es/reference/theory/materials-surfaces/#dispersión-superficial-y-difusión-iso-17497-1-iso-17497-2): la derivación de los coeficientes de dispersión y de difusión, y por qué son dos magnitudes distintas.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/diffusers/index.mdx
+++ b/site/src/content/docs/es/materials/diffusers/index.mdx
@@ -5,6 +5,7 @@ description: "Valorar y diseñar superficies por lo que reflejan: los coeficient
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Donde la subsección de
 [Absorbentes](/phonometry/es/materials/absorbers/) pregunta cuánta
@@ -53,6 +54,8 @@ métodos de pavimentos sirven al interés por el ruido exterior de
   Schroeder en sublongitud de onda profunda a partir de ranuras cargadas
   con resonadores, con sonido lento y secuencias ternarias.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -61,6 +64,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   [Absorción in situ de pavimentos de carretera](/phonometry/es/materials/surfaces/road-absorption/):
   la técnica de sustracción de ISO 13472-1 y el método puntual de
   ISO 13472-2.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/materials/diffusers/metadiffusers.mdx
+++ b/site/src/content/docs/es/materials/diffusers/metadiffusers.mdx
@@ -58,6 +58,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -583,6 +584,8 @@ ranura vive en
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Difusores y sus coeficientes](/phonometry/es/materials/diffusers/diffusers/): los
@@ -600,3 +603,5 @@ ranura vive en
   real de ranuras y resonadores.
 - Referencia de la API: [`materials.diffusers.metadiffuser`](/phonometry/es/reference/api/materials/metadiffuser/) y [`materials.diffusers.design`](/phonometry/es/reference/api/materials/design/).
 - Teoría: [Dispersión superficial y difusión](/phonometry/es/reference/theory/materials-surfaces/#dispersión-superficial-y-difusión-iso-17497-1-iso-17497-2): los coeficientes de dispersión y de difusión con los que se juzgan los diseños en sublongitud de onda profunda.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/resilient/dynamic-stiffness.mdx
+++ b/site/src/content/docs/es/materials/resilient/dynamic-stiffness.mdx
@@ -21,6 +21,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -514,6 +515,8 @@ señal solo si se aportan en los metadatos.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Predicción del comportamiento de capas elásticas](/phonometry/es/buildings/design/resilient-layers/):
@@ -528,3 +531,5 @@ señal solo si se aportan en los metadatos.
   encaja esta medición entre las guías de materiales.
 - Referencia de la API: [`materials.resilient.dynamic_stiffness`](/phonometry/es/reference/api/materials/dynamic-stiffness/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la resonancia masa-resorte que mide el banco de EN 29052-1, vista como una movilidad.
+
+</SeeAlso>

--- a/site/src/content/docs/es/materials/resilient/index.mdx
+++ b/site/src/content/docs/es/materials/resilient/index.mdx
@@ -5,6 +5,7 @@ description: "La propiedad mecánica en torno a la que se diseña un suelo flota
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Un suelo flotante es un sistema masa-resorte: la solera es la masa, la capa
 elástica es el resorte, y la mejora a ruido de impactos que compra el
@@ -52,6 +53,8 @@ adicional del Anexo D de ISO 12354-1.
   término del gas encerrado para capas permeables al aire, los regímenes por
   resistividad al flujo del apartado 8.2 y la ficha de informe de ensayo del apartado 9.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -61,6 +64,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   régimen.
 - [Predicción del comportamiento de capas elásticas](/phonometry/es/buildings/design/resilient-layers/):
   el consumidor, donde s' se convierte en la mejora de un suelo flotante.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/materials/surfaces/index.mdx
+++ b/site/src/content/docs/es/materials/surfaces/index.mdx
@@ -5,6 +5,7 @@ description: "Superficies que no tienen probeta: por qué un pavimento se caract
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Un coeficiente de cámara reverberante o de tubo de impedancia describe una
 *probeta*. Algunas superficies no tienen probeta. Un pavimento no se puede recortar
@@ -50,6 +51,8 @@ y el que alimenta el término de suelo de un modelo de propagación en exteriore
   funciones de geometría y validez, el tubo puntual de ISO 13472-2 con sus
   límites de aplicabilidad, y la comparación que decide entre ambos.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -62,6 +65,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
 - [Medio ambiente y transporte](/phonometry/es/environment/): donde se consume
   la absorción de una carretera, como término de suelo de una predicción en
   exteriores.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/materials/surfaces/road-absorption.mdx
+++ b/site/src/content/docs/es/materials/surfaces/road-absorption.mdx
@@ -29,6 +29,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Cuánto sonido absorbe un pavimento decide lo ruidoso que es su tráfico, y de una
@@ -688,6 +689,8 @@ biblioteca solo ve los dos arrays que salen de ellos.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Tubo de impedancia](/phonometry/es/materials/absorbers/impedance-tube/): el método de
@@ -704,3 +707,5 @@ biblioteca solo ve los dos arrays que salen de ellos.
   propagación.
 - Referencia de la API: [`materials.surfaces.road_absorption`](/phonometry/es/reference/api/materials/road-absorption/).
 - Teoría: [Absorción in situ de pavimentos de carretera](/phonometry/es/reference/theory/materials-surfaces/#absorción-in-situ-de-pavimentos-de-carretera-iso-13472-1-iso-13472-2): la sustracción de ISO 13472 y la geometría que hace posible una medición in situ.
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/hearing/hearing-threshold.mdx
+++ b/site/src/content/docs/es/perception/hearing/hearing-threshold.mdx
@@ -20,6 +20,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Dos normas describen dónde se sitúa el umbral de audición. **ISO 7029:2017** da
@@ -378,6 +379,8 @@ establecieron los valores de ISO 389-7 no están implementados.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Pérdida auditiva inducida por ruido](/phonometry/es/perception/hearing/noise-induced-hearing-loss/):
@@ -390,3 +393,5 @@ establecieron los valores de ISO 389-7 no están implementados.
   exposición diario de ISO 9612 que impulsa la componente de ruido.
 - Referencia de la API: [`hearing.threshold`](/phonometry/es/reference/api/hearing/threshold/).
 - Teoría: [Umbrales de audición y presbiacusia](/phonometry/es/reference/theory/perception/#umbrales-de-audición-y-presbiacusia-iso-389-7-iso-7029): los umbrales de referencia de ISO 389-7 y la estadística por edad de ISO 7029, y por qué son dos magnitudes distintas.
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/hearing/noise-induced-hearing-loss.mdx
+++ b/site/src/content/docs/es/perception/hearing/noise-induced-hearing-loss.mdx
@@ -32,6 +32,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 **ISO 1999:2013** estima la pérdida auditiva que sufre una población por el
@@ -523,6 +524,8 @@ aquí no se aplica ninguna, así que hay que aportarla y comprobarla uno mismo.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Exposición laboral al ruido](/phonometry/es/perception/hearing/occupational-exposure/): el
@@ -536,3 +539,5 @@ aquí no se aplica ninguna, así que hay que aportarla y comprobarla uno mismo.
   consecuencia que el trabajador nota de verdad.
 - Referencia de la API: [`hearing.noise_induced_hearing_loss`](/phonometry/es/reference/api/hearing/noise-induced-hearing-loss/).
 - Teoría: [Pérdida auditiva inducida por ruido (ISO 1999)](/phonometry/es/reference/theory/perception/#pérdida-auditiva-inducida-por-ruido-iso-1999): el modelo de desplazamiento del umbral de ISO 1999, su mediana y su dispersión por fractiles.
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/hearing/occupational-exposure.mdx
+++ b/site/src/content/docs/es/perception/hearing/occupational-exposure.mdx
@@ -30,6 +30,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una jornada laboral rara vez se mide de una sola toma: el nivel de exposición
@@ -544,6 +545,8 @@ eso el pico se declara sin ella en lugar de con una incertidumbre nula.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles](/phonometry/es/signals/levels/levels/): las primitivas de dosis `lex_8h` /
@@ -554,3 +557,5 @@ eso el pico se declara sin ella en lugar de con una incertidumbre nula.
 - [Teoría](/phonometry/es/reference/theory/environment-transport/): la derivación de las fórmulas de
   las estrategias y del balance del anexo C.
 - Referencia de la API: [`hearing.occupational_exposure`](/phonometry/es/reference/api/hearing/occupational-exposure/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/psychoacoustics/advanced-loudness.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/advanced-loudness.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 El método de Zwicker de ISO 532-1 es la vía de referencia hacia la sonoridad
@@ -564,6 +565,8 @@ si te importa la conformidad estricta apartado a apartado.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Sonoridad](/phonometry/es/perception/psychoacoustics/loudness/): el método de referencia de
@@ -574,6 +577,8 @@ si te importa la conformidad estricta apartado a apartado.
 - [Teoría](/phonometry/es/reference/theory/perception/): las ecuaciones que sustentan los modelos de sonoridad.
 - Referencia de la API: [`psychoacoustics.loudness.moore_glasberg`](/phonometry/es/reference/api/psychoacoustics/moore-glasberg/), [`psychoacoustics.loudness.moore_glasberg_time`](/phonometry/es/reference/api/psychoacoustics/moore-glasberg-time/) y [`psychoacoustics.loudness.ecma`](/phonometry/es/reference/api/psychoacoustics/ecma/).
 - Teoría: [Modelos avanzados de sonoridad y calidad sonora](/phonometry/es/reference/theory/perception/#modelos-avanzados-de-sonoridad-y-calidad-sonora): qué cambian los modelos de Moore-Glasberg y de Sottek respecto al de Zwicker, y por qué los tres discrepan donde lo hacen.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/perception/psychoacoustics/loudness.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/loudness.mdx
@@ -39,6 +39,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -461,6 +462,8 @@ espera una de las frecuencias de la Tabla 1.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Sonoridad avanzada (ISO 532-2/-3, ECMA-418-2)](/phonometry/es/perception/psychoacoustics/advanced-loudness/):
@@ -473,6 +476,8 @@ espera una de las frecuencias de la Tabla 1.
 - [Teoría](/phonometry/es/reference/theory/perception/): las ecuaciones que sustentan los modelos de sonoridad.
 - Referencia de la API: [`psychoacoustics.loudness.zwicker`](/phonometry/es/reference/api/psychoacoustics/zwicker/) y [`psychoacoustics.loudness.contours`](/phonometry/es/reference/api/psychoacoustics/contours/).
 - Teoría: [Sonoridad de Zwicker (ISO 532-1)](/phonometry/es/reference/theory/perception/#sonoridad-de-zwicker-iso-532-1): la integral de sonoridad específica de ISO 532-1 y el patrón de excitación sobre el que se calcula.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -31,6 +31,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Lo *molesto* que resulta un sonido depende de algo más que de su sonoridad.
@@ -446,6 +447,8 @@ sonora](/phonometry/es/perception/psychoacoustics/sound-quality/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Sonoridad](/phonometry/es/perception/psychoacoustics/loudness/): la sonoridad
@@ -464,3 +467,5 @@ sonora](/phonometry/es/perception/psychoacoustics/sound-quality/).
   niveles de evaluación con los que se valora.
 - Teoría: [Modelos avanzados de sonoridad y calidad sonora](/phonometry/es/reference/theory/perception/#modelos-avanzados-de-sonoridad-y-calidad-sonora): las métricas de sonoridad y de calidad sonora que combina el modelo de molestia, deducidas una a una.
 - Referencia de la API: [`psychoacoustics.quality.annoyance`](/phonometry/es/reference/api/psychoacoustics/annoyance/) y [`psychoacoustics.quality.fluctuation_strength`](/phonometry/es/reference/api/psychoacoustics/fluctuation-strength/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/psychoacoustics/sound-quality.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/sound-quality.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Dos sonidos igual de sonoros pueden diferir aún en cuán *afilados*, cuán
@@ -644,7 +645,11 @@ psicoacústica](/phonometry/es/perception/psychoacoustics/psychoacoustic-annoyan
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - Referencia de la API: [`psychoacoustics.quality.sharpness`](/phonometry/es/reference/api/psychoacoustics/sharpness/), [`psychoacoustics.quality.tonality_ecma`](/phonometry/es/reference/api/psychoacoustics/tonality-ecma/), [`psychoacoustics.quality.roughness_ecma`](/phonometry/es/reference/api/psychoacoustics/roughness-ecma/) y [`psychoacoustics.quality.fluctuation_strength_ecma`](/phonometry/es/reference/api/psychoacoustics/fluctuation-strength-ecma/).
 - Teoría: [Modelos avanzados de sonoridad y calidad sonora](/phonometry/es/reference/theory/perception/#modelos-avanzados-de-sonoridad-y-calidad-sonora): el patrón de sonoridad específica sobre el que se construyen la agudeza, la aspereza y la intensidad de fluctuación.
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/psychoacoustics/tone-audibility.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/tone-audibility.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Un tono estacionario inmerso en ruido de banda ancha resalta cuando emerge de
@@ -604,6 +605,8 @@ aplica quien llama porque el módulo es agnóstico a la ponderación.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Medición de ruido ambiental](/phonometry/es/environment/assessment/environmental-levels/):
@@ -620,3 +623,5 @@ aplica quien llama porque el módulo es agnóstico a la ponderación.
   la familia vecina de métricas tonales, el TNR y el PR, deducida del mismo
   modelo de bandas críticas.
 - Referencia de la API: [`psychoacoustics.quality.tone_audibility`](/phonometry/es/reference/api/psychoacoustics/tone-audibility/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/psychoacoustics/tone-prominence.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/tone-prominence.mdx
@@ -20,6 +20,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Los componentes tonales del ruido de maquinaria molestan mucho más de lo que
@@ -394,6 +395,8 @@ procedimiento de medida del Anexo D y las posiciones de operador/observador
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles ambientales](/phonometry/es/environment/assessment/environmental-levels/): los niveles de evaluación de
@@ -413,4 +416,6 @@ procedimiento de medida del Anexo D y las posiciones de operador/observador
   derivación de los criterios.
 - Referencia de la API: [`psychoacoustics.quality.tonality`](/phonometry/es/reference/api/psychoacoustics/tonality/).
 - Teoría: [Prominencia tonal: TNR y PR](/phonometry/es/reference/theory/perception/#prominencia-tonal-tnr-y-pr-ecma-418-1): la construcción en bandas críticas que sustenta el TNR y el PR, y los criterios que hacen prominente a un tono.
+
+</SeeAlso>
 

--- a/site/src/content/docs/es/perception/speech/objective-intelligibility.mdx
+++ b/site/src/content/docs/es/perception/speech/objective-intelligibility.mdx
@@ -34,6 +34,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 **STOI** y **ESTOI** son medidas de inteligibilidad objetiva basadas en
@@ -470,6 +471,8 @@ más allá de las ecuaciones de 2011/2016 anteriores.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Índice de transmisión del habla](/phonometry/es/perception/speech/speech-transmission/):
@@ -481,3 +484,5 @@ más allá de las ecuaciones de 2011/2016 anteriores.
   de octava en las que el procesado inicial agrupa la DFT.
 - Referencia de la API: [`speech.objective_intelligibility`](/phonometry/es/reference/api/speech/objective-intelligibility/).
 - Teoría: [Transferencia de modulación y STI](/phonometry/es/reference/theory/perception/#transferencia-de-modulación-y-sti-iec-60268-16): la derivación de la transferencia de modulación con la que se comparan las medidas intrusivas de esta página.
+
+</SeeAlso>

--- a/site/src/content/docs/es/perception/speech/speech-intelligibility.mdx
+++ b/site/src/content/docs/es/perception/speech/speech-intelligibility.mdx
@@ -25,6 +25,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 El **índice de inteligibilidad del habla** predice cuánto de una señal de habla
@@ -815,6 +816,8 @@ habla](/phonometry/es/perception/speech/speech-transmission/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Índice de transmisión del habla](/phonometry/es/perception/speech/speech-transmission/): el
@@ -828,6 +831,8 @@ habla](/phonometry/es/perception/speech/speech-transmission/).
   entradas de nivel espectral equivalente.
 - Referencia de la API: [`speech.sii`](/phonometry/es/reference/api/speech/sii/).
 - Teoría: [Índice de inteligibilidad del habla (ANSI S3.5)](/phonometry/es/reference/theory/perception/#índice-de-inteligibilidad-del-habla-ansi-s35): la ponderación por importancia de banda de ANSI S3.5 y la función de audibilidad que multiplica.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/perception/speech/speech-transmission.mdx
+++ b/site/src/content/docs/es/perception/speech/speech-transmission.mdx
@@ -24,6 +24,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -629,6 +630,8 @@ implementar.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): la respuesta al
@@ -643,3 +646,5 @@ implementar.
   de modulación y la correspondencia $m$ ↔ STI.
 - Referencia de la API: [`speech.sti`](/phonometry/es/reference/api/speech/sti/).
 - Teoría: [Transferencia de modulación y STI](/phonometry/es/reference/theory/perception/#transferencia-de-modulación-y-sti-iec-60268-16): la función de transferencia de modulación, por qué m es un cociente de profundidades de modulación y cómo la matriz de m por bandas de octava se reduce a un único índice.
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/filters/block-processing.mdx
+++ b/site/src/content/docs/es/signals/filters/block-processing.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Algunas mediciones nunca caben en memoria: una grabación ambiental de una hora,
@@ -417,6 +418,8 @@ estadísticos](/phonometry/es/signals/levels/levels/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Bancos de filtros](/phonometry/es/signals/filters/filter-banks/): el banco offline que el streaming reproduce bit a bit, y el modo `zero_phase` que el streaming no puede usar.
@@ -425,3 +428,5 @@ estadísticos](/phonometry/es/signals/levels/levels/).
 - [Niveles integrados y estadísticos](/phonometry/es/signals/levels/levels/): qué métricas se acumulan entre bloques y cuáles hay que recalcular sobre la envolvente conjunta.
 - Referencia de la API: [`filters.weighting`](/phonometry/es/reference/api/filters/weighting/) y [`filters.core`](/phonometry/es/reference/api/filters/core/).
 - Teoría: [Diseño del banco y estabilidad numérica](/phonometry/es/reference/theory/signal-analysis/#diseño-del-banco-y-estabilidad-numérica): por qué un banco se diseña como secciones de segundo orden y se diezma por banda, que es lo que hace posible el estado en streaming.
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/filters/filter-banks.mdx
+++ b/site/src/content/docs/es/signals/filters/filter-banks.mdx
@@ -49,6 +49,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 phonometry ofrece varios tipos de filtro, cada uno con su propia función de
@@ -651,6 +652,8 @@ respecto a Nyquist, o sube `fs`, y confirma el margen con
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Galería de arquitecturas de filtro](/phonometry/es/signals/filters/filter-gallery/):
@@ -662,6 +665,8 @@ respecto a Nyquist, o sube `fs`, y confirma el margen con
   conformidad de los bancos que se diseñan aquí.
 - Referencia de la API: [`phonometry`](/phonometry/es/reference/api/filters/phonometry/), [`filters.core`](/phonometry/es/reference/api/filters/core/) y [`filters.weighting`](/phonometry/es/reference/api/filters/weighting/).
 - Teoría: [Frecuencias de banda de octava](/phonometry/es/reference/theory/signal-analysis/#frecuencias-de-banda-de-octava-ansi-s111--iec-61260): de dónde salen la rejilla de frecuencias centrales en base 10 y los bordes de banda, y por qué el banco se diseña sobre ellos y no sobre las etiquetas nominales.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/filters/filter-compliance.mdx
+++ b/site/src/content/docs/es/signals/filters/filter-compliance.mdx
@@ -43,6 +43,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Un banco de filtros solo se convierte en instrumento de medida cuando sus
@@ -472,6 +473,8 @@ holgadamente por debajo de Nyquist o sube `fs`.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Bancos de filtros](/phonometry/es/signals/filters/filter-banks/): las matemáticas
@@ -488,6 +491,8 @@ holgadamente por debajo de Nyquist o sube `fs`.
 - Referencia de la API:
   [`filters.compliance`](/phonometry/es/reference/api/filters/compliance/).
 - Teoría: [Frecuencias de banda de octava](/phonometry/es/reference/theory/signal-analysis/#frecuencias-de-banda-de-octava-ansi-s111--iec-61260): las definiciones de bordes de banda alrededor de las cuales se traza la máscara de IEC 61260-1.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/filters/filter-gallery.mdx
+++ b/site/src/content/docs/es/signals/filters/filter-gallery.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Elegir una arquitectura de filtro es un compromiso: la selectividad, el
@@ -517,6 +518,8 @@ de filtros](/phonometry/es/signals/filters/filter-compliance/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Bancos de filtros](/phonometry/es/signals/filters/filter-banks/): las matemáticas
@@ -527,6 +530,8 @@ de filtros](/phonometry/es/signals/filters/filter-compliance/).
   conformidad de estas arquitecturas.
 - Referencia de la API: [`phonometry`](/phonometry/es/reference/api/filters/phonometry/) y [`filters.core`](/phonometry/es/reference/api/filters/core/).
 - Teoría: [Respuestas en magnitud](/phonometry/es/reference/theory/signal-analysis/#respuestas-en-magnitud): qué es una respuesta en magnitud como función de transferencia compleja, y en qué se diferencian las cinco arquitecturas antes de filtrar ninguna banda.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/filters/multichannel.mdx
+++ b/site/src/content/docs/es/signals/filters/multichannel.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La mayoría de las sesiones de medición reales producen más de un canal: los
@@ -333,6 +334,8 @@ modelos de entrada múltiple de Bendat y Piersol.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Correlación y retardo](/phonometry/es/signals/spectra/correlation-delay/): las preguntas cruzadas en el dominio del tiempo (retardo, alineación) que la ruta por canal deja deliberadamente en tus manos.
@@ -340,3 +343,5 @@ modelos de entrada múltiple de Bendat y Piersol.
 - [Procesado por bloques](/phonometry/es/signals/filters/block-processing/): la contrapartida en streaming, con un estado de filtro por canal.
 - [Niveles](/phonometry/es/signals/levels/levels/): las métricas de nivel por canal, y por qué los dB se combinan energéticamente.
 - Referencia de la API: [`phonometry`](/phonometry/es/reference/api/filters/phonometry/) y [`filters.core`](/phonometry/es/reference/api/filters/core/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/levels/index.mdx
+++ b/site/src/content/docs/es/signals/levels/index.mdx
@@ -5,6 +5,7 @@ description: "De la señal ponderada al número declarado: las ponderaciones fre
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Un sonómetro hace tres cosas a una señal calibrada, en orden: la **pondera en
 frecuencia** para imitar la sensibilidad del oído, la **suaviza en el tiempo**
@@ -74,6 +75,8 @@ las que se juzga una actividad.
   LAeq, niveles percentiles, LCpeak/SEL, dosis de ruido y espectrogramas de
   octava.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -84,6 +87,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
 - [Normativa española de ruido (RD 1367/2007)](/phonometry/es/environment/assessment/spanish-noise-regulation/):
   el nivel corregido LKeq, las correcciones Kt/Kf/Ki, los periodos temporales
   de evaluación y las fases de ruido, y las tablas de valores límite.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/signals/levels/levels.mdx
+++ b/site/src/content/docs/es/signals/levels/levels.mdx
@@ -36,6 +36,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una medición de ruido rara vez termina en una forma de onda: termina en un
@@ -850,6 +851,8 @@ edición implementada (1993), no las de la más reciente.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles ambientales (ISO 1996-1/-2)](/phonometry/es/environment/assessment/environmental-levels/): los indicadores $L_\mathrm{den}$/$L_\mathrm{dn}$, los niveles de evaluación y la cadena de determinación de ISO 1996-2 construidos sobre los niveles de esta página.
@@ -859,6 +862,8 @@ edición implementada (1993), no las de la más reciente.
 - [Multicanal y rendimiento](/phonometry/es/signals/filters/multichannel/): niveles por canal y cómo combinarlos energéticamente.
 - Referencia de la API: [`signals.levels`](/phonometry/es/reference/api/signals/levels/).
 - Teoría: [Métricas de evento y de dosis](/phonometry/es/reference/theory/signal-analysis/#métricas-de-evento-y-de-dosis): las definiciones energéticas detrás de $L_\mathrm{eq}$, el SEL y las magnitudes de exposición, y cómo se relacionan con ellas los niveles percentiles.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/levels/special-weightings.mdx
+++ b/site/src/content/docs/es/signals/levels/special-weightings.mdx
@@ -40,6 +40,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Más allá de A, C y Z, la familia de ponderaciones conserva cuatro curvas de
@@ -404,6 +405,8 @@ hoy el EPNL o niveles con ponderación A simples en lugar de D).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ponderación frecuencial](/phonometry/es/signals/levels/weighting/): las curvas A,
@@ -411,6 +414,8 @@ hoy el EPNL o niveles con ponderación A simples en lugar de D).
   Tabla 3 de IEC 61672-1 sobre las que se apoyan estas curvas.
 - Referencia de la API: [`filters.weighting`](/phonometry/es/reference/api/filters/weighting/) y [`filters.compliance`](/phonometry/es/reference/api/filters/compliance/).
 - Teoría: [Ponderación G (ISO 7196)](/phonometry/es/reference/theory/signal-analysis/#ponderación-g-iso-7196): la curva G de ISO 7196 y de dónde viene su normalización.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/levels/time-weighting.mdx
+++ b/site/src/content/docs/es/signals/levels/time-weighting.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -450,6 +451,8 @@ construida sobre la ponderación Impulse de aquí.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Niveles](/phonometry/es/signals/levels/levels/): los niveles percentiles definidos sobre la salida del detector, y las métricas integradas que lo evitan.
@@ -461,3 +464,5 @@ construida sobre la ponderación Impulse de aquí.
 - [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/): los ensayos periódicos de IEC 61672-3, en los que esta balística se comprueba por muestreo contra los límites de clase sobre un instrumento real.
 - Referencia de la API: [`filters.weighting`](/phonometry/es/reference/api/filters/weighting/).
 - Teoría: [Integración temporal](/phonometry/es/reference/theory/signal-analysis/#integración-temporal): la ecuación de primer orden que resuelven los detectores exponenciales, y qué cambiaría integrarla en su lugar sobre un bloque fijo.
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/levels/weighting.mdx
+++ b/site/src/content/docs/es/signals/levels/weighting.mdx
@@ -37,6 +37,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Las curvas de ponderación frecuencial simulan la sensibilidad del oído humano.
@@ -598,6 +599,8 @@ especiales](/phonometry/es/signals/levels/special-weightings/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ponderaciones especiales (G, B, D, AU)](/phonometry/es/signals/levels/special-weightings/):
@@ -605,6 +608,8 @@ especiales](/phonometry/es/signals/levels/special-weightings/).
   audible en presencia de ultrasonidos.
 - Referencia de la API: [`filters.weighting`](/phonometry/es/reference/api/filters/weighting/) y [`filters.compliance`](/phonometry/es/reference/api/filters/compliance/).
 - Teoría: [Curvas de ponderación (IEC 61672-1)](/phonometry/es/reference/theory/signal-analysis/#curvas-de-ponderación-iec-61672-1): la definición en polos y ceros de las curvas A, C y Z, y la deformación bilineal que el diseño ajustado cancela.
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/metrology/calibration.mdx
+++ b/site/src/content/docs/es/signals/metrology/calibration.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Cada nivel que devuelve esta biblioteca es tan fiable como el número que
@@ -707,6 +708,8 @@ de cualquier norma y no hace ninguna afirmación física.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Construye un sonómetro](/phonometry/es/signals/sound-level-meter/): el recorrido que empieza en este paso de calibración y termina en un instrumento verificado por clase.
@@ -714,6 +717,8 @@ de cualquier norma y no hace ninguna afirmación física.
 - [Multicanal y rendimiento](/phonometry/es/signals/filters/multichannel/): una sensibilidad por canal cuando los canales difieren.
 - [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/signals/metrology/gum-uncertainty/): propagar la tolerancia del calibrador y la cota de deriva a la incertidumbre de un nivel.
 - Referencia de la API: [`metrology.calibration`](/phonometry/es/reference/api/metrology/calibration/) y [`phonometry`](/phonometry/es/reference/api/filters/phonometry/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
@@ -56,6 +56,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import { totalChecks, domains, standards } from '../../../../../data/conformance-stats.mjs';
 
@@ -395,6 +396,8 @@ linealidad, y a ningún instrumento físico se le asigna una clase.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ponderación frecuencial](/phonometry/es/signals/levels/weighting/): las
@@ -415,6 +418,8 @@ linealidad, y a ningún instrumento físico se le asigna una clase.
   [`filters.compliance`](/phonometry/es/reference/api/filters/compliance/),
   [`filters.weighting_compliance`](/phonometry/es/reference/api/filters/weighting-compliance/)
   y [`emission.intensity_compliance`](/phonometry/es/reference/api/power/intensity-compliance/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/signals/metrology/data-qualification.mdx
+++ b/site/src/content/docs/es/signals/metrology/data-qualification.mdx
@@ -34,6 +34,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Todo promedio de esta documentación - una [PSD](/phonometry/es/signals/spectra/spectral-analysis/), un
@@ -706,6 +707,8 @@ módulo.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Análisis espectral](/phonometry/es/signals/spectra/spectral-analysis/): el intervalo de confianza chi-cuadrado que da por supuesta la estacionariedad que esta página comprueba.
@@ -714,3 +717,5 @@ módulo.
 - [Niveles](/phonometry/es/signals/levels/levels/): el $L_\mathrm{eq}$ cuya definición supone una única medición estacionaria.
 - Referencia de la API: [`metrology.data_qualification`](/phonometry/es/reference/api/metrology/data-qualification/).
 - Teoría: [Incertidumbre de medida (GUM)](/phonometry/es/reference/theory/signal-analysis/#incertidumbre-de-medida-isoiec-guide-98-3-gum-y-suplemento-1): el marco de incertidumbre que alimentan los criterios de cualificación de esta página.
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/metrology/gum-uncertainty.mdx
+++ b/site/src/content/docs/es/signals/metrology/gum-uncertainty.mdx
@@ -31,6 +31,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Todo resultado de medida está incompleto sin una declaración de su
@@ -487,9 +488,13 @@ implementan en sus propias páginas, listadas arriba, y no se derivan aquí.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Cualificación de datos](/phonometry/es/signals/metrology/data-qualification/): las comprobaciones de estacionariedad que toda entrada promediada supone en silencio.
 - [Calibración](/phonometry/es/signals/metrology/calibration/): las entradas de tolerancia y deriva de toda cadena calibrada.
 - Referencia de la API: [`metrology.uncertainty`](/phonometry/es/reference/api/metrology/uncertainty/).
 - Teoría: [Incertidumbre de medida (GUM)](/phonometry/es/reference/theory/signal-analysis/#incertidumbre-de-medida-isoiec-guide-98-3-gum-y-suplemento-1): la ley de propagación de la incertidumbre, el factor de cobertura y dónde toma el relevo el suplemento de Monte Carlo.
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/sound-level-meter.mdx
+++ b/site/src/content/docs/es/signals/sound-level-meter.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -435,6 +436,8 @@ de calibración](/phonometry/es/signals/metrology/calibration/) para lo que
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 El sonómetro construido aquí es el tronco; el resto del núcleo crece de él.
@@ -455,3 +458,5 @@ El sonómetro construido aquí es el tronco; el resto del núcleo crece de él.
   [`signals.levels`](/phonometry/es/reference/api/signals/levels/),
   [`phonometry`](/phonometry/es/reference/api/filters/phonometry/) y
   [`filters.compliance`](/phonometry/es/reference/api/filters/compliance/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/cepstrum-echoes.mdx
+++ b/site/src/content/docs/es/signals/spectra/cepstrum-echoes.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Los [estimadores
@@ -623,6 +624,8 @@ espectro logarítmico en frecuencia lineal.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Correlación, retardo temporal y envolvente](/phonometry/es/signals/spectra/correlation-delay/): la envolvente de Hilbert que esta página convierte en espectro.
@@ -631,3 +634,5 @@ espectro logarítmico en frecuencia lineal.
 - [Frecuencias de fallo de máquinas](/phonometry/es/vibration/machinery/machine-diagnostics/): las familias de rodamientos y engranajes que se leen exactamente sobre este espectro de la envolvente.
 - [Distorsión con barrido sinusoidal](/phonometry/es/devices/electroacoustics/swept-sine-distortion/): el plegado de fase mínima que comparte el núcleo de esta página.
 - Referencia de la API: [`signals.cepstrum`](/phonometry/es/reference/api/signals/cepstrum/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/correlation-delay.mdx
+++ b/site/src/content/docs/es/signals/spectra/correlation-delay.mdx
@@ -24,6 +24,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Donde los [estimadores espectrales calibrados](/phonometry/es/signals/spectra/spectral-analysis/)
@@ -543,6 +544,8 @@ de TDOA multisensor incorporada.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Cepstrum, ecos y espectro de la envolvente](/phonometry/es/signals/spectra/cepstrum-echoes/): la vía sin referencia hasta un retardo, y la envolvente que construye esta página.
@@ -550,3 +553,5 @@ de TDOA multisensor incorporada.
 - [Señales de prueba](/phonometry/es/signals/spectra/test-signals/): el núcleo de retardo fraccionario de banda limitada que hay detrás de la alineación submuestral.
 - [Promediado síncrono en el tiempo](/phonometry/es/signals/spectra/synchronous-averaging/): la misma alineación aplicada por revolución.
 - Referencia de la API: [`signals.correlation`](/phonometry/es/reference/api/signals/correlation/) y [`signals.envelope`](/phonometry/es/reference/api/signals/envelope/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/index.mdx
+++ b/site/src/content/docs/es/signals/spectra/index.mdx
@@ -5,6 +5,7 @@ description: "Análisis de señal en frecuencia y en tiempo en phonometry: estim
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Los niveles de banda responden a *cuánto*; esta sección responde a *qué hay
 en la señal*. Donde el resto del núcleo trabaja en bandas de fracción
@@ -171,6 +172,8 @@ estimaciones.
   magnitud objetivo arbitrario conformando el retardo de grupo, y la
   inversión con regularización de Kirkeby de una respuesta medida.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -181,6 +184,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   medido: frecuencias BPFO, BPFI, BSF y de jaula de los rodamientos, bandas
   laterales de engrane, deslizamiento, paso de polos y armónicos de ranura de
   los motores de inducción, y tonos de paso de pala.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/signals/spectra/miso-coherence.mdx
+++ b/site/src/content/docs/es/signals/spectra/miso-coherence.mdx
@@ -14,6 +14,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Cuando varias fuentes parcialmente correlacionadas excitan una misma respuesta, la
@@ -347,9 +348,13 @@ llamada a `miso_coherence` por cada salida.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Análisis espectral](/phonometry/es/signals/spectra/spectral-analysis/): el espectro de salida coherente de una entrada que esta página generaliza, y el núcleo de Welch compartido.
 - [Correlación y retardo](/phonometry/es/signals/spectra/correlation-delay/): estimar y eliminar los retardos globales que sesgan la coherencia a la baja.
 - [Multicanal y rendimiento](/phonometry/es/signals/filters/multichannel/): la ruta por canal que este análisis cruzado complementa.
 - Referencia de la API: [`signals.miso`](/phonometry/es/reference/api/signals/miso/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/spectral-analysis.mdx
+++ b/site/src/content/docs/es/signals/spectra/spectral-analysis.mdx
@@ -51,6 +51,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Un espectro sin su incertidumbre es media medición. Esta página cubre los
@@ -878,6 +879,8 @@ así que no lleva números de apartado ni límites de cumplimiento que comprobar
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Cualificación de datos](/phonometry/es/signals/metrology/data-qualification/): la estacionariedad que da por supuesta todo intervalo chi-cuadrado de esta página.
@@ -887,3 +890,5 @@ así que no lleva números de apartado ni límites de cumplimiento que comprobar
 - [Niveles](/phonometry/es/signals/levels/levels/): el lado de los niveles de banda de la conversión densidad/banda del §4.
 - Referencia de la API: [`signals.spectra`](/phonometry/es/reference/api/signals/spectra/), [`signals.windows`](/phonometry/es/reference/api/signals/windows/) y [`signals.multitaper`](/phonometry/es/reference/api/signals/multitaper/).
 - Teoría: [Resolución frecuencial vs separación de bins FFT](/phonometry/es/reference/theory/signal-analysis/#resolución-frecuencial-vs-separación-de-bins-fft): por qué la separación de bins de una FFT no es la resolución de la estimación, y qué le hace la ventana a ambas.
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/synchronous-averaging.mdx
+++ b/site/src/content/docs/es/signals/spectra/synchronous-averaging.mdx
@@ -16,6 +16,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una máquina rotativa repite su firma una vez por revolución. Enterrada en el
@@ -402,6 +403,8 @@ comprobar la implementación.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Cepstrum y ecos](/phonometry/es/signals/spectra/cepstrum-echoes/): detección sin referencia de familias de armónicos y bandas laterales, y el espectro de la envolvente.
@@ -409,3 +412,5 @@ comprobar la implementación.
 - [Señales de prueba](/phonometry/es/signals/spectra/test-signals/): el núcleo de retardo fraccionario que usa la alineación de periodo no entero.
 - [Frecuencias de fallo de máquinas](/phonometry/es/vibration/machinery/machine-diagnostics/): las familias de rodamientos y engranajes contra las que se lee el espectro de la envolvente del residuo.
 - Referencia de la API: [`signals.synchronous_average`](/phonometry/es/reference/api/signals/synchronous-average/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/system-measurement.mdx
+++ b/site/src/content/docs/es/signals/spectra/system-measurement.mdx
@@ -43,6 +43,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La [guía de acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/)
@@ -616,6 +617,8 @@ de su Ec. 17.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): las excitaciones de barrido y MLS de ISO 18233 junto a las que se sitúa el par de Golay.
@@ -624,3 +627,5 @@ de su Ec. 17.
 - [Análisis espectral calibrado](/phonometry/es/signals/spectra/spectral-analysis/): la maquinaria de Welch que verifica el barrido conformado, y el suavizado que la inversión quiere antes.
 - [Correlación y retardo](/phonometry/es/signals/spectra/correlation-delay/): la medida de retorno que alinea los dos registros de Golay.
 - Referencia de la API: [`signals.inversion`](/phonometry/es/reference/api/signals/inversion/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/test-signals.mdx
+++ b/site/src/content/docs/es/signals/spectra/test-signals.mdx
@@ -21,6 +21,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Una medición es tan fiable como su estímulo y su contabilidad de la
@@ -344,6 +345,8 @@ afirmaciones de exactitud son formas cerradas, no normativas.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ponderación temporal](/phonometry/es/signals/levels/time-weighting/): la balística de detector que ejercitan las ráfagas tonales (IEC 61672-1, Tabla 4).
@@ -353,3 +356,5 @@ afirmaciones de exactitud son formas cerradas, no normativas.
 - [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/): las excitaciones de MLS y barrido exponencial del retrato de familia, tal como las usa ISO 18233.
 - [Medición de sistemas](/phonometry/es/signals/spectra/system-measurement/): la pareja de Golay y el barrido conformado, los otros dos miembros de la familia.
 - Referencia de la API: [`signals.test_signals`](/phonometry/es/reference/api/signals/test-signals/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/es/signals/spectra/time-frequency.mdx
@@ -24,6 +24,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 Un espectro estacionario esconde todo lo que ocurre *en el tiempo*: una
@@ -373,6 +374,8 @@ Piersol, no una norma de certificación.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Análisis espectral](/phonometry/es/signals/spectra/spectral-analysis/): la estimación de Welch promediada para el fondo estacionario, y las figuras de mérito de las ventanas tras el enventanado del segmento.
@@ -380,3 +383,5 @@ Piersol, no una norma de certificación.
 - [Correlación y retardo](/phonometry/es/signals/spectra/correlation-delay/): la frecuencia instantánea de Hilbert para seguir una componente.
 - Referencia de la API: [`signals.time_frequency`](/phonometry/es/reference/api/signals/time-frequency/).
 - Teoría: [Resolución frecuencial vs separación de bins FFT](/phonometry/es/reference/theory/signal-analysis/#resolución-frecuencial-vs-separación-de-bins-fft): la separación de bins frente a la resolución efectiva, el compromiso al que esta página dedica toda su extensión.
+
+</SeeAlso>

--- a/site/src/content/docs/es/simulation/elastic-waves.mdx
+++ b/site/src/content/docs/es/simulation/elastic-waves.mdx
@@ -50,6 +50,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -788,6 +789,8 @@ observable en los campos pero no tiene aquí oráculo dedicado en forma cerrada.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Simulación de ondas FDTD 2D](/phonometry/es/simulation/fdtd-simulation/): el
@@ -804,6 +807,8 @@ observable en los campos pero no tiene aquí oráculo dedicado en forma cerrada.
   el modelo de reflexión de Rayleigh de fondo fluido cuya física de cizalla
   ausente cuantifica el §5.
 - Referencia de la API: [`simulation.elastic-fdtd`](/phonometry/es/reference/api/simulation/elastic-fdtd/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/simulation/fdtd-simulation.mdx
+++ b/site/src/content/docs/es/simulation/fdtd-simulation.mdx
@@ -38,6 +38,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -1088,6 +1089,8 @@ fluido-sólido](/phonometry/es/simulation/elastic-waves/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Ondas elásticas y acoplamiento fluido-sólido](/phonometry/es/simulation/elastic-waves/):
@@ -1097,6 +1100,8 @@ fluido-sólido](/phonometry/es/simulation/elastic-waves/).
   de validación en forma cerrada de la sección 6 se ejecutan ahí.
 - Referencia de la API: [`simulation.fdtd`](/phonometry/es/reference/api/simulation/fdtd/),
   [`simulation.ntff`](/phonometry/es/reference/api/simulation/ntff/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/underwater/marine-mammal-exposure.mdx
+++ b/site/src/content/docs/es/underwater/marine-mammal-exposure.mdx
@@ -56,6 +56,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Un mamífero marino no oye todas las frecuencias por igual, así que una
@@ -646,6 +647,8 @@ sonido](/phonometry/es/underwater/underwater-propagation/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Acústica submarina: ruido radiado e hincado de pilotes](/phonometry/es/underwater/underwater-acoustics/):
@@ -655,3 +658,5 @@ sonido](/phonometry/es/underwater/underwater-propagation/).
   la pérdida de propagación y la maquinaria de figura de mérito que convierte un
   criterio en una distancia.
 - Referencia de la API: [`underwater.bioacoustics.weighting`](/phonometry/es/reference/api/underwater/weighting/) y [`underwater.bioacoustics.audiograms`](/phonometry/es/reference/api/underwater/audiograms/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/underwater/underwater-acoustics.mdx
+++ b/site/src/content/docs/es/underwater/underwater-acoustics.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 El sonido submarino se refiere a **1 µPa** (no los 20 µPa de la acústica en
@@ -487,6 +488,8 @@ ningún otro lugar de phonometry.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Exposición a ruido de mamíferos marinos](/phonometry/es/underwater/marine-mammal-exposure/):
@@ -498,3 +501,5 @@ ningún otro lugar de phonometry.
   receptor, y la ecuación del sonar que alimentan.
 - Referencia de la API: [`underwater.acoustics`](/phonometry/es/reference/api/underwater/acoustics/), [`underwater.sources.pile_driving_noise`](/phonometry/es/reference/api/underwater/pile-driving-noise/) y [`underwater.sources.ship_radiated_noise`](/phonometry/es/reference/api/underwater/ship-radiated-noise/).
 - El modelado general de propagación submarina (rayos, modos normales, ecuación parabólica) se cubre en [Métodos numéricos de propagación submarina](/phonometry/es/underwater/underwater-solvers/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/underwater/underwater-propagation.mdx
+++ b/site/src/content/docs/es/underwater/underwater-propagation.mdx
@@ -161,6 +161,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -1061,6 +1062,8 @@ propagación submarina](/phonometry/es/underwater/underwater-solvers/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Métodos numéricos de propagación submarina](/phonometry/es/underwater/underwater-solvers/):
@@ -1068,3 +1071,5 @@ propagación submarina](/phonometry/es/underwater/underwater-solvers/).
   ecuación parabólica para los casos en que estas formas cerradas no bastan,
   y la guía de selección de modelo.
 - Referencia de la API: [`underwater.propagation.closed_form`](/phonometry/es/reference/api/underwater/closed-form/) y [`underwater.propagation.sound_speed`](/phonometry/es/reference/api/underwater/sound-speed/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/underwater/underwater-solvers.mdx
+++ b/site/src/content/docs/es/underwater/underwater-solvers.mdx
@@ -31,6 +31,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 La pérdida de propagación en forma cerrada de la
@@ -1251,6 +1252,8 @@ fluido-sólido](/phonometry/es/simulation/elastic-waves/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Propagación submarina del sonido](/phonometry/es/underwater/underwater-propagation/):
@@ -1268,6 +1271,8 @@ fluido-sólido](/phonometry/es/simulation/elastic-waves/).
   alternativa en el dominio del tiempo tras la animación del canal SOFAR de
   la guía de propagación.
 - Referencia de la API: [`underwater.propagation.numerical`](/phonometry/es/reference/api/underwater/numerical/).
+
+</SeeAlso>
 
 ## Respuestas rápidas
 

--- a/site/src/content/docs/es/vibration/human/human-vibration.mdx
+++ b/site/src/content/docs/es/vibration/human/human-vibration.mdx
@@ -78,6 +78,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La vibración transmitida a una persona se evalúa con la misma cadena de medida
@@ -1009,6 +1010,8 @@ página no sustituyen.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Vibración con choques múltiples](/phonometry/es/vibration/human/multiple-shock-vibration/): a dónde va un registro cuando su factor de cresta y sus cocientes del apartado 6.3.3 dicen que el valor eficaz no lo describe: el modelo de respuesta espinal de ISO 2631-5, y la adquisición con almohadilla de asiento a la que apunta la mitad de cuerpo entero de esta página.
@@ -1016,3 +1019,5 @@ página no sustituyen.
 - [Calibración](/phonometry/es/signals/metrology/calibration/): la comprobación de antes y después del apartado 6.3.1 y la trazabilidad que registra el campo `calibration` de la ficha.
 - Referencia de la API: [`vibration.human.exposure`](/phonometry/es/reference/api/vibration/exposure/).
 - Teoría: [Vibración en humanos](/phonometry/es/reference/theory/vibration/#vibración-en-humanos-iso-8041-1-iso-2631-12-iso-5349-12-directiva-200244ce): las ponderaciones frecuenciales de la ISO 2631-1 y la ISO 5349-1, y las definiciones de valor eficaz móvil, VDV y MTVV.
+
+</SeeAlso>

--- a/site/src/content/docs/es/vibration/human/multiple-shock-vibration.mdx
+++ b/site/src/content/docs/es/vibration/human/multiple-shock-vibration.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La vibración que contiene **choques mecánicos** repetidos (vehículos todoterreno,
@@ -545,8 +546,12 @@ ha aplicado la ventana y se le ha limitado la banda.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Vibración en humanos](/phonometry/es/vibration/human/human-vibration/): la cadena de ISO 2631-1 a la que esta página devuelve los ejes horizontales, y el factor de cresta y los cocientes del apartado 6.3.3 que deciden si un registro pertenece aquí siquiera.
 - Referencia de la API: [`vibration.human.multiple_shock`](/phonometry/es/reference/api/vibration/multiple-shock/).
 - Teoría: [Choques múltiples (ISO 2631-5)](/phonometry/es/reference/theory/vibration/#choques-múltiples-iso-2631-5): el modelo de respuesta de la ISO 2631-5, la dosis de aceleración y la ley de riesgo de Weibull.
+
+</SeeAlso>

--- a/site/src/content/docs/es/vibration/machinery/index.mdx
+++ b/site/src/content/docs/es/vibration/machinery/index.mdx
@@ -5,6 +5,7 @@ description: "Leer una máquina desde su vibración: las familias cinemáticas d
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Una máquina rotativa tiene una **firma cinemática**. Toda periodicidad de su
 vibración pertenece a algo que gira, engrana o pasa, y la geometría fija la
@@ -50,6 +51,8 @@ calcula las familias y las dibuja sobre un espectro de envolvente medido.
   de ventiladores, soplantes y bombas, todo a partir de la geometría y de la
   velocidad del eje (Norton y Karczub, sección 8.4).
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -64,6 +67,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   soporte que hace sonar el método de la envolvente.
 - [Transmisión de onda de flexión en uniones de placas](/phonometry/es/vibration/structural/junction-transmission/):
   adónde va la vibración de la máquina una vez que ha salido de la máquina.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/vibration/machinery/machine-diagnostics.mdx
+++ b/site/src/content/docs/es/vibration/machinery/machine-diagnostics.mdx
@@ -14,6 +14,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 El mantenimiento predictivo empieza por la aritmética, no por el tratamiento de
@@ -609,6 +610,8 @@ número de polos.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Cepstrum, ecos y espectro de la envolvente](/phonometry/es/signals/spectra/cepstrum-echoes/):
@@ -621,3 +624,5 @@ número de polos.
 - [Transmisión de onda de flexión en uniones de placas](/phonometry/es/vibration/structural/junction-transmission/):
   qué le ocurre a la vibración una vez sale de la máquina.
 - Referencia de la API: [`vibration.machinery.diagnostics`](/phonometry/es/reference/api/vibration/diagnostics/).
+
+</SeeAlso>

--- a/site/src/content/docs/es/vibration/structural/index.mdx
+++ b/site/src/content/docs/es/vibration/structural/index.mdx
@@ -5,6 +5,7 @@ description: "La cadena desde una máquina vibrante hasta el ruido oído varias 
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 
 Una máquina fijada a un edificio radia sonido dos veces: directamente desde
 su propia superficie vibrante, e indirectamente inyectando **potencia
@@ -72,6 +73,8 @@ receptor, que es donde esta sección se encuentra con los modelos de
   rigidez de transferencia dinámica de aisladores por los métodos directo e
   indirecto.
 
+<SeeAlso>
+
 ## Véase también
 
 Páginas de otras áreas del sitio en las que se apoya esta sección:
@@ -84,6 +87,8 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
   independientes de la placa.
 - [Ruido estructural instalado (EN 12354-5)](/phonometry/es/buildings/design/installed-structure-borne/):
   el nivel predicho en el recinto receptor desde el equipo instalado.
+
+</SeeAlso>
 
 ## Qué no cubre esta sección
 

--- a/site/src/content/docs/es/vibration/structural/junction-transmission.mdx
+++ b/site/src/content/docs/es/vibration/structural/junction-transmission.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 import Video from '../../../../../components/Video.astro';
 
@@ -637,6 +638,8 @@ que hace el lector, no una que automatice la biblioteca.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Predicción del aislamiento acústico (EN 12354)](/phonometry/es/buildings/design/insulation-prediction/):
@@ -651,3 +654,5 @@ que hace el lector, no una que automatice la biblioteca.
   las movilidades de placa tras los parámetros de onda.
 - Referencia de la API: [`vibration.structural.junction_transmission`](/phonometry/es/reference/api/vibration/junction-transmission/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): la descripción en movilidades que hay detrás de una unión, y la eficiencia de radiación que lleva cada elemento.
+
+</SeeAlso>

--- a/site/src/content/docs/es/vibration/structural/mechanical-mobility.mdx
+++ b/site/src/content/docs/es/vibration/structural/mechanical-mobility.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La **movilidad** mecánica es el cociente complejo entre una respuesta en
@@ -757,6 +758,8 @@ transferencia](/phonometry/es/vibration/structural/transfer-stiffness/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Rigidez dinámica de transferencia (ISO 10846)](/phonometry/es/vibration/structural/transfer-stiffness/):
@@ -775,3 +778,5 @@ transferencia](/phonometry/es/vibration/structural/transfer-stiffness/).
   los estimadores `transfer_function` y `coherence` que ejecuta la sección 3.
 - Referencia de la API: [`vibration.structural.mechanical_mobility`](/phonometry/es/reference/api/vibration/mechanical-mobility/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): las movilidades puntuales de estructura infinita y la eficiencia de radiación, y por qué son promedios en torno a los que oscila una estructura finita.
+
+</SeeAlso>

--- a/site/src/content/docs/es/vibration/structural/transfer-stiffness.mdx
+++ b/site/src/content/docs/es/vibration/structural/transfer-stiffness.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../../components/ReportPreview.astro';
 import Scope from '../../../../../components/Scope.astro';
 import ScopeClaim from '../../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../../components/ThemeImage.astro';
 
 La propiedad de transferencia vibroacústica de un elemento resiliente (un
@@ -541,6 +542,8 @@ amplitud por diseño, así que un único $L_k(f)$ no los caracteriza.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## Véase también
 
 - [Movilidad mecánica y la familia de FRF (ISO 7626-1)](/phonometry/es/vibration/structural/mechanical-mobility/):
@@ -554,3 +557,5 @@ amplitud por diseño, así que un único $L_k(f)$ no los caracteriza.
   convierte en un nivel en un recinto receptor.
 - Referencia de la API: [`vibration.structural.transfer_stiffness`](/phonometry/es/reference/api/vibration/transfer-stiffness/) y [`vibration.structural.mechanical_mobility`](/phonometry/es/reference/api/vibration/mechanical-mobility/).
 - Teoría: [Movilidades puntuales y eficiencia de radiación](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29): las definiciones de movilidad e impedancia de las que la rigidez de transferencia es la inversa.
+
+</SeeAlso>

--- a/site/src/content/docs/io/audio-files.mdx
+++ b/site/src/content/docs/io/audio-files.mdx
@@ -43,6 +43,7 @@ references:
     note: "Why the optional dither is triangular-PDF at one LSB, why it is offered only when quantising to 16 bits, and why it stays opt-in for data that faces numerical analysis."
 ---
 
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 
 A measurement WAV is only interpretable together with three things the
@@ -518,6 +519,8 @@ multichannel and RF64 files past 4 GiB. The extra is for FLAC archives,
 AIFF/Ogg/Opus/MP3, and the compressed WAV listening copies — and it bundles
 libsndfile under the LGPL, which the base install deliberately avoids.
 
+<SeeAlso>
+
 ## See also
 
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): where the sensitivity factor comes from, and the field discipline around it.
@@ -526,3 +529,5 @@ libsndfile under the LGPL, which the base install deliberately avoids.
 - [Programme loudness](/phonometry/devices/broadcast/program-loudness/): the BS.1770 implementation behind `bext="loudness"`.
 - [Build a sound level meter](/phonometry/signals/sound-level-meter/): the whole chain this page's files enter and leave.
 - API reference: [`phonometry.io`](/phonometry/reference/api/io/io/).
+
+</SeeAlso>

--- a/site/src/content/docs/materials/absorbers/absorption-measurement.mdx
+++ b/site/src/content/docs/materials/absorbers/absorption-measurement.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -938,6 +939,8 @@ measurement method (road-traffic noise-reducing devices) is not.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Impedance Tube](/phonometry/materials/absorbers/impedance-tube/): the normal-incidence
@@ -958,3 +961,5 @@ measurement method (road-traffic noise-reducing devices) is not.
   the sound-insulation companion uncertainty standard, ISO 12999-1.
 - API reference: [`materials.absorbers.sound_absorption`](/phonometry/reference/api/materials/sound-absorption/), [`materials.absorbers.rating`](/phonometry/reference/api/materials/rating/) and [`materials.absorbers.uncertainty`](/phonometry/reference/api/materials/uncertainty/).
 - Theory: [Acoustic material characterisation](/phonometry/reference/theory/materials-surfaces/#acoustic-material-characterisation-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): the ISO 354 decay difference, the ISO 11654 rating and where the practical coefficients come from.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/absorbers/airflow-resistance.mdx
+++ b/site/src/content/docs/materials/absorbers/airflow-resistance.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Push air slowly through a porous absorber and it pushes back. That viscous
@@ -582,6 +583,8 @@ rating, so the fiche carries neither.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Porous and Multilayer Absorbers](/phonometry/materials/absorbers/porous-absorbers/): the
@@ -594,3 +597,5 @@ rating, so the fiche carries neither.
   absorber.
 - API reference: [`materials.absorbers.airflow_resistance`](/phonometry/reference/api/materials/airflow-resistance/).
 - Theory: [Acoustic material characterisation](/phonometry/reference/theory/materials-surfaces/#acoustic-material-characterisation-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): the ISO 9053 definitions of resistance, resistivity and the flow regime they assume.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/absorbers/impedance-tube.mdx
+++ b/site/src/content/docs/materials/absorbers/impedance-tube.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -993,6 +994,8 @@ Rating](/phonometry/materials/absorbers/absorption-measurement/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Sound Absorption Measurement and Rating](/phonometry/materials/absorbers/absorption-measurement/):
@@ -1010,3 +1013,5 @@ Rating](/phonometry/materials/absorbers/absorption-measurement/).
   of the two-microphone transfer function.
 - API reference: [`materials.absorbers.impedance_tube`](/phonometry/reference/api/materials/impedance-tube/).
 - Theory: [Acoustic material characterisation](/phonometry/reference/theory/materials-surfaces/#acoustic-material-characterisation-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): the transfer-function derivation of ISO 10534-2 and the ASTM E2611 four-microphone extension.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/absorbers/metamaterial-absorbers.mdx
+++ b/site/src/content/docs/materials/absorbers/metamaterial-absorbers.mdx
@@ -63,6 +63,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -639,6 +640,8 @@ subject of [Metadiffusers](/phonometry/materials/diffusers/metadiffusers/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Porous and Multilayer Absorbers](/phonometry/materials/absorbers/porous-absorbers/):
@@ -655,3 +658,5 @@ subject of [Metadiffusers](/phonometry/materials/diffusers/metadiffusers/).
   physics of the narrow channels, measured on the bulk material.
 - API reference: [`materials.absorbers.slow_sound`](/phonometry/reference/api/materials/slow-sound/).
 - Theory: [Acoustic material characterisation](/phonometry/reference/theory/materials-surfaces/#acoustic-material-characterisation-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): the surface-impedance and absorption definitions the resonator models are evaluated against.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/absorbers/porous-absorbers.mdx
+++ b/site/src/content/docs/materials/absorbers/porous-absorbers.mdx
@@ -92,6 +92,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Given a porous material's **flow resistivity** (the quantity the
@@ -1276,6 +1277,8 @@ Absorbers](/phonometry/materials/absorbers/metamaterial-absorbers/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Airflow Resistance](/phonometry/materials/absorbers/airflow-resistance/),
@@ -1288,3 +1291,5 @@ Absorbers](/phonometry/materials/absorbers/metamaterial-absorbers/).
   slow-sound slit panels and the critical-coupling condition that push
   perfect absorption into the deep-subwavelength regime.
 - Theory: [Acoustic material characterisation](/phonometry/reference/theory/materials-surfaces/#acoustic-material-characterisation-iso-11654-iso-9053-12-iso-10534-12-astm-e2611): the characterisation quantities the empirical and phenomenological models take as input.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/diffusers/diffusers.mdx
+++ b/site/src/content/docs/materials/diffusers/diffusers.mdx
@@ -56,6 +56,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -1188,6 +1189,8 @@ arguments. Resonator-loaded deep-subwavelength panels are the subject of the
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Metadiffusers](/phonometry/materials/diffusers/metadiffusers/): the deep-subwavelength
@@ -1205,3 +1208,5 @@ arguments. Resonator-loaded deep-subwavelength panels are the subject of the
   ISO 17497-1 air-attenuation relations consume.
 - API reference: [`materials.diffusers.scattering_diffusion`](/phonometry/reference/api/materials/scattering-diffusion/) and [`materials.diffusers.design`](/phonometry/reference/api/materials/design/).
 - Theory: [Surface scattering and diffusion](/phonometry/reference/theory/materials-surfaces/#surface-scattering-and-diffusion-iso-17497-1-iso-17497-2): the derivation of the scattering and diffusion coefficients and why the two are different quantities.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/diffusers/index.mdx
+++ b/site/src/content/docs/materials/diffusers/index.mdx
@@ -5,6 +5,7 @@ description: "Grading and designing surfaces by what they reflect: the ISO 17497
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 Where the [Absorbers](/phonometry/materials/absorbers/) subsection asks
 how much energy a material removes from the field, this one asks what a
@@ -50,6 +51,8 @@ methods serve the outdoor-noise interest of
   Schroeder diffusers from resonator-loaded slits, with slow sound and
   ternary sequences.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -57,6 +60,8 @@ Pages elsewhere on the site that this section leans on:
 - [Surfaces measured in place](/phonometry/materials/surfaces/) and its guide
   [In-situ Road-Surface Absorption](/phonometry/materials/surfaces/road-absorption/):
   the ISO 13472-1 subtraction technique and the ISO 13472-2 spot method.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/materials/diffusers/metadiffusers.mdx
+++ b/site/src/content/docs/materials/diffusers/metadiffusers.mdx
@@ -58,6 +58,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -552,6 +553,8 @@ Absorbers](/phonometry/materials/absorbers/metamaterial-absorbers/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Diffusers and Their Coefficients](/phonometry/materials/diffusers/diffusers/): the
@@ -569,3 +572,5 @@ Absorbers](/phonometry/materials/absorbers/metamaterial-absorbers/).
   geometry.
 - API reference: [`materials.diffusers.metadiffuser`](/phonometry/reference/api/materials/metadiffuser/) and [`materials.diffusers.design`](/phonometry/reference/api/materials/design/).
 - Theory: [Surface scattering and diffusion](/phonometry/reference/theory/materials-surfaces/#surface-scattering-and-diffusion-iso-17497-1-iso-17497-2): the scattering and diffusion coefficients the deep-subwavelength designs are judged by.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/resilient/dynamic-stiffness.mdx
+++ b/site/src/content/docs/materials/resilient/dynamic-stiffness.mdx
@@ -21,6 +21,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -494,6 +495,8 @@ supplied in the metadata.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Predicting Resilient-Layer Performance](/phonometry/buildings/design/resilient-layers/):
@@ -508,3 +511,5 @@ supplied in the metadata.
   measurement sits among the materials guides.
 - API reference: [`materials.resilient.dynamic_stiffness`](/phonometry/reference/api/materials/dynamic-stiffness/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the mass-spring resonance the EN 29052-1 rig measures, seen as a mobility.
+
+</SeeAlso>

--- a/site/src/content/docs/materials/resilient/index.mdx
+++ b/site/src/content/docs/materials/resilient/index.mdx
@@ -5,6 +5,7 @@ description: "The mechanical property a floating floor is designed around: the d
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 A floating floor is a mass-spring system: the screed is the mass, the resilient
 layer is the spring, and the impact improvement the pair buys begins above the
@@ -47,6 +48,8 @@ lining rating.
   enclosed-gas term for air-permeable layers, the airflow-resistivity regimes
   of clause 8.2 and the clause 9 test-report fiche.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -55,6 +58,8 @@ Pages elsewhere on the site that this section leans on:
   ISO 9053 measurement of the lateral resistivity the regime rule needs.
 - [Predicting resilient-layer performance](/phonometry/buildings/design/resilient-layers/):
   the consumer, where s' becomes a floating-floor improvement.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/materials/surfaces/index.mdx
+++ b/site/src/content/docs/materials/surfaces/index.mdx
@@ -5,6 +5,7 @@ description: "Surfaces that have no sample: why a pavement is characterised wher
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 A reverberation-room or impedance-tube coefficient describes a *sample*. Some
 surfaces have no sample. A pavement cannot be cut out and carried to a
@@ -47,6 +48,8 @@ outdoor propagation model consumes.
   geometry and validity helpers, the ISO 13472-2 spot tube with its
   applicability limits, and the comparison that decides between them.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -57,6 +60,8 @@ Pages elsewhere on the site that this section leans on:
   the laboratory route, for materials that can be brought indoors.
 - [Environment and transport](/phonometry/environment/): where a road's
   absorption is consumed, as the ground term of an outdoor prediction.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/materials/surfaces/road-absorption.mdx
+++ b/site/src/content/docs/materials/surfaces/road-absorption.mdx
@@ -29,6 +29,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 How much sound a road surface absorbs decides how loud its traffic is, and a
@@ -662,6 +663,8 @@ operator's, and the library only sees the two arrays that come out of them.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Impedance Tube](/phonometry/materials/absorbers/impedance-tube/): the ISO 10534-2
@@ -677,3 +680,5 @@ operator's, and the library only sees the two arrays that come out of them.
   the absorption of the ground surface enters the propagation models.
 - API reference: [`materials.surfaces.road_absorption`](/phonometry/reference/api/materials/road-absorption/).
 - Theory: [In-situ road surface absorption](/phonometry/reference/theory/materials-surfaces/#in-situ-road-surface-absorption-iso-13472-1-iso-13472-2): the ISO 13472 subtraction and the geometry that makes an in-situ measurement possible at all.
+
+</SeeAlso>

--- a/site/src/content/docs/perception/hearing/hearing-threshold.mdx
+++ b/site/src/content/docs/perception/hearing/hearing-threshold.mdx
@@ -20,6 +20,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Two standards describe where the hearing threshold sits. **ISO 7029:2017**
@@ -362,6 +363,8 @@ implemented.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Noise-induced hearing loss](/phonometry/perception/hearing/noise-induced-hearing-loss/): the
@@ -374,3 +377,5 @@ implemented.
   daily exposure level that drives the noise component.
 - API reference: [`hearing.threshold`](/phonometry/reference/api/hearing/threshold/).
 - Theory: [Hearing thresholds and presbycusis](/phonometry/reference/theory/perception/#hearing-thresholds-and-presbycusis-iso-389-7-iso-7029): the ISO 389-7 reference thresholds and the ISO 7029 age statistics, and why the two are different quantities.
+
+</SeeAlso>

--- a/site/src/content/docs/perception/hearing/noise-induced-hearing-loss.mdx
+++ b/site/src/content/docs/perception/hearing/noise-induced-hearing-loss.mdx
@@ -32,6 +32,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 **ISO 1999:2013** estimates the hearing loss a population suffers from
@@ -505,6 +506,8 @@ supply and check it yourself.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Occupational noise exposure](/phonometry/perception/hearing/occupational-exposure/): the
@@ -518,3 +521,5 @@ supply and check it yourself.
   worker actually notices.
 - API reference: [`hearing.noise_induced_hearing_loss`](/phonometry/reference/api/hearing/noise-induced-hearing-loss/).
 - Theory: [Noise-induced hearing loss (ISO 1999)](/phonometry/reference/theory/perception/#noise-induced-hearing-loss-iso-1999): the ISO 1999 threshold-shift model, its median and its percentile spread.
+
+</SeeAlso>

--- a/site/src/content/docs/perception/hearing/occupational-exposure.mdx
+++ b/site/src/content/docs/perception/hearing/occupational-exposure.mdx
@@ -30,6 +30,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A working day is rarely measured in one take: the daily exposure level a
@@ -507,6 +508,8 @@ one rather than with a zero one.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Levels](/phonometry/signals/levels/levels/): the `lex_8h` / `sound_exposure` dose primitives
@@ -516,3 +519,5 @@ one rather than with a zero one.
 - [Theory](/phonometry/reference/theory/environment-transport/): the derivation of the strategy formulas and the
   Annex C budget.
 - API reference: [`hearing.occupational_exposure`](/phonometry/reference/api/hearing/occupational-exposure/).
+
+</SeeAlso>

--- a/site/src/content/docs/perception/psychoacoustics/advanced-loudness.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/advanced-loudness.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The Zwicker method of ISO 532-1 is the reference route to loudness in sones
@@ -547,6 +548,8 @@ conformance matters.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Loudness](/phonometry/perception/psychoacoustics/loudness/): the Zwicker reference method
@@ -556,6 +559,8 @@ conformance matters.
 - [Theory](/phonometry/reference/theory/perception/): the equations behind the loudness models.
 - API reference: [`psychoacoustics.loudness.moore_glasberg`](/phonometry/reference/api/psychoacoustics/moore-glasberg/), [`psychoacoustics.loudness.moore_glasberg_time`](/phonometry/reference/api/psychoacoustics/moore-glasberg-time/) and [`psychoacoustics.loudness.ecma`](/phonometry/reference/api/psychoacoustics/ecma/).
 - Theory: [Advanced loudness models and sound quality](/phonometry/reference/theory/perception/#advanced-loudness-models--sound-quality): what the Moore-Glasberg and Sottek models change relative to Zwicker, and why the three disagree where they do.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/perception/psychoacoustics/loudness.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/loudness.mdx
@@ -39,6 +39,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -436,6 +437,8 @@ expects one of the Table 1 frequencies.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Advanced Loudness (ISO 532-2/-3, ECMA-418-2)](/phonometry/perception/psychoacoustics/advanced-loudness/):
@@ -447,6 +450,8 @@ expects one of the Table 1 frequencies.
 - [Theory](/phonometry/reference/theory/perception/): the equations behind the loudness models.
 - API reference: [`psychoacoustics.loudness.zwicker`](/phonometry/reference/api/psychoacoustics/zwicker/) and [`psychoacoustics.loudness.contours`](/phonometry/reference/api/psychoacoustics/contours/).
 - Theory: [Zwicker loudness (ISO 532-1)](/phonometry/reference/theory/perception/#zwicker-loudness-iso-532-1): the specific-loudness integral of ISO 532-1 and the excitation pattern it runs over.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -31,6 +31,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 How *annoying* a sound is depends on more than how loud it is. Fastl & Zwicker,
@@ -425,6 +426,8 @@ Metrics](/phonometry/perception/psychoacoustics/sound-quality/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Loudness](/phonometry/perception/psychoacoustics/loudness/): the ISO 532-1
@@ -442,3 +445,5 @@ Metrics](/phonometry/perception/psychoacoustics/sound-quality/).
   is assessed with.
 - Theory: [Advanced loudness models and sound quality](/phonometry/reference/theory/perception/#advanced-loudness-models--sound-quality): the loudness and sound-quality metrics the annoyance model combines, derived one at a time.
 - API reference: [`psychoacoustics.quality.annoyance`](/phonometry/reference/api/psychoacoustics/annoyance/) and [`psychoacoustics.quality.fluctuation_strength`](/phonometry/reference/api/psychoacoustics/fluctuation-strength/).
+
+</SeeAlso>

--- a/site/src/content/docs/perception/psychoacoustics/sound-quality.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/sound-quality.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Two sounds of equal loudness can still differ in how *sharp*, how *tonal*,
@@ -618,7 +619,11 @@ Annoyance](/phonometry/perception/psychoacoustics/psychoacoustic-annoyance/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - API reference: [`psychoacoustics.quality.sharpness`](/phonometry/reference/api/psychoacoustics/sharpness/), [`psychoacoustics.quality.tonality_ecma`](/phonometry/reference/api/psychoacoustics/tonality-ecma/), [`psychoacoustics.quality.roughness_ecma`](/phonometry/reference/api/psychoacoustics/roughness-ecma/) and [`psychoacoustics.quality.fluctuation_strength_ecma`](/phonometry/reference/api/psychoacoustics/fluctuation-strength-ecma/).
 - Theory: [Advanced loudness models and sound quality](/phonometry/reference/theory/perception/#advanced-loudness-models--sound-quality): the specific-loudness pattern the sharpness, roughness and fluctuation-strength metrics are all built on.
+
+</SeeAlso>

--- a/site/src/content/docs/perception/psychoacoustics/tone-audibility.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/tone-audibility.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A steady tone embedded in broadband noise stands out when it rises audibly above
@@ -578,6 +579,8 @@ weighting agnostic.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Environmental noise measurement](/phonometry/environment/assessment/environmental-levels/):
@@ -593,3 +596,5 @@ weighting agnostic.
   the neighbouring family of tone metrics, TNR and PR, derived from the same
   critical-band picture.
 - API reference: [`psychoacoustics.quality.tone_audibility`](/phonometry/reference/api/psychoacoustics/tone-audibility/).
+
+</SeeAlso>

--- a/site/src/content/docs/perception/psychoacoustics/tone-prominence.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/tone-prominence.mdx
@@ -20,6 +20,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Tonal components in machinery noise are far more annoying than their level
@@ -377,6 +378,8 @@ context) are not implemented here.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Environmental Levels](/phonometry/environment/assessment/environmental-levels/): the ISO 1996-1 rating levels and their Table A.1
@@ -393,4 +396,6 @@ context) are not implemented here.
 - [Theory](/phonometry/reference/theory/perception/): the critical-band model and criteria derivation.
 - API reference: [`psychoacoustics.quality.tonality`](/phonometry/reference/api/psychoacoustics/tonality/).
 - Theory: [Tone prominence: TNR and PR](/phonometry/reference/theory/perception/#tone-prominence-tnr-and-pr-ecma-418-1): the critical-band construction behind TNR and PR, and the criteria that make a tone prominent.
+
+</SeeAlso>
 

--- a/site/src/content/docs/perception/speech/objective-intelligibility.mdx
+++ b/site/src/content/docs/perception/speech/objective-intelligibility.mdx
@@ -34,6 +34,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 **STOI** and **ESTOI** are correlation-based objective intelligibility
@@ -455,6 +456,8 @@ above.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Speech Transmission Index](/phonometry/perception/speech/speech-transmission/): rates a
@@ -465,3 +468,5 @@ above.
   the front end groups the DFT into.
 - API reference: [`speech.objective_intelligibility`](/phonometry/reference/api/speech/objective-intelligibility/).
 - Theory: [Modulation transfer and STI](/phonometry/reference/theory/perception/#modulation-transfer-and-sti-iec-60268-16): the modulation-transfer derivation the intrusive measures on this page are compared against.
+
+</SeeAlso>

--- a/site/src/content/docs/perception/speech/speech-intelligibility.mdx
+++ b/site/src/content/docs/perception/speech/speech-intelligibility.mdx
@@ -25,6 +25,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The **Speech Intelligibility Index** predicts how much of a speech signal is
@@ -777,6 +778,8 @@ guide](/phonometry/perception/speech/speech-transmission/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Speech Transmission Index](/phonometry/perception/speech/speech-transmission/): the STI/STIPA
@@ -790,6 +793,8 @@ guide](/phonometry/perception/speech/speech-transmission/).
   spectrum-level inputs.
 - API reference: [`speech.sii`](/phonometry/reference/api/speech/sii/).
 - Theory: [Speech Intelligibility Index (ANSI S3.5)](/phonometry/reference/theory/perception/#speech-intelligibility-index-ansi-s35): the band-importance weighting of ANSI S3.5 and the audibility function it multiplies.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/perception/speech/speech-transmission.mdx
+++ b/site/src/content/docs/perception/speech/speech-transmission.mdx
@@ -24,6 +24,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -602,6 +603,8 @@ d), so there is nothing left to implement.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Room Acoustics](/phonometry/buildings/rooms/room-acoustics/): the measured impulse response the
@@ -616,3 +619,5 @@ d), so there is nothing left to implement.
   mapping.
 - API reference: [`speech.sti`](/phonometry/reference/api/speech/sti/).
 - Theory: [Modulation transfer and STI](/phonometry/reference/theory/perception/#modulation-transfer-and-sti-iec-60268-16): the modulation transfer function, why m is a ratio of modulation depths, and how the octave-band m matrix collapses to one index.
+
+</SeeAlso>

--- a/site/src/content/docs/signals/filters/block-processing.mdx
+++ b/site/src/content/docs/signals/filters/block-processing.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Some measurements never fit in memory: an hour-long environmental recording,
@@ -401,6 +402,8 @@ describes.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Filter Banks](/phonometry/signals/filters/filter-banks/): the offline bank streaming reproduces bit for bit, and the `zero_phase` mode streaming cannot use.
@@ -409,3 +412,5 @@ describes.
 - [Integrated and Statistical Levels](/phonometry/signals/levels/levels/): which metrics accumulate across blocks and which must be recomputed on the pooled envelope.
 - API reference: [`filters.weighting`](/phonometry/reference/api/filters/weighting/) and [`filters.core`](/phonometry/reference/api/filters/core/).
 - Theory: [Filter Bank Design and Numerical Stability](/phonometry/reference/theory/signal-analysis/#filter-bank-design--numerical-stability): why a bank is designed as second-order sections and decimated per band, which is what makes streaming state possible at all.
+
+</SeeAlso>

--- a/site/src/content/docs/signals/filters/filter-banks.mdx
+++ b/site/src/content/docs/signals/filters/filter-banks.mdx
@@ -49,6 +49,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 phonometry supports several filter types, each with its own transfer function
@@ -621,6 +622,8 @@ edge comfortably below Nyquist or raise `fs`, and confirm the margin with
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Filter Architecture Gallery](/phonometry/signals/filters/filter-gallery/): the
@@ -631,6 +634,8 @@ edge comfortably below Nyquist or raise `fs`, and confirm the margin with
   designed here.
 - API reference: [`phonometry`](/phonometry/reference/api/filters/phonometry/), [`filters.core`](/phonometry/reference/api/filters/core/) and [`filters.weighting`](/phonometry/reference/api/filters/weighting/).
 - Theory: [Octave Band Frequencies](/phonometry/reference/theory/signal-analysis/#octave-band-frequencies-ansi-s111--iec-61260): where the base-10 midband grid and the band edges come from, and why the bank is designed on them rather than on nominal labels.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/filters/filter-compliance.mdx
+++ b/site/src/content/docs/signals/filters/filter-compliance.mdx
@@ -43,6 +43,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A filter bank becomes a measuring instrument only once its bands have been
@@ -450,6 +451,8 @@ Nyquist or raise `fs`.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Filter Banks](/phonometry/signals/filters/filter-banks/): the band mathematics and
@@ -465,6 +468,8 @@ Nyquist or raise `fs`.
 - API reference:
   [`filters.compliance`](/phonometry/reference/api/filters/compliance/).
 - Theory: [Octave Band Frequencies](/phonometry/reference/theory/signal-analysis/#octave-band-frequencies-ansi-s111--iec-61260): the band-edge definitions the IEC 61260-1 mask is drawn around.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/filters/filter-gallery.mdx
+++ b/site/src/content/docs/signals/filters/filter-gallery.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Choosing a filter architecture is a trade-off: selectivity, passband ripple
@@ -508,6 +509,8 @@ Verification](/phonometry/signals/filters/filter-compliance/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Filter Banks](/phonometry/signals/filters/filter-banks/): the band mathematics,
@@ -518,6 +521,8 @@ Verification](/phonometry/signals/filters/filter-compliance/).
   architectures.
 - API reference: [`phonometry`](/phonometry/reference/api/filters/phonometry/) and [`filters.core`](/phonometry/reference/api/filters/core/).
 - Theory: [Magnitude Responses](/phonometry/reference/theory/signal-analysis/#magnitude-responses): what a magnitude response is as a complex transfer function, and how the five architectures differ before any band is filtered.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/filters/multichannel.mdx
+++ b/site/src/content/docs/signals/filters/multichannel.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Most real measurement sessions produce more than one channel: the two ears
@@ -328,6 +329,8 @@ multiple-input models.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Correlation and delay](/phonometry/signals/spectra/correlation-delay/): the cross-channel time-domain questions (delay, alignment) the per-channel path deliberately leaves to you.
@@ -335,3 +338,5 @@ multiple-input models.
 - [Block Processing](/phonometry/signals/filters/block-processing/): the streaming counterpart, with one filter state per channel.
 - [Levels](/phonometry/signals/levels/levels/): the per-channel level metrics, and why dB values are combined energetically.
 - API reference: [`phonometry`](/phonometry/reference/api/filters/phonometry/) and [`filters.core`](/phonometry/reference/api/filters/core/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/levels/index.mdx
+++ b/site/src/content/docs/signals/levels/index.mdx
@@ -5,6 +5,7 @@ description: "From weighted signal to reported number: the IEC 61672-1 frequency
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 A sound level meter does three things to a calibrated signal, in order: it
 **weights it in frequency** to mimic the ear's sensitivity, it **smooths it in
@@ -65,6 +66,8 @@ noise phases, and the limit tables an activity is judged against.
 - [Integrated and Statistical Levels](/phonometry/signals/levels/levels/): Leq and
   LAeq, percentile levels, LCpeak/SEL, noise dose and octave spectrograms.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -75,6 +78,8 @@ Pages elsewhere on the site that this section leans on:
 - [Spanish Noise Regulation (RD 1367/2007)](/phonometry/environment/assessment/spanish-noise-regulation/):
   the corrected level LKeq, the Kt/Kf/Ki corrections, the evaluation periods
   and noise phases, and the limit tables.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/signals/levels/levels.mdx
+++ b/site/src/content/docs/signals/levels/levels.mdx
@@ -36,6 +36,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A noise measurement rarely ends with a waveform: it ends with a handful of
@@ -828,6 +829,8 @@ are here, not the newer one.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Environmental Levels (ISO 1996-1/-2)](/phonometry/environment/assessment/environmental-levels/): the $L_\mathrm{den}$/$L_\mathrm{dn}$ indicators, rating levels and the ISO 1996-2 determination chain built on the levels of this page.
@@ -837,6 +840,8 @@ are here, not the newer one.
 - [Multichannel and Performance](/phonometry/signals/filters/multichannel/): per-channel levels and how to combine them energetically.
 - API reference: [`signals.levels`](/phonometry/reference/api/signals/levels/).
 - Theory: [Event and dose metrics](/phonometry/reference/theory/signal-analysis/#event-and-dose-metrics): the energy definitions behind Leq, SEL and the exposure quantities, and how the percentile levels relate to them.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/levels/special-weightings.mdx
+++ b/site/src/content/docs/signals/levels/special-weightings.mdx
@@ -40,6 +40,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Beyond A, C and Z, the weighting family keeps four special-purpose curves,
@@ -385,6 +386,8 @@ levels instead of D).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Frequency Weighting](/phonometry/signals/levels/weighting/): the A, C and Z
@@ -392,6 +395,8 @@ levels instead of D).
   verification these curves build on.
 - API reference: [`filters.weighting`](/phonometry/reference/api/filters/weighting/) and [`filters.compliance`](/phonometry/reference/api/filters/compliance/).
 - Theory: [G-weighting (ISO 7196)](/phonometry/reference/theory/signal-analysis/#g-weighting-iso-7196): the G curve of ISO 7196 and where its normalisation comes from.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/levels/time-weighting.mdx
+++ b/site/src/content/docs/signals/levels/time-weighting.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -429,6 +430,8 @@ built on the Impulse weighting here.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Levels](/phonometry/signals/levels/levels/): the percentile levels defined on the detector's output, and the integrated metrics that bypass it.
@@ -440,3 +443,5 @@ built on the Impulse weighting here.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): the IEC 61672-3 periodic tests, in which these ballistics are spot-checked against the class limits on a real instrument.
 - API reference: [`filters.weighting`](/phonometry/reference/api/filters/weighting/).
 - Theory: [Time Integration](/phonometry/reference/theory/signal-analysis/#time-integration): the first-order equation the exponential detectors solve, and what integrating it over a fixed block instead would change.
+
+</SeeAlso>

--- a/site/src/content/docs/signals/levels/weighting.mdx
+++ b/site/src/content/docs/signals/levels/weighting.mdx
@@ -37,6 +37,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Frequency weighting curves simulate the human ear's sensitivity. This guide
@@ -578,6 +579,8 @@ verification of B and AU against their tolerance tables, have their own guide:
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Special Weightings (G, B, D, AU)](/phonometry/signals/levels/special-weightings/):
@@ -585,6 +588,8 @@ verification of B and AU against their tolerance tables, have their own guide:
   in the presence of ultrasound.
 - API reference: [`filters.weighting`](/phonometry/reference/api/filters/weighting/) and [`filters.compliance`](/phonometry/reference/api/filters/compliance/).
 - Theory: [Weighting Curves (IEC 61672-1)](/phonometry/reference/theory/signal-analysis/#weighting-curves-iec-61672-1): the pole-zero definition of the A, C and Z curves and the bilinear warping the fitted design cancels.
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/metrology/calibration.mdx
+++ b/site/src/content/docs/signals/metrology/calibration.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Every level this library reports is only as trustworthy as the one number
@@ -667,6 +668,8 @@ standard and makes no physical claim.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Build a sound level meter](/phonometry/signals/sound-level-meter/): the walkthrough that starts from this calibration step and ends at a class-checked instrument.
@@ -674,6 +677,8 @@ standard and makes no physical claim.
 - [Multichannel and Performance](/phonometry/signals/filters/multichannel/): one sensitivity per channel when the channels differ.
 - [GUM uncertainty](/phonometry/signals/metrology/gum-uncertainty/): propagating the calibrator tolerance and drift bound into a level's uncertainty.
 - API reference: [`metrology.calibration`](/phonometry/reference/api/metrology/calibration/) and [`phonometry`](/phonometry/reference/api/filters/phonometry/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/signals/metrology/compliance-verification.mdx
@@ -56,6 +56,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import { totalChecks, domains, standards } from '../../../../data/conformance-stats.mjs';
 
@@ -364,6 +365,8 @@ physical instrument is assigned a class.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Frequency Weighting](/phonometry/signals/levels/weighting/): the A/C/Z
@@ -381,6 +384,8 @@ physical instrument is assigned a class.
 - API reference: [`filters.compliance`](/phonometry/reference/api/filters/compliance/),
   [`filters.weighting_compliance`](/phonometry/reference/api/filters/weighting-compliance/)
   and [`emission.intensity_compliance`](/phonometry/reference/api/power/intensity-compliance/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/signals/metrology/data-qualification.mdx
+++ b/site/src/content/docs/signals/metrology/data-qualification.mdx
@@ -34,6 +34,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Every average in this documentation - a [PSD](/phonometry/signals/spectra/spectral-analysis/), a
@@ -680,6 +681,8 @@ book describes them, outside this module.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Spectral analysis](/phonometry/signals/spectra/spectral-analysis/): the chi-square confidence interval that assumes the stationarity this page tests.
@@ -688,3 +691,5 @@ book describes them, outside this module.
 - [Levels](/phonometry/signals/levels/levels/): the $L_\mathrm{eq}$ whose definition assumes one stationary measurement.
 - API reference: [`metrology.data_qualification`](/phonometry/reference/api/metrology/data-qualification/).
 - Theory: [Measurement uncertainty (GUM)](/phonometry/reference/theory/signal-analysis/#measurement-uncertainty-isoiec-guide-98-3-gum-and-supplement-1): the uncertainty framework the qualification criteria of this page feed.
+
+</SeeAlso>

--- a/site/src/content/docs/signals/metrology/gum-uncertainty.mdx
+++ b/site/src/content/docs/signals/metrology/gum-uncertainty.mdx
@@ -31,6 +31,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Every measurement result is incomplete without a statement of its uncertainty.
@@ -466,9 +467,13 @@ implemented on their own pages, listed above, and are not derived here.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Data qualification](/phonometry/signals/metrology/data-qualification/): the stationarity checks every averaged input silently assumes.
 - [Calibration](/phonometry/signals/metrology/calibration/): the tolerance and drift inputs of every calibrated chain.
 - API reference: [`metrology.uncertainty`](/phonometry/reference/api/metrology/uncertainty/).
 - Theory: [Measurement uncertainty (GUM)](/phonometry/reference/theory/signal-analysis/#measurement-uncertainty-isoiec-guide-98-3-gum-and-supplement-1): the law of propagation of uncertainty, the coverage factor and where the Monte Carlo supplement takes over.
+
+</SeeAlso>

--- a/site/src/content/docs/signals/sound-level-meter.mdx
+++ b/site/src/content/docs/signals/sound-level-meter.mdx
@@ -27,6 +27,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 import Video from '../../../components/Video.astro';
 
@@ -413,6 +414,8 @@ what `sensitivity()` does and does not check.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 The meter built here is the trunk; the rest of the core grows from it.
@@ -431,3 +434,5 @@ The meter built here is the trunk; the rest of the core grows from it.
   [`signals.levels`](/phonometry/reference/api/signals/levels/),
   [`phonometry`](/phonometry/reference/api/filters/phonometry/) and
   [`filters.compliance`](/phonometry/reference/api/filters/compliance/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/cepstrum-echoes.mdx
+++ b/site/src/content/docs/signals/spectra/cepstrum-echoes.mdx
@@ -28,6 +28,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The [spectral estimators](/phonometry/signals/spectra/spectral-analysis/) describe *what
@@ -593,6 +594,8 @@ spectrum only.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Correlation, time delay and envelope](/phonometry/signals/spectra/correlation-delay/): the Hilbert envelope this page transforms into a spectrum.
@@ -601,3 +604,5 @@ spectrum only.
 - [Machine fault frequencies](/phonometry/vibration/machinery/machine-diagnostics/): the bearing and gear families read off exactly this envelope spectrum.
 - [Swept-sine distortion](/phonometry/devices/electroacoustics/swept-sine-distortion/): the minimum-phase folding that shares this page's core.
 - API reference: [`signals.cepstrum`](/phonometry/reference/api/signals/cepstrum/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/correlation-delay.mdx
+++ b/site/src/content/docs/signals/spectra/correlation-delay.mdx
@@ -24,6 +24,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Where the [calibrated spectral estimators](/phonometry/signals/spectra/spectral-analysis/) describe a
@@ -519,6 +520,8 @@ solver.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Cepstrum, echoes and the envelope spectrum](/phonometry/signals/spectra/cepstrum-echoes/): the reference-free route to a delay, and the envelope this page constructs.
@@ -526,3 +529,5 @@ solver.
 - [Test signals](/phonometry/signals/spectra/test-signals/): the band-limited fractional-delay kernel behind the sub-sample alignment.
 - [Time synchronous averaging](/phonometry/signals/spectra/synchronous-averaging/): the same alignment applied per revolution.
 - API reference: [`signals.correlation`](/phonometry/reference/api/signals/correlation/) and [`signals.envelope`](/phonometry/reference/api/signals/envelope/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/index.mdx
+++ b/site/src/content/docs/signals/spectra/index.mdx
@@ -5,6 +5,7 @@ description: "Frequency- and time-domain signal analysis in phonometry: calibrat
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 Band levels answer *how much*; this section answers *what is in the signal*.
 Where the rest of the core works in fractional octave bands, these pages work
@@ -151,6 +152,8 @@ supply the error-analysis vocabulary the estimates are stated in.
   spectrum by group-delay shaping, and the Kirkeby-regularized inversion
   of a measured response.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -160,6 +163,8 @@ Pages elsewhere on the site that this section leans on:
   Karczub Section 8.4) drawn on top of a measured envelope spectrum: bearing
   BPFO, BPFI, BSF and cage frequencies, gear-mesh sidebands, induction-motor
   slip, pole-pass and rotor-slot harmonics, and blade-passing tones.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/signals/spectra/miso-coherence.mdx
+++ b/site/src/content/docs/signals/spectra/miso-coherence.mdx
@@ -14,6 +14,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 When several partially correlated sources drive one response, the ordinary
@@ -332,9 +333,13 @@ outputs needs one `miso_coherence` call per output.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Spectral analysis](/phonometry/signals/spectra/spectral-analysis/): the single-input coherent output spectrum this page generalizes, and the shared Welch core.
 - [Correlation and delay](/phonometry/signals/spectra/correlation-delay/): estimating and removing the bulk delays that bias coherence low.
 - [Multichannel and Performance](/phonometry/signals/filters/multichannel/): the per-channel path this cross-channel analysis complements.
 - API reference: [`signals.miso`](/phonometry/reference/api/signals/miso/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/spectral-analysis.mdx
+++ b/site/src/content/docs/signals/spectra/spectral-analysis.mdx
@@ -51,6 +51,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A spectrum without its uncertainty is half a measurement. This page covers the
@@ -832,6 +833,8 @@ against.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Data qualification](/phonometry/signals/metrology/data-qualification/): the stationarity every chi-square interval on this page assumes.
@@ -841,3 +844,5 @@ against.
 - [Levels](/phonometry/signals/levels/levels/): the band-level side of the density/band conversion of section 4.
 - API reference: [`signals.spectra`](/phonometry/reference/api/signals/spectra/), [`signals.windows`](/phonometry/reference/api/signals/windows/) and [`signals.multitaper`](/phonometry/reference/api/signals/multitaper/).
 - Theory: [Frequency Resolution vs FFT Bin Spacing](/phonometry/reference/theory/signal-analysis/#frequency-resolution-vs-fft-bin-spacing): why the bin spacing of an FFT is not the resolution of the estimate, and what the window does to both.
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/synchronous-averaging.mdx
+++ b/site/src/content/docs/signals/spectra/synchronous-averaging.mdx
@@ -16,6 +16,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A rotating machine repeats its signature once per revolution. Buried in
@@ -386,6 +387,8 @@ there is no compliance clause to check the implementation against.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Cepstrum and echoes](/phonometry/signals/spectra/cepstrum-echoes/): reference-free detection of harmonic and sideband families, and the envelope spectrum.
@@ -393,3 +396,5 @@ there is no compliance clause to check the implementation against.
 - [Test signals](/phonometry/signals/spectra/test-signals/): the fractional-delay kernel the non-integer period alignment uses.
 - [Machine fault frequencies](/phonometry/vibration/machinery/machine-diagnostics/): the bearing and gear families the residual's envelope spectrum is read against.
 - API reference: [`signals.synchronous_average`](/phonometry/reference/api/signals/synchronous-average/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/system-measurement.mdx
+++ b/site/src/content/docs/signals/spectra/system-measurement.mdx
@@ -43,6 +43,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The [room-acoustics guide](/phonometry/buildings/rooms/room-acoustics/) recovers
@@ -592,6 +593,8 @@ single-channel, scalar case of their Eq. 17.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Room acoustics](/phonometry/buildings/rooms/room-acoustics/): the ISO 18233 sweep and MLS excitations the Golay pair sits beside.
@@ -600,3 +603,5 @@ single-channel, scalar case of their Eq. 17.
 - [Calibrated spectral analysis](/phonometry/signals/spectra/spectral-analysis/): the Welch machinery that verifies the shaped sweep, and the smoothing the inversion wants first.
 - [Correlation and delay](/phonometry/signals/spectra/correlation-delay/): the loopback measurement that aligns the two Golay records.
 - API reference: [`signals.inversion`](/phonometry/reference/api/signals/inversion/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/test-signals.mdx
+++ b/site/src/content/docs/signals/spectra/test-signals.mdx
@@ -21,6 +21,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A measurement is only as trustworthy as its stimulus and its sample-rate
@@ -325,6 +326,8 @@ accuracy claims are closed-form, not normative.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Time Weighting](/phonometry/signals/levels/time-weighting/): the detector ballistics the tone bursts exercise (IEC 61672-1 Table 4).
@@ -334,3 +337,5 @@ accuracy claims are closed-form, not normative.
 - [Room acoustics](/phonometry/buildings/rooms/room-acoustics/): the MLS and exponential-sweep excitations of the family portrait, as ISO 18233 uses them.
 - [System measurement](/phonometry/signals/spectra/system-measurement/): the Golay pair and the shaped sweep, the other two members of the family.
 - API reference: [`signals.test_signals`](/phonometry/reference/api/signals/test-signals/).
+
+</SeeAlso>

--- a/site/src/content/docs/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/signals/spectra/time-frequency.mdx
@@ -24,6 +24,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 A stationary spectrum hides everything that happens *in time*: a passing
@@ -348,6 +349,8 @@ estimators, not a certification standard.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Spectral analysis](/phonometry/signals/spectra/spectral-analysis/): the averaged Welch estimate for the stationary background, and the window figures of merit behind the segment taper.
@@ -355,3 +358,5 @@ estimators, not a certification standard.
 - [Correlation and delay](/phonometry/signals/spectra/correlation-delay/): the Hilbert instantaneous frequency for tracking one component.
 - API reference: [`signals.time_frequency`](/phonometry/reference/api/signals/time-frequency/).
 - Theory: [Frequency Resolution vs FFT Bin Spacing](/phonometry/reference/theory/signal-analysis/#frequency-resolution-vs-fft-bin-spacing): the bin spacing against the effective resolution, which is the trade this page spends its whole length on.
+
+</SeeAlso>

--- a/site/src/content/docs/simulation/elastic-waves.mdx
+++ b/site/src/content/docs/simulation/elastic-waves.mdx
@@ -50,6 +50,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 import Video from '../../../components/Video.astro';
 
@@ -734,6 +735,8 @@ dedicated closed-form oracle here.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [2D FDTD wave simulation](/phonometry/simulation/fdtd-simulation/): the
@@ -749,6 +752,8 @@ dedicated closed-form oracle here.
   the fluid-bottom Rayleigh reflection model whose missing shear physics §5
   quantifies.
 - API reference: [`simulation.elastic-fdtd`](/phonometry/reference/api/simulation/elastic-fdtd/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/simulation/fdtd-simulation.mdx
+++ b/site/src/content/docs/simulation/fdtd-simulation.mdx
@@ -38,6 +38,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 import Video from '../../../components/Video.astro';
 
@@ -1023,6 +1024,8 @@ coupling](/phonometry/simulation/elastic-waves/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Elastic waves and fluid-solid coupling](/phonometry/simulation/elastic-waves/):
@@ -1032,6 +1035,8 @@ coupling](/phonometry/simulation/elastic-waves/).
   validation anchors of section 6 run there.
 - API reference: [`simulation.fdtd`](/phonometry/reference/api/simulation/fdtd/),
   [`simulation.ntff`](/phonometry/reference/api/simulation/ntff/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/underwater/marine-mammal-exposure.mdx
+++ b/site/src/content/docs/underwater/marine-mammal-exposure.mdx
@@ -56,6 +56,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 
 A marine mammal does not hear every frequency equally, so an underwater noise
@@ -627,6 +628,8 @@ propagation](/phonometry/underwater/underwater-propagation/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Underwater acoustics: radiated noise and pile driving](/phonometry/underwater/underwater-acoustics/):
@@ -636,3 +639,5 @@ propagation](/phonometry/underwater/underwater-propagation/).
   the propagation loss and figure-of-merit machinery that turns a criterion
   into a range.
 - API reference: [`underwater.bioacoustics.weighting`](/phonometry/reference/api/underwater/weighting/) and [`underwater.bioacoustics.audiograms`](/phonometry/reference/api/underwater/audiograms/).
+
+</SeeAlso>

--- a/site/src/content/docs/underwater/underwater-acoustics.mdx
+++ b/site/src/content/docs/underwater/underwater-acoustics.mdx
@@ -48,6 +48,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 
 Underwater sound is referenced to **1 µPa** (not the 20 µPa of airborne
@@ -459,6 +460,8 @@ phonometry.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Marine-mammal noise exposure](/phonometry/underwater/marine-mammal-exposure/):
@@ -470,3 +473,5 @@ phonometry.
   sonar equation they feed.
 - API reference: [`underwater.acoustics`](/phonometry/reference/api/underwater/acoustics/), [`underwater.sources.pile_driving_noise`](/phonometry/reference/api/underwater/pile-driving-noise/) and [`underwater.sources.ship_radiated_noise`](/phonometry/reference/api/underwater/ship-radiated-noise/).
 - General underwater propagation modelling (ray, normal mode, parabolic equation) is covered in [Underwater propagation solvers](/phonometry/underwater/underwater-solvers/).
+
+</SeeAlso>

--- a/site/src/content/docs/underwater/underwater-propagation.mdx
+++ b/site/src/content/docs/underwater/underwater-propagation.mdx
@@ -161,6 +161,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 import Video from '../../../components/Video.astro';
 
@@ -1024,6 +1025,8 @@ solvers](/phonometry/underwater/underwater-solvers/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Underwater propagation solvers](/phonometry/underwater/underwater-solvers/):
@@ -1031,3 +1034,5 @@ solvers](/phonometry/underwater/underwater-solvers/).
   for the cases where these closed forms are not enough, and the
   model-selection guidance.
 - API reference: [`underwater.propagation.closed_form`](/phonometry/reference/api/underwater/closed-form/) and [`underwater.propagation.sound_speed`](/phonometry/reference/api/underwater/sound-speed/).
+
+</SeeAlso>

--- a/site/src/content/docs/underwater/underwater-solvers.mdx
+++ b/site/src/content/docs/underwater/underwater-solvers.mdx
@@ -31,6 +31,7 @@ references:
 
 import Scope from '../../../components/Scope.astro';
 import ScopeClaim from '../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../components/SeeAlso.astro';
 import ThemeImage from '../../../components/ThemeImage.astro';
 
 The closed-form propagation loss of
@@ -1183,6 +1184,8 @@ coupling](/phonometry/simulation/elastic-waves/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Underwater sound propagation](/phonometry/underwater/underwater-propagation/):
@@ -1198,6 +1201,8 @@ coupling](/phonometry/simulation/elastic-waves/).
   time-domain alternative behind the SOFAR ducting animation of the
   propagation guide.
 - API reference: [`underwater.propagation.numerical`](/phonometry/reference/api/underwater/numerical/).
+
+</SeeAlso>
 
 ## Quick answers
 

--- a/site/src/content/docs/vibration/human/human-vibration.mdx
+++ b/site/src/content/docs/vibration/human/human-vibration.mdx
@@ -78,6 +78,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Vibration transmitted to a person is evaluated with the same measurement chain
@@ -976,6 +977,8 @@ not substitute for.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Multiple Shock Vibration](/phonometry/vibration/human/multiple-shock-vibration/): where a record goes once its crest factor and its clause 6.3.3 ratios say the r.m.s. cannot describe it — the ISO 2631-5 spinal-response model, and the seat-pad acquisition this page's whole-body half points at.
@@ -983,3 +986,5 @@ not substitute for.
 - [Calibration](/phonometry/signals/metrology/calibration/): the before-and-after check of clause 6.3.1 and the traceability the fiche's `calibration` field records.
 - API reference: [`vibration.human.exposure`](/phonometry/reference/api/vibration/exposure/).
 - Theory: [Human vibration](/phonometry/reference/theory/vibration/#human-vibration-iso-8041-1-iso-2631-12-iso-5349-12-directive-200244ec): the frequency weightings of ISO 2631-1 and ISO 5349-1, and the running r.m.s., VDV and MTVV definitions.
+
+</SeeAlso>

--- a/site/src/content/docs/vibration/human/multiple-shock-vibration.mdx
+++ b/site/src/content/docs/vibration/human/multiple-shock-vibration.mdx
@@ -28,6 +28,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Vibration that contains repeated **mechanical shocks** (off-road vehicles,
@@ -518,8 +519,12 @@ boundaries, offset-corrected, tapered and band-limited.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Human Vibration](/phonometry/vibration/human/human-vibration/): the ISO 2631-1 chain this page hands back to for the horizontal axes, and the crest factor and clause 6.3.3 ratios that decide whether a record belongs here at all.
 - API reference: [`vibration.human.multiple_shock`](/phonometry/reference/api/vibration/multiple-shock/).
 - Theory: [Multiple shocks (ISO 2631-5)](/phonometry/reference/theory/vibration/#multiple-shocks-iso-2631-5): the ISO 2631-5 response model, the acceleration dose and the Weibull risk law.
+
+</SeeAlso>

--- a/site/src/content/docs/vibration/machinery/index.mdx
+++ b/site/src/content/docs/vibration/machinery/index.mdx
@@ -5,6 +5,7 @@ description: "Reading a machine from its vibration: the kinematic bearing, gear,
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 A rotating machine has a **kinematic signature**. Every periodicity in its
 vibration belongs to something that turns, meshes or passes, and the geometry
@@ -43,6 +44,8 @@ computes the families and draws them on a measured envelope spectrum.
   harmonics, and the blade-passing tones of fans, blowers and pumps, all from
   the geometry and the shaft speed (Norton & Karczub, Section 8.4).
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -57,6 +60,8 @@ Pages elsewhere on the site that this section leans on:
   method rings.
 - [Bending-wave transmission at plate junctions](/phonometry/vibration/structural/junction-transmission/):
   where the machine's vibration goes once it has left the machine.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/vibration/machinery/machine-diagnostics.mdx
+++ b/site/src/content/docs/vibration/machinery/machine-diagnostics.mdx
@@ -14,6 +14,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Condition monitoring begins with arithmetic, not with signal processing. Every
@@ -562,6 +563,8 @@ by the pole count.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Cepstrum, echoes and the envelope spectrum](/phonometry/signals/spectra/cepstrum-echoes/): the
@@ -574,3 +577,5 @@ by the pole count.
 - [Bending-wave transmission at plate junctions](/phonometry/vibration/structural/junction-transmission/): what
   happens to the vibration once it leaves the machine.
 - API reference: [`vibration.machinery.diagnostics`](/phonometry/reference/api/vibration/diagnostics/).
+
+</SeeAlso>

--- a/site/src/content/docs/vibration/structural/index.mdx
+++ b/site/src/content/docs/vibration/structural/index.mdx
@@ -5,6 +5,7 @@ description: "The chain from a vibrating machine to the noise heard rooms away: 
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 
 A machine fixed to a building radiates sound twice: directly from its own
 vibrating surface, and indirectly by injecting **structure-borne power** into
@@ -64,6 +65,8 @@ which is where this section meets the
 - [Transfer stiffness of resilient elements (ISO 10846)](/phonometry/vibration/structural/transfer-stiffness/):
   dynamic transfer stiffness of isolators by the direct and indirect methods.
 
+<SeeAlso>
+
 ## See also
 
 Pages elsewhere on the site that this section leans on:
@@ -74,6 +77,8 @@ Pages elsewhere on the site that this section leans on:
   the reception-plate method and plate-independent source quantities.
 - [Installed structure-borne sound (EN 12354-5)](/phonometry/buildings/design/installed-structure-borne/):
   the predicted receiving-room level from installed equipment.
+
+</SeeAlso>
 
 ## What this section does not cover
 

--- a/site/src/content/docs/vibration/structural/junction-transmission.mdx
+++ b/site/src/content/docs/vibration/structural/junction-transmission.mdx
@@ -35,6 +35,7 @@ references:
 
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 import Video from '../../../../components/Video.astro';
 
@@ -611,6 +612,8 @@ consistency check the reader performs rather than one the library automates.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Predicting Sound Insulation (EN 12354)](/phonometry/buildings/design/insulation-prediction/):
@@ -624,3 +627,5 @@ consistency check the reader performs rather than one the library automates.
   the plate mobilities behind the wave parameters.
 - API reference: [`vibration.structural.junction_transmission`](/phonometry/reference/api/vibration/junction-transmission/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the mobility picture behind a junction, and the radiation efficiency each element carries.
+
+</SeeAlso>

--- a/site/src/content/docs/vibration/structural/mechanical-mobility.mdx
+++ b/site/src/content/docs/vibration/structural/mechanical-mobility.mdx
@@ -29,6 +29,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 Mechanical **mobility** is the complex ratio of a velocity response to the
@@ -717,6 +718,8 @@ page](/phonometry/vibration/structural/transfer-stiffness/).
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Transfer stiffness of resilient elements (ISO 10846)](/phonometry/vibration/structural/transfer-stiffness/):
@@ -733,3 +736,5 @@ page](/phonometry/vibration/structural/transfer-stiffness/).
   the `transfer_function` and `coherence` estimators section 3 runs on.
 - API reference: [`vibration.structural.mechanical_mobility`](/phonometry/reference/api/vibration/mechanical-mobility/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the infinite-structure point mobilities and the radiation efficiency, and why they are averages a finite structure oscillates about.
+
+</SeeAlso>

--- a/site/src/content/docs/vibration/structural/transfer-stiffness.mdx
+++ b/site/src/content/docs/vibration/structural/transfer-stiffness.mdx
@@ -36,6 +36,7 @@ references:
 import ReportPreview from '../../../../components/ReportPreview.astro';
 import Scope from '../../../../components/Scope.astro';
 import ScopeClaim from '../../../../components/ScopeClaim.astro';
+import SeeAlso from '../../../../components/SeeAlso.astro';
 import ThemeImage from '../../../../components/ThemeImage.astro';
 
 The vibro-acoustic transfer property of a resilient element (a vibration
@@ -515,6 +516,8 @@ does not characterise them.
 </ScopeClaim>
 </Scope>
 
+<SeeAlso>
+
 ## See also
 
 - [Mechanical mobility and the FRF family (ISO 7626-1)](/phonometry/vibration/structural/mechanical-mobility/):
@@ -527,3 +530,5 @@ does not characterise them.
   turns it into a level in a receiving room.
 - API reference: [`vibration.structural.transfer_stiffness`](/phonometry/reference/api/vibration/transfer-stiffness/) and [`vibration.structural.mechanical_mobility`](/phonometry/reference/api/vibration/mechanical-mobility/).
 - Theory: [Point mobilities and radiation efficiency](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29): the mobility and impedance definitions the transfer stiffness is the reciprocal of.
+
+</SeeAlso>

--- a/site/src/styles/scope.css
+++ b/site/src/styles/scope.css
@@ -33,10 +33,11 @@
  * panel label in see-also.css, so the two panels read as one family.
  *
  * The section HEADING stays in the markdown, above the component and
- * outside it, for the reason see-also.css records: a heading that moves
- * into a component drops out of the table of contents and loses its
- * anchor. Framing prose that introduces the claims stays in the markdown
- * too. Everything INSIDE the component is a claim, and nothing else is;
+ * outside it, for the reason Scope.astro records: a heading a component
+ * RENDERS drops out of the table of contents and loses its anchor. One a
+ * component merely wraps keeps both, which is what lets SeeAlso.astro take
+ * its heading inside. Framing prose that introduces the claims stays in the
+ * markdown too. Everything INSIDE the component is a claim, and nothing else is;
  * that is the contract scripts/list_coverage_claims.py enumerates.
  *
  * All selectors are unlayered, so they win over Starlight's layered styles

--- a/site/src/styles/see-also.css
+++ b/site/src/styles/see-also.css
@@ -1,47 +1,56 @@
 /* ------------------------------------------------------------------ *
  * "See also", as a panel.
  *
- * Ninety-one guides end with a `## See also` section (`## Véase también` in
- * Spanish), always a heading followed by a list of links. Set in the body
- * typography it is indistinguishable from the sections that carry the actual
- * argument, so a reader scrolling to the end of a long page meets three
- * identically weighted H2s in a row.
+ * Guides end with a `## See also` section (`## Véase también` in Spanish),
+ * a heading, sometimes a sentence introducing it, and a list of links to
+ * related pages. Set in the body typography it is indistinguishable from the
+ * sections that carry the actual argument, so a reader scrolling to the end of
+ * a long page meets three identically weighted H2s in a row.
  *
- * Starlight's own answer would be an aside (`:::note`), and it is the wrong one
- * here: an aside's title is a plain <p>, so the section would drop out of the
- * table of contents and lose its anchor, and 182 pages of authored markdown
- * would have to be rewritten to get there. This keeps the markup exactly as it
- * is, heading and list, and styles the pair into one panel: the heading is
- * still an H2 with its own id, its hover anchor and its line in "On this page",
- * and the two elements are joined by giving the heading the top of the box and
- * the list the bottom.
+ * Starlight's own answer would be an aside (`:::note`), and it is the wrong
+ * one here: an aside's title is a plain <p>, so the section would drop out of
+ * the table of contents and lose its anchor. The heading therefore stays
+ * authored markdown, with its own id, its hover anchor and its line in "On
+ * this page", and src/components/SeeAlso.astro wraps the section so that the
+ * whole of it — heading, framing sentence and list — sits inside one element
+ * this sheet can draw a box around.
  *
- * Selected by heading id, which is derived from the heading text and so is
- * stable per language; both are listed. A page that says it another way simply
- * keeps the default rendering.
+ * It used to draw that box in two halves, giving the heading wrapper the top
+ * and an adjacent `+ ul` the bottom, which is why it only ever closed on the
+ * pages whose list ran straight on from the heading. The component records
+ * why that could not be fixed in CSS. Selecting the panel by class rather
+ * than by the heading's slug also drops this sheet's dependence on the two
+ * language-specific ids it used to list.
  *
  * The label is set like the rest of the instrument chrome, small and
  * monospaced, rather than at heading size: the panel itself is what announces
  * the section now, and a heading-sized title on a box of links is the weight
- * the complaint was about.
+ * the complaint was about. It is the same treatment as the legend in
+ * scope.css, so the two panels read as one family.
+ *
+ * All selectors are unlayered, so they win over Starlight's layered styles —
+ * including the `* + *` flow margins, which would otherwise space the panel's
+ * children as if they were still loose in the article.
  * ------------------------------------------------------------------ */
+
+.sl-markdown-content .see-also {
+  margin-top: 2.5rem;
+  padding: 0.7rem 1rem 0.85rem;
+  background: var(--ph-surface);
+  border: 1px solid var(--ph-border);
+  border-radius: var(--ph-radius);
+}
 
 /* The size goes on the wrapper, not on the heading: Starlight sizes the hover
    anchor icon in the wrapper's em, so a heading shrunk on its own gets an icon
    drawn for the size it used to be, sitting on top of its own last word. */
-.sl-markdown-content .sl-heading-wrapper:has(> h2#see-also),
-.sl-markdown-content .sl-heading-wrapper:has(> h2#véase-también) {
-  margin-top: 2.5rem;
-  padding: 0.7rem 1rem 0.1rem;
+.sl-markdown-content .see-also .sl-heading-wrapper {
+  margin-top: 0;
   font-size: var(--sl-text-xs);
-  background: var(--ph-surface);
-  border: 1px solid var(--ph-border);
-  border-bottom: 0;
-  border-radius: var(--ph-radius) var(--ph-radius) 0 0;
 }
 
-.sl-markdown-content .sl-heading-wrapper:has(> h2#see-also) > h2,
-.sl-markdown-content .sl-heading-wrapper:has(> h2#véase-también) > h2 {
+.sl-markdown-content .see-also .sl-heading-wrapper > h2 {
+  margin-top: 0;
   font-family: var(--ph-mono);
   font-size: inherit;
   font-weight: 600;
@@ -50,21 +59,25 @@
   color: var(--sl-color-gray-3);
 }
 
-.sl-markdown-content .sl-heading-wrapper:has(> h2#see-also) + ul,
-.sl-markdown-content .sl-heading-wrapper:has(> h2#véase-también) + ul {
-  margin-top: 0;
-  padding: 0.55rem 1rem 0.85rem 2.2rem;
-  background: var(--ph-surface);
-  border: 1px solid var(--ph-border);
-  border-top: 0;
-  border-radius: 0 0 var(--ph-radius) var(--ph-radius);
+/* The sentence some pages open the section with, and the list. One gap for
+   both, and it is the gap the panel had before the box became one element:
+   the label used to carry 0.1rem of padding below it and the list 0.55rem
+   above, so 0.65rem here leaves the two hundred and fourteen panels that
+   already closed correctly rendering pixel for pixel as they did. */
+.sl-markdown-content .see-also > p,
+.sl-markdown-content .see-also > ul {
+  margin-top: 0.65rem;
 }
 
-.sl-markdown-content .sl-heading-wrapper:has(> h2#see-also) + ul > li,
-.sl-markdown-content .sl-heading-wrapper:has(> h2#véase-también) + ul > li {
+.sl-markdown-content .see-also > ul {
+  margin-bottom: 0;
+  padding-inline-start: 1.2rem;
+}
+
+.sl-markdown-content .see-also > ul > li {
   line-height: 1.5;
 }
-.sl-markdown-content .sl-heading-wrapper:has(> h2#see-also) + ul > li + li,
-.sl-markdown-content .sl-heading-wrapper:has(> h2#véase-también) + ul > li + li {
+
+.sl-markdown-content .see-also > ul > li + li {
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
The "See also" box was drawn in two halves. A `:has()` rule painted the top on the heading wrapper, and a `+ ul` rule painted the bottom on whatever followed. Adjacent-sibling only matches when the list comes straight after the heading, so on every page that opens the section with a sentence the bottom half was never drawn at all and the border hung open. 214 pages looked right and 28 were broken, and which ones depended on whether an author had written an introductory line.

CSS alone cannot close this. There is no "until the next heading" combinator, so no selector can wrap a heading, an optional paragraph and a list as one block. Any rule that paints the bottom on `:is(p, ul)` just moves the seam.

So the section now has an element to be. `SeeAlso.astro` renders a `<nav>` with the heading inside it, which bounds the box explicitly at both ends and lets the styling stop guessing where the section ends. It wraps the heading rather than rendering it, so the id, the anchor link and the table of contents entry all survive: Astro collects headings from the MDX tree at compile time, and a heading a component renders would leave the table of contents, while one it wraps stays. The `<nav>` also carries `aria-labelledby`, so a screen reader announces the landmark by its own heading in the page language.

All 242 sections are migrated, both languages. This is mechanical apart from the component and the stylesheet.

Stack: this sits on top of #652.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

