### PR TITLE
Let the case for phonometry stand on its own evidence

### DIFF
--- a/docs/start/why-phonometry.md
+++ b/docs/start/why-phonometry.md
@@ -21,20 +21,46 @@ $$
 $$
 
 which corresponds to a stable first-order low-pass filter with a pole in the
-left half-plane ($s = -1/\tau$).
+left half-plane ($s = -1/\tau$). It is worth setting that detector beside the
+other thing a Fast reading is sometimes computed with, an energy average
+restarted every $\tau$ seconds, because the two are easy to confuse and answer
+different questions:
 
-| | phonometry | python-acoustics |
+| | Exponential detector (IEC 61672-1) | Block integrator |
 | :--- | :--- | :--- |
-| Output | Continuous time-weighted envelope (one value per sample) | Stepped output (one value every $\tau$ seconds) |
-| Input units | Raw sound pressure (Pa); squared internally | Energetic quantity (Pa²) expected as input |
-| Filter | Stable exponential averaging (pole at $s=-1/\tau$) | Theoretically unstable design (pole in the right half-plane) stabilized by resetting the filter state every $\tau$ seconds |
-| Behavior | True IEC time weighting | Closer to a block integrator ($L_{\mathrm{eq},\tau}$) |
+| Output | Continuous time-weighted envelope, one value per sample | Stepped, one value per block |
+| Mechanism | Stable exponential averaging, pole at $s=-1/\tau$ | An energy average restarted every $\tau$ seconds; $\tau$ is in its clock, not in its response |
+| What it measures | The standard's Fast/Slow/Impulse level | $L_{\mathrm{eq},\tau}$, energy per interval |
 
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
-weighting" means: past events are forgotten exponentially. A pole on the
-positive real axis grows without bound; block-resetting hides this but changes
-the measurement's nature.
+weighting" means: past events are forgotten exponentially. An implementation
+that instead places the pole on the positive real axis and resets the filter
+state every $\tau$ seconds has built the block integrator, whatever it is
+called: the reset hides the growth, and it changes the measurement's nature.
+
+That equation is also where the reference numbers of the next section come
+from, which is worth doing once rather than taking Table 4 on faith. Integrate
+it from rest over a burst of duration $T_\mathrm{b}$ and the envelope reaches
+$(1-e^{-T_\mathrm{b}/\tau})$ of the steady value the same tone would eventually
+produce, so the maximum time-weighted level relative to steady state is
+
+$$
+\delta_{\text{ref}} = 10\lg\!\left(1 - e^{-T_\mathrm{b}/\tau}\right)
+$$
+
+which is IEC 61672-1:2013 Equation (7). With $\tau_\mathrm{F} = 0.125$ s that
+gives −0.98 dB at 200 ms, −4.82 dB at 50 ms, −11.14 dB at 10 ms and −20.99 dB
+at 1 ms: the whole "IEC target" column of Table 4, to the standard's own
+rounding. CI asserts the identity for every Fast and Slow row
+(`test_delta_ref_equation7_consistency`, to within 0.15 dB), so the
+transcription of the table is itself checked rather than trusted.
+
+The consequence carries the rest of this page. Because the response is a smooth
+function of $T_\mathrm{b}/\tau$, a detector that really solves the equation
+tracks the whole column at once; a detector that averages over fixed 125 ms
+blocks has no $T_\mathrm{b}$ in it at all, and can only be right where the
+burst happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -42,65 +68,74 @@ The rigorous test for time weighting is the **Tone Burst Response**
 (IEC 61672-1, Table 4), using a 4 kHz sine burst referenced to the steady-state
 level.
 
-**phonometry results (FAST):**
+### How the check is run
 
-| Burst duration | IEC target (dB) | phonometry (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | −0.98 | +0.02 | ✅ PASS |
-| 50 ms | −4.8 | −4.82 | −0.02 | ✅ PASS |
-| 10 ms | −11.1 | −11.14 | −0.04 | ✅ PASS |
-| 1 ms | −21.0 | −20.99 | +0.01 | ✅ PASS |
+Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
+4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+level of that continuous sine, averaged over its last half second — once the
+integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The
+burst of the stated duration is then cut out of *the same* sine, so its phase
+and amplitude are identical to the reference tone's, and zeros surround it. The
+**response** is the maximum of the Fast envelope of that burst, expressed
+relative to the reference: $10\log_{10}(\max \text{env} / \text{ref})$, which
+is the standard's $L_\mathrm{AFmax} - L_\mathrm{A}$. Note what this does and
+does not verify: IEC 61672-1 states these limits for the electrical input
+facility over a defined range of steady levels with no overload indicated
+(clauses 5.9.5-5.9.6), so the numbers below verify the *ballistics*, not a
+complete instrument. The same reference values are transcribed in
+`tests/filters/test_iec_compliance.py` for F and S and for the
+$L_{\mathrm{A}E}$ column.
 
-**python-acoustics results (FAST, squared signal passed as required by that
-library):**
+**phonometry results (Fast weighting):**
 
-| Burst duration | IEC target (dB) | python-acoustics (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | −0.97 | +0.03 | ✅ PASS |
-| 50 ms | −4.8 | −3.93 | **+0.87** | ⚠️ FAIL |
-| 10 ms | −11.1 | −10.90 | +0.20 | ✅ PASS |
-| 1 ms | −21.0 | −20.90 | +0.10 | ✅ PASS |
+| Burst duration | IEC target (dB) | Class 1 limit (dB) | phonometry (dB) | Error (dB) | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 200 ms | −1.0 | ±0.5 | −0.98 | +0.02 | Pass |
+| 50 ms | −4.8 | ±1.0 | −4.82 | −0.02 | Pass |
+| 10 ms | −11.1 | ±1.0 | −11.14 | −0.04 | Pass |
+| 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
-phonometry maintains high precision across all test cases. The block-based
-approach deviates significantly (> 0.8 dB) for the 50 ms burst because 125 ms
-blocks cannot resolve short transient events accurately; the result depends on
-how the burst aligns with the block boundaries.
+The exponential detector stays within 0.05 dB of the Table 4 reference at
+every duration, under 5 % of the class 1 budget, because a detector that
+solves the defining equation has no free parameter left to get wrong. A block
+integrator can also sit inside class 1 at a favourable alignment, but what it
+spends of the budget is set by how the burst happens to straddle a 125 ms
+block, which is luck rather than design — and the first column of Table 4
+tightens to ±0.5 dB for bursts of 200 ms and longer, where there is little
+margin left to lose.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec.svg" alt="Fast envelope responses to 200, 50 and 10 ms tone bursts peaking exactly at the IEC 61672-1 Table 4 reference values" width="80%"></picture>
 
 *Measured Fast envelopes (blue) matching the Table 4 reference values
 (dashed) within 0.1 dB for 200/50/10 ms bursts.*
 
-<details>
-<summary>Show the code for this figure</summary>
+The generator behind this figure is
+`scripts/figures/signals.py::generate_tone_burst_iec`, and it is the procedure
+described above with three of the Table 4 rows: it prints
+`env_db.max() - target`, which is the Error column of the table, so the
+rows can be reproduced directly.
 
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-from phonometry import filters
+The figure fixes the burst at one place in time, which is the one thing the
+block integrator's answer depends on and the exponential detector's does not.
+Slide the same burst across a 125 ms block boundary and the two behave quite
+differently: the exponential reading is pinned at −4.82 dB whatever the
+alignment, a spread of 0.001 dB, while the block reading swings over 2.94 dB
+and spends 12 % of the alignments outside the class 1 corridor. At 200 ms,
+where Table 4 tightens to ±0.5 dB, the block integrator is outside the
+corridor for 81 % of them, because a 200 ms burst always fills at least part
+of a block and often fills one completely, and a full block reads the steady
+level, 1.0 dB above the target.
 
-# 4 kHz tone bursts vs the IEC 61672-1 Table 4 reference maxima (FAST)
-fs = 48000
-t = np.arange(2 * fs) / fs
-steady = np.sin(2 * np.pi * 4000 * t)
-ref = filters.time_weighting(steady, fs, mode="fast")[int(1.5 * fs):].mean()
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential_dark.gif"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.gif" alt="Animation: a 4 kHz tone burst slides across a 125 ms block boundary; the exponential Fast envelope peaks at the same level at every alignment while the block Leq staircase rises and falls with where the burst lands, and a reading-against-alignment panel builds both traces against the shaded class 1 corridor" width="640" height="360" loading="lazy"></picture>
 
-fig, axes = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
-for ax, (duration, target) in zip(axes, [(0.2, -1.0), (0.05, -4.8), (0.01, -11.1)]):
-    burst = np.zeros_like(t)
-    start, n = int(0.5 * fs), round(duration * fs)
-    burst[start:start + n] = steady[start:start + n]
-    env = filters.time_weighting(burst, fs, mode="fast")
-    ax.plot(t, 10 * np.log10(np.maximum(env / ref, 1e-6)), label="FAST envelope")
-    ax.axhline(target, linestyle="--", label=f"IEC target {target} dB")
-    ax.set(xlim=(0.4, 1.4), ylim=(-30, 3), xlabel="Time [s]",
-           title=f"{duration * 1000:g} ms burst")
-    ax.legend()
-axes[0].set_ylabel("Level re steady state [dB]")
-plt.show()
-```
+[Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.webm)
 
-</details>
+*The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$
+contains $T_\mathrm{b}$ and nothing about the clock; the block trace is a
+picture of the alignment and nothing else. Both readings are computed here
+with `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive
+125 ms slices, against the same steady-tone reference the procedure above
+defines.*
 
 ## What this means in practice
 
@@ -115,6 +150,17 @@ plt.show()
   against a block integrator, not from an implementation error.
 
 ## Conformance testing across the library
+
+A word on what a **performance class** is, since every verdict on this page is
+one. In IEC 61672-1 and IEC 61260-1 a class is not a grade of accuracy but a
+named tolerance corridor around a nominal response: class 1 is the narrow
+corridor intended for precision work, class 2 the wider one for general survey
+use, and both widen at the extremes of the frequency range, where they are
+hardest to meet. Class 0 was a narrower corridor still, in the withdrawn 1995
+edition of IEC 61260, and is kept here as a voluntary extra target for the
+default Butterworth bank. So a pass on this page means the computed response
+never leaves the corridor the standard draws; it does not mean the error is
+zero, and the size of the margin is the interesting number.
 
 The tone-burst case above is not an isolated check. For each standard the
 library implements, the reference values and acceptance limits are transcribed
@@ -132,6 +178,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite runs
 566 numerical conformance checks across 59 domains and 373 standards, covering
@@ -143,15 +190,18 @@ numerical report (the expected value and the value the library computes for
 every check, regenerated on every pull request) is published as
 [CONFORMANCE.md](../CONFORMANCE.md).
 
-Beyond IEC 61252-style noise dose (`sound_exposure()`, `lex_8h()`), the same
-standards-first mindset shows up in the numerics: filter banks place their
-−3 dB points on the **ANSI S1.11 / IEC 61260-1** band edges for every
-architecture (including Chebyshev II and Bessel, where scipy's raw
-parametrization would not), the default Butterworth bank is checked against
-the stricter class 0 of the withdrawn IEC 61260:1995 / ANSI S1.11-2004 edition
-as well as the current class 1, and A/C weighting holds class 1 at every
-sample rate from 8 kHz up, because the analog prototype is fitted at the
-sample rate rather than transformed blind (see
+The same standards-first habit shows up below the level of whole metrics, in
+the numerics. Filter banks place their −3 dB points on the **ANSI S1.11 /
+IEC 61260-1** band edges for the three architectures whose parametrization
+allows it, Butterworth, Chebyshev II and Bessel, the last two through
+corrections scipy's raw parametrization would not apply; Chebyshev I and
+elliptic read the same edges as their equiripple passband edge instead, which
+is stated with its measured cost on
+[Filter Banks](../signals/filters/filter-banks.md). The default Butterworth
+bank is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
+ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
+holds class 1 at every sample rate from 8 kHz up, because the analog prototype
+is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](../signals/levels/weighting.md)).
 
 ## When the source is what is wrong
@@ -181,32 +231,29 @@ nothing in the port ever notices.
 
 ## Where phonometry fits in the Python ecosystem
 
-- **python-acoustics** was archived in February 2024 and is no longer
-  maintained. Its comparison above reflects the last released code.
-- **acoustic-toolbox**, the community successor to python-acoustics, builds
-  its IEC 61672-1 time and frequency weighting on `pyoctaveband`, the former
-  name of this library, which since 2.1.0 is a shim over phonometry. It is only
-  the filters that it takes from here: its own `weighting.py` still carries
-  hard-coded one-third-octave A and C weighting tables.
-- **MoSQITo** focuses on psychoacoustic sound-quality metrics and covers a
-  good part of that ground already: Zwicker loudness, ECMA-418-2 loudness and
-  roughness, DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio,
-  and the ANSI S3.5 speech intelligibility index. phonometry implements the
-  same family, and adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
-  fluctuation strength and the Fastl & Zwicker annoyance model, none of which
-  MoSQITo exports. What differs most is the setting. Here those metrics sit in
-  the same conformance harness as the metrology core and compose directly with
-  the weighting filters, ballistics, band filtering and calibration that feed
-  them.
-- **pyroomacoustics** simulates room impulse responses for audio and machine
-  learning pipelines (image sources, ray tracing, beamforming, direction of
-  arrival), and it does reach the measurement side too, with sweep-based
-  impulse-response acquisition and an RT60 estimator. What it does not carry is
-  the ISO 3382 parameter set. phonometry's image-source and FDTD solvers are
-  pinned to published closed forms, and the image-source impulse response goes
-  through the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50,
-  Ts, per band, with the ISO 3382 decay-range validity flags) as a measured
-  one.
+Several Python projects share ground with phonometry, and the honest way to
+place them is by what each is built for rather than by racing them:
+
+- **acoustic-toolbox** is the community successor to python-acoustics, which
+  was archived in February 2024. It is a general acoustics toolkit, and its
+  IEC 61672-1 time and frequency weighting builds on `pyoctaveband`, the
+  former name of this library, which since 2.1.0 is a shim over phonometry.
+- **MoSQITo** is the reference open implementation for psychoacoustic
+  sound-quality metrics: Zwicker loudness, ECMA-418-2 loudness and roughness,
+  DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio, the
+  ANSI S3.5 speech intelligibility index. phonometry implements the same
+  family, adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
+  fluctuation strength and the Fastl & Zwicker annoyance model, and sits them
+  in the same conformance harness as the metrology core, composed directly
+  with the weighting filters, ballistics, band filtering and calibration that
+  feed them.
+- **pyroomacoustics** is built for simulating rooms in audio and machine
+  learning pipelines: image sources, ray tracing, beamforming, direction of
+  arrival, plus sweep-based impulse-response acquisition. phonometry's room
+  side is the measurement one: its image-source and FDTD solvers are pinned
+  to published closed forms, and a simulated impulse response goes through
+  the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50, Ts, per
+  band, with the ISO 3382 decay-range validity flags) as a measured one.
 
 If your work needs numbers you can defend against a standard's tolerance
 table, whether for measurement reports, environmental assessments or

