### PR TITLE
Give the errata registry a Spanish edition, entry for entry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,15 @@ python scripts/check_errata_evidence.py --ratios # only the irrational-ratio lin
    a dpi figure, or the word render. That belongs here, not in a public
    statement about someone else's document.
 
+A Spanish edition of the registry lives in
+[`docs/ERRATA.es.md`](docs/ERRATA.es.md), translated entry for entry. A new or
+removed entry must land in both files: `make site-reports` (and its CI job)
+fails while the two editions differ in entry count, order, or the document
+each heading names. Quoted print, mathematics, printed values and decimal
+separators stay exactly as the cited source prints them, in both editions; the
+English wording is the authoritative one and the three checks above run on it
+alone.
+
 A second script is a contributor tool rather than a gate:
 
 ```bash

--- a/docs/ERRATA.es.md
+++ b/docs/ERRATA.es.md
@@ -46,7 +46,8 @@ Esta edición española traduce la prosa del registro entrada a entrada. La
 redacción autoritativa es la inglesa de [ERRATA.md](ERRATA.md), que es la que
 se ha comunicado o se comunicará a los organismos emisores; las citas
 textuales, las matemáticas y los valores impresos se reproducen aquí sin
-traducir, tal como los imprime cada fuente.
+traducir, tal como los imprime cada fuente. `make site-reports` mantiene las
+dos ediciones con las mismas entradas y en el mismo orden.
 
 
 ---
@@ -78,7 +79,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** implementa A.2.1 tal como está escrito
   y fija $C_I = -11$ con el impreso de 2013 como oráculo
   ([`tests/reference_data/`](../tests/reference_data/), comprobación de
-  conformidad "ISO 717-2 Annex C, Table C.1").
+  conformidad «ISO 717-2 Annex C, Table C.1»).
 - **Estado:** sin notificar.
 
 ## ISO 717-2:2020, Anexo C, ejemplo C.2 (suelo revestido: valor de 800 Hz y cadena del CI)
@@ -105,7 +106,7 @@ traducir, tal como los imprime cada fuente.
   32,0 dB, así que $L_{n,w,r} = 63\ \text{dB}$ y
   $\Delta L_w = 15\ \text{dB}$ en cualquier caso. (b) Los 75,2527 dB impresos
   son exactamente la suma energética de la *columna equivocada sobre el rango
-  equivocado*: el suelo medido «con revestimiento» sobre las dieciséis bandas
+  equivocado*: el suelo medido «with covering» sobre las dieciséis bandas
   de 100 Hz a 3150 Hz. A.2.1 define $C_I$ desde el suelo de referencia con
   revestimiento (la columna $L_{n,r,0} - \Delta L$) de 100 Hz a 2500 Hz (15
   bandas), lo que da 75,674 dB (cadena impresa) o 75,710 dB (celda de 800 Hz
@@ -902,7 +903,7 @@ traducir, tal como los imprime cada fuente.
   apartado, cinco párrafos y una NOTA antes, lista las mediciones requeridas
   como «the sound pressure levels in both rooms with the source(s) operating,
   the background noise in the receiving room ... and the reverberation times
-  **in the receiving room»**. El apartado 10, que es donde de verdad se
+  **in the receiving room**». El apartado 10, que es donde de verdad se
   especifican los procedimientos de tiempo de reverberación, dice lo mismo
   cuatro veces: su título es «Reverberation time **in the receiving room**
   (default and low-frequency procedure)», su apartado 10.1 acota todo el
@@ -1243,7 +1244,7 @@ traducir, tal como los imprime cada fuente.
   revés y describía el flanco superior como «a la mitad», cuando en realidad
   el divisor falta, no está a la mitad. Los tonos límite con pendiente de un
   solo flanco entre $24/\sqrt{2} = 17$ y
-  $24 \cdot \sqrt{2} = 34\ \text{dB/octava}$ cambian de clasificación entre
+  $24 \cdot \sqrt{2} = 34\ \text{dB/octave}$ cambian de clasificación entre
   las dos lecturas.
 - **Evidencia:** comparación lado a lado del impreso ISO, el impreso de
   DIN 45681 y el programa del Anhang J de DIN. Los radicales de DIN son

--- a/docs/ERRATA.es.md
+++ b/docs/ERRATA.es.md
@@ -1,45 +1,6 @@
----
-title: "Erratas de las fuentes publicadas"
-description: "Defectos encontrados en las normas, los documentos de guía y los libros de los que parte la biblioteca: erratas de imprenta, ejemplos resueltos que contradicen su propio articulado y qué hace la biblioteca con cada uno."
----
+← [Índice de la documentación](README.md)
 
-Implementar una norma en sala limpia significa volver a deducir cada fórmula,
-constante y ejemplo resuelto a partir del documento fuente y no del código de
-otra persona. Hecho sobre cientos de documentos, ese proceso encuentra
-defectos en las propias fuentes: un ejemplo resuelto que contradice su
-articulado, una constante a la que la composición tipográfica le comió un
-dígito, una referencia cruzada que apunta a la ecuación equivocada.
-
-Esta página es el registro de esos hallazgos. Cada entrada nombra la edición
-impresa y el punto exacto, cita lo que dice el documento, muestra por qué no
-puede ser correcto, aporta la evidencia independiente y declara qué lectura
-implementa la biblioteca y qué test de regresión la fija. Un defecto listado
-aquí nunca es un defecto del *método*: en todos los casos la lectura
-pretendida se ha podido establecer a partir del propio documento o de la
-física.
-
-Léela junto al
-[informe de conformidad](/phonometry/es/reference/conformance/), que muestra
-los números que calcula la biblioteca; esta página explica el puñado de sitios
-donde lo que está mal es el valor esperado impreso.
-
-:::note
-Esta página reproduce la edición española del registro, traducida entrada a
-entrada. La redacción autoritativa es la inglesa, que es la que se ha
-comunicado o se comunicará a los organismos emisores; las citas textuales, las
-matemáticas y los valores impresos se reproducen sin traducir, tal como los
-imprime cada fuente.
-:::
-
-El registro vive en
-[`docs/ERRATA.md`](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.md)
-con su edición española en
-[`docs/ERRATA.es.md`](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.es.md),
-y esta última se trasplanta aquí en tiempo de compilación con
-`make site-reports`, que además exige que las dos ediciones lleven las mismas
-entradas en el mismo orden, así que ninguna pareja puede discrepar.
-
-<!-- BEGIN GENERATED BODY - transplanted from docs/ERRATA.es.md by scripts/generate_site_reports.py (`make site-reports`). Edit the source document, never the text below. -->
+# Erratas encontradas en las fuentes publicadas
 
 Durante la implementación en sala limpia de esta biblioteca, cada fórmula,
 constante y ejemplo resuelto se vuelve a deducir y a recalcular de forma
@@ -77,12 +38,12 @@ desplazamiento de páginas de cada documento se establece empíricamente, porque
 difiere entre documentos y deriva entre capítulos de un mismo libro. Las
 entradas que descansan en otra cosa, un recálculo o la comparación de dos
 frases, lo dicen en un aviso inicial o figuran en la lista de excepciones de
-[`scripts/check_errata_evidence.py`](https://github.com/jmrplens/phonometry/blob/main/scripts/check_errata_evidence.py),
+[`scripts/check_errata_evidence.py`](../scripts/check_errata_evidence.py),
 que es la comprobación que hace cumplir la regla; véase
-[CONTRIBUTING.md](https://github.com/jmrplens/phonometry/blob/main/CONTRIBUTING.md#6-filing-an-errata-entry).
+[CONTRIBUTING.md](../CONTRIBUTING.md#6-filing-an-errata-entry).
 
 Esta edición española traduce la prosa del registro entrada a entrada. La
-redacción autoritativa es la inglesa de [ERRATA.md](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.md), que es la que
+redacción autoritativa es la inglesa de [ERRATA.md](ERRATA.md), que es la que
 se ha comunicado o se comunicará a los organismos emisores; las citas
 textuales, las matemáticas y los valores impresos se reproducen aquí sin
 traducir, tal como los imprime cada fuente.
@@ -116,7 +77,7 @@ traducir, tal como los imprime cada fuente.
   página 22 del PDF (p. 14 impresa) de ISO 717-2:2013.
 - **Comportamiento de la biblioteca:** implementa A.2.1 tal como está escrito
   y fija $C_I = -11$ con el impreso de 2013 como oráculo
-  ([`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data), comprobación de
+  ([`tests/reference_data/`](../tests/reference_data/), comprobación de
   conformidad "ISO 717-2 Annex C, Table C.1").
 - **Estado:** sin notificar.
 
