### PR TITLE
Say what the deterministic weighting design actually costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,9 +144,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   anywhere else, and a plotted curve shifted by 0.0225 pt against a figure
   tolerance of 0.0175. The documentation figure job has also been failing
   intermittently on unchanged drawing code, and the figures it fails on are
-  drawn from this design, but that the one causes the other is inference: it
-  was never watched happening, and the failure could not be reproduced on a
-  developer machine under any kernel set selectable there.
+  drawn from this design. The coefficient difference behind that is reproduced
+  exactly, digest for digest, under emulated AVX512; what remains inference is
+  only the last step, because the same difference stays inside the image
+  comparison tolerance on a developer machine and crosses it on the runner.
 
   The test suite went with it. `tests/filters` failed on sixteen of those
   twenty-five settings, at the guard that stops an accuracy bound going slack,
@@ -154,10 +155,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the 0.0044 the guard asks for, than the bound was sized against. The guard
   is right and the measurement it read was not a function of the source.
 
-  The fit no longer asks a library to add anything up. Its reductions fold
-  their operands in half and add the halves elementwise, in an order the
-  module fixes, and the dozen-by-dozen system at the heart of each step is
-  eliminated in the module rather than by LAPACK. Two more places had the same
+  The fit no longer asks a library to add up anything that was found to move.
+  The reductions that feed each step fold their operands in half and add the
+  halves elementwise, in an order the module fixes, and the dozen-by-dozen
+  system at the heart of each step is eliminated in the module rather than by
+  LAPACK. The two sums that collect a factor group are still numpy's, because
+  they were measured not to differ on any kernel set including AVX512, and
+  taking them over moved all ninety-one designs for nothing. Two more places
+  had the same
   problem for a different reason: the printed curve the fit aims at, and the
   single read-back that sets the shipped gain, were complex expressions, and a
   complex multiply or magnitude fuses a multiply into an add where the CPU
@@ -167,10 +172,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   already fixed, dropping numpy to its baseline kernels still moved all
   ninety-one designs.
 
+  That was still not the whole of it, and finding the rest needed a processor
+  nobody here has. AMD does not ship AVX512 before Zen 4 and Intel dropped it
+  from the 12th generation onward, so the case that fails could not be run on
+  either machine this was developed on, and every measurement of it had been
+  taken on hardware that cannot fail that way. Intel's Software Development
+  Emulator runs it in software, and under it this machine returns the
+  continuous integration runner's digest byte for byte. Measured there,
+  numpy's `log`, `exp`, `tan`, `power`, `arctan`, `sin` and `log1p` each
+  answer differently from the same host running natively, while the standard
+  library's do not. Every transcendental on the design path is now taken from
+  `math` one element at a time.
+
+  The root of it then turned out to sit one line before the fit rather than
+  anywhere inside it. `numpy.geomspace` is `10 ** linspace(...)`, so the grid
+  every residual is evaluated on came out different and each step inherited
+  it. The grid is now built from numpy's own formula, term for term, with the
+  power taken elementwise and the endpoints pinned as `geomspace` pins them,
+  which returns the identical array where AVX512 is absent and therefore moved
+  no coefficient, figure or published value.
+
   Every design in the corpus is now identical bit for bit across sixty-five
   configurations: all twenty-seven OpenBLAS kernel sets, with and without
   numpy's dispatched kernels, six thread counts and five hash seeds. Two of
-  those kernel sets used to fault outright.
+  those kernel sets used to fault outright. It is also identical between this
+  machine and the same machine under emulated AVX512, which is the comparison
+  that had been failing.
 
   The accuracy is where the design already reached. Five of the seven curves
   move by less than 0.0003 dB, two of them downwards, and AU reads 0.0059 dB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   checked with the same function, so the check could not see an error in it;
   measured against a wider precision, the pin is now good to 1.6e-14 relative
   and `sosfreqz` is the thing that cannot read it, being out by 1.3e-10 at the
-  G weighting's 10 Hz reference frequency. A design costs about 150 ms, paid
+  G weighting's 10 Hz reference frequency. A design costs about 260 ms, paid
   once per curve, rate and mode.
 
 - The ANSI S1.4-1983 Table V Type 2 cell at 20 Hz is read as +/-3 dB. It
@@ -390,9 +390,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
   The third was speed. Weighting one minute of 44.1 kHz audio costs about
   18 ms where it cost 377 ms for A and 775 ms for 468, and holds 21 MB of
-  intermediates instead of 169 MB. The design itself costs about 70 ms and is
+  intermediates instead of 169 MB. The design itself costs about 260 ms and is
   cached per curve, rate and mode, so even a first call is quicker than the
