### PR TITLE
Ask for the missing sources by name, beside the sponsor button

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ The repository ships a
 [`CITATION.cff`](https://github.com/jmrplens/phonometry/blob/main/CITATION.cff),
 so GitHub's *Cite this repository* button produces BibTeX and APA entries.
 
+## 💚 Support the project
+
+phonometry is one person's work, and its main cost is the primary sources:
+every metric is implemented from the governing standard's paid text. You can
+[sponsor the project on GitHub](https://github.com/sponsors/jmrplens), and the
+documentation keeps a live list of the
+[sources that resisted every legitimate acquisition route](https://jmrplens.github.io/phonometry/start/support/),
+with three ways to help get them: fund the purchase, verify against your own
+licensed copy, or point at a channel that was missed.
+
 ## 🧪 Development
 
 ```bash

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -197,6 +197,16 @@ The repository ships a
 [`CITATION.cff`](https://github.com/jmrplens/phonometry/blob/v3.3.0/CITATION.cff),
 so GitHub's *Cite this repository* button produces BibTeX and APA entries.
 
+## 💚 Support the project
+
+phonometry is one person's work, and its main cost is the primary sources:
+every metric is implemented from the governing standard's paid text. You can
+[sponsor the project on GitHub](https://github.com/sponsors/jmrplens), and the
+documentation keeps a live list of the
+[sources that resisted every legitimate acquisition route](https://jmrplens.github.io/phonometry/start/support/),
+with three ways to help get them: fund the purchase, verify against your own
+licensed copy, or point at a channel that was missed.
+
 ## 🧪 Development
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,12 @@ Every guide in the library, grouped by the folder it lives in. Each group
 heading links the overview page that says what the area is for and what it
 deliberately leaves out; each bold line links a section overview inside it.
 
-Before any of them, [Start](start/index.md) is the four pages meant to be read
+Before any of them, [Start](start/index.md) is the five pages meant to be read
 once: [Getting Started](start/getting-started.md) installs the library and runs
 a first calibrated analysis, [Why phonometry](start/why-phonometry.md) shows
-how a metric is checked against its standard, and [About](start/about.md) says
+how a metric is checked against its standard,
+[Support the project](start/support.md) lists the ways to help, starting with
+the sources the library still lacks, and [About](start/about.md) says
 who maintains it, how to report an error and how to cite it.
 
 ### [Signal analysis](signals/index.md)

--- a/docs/start/about.md
+++ b/docs/start/about.md
@@ -179,4 +179,6 @@ substitute for buying the documents.
 calibrated analysis, and [All guides](../README.md) is the map of the whole
 library grouped by topic. To check a number rather than install anything, the
 [conformance report](../CONFORMANCE.md) and the [errata registry](../ERRATA.md)
-are the two pages that answer that.
+are the two pages that answer that. And if the project is useful to you,
+[Support the project](support.md) says how to help, starting with the sources
+it still lacks.

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -8,7 +8,7 @@ define them — ISO, IEC, ANSI and ASTM, the CNOSSOS-EU annex to Directive
 the clause it implements. What that buys you, and how it is checked, is
 [Why phonometry](why-phonometry.md).
 
-Five short pages, meant to be read once before anything else. Each answers one
+Six short pages, meant to be read once before anything else. Each answers one
 question, and they are in the order the questions arrive.
 
 **Can I install it and get a number out?**

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -43,6 +43,9 @@ tone-burst check worked through against the acceptance limits.
 [About](about.md) states who maintains it, how to cite it and
 under what licence.
 
+[Support the project](support.md) lists the ways to help,
+starting with the primary sources the library still lacks.
+
 ## Two things to settle before any guide works
 
 **Which reference frame a level is in.** A level is either *physical*, in

--- a/docs/start/support.md
+++ b/docs/start/support.md
@@ -1,0 +1,64 @@
+← [Documentation index](../README.md)
+
+# Support the project
+
+phonometry is maintained by one person, and its real cost is not hosting or
+tooling: it is the primary sources. Every metric in the library is implemented
+from the governing standard's own text, and standards are paid documents that
+go out of print, get superseded and occasionally resist every legitimate
+acquisition route there is. This page lists the ways to help, from free to
+concrete.
+
+## Use it, and tell me when a number looks wrong
+
+The cheapest support is using the library and reporting the number that does
+not match your reference. A report that names a standard and a clause is the
+most valuable issue this project receives: the
+[errata register](../ERRATA.md) exists because sources get read closely, and
+several of its entries began as a user's raised eyebrow.
+[Open an issue](https://github.com/jmrplens/phonometry/issues) with what you
+measured and what you expected.
+
+## Sponsor
+
+[GitHub Sponsors](https://github.com/sponsors/jmrplens) funds the project
+directly, and the money goes where the cost is: buying the standards and
+editions the implementations are written from. A one-off sponsorship that
+names one of the documents below buys exactly that document, and the entry
+leaves the table when it lands.
+
+## The sources I could not obtain
+
+Everything below stands between the library and work it would otherwise do.
+Each entry has survived the whole acquisition effort: my own library, the
+official stores, the open-access indexes and every other legitimate channel I
+could find, re-checked on the date shown. Three routes help:
+
+- **Fund the purchase.** A one-off sponsorship naming the document; the
+  official store price is on each linked page.
+- **Verify against your licensed copy.** If your lab or employer already
+  holds one, you can check the implementation and its reference values
+  against your copy without sending me anything. The repository never
+  redistributes documents; what lands in the tree are the derived numeric
+  values, which is how the [conformance suite](../CONFORMANCE.md) is built.
+- **Point me at a channel I missed.** A lending library, an author's own
+  copy of a thesis, a proceedings archive that actually resolves.
+  [Open an issue](https://github.com/jmrplens/phonometry/issues).
+
+One route does not help: sending scans or PDFs of paywalled documents. I
+cannot accept them, and the project's credibility rests on its sources being
+clean.
+
+| Source | What it would unlock | Last checked |
+| :--- | :--- | :--- |
+| [IEC 60268-16:2020 (Ed. 5)](https://webstore.iec.ch/en/publication/26771) | The STI edition in force. The library implements the numerically identical Ed. 4 chain and holds Ed. 5 store previews and Corrigendum 1:2025; the full text would let the four new annexes and the ten-page Annex M be verified instead of described | 2026-09-01 |
+| [IEC 61252:2025](https://webstore.iec.ch/en/publication/68929) | The edition that superseded IEC 61252:1993+A1+A2 on 17 October 2025. The suite transcribes the 1993+A2 text for `sound_exposure()` and `lex_8h()`; the 2025 text is needed to review the delta | 2026-09-01 |
+| Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
+| Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
+| Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+
+Two Spanish print classics would also make a difference to the Spanish
+guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
+Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
+count, through the same routes.

--- a/docs/start/support.md
+++ b/docs/start/support.md
@@ -34,8 +34,9 @@ Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
 could find, re-checked on the date shown. Three routes help:
 
-- **Fund the purchase.** A one-off sponsorship naming the document; the
-  official store price is on each linked page.
+- **Fund the purchase.** A one-off sponsorship naming the document; where a
+  link goes to an official store, the price is on that page, and for the rest
+  name the item and I will quote it in the issue.
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
   against your copy without sending me anything. The repository never
@@ -56,9 +57,9 @@ clean.
 | Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
 | Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
 | Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
-| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, doi 10.25144/19134) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
 
-Two Spanish print classics would also make a difference to the Spanish
-guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
-Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
-count, through the same routes.
+| Recuero, *Ingeniería acústica* (Paraninfo) | Canonical Spanish textbook; print only, and it would enrich the terminology and worked examples of the Spanish guides | 2026-09-01 |
+| Arau, *ABC de la acústica arquitectónica* (CEAC, 2007) | Spanish room-acoustics authority behind the Arau-Puchades formula the library implements; print only | 2026-09-01 |
+
+Second-hand print copies count, through the same routes.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -49888,7 +49888,7 @@ define them — ISO, IEC, ANSI and ASTM, the CNOSSOS-EU annex to Directive
 the clause it implements. What that buys you, and how it is checked, is
 [Why phonometry](https://jmrplens.github.io/phonometry/start/why-phonometry/).
 
-Five short pages, meant to be read once before anything else. Each answers one
+Six short pages, meant to be read once before anything else. Each answers one
 question, and they are in the order the questions arrive.
 
 **Can I install it and get a number out?**
@@ -50016,8 +50016,9 @@ Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
 could find, re-checked on the date shown. Three routes help:
 
-- **Fund the purchase.** A one-off sponsorship naming the document; the
-  official store price is on each linked page.
+- **Fund the purchase.** A one-off sponsorship naming the document; where a
+  link goes to an official store, the price is on that page, and for the rest
+  name the item and I will quote it in the issue.
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
   against your copy without sending me anything. The repository never
@@ -50038,12 +50039,12 @@ clean.
 | Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
 | Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
 | Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
-| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, doi 10.25144/19134) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
 
-Two Spanish print classics would also make a difference to the Spanish
-guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
-Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
-count, through the same routes.
+| Recuero, *Ingeniería acústica* (Paraninfo) | Canonical Spanish textbook; print only, and it would enrich the terminology and worked examples of the Spanish guides | 2026-09-01 |
+| Arau, *ABC de la acústica arquitectónica* (CEAC, 2007) | Spanish room-acoustics authority behind the Arau-Puchades formula the library implements; print only | 2026-09-01 |
+
+Second-hand print copies count, through the same routes.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -40,6 +40,7 @@ If you are an AI assistant setting this up for a user: install from PyPI (no sys
 - [Getting Started](https://jmrplens.github.io/phonometry/start/getting-started/)
 - [Why phonometry](https://jmrplens.github.io/phonometry/start/why-phonometry/)
 - [About](https://jmrplens.github.io/phonometry/start/about/)
+- [Support the project](https://jmrplens.github.io/phonometry/start/support/)
 - [Guides index](https://jmrplens.github.io/phonometry/start/guides/)
 - [Glossary of quantities](https://jmrplens.github.io/phonometry/reference/glossary/)
 
@@ -49667,7 +49668,9 @@ substitute for buying the documents.
 calibrated analysis, and [All guides](https://jmrplens.github.io/phonometry/) is the map of the whole
 library grouped by topic. To check a number rather than install anything, the
 [conformance report](https://jmrplens.github.io/phonometry/reference/conformance/) and the [errata registry](https://jmrplens.github.io/phonometry/reference/errata/)
-are the two pages that answer that.
+are the two pages that answer that. And if the project is useful to you,
+[Support the project](https://jmrplens.github.io/phonometry/start/support/) says how to help, starting with the sources
+it still lacks.
 
 ---
 
@@ -49920,6 +49923,9 @@ tone-burst check worked through against the acceptance limits.
 [About](https://jmrplens.github.io/phonometry/start/about/) states who maintains it, how to cite it and
 under what licence.
 
+[Support the project](https://jmrplens.github.io/phonometry/start/support/) lists the ways to help,
+starting with the primary sources the library still lacks.
+
 ## Two things to settle before any guide works
 
 **Which reference frame a level is in.** A level is either *physical*, in
@@ -49969,6 +49975,75 @@ published standards themselves, the glossary of symbols and the bibliography
 are all in [Reference](https://jmrplens.github.io/phonometry/reference/). And the acoustics itself is
 assumed rather than taught: the guides explain the method a standard
 prescribes and why it is written that way, not what a decibel is.
+
+---
+
+
+<!-- source: docs/start/support.md | canonical: https://jmrplens.github.io/phonometry/start/support/ -->
+Source: https://jmrplens.github.io/phonometry/start/support/
+
+# Support the project
+
+phonometry is maintained by one person, and its real cost is not hosting or
+tooling: it is the primary sources. Every metric in the library is implemented
+from the governing standard's own text, and standards are paid documents that
+go out of print, get superseded and occasionally resist every legitimate
+acquisition route there is. This page lists the ways to help, from free to
+concrete.
+
+## Use it, and tell me when a number looks wrong
+
+The cheapest support is using the library and reporting the number that does
+not match your reference. A report that names a standard and a clause is the
+most valuable issue this project receives: the
+[errata register](https://jmrplens.github.io/phonometry/reference/errata/) exists because sources get read closely, and
+several of its entries began as a user's raised eyebrow.
+[Open an issue](https://github.com/jmrplens/phonometry/issues) with what you
+measured and what you expected.
+
+## Sponsor
+
+[GitHub Sponsors](https://github.com/sponsors/jmrplens) funds the project
+directly, and the money goes where the cost is: buying the standards and
+editions the implementations are written from. A one-off sponsorship that
+names one of the documents below buys exactly that document, and the entry
+leaves the table when it lands.
+
+## The sources I could not obtain
+
+Everything below stands between the library and work it would otherwise do.
+Each entry has survived the whole acquisition effort: my own library, the
+official stores, the open-access indexes and every other legitimate channel I
+could find, re-checked on the date shown. Three routes help:
+
+- **Fund the purchase.** A one-off sponsorship naming the document; the
+  official store price is on each linked page.
+- **Verify against your licensed copy.** If your lab or employer already
+  holds one, you can check the implementation and its reference values
+  against your copy without sending me anything. The repository never
+  redistributes documents; what lands in the tree are the derived numeric
+  values, which is how the [conformance suite](https://jmrplens.github.io/phonometry/reference/conformance/) is built.
+- **Point me at a channel I missed.** A lending library, an author's own
+  copy of a thesis, a proceedings archive that actually resolves.
+  [Open an issue](https://github.com/jmrplens/phonometry/issues).
+
+One route does not help: sending scans or PDFs of paywalled documents. I
+cannot accept them, and the project's credibility rests on its sources being
+clean.
+
+| Source | What it would unlock | Last checked |
+| :--- | :--- | :--- |
+| [IEC 60268-16:2020 (Ed. 5)](https://webstore.iec.ch/en/publication/26771) | The STI edition in force. The library implements the numerically identical Ed. 4 chain and holds Ed. 5 store previews and Corrigendum 1:2025; the full text would let the four new annexes and the ten-page Annex M be verified instead of described | 2026-09-01 |
+| [IEC 61252:2025](https://webstore.iec.ch/en/publication/68929) | The edition that superseded IEC 61252:1993+A1+A2 on 17 October 2025. The suite transcribes the 1993+A2 text for `sound_exposure()` and `lex_8h()`; the 2025 text is needed to review the delta | 2026-09-01 |
+| Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
+| Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
+| Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+
+Two Spanish print classics would also make a difference to the Spanish
+guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
+Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
+count, through the same routes.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -40,6 +40,7 @@ If you are an AI assistant setting this up for a user: install from PyPI (no sys
 - [Getting Started](https://jmrplens.github.io/phonometry/start/getting-started/)
 - [Why phonometry](https://jmrplens.github.io/phonometry/start/why-phonometry/)
 - [About](https://jmrplens.github.io/phonometry/start/about/)
+- [Support the project](https://jmrplens.github.io/phonometry/start/support/)
 - [Guides index](https://jmrplens.github.io/phonometry/start/guides/)
 - [Glossary of quantities](https://jmrplens.github.io/phonometry/reference/glossary/)
 

--- a/scripts/generate_llms.py
+++ b/scripts/generate_llms.py
@@ -113,7 +113,12 @@ AREAS: tuple[tuple[str, str], ...] = (
 #: absolute URL from the provenance section instead. It used to be listed
 #: without a mirror and silently dropped, which is why an unresolvable entry is
 #: fatal now.
-START_ROUTES = ("start/getting-started", "start/why-phonometry", "start/about")
+START_ROUTES = (
+    "start/getting-started",
+    "start/why-phonometry",
+    "start/about",
+    "start/support",
+)
 
 
 def _check_areas_cover_the_tree() -> None:

--- a/site/public/llms/llms-start.txt
+++ b/site/public/llms/llms-start.txt
@@ -15,7 +15,7 @@ define them — ISO, IEC, ANSI and ASTM, the CNOSSOS-EU annex to Directive
 the clause it implements. What that buys you, and how it is checked, is
 [Why phonometry](https://jmrplens.github.io/phonometry/start/why-phonometry/).
 
-Five short pages, meant to be read once before anything else. Each answers one
+Six short pages, meant to be read once before anything else. Each answers one
 question, and they are in the order the questions arrive.
 
 **Can I install it and get a number out?**
@@ -811,8 +811,9 @@ Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
 could find, re-checked on the date shown. Three routes help:
 
-- **Fund the purchase.** A one-off sponsorship naming the document; the
-  official store price is on each linked page.
+- **Fund the purchase.** A one-off sponsorship naming the document; where a
+  link goes to an official store, the price is on that page, and for the rest
+  name the item and I will quote it in the issue.
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
   against your copy without sending me anything. The repository never
@@ -833,11 +834,11 @@ clean.
 | Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
 | Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
 | Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
-| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, doi 10.25144/19134) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
 
-Two Spanish print classics would also make a difference to the Spanish
-guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
-Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
-count, through the same routes.
+| Recuero, *Ingeniería acústica* (Paraninfo) | Canonical Spanish textbook; print only, and it would enrich the terminology and worked examples of the Spanish guides | 2026-09-01 |
+| Arau, *ABC de la acústica arquitectónica* (CEAC, 2007) | Spanish room-acoustics authority behind the Arau-Puchades formula the library implements; print only | 2026-09-01 |
+
+Second-hand print copies count, through the same routes.
 
 ---

--- a/site/public/llms/llms-start.txt
+++ b/site/public/llms/llms-start.txt
@@ -50,6 +50,9 @@ tone-burst check worked through against the acceptance limits.
 [About](https://jmrplens.github.io/phonometry/start/about/) states who maintains it, how to cite it and
 under what licence.
 
+[Support the project](https://jmrplens.github.io/phonometry/start/support/) lists the ways to help,
+starting with the primary sources the library still lacks.
+
 ## Two things to settle before any guide works
 
 **Which reference frame a level is in.** A level is either *physical*, in
@@ -764,6 +767,77 @@ substitute for buying the documents.
 calibrated analysis, and [All guides](https://jmrplens.github.io/phonometry/) is the map of the whole
 library grouped by topic. To check a number rather than install anything, the
 [conformance report](https://jmrplens.github.io/phonometry/reference/conformance/) and the [errata registry](https://jmrplens.github.io/phonometry/reference/errata/)
-are the two pages that answer that.
+are the two pages that answer that. And if the project is useful to you,
+[Support the project](https://jmrplens.github.io/phonometry/start/support/) says how to help, starting with the sources
+it still lacks.
+
+---
+
+
+<!-- source: docs/start/support.md | canonical: https://jmrplens.github.io/phonometry/start/support/ -->
+Source: https://jmrplens.github.io/phonometry/start/support/
+
+# Support the project
+
+phonometry is maintained by one person, and its real cost is not hosting or
+tooling: it is the primary sources. Every metric in the library is implemented
+from the governing standard's own text, and standards are paid documents that
+go out of print, get superseded and occasionally resist every legitimate
+acquisition route there is. This page lists the ways to help, from free to
+concrete.
+
+## Use it, and tell me when a number looks wrong
+
+The cheapest support is using the library and reporting the number that does
+not match your reference. A report that names a standard and a clause is the
+most valuable issue this project receives: the
+[errata register](https://jmrplens.github.io/phonometry/reference/errata/) exists because sources get read closely, and
+several of its entries began as a user's raised eyebrow.
+[Open an issue](https://github.com/jmrplens/phonometry/issues) with what you
+measured and what you expected.
+
+## Sponsor
+
+[GitHub Sponsors](https://github.com/sponsors/jmrplens) funds the project
+directly, and the money goes where the cost is: buying the standards and
+editions the implementations are written from. A one-off sponsorship that
+names one of the documents below buys exactly that document, and the entry
+leaves the table when it lands.
+
+## The sources I could not obtain
+
+Everything below stands between the library and work it would otherwise do.
+Each entry has survived the whole acquisition effort: my own library, the
+official stores, the open-access indexes and every other legitimate channel I
+could find, re-checked on the date shown. Three routes help:
+
+- **Fund the purchase.** A one-off sponsorship naming the document; the
+  official store price is on each linked page.
+- **Verify against your licensed copy.** If your lab or employer already
+  holds one, you can check the implementation and its reference values
+  against your copy without sending me anything. The repository never
+  redistributes documents; what lands in the tree are the derived numeric
+  values, which is how the [conformance suite](https://jmrplens.github.io/phonometry/reference/conformance/) is built.
+- **Point me at a channel I missed.** A lending library, an author's own
+  copy of a thesis, a proceedings archive that actually resolves.
+  [Open an issue](https://github.com/jmrplens/phonometry/issues).
+
+One route does not help: sending scans or PDFs of paywalled documents. I
+cannot accept them, and the project's credibility rests on its sources being
+clean.
+
+| Source | What it would unlock | Last checked |
+| :--- | :--- | :--- |
+| [IEC 60268-16:2020 (Ed. 5)](https://webstore.iec.ch/en/publication/26771) | The STI edition in force. The library implements the numerically identical Ed. 4 chain and holds Ed. 5 store previews and Corrigendum 1:2025; the full text would let the four new annexes and the ten-page Annex M be verified instead of described | 2026-09-01 |
+| [IEC 61252:2025](https://webstore.iec.ch/en/publication/68929) | The edition that superseded IEC 61252:1993+A1+A2 on 17 October 2025. The suite transcribes the 1993+A2 text for `sound_exposure()` and `lex_8h()`; the 2025 text is needed to review the delta | 2026-09-01 |
+| Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
+| Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
+| Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+
+Two Spanish print classics would also make a difference to the Spanish
+guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
+Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
+count, through the same routes.
 
 ---

--- a/site/src/content/docs/es/start/about.md
+++ b/site/src/content/docs/es/start/about.md
@@ -201,4 +201,6 @@ biblioteca entera agrupada por temas. Si has venido a comprobar un número y no
 a instalar nada, el [informe de
 conformidad](/phonometry/es/reference/conformance/) y el [registro de
 erratas](/phonometry/es/reference/errata/) son las dos páginas que responden a
-eso.
+eso. Y si el proyecto te resulta útil,
+[Apoya el proyecto](/phonometry/es/start/support/) cuenta cómo ayudar,
+empezando por las fuentes que aún le faltan.

--- a/site/src/content/docs/es/start/index.md
+++ b/site/src/content/docs/es/start/index.md
@@ -9,7 +9,7 @@ las definen — ISO, IEC, ANSI y ASTM, el anexo CNOSSOS-EU de la Directiva
 el apartado que implementa. Qué te aporta eso, y cómo se comprueba, está en
 [Por qué phonometry](/phonometry/es/start/why-phonometry/).
 
-Cinco páginas breves, pensadas para leerse una vez antes que nada. Cada una
+Seis páginas breves, pensadas para leerse una vez antes que nada. Cada una
 responde a una pregunta, y están en el orden en que llegan las preguntas.
 
 **¿Puedo instalarla y sacar un número?**

--- a/site/src/content/docs/es/start/index.md
+++ b/site/src/content/docs/es/start/index.md
@@ -46,6 +46,10 @@ aceptación.
 [Acerca de](/phonometry/es/start/about/) dice quién la mantiene, cómo citarla y
 bajo qué licencia.
 
+[Apoya el proyecto](/phonometry/es/start/support/) lista las maneras de
+ayudar, empezando por las fuentes primarias que aún le faltan a la
+biblioteca.
+
 ## Dos cosas que conviene resolver antes de que ninguna guía funcione
 
 **En qué marco de referencia está un nivel.** Un nivel es o bien *físico*, en

--- a/site/src/content/docs/es/start/support.mdx
+++ b/site/src/content/docs/es/start/support.mdx
@@ -37,8 +37,9 @@ propia biblioteca, las tiendas oficiales, los índices de acceso abierto y
 todos los demás canales legítimos que he encontrado, revisado de nuevo en la
 fecha indicada. Ayudan tres vías:
 
-- **Financiar la compra.** Un patrocinio puntual que nombre el documento; el
-  precio de la tienda oficial está en cada página enlazada.
+- **Financiar la compra.** Un patrocinio puntual que nombre el documento;
+  donde un enlace va a una tienda oficial, el precio está en esa página, y
+  para el resto nombra el ítem y te doy el precio en la incidencia.
 - **Verificar contra tu copia con licencia.** Si tu laboratorio o tu empresa
   ya tiene una, puedes cotejar la implementación y sus valores de referencia
   contra tu copia sin enviarme nada. El repositorio nunca redistribuye
@@ -61,9 +62,9 @@ estén limpias.
 | Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, tesis doctoral de la TUM | La fuente primaria del modelo de molestia psicoacústica. El modelo está implementado desde Fastl y Zwicker (2006); la tesis, 116 páginas impresas anteriores al depósito electrónico, permitiría al registro citar el origen de primera mano | 2026-09-01 |
 | Bowdler y Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | La referencia estándar detrás de la guía de ruido de aerogeneradores; solo circulan sus reseñas | 2026-09-01 |
 | Crispin, Blasco, Ingelaere y Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Valores medidos de Kij de unión como oráculo independiente para las implementaciones de ISO 10848 y EN 12354-1 | 2026-09-01 |
-| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Datos de flancos medidos por intensidad junto a la implementación de ISO 15186; el enlace del propio editor lleva años muerto | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, doi 10.25144/19134) | Datos de flancos medidos por intensidad junto a la implementación de ISO 15186; el enlace del propio editor lleva años muerto | 2026-09-01 |
 
-Dos clásicos españoles en papel también marcarían la diferencia en las guías
-en español, y ambos existen solo impresos: Recuero, *Ingeniería acústica*, y
-Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Las copias de segunda
-mano cuentan, por las mismas vías.
+| Recuero, *Ingeniería acústica* (Paraninfo) | Manual canónico en español; solo existe impreso, y enriquecería la terminología y los ejemplos resueltos de las guías en español | 2026-09-01 |
+| Arau, *ABC de la acústica arquitectónica* (CEAC, 2007) | La autoridad española de acústica de salas detrás de la fórmula de Arau-Puchades que la biblioteca implementa; solo impreso | 2026-09-01 |
+
+Las copias impresas de segunda mano cuentan, por las mismas vías.

--- a/site/src/content/docs/es/start/support.mdx
+++ b/site/src/content/docs/es/start/support.mdx
@@ -1,0 +1,69 @@
+---
+title: "Apoya el proyecto"
+description: "Cómo apoyar phonometry: reportar números que no cuadren, patrocinar el trabajo y ayudar a conseguir las fuentes primarias que han resistido todas las vías legítimas de adquisición."
+---
+
+phonometry lo mantiene una persona, y su coste real no es el alojamiento ni
+las herramientas: son las fuentes primarias. Cada métrica de la biblioteca se
+implementa a partir del propio texto de la norma que la rige, y las normas son
+documentos de pago que se descatalogan, se sustituyen y a veces resisten todas
+las vías legítimas de adquisición que existen. Esta página lista las maneras
+de ayudar, de la gratuita a la concreta.
+
+## Úsala, y dime cuándo un número no cuadra
+
+El apoyo más barato es usar la biblioteca y reportar el número que no coincide
+con tu referencia. Un reporte que nombre una norma y un apartado es la
+incidencia más valiosa que recibe este proyecto: el
+[registro de erratas](/phonometry/es/reference/errata/) existe porque las
+fuentes se leen con lupa, y varias de sus entradas empezaron como la ceja
+levantada de un usuario.
+[Abre una incidencia](https://github.com/jmrplens/phonometry/issues) con lo
+que mediste y lo que esperabas.
+
+## Patrocina
+
+[GitHub Sponsors](https://github.com/sponsors/jmrplens) financia el proyecto
+directamente, y el dinero va a donde está el coste: comprar las normas y
+ediciones de las que se escriben las implementaciones. Un patrocinio puntual
+que nombre uno de los documentos de abajo compra exactamente ese documento, y
+la entrada sale de la tabla cuando llega.
+
+## Las fuentes que no he podido conseguir
+
+Todo lo de abajo se interpone entre la biblioteca y trabajo que de otro modo
+haría. Cada entrada ha sobrevivido al esfuerzo de adquisición completo: mi
+propia biblioteca, las tiendas oficiales, los índices de acceso abierto y
+todos los demás canales legítimos que he encontrado, revisado de nuevo en la
+fecha indicada. Ayudan tres vías:
+
+- **Financiar la compra.** Un patrocinio puntual que nombre el documento; el
+  precio de la tienda oficial está en cada página enlazada.
+- **Verificar contra tu copia con licencia.** Si tu laboratorio o tu empresa
+  ya tiene una, puedes cotejar la implementación y sus valores de referencia
+  contra tu copia sin enviarme nada. El repositorio nunca redistribuye
+  documentos; lo que entra en el árbol son los valores numéricos derivados,
+  que es como está construida la
+  [batería de conformidad](/phonometry/es/reference/conformance/).
+- **Señalarme un canal que se me haya escapado.** Una biblioteca de préstamo,
+  la copia del propio autor de una tesis, un archivo de actas que de verdad
+  resuelva.
+  [Abre una incidencia](https://github.com/jmrplens/phonometry/issues).
+
+Hay una vía que no ayuda: enviar escaneos o PDF de documentos de pago. No
+puedo aceptarlos, y la credibilidad del proyecto descansa en que sus fuentes
+estén limpias.
+
+| Fuente | Qué desbloquearía | Última revisión |
+| :--- | :--- | :--- |
+| [IEC 60268-16:2020 (Ed. 5)](https://webstore.iec.ch/en/publication/26771) | La edición vigente del STI. La biblioteca implementa la cadena de la Ed. 4, numéricamente idéntica, y tiene las vistas previas de tienda de la Ed. 5 y el Corrigendum 1:2025; el texto completo permitiría verificar, en vez de describir, los cuatro anexos nuevos y las diez páginas del Anexo M | 2026-09-01 |
+| [IEC 61252:2025](https://webstore.iec.ch/en/publication/68929) | La edición que sustituyó a IEC 61252:1993+A1+A2 el 17 de octubre de 2025. La batería transcribe el texto 1993+A2 para `sound_exposure()` y `lex_8h()`; el texto de 2025 hace falta para revisar el delta | 2026-09-01 |
+| Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, tesis doctoral de la TUM | La fuente primaria del modelo de molestia psicoacústica. El modelo está implementado desde Fastl y Zwicker (2006); la tesis, 116 páginas impresas anteriores al depósito electrónico, permitiría al registro citar el origen de primera mano | 2026-09-01 |
+| Bowdler y Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | La referencia estándar detrás de la guía de ruido de aerogeneradores; solo circulan sus reseñas | 2026-09-01 |
+| Crispin, Blasco, Ingelaere y Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Valores medidos de Kij de unión como oráculo independiente para las implementaciones de ISO 10848 y EN 12354-1 | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Datos de flancos medidos por intensidad junto a la implementación de ISO 15186; el enlace del propio editor lleva años muerto | 2026-09-01 |
+
+Dos clásicos españoles en papel también marcarían la diferencia en las guías
+en español, y ambos existen solo impresos: Recuero, *Ingeniería acústica*, y
+Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Las copias de segunda
+mano cuentan, por las mismas vías.

--- a/site/src/content/docs/start/about.md
+++ b/site/src/content/docs/start/about.md
@@ -192,3 +192,6 @@ measure?](/phonometry/start/tasks/) finds the page for a particular job, and
 by topic. If you arrived to check a number rather than to install anything, the
 [conformance report](/phonometry/reference/conformance/) and the [errata
 registry](/phonometry/reference/errata/) are the two pages that answer that.
+And if the project is useful to you,
+[Support the project](/phonometry/start/support/) says how to help, starting
+with the sources it still lacks.

--- a/site/src/content/docs/start/index.md
+++ b/site/src/content/docs/start/index.md
@@ -9,7 +9,7 @@ define them — ISO, IEC, ANSI and ASTM, the CNOSSOS-EU annex to Directive
 the clause it implements. What that buys you, and how it is checked, is
 [Why phonometry](/phonometry/start/why-phonometry/).
 
-Five short pages, meant to be read once before anything else. Each answers one
+Six short pages, meant to be read once before anything else. Each answers one
 question, and they are in the order the questions arrive.
 
 **Can I install it and get a number out?**

--- a/site/src/content/docs/start/index.md
+++ b/site/src/content/docs/start/index.md
@@ -44,6 +44,9 @@ tone-burst check worked through against the acceptance limits.
 [About](/phonometry/start/about/) states who maintains it, how to cite it and
 under what licence.
 
+[Support the project](/phonometry/start/support/) lists the ways to help,
+starting with the primary sources the library still lacks.
+
 ## Two things to settle before any guide works
 
 **Which reference frame a level is in.** A level is either *physical*, in

--- a/site/src/content/docs/start/support.mdx
+++ b/site/src/content/docs/start/support.mdx
@@ -35,8 +35,9 @@ Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
 could find, re-checked on the date shown. Three routes help:
 
-- **Fund the purchase.** A one-off sponsorship naming the document; the
-  official store price is on each linked page.
+- **Fund the purchase.** A one-off sponsorship naming the document; where a
+  link goes to an official store, the price is on that page, and for the rest
+  name the item and I will quote it in the issue.
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
   against your copy without sending me anything. The repository never
@@ -58,9 +59,9 @@ clean.
 | Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
 | Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
 | Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
-| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, doi 10.25144/19134) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
 
-Two Spanish print classics would also make a difference to the Spanish
-guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
-Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
-count, through the same routes.
+| Recuero, *Ingeniería acústica* (Paraninfo) | Canonical Spanish textbook; print only, and it would enrich the terminology and worked examples of the Spanish guides | 2026-09-01 |
+| Arau, *ABC de la acústica arquitectónica* (CEAC, 2007) | Spanish room-acoustics authority behind the Arau-Puchades formula the library implements; print only | 2026-09-01 |
+
+Second-hand print copies count, through the same routes.

--- a/site/src/content/docs/start/support.mdx
+++ b/site/src/content/docs/start/support.mdx
@@ -1,0 +1,66 @@
+---
+title: "Support the project"
+description: "How to support phonometry: report numbers that look wrong, sponsor the work, and help obtain the primary sources that have resisted every legitimate acquisition route."
+---
+
+phonometry is maintained by one person, and its real cost is not hosting or
+tooling: it is the primary sources. Every metric in the library is implemented
+from the governing standard's own text, and standards are paid documents that
+go out of print, get superseded and occasionally resist every legitimate
+acquisition route there is. This page lists the ways to help, from free to
+concrete.
+
+## Use it, and tell me when a number looks wrong
+
+The cheapest support is using the library and reporting the number that does
+not match your reference. A report that names a standard and a clause is the
+most valuable issue this project receives: the
+[errata register](/phonometry/reference/errata/) exists because sources get
+read closely, and several of its entries began as a user's raised eyebrow.
+[Open an issue](https://github.com/jmrplens/phonometry/issues) with what you
+measured and what you expected.
+
+## Sponsor
+
+[GitHub Sponsors](https://github.com/sponsors/jmrplens) funds the project
+directly, and the money goes where the cost is: buying the standards and
+editions the implementations are written from. A one-off sponsorship that
+names one of the documents below buys exactly that document, and the entry
+leaves the table when it lands.
+
+## The sources I could not obtain
+
+Everything below stands between the library and work it would otherwise do.
+Each entry has survived the whole acquisition effort: my own library, the
+official stores, the open-access indexes and every other legitimate channel I
+could find, re-checked on the date shown. Three routes help:
+
+- **Fund the purchase.** A one-off sponsorship naming the document; the
+  official store price is on each linked page.
+- **Verify against your licensed copy.** If your lab or employer already
+  holds one, you can check the implementation and its reference values
+  against your copy without sending me anything. The repository never
+  redistributes documents; what lands in the tree are the derived numeric
+  values, which is how the
+  [conformance suite](/phonometry/reference/conformance/) is built.
+- **Point me at a channel I missed.** A lending library, an author's own
+  copy of a thesis, a proceedings archive that actually resolves.
+  [Open an issue](https://github.com/jmrplens/phonometry/issues).
+
+One route does not help: sending scans or PDFs of paywalled documents. I
+cannot accept them, and the project's credibility rests on its sources being
+clean.
+
+| Source | What it would unlock | Last checked |
+| :--- | :--- | :--- |
+| [IEC 60268-16:2020 (Ed. 5)](https://webstore.iec.ch/en/publication/26771) | The STI edition in force. The library implements the numerically identical Ed. 4 chain and holds Ed. 5 store previews and Corrigendum 1:2025; the full text would let the four new annexes and the ten-page Annex M be verified instead of described | 2026-09-01 |
+| [IEC 61252:2025](https://webstore.iec.ch/en/publication/68929) | The edition that superseded IEC 61252:1993+A1+A2 on 17 October 2025. The suite transcribes the 1993+A2 text for `sound_exposure()` and `lex_8h()`; the 2025 text is needed to review the delta | 2026-09-01 |
+| Widmann (1992), *Ein Modell der psychoakustischen Lästigkeit von Schallen*, TUM doctoral thesis | The primary source of the psychoacoustic-annoyance model. The model is implemented from Fastl & Zwicker (2006); the thesis, 116 printed pages that predate electronic deposit, would let the register cite the origin at first hand | 2026-09-01 |
+| Bowdler & Leventhall (eds.), *Wind Turbine Noise* (Multi-Science, 2011) | The standard reference behind the wind-turbine noise guide; only its book reviews circulate | 2026-09-01 |
+| Crispin, Blasco, Ingelaere & Van Damme, *The vibration reduction index Kij: laboratory measurements versus predictions EN 12354-1* ([doi:10.1201/9781003078852-125](https://doi.org/10.1201/9781003078852-125)) | Measured junction Kij values as an independent oracle for the ISO 10848 and EN 12354-1 implementations | 2026-09-01 |
+| Hopkins, *Sound insulation measurements with intensity techniques: flanking transmission* (IoA 1997, [doi:10.25144/19134](https://doi.org/10.25144/19134)) | Intensity-measured flanking data beside the ISO 15186 implementation; the publisher's own link has been dead for years | 2026-09-01 |
+
+Two Spanish print classics would also make a difference to the Spanish
+guides, and both exist only on paper: Recuero, *Ingeniería acústica*, and
+Arau, *ABC de la acústica arquitectónica* (CEAC, 2007). Second-hand copies
+count, through the same routes.

--- a/site/src/data/topics.mjs
+++ b/site/src/data/topics.mjs
@@ -56,6 +56,7 @@ export const topics = [
       { slug: 'start/guides', label: 'All guides', translations: { es: 'Todas las guías' } },
       'start/why-phonometry',
       'start/about',
+      'start/support',
     ],
   },
   {


### PR DESCRIPTION
The project's real cost is its primary sources, and until now the only place that said so was a sponsor button with nothing behind it. This adds a Support the project page, in the three editions beside About, that names the ways to help in order of cost: use the library and report the number that does not match your reference, sponsor the work, and help obtain the specific documents that have resisted every legitimate acquisition route.

Those documents are a table, not a wishlist. Every entry survived the whole escalation and was re-checked today through the acquisition tooling before being listed: the full text of IEC 60268-16:2020 beyond its store previews and Corrigendum 1:2025, the IEC 61252:2025 edition that superseded the 1993+A2 text the suite transcribes (withdrawal date verified on the IEC webstore), the 1992 Widmann thesis that psychoacoustic annoyance descends from, the Bowdler and Leventhall wind-turbine reference of which only book reviews circulate, and the two flanking-transmission oracles whose DOIs resolve to nothing through any open-access index. Two Spanish print classics close the page as a softer ask for the Spanish guides.

Three routes are offered, all of them clean: fund the purchase through a one-off sponsorship that names the document, verify the implementation and its reference values against a copy your organisation already licenses without sending anything, or point at a legitimate channel the search missed. One route is refused in writing, scans and PDFs of paywalled documents, because the repository never redistributes sources and its credibility rests on that.

The README gains a short section linking the live list, the Start index and About point at the page in both languages, the sidebar lists it after About, and the page joins the start shard of llms.txt. Overview mirrors, llms artifacts and the PyPI README are regenerated, and the entry-count sentence in the docs index now says five pages instead of four.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new 'Support the project' section to the documentation and README files to encourage sponsorship and help with acquiring primary source standards.</li>
<li>Created a new documentation page 'docs/start/support.md' (and corresponding localized versions) detailing how to support the project.</li>
<li>Updated documentation navigation and index pages to include the new support page.</li>
<li>Updated 'site/src/data/topics.mjs' to include the new support topic.</li>
</ul></div>

## Summary by Sourcery

Add a multilingual support hub that channels project assistance toward validation and obtaining missing primary sources.

New Features:
- Add multilingual Support the project documentation pages describing reporting issues, sponsorship, licensed-copy verification, legitimate acquisition leads, and currently unobtainable primary sources.

Enhancements:
- Expose the support page throughout the README, documentation indexes, start pages, navigation, and About pages.
- Regenerate the llms.txt artifacts and include the support page in the Start content shard.

Documentation:
- Document the specific standards, books, theses, and research papers whose acquisition would unlock further verification and implementation work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new “Support the project” guide in English and Spanish.
  - Explained ways to contribute, including reporting discrepancies, sponsoring source purchases, verifying results against licensed standards, and suggesting legitimate acquisition channels.
  - Documented unavailable standards and other primary sources, including their intended uses and review dates.
  - Clarified that paywalled scans or PDFs should not be shared.
  - Added links to the guide throughout the getting-started documentation and published documentation navigation.
  - Updated conformance documentation to report 585 checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->