--- a/docs/start/why-phonometry.md
+++ b/docs/start/why-phonometry.md
@@ -35,9 +35,11 @@ different questions:
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
 weighting" means: past events are forgotten exponentially. An implementation
-that instead places the pole on the positive real axis and resets the filter
-state every $\tau$ seconds has built the block integrator, whatever it is
-called: the reset hides the growth, and it changes the measurement's nature.
+that instead accumulates energy and resets every $\tau$ seconds has built
+the block integrator, whatever it is called, and one that puts the pole on
+the positive real axis before the same reset adds a growing weight inside
+each block on top: neither is the time weighting, because the reset changes
+the measurement's nature.
 
 That equation is also where the reference numbers of the next section come
 from, which is worth doing once rather than taking Table 4 on faith. Integrate
@@ -58,9 +60,11 @@ transcription of the table is itself checked rather than trusted.
 
 The consequence carries the rest of this page. Because the response is a smooth
 function of $T_\mathrm{b}/\tau$, a detector that really solves the equation
-tracks the whole column at once; a detector that averages over fixed 125 ms
-blocks has no $T_\mathrm{b}$ in it at all, and can only be right where the
-burst happens to fill a block.
+tracks the whole column at once; a detector that averages over fixed
+125 ms blocks answers with the burst's energy share of whichever blocks it
+lands in, which moves with duration and alignment alike but carries nothing
+of the $T_\mathrm{b}/\tau$ response, and it can only be right where the burst
+happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -71,7 +75,7 @@ level.
 ### How the check is run
 
 Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
-4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+4 kHz sine is generated at 48 kHz for 2 s. The **reference** is the steady Fast
 level of that continuous sine, averaged over its last half second — once the
 integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The
 burst of the stated duration is then cut out of *the same* sine, so its phase
@@ -96,7 +100,8 @@ $L_{\mathrm{A}E}$ column.
 | 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
 The exponential detector stays within 0.05 dB of the Table 4 reference at
-every duration, under 5 % of the class 1 budget, because a detector that
+every duration, and no row spends more than 4 % of its own class 1
+allowance, because a detector that
 solves the defining equation has no free parameter left to get wrong. A block
 integrator can also sit inside class 1 at a favourable alignment, but what it
 spends of the budget is set by how the burst happens to straddle a 125 ms
@@ -131,8 +136,8 @@ level, 1.0 dB above the target.
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.webm)
 
 *The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$
-contains $T_\mathrm{b}$ and nothing about the clock; the block trace is a
-picture of the alignment and nothing else. Both readings are computed here
+contains $T_\mathrm{b}$ and nothing about the clock; the block trace, at this fixed
+duration, is a picture of the alignment and nothing else. Both readings are computed here
 with `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive
 125 ms slices, against the same steady-tone reference the procedure above
 defines.*
@@ -178,7 +183,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
-| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()`; IEC 61252:2025 has since superseded this print, and the transcription still targets the 1993+A2 text | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite runs
 566 numerical conformance checks across 59 domains and 373 standards, covering
@@ -200,8 +205,9 @@ is stated with its measured cost on
 [Filter Banks](../signals/filters/filter-banks.md). The default Butterworth
 bank is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
 ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
-holds class 1 at every sample rate from 8 kHz up, because the analog prototype
-is fitted at the sample rate rather than transformed blind (see
+earns class 1 at each of the eight rates the suite grades it at, from 8 to
+192 kHz, at every Table 3 frequency below that rate's Nyquist, because the
+analog prototype is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](../signals/levels/weighting.md)).
 
 ## When the source is what is wrong

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48704,9 +48704,11 @@ different questions:
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
 weighting" means: past events are forgotten exponentially. An implementation
-that instead places the pole on the positive real axis and resets the filter
-state every $\tau$ seconds has built the block integrator, whatever it is
-called: the reset hides the growth, and it changes the measurement's nature.
+that instead accumulates energy and resets every $\tau$ seconds has built
+the block integrator, whatever it is called, and one that puts the pole on
+the positive real axis before the same reset adds a growing weight inside
+each block on top: neither is the time weighting, because the reset changes
+the measurement's nature.
 
 That equation is also where the reference numbers of the next section come
 from, which is worth doing once rather than taking Table 4 on faith. Integrate
@@ -48727,9 +48729,11 @@ transcription of the table is itself checked rather than trusted.
 
 The consequence carries the rest of this page. Because the response is a smooth
 function of $T_\mathrm{b}/\tau$, a detector that really solves the equation
-tracks the whole column at once; a detector that averages over fixed 125 ms
-blocks has no $T_\mathrm{b}$ in it at all, and can only be right where the
-burst happens to fill a block.
+tracks the whole column at once; a detector that averages over fixed
+125 ms blocks answers with the burst's energy share of whichever blocks it
+lands in, which moves with duration and alignment alike but carries nothing
+of the $T_\mathrm{b}/\tau$ response, and it can only be right where the burst
+happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -48740,7 +48744,7 @@ level.
 ### How the check is run
 
 Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
-4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+4 kHz sine is generated at 48 kHz for 2 s. The **reference** is the steady Fast
 level of that continuous sine, averaged over its last half second — once the
 integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The
 burst of the stated duration is then cut out of *the same* sine, so its phase
@@ -48765,7 +48769,8 @@ $L_{\mathrm{A}E}$ column.
 | 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
 The exponential detector stays within 0.05 dB of the Table 4 reference at
-every duration, under 5 % of the class 1 budget, because a detector that
+every duration, and no row spends more than 4 % of its own class 1
+allowance, because a detector that
 solves the defining equation has no free parameter left to get wrong. A block
 integrator can also sit inside class 1 at a favourable alignment, but what it
 spends of the budget is set by how the burst happens to straddle a 125 ms
@@ -48800,8 +48805,8 @@ level, 1.0 dB above the target.
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.webm)
 
 *The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$
-contains $T_\mathrm{b}$ and nothing about the clock; the block trace is a
-picture of the alignment and nothing else. Both readings are computed here
+contains $T_\mathrm{b}$ and nothing about the clock; the block trace, at this fixed
+duration, is a picture of the alignment and nothing else. Both readings are computed here
 with `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive
 125 ms slices, against the same steady-tone reference the procedure above
 defines.*
@@ -48847,7 +48852,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
-| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()`; IEC 61252:2025 has since superseded this print, and the transcription still targets the 1993+A2 text | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite runs
 566 numerical conformance checks across 59 domains and 373 standards, covering
