### PR TITLE
Accept every copy that arrives, and stop translating issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ every metric is implemented from the governing standard's paid text. You can
 [sponsor the project on GitHub](https://github.com/sponsors/jmrplens), and the
 documentation keeps a live list of the
 [sources that resisted every legitimate acquisition route](https://jmrplens.github.io/phonometry/start/support/),
-with three ways to help get them: fund the purchase, verify against your own
+with four ways to help get them: fund the purchase, send a copy privately
+(whatever its origin, it is never republished), verify against your own
 licensed copy, or point at a channel that was missed.
 
 ## 🧪 Development

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -204,7 +204,8 @@ every metric is implemented from the governing standard's paid text. You can
 [sponsor the project on GitHub](https://github.com/sponsors/jmrplens), and the
 documentation keeps a live list of the
 [sources that resisted every legitimate acquisition route](https://jmrplens.github.io/phonometry/start/support/),
-with three ways to help get them: fund the purchase, verify against your own
+with four ways to help get them: fund the purchase, send a copy privately
+(whatever its origin, it is never republished), verify against your own
 licensed copy, or point at a channel that was missed.
 
 ## 🧪 Development

--- a/docs/start/support.md
+++ b/docs/start/support.md
@@ -32,23 +32,22 @@ leaves the table when it lands.
 Everything below stands between the library and work it would otherwise do.
 Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
-could find, re-checked on the date shown. Three routes help:
+could find, re-checked on the date shown. Four routes help:
 
 - **Fund the purchase.** A one-off sponsorship naming the document; where a
   link goes to an official store, the price is on that page, and for the rest
   name the item and I will quote it in the issue.
+- **Send me a copy.** Whatever its origin. It stays private, it is used only
+  to implement and to verify, and it is never republished: the repository
+  only ever carries the derived numeric values. Write to
+  [mail@jmrp.io](mailto:mail@jmrp.io).
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
-  against your copy without sending me anything. The repository never
-  redistributes documents; what lands in the tree are the derived numeric
-  values, which is how the [conformance suite](../CONFORMANCE.md) is built.
+  against your copy. What lands in the tree are the derived numeric values,
+  which is how the [conformance suite](../CONFORMANCE.md) is built.
 - **Point me at a channel I missed.** A lending library, an author's own
   copy of a thesis, a proceedings archive that actually resolves.
   [Open an issue](https://github.com/jmrplens/phonometry/issues).
-
-One route does not help: sending scans or PDFs of paywalled documents. I
-cannot accept them, and the project's credibility rests on its sources being
-clean.
 
 | Source | What it would unlock | Last checked |
 | :--- | :--- | :--- |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -50014,23 +50014,22 @@ leaves the table when it lands.
 Everything below stands between the library and work it would otherwise do.
 Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
-could find, re-checked on the date shown. Three routes help:
+could find, re-checked on the date shown. Four routes help:
 
 - **Fund the purchase.** A one-off sponsorship naming the document; where a
   link goes to an official store, the price is on that page, and for the rest
   name the item and I will quote it in the issue.
+- **Send me a copy.** Whatever its origin. It stays private, it is used only
+  to implement and to verify, and it is never republished: the repository
+  only ever carries the derived numeric values. Write to
+  [mail@jmrp.io](mailto:mail@jmrp.io).
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
-  against your copy without sending me anything. The repository never
-  redistributes documents; what lands in the tree are the derived numeric
-  values, which is how the [conformance suite](https://jmrplens.github.io/phonometry/reference/conformance/) is built.
+  against your copy. What lands in the tree are the derived numeric values,
+  which is how the [conformance suite](https://jmrplens.github.io/phonometry/reference/conformance/) is built.
 - **Point me at a channel I missed.** A lending library, an author's own
   copy of a thesis, a proceedings archive that actually resolves.
   [Open an issue](https://github.com/jmrplens/phonometry/issues).
-
-One route does not help: sending scans or PDFs of paywalled documents. I
-cannot accept them, and the project's credibility rests on its sources being
-clean.
 
 | Source | What it would unlock | Last checked |
 | :--- | :--- | :--- |

--- a/site/public/llms/llms-start.txt
+++ b/site/public/llms/llms-start.txt
@@ -809,23 +809,22 @@ leaves the table when it lands.
 Everything below stands between the library and work it would otherwise do.
 Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
-could find, re-checked on the date shown. Three routes help:
+could find, re-checked on the date shown. Four routes help:
 
 - **Fund the purchase.** A one-off sponsorship naming the document; where a
   link goes to an official store, the price is on that page, and for the rest
   name the item and I will quote it in the issue.
+- **Send me a copy.** Whatever its origin. It stays private, it is used only
+  to implement and to verify, and it is never republished: the repository
+  only ever carries the derived numeric values. Write to
+  [mail@jmrp.io](mailto:mail@jmrp.io).
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
-  against your copy without sending me anything. The repository never
-  redistributes documents; what lands in the tree are the derived numeric
-  values, which is how the [conformance suite](https://jmrplens.github.io/phonometry/reference/conformance/) is built.
+  against your copy. What lands in the tree are the derived numeric values,
+  which is how the [conformance suite](https://jmrplens.github.io/phonometry/reference/conformance/) is built.
 - **Point me at a channel I missed.** A lending library, an author's own
   copy of a thesis, a proceedings archive that actually resolves.
   [Open an issue](https://github.com/jmrplens/phonometry/issues).
-
-One route does not help: sending scans or PDFs of paywalled documents. I
-cannot accept them, and the project's credibility rests on its sources being
-clean.
 
 | Source | What it would unlock | Last checked |
 | :--- | :--- | :--- |

--- a/site/src/content/docs/es/start/about.md
+++ b/site/src/content/docs/es/start/about.md
@@ -94,7 +94,7 @@ confiar en él de forma general.
 Infórmalo, por favor. Un número equivocado del que nadie me avisa se queda
 equivocado.
 
-Abre una incidencia en
+Abre una issue en
 [github.com/jmrplens/phonometry/issues](https://github.com/jmrplens/phonometry/issues).
 El informe más útil me indica la norma y el apartado contra el que estás
 comprobando, el valor esperado, el valor que ha dado phonometry y un fragmento

--- a/site/src/content/docs/es/start/support.mdx
+++ b/site/src/content/docs/es/start/support.mdx
@@ -18,7 +18,7 @@ incidencia más valiosa que recibe este proyecto: el
 [registro de erratas](/phonometry/es/reference/errata/) existe porque las
 fuentes se leen con lupa, y varias de sus entradas empezaron como la ceja
 levantada de un usuario.
-[Abre una incidencia](https://github.com/jmrplens/phonometry/issues) con lo
+[Abre una issue](https://github.com/jmrplens/phonometry/issues) con lo
 que mediste y lo que esperabas.
 
 ## Patrocina
@@ -34,26 +34,25 @@ la entrada sale de la tabla cuando llega.
 Todo lo de abajo se interpone entre la biblioteca y trabajo que de otro modo
 haría. Cada entrada ha sobrevivido al esfuerzo de adquisición completo: mi
 propia biblioteca, las tiendas oficiales, los índices de acceso abierto y
-todos los demás canales legítimos que he encontrado, revisado de nuevo en la
-fecha indicada. Ayudan tres vías:
+todos los demás canales legítimos que he encontrado, revisado de nuevo en la fecha indicada. Ayudan cuatro
+vías:
 
 - **Financiar la compra.** Un patrocinio puntual que nombre el documento;
   donde un enlace va a una tienda oficial, el precio está en esa página, y
-  para el resto nombra el ítem y te doy el precio en la incidencia.
+  para el resto nombra el ítem y te doy el precio en la issue.
+- **Envíame una copia.** Del origen que sea. Queda en privado, se usa solo
+  para implementar y verificar, y no se publica nunca: el repositorio solo
+  lleva los valores numéricos derivados. Escribe a
+  [mail@jmrp.io](mailto:mail@jmrp.io).
 - **Verificar contra tu copia con licencia.** Si tu laboratorio o tu empresa
   ya tiene una, puedes cotejar la implementación y sus valores de referencia
-  contra tu copia sin enviarme nada. El repositorio nunca redistribuye
-  documentos; lo que entra en el árbol son los valores numéricos derivados,
-  que es como está construida la
+  contra tu copia. Lo que entra en el árbol son los valores numéricos
+  derivados, que es como está construida la
   [batería de conformidad](/phonometry/es/reference/conformance/).
 - **Señalarme un canal que se me haya escapado.** Una biblioteca de préstamo,
   la copia del propio autor de una tesis, un archivo de actas que de verdad
   resuelva.
-  [Abre una incidencia](https://github.com/jmrplens/phonometry/issues).
-
-Hay una vía que no ayuda: enviar escaneos o PDF de documentos de pago. No
-puedo aceptarlos, y la credibilidad del proyecto descansa en que sus fuentes
-estén limpias.
+  [Abre una issue](https://github.com/jmrplens/phonometry/issues).
 
 | Fuente | Qué desbloquearía | Última revisión |
 | :--- | :--- | :--- |

--- a/site/src/content/docs/es/start/why-phonometry.mdx
+++ b/site/src/content/docs/es/start/why-phonometry.mdx
@@ -15,7 +15,7 @@ norma se transcriben a la batería de tests y se exigen en CI. Esta página
 explica ese enfoque con un caso de estudio concreto (la ponderación temporal
 según **IEC 61672-1:2013**) y resume qué está verificado por conformidad hoy.
 El análisis de la ponderación temporal se publicó originalmente en la
-[incidencia #38](https://github.com/jmrplens/phonometry/issues/38).
+[issue #38](https://github.com/jmrplens/phonometry/issues/38).
 
 ## Filosofía de diseño: un caso de estudio sobre la ponderación temporal
 
@@ -166,7 +166,7 @@ procedimiento de arriba.*
   es una métrica distinta e igualmente válida; puedes calcularla con
   [`leq`](/phonometry/es/signals/levels/levels/) sobre segmentos consecutivos.
 - Ambos enfoques son útiles; simplemente responden a preguntas distintas. La
-  discrepancia descrita en la incidencia #38 proviene de comparar una
+  discrepancia descrita en la issue #38 proviene de comparar una
   envolvente continua con un integrador por bloques, no de un error de
   implementación.
 

--- a/site/src/content/docs/start/support.mdx
+++ b/site/src/content/docs/start/support.mdx
@@ -33,24 +33,23 @@ leaves the table when it lands.
 Everything below stands between the library and work it would otherwise do.
 Each entry has survived the whole acquisition effort: my own library, the
 official stores, the open-access indexes and every other legitimate channel I
-could find, re-checked on the date shown. Three routes help:
+could find, re-checked on the date shown. Four routes help:
 
 - **Fund the purchase.** A one-off sponsorship naming the document; where a
   link goes to an official store, the price is on that page, and for the rest
   name the item and I will quote it in the issue.
+- **Send me a copy.** Whatever its origin. It stays private, it is used only
+  to implement and to verify, and it is never republished: the repository
+  only ever carries the derived numeric values. Write to
+  [mail@jmrp.io](mailto:mail@jmrp.io).
 - **Verify against your licensed copy.** If your lab or employer already
   holds one, you can check the implementation and its reference values
-  against your copy without sending me anything. The repository never
-  redistributes documents; what lands in the tree are the derived numeric
-  values, which is how the
+  against your copy. What lands in the tree are the derived numeric values,
+  which is how the
   [conformance suite](/phonometry/reference/conformance/) is built.
 - **Point me at a channel I missed.** A lending library, an author's own
   copy of a thesis, a proceedings archive that actually resolves.
   [Open an issue](https://github.com/jmrplens/phonometry/issues).
-
-One route does not help: sending scans or PDFs of paywalled documents. I
-cannot accept them, and the project's credibility rests on its sources being
-clean.
 
 | Source | What it would unlock | Last checked |
 | :--- | :--- | :--- |


### PR DESCRIPTION
The support page refused scans and PDFs of paywalled documents in writing. That refusal is withdrawn: a copy of a listed source is welcome whatever its origin, it stays private, it is used only to implement and to verify, and it is never republished, since the repository only ever carries the derived numeric values. The routes are four now, with sending a copy to the address About already publishes as the second, and the licensed-copy route no longer implies that sending is unwelcome.

And in the Spanish editions, a GitHub issue is an issue. Incidencia belongs to acoustics in this corpus, the angle and the incident field, so the six places the start pages had borrowed it for the tracker now say issue, and the translation glossary carries the ruling so it does not come back.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Broaden source-acquisition guidance to accept private document copies and standardize GitHub issue terminology across Spanish documentation.

New Features:
- Add a private copy-submission route for obtaining source documents, explicitly allowing copies regardless of origin while limiting their use to implementation and verification.

Enhancements:
- Update support guidance to describe four acquisition routes and clarify that only derived numeric values are published.
- Standardize Spanish GitHub terminology by using “issue” instead of “incidencia” in start-page content and glossary-derived text.

Documentation:
- Update README, support pages, and generated LLM documentation to reflect the new document-submission route and privacy policy.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated documentation to include a new method for supporting the project: sending private copies of documents.</li>
<li>Removed the explicit prohibition against sending scans or PDFs of paywalled documents, replacing it with a policy that private copies are accepted for implementation and verification purposes only and are never republished.</li>
<li>Standardized terminology in documentation by replacing 'incidencia' with 'issue' in Spanish language files.</li>
<li>Updated the count of support routes from three to four across all relevant documentation files.</li>
</ul></div>