-  path it replaces: 85 ms against 377 for A, 92 against 775 for 468.
+  path it replaces: about 280 ms against 377 for A, 285 against 775 for 468.
 
   `high_accuracy=False` keeps its old meaning: the plain bilinear transform of
   the printed prototype, the closed form a reader can check against the

--- a/docs/signals/levels/weighting.md
+++ b/docs/signals/levels/weighting.md
@@ -281,11 +281,11 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 70 ms and is cached per curve and sample rate, so it is
-  paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: 85 ms against 377 ms for A, and 92 ms against
-  775 ms for the 468 curve. Once the design is cached the filtering alone is
-  about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
+- The fit costs about 260 ms and is cached per curve and sample rate, so it
+  is paid once. Even including it, weighting one minute of 44.1 kHz audio is
+  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  against 775 ms for the 468 curve. Once the design is cached the filtering
+  alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 
 ```python
 import numpy as np

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -41968,11 +41968,11 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 70 ms and is cached per curve and sample rate, so it is
-  paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: 85 ms against 377 ms for A, and 92 ms against
-  775 ms for the 468 curve. Once the design is cached the filtering alone is
-  about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
+- The fit costs about 260 ms and is cached per curve and sample rate, so it
+  is paid once. Even including it, weighting one minute of 44.1 kHz audio is
+  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  against 775 ms for the 468 curve. Once the design is cached the filtering
+  alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 
 ```python
 import numpy as np

--- a/site/public/llms/llms-signals-levels.txt
+++ b/site/public/llms/llms-signals-levels.txt
@@ -385,11 +385,11 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 70 ms and is cached per curve and sample rate, so it is
-  paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: 85 ms against 377 ms for A, and 92 ms against
-  775 ms for the 468 curve. Once the design is cached the filtering alone is
-  about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
+- The fit costs about 260 ms and is cached per curve and sample rate, so it
+  is paid once. Even including it, weighting one minute of 44.1 kHz audio is
+  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  against 775 ms for the 468 curve. Once the design is cached the filtering
+  alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 
 ```python
 import numpy as np

--- a/site/src/content/docs/es/signals/levels/weighting.mdx
+++ b/site/src/content/docs/es/signals/levels/weighting.mdx
@@ -426,11 +426,12 @@ plt.show()
   `high_accuracy` son independientes, stateful usa por defecto el diseño
   ajustado como todo lo demás, y los bloques concatenados reproducen
   exactamente una llamada única.
-- El ajuste cuesta unos 70 ms y se cachea por curva y frecuencia de muestreo,
-  así que se paga una sola vez. Incluso contándolo, ponderar un minuto de
-  audio a 44,1 kHz es más rápido que antes: 85 ms frente a 377 ms para la A y
-  92 ms frente a 775 ms para la 468. Con el diseño ya cacheado, el filtrado
-  solo son unos 18 ms, y retiene 21 MB de intermedios en vez de 169 MB.
+- El ajuste cuesta unos 260 ms y se cachea por curva y frecuencia de
+  muestreo, así que se paga una sola vez. Incluso contándolo, ponderar un
+  minuto de audio a 44,1 kHz es más rápido que antes: unos 280 ms frente a
+  377 ms para la A y 285 ms frente a 775 ms para la 468. Con el diseño ya
+  cacheado, el filtrado solo son unos 18 ms, y retiene 21 MB de intermedios
+  en vez de 169 MB.
 
 ```python
 import numpy as np

--- a/site/src/content/docs/reference/api/filters/weighting.md
+++ b/site/src/content/docs/reference/api/filters/weighting.md
@@ -83,8 +83,9 @@ each of them used to be a documented limitation of this module:
 * one minute of 44.1 kHz audio costs about 18 ms instead of 377 ms for A and
   775 ms for 468, and holds 21 MB of intermediates instead of 169 MB
   (measured back to back in one process, mean of five runs). The design
-  itself costs about 130 ms and is cached, so even a first call is quicker
-  than the path it replaces.
+  itself costs about 260 ms and is cached, so even a first call is quicker
+  than the path it replaces: about 280 ms against 377 for A, 285 against
+  775 for 468.
 
 > Auto-generated from the source docstrings by `scripts/generate_api_docs.py` (`make api-docs`). Do not edit by hand.
 