@@ -319,11 +280,11 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** no le afecta. Ningún camino de código
   implementa la forma reducida: el modelo de fachada calcula $D_{2m,nT}$
   desde la Fórmula (13)
-  ([`facade.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/building/prediction/facade.py)), y el
+  ([`facade.py`](../src/phonometry/building/prediction/facade.py)), y el
   método de inspección convierte con la forma sin reducir
   $D_{2m,n} = D_{2m} + k + 10\log_{10}[A_0 T_0/(0{,}16 V)]$ del apartado 3.15
   de ISO 10052
-  ([`survey_insulation.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/building/measurement/survey_insulation.py)).
+  ([`survey_insulation.py`](../src/phonometry/building/measurement/survey_insulation.py)).
   Las dos constantes de estandarización que *sí* están pre-plegadas en otros
   puntos de la biblioteca son ambas correctas: $0{,}032$ para la forma de
   impacto de la Parte 2 y $0{,}32$ para la forma aérea de la Parte 1,
@@ -520,7 +481,7 @@ traducir, tal como los imprime cada fuente.
   $\sum l_k \alpha_k$ como entrada y `perimeter_absorption_coefficient`
   implementa la Fórmula (C.4); la fixture del Anexo L deduce las cinco sumas
   por esa vía en lugar de usar el bloque impreso, y lo dice