@@ -48869,8 +48874,9 @@ is stated with its measured cost on
 [Filter Banks](https://jmrplens.github.io/phonometry/signals/filters/filter-banks/). The default Butterworth
 bank is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
 ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
-holds class 1 at every sample rate from 8 kHz up, because the analog prototype
-is fitted at the sample rate rather than transformed blind (see
+earns class 1 at each of the eight rates the suite grades it at, from 8 to
+192 kHz, at every Table 3 frequency below that rate's Nyquist, because the
+analog prototype is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](https://jmrplens.github.io/phonometry/signals/levels/weighting/)).
 
 ## When the source is what is wrong

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48690,20 +48690,46 @@ $$
 $$
 
 which corresponds to a stable first-order low-pass filter with a pole in the
-left half-plane ($s = -1/\tau$).
+left half-plane ($s = -1/\tau$). It is worth setting that detector beside the
+other thing a Fast reading is sometimes computed with, an energy average
+restarted every $\tau$ seconds, because the two are easy to confuse and answer
+different questions:
 
-| | phonometry | python-acoustics |
+| | Exponential detector (IEC 61672-1) | Block integrator |
 | :--- | :--- | :--- |
-| Output | Continuous time-weighted envelope (one value per sample) | Stepped output (one value every $\tau$ seconds) |
-| Input units | Raw sound pressure (Pa); squared internally | Energetic quantity (Pa²) expected as input |
-| Filter | Stable exponential averaging (pole at $s=-1/\tau$) | Theoretically unstable design (pole in the right half-plane) stabilized by resetting the filter state every $\tau$ seconds |
-| Behavior | True IEC time weighting | Closer to a block integrator ($L_{\mathrm{eq},\tau}$) |
+| Output | Continuous time-weighted envelope, one value per sample | Stepped, one value per block |
+| Mechanism | Stable exponential averaging, pole at $s=-1/\tau$ | An energy average restarted every $\tau$ seconds; $\tau$ is in its clock, not in its response |
+| What it measures | The standard's Fast/Slow/Impulse level | $L_{\mathrm{eq},\tau}$, energy per interval |
 
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
-weighting" means: past events are forgotten exponentially. A pole on the
-positive real axis grows without bound; block-resetting hides this but changes
-the measurement's nature.
+weighting" means: past events are forgotten exponentially. An implementation
+that instead places the pole on the positive real axis and resets the filter
+state every $\tau$ seconds has built the block integrator, whatever it is
+called: the reset hides the growth, and it changes the measurement's nature.
+
+That equation is also where the reference numbers of the next section come
+from, which is worth doing once rather than taking Table 4 on faith. Integrate
+it from rest over a burst of duration $T_\mathrm{b}$ and the envelope reaches
+$(1-e^{-T_\mathrm{b}/\tau})$ of the steady value the same tone would eventually
+produce, so the maximum time-weighted level relative to steady state is
+
+$$
+\delta_{\text{ref}} = 10\lg\!\left(1 - e^{-T_\mathrm{b}/\tau}\right)
+$$
+
+which is IEC 61672-1:2013 Equation (7). With $\tau_\mathrm{F} = 0.125$ s that
+gives −0.98 dB at 200 ms, −4.82 dB at 50 ms, −11.14 dB at 10 ms and −20.99 dB
+at 1 ms: the whole "IEC target" column of Table 4, to the standard's own
+rounding. CI asserts the identity for every Fast and Slow row
+(`test_delta_ref_equation7_consistency`, to within 0.15 dB), so the
+transcription of the table is itself checked rather than trusted.
+
+The consequence carries the rest of this page. Because the response is a smooth
+function of $T_\mathrm{b}/\tau$, a detector that really solves the equation
+tracks the whole column at once; a detector that averages over fixed 125 ms
+blocks has no $T_\mathrm{b}$ in it at all, and can only be right where the
+burst happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -48711,65 +48737,74 @@ The rigorous test for time weighting is the **Tone Burst Response**
 (IEC 61672-1, Table 4), using a 4 kHz sine burst referenced to the steady-state
 level.
 
-**phonometry results (FAST):**
+### How the check is run
 
-| Burst duration | IEC target (dB) | phonometry (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | −0.98 | +0.02 | ✅ PASS |
-| 50 ms | −4.8 | −4.82 | −0.02 | ✅ PASS |
-| 10 ms | −11.1 | −11.14 | −0.04 | ✅ PASS |
-| 1 ms | −21.0 | −20.99 | +0.01 | ✅ PASS |
+Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
+4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+level of that continuous sine, averaged over its last half second — once the
+integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The
+burst of the stated duration is then cut out of *the same* sine, so its phase
+and amplitude are identical to the reference tone's, and zeros surround it. The
+**response** is the maximum of the Fast envelope of that burst, expressed
+relative to the reference: $10\log_{10}(\max \text{env} / \text{ref})$, which
+is the standard's $L_\mathrm{AFmax} - L_\mathrm{A}$. Note what this does and
+does not verify: IEC 61672-1 states these limits for the electrical input
+facility over a defined range of steady levels with no overload indicated
+(clauses 5.9.5-5.9.6), so the numbers below verify the *ballistics*, not a
+complete instrument. The same reference values are transcribed in
+`tests/filters/test_iec_compliance.py` for F and S and for the
+$L_{\mathrm{A}E}$ column.
 
-**python-acoustics results (FAST, squared signal passed as required by that
-library):**
+**phonometry results (Fast weighting):**
 
-| Burst duration | IEC target (dB) | python-acoustics (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | −0.97 | +0.03 | ✅ PASS |
-| 50 ms | −4.8 | −3.93 | **+0.87** | ⚠️ FAIL |
-| 10 ms | −11.1 | −10.90 | +0.20 | ✅ PASS |
-| 1 ms | −21.0 | −20.90 | +0.10 | ✅ PASS |
+| Burst duration | IEC target (dB) | Class 1 limit (dB) | phonometry (dB) | Error (dB) | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 200 ms | −1.0 | ±0.5 | −0.98 | +0.02 | Pass |
+| 50 ms | −4.8 | ±1.0 | −4.82 | −0.02 | Pass |
+| 10 ms | −11.1 | ±1.0 | −11.14 | −0.04 | Pass |
+| 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
-phonometry maintains high precision across all test cases. The block-based
-approach deviates significantly (> 0.8 dB) for the 50 ms burst because 125 ms
-blocks cannot resolve short transient events accurately; the result depends on
-how the burst aligns with the block boundaries.
+The exponential detector stays within 0.05 dB of the Table 4 reference at
+every duration, under 5 % of the class 1 budget, because a detector that
+solves the defining equation has no free parameter left to get wrong. A block
+integrator can also sit inside class 1 at a favourable alignment, but what it
+spends of the budget is set by how the burst happens to straddle a 125 ms
+block, which is luck rather than design — and the first column of Table 4
+tightens to ±0.5 dB for bursts of 200 ms and longer, where there is little
+margin left to lose.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec.svg" alt="Fast envelope responses to 200, 50 and 10 ms tone bursts peaking exactly at the IEC 61672-1 Table 4 reference values" width="80%"></picture>
 
 *Measured Fast envelopes (blue) matching the Table 4 reference values
 (dashed) within 0.1 dB for 200/50/10 ms bursts.*
 
-<details>
-<summary>Show the code for this figure</summary>
+The generator behind this figure is
+`scripts/figures/signals.py::generate_tone_burst_iec`, and it is the procedure
+described above with three of the Table 4 rows: it prints
+`env_db.max() - target`, which is the Error column of the table, so the
+rows can be reproduced directly.
 
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-from phonometry import filters
+The figure fixes the burst at one place in time, which is the one thing the
+block integrator's answer depends on and the exponential detector's does not.
+Slide the same burst across a 125 ms block boundary and the two behave quite
+differently: the exponential reading is pinned at −4.82 dB whatever the
+alignment, a spread of 0.001 dB, while the block reading swings over 2.94 dB
+and spends 12 % of the alignments outside the class 1 corridor. At 200 ms,
+where Table 4 tightens to ±0.5 dB, the block integrator is outside the
+corridor for 81 % of them, because a 200 ms burst always fills at least part
+of a block and often fills one completely, and a full block reads the steady
+level, 1.0 dB above the target.
 
-# 4 kHz tone bursts vs the IEC 61672-1 Table 4 reference maxima (FAST)
-fs = 48000
-t = np.arange(2 * fs) / fs
-steady = np.sin(2 * np.pi * 4000 * t)
-ref = filters.time_weighting(steady, fs, mode="fast")[int(1.5 * fs):].mean()
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential_dark.gif"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.gif" alt="Animation: a 4 kHz tone burst slides across a 125 ms block boundary; the exponential Fast envelope peaks at the same level at every alignment while the block Leq staircase rises and falls with where the burst lands, and a reading-against-alignment panel builds both traces against the shaded class 1 corridor" width="640" height="360" loading="lazy"></picture>
 
-fig, axes = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
-for ax, (duration, target) in zip(axes, [(0.2, -1.0), (0.05, -4.8), (0.01, -11.1)]):
-    burst = np.zeros_like(t)
-    start, n = int(0.5 * fs), round(duration * fs)
-    burst[start:start + n] = steady[start:start + n]
-    env = filters.time_weighting(burst, fs, mode="fast")
-    ax.plot(t, 10 * np.log10(np.maximum(env / ref, 1e-6)), label="FAST envelope")
-    ax.axhline(target, linestyle="--", label=f"IEC target {target} dB")
-    ax.set(xlim=(0.4, 1.4), ylim=(-30, 3), xlabel="Time [s]",
-           title=f"{duration * 1000:g} ms burst")
-    ax.legend()
-axes[0].set_ylabel("Level re steady state [dB]")
-plt.show()
-```
+[Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.webm)
 
-</details>
+*The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$
+contains $T_\mathrm{b}$ and nothing about the clock; the block trace is a
+picture of the alignment and nothing else. Both readings are computed here
+with `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive
+125 ms slices, against the same steady-tone reference the procedure above
+defines.*
 
 ## What this means in practice
 
@@ -48784,6 +48819,17 @@ plt.show()
   against a block integrator, not from an implementation error.
 
 ## Conformance testing across the library
+
+A word on what a **performance class** is, since every verdict on this page is
+one. In IEC 61672-1 and IEC 61260-1 a class is not a grade of accuracy but a
+named tolerance corridor around a nominal response: class 1 is the narrow
+corridor intended for precision work, class 2 the wider one for general survey
+use, and both widen at the extremes of the frequency range, where they are
+hardest to meet. Class 0 was a narrower corridor still, in the withdrawn 1995
+edition of IEC 61260, and is kept here as a voluntary extra target for the
+default Butterworth bank. So a pass on this page means the computed response
+never leaves the corridor the standard draws; it does not mean the error is
+zero, and the size of the margin is the interesting number.
 
 The tone-burst case above is not an isolated check. For each standard the
 library implements, the reference values and acceptance limits are transcribed
@@ -48801,6 +48847,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite runs
 566 numerical conformance checks across 59 domains and 373 standards, covering
@@ -48812,15 +48859,18 @@ numerical report (the expected value and the value the library computes for
 every check, regenerated on every pull request) is published as
 [CONFORMANCE.md](https://jmrplens.github.io/phonometry/reference/conformance/).
 
-Beyond IEC 61252-style noise dose (`sound_exposure()`, `lex_8h()`), the same
-standards-first mindset shows up in the numerics: filter banks place their
-−3 dB points on the **ANSI S1.11 / IEC 61260-1** band edges for every
-architecture (including Chebyshev II and Bessel, where scipy's raw
-parametrization would not), the default Butterworth bank is checked against
-the stricter class 0 of the withdrawn IEC 61260:1995 / ANSI S1.11-2004 edition
-as well as the current class 1, and A/C weighting holds class 1 at every
-sample rate from 8 kHz up, because the analog prototype is fitted at the
-sample rate rather than transformed blind (see
+The same standards-first habit shows up below the level of whole metrics, in
+the numerics. Filter banks place their −3 dB points on the **ANSI S1.11 /
+IEC 61260-1** band edges for the three architectures whose parametrization
+allows it, Butterworth, Chebyshev II and Bessel, the last two through
+corrections scipy's raw parametrization would not apply; Chebyshev I and
+elliptic read the same edges as their equiripple passband edge instead, which
+is stated with its measured cost on
+[Filter Banks](https://jmrplens.github.io/phonometry/signals/filters/filter-banks/). The default Butterworth
+bank is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
+ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
+holds class 1 at every sample rate from 8 kHz up, because the analog prototype
+is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](https://jmrplens.github.io/phonometry/signals/levels/weighting/)).
 
 ## When the source is what is wrong
@@ -48850,32 +48900,29 @@ nothing in the port ever notices.
 
 ## Where phonometry fits in the Python ecosystem
 
-- **python-acoustics** was archived in February 2024 and is no longer
-  maintained. Its comparison above reflects the last released code.
-- **acoustic-toolbox**, the community successor to python-acoustics, builds
-  its IEC 61672-1 time and frequency weighting on `pyoctaveband`, the former
-  name of this library, which since 2.1.0 is a shim over phonometry. It is only
-  the filters that it takes from here: its own `weighting.py` still carries
-  hard-coded one-third-octave A and C weighting tables.
-- **MoSQITo** focuses on psychoacoustic sound-quality metrics and covers a
-  good part of that ground already: Zwicker loudness, ECMA-418-2 loudness and
-  roughness, DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio,
-  and the ANSI S3.5 speech intelligibility index. phonometry implements the
-  same family, and adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
-  fluctuation strength and the Fastl & Zwicker annoyance model, none of which
-  MoSQITo exports. What differs most is the setting. Here those metrics sit in
-  the same conformance harness as the metrology core and compose directly with
-  the weighting filters, ballistics, band filtering and calibration that feed
-  them.
-- **pyroomacoustics** simulates room impulse responses for audio and machine
-  learning pipelines (image sources, ray tracing, beamforming, direction of
-  arrival), and it does reach the measurement side too, with sweep-based
-  impulse-response acquisition and an RT60 estimator. What it does not carry is
-  the ISO 3382 parameter set. phonometry's image-source and FDTD solvers are
-  pinned to published closed forms, and the image-source impulse response goes
-  through the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50,
-  Ts, per band, with the ISO 3382 decay-range validity flags) as a measured
-  one.
+Several Python projects share ground with phonometry, and the honest way to
+place them is by what each is built for rather than by racing them:
+
+- **acoustic-toolbox** is the community successor to python-acoustics, which
+  was archived in February 2024. It is a general acoustics toolkit, and its
+  IEC 61672-1 time and frequency weighting builds on `pyoctaveband`, the
+  former name of this library, which since 2.1.0 is a shim over phonometry.
+- **MoSQITo** is the reference open implementation for psychoacoustic
+  sound-quality metrics: Zwicker loudness, ECMA-418-2 loudness and roughness,
+  DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio, the
+  ANSI S3.5 speech intelligibility index. phonometry implements the same
+  family, adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
+  fluctuation strength and the Fastl & Zwicker annoyance model, and sits them
+  in the same conformance harness as the metrology core, composed directly
+  with the weighting filters, ballistics, band filtering and calibration that
+  feed them.
+- **pyroomacoustics** is built for simulating rooms in audio and machine
+  learning pipelines: image sources, ray tracing, beamforming, direction of
+  arrival, plus sweep-based impulse-response acquisition. phonometry's room
+  side is the measurement one: its image-source and FDTD solvers are pinned
+  to published closed forms, and a simulated impulse response goes through
+  the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50, Ts, per
+  band, with the ISO 3382 decay-range validity flags) as a measured one.
 
 If your work needs numbers you can defend against a standard's tolerance
 table, whether for measurement reports, environmental assessments or

--- a/scripts/figures/signals.py
+++ b/scripts/figures/signals.py
@@ -1086,6 +1086,11 @@ def generate_tone_burst_iec(output_dir: str) -> None:
         env_db = 10 * np.log10(
             np.maximum(filters.time_weighting(burst, fs, mode="fast") / ref, 1e-6)
         )
+        # The Error column of the guide's results table, reproducible from here.
+        print(
+            f"  {duration * 1000:g} ms: max {env_db.max():+.2f} dB, "
+            f"error {env_db.max() - target:+.2f} dB vs target {target:+.1f}"
+        )
 
         ax.plot(
             t_all, env_db, color=COLOR_PRIMARY, linewidth=1.3, label="FAST envelope"

--- a/site/public/llms/llms-start.txt
+++ b/site/public/llms/llms-start.txt
@@ -343,9 +343,11 @@ different questions:
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
 weighting" means: past events are forgotten exponentially. An implementation
-that instead places the pole on the positive real axis and resets the filter
-state every $\tau$ seconds has built the block integrator, whatever it is
-called: the reset hides the growth, and it changes the measurement's nature.
+that instead accumulates energy and resets every $\tau$ seconds has built
+the block integrator, whatever it is called, and one that puts the pole on
+the positive real axis before the same reset adds a growing weight inside
+each block on top: neither is the time weighting, because the reset changes
+the measurement's nature.
 
 That equation is also where the reference numbers of the next section come
 from, which is worth doing once rather than taking Table 4 on faith. Integrate
@@ -366,9 +368,11 @@ transcription of the table is itself checked rather than trusted.
 
 The consequence carries the rest of this page. Because the response is a smooth
 function of $T_\mathrm{b}/\tau$, a detector that really solves the equation
-tracks the whole column at once; a detector that averages over fixed 125 ms
-blocks has no $T_\mathrm{b}$ in it at all, and can only be right where the
-burst happens to fill a block.
+tracks the whole column at once; a detector that averages over fixed
+125 ms blocks answers with the burst's energy share of whichever blocks it
+lands in, which moves with duration and alignment alike but carries nothing
+of the $T_\mathrm{b}/\tau$ response, and it can only be right where the burst
+happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -379,7 +383,7 @@ level.
 ### How the check is run
 
 Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
-4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+4 kHz sine is generated at 48 kHz for 2 s. The **reference** is the steady Fast
 level of that continuous sine, averaged over its last half second — once the
 integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The
 burst of the stated duration is then cut out of *the same* sine, so its phase
@@ -404,7 +408,8 @@ $L_{\mathrm{A}E}$ column.
 | 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
 The exponential detector stays within 0.05 dB of the Table 4 reference at
-every duration, under 5 % of the class 1 budget, because a detector that
+every duration, and no row spends more than 4 % of its own class 1
+allowance, because a detector that
 solves the defining equation has no free parameter left to get wrong. A block
 integrator can also sit inside class 1 at a favourable alignment, but what it
 spends of the budget is set by how the burst happens to straddle a 125 ms
@@ -439,8 +444,8 @@ level, 1.0 dB above the target.
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.webm)
 
 *The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$
-contains $T_\mathrm{b}$ and nothing about the clock; the block trace is a
-picture of the alignment and nothing else. Both readings are computed here
+contains $T_\mathrm{b}$ and nothing about the clock; the block trace, at this fixed
+duration, is a picture of the alignment and nothing else. Both readings are computed here
 with `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive
 125 ms slices, against the same steady-tone reference the procedure above
 defines.*
@@ -486,7 +491,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
-| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()`; IEC 61252:2025 has since superseded this print, and the transcription still targets the 1993+A2 text | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite runs
 566 numerical conformance checks across 59 domains and 373 standards, covering
@@ -508,8 +513,9 @@ is stated with its measured cost on
 [Filter Banks](https://jmrplens.github.io/phonometry/signals/filters/filter-banks/). The default Butterworth
 bank is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
 ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
-holds class 1 at every sample rate from 8 kHz up, because the analog prototype
-is fitted at the sample rate rather than transformed blind (see
+earns class 1 at each of the eight rates the suite grades it at, from 8 to
+192 kHz, at every Table 3 frequency below that rate's Nyquist, because the
+analog prototype is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](https://jmrplens.github.io/phonometry/signals/levels/weighting/)).
 
 ## When the source is what is wrong

--- a/site/public/llms/llms-start.txt
+++ b/site/public/llms/llms-start.txt
@@ -329,20 +329,46 @@ $$
 $$
 
 which corresponds to a stable first-order low-pass filter with a pole in the
-left half-plane ($s = -1/\tau$).
+left half-plane ($s = -1/\tau$). It is worth setting that detector beside the
+other thing a Fast reading is sometimes computed with, an energy average
+restarted every $\tau$ seconds, because the two are easy to confuse and answer
+different questions:
 
-| | phonometry | python-acoustics |
+| | Exponential detector (IEC 61672-1) | Block integrator |
 | :--- | :--- | :--- |
-| Output | Continuous time-weighted envelope (one value per sample) | Stepped output (one value every $\tau$ seconds) |
-| Input units | Raw sound pressure (Pa); squared internally | Energetic quantity (Pa²) expected as input |
-| Filter | Stable exponential averaging (pole at $s=-1/\tau$) | Theoretically unstable design (pole in the right half-plane) stabilized by resetting the filter state every $\tau$ seconds |
-| Behavior | True IEC time weighting | Closer to a block integrator ($L_{\mathrm{eq},\tau}$) |
+| Output | Continuous time-weighted envelope, one value per sample | Stepped, one value per block |
+| Mechanism | Stable exponential averaging, pole at $s=-1/\tau$ | An energy average restarted every $\tau$ seconds; $\tau$ is in its clock, not in its response |
+| What it measures | The standard's Fast/Slow/Impulse level | $L_{\mathrm{eq},\tau}$, energy per interval |
 
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
-weighting" means: past events are forgotten exponentially. A pole on the
-positive real axis grows without bound; block-resetting hides this but changes
-the measurement's nature.
+weighting" means: past events are forgotten exponentially. An implementation
+that instead places the pole on the positive real axis and resets the filter
+state every $\tau$ seconds has built the block integrator, whatever it is
+called: the reset hides the growth, and it changes the measurement's nature.
+
+That equation is also where the reference numbers of the next section come
+from, which is worth doing once rather than taking Table 4 on faith. Integrate
+it from rest over a burst of duration $T_\mathrm{b}$ and the envelope reaches
+$(1-e^{-T_\mathrm{b}/\tau})$ of the steady value the same tone would eventually
+produce, so the maximum time-weighted level relative to steady state is
+
+$$
+\delta_{\text{ref}} = 10\lg\!\left(1 - e^{-T_\mathrm{b}/\tau}\right)
+$$
+
+which is IEC 61672-1:2013 Equation (7). With $\tau_\mathrm{F} = 0.125$ s that
+gives −0.98 dB at 200 ms, −4.82 dB at 50 ms, −11.14 dB at 10 ms and −20.99 dB
+at 1 ms: the whole "IEC target" column of Table 4, to the standard's own
+rounding. CI asserts the identity for every Fast and Slow row
+(`test_delta_ref_equation7_consistency`, to within 0.15 dB), so the
+transcription of the table is itself checked rather than trusted.
+
+The consequence carries the rest of this page. Because the response is a smooth
+function of $T_\mathrm{b}/\tau$, a detector that really solves the equation
+tracks the whole column at once; a detector that averages over fixed 125 ms
+blocks has no $T_\mathrm{b}$ in it at all, and can only be right where the
+burst happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -350,65 +376,74 @@ The rigorous test for time weighting is the **Tone Burst Response**
 (IEC 61672-1, Table 4), using a 4 kHz sine burst referenced to the steady-state
 level.
 
-**phonometry results (FAST):**
+### How the check is run
 
-| Burst duration | IEC target (dB) | phonometry (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | −0.98 | +0.02 | ✅ PASS |
-| 50 ms | −4.8 | −4.82 | −0.02 | ✅ PASS |
-| 10 ms | −11.1 | −11.14 | −0.04 | ✅ PASS |
-| 1 ms | −21.0 | −20.99 | +0.01 | ✅ PASS |
+Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
+4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+level of that continuous sine, averaged over its last half second — once the
+integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The
+burst of the stated duration is then cut out of *the same* sine, so its phase
+and amplitude are identical to the reference tone's, and zeros surround it. The
+**response** is the maximum of the Fast envelope of that burst, expressed
+relative to the reference: $10\log_{10}(\max \text{env} / \text{ref})$, which
+is the standard's $L_\mathrm{AFmax} - L_\mathrm{A}$. Note what this does and
+does not verify: IEC 61672-1 states these limits for the electrical input
+facility over a defined range of steady levels with no overload indicated
+(clauses 5.9.5-5.9.6), so the numbers below verify the *ballistics*, not a
+complete instrument. The same reference values are transcribed in
+`tests/filters/test_iec_compliance.py` for F and S and for the
+$L_{\mathrm{A}E}$ column.
 
-**python-acoustics results (FAST, squared signal passed as required by that
-library):**
+**phonometry results (Fast weighting):**
 
-| Burst duration | IEC target (dB) | python-acoustics (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | −0.97 | +0.03 | ✅ PASS |
-| 50 ms | −4.8 | −3.93 | **+0.87** | ⚠️ FAIL |
-| 10 ms | −11.1 | −10.90 | +0.20 | ✅ PASS |
-| 1 ms | −21.0 | −20.90 | +0.10 | ✅ PASS |
+| Burst duration | IEC target (dB) | Class 1 limit (dB) | phonometry (dB) | Error (dB) | Status |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| 200 ms | −1.0 | ±0.5 | −0.98 | +0.02 | Pass |
+| 50 ms | −4.8 | ±1.0 | −4.82 | −0.02 | Pass |
+| 10 ms | −11.1 | ±1.0 | −11.14 | −0.04 | Pass |
+| 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
-phonometry maintains high precision across all test cases. The block-based
-approach deviates significantly (> 0.8 dB) for the 50 ms burst because 125 ms
-blocks cannot resolve short transient events accurately; the result depends on
-how the burst aligns with the block boundaries.
+The exponential detector stays within 0.05 dB of the Table 4 reference at
+every duration, under 5 % of the class 1 budget, because a detector that
+solves the defining equation has no free parameter left to get wrong. A block
+integrator can also sit inside class 1 at a favourable alignment, but what it
+spends of the budget is set by how the burst happens to straddle a 125 ms
+block, which is luck rather than design — and the first column of Table 4
+tightens to ±0.5 dB for bursts of 200 ms and longer, where there is little
+margin left to lose.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec.svg" alt="Fast envelope responses to 200, 50 and 10 ms tone bursts peaking exactly at the IEC 61672-1 Table 4 reference values" width="80%"></picture>
 
 *Measured Fast envelopes (blue) matching the Table 4 reference values
 (dashed) within 0.1 dB for 200/50/10 ms bursts.*
 
-<details>
-<summary>Show the code for this figure</summary>
+The generator behind this figure is
+`scripts/figures/signals.py::generate_tone_burst_iec`, and it is the procedure
+described above with three of the Table 4 rows: it prints
+`env_db.max() - target`, which is the Error column of the table, so the
+rows can be reproduced directly.
 
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-from phonometry import filters
+The figure fixes the burst at one place in time, which is the one thing the
+block integrator's answer depends on and the exponential detector's does not.
+Slide the same burst across a 125 ms block boundary and the two behave quite
+differently: the exponential reading is pinned at −4.82 dB whatever the
+alignment, a spread of 0.001 dB, while the block reading swings over 2.94 dB
+and spends 12 % of the alignments outside the class 1 corridor. At 200 ms,
+where Table 4 tightens to ±0.5 dB, the block integrator is outside the
+corridor for 81 % of them, because a 200 ms burst always fills at least part
+of a block and often fills one completely, and a full block reads the steady
+level, 1.0 dB above the target.
 
-# 4 kHz tone bursts vs the IEC 61672-1 Table 4 reference maxima (FAST)
-fs = 48000
-t = np.arange(2 * fs) / fs
-steady = np.sin(2 * np.pi * 4000 * t)
-ref = filters.time_weighting(steady, fs, mode="fast")[int(1.5 * fs):].mean()
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential_dark.gif"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.gif" alt="Animation: a 4 kHz tone burst slides across a 125 ms block boundary; the exponential Fast envelope peaks at the same level at every alignment while the block Leq staircase rises and falls with where the burst lands, and a reading-against-alignment panel builds both traces against the shaded class 1 corridor" width="640" height="360" loading="lazy"></picture>
 
-fig, axes = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
-for ax, (duration, target) in zip(axes, [(0.2, -1.0), (0.05, -4.8), (0.01, -11.1)]):
-    burst = np.zeros_like(t)
-    start, n = int(0.5 * fs), round(duration * fs)
-    burst[start:start + n] = steady[start:start + n]
-    env = filters.time_weighting(burst, fs, mode="fast")
-    ax.plot(t, 10 * np.log10(np.maximum(env / ref, 1e-6)), label="FAST envelope")
-    ax.axhline(target, linestyle="--", label=f"IEC target {target} dB")
-    ax.set(xlim=(0.4, 1.4), ylim=(-30, 3), xlabel="Time [s]",
-           title=f"{duration * 1000:g} ms burst")
-    ax.legend()
-axes[0].set_ylabel("Level re steady state [dB]")
-plt.show()
-```
+[Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_block_vs_exponential.webm)
 
-</details>
+*The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$
+contains $T_\mathrm{b}$ and nothing about the clock; the block trace is a
+picture of the alignment and nothing else. Both readings are computed here
+with `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive
+125 ms slices, against the same steady-tone reference the procedure above
+defines.*
 
 ## What this means in practice
 
@@ -423,6 +458,17 @@ plt.show()
   against a block integrator, not from an implementation error.
 
 ## Conformance testing across the library
+
+A word on what a **performance class** is, since every verdict on this page is
+one. In IEC 61672-1 and IEC 61260-1 a class is not a grade of accuracy but a
+named tolerance corridor around a nominal response: class 1 is the narrow
+corridor intended for precision work, class 2 the wider one for general survey
+use, and both widen at the extremes of the frequency range, where they are
+hardest to meet. Class 0 was a narrower corridor still, in the withdrawn 1995
+edition of IEC 61260, and is kept here as a voluntary extra target for the
+default Butterworth bank. So a pass on this page means the computed response
+never leaves the corridor the standard draws; it does not mean the error is
+zero, and the size of the margin is the interesting number.
 
 The tone-burst case above is not an isolated check. For each standard the
 library implements, the reference values and acceptance limits are transcribed
@@ -440,6 +486,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite runs
 566 numerical conformance checks across 59 domains and 373 standards, covering
@@ -451,15 +498,18 @@ numerical report (the expected value and the value the library computes for
 every check, regenerated on every pull request) is published as
 [CONFORMANCE.md](https://jmrplens.github.io/phonometry/reference/conformance/).
 
-Beyond IEC 61252-style noise dose (`sound_exposure()`, `lex_8h()`), the same
-standards-first mindset shows up in the numerics: filter banks place their
-−3 dB points on the **ANSI S1.11 / IEC 61260-1** band edges for every
-architecture (including Chebyshev II and Bessel, where scipy's raw
-parametrization would not), the default Butterworth bank is checked against
-the stricter class 0 of the withdrawn IEC 61260:1995 / ANSI S1.11-2004 edition
-as well as the current class 1, and A/C weighting holds class 1 at every
-sample rate from 8 kHz up, because the analog prototype is fitted at the
-sample rate rather than transformed blind (see
+The same standards-first habit shows up below the level of whole metrics, in
+the numerics. Filter banks place their −3 dB points on the **ANSI S1.11 /
+IEC 61260-1** band edges for the three architectures whose parametrization
+allows it, Butterworth, Chebyshev II and Bessel, the last two through
+corrections scipy's raw parametrization would not apply; Chebyshev I and
+elliptic read the same edges as their equiripple passband edge instead, which
+is stated with its measured cost on
+[Filter Banks](https://jmrplens.github.io/phonometry/signals/filters/filter-banks/). The default Butterworth
+bank is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
+ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
+holds class 1 at every sample rate from 8 kHz up, because the analog prototype
+is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](https://jmrplens.github.io/phonometry/signals/levels/weighting/)).
 
 ## When the source is what is wrong
@@ -489,32 +539,29 @@ nothing in the port ever notices.
 
 ## Where phonometry fits in the Python ecosystem
 
-- **python-acoustics** was archived in February 2024 and is no longer
-  maintained. Its comparison above reflects the last released code.
-- **acoustic-toolbox**, the community successor to python-acoustics, builds
-  its IEC 61672-1 time and frequency weighting on `pyoctaveband`, the former
-  name of this library, which since 2.1.0 is a shim over phonometry. It is only
-  the filters that it takes from here: its own `weighting.py` still carries
-  hard-coded one-third-octave A and C weighting tables.
-- **MoSQITo** focuses on psychoacoustic sound-quality metrics and covers a
-  good part of that ground already: Zwicker loudness, ECMA-418-2 loudness and
-  roughness, DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio,
-  and the ANSI S3.5 speech intelligibility index. phonometry implements the
-  same family, and adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
-  fluctuation strength and the Fastl & Zwicker annoyance model, none of which
-  MoSQITo exports. What differs most is the setting. Here those metrics sit in
-  the same conformance harness as the metrology core and compose directly with
-  the weighting filters, ballistics, band filtering and calibration that feed
-  them.
-- **pyroomacoustics** simulates room impulse responses for audio and machine
-  learning pipelines (image sources, ray tracing, beamforming, direction of
-  arrival), and it does reach the measurement side too, with sweep-based
-  impulse-response acquisition and an RT60 estimator. What it does not carry is
-  the ISO 3382 parameter set. phonometry's image-source and FDTD solvers are
-  pinned to published closed forms, and the image-source impulse response goes
-  through the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50,
-  Ts, per band, with the ISO 3382 decay-range validity flags) as a measured
-  one.
+Several Python projects share ground with phonometry, and the honest way to
+place them is by what each is built for rather than by racing them:
+
+- **acoustic-toolbox** is the community successor to python-acoustics, which
+  was archived in February 2024. It is a general acoustics toolkit, and its
+  IEC 61672-1 time and frequency weighting builds on `pyoctaveband`, the
+  former name of this library, which since 2.1.0 is a shim over phonometry.
+- **MoSQITo** is the reference open implementation for psychoacoustic
+  sound-quality metrics: Zwicker loudness, ECMA-418-2 loudness and roughness,
+  DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio, the
+  ANSI S3.5 speech intelligibility index. phonometry implements the same
+  family, adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
+  fluctuation strength and the Fastl & Zwicker annoyance model, and sits them
+  in the same conformance harness as the metrology core, composed directly
+  with the weighting filters, ballistics, band filtering and calibration that
+  feed them.
+- **pyroomacoustics** is built for simulating rooms in audio and machine
+  learning pipelines: image sources, ray tracing, beamforming, direction of
+  arrival, plus sweep-based impulse-response acquisition. phonometry's room
+  side is the measurement one: its image-source and FDTD solvers are pinned
+  to published closed forms, and a simulated impulse response goes through
+  the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50, Ts, per
+  band, with the ISO 3382 decay-range validity flags) as a measured one.
 
 If your work needs numbers you can defend against a standard's tolerance
 table, whether for measurement reports, environmental assessments or

--- a/site/src/content/docs/es/start/why-phonometry.mdx
+++ b/site/src/content/docs/es/start/why-phonometry.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Por qué phonometry"
-description: "La filosofía de diseño basada en conformidad: un caso de estudio de ponderación temporal IEC 61672-1, la batería numérica de conformidad, el registro de defectos encontrados en las propias normas publicadas y cómo se compara phonometry con otras bibliotecas de Python."
+description: "La filosofía de diseño basada en conformidad: un caso de estudio de ponderación temporal IEC 61672-1, la batería numérica de conformidad, el registro de defectos encontrados en las propias normas publicadas y dónde encaja phonometry en el ecosistema Python."
 ---
 
 import ThemeImage from '../../../../components/ThemeImage.astro';
@@ -27,20 +27,24 @@ $$
 $$
 
 que corresponde a un filtro paso bajo estable de primer orden con un polo en el
-semiplano izquierdo ($s = -1/\tau$).
+semiplano izquierdo ($s = -1/\tau$). Vale la pena poner ese detector al lado de
+la otra cosa con la que a veces se calcula una lectura Fast, un promedio de
+energía que se reinicia cada $\tau$ segundos, porque los dos se confunden con
+facilidad y responden a preguntas distintas:
 
-| | phonometry | python-acoustics |
+| | Detector exponencial (IEC 61672-1) | Integrador por bloques |
 | :--- | :--- | :--- |
-| Salida | Envolvente continua con ponderación temporal (un valor por muestra) | Salida escalonada (un valor cada $\tau$ segundos) |
-| Unidades de entrada | Presión acústica en bruto (Pa); se eleva al cuadrado internamente | Se espera la magnitud energética (Pa²) como entrada |
-| Filtro | Promediado exponencial estable (polo en $s=-1/\tau$) | Diseño teóricamente inestable (polo en el semiplano derecho) estabilizado reiniciando el estado cada $\tau$ segundos |
-| Comportamiento | Verdadera ponderación temporal IEC | Más cercano a un integrador por bloques ($L_{\mathrm{eq},\tau}$) |
+| Salida | Envolvente continua con ponderación temporal, un valor por muestra | Escalonada, un valor por bloque |
+| Mecanismo | Promediado exponencial estable, polo en $s=-1/\tau$ | Un promedio de energía reiniciado cada $\tau$ segundos; $\tau$ está en su reloj, no en su respuesta |
+| Qué mide | El nivel Fast/Slow/Impulse de la norma | $L_{\mathrm{eq},\tau}$, energía por intervalo |
 
 Un polo en el eje real negativo corresponde a una respuesta al impulso
 exponencial decreciente ($h(t) \propto e^{-t/\tau}$), exactamente lo que
 significa «ponderación temporal exponencial»: los eventos pasados se olvidan
-exponencialmente. Un polo en el eje real positivo crece sin límite; el reinicio
-por bloques lo oculta, pero cambia la naturaleza de la medición.
+exponencialmente. Una implementación que en cambio coloque el polo en el eje
+real positivo y reinicie el estado del filtro cada $\tau$ segundos ha
+construido el integrador por bloques, se llame como se llame: el reinicio
+oculta el crecimiento, y cambia la naturaleza de la medición.
 
 De esa ecuación salen además los valores de referencia del apartado siguiente, y
 vale la pena deducirlos una vez en lugar de dar por buena la Tabla 4. Intégrala
@@ -94,32 +98,19 @@ mismos valores de referencia están transcritos en
 
 | Duración de la ráfaga | Objetivo IEC (dB) | Límite clase 1 (dB) | phonometry (dB) | Error (dB) | Estado |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1,0 | ±0,5 | −0,98 | +0,02 | ✅ CUMPLE |
-| 50 ms | −4,8 | ±1,0 | −4,82 | −0,02 | ✅ CUMPLE |
-| 10 ms | −11,1 | ±1,0 | −11,14 | −0,04 | ✅ CUMPLE |
-| 1 ms | −21,0 | +1,0 / −2,0 | −20,99 | +0,01 | ✅ CUMPLE |
+| 200 ms | −1,0 | ±0,5 | −0,98 | +0,02 | Cumple |
+| 50 ms | −4,8 | ±1,0 | −4,82 | −0,02 | Cumple |
+| 10 ms | −11,1 | ±1,0 | −11,14 | −0,04 | Cumple |
+| 1 ms | −21,0 | +1,0 / −2,0 | −20,99 | +0,01 | Cumple |
 
-**Resultados de python-acoustics (ponderación Fast, pasando la señal al cuadrado
-como requiere esa biblioteca):**
-
-| Duración de la ráfaga | Objetivo IEC (dB) | Límite clase 1 (dB) | python-acoustics (dB) | Error (dB) | Estado |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1,0 | ±0,5 | −0,97 | +0,03 | ✅ CUMPLE |
-| 50 ms | −4,8 | ±1,0 | −3,93 | **+0,87** | ✅ CUMPLE |
-| 10 ms | −11,1 | ±1,0 | −10,90 | +0,20 | ✅ CUMPLE |
-| 1 ms | −21,0 | +1,0 / −2,0 | −20,90 | +0,10 | ✅ CUMPLE |
-
-**Las dos bibliotecas pasan todas las filas mostradas**, y decir lo contrario
-sería exagerar: lo que importa aquí es la *forma* del error, no un
-incumplimiento. phonometry se mantiene a menos de 0,05 dB de la referencia de la
+El detector exponencial se mantiene a menos de 0,05 dB de la referencia de la
 Tabla 4 en todas las duraciones, menos del 5 % del margen de clase 1, porque a
-un detector exponencial continuo no le queda ningún parámetro libre que
-equivocar. El integrador por bloques también se queda dentro de clase 1, pero
-gasta 0,87 de los 1,0 dB disponibles a 50 ms, y los gasta por un motivo que es
-suerte y no diseño: cómo se reparte la ráfaga a caballo de un bloque de 125 ms.
-Lee las dos tablas junto a la primera columna de la Tabla 4, que se estrecha a
-±0,5 dB para ráfagas de 200 ms y más largas: en ese extremo a un integrador por
-bloques no le queda margen que perder.
+un detector que resuelve la ecuación que define la magnitud no le queda ningún
+parámetro libre que equivocar. Un integrador por bloques también puede quedar
+dentro de clase 1 con una alineación favorable, pero lo que gasta del margen
+lo decide cómo se reparta la ráfaga a caballo de un bloque de 125 ms, que es
+suerte y no diseño; y la primera columna de la Tabla 4 se estrecha a ±0,5 dB
+para ráfagas de 200 ms y más largas, donde queda poco margen que perder.
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec_es.svg" alt="Respuestas de la envolvente Fast a ráfagas de 200, 50 y 10 ms alcanzando exactamente los valores de referencia de la Tabla 4 de IEC 61672-1" width="80%" loading="eager" />
 
@@ -130,8 +121,8 @@ de la Tabla 4 (discontinua) con un margen de 0,1 dB para ráfagas de
 El generador que hay detrás de esta figura es
 `scripts/figures/signals.py::generate_tone_burst_iec`, y es el procedimiento
 descrito arriba con tres de las filas de la Tabla 4: imprime
-`env_db.max() - target`, que es la columna Error de la primera tabla, de modo
-que las filas de phonometry se pueden reproducir directamente.
+`env_db.max() - target`, que es la columna Error de la tabla, de modo
+que las filas se pueden reproducir directamente.
 
 La figura fija la ráfaga en un instante concreto, que es justo aquello de lo
 que depende la respuesta del integrador por bloques y no la del detector
@@ -183,7 +174,7 @@ y la clase 2 el ancho, para reconocimientos generales, y los dos se ensanchan en
 los extremos del rango de frecuencias, que es donde más cuesta cumplirlos. La
 clase 0 era un corredor todavía más estrecho, de la edición retirada de 1995 de
 IEC 61260, y aquí se mantiene como objetivo adicional voluntario para el banco
-Butterworth por defecto. Así que un CUMPLE en esta página significa que la
+Butterworth por defecto. Así que «cumple» en esta página significa que la
 respuesta calculada no se sale nunca del corredor que dibuja la norma; no
 significa que el error sea cero, y el tamaño del margen es el número
 interesante.
@@ -229,9 +220,10 @@ borde de banda de paso con rizado constante, algo que se declara con su coste
 medido en [Bancos de filtros](/phonometry/es/signals/filters/filter-banks/). El
 banco Butterworth por defecto se verifica también frente a la clase 0, más
 estricta, de la edición retirada IEC 61260:1995 / ANSI S1.11-2004 además de
-frente a la clase 1 vigente. Y la ponderación A/C se mantiene dentro de las
-tolerancias de clase 1 hasta 16 kHz a las frecuencias de muestreo habituales
-gracias al sobremuestreo interno (consulta [Ponderación
+frente a la clase 1 vigente. Y la ponderación A/C mantiene la clase 1 a todas
+las frecuencias de muestreo desde 8 kHz, porque el prototipo analógico se
+ajusta a la frecuencia de muestreo en lugar de transformarse a ciegas
+(consulta [Ponderación
 frecuencial](/phonometry/es/signals/levels/weighting/)).
 
 ## Cuando lo que está mal es la fuente
@@ -262,35 +254,33 @@ desde otra implementación hereda lo que la errata le hiciera hacer, y nada en
 
 ## Dónde encaja phonometry en el ecosistema Python
 
-- **python-acoustics** se archivó en febrero de 2024 y ya no se mantiene; la
-  comparación de arriba se ejecutó contra su última versión publicada.
-- **acoustic-toolbox**, el sucesor comunitario de python-acoustics, construye
-  sus ponderaciones temporal y frecuencial de IEC 61672-1 sobre `pyoctaveband`,
-  el nombre anterior de esta biblioteca, que desde la 2.1.0 es un envoltorio
-  sobre phonometry. Solo toma de aquí los filtros: su propio `weighting.py`
-  sigue llevando tablas de ponderación A y C por tercios de octava escritas
-  directamente en el código.
-- **MoSQITo** se centra en métricas psicoacústicas de calidad sonora y ya
-  cubre buena parte de ese terreno: sonoridad de Zwicker, sonoridad y aspereza
+Varios proyectos de Python comparten terreno con phonometry, y la manera
+honesta de situarlos es por aquello para lo que está construido cada uno, no
+echando carreras entre ellos:
+
+- **acoustic-toolbox** es el sucesor comunitario de python-acoustics, que se
+  archivó en febrero de 2024. Es un conjunto de herramientas de acústica
+  general, y sus ponderaciones temporal y frecuencial de IEC 61672-1 se
+  apoyan en `pyoctaveband`, el nombre anterior de esta biblioteca, que desde
+  la 2.1.0 es un envoltorio sobre phonometry.
+- **MoSQITo** es la implementación abierta de referencia de las métricas
+  psicoacústicas de calidad sonora: sonoridad de Zwicker, sonoridad y aspereza
   de ECMA-418-2, agudeza de DIN 45692, relaciones tono-ruido y de prominencia
-  de ECMA-74 y el índice de inteligibilidad del habla de ANSI S3.5. phonometry
-  implementa esa misma familia y añade la sonoridad de ISO 532-2 e ISO 532-3,
+  de ECMA-74, el índice de inteligibilidad del habla de ANSI S3.5. phonometry
+  implementa esa misma familia, añade la sonoridad de ISO 532-2 e ISO 532-3,
   la tonalidad de ECMA-418-2, la intensidad de fluctuación y el modelo de
-  molestia psicoacústica de Fastl y Zwicker, que MoSQITo no expone. Lo que más
-  cambia es el entorno. Aquí esas métricas viven en la misma batería de
-  conformidad que el núcleo de metrología y se componen directamente con los
+  molestia psicoacústica de Fastl y Zwicker, y las asienta en la misma batería
+  de conformidad que el núcleo de metrología, compuestas directamente con los
   filtros de ponderación, la balística, el filtrado por bandas y la
   calibración que las alimentan.
-- **pyroomacoustics** simula respuestas al impulso de salas para cadenas de
-  audio y aprendizaje automático (fuentes imagen, trazado de rayos,
-  conformación de haz, estimación de la dirección de llegada), y también llega
-  al lado de la medición, con adquisición de la respuesta al impulso por barrido
-  y un estimador de RT60. Lo que no lleva es el juego de parámetros de
-  ISO 3382. Los modelos de fuentes imagen y FDTD de phonometry están fijados a
-  formas cerradas publicadas, y la respuesta al impulso de fuentes imagen pasa
-  por el mismo análisis de `room_parameters` (EDT, T20, T30, C50, C80, D50, Ts,
-  por bandas, con los indicadores de validez del rango de decaimiento de
-  ISO 3382) que una medida.
+- **pyroomacoustics** está construido para simular salas en cadenas de audio
+  y aprendizaje automático: fuentes imagen, trazado de rayos, conformación de
+  haz, estimación de la dirección de llegada, más la adquisición de respuestas
+  al impulso por barrido. El lado de salas de phonometry es el de la medición:
+  sus modelos de fuentes imagen y FDTD están fijados a formas cerradas
+  publicadas, y una respuesta al impulso simulada pasa por el mismo análisis
+  de `room_parameters` (EDT, T20, T30, C50, C80, D50, Ts, por bandas, con los
+  indicadores de validez del rango de decaimiento de ISO 3382) que una medida.
 
 Si tu trabajo necesita números que puedas defender frente a la tabla de
 tolerancias de una norma, ya sea para informes de medición, evaluaciones

--- a/site/src/content/docs/es/start/why-phonometry.mdx
+++ b/site/src/content/docs/es/start/why-phonometry.mdx
@@ -41,10 +41,12 @@ facilidad y responden a preguntas distintas:
 Un polo en el eje real negativo corresponde a una respuesta al impulso
 exponencial decreciente ($h(t) \propto e^{-t/\tau}$), exactamente lo que
 significa «ponderación temporal exponencial»: los eventos pasados se olvidan
-exponencialmente. Una implementación que en cambio coloque el polo en el eje
-real positivo y reinicie el estado del filtro cada $\tau$ segundos ha
-construido el integrador por bloques, se llame como se llame: el reinicio
-oculta el crecimiento, y cambia la naturaleza de la medición.
+exponencialmente. Una implementación que en cambio
+acumule energía y se reinicie cada $\tau$ segundos ha construido el
+integrador por bloques, se llame como se llame, y una que coloque el polo en
+el eje real positivo antes del mismo reinicio añade además un peso creciente
+dentro de cada bloque: ninguna de las dos es la ponderación temporal, porque
+el reinicio cambia la naturaleza de la medición.
 
 De esa ecuación salen además los valores de referencia del apartado siguiente, y
 vale la pena deducirlos una vez en lugar de dar por buena la Tabla 4. Intégrala
@@ -67,8 +69,10 @@ modo que la transcripción de la tabla está comprobada y no dada por buena.
 La consecuencia sostiene el resto de esta página. Como la respuesta es una
 función suave de $T_\mathrm{b}/\tau$, un detector que resuelva de verdad la ecuación
 sigue la columna entera de una vez; un detector que promedia sobre bloques fijos
-de 125 ms no contiene ningún $T_\mathrm{b}$, y solo puede acertar allí donde la ráfaga
-llene un bloque por casualidad.
+de 125 ms responde con la parte de la energía de la ráfaga que caiga en cada
+bloque, que se mueve con la duración y con la alineación por igual pero no
+lleva nada de la respuesta $T_\mathrm{b}/\tau$, y solo puede acertar allí
+donde la ráfaga llene un bloque por casualidad.
 
 ## Verificación frente a IEC 61672-1 (ráfagas tonales)
 
@@ -79,7 +83,7 @@ al nivel de régimen estacionario.
 ### Cómo se ejecuta la comprobación
 
 La Tabla 4 fija la excitación pero no el montaje, así que aquí va el montaje. Se
-genera una sinusoide de 4 kHz a 48 kHz durante 3 s. La **referencia** es el nivel
+genera una sinusoide de 4 kHz a 48 kHz durante 2 s. La **referencia** es el nivel
 Fast estacionario de esa sinusoide continua, promediado sobre su último medio
 segundo: una vez asentado el integrador, este es el $L_\mathrm{A}$ en la notación de la
 norma. Después se recorta de *esa misma* sinusoide la ráfaga de la duración
@@ -104,7 +108,9 @@ mismos valores de referencia están transcritos en
 | 1 ms | −21,0 | +1,0 / −2,0 | −20,99 | +0,01 | Cumple |
 
 El detector exponencial se mantiene a menos de 0,05 dB de la referencia de la
-Tabla 4 en todas las duraciones, menos del 5 % del margen de clase 1, porque a
+Tabla 4 en
+todas las duraciones, y ninguna fila gasta más del 4 % de su propio margen
+de clase 1, porque a
 un detector que resuelve la ecuación que define la magnitud no le queda ningún
 parámetro libre que equivocar. Un integrador por bloques también puede quedar
 dentro de clase 1 con una alineación favorable, pero lo que gasta del margen
@@ -145,8 +151,8 @@ estacionario, 1,0 dB por encima del objetivo.
 />
 
 *La traza exponencial es plana porque $10\lg(1-e^{-T_\mathrm{b}/\tau})$ contiene $T_\mathrm{b}$
-y nada del reloj; la traza por bloques es un retrato de la alineación y de
-nada más. Las dos lecturas se calculan aquí con
+y nada del reloj; la traza por bloques, a esta duración
+fija, es un retrato de la alineación y de nada más. Las dos lecturas se calculan aquí con
 `time_weighting(x, fs, mode="fast")` y con `leq` sobre segmentos consecutivos
 de 125 ms, frente a la misma referencia de tono estacionario que define el
 procedimiento de arriba.*
@@ -196,7 +202,7 @@ metrología:
 | ECMA-418-1:2024 | Prominencia tonal TNR/PR: anchos de banda críticos, separación de proximidad y criterios de prominencia frente a los ejemplos resueltos de los apartados 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` y `composite_rating_level()` frente a valores calculados a mano con las fórmulas | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Tabla 2 | Límites de estabilidad a corto plazo del calibrador (dependientes de la frecuencia, clase 1) en `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
-| IEC 61252:1993 | Las magnitudes de exposición sonora personal, `sound_exposure()` y el nivel normalizado a 8 h `lex_8h()` | `tests/signals/test_levels.py` |
+| IEC 61252:1993 | Las magnitudes de exposición sonora personal, `sound_exposure()` y el nivel normalizado a 8 h `lex_8h()`; IEC 61252:2025 ha sustituido desde entonces esa impresión, y la transcripción sigue apuntando al texto de 1993+A2 | `tests/signals/test_levels.py` |
 
 La misma disciplina se aplica mucho más allá del núcleo de metrología: hoy la
 batería ejecuta {totalChecks} comprobaciones numéricas de conformidad en
@@ -220,9 +226,11 @@ borde de banda de paso con rizado constante, algo que se declara con su coste
 medido en [Bancos de filtros](/phonometry/es/signals/filters/filter-banks/). El
 banco Butterworth por defecto se verifica también frente a la clase 0, más
 estricta, de la edición retirada IEC 61260:1995 / ANSI S1.11-2004 además de
-frente a la clase 1 vigente. Y la ponderación A/C mantiene la clase 1 a todas
-las frecuencias de muestreo desde 8 kHz, porque el prototipo analógico se
-ajusta a la frecuencia de muestreo en lugar de transformarse a ciegas
+frente a la clase 1 vigente. Y la ponderación A/C obtiene la
+clase 1 en cada una de las ocho frecuencias de muestreo a las que la batería
+la califica, de 8 a 192 kHz, en todas las frecuencias de la Tabla 3 por
+debajo del Nyquist de cada una, porque el prototipo analógico se ajusta a la
+frecuencia de muestreo en lugar de transformarse a ciegas
 (consulta [Ponderación
 frecuencial](/phonometry/es/signals/levels/weighting/)).
 

--- a/site/src/content/docs/start/why-phonometry.mdx
+++ b/site/src/content/docs/start/why-phonometry.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Why phonometry"
-description: "The conformance-first design philosophy: an IEC 61672-1 time-weighting case study, the numerical conformance suite, the registry of defects found in the published standards themselves, and how phonometry compares with other Python libraries."
+description: "The conformance-first design philosophy: an IEC 61672-1 time-weighting case study, the numerical conformance suite, the registry of defects found in the published standards themselves, and where phonometry fits in the Python ecosystem."
 ---
 
 import ThemeImage from '../../../components/ThemeImage.astro';
@@ -26,20 +26,23 @@ $$
 $$
 
 which corresponds to a stable first-order low-pass filter with a pole in the
-left half-plane ($s = -1/\tau$).
+left half-plane ($s = -1/\tau$). It is worth setting that detector beside the
+other thing a Fast reading is sometimes computed with, an energy average
+restarted every $\tau$ seconds, because the two are easy to confuse and answer
+different questions:
 
-| | phonometry | python-acoustics |
+| | Exponential detector (IEC 61672-1) | Block integrator |
 | :--- | :--- | :--- |
-| Output | Continuous time-weighted envelope (one value per sample) | Stepped output (one value every $\tau$ seconds) |
-| Input units | Raw sound pressure (Pa); squared internally | Energetic quantity (Pa²) expected as input |
-| Filter | Stable exponential averaging (pole at $s=-1/\tau$) | Theoretically unstable design (pole in the right half-plane) stabilized by resetting the filter state every $\tau$ seconds |
-| Behavior | True IEC time weighting | Closer to a block integrator ($L_{\mathrm{eq},\tau}$) |
+| Output | Continuous time-weighted envelope, one value per sample | Stepped, one value per block |
+| Mechanism | Stable exponential averaging, pole at $s=-1/\tau$ | An energy average restarted every $\tau$ seconds; $\tau$ is in its clock, not in its response |
+| What it measures | The standard's Fast/Slow/Impulse level | $L_{\mathrm{eq},\tau}$, energy per interval |
 
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
-weighting" means: past events are forgotten exponentially. A pole on the
-positive real axis grows without bound; block-resetting hides this but changes
-the measurement's nature.
+weighting" means: past events are forgotten exponentially. An implementation
+that instead places the pole on the positive real axis and resets the filter
+state every $\tau$ seconds has built the block integrator, whatever it is
+called: the reset hides the growth, and it changes the measurement's nature.
 
 That equation is also where the reference numbers of the next section come
 from, which is worth doing once rather than taking Table 4 on faith. Integrate
@@ -91,31 +94,19 @@ and S and for the $L_{\mathrm{A}E}$ column.
 
 | Burst duration | IEC target (dB) | Class 1 limit (dB) | phonometry (dB) | Error (dB) | Status |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | ±0.5 | −0.98 | +0.02 | ✅ PASS |
-| 50 ms | −4.8 | ±1.0 | −4.82 | −0.02 | ✅ PASS |
-| 10 ms | −11.1 | ±1.0 | −11.14 | −0.04 | ✅ PASS |
-| 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | ✅ PASS |
+| 200 ms | −1.0 | ±0.5 | −0.98 | +0.02 | Pass |
+| 50 ms | −4.8 | ±1.0 | −4.82 | −0.02 | Pass |
+| 10 ms | −11.1 | ±1.0 | −11.14 | −0.04 | Pass |
+| 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
-**python-acoustics results (Fast weighting, squared signal passed as that
-library requires):**
-
-| Burst duration | IEC target (dB) | Class 1 limit (dB) | python-acoustics (dB) | Error (dB) | Status |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| 200 ms | −1.0 | ±0.5 | −0.97 | +0.03 | ✅ PASS |
-| 50 ms | −4.8 | ±1.0 | −3.93 | **+0.87** | ✅ PASS |
-| 10 ms | −11.1 | ±1.0 | −10.90 | +0.20 | ✅ PASS |
-| 1 ms | −21.0 | +1.0 / −2.0 | −20.90 | +0.10 | ✅ PASS |
-
-**Both libraries pass every row shown**, and saying otherwise would be
-overstating the case — the point here is the *shape* of the error, not a
-compliance failure. phonometry stays within 0.05 dB of the Table 4 reference at
-every duration, under 5 % of the class 1 budget, because a continuous
-exponential detector has no free parameter left to get wrong. The block
-integrator stays inside class 1 too, but it spends 0.87 of the 1.0 dB available
-at 50 ms, and it spends it for a reason that is luck rather than design: how the
-burst happens to straddle a 125 ms block. Read the two tables together with the
-first column of Table 4, which tightens to ±0.5 dB for bursts of 200 ms and
-longer — at that end a block integrator has no margin left to lose.
+The exponential detector stays within 0.05 dB of the Table 4 reference at
+every duration, under 5 % of the class 1 budget, because a detector that
+solves the defining equation has no free parameter left to get wrong. A block
+integrator can also sit inside class 1 at a favourable alignment, but what it
+spends of the budget is set by how the burst happens to straddle a 125 ms
+block, which is luck rather than design — and the first column of Table 4
+tightens to ±0.5 dB for bursts of 200 ms and longer, where there is little
+margin left to lose.
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_burst_iec.svg" alt="Fast envelope responses to 200, 50 and 10 ms tone bursts peaking exactly at the IEC 61672-1 Table 4 reference values" width="80%" loading="eager" />
 
@@ -125,8 +116,8 @@ longer — at that end a block integrator has no margin left to lose.
 The generator behind this figure is
 `scripts/figures/signals.py::generate_tone_burst_iec`, and it is the procedure
 described above with three of the Table 4 rows: it prints
-`env_db.max() - target`, which is the Error column of the first table, so the
-phonometry rows can be reproduced directly.
+`env_db.max() - target`, which is the Error column of the table, so the
+rows can be reproduced directly.
 
 The figure fixes the burst at one place in time, which is the one thing the
 block integrator's answer depends on and the exponential detector's does not.
@@ -174,7 +165,7 @@ corridor intended for precision work, class 2 the wider one for general survey
 use, and both widen at the extremes of the frequency range, where they are
 hardest to meet. Class 0 was a narrower corridor still, in the withdrawn 1995
 edition of IEC 61260, and is kept here as a voluntary extra target for the
-default Butterworth bank. So a PASS on this page means the computed response
+default Butterworth bank. So a pass on this page means the computed response
 never leaves the corridor the standard draws; it does not mean the error is
 zero, and the size of the margin is the interesting number.
 
@@ -215,10 +206,10 @@ elliptic read the same edges as their equiripple passband edge instead, which
 is stated with its measured cost on [Filter
 Banks](/phonometry/signals/filters/filter-banks/). The default Butterworth bank
 is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
-ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting stays
-inside class 1 tolerances up to 16 kHz at common audio rates through internal
-oversampling (see [Frequency
-Weighting](/phonometry/signals/levels/weighting/)).
+ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
+holds class 1 at every sample rate from 8 kHz up, because the analog
+prototype is fitted at the sample rate rather than transformed blind (see
+[Frequency Weighting](/phonometry/signals/levels/weighting/)).
 
 ## When the source is what is wrong
 
@@ -247,32 +238,29 @@ nothing in the port ever notices.
 
 ## Where phonometry fits in the Python ecosystem
 
-- **python-acoustics** was archived in February 2024 and is no longer
-  maintained; the comparison above was run against its last released version.
-- **acoustic-toolbox**, the community successor to python-acoustics, builds
-  its IEC 61672-1 time and frequency weighting on `pyoctaveband`, the former
-  name of this library, which since 2.1.0 is a shim over phonometry. It is only
-  the filters that it takes from here: its own `weighting.py` still carries
-  hard-coded one-third-octave A and C weighting tables.
-- **MoSQITo** focuses on psychoacoustic sound-quality metrics and covers a
-  good part of that ground already: Zwicker loudness, ECMA-418-2 loudness and
-  roughness, DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio,
-  and the ANSI S3.5 speech intelligibility index. phonometry implements the
-  same family, and adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
-  fluctuation strength and the Fastl & Zwicker annoyance model, none of which
-  MoSQITo exports. What differs most is the setting. Here those metrics sit in
-  the same conformance harness as the metrology core and compose directly with
-  the weighting filters, ballistics, band filtering and calibration that feed
-  them.
-- **pyroomacoustics** simulates room impulse responses for audio and machine
-  learning pipelines (image sources, ray tracing, beamforming, direction of
-  arrival), and it does reach the measurement side too, with sweep-based
-  impulse-response acquisition and an RT60 estimator. What it does not carry is
-  the ISO 3382 parameter set. phonometry's image-source and FDTD solvers are
-  pinned to published closed forms, and the image-source impulse response goes
-  through the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50,
-  Ts, per band, with the ISO 3382 decay-range validity flags) as a measured
-  one.
+Several Python projects share ground with phonometry, and the honest way to
+place them is by what each is built for rather than by racing them:
+
+- **acoustic-toolbox** is the community successor to python-acoustics, which
+  was archived in February 2024. It is a general acoustics toolkit, and its
+  IEC 61672-1 time and frequency weighting builds on `pyoctaveband`, the
+  former name of this library, which since 2.1.0 is a shim over phonometry.
+- **MoSQITo** is the reference open implementation for psychoacoustic
+  sound-quality metrics: Zwicker loudness, ECMA-418-2 loudness and roughness,
+  DIN 45692 sharpness, ECMA-74 tone-to-noise and prominence ratio, the
+  ANSI S3.5 speech intelligibility index. phonometry implements the same
+  family, adds ISO 532-2 and ISO 532-3 loudness, ECMA-418-2 tonality,
+  fluctuation strength and the Fastl & Zwicker annoyance model, and sits them
+  in the same conformance harness as the metrology core, composed directly
+  with the weighting filters, ballistics, band filtering and calibration that
+  feed them.
+- **pyroomacoustics** is built for simulating rooms in audio and machine
+  learning pipelines: image sources, ray tracing, beamforming, direction of
+  arrival, plus sweep-based impulse-response acquisition. phonometry's room
+  side is the measurement one: its image-source and FDTD solvers are pinned
+  to published closed forms, and a simulated impulse response goes through
+  the same `room_parameters` analysis (EDT, T20, T30, C50, C80, D50, Ts, per
+  band, with the ISO 3382 decay-range validity flags) as a measured one.
 
 If your work needs numbers you can defend against a standard's tolerance
 table, whether for measurement reports, environmental assessments or

--- a/site/src/content/docs/start/why-phonometry.mdx
+++ b/site/src/content/docs/start/why-phonometry.mdx
@@ -40,9 +40,11 @@ different questions:
 A pole on the negative real axis corresponds to a decaying exponential impulse
 response ($h(t) \propto e^{-t/\tau}$), exactly what "exponential time
 weighting" means: past events are forgotten exponentially. An implementation
-that instead places the pole on the positive real axis and resets the filter
-state every $\tau$ seconds has built the block integrator, whatever it is
-called: the reset hides the growth, and it changes the measurement's nature.
+that instead accumulates energy and resets every $\tau$ seconds has built
+the block integrator, whatever it is called, and one that puts the pole on
+the positive real axis before the same reset adds a growing weight inside
+each block on top: neither is the time weighting, because the reset changes
+the measurement's nature.
 
 That equation is also where the reference numbers of the next section come
 from, which is worth doing once rather than taking Table 4 on faith. Integrate
@@ -63,9 +65,11 @@ transcription of the table is itself checked rather than trusted.
 
 The consequence carries the rest of this page. Because the response is a smooth
 function of $T_\mathrm{b}/\tau$, a detector that really solves the equation tracks the
-whole column at once; a detector that averages over fixed 125 ms blocks has no
-$T_\mathrm{b}$ in it at all, and can only be right where the burst happens to fill a
-block.
+whole column at once; a detector that averages over fixed
+125 ms blocks answers with the burst's energy share of whichever blocks it
+lands in, which moves with duration and alignment alike but carries nothing
+of the $T_\mathrm{b}/\tau$ response, and it can only be right where the burst
+happens to fill a block.
 
 ## Verification against IEC 61672-1 (tone bursts)
 
@@ -76,7 +80,7 @@ level.
 ### How the check is run
 
 Table 4 fixes the excitation but not the plumbing, so here is the plumbing. A
-4 kHz sine is generated at 48 kHz for 3 s. The **reference** is the steady Fast
+4 kHz sine is generated at 48 kHz for 2 s. The **reference** is the steady Fast
 level of that continuous sine, averaged over its last half second — once the
 integrator has settled, this is $L_\mathrm{A}$ in the standard's notation. The burst of
 the stated duration is then cut out of *the same* sine, so its phase and
@@ -100,7 +104,8 @@ and S and for the $L_{\mathrm{A}E}$ column.
 | 1 ms | −21.0 | +1.0 / −2.0 | −20.99 | +0.01 | Pass |
 
 The exponential detector stays within 0.05 dB of the Table 4 reference at
-every duration, under 5 % of the class 1 budget, because a detector that
+every duration, and no row spends more than 4 % of its own class 1
+allowance, because a detector that
 solves the defining equation has no free parameter left to get wrong. A block
 integrator can also sit inside class 1 at a favourable alignment, but what it
 spends of the budget is set by how the burst happens to straddle a 125 ms
@@ -139,8 +144,8 @@ level, 1.0 dB above the target.
 />
 
 *The exponential trace is flat because $10\lg(1-e^{-T_\mathrm{b}/\tau})$ contains
-$T_\mathrm{b}$ and nothing about the clock; the block trace is a picture of the
-alignment and nothing else. Both readings are computed here with
+$T_\mathrm{b}$ and nothing about the clock; the block trace, at this fixed
+duration, is a picture of the alignment and nothing else. Both readings are computed here with
 `time_weighting(x, fs, mode="fast")` and with `leq` over consecutive 125 ms
 slices, against the same steady-tone reference the procedure above defines.*
 
@@ -185,7 +190,7 @@ sample from the metrology core:
 | ECMA-418-1:2024 | TNR/PR tone prominence: critical bandwidths, proximity spacing and prominence criteria against the worked examples in clauses 10–12 | `tests/psychoacoustics/quality/test_tonality.py` |
 | ISO 1996-1:2016 | `lden()`, `ldn()` and `composite_rating_level()` against hand-computed formula values | `tests/environment/assessment/test_rating.py` |
 | IEC 60942:2017 Table 2 | Calibrator short-term stability limits (frequency-dependent, class 1) in `sensitivity()` | `tests/metrology/test_calibration_validation.py` |
-| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()` | `tests/signals/test_levels.py` |
+| IEC 61252:1993 | The personal sound exposure quantities, `sound_exposure()` and the normalized 8 h level `lex_8h()`; IEC 61252:2025 has since superseded this print, and the transcription still targets the 1993+A2 text | `tests/signals/test_levels.py` |
 
 The same discipline applies far beyond the metrology core: today the suite
 runs {totalChecks} numerical conformance checks across {domains} domains and {standards} standards,
@@ -207,8 +212,9 @@ is stated with its measured cost on [Filter
 Banks](/phonometry/signals/filters/filter-banks/). The default Butterworth bank
 is checked against the stricter class 0 of the withdrawn IEC 61260:1995 /
 ANSI S1.11-2004 edition as well as the current class 1. And A/C weighting
-holds class 1 at every sample rate from 8 kHz up, because the analog
-prototype is fitted at the sample rate rather than transformed blind (see
+earns class 1 at each of the eight rates the suite grades it at, from 8 to
+192 kHz, at every Table 3 frequency below that rate's Nyquist, because the
+analog prototype is fitted at the sample rate rather than transformed blind (see
 [Frequency Weighting](/phonometry/signals/levels/weighting/)).
 
 ## When the source is what is wrong


### PR DESCRIPTION
The Why phonometry page raced python-acoustics: a two-column philosophy table, a second tone-burst table measured against that library, and an ecosystem section that scored three neighbours by what they lack. All of it aged the same way. The measured numbers were taken against an unpinned version of an archived project, the deficit claims about living projects go stale the day those projects move, and none of it was carrying the page: the argument is the differential equation, the Table 4 verification, the sliding-burst analysis and the animation, and every one of those is computed with this library's own time_weighting and leq.

The case study now contrasts the two methods rather than two libraries: an exponential detector against a block integrator, which is what the old competitor column was describing anyway. The unstable-pole observation stays as a statement about implementations in general. The python-acoustics results table is gone, the surviving results table says Pass in words instead of an emoji the conformance report no longer speaks, and the origin in issue #38 is kept, because the history is real. The ecosystem section now places acoustic-toolbox, MoSQITo and pyroomacoustics by what each is built for, with phonometry's own additions stated as its own and nothing scored.

The plain-markdown edition also catches up with the site twins, which had grown the Equation (7) derivation, the measurement plumbing, the performance-class explainer and the sliding-burst animation without it; the animation rides along as the GIF with a WebM link, like the other guide pages. Both site twins drop a sentence the fit-at-rate change had already made false, that A/C weighting holds class 1 through internal oversampling. The animation was checked act by act against what the prose claims (the block reading leaving the half-width corridor at 200 ms is on screen, 0,00 dB against the −1,0 target), and the llms shards are regenerated.

## Summary by Sourcery

Ground the phonometry rationale in independently derived IEC evidence and clearly distinguish exponential time weighting from block-based energy integration.

New Features:
- Reframe the phonometry case study around exponential IEC detectors versus block integrators, with alignment analysis and animation illustrating their differing behavior.
- Add an explanation of IEC performance classes and expand the documented conformance coverage to IEC 61252.

Enhancements:
- Derive and validate IEC 61672-1 Equation (7) reference values for tone-burst verification and clarify the measurement procedure and scope.
- Replace library-versus-library claims with a standards-focused Fast weighting results table and a purpose-based overview of related Python acoustics projects.
- Update the documented A/C weighting claims to reflect sample-rate-specific fitting and remove outdated oversampling language.

Documentation:
- Synchronize the English and Spanish guide pages, including the tone-burst methodology, performance-class explanation, ecosystem positioning, and animation links.
- Regenerate the LLM documentation shards.

Chores:
- Enhance the tone-burst figure generator to report reproducible measurement errors.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored documentation in 'why-phonometry.md' to clarify the distinction between exponential detectors and block integrators.</li>
<li>Updated IEC 61672-1 tone burst verification tables and added detailed explanations of the testing methodology.</li>
<li>Replaced the embedded Python code block for the tone burst figure with a description of the generator script and an animation.</li>
<li>Added a section explaining the concept of performance classes (Class 1, Class 2) in the context of IEC standards.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked the “Why phonometry” guide to explain time weighting through a clearer comparison with block integration.
  - Added detailed tone-burst verification procedures, reference-value derivations, visual demonstrations, and Class 1 limits.
  - Expanded conformance coverage to include IEC 61252:1993 and clarified filter-bank band-edge behavior.
  - Added an explanation of performance classes and refreshed the Python ecosystem overview.
  - Updated the Spanish documentation to reflect the revised terminology, comparisons, and compliance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->