--- a/site/src/content/docs/signals/levels/weighting.mdx
+++ b/site/src/content/docs/signals/levels/weighting.mdx
@@ -412,11 +412,11 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 70 ms and is cached per curve and sample rate, so it is
-  paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: 85 ms against 377 ms for A, and 92 ms against
-  775 ms for the 468 curve. Once the design is cached the filtering alone is
-  about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
+- The fit costs about 260 ms and is cached per curve and sample rate, so it
+  is paid once. Even including it, weighting one minute of 44.1 kHz audio is
+  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  against 775 ms for the 468 curve. Once the design is cached the filtering
+  alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 
 ```python
 import numpy as np

--- a/src/phonometry/filters/_weighting_design.py
+++ b/src/phonometry/filters/_weighting_design.py
@@ -39,9 +39,9 @@ output:
   fit did is legible. The corners the standard places low, where the warp is
   negligible, come back where they were printed: at 48 kHz the A weighting's
   double real pole at 20.598997 Hz comes back as a pair at
-  :math:`-20.5981 \pm 0.1905\,\mathrm{j}` Hz -- the same corner to five
+  :math:`-20.5981 \pm 0.1871\,\mathrm{j}` Hz -- the same corner to five
   digits, with a whisker of damping -- beside 107.657 for the printed
-  107.65265 and 737.268 for 737.86223. The corners near the top of the band
+  107.65265 and 737.269 for 737.86223. The corners near the top of the band
   move much further, and moving them is the whole point: that displacement is
   the warp being cancelled.
 * **The residual is in decibels.** The response enters only as

--- a/src/phonometry/filters/_weighting_design.py
+++ b/src/phonometry/filters/_weighting_design.py
@@ -152,10 +152,10 @@ _GRID_POINTS = 257
 #: Both are fixed budgets rather than convergence tests, so the routine always
 #: does the same arithmetic, and they are set where the accuracy curve
 #: flattens: measured over this corpus, raising them to 40 by 12 -- 2.4 times
-#: the work, about 310 ms per design instead of 130 -- moves the worst
-#: deviation of any (curve, rate) by at most 0.007 dB, and that one case (A at
-#: 32 kHz, 0.008 dB to 0.001 dB) is already two orders of magnitude inside the
-#: 0.05 dB its table is printed to.
+#: the work, about 610 ms per design instead of 260 -- moves no (curve, rate)
+#: fit by more than 0.013 dB (the largest, D at 12 kHz, from 0.020 to 0.008)
+#: and moves the corpus's worst, BS.468-4 at 48 kHz, from 0.062 only to 0.060,
+#: so the extra work buys nothing where the budget actually binds.
 _LM_STEPS = 25
 _LAWSON_ROUNDS = 8
 
@@ -1097,17 +1097,18 @@ def fit_prototype(
     are tried only if what comes back is further than :data:`_FIT_FAILED_DB`
     from the printed curve. Trying every start and keeping the lowest peak was
     measured and rejected, which is worth recording because on the face of it
-    it should win: the first start is beaten somewhere by a later one in 72 of
+    it should win: the first start is beaten somewhere by a later one in 74 of
     the 91 (curve, rate) pairs, and taking the best of all eight takes the peak
     deviation over the fit band from 0.062 dB to 0.035 across the corpus.
 
     What that criterion minimises is the wrong thing. The peak over the band
     weights every frequency alike; the masks these curves are graded against do
     not. BS.468-4's 6.3 kHz row is allowed 0.05 dB where its neighbours are
-    allowed ten to forty times as much, and at 44.1 kHz the lower-peak design
-    spends 62 % of that row against the 50 % this library holds itself to,
-    where the design kept here spends 13 % of it and 23 % of its worst row
-    anywhere. A criterion that cannot see the mask does not get the last word
+    allowed ten to forty times as much, and at 44.1 kHz that row is the worst
+    row of both designs: the lower-peak design spends 29 % of it where the
+    design kept here spends 21 %, so the start that wins the flat criterion
+    loses the one row the mask makes hardest. A criterion that cannot see the
+    mask does not get the last word
     over one that was chosen against it. It costs eight times the work as well,
     but that is not why it was refused.
 

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -515,8 +515,9 @@ def _weighting_sos(curve: str, fs: int, high_accuracy: bool) -> np.ndarray:
     standard in the corpus places a requirement at.
 
     The fit costs about 260 ms, which is why it is cached: it is paid once per
-    (curve, rate, mode), and it is still a third of what the resampled path
-    it replaces spent *filtering* one minute of audio. Where the first start
+    (curve, rate, mode), and it is still a third of the 775 ms the resampled
+    path it replaces spent *filtering* one minute of 468-weighted audio, and
+    about 70 % of the A curve's 377. Where the first start
     does not land close enough, the routine works through the other starts of
     :func:`~phonometry.filters._weighting_design._spare_placements` and the
     design takes about 3 s instead. That is common below about 2 kHz, and it

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -79,8 +79,9 @@ each of them used to be a documented limitation of this module:
 * one minute of 44.1 kHz audio costs about 18 ms instead of 377 ms for A and
   775 ms for 468, and holds 21 MB of intermediates instead of 169 MB
   (measured back to back in one process, mean of five runs). The design
-  itself costs about 130 ms and is cached, so even a first call is quicker
-  than the path it replaces.
+  itself costs about 260 ms and is cached, so even a first call is quicker
+  than the path it replaces: about 280 ms against 377 for A, 285 against
+  775 for 468.
 """
 
 from __future__ import annotations
@@ -513,12 +514,12 @@ def _weighting_sos(curve: str, fs: int, high_accuracy: bool) -> np.ndarray:
     library never actually applied, and the rates where they win are ones no
     standard in the corpus places a requirement at.
 
-    The fit costs about 130 ms, which is why it is cached: it is paid once per
-    (curve, rate, mode), and it is already a fifth of what the resampled path
+    The fit costs about 260 ms, which is why it is cached: it is paid once per
+    (curve, rate, mode), and it is still a third of what the resampled path
     it replaces spent *filtering* one minute of audio. Where the first start
     does not land close enough, the routine works through the other starts of
     :func:`~phonometry.filters._weighting_design._spare_placements` and the
-    design takes about 1.2 s instead. That is common below about 2 kHz, and it
+    design takes about 3 s instead. That is common below about 2 kHz, and it
     also happens at scattered rates inside the audio band: measured over every
     rate from 2 Hz to 200 kHz, 52 of them at or above 2 kHz take the retry, of
     which five are at or above 8 kHz -- 468 at nine rates between 45 and


### PR DESCRIPTION
The determinism fix for the weighting design multiplied its cost, and the tree kept quoting the old prices: about 70 ms in the guides, 130 ms in two docstrings, and 150 ms and 70 ms in two changelog entries under the same heading. This brings every quoted number to what the machine at rest actually measures, and records the cause where the cost is described.

The cause is the fix itself. Walking the fit's grids through scalar transcendentals is what makes the design identical on every CPU, and it is also what took a design from about 70 ms to about 260 (A 259, C 226, 468 273 at 48 kHz; CPU time, minimum of repeats). The changelog entry now says so, names the two reductions that were considered and rejected for it, and the docstring's two stale pole digits are corrected to what the fit returns.

Every measured claim around the design was rerun rather than scaled. The first-call comparison still wins, at its new price: about 280 ms against the 377 ms the resampled path spent weighting one minute of A, 285 against its 775 for 468, and 18 ms once the design is cached. The 40 by 12 budget comparison is about 610 ms against 260, still 2.4 times the work, its largest mover is now D at 12 kHz (0.020 dB to 0.008), and the corpus's worst fit, BS.468-4 at 48 kHz, moves from 0.062 dB only to 0.060, so the fixed budget stays where it was. The multi-start passage of fit_prototype now reads 74 of the 91 pairs, and the mask argument carries its remeasured percentages: at 44.1 kHz the 6.3 kHz row is the worst row of both candidate designs, 29 % of it for the lower-peak start against 21 % for the kept one. The retry path costs about 3 s, not 1.2.

Whether some of this cost can be won back without giving up the determinism is a separate question and stays open; this makes the prose stop answering it with numbers from before the question existed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Improved numerical stability and cross-platform consistency by replacing NumPy transcendental functions with standard library math functions in the weighting design path.</li>
<li>Fixed a bug in grid generation by replacing `numpy.geomspace` with a manual implementation to ensure identical results across different CPU architectures (specifically avoiding AVX512-related discrepancies).</li>
<li>Updated performance benchmarks and documentation to reflect increased design costs (from ~130ms to ~260ms) and improved filtering efficiency.</li>
<li>Refined the filter design optimization criteria to better align with mask requirements, ensuring the chosen start point performs better on critical rows.</li>
</ul></div>

## Summary by Sourcery

Ensure weighting designs are reproducible across CPU architectures and accurately document their performance, fit behavior, and design trade-offs.

Enhancements:
- Make the weighting design deterministic across CPU architectures by standardizing transcendental evaluation and grid generation.
- Refresh weighting-design benchmarks and optimization documentation to reflect the deterministic implementation’s actual cost and measured trade-offs.
- Correct documented fitted pole values and clarify the rationale for retaining the mask-aware design criterion.

Documentation:
- Update weighting guides, API documentation, localized documentation, docstrings, and changelog entries with remeasured design and filtering performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Frequency-weighting results are now reproducible across supported configurations, including emulated AVX512 environments.
  - Weighting output is bit-for-bit consistent across 65 tested configurations.

- **Documentation**
  - Updated performance estimates for high-accuracy filter design and first-time processing.
  - Design now takes approximately 260 ms; processing one minute of 44.1 kHz audio takes about 280 ms for A weighting and 285 ms for 468 weighting.
  - Cached filtering remains approximately 18 ms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->