-  ([`tests/building/prediction/test_detailed_model.py`](https://github.com/jmrplens/phonometry/blob/main/tests/building/prediction/test_detailed_model.py)).
+  ([`tests/building/prediction/test_detailed_model.py`](../tests/building/prediction/test_detailed_model.py)).
 - **Estado:** sin notificar.
 
 ## ISO 12354-1:2017 Tabla L.3 / ISO 12354-2:2017 Tabla G.3 (ηint de la pared exterior)
@@ -732,7 +693,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** `weighted_lining_improvement` devuelve
   los -10 dB más conservadores exactamente a 1 600 Hz y -5 dB por encima, la
   lectura de 2000, con la ambigüedad nombrada en el docstring y fijada en
-  [`tests/building/prediction/test_resilient_layers.py`](https://github.com/jmrplens/phonometry/blob/main/tests/building/prediction/test_resilient_layers.py).
+  [`tests/building/prediction/test_resilient_layers.py`](../tests/building/prediction/test_resilient_layers.py).
 - **Estado:** sin notificar.
 
 - **Relacionado, no una errata:** la NOTA 1 de la misma tabla pone un suelo
@@ -909,7 +870,7 @@ traducir, tal como los imprime cada fuente.
   $\alpha_p$. Verificado en la página 13 del PDF (p. 7 impresa) y la página
   11 del PDF (p. 5 impresa) de ISO 12999-2:2020.
 - **Comportamiento de la biblioteca:** `_TABLE2` en
-  [`uncertainty.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/materials/absorbers/uncertainty.py)
+  [`uncertainty.py`](../src/phonometry/materials/absorbers/uncertainty.py)
   está indexada por frecuencia central de *octava*, siguiendo la Tabla 2 y la
   definición de $\alpha_p$ de ISO 11654 y no el encabezado de la Tabla 5.
 - **Estado:** sin notificar.
@@ -1096,7 +1057,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** usa el rango internamente consistente
   de $89{,}1\ \text{Hz}$ a 11 200 Hz (extremo superior exclusivo según las
   fórmulas), con una nota en el código en
-  [`tonality.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/psychoacoustics/quality/tonality.py).
+  [`tonality.py`](../src/phonometry/psychoacoustics/quality/tonality.py).
 - **Estado:** sin notificar.
 
 ## ECMA-418-1:2024 (3.ª edición), Fórmula (21) (término constante repetido)
@@ -1121,7 +1082,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** implementa la lectura con $C_{L,1}$,
   que es la única que devuelve un borde de banda usable, con una nota en el
   código en
-  [`tonality.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/psychoacoustics/quality/tonality.py).
+  [`tonality.py`](../src/phonometry/psychoacoustics/quality/tonality.py).
 - **Estado:** sin notificar.
 
 ## ECMA-418-1:2024 (3.ª edición), apartado 11.3 (referencias de campo sin resolver)
@@ -1165,7 +1126,7 @@ traducir, tal como los imprime cada fuente.
   apartado 7 ($1\ \text{asper}$) a $0{,}9999$.
 - **Comportamiento de la biblioteca:** implementa la lectura a ras del final
   con una nota en el código en
-  [`roughness_ecma.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/psychoacoustics/quality/roughness_ecma.py).
+  [`roughness_ecma.py`](../src/phonometry/psychoacoustics/quality/roughness_ecma.py).
 - **Estado:** sin notificar.
 
 ## ECMA-418-2:2025 (4.ª edición), apartado 9.1.4, Fórmula (127) (fase del núcleo HSA)
@@ -1293,7 +1254,7 @@ traducir, tal como los imprime cada fuente.
   20065:2016 y la página 14 del PDF (p. 14 impresa) de DIN 45681:2005-03.
 - **Comportamiento de la biblioteca:** sigue la lectura DIN/$\sqrt{2}$ (casa
   con la única referencia ejecutable), con la elección registrada en
-  [`tone_audibility.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/psychoacoustics/quality/tone_audibility.py).
+  [`tone_audibility.py`](../src/phonometry/psychoacoustics/quality/tone_audibility.py).
 - **Estado:** sin notificar.
 
 ## DIN 45681:2005-03, Anhang I, Tabelle I.6, fila «6 FG»
@@ -1409,7 +1370,7 @@ traducir, tal como los imprime cada fuente.
   Recomendación ITU-R BS.468-4.
 - **Comportamiento de la biblioteca:** no le afecta. La red de ponderación se
   construye desde los valores de componentes de la Figura 1a de BS.468-4 en
-  [`filters/weighting.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/filters/weighting.py), con
+  [`filters/weighting.py`](../src/phonometry/filters/weighting.py), con
   31.47 nF, y las filas de la Table 1 son el oráculo. La entrada importa
   porque el subapartado 14.12.11 de IEC 60268-3:2013 remite al lector a «a
   weighting network complying with Appendix A of IEC 60268-1», así que una
@@ -1446,7 +1407,7 @@ traducir, tal como los imprime cada fuente.
   impresa) de la Recomendación ITU-R BS.468-4.
 - **Comportamiento de la biblioteca:** no le afecta. Las once ventanas de
   aceptación están transcritas de las Tables 2 y 3 de BS.468-4 en
-  [`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data), que concuerdan con la
+  [`tests/reference_data/`](../tests/reference_data/), que concuerdan con la
   tabla IEC enmendada. Se registra porque el documento base sin enmendar es
   el que probablemente tenga un lector, y ensancha las ventanas de aceptación
   de 50 ms y 100 ms en 1.1 dB y 1.3 dB por abajo.
@@ -1487,7 +1448,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** las filas de porcentajes son primarias
   y las filas en dB se derivan de ellas, que es la decisión que esta entrada
   fuerza. Las once ventanas de aceptación se almacenan como porcentajes en
-  [`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data) y se comprueban como
+  [`tests/reference_data/`](../tests/reference_data/) y se comprueban como
   porcentajes, en la suite de tests y en las filas de conformidad «ITU-R
   BS.468-4 Table 2» y «ITU-R BS.468-4 Table 3».
 - **Estado:** sin notificar.
@@ -1554,7 +1515,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** sigue la definición de 14.12.9.1
   (referencia = la amplitud de salida a $f_s$), con un comentario en el
   código junto a la medición de referencia en
-  [`distortion.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/electroacoustics/distortion.py).
+  [`distortion.py`](../src/phonometry/electroacoustics/distortion.py).
 - **Estado:** sin notificar.
 
 ## IEC 60268-16:2011, Table M.1 (la fila beta declara el término de redundancia equivocado)
@@ -1592,7 +1553,7 @@ traducir, tal como los imprime cada fuente.
   IEC 60268-16:2011.
 - **Comportamiento de la biblioteca:** implementa A.5.6 con el término de
   redundancia tal como allí está impreso, en
-  [`_index_from_corrected_mtf`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/speech/sti.py); el test de
+  [`_index_from_corrected_mtf`](../src/phonometry/speech/sti.py); el test de
   factores de ponderación por pares de A.2.2 lo fija de forma independiente,
   y las filas de conformidad «IEC 60268-16:2020 A.2.2» e «IEC 60268-16 Annex
   M» leen ambas el índice que produce.
@@ -1630,8 +1591,8 @@ traducir, tal como los imprime cada fuente.
   IEC 60268-16:2011.
 - **Comportamiento de la biblioteca:** lleva las tres cantidades en una sola
   escala, la razón simple a $p_0^2 = (20\ \mu\text{Pa})^2$, en la corrección
-  de [`sti.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/speech/sti.py); la transcripción en
-  [`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data) conserva las celdas
+  de [`sti.py`](../src/phonometry/speech/sti.py); la transcripción en
+  [`tests/reference_data/`](../tests/reference_data/) conserva las celdas
   impresas al pie de la letra y nombra el $10^{6}$ por el que las reescala, y
   la fila de conformidad «IEC 60268-16 Annex M» lee el ajuste que alimentan.
 - **Estado:** sin notificar.
@@ -1663,7 +1624,7 @@ traducir, tal como los imprime cada fuente.
   (p. 64 impresa) de IEC 60268-16:2011.
 - **Comportamiento de la biblioteca:** calcula $I_{am,k}$ desde el factor de
   enmascaramiento sin redondear. La transcripción en
-  [`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data) conserva la celda
+  [`tests/reference_data/`](../tests/reference_data/) conserva la celda
   impresa y el test
   `test_annex_m_step3_masking_intensity_at_250_hz_is_the_printed_erratum`
   afirma el valor calculado contra 2 858 804 y contra el impreso, para que la
@@ -1700,12 +1661,12 @@ traducir, tal como los imprime cada fuente.
   octava»), aparta los procesadores de solo octavas como caso especial. Ambas
   son redundantes si todo procesador de clase 2 es de bandas de octava.
 - **Comportamiento de la biblioteca:** implementa la lectura EN/IEC.
-  [`verify_intensity_class`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/intensity_compliance.py)
+  [`verify_intensity_class`](../src/phonometry/emission/intensity_compliance.py)
   trata el conjunto completo de 22 bandas de tercio de octava como
   acreditación de cualquiera de las dos clases, y el conjunto de 7 bandas de
   octava (63 Hz a 4 kHz) como alternativa de clase 2 que nunca acredita la
   clase 1, con ambas ramas fijadas por tests de regresión
-  ([`tests/emission/test_intensity_compliance.py`](https://github.com/jmrplens/phonometry/blob/main/tests/emission/test_intensity_compliance.py)).
+  ([`tests/emission/test_intensity_compliance.py`](../tests/emission/test_intensity_compliance.py)).
 - **Estado:** sin notificar (traducción nacional, no el texto del organismo
   emisor).
 
@@ -1745,7 +1706,7 @@ traducir, tal como los imprime cada fuente.
   está presente.
 - **Comportamiento de la biblioteca:** implementa la lectura con signo en
   todo el recorrido, que es el texto ISO.
-  [`sound_power_intensity_points`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/sound_power_intensity_points.py)
+  [`sound_power_intensity_points`](../src/phonometry/emission/sound_power_intensity_points.py)
   suma potencias parciales con signo, marca las bandas cuya suma no es
   positiva como fuera del método, y reporta $F_3 - F_2$ como el exceso que
   produce el flujo entrante; `normal_intensity_from_levels` lleva el $(-)$
@@ -1753,7 +1714,7 @@ traducir, tal como los imprime cada fuente.
   contiene. Fijado por
   `test_a_genuinely_negative_partial_power_is_kept_and_summed` y los tests de
   conversión con signo en
-  [`tests/emission/test_sound_power_intensity_points.py`](https://github.com/jmrplens/phonometry/blob/main/tests/emission/test_sound_power_intensity_points.py).
+  [`tests/emission/test_sound_power_intensity_points.py`](../tests/emission/test_sound_power_intensity_points.py).
 - **Estado:** sin notificar (traducción nacional, no el texto del organismo
   emisor: un lector que trabaje desde la edición ISO no tiene nada que
   sortear).
@@ -1782,7 +1743,7 @@ traducir, tal como los imprime cada fuente.
   impresa) de ISO 9614-1:1993.
 - **Comportamiento de la biblioteca:** no hizo falta ninguno.
   `field_indicators` en
-  [`intensity.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/intensity.py) forma $F_3$ desde
+  [`intensity.py`](../src/phonometry/emission/intensity.py) forma $F_3$ desde
   la media algebraica de la Fórmula (A.7) y $F_2$ desde el módulo medio de la
   Fórmula (A.5), que es lo que hace de $F_3 - F_2$ el exceso de flujo
   entrante sobre el que está escrita la compuerta del Anexo B. Registrado
@@ -1814,7 +1775,7 @@ traducir, tal como los imprime cada fuente.
   UNE-EN ISO 9614-1:2010.
 - **Comportamiento de la biblioteca:** sigue el destino pretendido.
   $F_4(\alpha)$ y $F_4(1-\alpha)$ se calculan según A.2.4 en
-  [`partial_power_concentration`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/sound_power_intensity_points.py).
+  [`partial_power_concentration`](../src/phonometry/emission/sound_power_intensity_points.py).
   La referencia no cambia ningún número que la biblioteca reporte, así que no
   hizo falta ningún otro cambio.
 - **Estado:** sin notificar (defecto de referencia cruzada, sin consecuencia
@@ -1848,7 +1809,7 @@ traducir, tal como los imprime cada fuente.
   (B.3) para todas las bandas, así que la declaración que pide el apartado
   10.5 c) puede hacerse sobre cualquier banda que la necesite.
   `confidence_interval` en
-  [`DiscretePointIntensityResult`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/sound_power_intensity_points.py)
+  [`DiscretePointIntensityResult`](../src/phonometry/emission/sound_power_intensity_points.py)
   lleva el par, y `criterion_2` dice a qué bandas aplica el requisito. El
   defecto no cambia ningún número, solo adónde se manda al lector a buscar la
   fórmula.
@@ -1881,11 +1842,11 @@ traducir, tal como los imprime cada fuente.
   y 17 del PDF (pp. 26, 27 y 17 impresas) de UNE-EN ISO 9614-1:2010.
 - **Comportamiento de la biblioteca:** sigue la Figura B.1 y el apartado
   8.3.2. `required_actions` en
-  [`DiscretePointIntensityResult`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/sound_power_intensity_points.py)
+  [`DiscretePointIntensityResult`](../src/phonometry/emission/sound_power_intensity_points.py)
   responde a una banda que falla el criterio 2 con la acción c por encima de
   1 dB y la acción d a 1 dB y por debajo, fijado en el propio límite por
   `test_action_d_is_the_action_at_exactly_one_decibel` en
-  [`tests/emission/test_sound_power_intensity_points.py`](https://github.com/jmrplens/phonometry/blob/main/tests/emission/test_sound_power_intensity_points.py).
+  [`tests/emission/test_sound_power_intensity_points.py`](../tests/emission/test_sound_power_intensity_points.py).
 - **Estado:** sin notificar.
 
 ## ISO 9614-1:1993, ecuaciones (A.1) y (A.8) (la intensidad normalizadora sin su barra)
@@ -1916,7 +1877,7 @@ traducir, tal como los imprime cada fuente.
   (pp. 21 y 22 impresas) de UNE-EN ISO 9614-1:2010.
 - **Comportamiento de la biblioteca:** no hizo falta ninguno. El coeficiente
   de variación tras `field_indicators` y `temporal_variability_indicator` en
-  [`intensity.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/intensity.py) divide por la
+  [`intensity.py`](../src/phonometry/emission/intensity.py) divide por la
   media algebraica, y rechaza una media que no sea positiva en lugar de
   dividir por ella. Registrado como defecto tipográfico.
 - **Estado:** sin notificar (tipográfico).
@@ -1950,7 +1911,7 @@ traducir, tal como los imprime cada fuente.
   aplica la sustitución siempre que la condición se cumple en lugar de
   dejarla al llamante, lo que satisface ambos impresos. `_a_weighted_factor`
   en
-  [`sound_power_intensity_points.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/emission/sound_power_intensity_points.py)
+  [`sound_power_intensity_points.py`](../src/phonometry/emission/sound_power_intensity_points.py)
   compara la contribución ponderada A sumada de las bandas de 800 Hz a 5 kHz
   con la mitad de la contribución total y lee la fila de 200 Hz a 630 Hz de
   la Tabla B.2 cuando se queda corta.
@@ -1982,7 +1943,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** implementa la lectura desarrollada,
   ponderando la velocidad de aparición por 3 y la diferencia de niveles por 2
   (`predicted_prominence` en
-  [`impulsive_sound.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/environment/assessment/impulsive_sound.py)),
+  [`impulsive_sound.py`](../src/phonometry/environment/assessment/impulsive_sound.py)),
   que es además la forma de NT ACOU 112:2002 que el PAS arrastra.
 - **Estado:** sin notificar.
 
@@ -2008,7 +1969,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** no le afecta. La biblioteca nunca lee
   la Tabla 2: calcula $A_\text{atm}$ desde la fórmula de ISO 9613-1
   directamente
-  ([`air_absorption.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/environment/propagation/air_absorption.py)),
+  ([`air_absorption.py`](../src/phonometry/environment/propagation/air_absorption.py)),
   así que da $4{,}15\ \text{dB/km}$ para esta condición.
 - **Estado:** sin notificar.
 
@@ -2061,7 +2022,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** no le afecta; la biblioteca calcula
   los valores corregidos desde los apartados normativos y siempre lo hizo.
   Sus anclas del Anexo C.2
-  ([`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data),
+  ([`tests/reference_data/`](../tests/reference_data/),
   `ANSIS3_5_ANNEX_C1*` y `ANSIS3_5_ANNEX_C2*`) fijan la cadena consistente
   con las erratas de ambos ejemplos, contrastada a doble precisión con la
   propia implementación de referencia del grupo de trabajo `SII.C` y sus
@@ -2112,7 +2073,7 @@ traducir, tal como los imprime cada fuente.
   `speech_spectrum` ($U_i$) e `internal_noise` ($X_i$), y el umbral de
   audición sigue siendo el argumento `threshold=` de
   `speech_intelligibility_index`
-  ([`src/phonometry/speech/sii.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/speech/sii.py)).
+  ([`src/phonometry/speech/sii.py`](../src/phonometry/speech/sii.py)).
 - **Estado:** corrección publicada por el grupo de trabajo emisor; nada que
   notificar aguas arriba.
 
@@ -2372,7 +2333,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** implementa $0.76 \cdot 10^{-3}$ con
   una nota junto a la fórmula; el test de barrido de frecuencia portadora
   cazaría una regresión al valor impreso
-  ([`fluctuation_strength.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/psychoacoustics/quality/fluctuation_strength.py)).
+  ([`fluctuation_strength.py`](../src/phonometry/psychoacoustics/quality/fluctuation_strength.py)).
 - **Estado:** sin notificar (artículo de congreso, no una norma).
 
 ## Medwin & Clay, Fundamentals of Acoustical Oceanography (1998), Ec. (3.4.30) (coeficiente del ácido bórico)
@@ -2481,7 +2442,7 @@ traducir, tal como los imprime cada fuente.
   los artículos (Ec. (6)) solo con 64.
 - **Comportamiento de la biblioteca:** implementa 64 con una nota en el
   docstring; los límites están fijados en
-  [`tests/materials/absorbers/test_slow_sound.py`](https://github.com/jmrplens/phonometry/blob/main/tests/materials/absorbers/test_slow_sound.py)
+  [`tests/materials/absorbers/test_slow_sound.py`](../tests/materials/absorbers/test_slow_sound.py)
   y la comprobación de conformidad «Poiseuille limit (Stinson 1991)».
 - **Estado:** sin notificar (artículo de revista, no una norma).
 
@@ -2512,7 +2473,7 @@ traducir, tal como los imprime cada fuente.
   el término impreso exactamente igual que conjuga la serie de conducto de
   Stinson de los artículos; dirección y pico están fijados por
   ``test_slit_radiation_correction_lowers_resonance`` en
-  [`tests/materials/absorbers/test_slow_sound.py`](https://github.com/jmrplens/phonometry/blob/main/tests/materials/absorbers/test_slow_sound.py).
+  [`tests/materials/absorbers/test_slow_sound.py`](../tests/materials/absorbers/test_slow_sound.py).
 - **Estado:** sin notificar (artículos de revista, no normas).
 
 ## Attenborough & Van Renterghem, Predicting Outdoor Sound 2e (2021), Tabla 5.1
@@ -2602,10 +2563,10 @@ traducir, tal como los imprime cada fuente.
   reproduce el clásico de la expansión brusca (0.512 dB, en ambos sentidos) y
   es recíproca.
 - **Comportamiento de la biblioteca:** `transmission_loss` en
-  [`silencers.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/noise_control/silencers.py) implementa
+  [`silencers.py`](../src/phonometry/noise_control/silencers.py) implementa
   la Ec. (3.27) de Munjal, con el límite de expansión brusca y la
   reciprocidad de la TL fijados por tests de regresión
-  ([`tests/noise_control/test_silencers.py`](https://github.com/jmrplens/phonometry/blob/main/tests/noise_control/test_silencers.py))
+  ([`tests/noise_control/test_silencers.py`](../tests/noise_control/test_silencers.py))
   y una nota defensiva junto a la fórmula.
 - **Estado:** sin notificar (libro, no una norma).
 
@@ -2651,10 +2612,10 @@ traducir, tal como los imprime cada fuente.
   Ninguno de los dos casos particulares es recuperable desde la Ec. (18.24)
   impresa.
 - **Comportamiento de la biblioteca:** `feedback_stability` en
-  [`sound_reinforcement.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/electroacoustics/sound_reinforcement.py)
+  [`sound_reinforcement.py`](../src/phonometry/electroacoustics/sound_reinforcement.py)
   implementa el signo de la Ec. (18.20), con una nota junto al criterio.
   Ambos casos particulares de Long están fijados por tests de regresión
-  ([`tests/electroacoustics/test_sound_reinforcement.py`](https://github.com/jmrplens/phonometry/blob/main/tests/electroacoustics/test_sound_reinforcement.py))
+  ([`tests/electroacoustics/test_sound_reinforcement.py`](../tests/electroacoustics/test_sound_reinforcement.py))
   y por las comprobaciones de conformidad «Long, Architectural Acoustics 2e,
   Eq. (18.21)» y «Eq. (18.22)».
 - **Estado:** sin notificar (libro, no una norma, así que no normativo).
@@ -2689,11 +2650,11 @@ traducir, tal como los imprime cada fuente.
   esa conversión como corroboración. Verificado en la página 665 del PDF
   (p. 666 impresa) de Long, Architectural Acoustics 2e (2014).
 - **Comportamiento de la biblioteca:** `absorption_per_table` en
-  [`crowd_noise.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/room/crowd_noise.py) calcula la cota
+  [`crowd_noise.py`](../src/phonometry/room/crowd_noise.py) calcula la cota
   desde la Ec. (17.52) en lugar de cablear ninguna de las dos constantes, así
   que ambas cotas se mantienen mutuamente consistentes; el valor 6.313 y el
   3.16 impreso están fijados por tests de regresión
-  ([`tests/room/test_crowd_noise.py`](https://github.com/jmrplens/phonometry/blob/main/tests/room/test_crowd_noise.py)) y
+  ([`tests/room/test_crowd_noise.py`](../tests/room/test_crowd_noise.py)) y
   la constante 3.16 por la comprobación de conformidad «Long, Architectural
   Acoustics 2e, Eq. (17.54)».
 - **Estado:** sin notificar (libro, no una norma, así que no normativo);
@@ -2727,10 +2688,10 @@ traducir, tal como los imprime cada fuente.
   correcto. Verificado en la página 542 del PDF (p. 541 impresa) y la página
   541 del PDF (p. 540 impresa) de Long, Architectural Acoustics 2e (2014).
 - **Comportamiento de la biblioteca:** `elbow_insertion_loss` en
-  [`hvac.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/noise_control/hvac.py) lleva la columna
+  [`hvac.py`](../src/phonometry/noise_control/hvac.py) lleva la columna
   redonda de seis filas con 3 dB en la banda que falta, fijada por
   `test_elbow_tables_by_frequency_width_product`
-  ([`tests/noise_control/test_hvac_long.py`](https://github.com/jmrplens/phonometry/blob/main/tests/noise_control/test_hvac_long.py)).
+  ([`tests/noise_control/test_hvac_long.py`](../tests/noise_control/test_hvac_long.py)).
 - **Estado:** sin notificar (libro, no una norma).
 
 ## Long, Architectural Acoustics 2e (2014), Ec. 13.28 (unidades de U_G)
@@ -2770,10 +2731,10 @@ traducir, tal como los imprime cada fuente.
   Verificado en la página 522 del PDF (p. 521 impresa) de Long, Architectural
   Acoustics 2e (2014).
 - **Comportamiento de la biblioteca:** `diffuser_sound_power` en
-  [`hvac.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/noise_control/hvac.py) lee $U_G$ en ft/s
+  [`hvac.py`](../src/phonometry/noise_control/hvac.py) lee $U_G$ en ft/s
   internamente (SI en la interfaz), con la fila de la Tabla 14.9 fijada por
   `test_diffuser_sound_power_reproduces_the_table_14_9_row`
-  ([`tests/noise_control/test_hvac_long.py`](https://github.com/jmrplens/phonometry/blob/main/tests/noise_control/test_hvac_long.py))
+  ([`tests/noise_control/test_hvac_long.py`](../tests/noise_control/test_hvac_long.py))
   y la comprobación de conformidad «Long 2e Eqs. 13.27-13.33».
 - **Estado:** sin notificar (libro, no una norma).
 
@@ -2844,10 +2805,10 @@ traducir, tal como los imprime cada fuente.
   Vibration Analysis for Engineers 2e:2003.
 - **Comportamiento de la biblioteca:**
   `point_connection_coupling_loss_factor` en
-  [`junction_transmission.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/vibration/structural/junction_transmission.py)
+  [`junction_transmission.py`](../src/phonometry/vibration/structural/junction_transmission.py)
   implementa la forma al cuadrado, con la columna impresa fijada por un test
   de regresión
-  ([`tests/vibration/structural/test_junction_transmission.py`](https://github.com/jmrplens/phonometry/blob/main/tests/vibration/structural/test_junction_transmission.py))
+  ([`tests/vibration/structural/test_junction_transmission.py`](../tests/vibration/structural/test_junction_transmission.py))
   y una nota junto a la fórmula.
 - **Estado:** sin notificar (libro, no una norma).
 
@@ -2875,7 +2836,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** las columnas de $\eta_{12}$ se usan
   como oráculo de regresión; $\eta_{21}$ se obtiene de la Ec. (6.8) con las
   densidades modales completas, y un test fija la razón 2.292 explícitamente
-  ([`tests/vibration/structural/test_junction_transmission.py`](https://github.com/jmrplens/phonometry/blob/main/tests/vibration/structural/test_junction_transmission.py)).
+  ([`tests/vibration/structural/test_junction_transmission.py`](../tests/vibration/structural/test_junction_transmission.py)).
 - **Estado:** sin notificar (libro, no una norma).
 
 ## Norton & Karczub 2e (2003), problema 6.10 (área de la plataforma)
@@ -2906,10 +2867,10 @@ traducir, tal como los imprime cada fuente.
   enunciado y sus dimensiones, y la página 637 del PDF (p. 617 impresa), que
   lleva las tres respuestas, de Norton & Karczub 2e:2003.
 - **Comportamiento de la biblioteca:** `power_injection_clf` en
-  [`experimental_sea.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/vibration/structural/experimental_sea.py)
+  [`experimental_sea.py`](../src/phonometry/vibration/structural/experimental_sea.py)
   implementa la inversión tal como está publicada; el test de regresión usa
   el área libre de la plataforma y documenta la discrepancia
-  ([`tests/vibration/structural/test_experimental_sea.py`](https://github.com/jmrplens/phonometry/blob/main/tests/vibration/structural/test_experimental_sea.py)).
+  ([`tests/vibration/structural/test_experimental_sea.py`](../tests/vibration/structural/test_experimental_sea.py)).
 - **Estado:** sin notificar (libro, no una norma).
 
 ## Norton & Karczub 2e (2003), problema 3.14 (factor de pérdida estructural)
@@ -2936,7 +2897,7 @@ traducir, tal como los imprime cada fuente.
   Karczub 2e (2003).
 - **Comportamiento de la biblioteca:** el test de regresión usa
   $\eta = 1.5 \cdot 10^{-3}$, el valor que las respuestas impresas exigen
-  ([`tests/building/prediction/test_panel_transmission.py`](https://github.com/jmrplens/phonometry/blob/main/tests/building/prediction/test_panel_transmission.py)).
+  ([`tests/building/prediction/test_panel_transmission.py`](../tests/building/prediction/test_panel_transmission.py)).
 - **Estado:** sin notificar (libro, no una norma).
 
 ---
@@ -2985,7 +2946,7 @@ traducir, tal como los imprime cada fuente.
   mientras el exponente de la misma expresión lleva el $m'_R$ con prima de la
   Ec. (9.17).
 - **Comportamiento de la biblioteca:** `plenum_flanking_reduction_index` en
-  [`ceiling_plenum.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/building/prediction/ceiling_plenum.py)
+  [`ceiling_plenum.py`](../src/phonometry/building/prediction/ceiling_plenum.py)
   implementa el $m'_R$ deducido en el exponente y en el denominador, con la
   lectura documentada junto a la fórmula, y rechaza un factor de transmisión
   por encima de la unidad en lugar de reportar un índice de reducción sonora
@@ -2994,7 +2955,7 @@ traducir, tal como los imprime cada fuente.
   fuga de la Ec. (9.17) en un techo realista) y la única propiedad que separa
   las dos lecturas: un plénum desnudo no peor que el valor sin amortiguar de
   la Ec. (9.20)
-  ([`tests/building/prediction/test_ceiling_plenum.py`](https://github.com/jmrplens/phonometry/blob/main/tests/building/prediction/test_ceiling_plenum.py)).
+  ([`tests/building/prediction/test_ceiling_plenum.py`](../tests/building/prediction/test_ceiling_plenum.py)).
 - **Estado:** sin notificar (libro, no una norma). El artículo original de
   Mechel de 1980, que Vigran reproduce, no estuvo disponible para comprobar
   si la errata se origina allí.
@@ -3020,7 +2981,7 @@ traducir, tal como los imprime cada fuente.
   la que el «>» de ambas filas centrales es inequívoco contra los glifos
   «<=» de la misma celda.
 - **Comportamiento de la biblioteca:**
-  [`low_frequency_correction`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/environment/assessment/spain.py)
+  [`low_frequency_correction`](../src/phonometry/environment/assessment/spain.py)
   e `impulsive_correction` implementan $10 < L \le 15$, con un test de
   regresión fijando las tres ramas en los límites de 10 dB y 15 dB.
 - **Estado:** sin notificar (reglamento nacional, no un organismo de
@@ -3054,7 +3015,7 @@ traducir, tal como los imprime cada fuente.
   (p. L 168/4 impresa) y la página 124 del PDF (p. L 168/124 impresa) de la
   Directiva para el rango conforme.
 - **Comportamiento de la biblioteca:**
-  [`cnossos_road`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/environment/sources/cnossos_road.py)
+  [`cnossos_road`](../src/phonometry/environment/sources/cnossos_road.py)
   trabaja sobre la rejilla corregida de 63 Hz a 8 kHz
   (`ROAD_OCTAVE_BANDS`), fijada por
   `test_octave_bands_are_the_corrected_range` y por los casos del libro de
@@ -3124,7 +3085,7 @@ traducir, tal como los imprime cada fuente.
   (p. 453 impresa) y la página 487 del PDF (p. 457 impresa) de Ainslie,
   Principles of Sonar Performance Modelling (2010).
 - **Comportamiento de la biblioteca:** `weston_regime_boundaries` en
-  [`propagation/weston_regimes.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/underwater/propagation/weston_regimes.py)
+  [`propagation/weston_regimes.py`](../src/phonometry/underwater/propagation/weston_regimes.py)
   implementa el $k^2H_e^2H/(9\pi\eta)$ consistente con la deducción, que es
   además lo que mantiene $\theta_\text{eff}$ definido con $H$ en todos los
   puntos donde el módulo evalúa la Ec. (9.47). La regla de igualación está
@@ -3134,7 +3095,7 @@ traducir, tal como los imprime cada fuente.
   implementación, y la definición compartida de $\theta_\text{eff}$ por
   `test_composite_loss_and_the_boundary_use_the_same_effective_angle` (ambos
   en
-  [`tests/underwater/propagation/test_weston_regimes.py`](https://github.com/jmrplens/phonometry/blob/main/tests/underwater/propagation/test_weston_regimes.py)).
+  [`tests/underwater/propagation/test_weston_regimes.py`](../tests/underwater/propagation/test_weston_regimes.py)).
 - **Estado:** sin notificar (libro, no una norma).
 
 ---
@@ -3167,7 +3128,7 @@ traducir, tal como los imprime cada fuente.
   página 46 del PDF (p. 35 impresa) de NMFS Updated Technical Guidance
   v3.0:2024, las tres llevando 1.37 con la nota idéntica.
 - **Comportamiento de la biblioteca:**
-  [`bioacoustics/weighting.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/underwater/bioacoustics/weighting.py)
+  [`bioacoustics/weighting.py`](../src/phonometry/underwater/bioacoustics/weighting.py)
   implementa 1.36 y mantiene el 1.37 impreso disponible como
   `WeightingParameters.c_db_as_printed`, para que una evaluación que deba
   reproducir la tabla publicada al pie de la letra aún pueda. Fijado por
@@ -3251,7 +3212,7 @@ traducir, tal como los imprime cada fuente.
   / 161 y OCA 146 / 170 / 161 / 176.
 - **Comportamiento de la biblioteca:** los valores corregidos por las erratas
   son los implementados en
-  [`bioacoustics/weighting.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/underwater/bioacoustics/weighting.py),
+  [`bioacoustics/weighting.py`](../src/phonometry/underwater/bioacoustics/weighting.py),
   fijados por `test_southall_table_7_errata_values_are_implemented`, con la
   propia regla de +159 dB comprobada contra el audiograma en
   `test_southall_impulsive_peak_spl_is_threshold_at_f0_plus_159_db` para los
@@ -3784,7 +3745,7 @@ traducir, tal como los imprime cada fuente.
   página 10 del PDF (p. 8 impresa, marcada «[IEC page 19]») de BS 5969:1981,
   la adopción británica idéntica de IEC 651:1979.
 - **Comportamiento de la biblioteca:** `_ANSI_S14_TABLE5_12` en
-  [`weighting_compliance.py`](https://github.com/jmrplens/phonometry/blob/main/src/phonometry/filters/weighting_compliance.py)
+  [`weighting_compliance.py`](../src/phonometry/filters/weighting_compliance.py)
   y su gemela de `reference_data` llevan −3 dB como límite inferior de tipo 2
   a 20 Hz, la más estricta de las dos lecturas, con la nota al lado.
   `test_b_masks_match_reference_data` fija las dos transcripciones una contra
@@ -3876,10 +3837,8 @@ concordancia con las fuentes publicadas:
   biblioteca implementa las ecuaciones y tablas impresas, y usa la hoja solo
   para lo que fija de verdad, la aritmética de la cascada; sus filas de
   elementos se introducen tal como están publicadas en
-  [`tests/noise_control/test_duct_path.py`](https://github.com/jmrplens/phonometry/blob/main/tests/noise_control/test_duct_path.py).
+  [`tests/noise_control/test_duct_path.py`](../tests/noise_control/test_duct_path.py).
   El propio redondeo de la hoja tampoco es siempre autoconsistente (la fila 3
   de impulsión imprime un *Sum* de 49 dB a 500 Hz donde $76 - 28 = 48$, y
   después un *Combined* consistente con 48), que es por lo que la comparación
   corre al 1 dB que la hoja impresa lleva.
-
-<!-- END GENERATED BODY -->

--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -39,6 +39,12 @@ either in a leading notice or on the allowlist of
 which is the check that enforces the rule; see
 [CONTRIBUTING.md](../CONTRIBUTING.md#6-filing-an-errata-entry).
 
+A Spanish edition of this registry, translated entry for entry, is maintained
+in [ERRATA.es.md](ERRATA.es.md). The wording here is the authoritative one,
+and quoted print, mathematics and printed values are reproduced there
+untranslated; `make site-reports` holds the two editions to the same entries
+in the same order.
+
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -282,7 +282,7 @@ field itself on a finite-difference grid.
 - [Glossary](reference/glossary.md): every quantity the guides compute, grouped by domain, each with its symbol, a one-sentence definition, its unit, the standard and clause that defines it and the guide that implements it, plus the table of symbols that collide across domains
 - [Bibliography](reference/bibliography.md): the books and papers behind the guides, grouped by domain, every entry with a verified DOI or official publisher link
 - [Conformance report](CONFORMANCE.md): auto-generated numerical validation: every check pins a standard clause's expected value against the library's computed value, regenerated in CI
-- [Standards errata](ERRATA.md): defects found in the published standards themselves during implementation: misprints, examples contradicting their own normative text, ambiguous wording, each with evidence and the library's disposition
+- [Standards errata](ERRATA.md): defects found in the published standards themselves during implementation: misprints, examples contradicting their own normative text, ambiguous wording, each with evidence and the library's disposition; a Spanish edition, translated entry for entry, lives in [ERRATA.es.md](ERRATA.es.md)
 
 ## Development
 

--- a/scripts/generate_llms.py
+++ b/scripts/generate_llms.py
@@ -89,7 +89,7 @@ DOI = "10.5281/zenodo.21215280"
 SHARD_LIMIT_BYTES = 200_000
 
 #: Markdown files under docs/ that are not documentation pages.
-NOT_PAGES = frozenset({"README", "CONFORMANCE", "ERRATA"})
+NOT_PAGES = frozenset({"README", "CONFORMANCE", "ERRATA", "ERRATA.es"})
 
 #: The documented topics, in the order the landing page lists them. Each is a
 #: folder of `content/docs/` whose `index` page links the guides inside it, so
@@ -737,6 +737,7 @@ def _absolutize_links(content: str, md_name: str) -> str:
         "README": "",
         "CONFORMANCE": "reference/conformance",
         "ERRATA": "reference/errata",
+        "ERRATA.es": "es/reference/errata",
     }
 
     def repl(match: re.Match[str]) -> str:

--- a/scripts/generate_site_reports.py
+++ b/scripts/generate_site_reports.py
@@ -160,6 +160,14 @@ PAGES: tuple[Page, ...] = (
 #: "ISO 717-2:2020, Annex C, example C.1" and "ISO 717-2:2020, Anexo C,
 #: ejemplo C.1" alike to ``717-2:2020``, and survives headings whose prose is
 #: reordered in translation (``NORAH2``, ``S3.5-1997``, ``2015/996``).
+#:
+#: Deliberately excluded: the space-separated issuer word, because translation
+#: moves and translates it ("Commission Directive (EU) 2015/996" is "Directiva
+#: (UE) 2015/996 de la Comisión"), so requiring it would fail correct pairs.
+#: The residual blind spot is a swap of two entries that share the numeric
+#: token -- which, designations being what they are, means two entries about
+#: the same document -- and such a swap cannot pair a heading with the wrong
+#: source. ``tests/test_generate_site_reports.py`` pins both sides of this.
 _DESIGNATION_RE = re.compile(r"[A-Za-z]*\d[\dA-Za-z.:/-]*")
 
 
@@ -186,11 +194,17 @@ def check_edition_parity(english: pathlib.Path, spanish: pathlib.Path) -> None:
         lines = path.read_text(encoding="utf8").splitlines()
         return [line for line in lines if line.startswith("## ")]
 
+    def shown(path: pathlib.Path) -> str:
+        try:
+            return str(path.relative_to(ROOT))
+        except ValueError:
+            return str(path)
+
     en, es = headings(english), headings(spanish)
     if len(en) != len(es):
         sys.exit(
-            f"{spanish.relative_to(ROOT)}: {len(es)} entries against "
-            f"{len(en)} in {english.relative_to(ROOT)}. Translate the "
+            f"{shown(spanish)}: {len(es)} entries against "
+            f"{len(en)} in {shown(english)}. Translate the "
             "missing entry (or delete the stale one) so the editions match."
         )
     pairs = zip(en, es, strict=True)
@@ -201,8 +215,8 @@ def check_edition_parity(english: pathlib.Path, spanish: pathlib.Path) -> None:
         token_es = match_es.group(0) if match_es else None
         if token_en != token_es:
             sys.exit(
-                f"{spanish.relative_to(ROOT)}: entry {index} names "
-                f"{token_es!r} where {english.relative_to(ROOT)} names "
+                f"{shown(spanish)}: entry {index} names "
+                f"{token_es!r} where {shown(english)} names "
                 f"{token_en!r}:\n  {heading_en}\n  {heading_es}\n"
                 "The editions are out of order or an entry was mistranslated."
             )

--- a/scripts/generate_site_reports.py
+++ b/scripts/generate_site_reports.py
@@ -23,8 +23,13 @@ timestamps, no environment-dependent text), so CI can diff a fresh run against
 the committed pages exactly like it does for the generated API reference (see
 the ``site-reports`` job in .github/workflows/python-app.yml).
 
-The Spanish page carries the same generated body: the registry is generated
-English text, and the Spanish prose above the marker says so.
+The Spanish page transplants ``docs/ERRATA.es.md``, the hand-maintained
+entry-for-entry translation of the registry. The English wording stays the
+authoritative one (it is what has been or will be communicated to the issuing
+bodies; both introductions say so), and this script holds the two editions
+together: same number of ``##`` entries, same order, and each pair of headings
+naming the same source document. A run fails before writing anything when the
+editions drift.
 
 Stdlib only. Regenerate with ``make site-reports``.
 """
@@ -144,11 +149,63 @@ PAGES: tuple[Page, ...] = (
         start=re.compile(r"^During the clean-room implementation"),
     ),
     Page(
-        source=DOCS / "ERRATA.md",
+        source=DOCS / "ERRATA.es.md",
         target="es/reference/errata.md",
-        start=re.compile(r"^During the clean-room implementation"),
+        start=re.compile(r"^Durante la implementación en sala limpia"),
     ),
 )
+
+#: First designation-like token of a heading: an optional alphabetic run glued
+#: to its first digit, plus the digits and punctuation that follow. It reduces
+#: "ISO 717-2:2020, Annex C, example C.1" and "ISO 717-2:2020, Anexo C,
+#: ejemplo C.1" alike to ``717-2:2020``, and survives headings whose prose is
+#: reordered in translation (``NORAH2``, ``S3.5-1997``, ``2015/996``).
+_DESIGNATION_RE = re.compile(r"[A-Za-z]*\d[\dA-Za-z.:/-]*")
+
+
+def check_edition_parity(english: pathlib.Path, spanish: pathlib.Path) -> None:
+    """Refuse to render while the Spanish edition drifts from the registry.
+
+    ``docs/ERRATA.es.md`` is a hand-maintained, entry-for-entry translation of
+    ``docs/ERRATA.md``. Three structural invariants survive translation and
+    are enforced here: the two documents carry the same number of ``##``
+    headings, in the same order, and each pair of headings names the same
+    source document (its first designation token, :data:`_DESIGNATION_RE`).
+    The wording of each entry is deliberately not compared: the English text
+    is the authoritative one and the translation tracks it by hand.
+
+    :param english: The English registry, ``docs/ERRATA.md``.
+    :type english: pathlib.Path
+    :param spanish: The Spanish edition, ``docs/ERRATA.es.md``.
+    :type spanish: pathlib.Path
+    :raises SystemExit: If the heading counts differ or any pair of headings
+        disagrees on its designation token.
+    """
+
+    def headings(path: pathlib.Path) -> list[str]:
+        lines = path.read_text(encoding="utf8").splitlines()
+        return [line for line in lines if line.startswith("## ")]
+
+    en, es = headings(english), headings(spanish)
+    if len(en) != len(es):
+        sys.exit(
+            f"{spanish.relative_to(ROOT)}: {len(es)} entries against "
+            f"{len(en)} in {english.relative_to(ROOT)}. Translate the "
+            "missing entry (or delete the stale one) so the editions match."
+        )
+    pairs = zip(en, es, strict=True)
+    for index, (heading_en, heading_es) in enumerate(pairs, start=1):
+        match_en = _DESIGNATION_RE.search(heading_en)
+        match_es = _DESIGNATION_RE.search(heading_es)
+        token_en = match_en.group(0) if match_en else None
+        token_es = match_es.group(0) if match_es else None
+        if token_en != token_es:
+            sys.exit(
+                f"{spanish.relative_to(ROOT)}: entry {index} names "
+                f"{token_es!r} where {english.relative_to(ROOT)} names "
+                f"{token_en!r}:\n  {heading_en}\n  {heading_es}\n"
+                "The editions are out of order or an entry was mistranslated."
+            )
 
 
 def render(page: Page) -> str:
@@ -190,6 +247,8 @@ def main(argv: list[str] | None = None) -> int:
         help="do not write; exit non-zero if any page is out of date",
     )
     args = parser.parse_args(argv)
+
+    check_edition_parity(DOCS / "ERRATA.md", DOCS / "ERRATA.es.md")
 
     stale: list[str] = []
     for page in PAGES:

--- a/scripts/mirror_overviews.py
+++ b/scripts/mirror_overviews.py
@@ -182,9 +182,10 @@ def render(page: Path) -> tuple[Path, str]:
 
 
 #: Mirror files that legitimately do not open with the index backlink: the
-#: README is the index, and the other two are generated elsewhere and start
-#: with an HTML comment.
-_NO_BACKLINK = {"README.md", "CONFORMANCE.md", "ERRATA.md"}
+#: README is the index, two are generated elsewhere and start with an HTML
+#: comment, and the Spanish errata edition carries the same backlink in
+#: Spanish.
+_NO_BACKLINK = {"README.md", "CONFORMANCE.md", "ERRATA.md", "ERRATA.es.md"}
 
 _BACKLINK = "← [Documentation index]("
 

--- a/site/src/content/docs/es/reference/errata.md
+++ b/site/src/content/docs/es/reference/errata.md
@@ -85,7 +85,8 @@ Esta edición española traduce la prosa del registro entrada a entrada. La
 redacción autoritativa es la inglesa de [ERRATA.md](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.md), que es la que
 se ha comunicado o se comunicará a los organismos emisores; las citas
 textuales, las matemáticas y los valores impresos se reproducen aquí sin
-traducir, tal como los imprime cada fuente.
+traducir, tal como los imprime cada fuente. `make site-reports` mantiene las
+dos ediciones con las mismas entradas y en el mismo orden.
 
 
 ---
@@ -117,7 +118,7 @@ traducir, tal como los imprime cada fuente.
 - **Comportamiento de la biblioteca:** implementa A.2.1 tal como está escrito
   y fija $C_I = -11$ con el impreso de 2013 como oráculo
   ([`tests/reference_data/`](https://github.com/jmrplens/phonometry/blob/main/tests/reference_data), comprobación de
-  conformidad "ISO 717-2 Annex C, Table C.1").
+  conformidad «ISO 717-2 Annex C, Table C.1»).
 - **Estado:** sin notificar.
 
 ## ISO 717-2:2020, Anexo C, ejemplo C.2 (suelo revestido: valor de 800 Hz y cadena del CI)
@@ -144,7 +145,7 @@ traducir, tal como los imprime cada fuente.
   32,0 dB, así que $L_{n,w,r} = 63\ \text{dB}$ y
   $\Delta L_w = 15\ \text{dB}$ en cualquier caso. (b) Los 75,2527 dB impresos
   son exactamente la suma energética de la *columna equivocada sobre el rango
-  equivocado*: el suelo medido «con revestimiento» sobre las dieciséis bandas
+  equivocado*: el suelo medido «with covering» sobre las dieciséis bandas
   de 100 Hz a 3150 Hz. A.2.1 define $C_I$ desde el suelo de referencia con
   revestimiento (la columna $L_{n,r,0} - \Delta L$) de 100 Hz a 2500 Hz (15
   bandas), lo que da 75,674 dB (cadena impresa) o 75,710 dB (celda de 800 Hz
@@ -941,7 +942,7 @@ traducir, tal como los imprime cada fuente.
   apartado, cinco párrafos y una NOTA antes, lista las mediciones requeridas
   como «the sound pressure levels in both rooms with the source(s) operating,
   the background noise in the receiving room ... and the reverberation times
-  **in the receiving room»**. El apartado 10, que es donde de verdad se
+  **in the receiving room**». El apartado 10, que es donde de verdad se
   especifican los procedimientos de tiempo de reverberación, dice lo mismo
   cuatro veces: su título es «Reverberation time **in the receiving room**
   (default and low-frequency procedure)», su apartado 10.1 acota todo el
@@ -1282,7 +1283,7 @@ traducir, tal como los imprime cada fuente.
   revés y describía el flanco superior como «a la mitad», cuando en realidad
   el divisor falta, no está a la mitad. Los tonos límite con pendiente de un
   solo flanco entre $24/\sqrt{2} = 17$ y
-  $24 \cdot \sqrt{2} = 34\ \text{dB/octava}$ cambian de clasificación entre
+  $24 \cdot \sqrt{2} = 34\ \text{dB/octave}$ cambian de clasificación entre
   las dos lecturas.
 - **Evidencia:** comparación lado a lado del impreso ISO, el impreso de
   DIN 45681 y el programa del Anhang J de DIN. Los radicales de DIN son

--- a/site/src/content/docs/reference/errata.md
+++ b/site/src/content/docs/reference/errata.md
@@ -65,6 +65,12 @@ either in a leading notice or on the allowlist of
 which is the check that enforces the rule; see
 [CONTRIBUTING.md](https://github.com/jmrplens/phonometry/blob/main/CONTRIBUTING.md#6-filing-an-errata-entry).
 
+A Spanish edition of this registry, translated entry for entry, is maintained
+in [ERRATA.es.md](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.es.md). The wording here is the authoritative one,
+and quoted print, mathematics and printed values are reproduced there
+untranslated; `make site-reports` holds the two editions to the same entries
+in the same order.
+
 
 ---
 

--- a/tests/test_generate_site_reports.py
+++ b/tests/test_generate_site_reports.py
@@ -1,0 +1,159 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""The parity gate between the errata registry and its Spanish edition.
+
+``scripts/generate_site_reports.py`` refuses to render while
+``docs/ERRATA.es.md`` drifts from ``docs/ERRATA.md``: same number of ``##``
+entries, same order, and each pair of headings naming the same source
+document through its first designation token. These tests pin the three
+failure modes, the pass, and the one blind spot the token deliberately
+accepts.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import generate_site_reports
+
+_ENGLISH = """## ISO 717-2:2020, Annex C, example C.1 (bare floor)
+
+body
+
+## Commission Directive (EU) 2015/996, Annex II 2.2.1 (road source)
+
+body
+
+## IEC 60268-16:2011, Table M.1 (the beta row)
+
+body
+
+## IEC 60268-16:2011, Table M.1 (step 3 at 250 Hz)
+
+body
+"""
+
+_SPANISH = """## ISO 717-2:2020, Anexo C, ejemplo C.1 (suelo desnudo)
+
+cuerpo
+
+## Directiva (UE) 2015/996 de la Comisión, Anexo II 2.2.1 (fuente de carretera)
+
+cuerpo
+
+## IEC 60268-16:2011, Table M.1 (la fila beta)
+
+cuerpo
+
+## IEC 60268-16:2011, Table M.1 (paso 3 a 250 Hz)
+
+cuerpo
+"""
+
+
+def _editions(
+    tmp_path: pathlib.Path, english: str, spanish: str
+) -> tuple[pathlib.Path, pathlib.Path]:
+    en = tmp_path / "ERRATA.md"
+    es = tmp_path / "ERRATA.es.md"
+    en.write_text(english, encoding="utf8")
+    es.write_text(spanish, encoding="utf8")
+    return en, es
+
+
+def test_matching_editions_pass(tmp_path: pathlib.Path) -> None:
+    """Same count, same order, same designations: no complaint."""
+    en, es = _editions(tmp_path, _ENGLISH, _SPANISH)
+    generate_site_reports.check_edition_parity(en, es)
+
+
+def test_a_missing_entry_fails_with_both_counts(tmp_path: pathlib.Path) -> None:
+    """Dropping one Spanish entry names both counts in the refusal."""
+    short = _SPANISH.replace(
+        "## Directiva (UE) 2015/996 de la Comisión, Anexo II 2.2.1 "
+        "(fuente de carretera)\n\ncuerpo\n\n",
+        "",
+    )
+    en, es = _editions(tmp_path, _ENGLISH, short)
+    with pytest.raises(SystemExit, match="3 entries against 4"):
+        generate_site_reports.check_edition_parity(en, es)
+
+
+def test_a_reordered_entry_fails_at_its_index(tmp_path: pathlib.Path) -> None:
+    """Swapping entries about different documents is caught positionally."""
+    swapped = _SPANISH.replace(
+        "## ISO 717-2:2020, Anexo C, ejemplo C.1 (suelo desnudo)",
+        "## MARK",
+    ).replace(
+        "## Directiva (UE) 2015/996 de la Comisión, Anexo II 2.2.1 "
+        "(fuente de carretera)",
+        "## ISO 717-2:2020, Anexo C, ejemplo C.1 (suelo desnudo)",
+    )
+    swapped = swapped.replace(
+        "## MARK",
+        "## Directiva (UE) 2015/996 de la Comisión, Anexo II 2.2.1 "
+        "(fuente de carretera)",
+    )
+    en, es = _editions(tmp_path, _ENGLISH, swapped)
+    with pytest.raises(SystemExit, match="entry 1 names '2015/996'"):
+        generate_site_reports.check_edition_parity(en, es)
+
+
+def test_a_mistranslated_designation_fails(tmp_path: pathlib.Path) -> None:
+    """A digit slipping in a designation is a mistranslation, not a variant."""
+    wrong = _SPANISH.replace("ISO 717-2:2020, Anexo", "ISO 717-3:2020, Anexo")
+    en, es = _editions(tmp_path, _ENGLISH, wrong)
+    with pytest.raises(SystemExit, match="'717-3:2020' where"):
+        generate_site_reports.check_edition_parity(en, es)
+
+
+def test_translated_issuer_words_do_not_fail_the_pair(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The issuer word moves and translates; the token must not require it.
+
+    "Commission Directive (EU) 2015/996" pairs with "Directiva (UE) 2015/996
+    de la Comisión": nothing about the issuer survives translation verbatim,
+    which is why the token starts at the first digit-bearing word.
+    """
+    en, es = _editions(tmp_path, _ENGLISH, _SPANISH)
+    generate_site_reports.check_edition_parity(en, es)
+
+
+def test_the_accepted_blind_spot_is_within_one_document(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Swapping two entries of the same document passes, and may.
+
+    The two IEC 60268-16:2011 Table M.1 entries share their designation
+    token, so exchanging them is invisible to the gate. That is the accepted
+    residual: both headings still name the source they describe, so no
+    heading is paired with the wrong document; only the entry order within
+    one document's run would be off, which the translation review reads, not
+    this gate.
+    """
+    swapped = _SPANISH.replace(
+        "## IEC 60268-16:2011, Table M.1 (la fila beta)", "## MARK"
+    ).replace(
+        "## IEC 60268-16:2011, Table M.1 (paso 3 a 250 Hz)",
+        "## IEC 60268-16:2011, Table M.1 (la fila beta)",
+    )
+    swapped = swapped.replace(
+        "## MARK", "## IEC 60268-16:2011, Table M.1 (paso 3 a 250 Hz)"
+    )
+    en, es = _editions(tmp_path, _ENGLISH, swapped)
+    generate_site_reports.check_edition_parity(en, es)
+
+
+def test_the_shipped_editions_pass_the_gate() -> None:
+    """The committed registry and its Spanish edition satisfy the invariants."""
+    root = pathlib.Path(generate_site_reports.__file__).resolve().parent.parent
+    generate_site_reports.check_edition_parity(
+        root / "docs" / "ERRATA.md", root / "docs" / "ERRATA.es.md"
+    )


### PR DESCRIPTION
The errata registry gains a Spanish edition, `docs/ERRATA.es.md`, translated entry for entry from `docs/ERRATA.md`: all 108 entries plus the closing list of source properties that are not errata.

The Spanish site page now transplants that edition instead of reproducing the English body, so the registry reads in Spanish at `/es/reference/errata/`. The English wording stays the authoritative one, since it is what has been or will be communicated to the issuing bodies, and both introductions say so.

Translation rules, applied throughout: quoted print, mathematics, printed values and decimal separators are reproduced exactly as each cited source prints them, untranslated; entry headings are translated but keep the designation of the document they name; the word issue stays untranslated.

`generate_site_reports.py` now holds the two editions together: same number of `##` entries, same order, and each pair of headings naming the same source document (its first designation token, so `ISO 717-2:2020, Annex C` and `ISO 717-2:2020, Anexo C` both reduce to `717-2:2020`). A run, including the CI `--check`, fails before writing anything when the editions drift. Both failure modes were exercised locally: removing one Spanish entry and altering one designation each stop the run with a message naming the entry.

The three evidence checks of `check_errata_evidence.py` keep running on the English registry alone, which remains the evidential authority; CONTRIBUTING documents that a new entry must land in both files and what the parity gate enforces.

`generate_llms.py` learns that `ERRATA.es.md` is not a mirror page and maps links to it onto the Spanish route, mirroring the existing ERRATA handling.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a Spanish edition of the errata registry (docs/ERRATA.es.md).</li>
<li>Updated CONTRIBUTING.md to include guidelines for maintaining the Spanish errata registry.</li>
<li>Updated scripts/generate_llms.py and scripts/generate_site_reports.py to support the new Spanish errata file.</li>
<li>Synchronized errata documentation across English and Spanish versions in site/src/content/docs/.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Spanish edition of the errata registry, translated entry-for-entry.
  * Added links to the Spanish edition from relevant documentation and site pages.
* **Documentation**
  * Clarified that English wording is authoritative and quoted material remains untranslated.
  * Documented synchronization requirements between both editions.
* **Bug Fixes**
  * Added validation to ensure matching entries appear in the same order before publication.
  * Updated Spanish pages to display the translated registry content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->