### PR TITLE
Spell the C library's log in pinned numpy, and get the design's speed back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,7 +282,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   checked with the same function, so the check could not see an error in it;
   measured against a wider precision, the pin is now good to 1.6e-14 relative
   and `sosfreqz` is the thing that cannot read it, being out by 1.3e-10 at the
-  G weighting's 10 Hz reference frequency. A design costs about 260 ms, paid
+  G weighting's 10 Hz reference frequency. A design costs about 200 ms, paid
   once per curve, rate and mode.
 
 - The ANSI S1.4-1983 Table V Type 2 cell at 20 Hz is read as +/-3 dB. It
@@ -423,6 +423,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The weighting fit takes its logarithms from `filters._pinned_log` instead of
+  from a `math.log` loop, and a cold design costs about 200 ms where it had
+  come to cost about 260. The loop was the price of determinism: numpy's `log`
+  is dispatched on what the CPU offers and its AVX512 kernels disagree with
+  the rest in the last bit, so every transcendental on the design path was
+  taken from `math` one element at a time, and `log` -- the one that runs
+  inside the Levenberg-Marquardt iteration, three quarters of a million calls
+  per design -- carried almost all of the cost. The new module spells the C
+  library's own `log`, the table-driven routine from ARM's optimized-routines
+  that glibc ships, in numpy operations IEEE 754 pins exactly: plain
+  arithmetic, integer bit work and table takes, with the routine's fused
+  multiply-adds emulated through error-free transformations. Verified bit for
+  bit against `math.log` over the 91 658 333 distinct values the whole design
+  corpus evaluates and over a hundred million adversarial draws, zero
+  mismatches, and the corpus of designs is byte-identical before and after:
+  no shipped coefficient, figure or conformance value moved. The fit also
+  batches each evaluation's logarithms into one call and reuses the normal
+  equations' index pattern across steps, which is where the rest of the
+  recovery comes from; the transcendentals outside the iteration stay on the
+  `math` loop, where a design pays them once.
+
 - The frequency weightings are designed at the sample rate instead of being
   outrun at eight times it. Every curve in `filters.weighting` starts as poles
   and zeros in the s plane, and the bilinear transform that makes a digital
@@ -459,9 +480,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
   The third was speed. Weighting one minute of 44.1 kHz audio costs about
   18 ms where it cost 377 ms for A and 775 ms for 468, and holds 21 MB of
-  intermediates instead of 169 MB. The design itself costs about 260 ms and is
+  intermediates instead of 169 MB. The design itself costs about 200 ms and is
   cached per curve, rate and mode, so even a first call is quicker than the
-  path it replaces: about 280 ms against 377 for A, 285 against 775 for 468.
+  path it replaces: about 215 ms against 377 for A, 220 against 775 for 468.
 
   `high_accuracy=False` keeps its old meaning: the plain bilinear transform of
   the printed prototype, the closed form a reader can check against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   recovery comes from; the transcendentals outside the iteration stay on the
   `math` loop, where a design pays them once.
 
+  On platforms whose C library is not glibc the byte-for-byte clause reads
+  the other way round, and it is an improvement: Apple's and musl's `log`
+  round a handful of inputs to the other neighbouring double, so the retired
+  `math.log` loop silently returned different designs on macOS than on
+  Linux. The pinned routine returns its own bits everywhere, so the designs
+  are now identical across platforms as well as across CPUs; on a non-glibc
+  platform they moved by that last ulp once, onto the values every other
+  platform already shipped.
+
 - The frequency weightings are designed at the sample rate instead of being
   outrun at eight times it. Every curve in `filters.weighting` starts as poles
   and zeros in the s plane, and the bilinear transform that makes a digital

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -435,10 +435,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   that glibc ships, in numpy operations IEEE 754 pins exactly: plain
   arithmetic, integer bit work and table takes, with the routine's fused
   multiply-adds emulated through error-free transformations. Verified bit for
-  bit against `math.log` over the 91 658 333 distinct values the whole design
-  corpus evaluates and over a hundred million adversarial draws, zero
-  mismatches, and the corpus of designs is byte-identical before and after:
-  no shipped coefficient, figure or conformance value moved. The fit also
+  bit against glibc's `log` over the 91 658 333 distinct values the whole
+  design corpus evaluates, zero mismatches, and the corpus of designs is
+  byte-identical before and after: no shipped coefficient, figure or
+  conformance value moved. Beyond the corpus the agreement with glibc is
+  statistical rather than structural: an adversarial search found about one
+  input in thirty million, in the narrow band just outside the near-one
+  window, whose true logarithm falls almost exactly between two doubles and
+  where the compiled binary's own compiler-fused pairs round the other way;
+  a further hundred million draws found no other kind of divergence, and
+  none of it can reach a design, since the pinned routine is the definition
+  on the design path. The fit also
   batches each evaluation's logarithms into one call and reuses the normal
   equations' index pattern across steps, which is where the rest of the
   recovery comes from; the transcendentals outside the iteration stay on the

--- a/docs/signals/levels/weighting.md
+++ b/docs/signals/levels/weighting.md
@@ -281,9 +281,9 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 260 ms and is cached per curve and sample rate, so it
+- The fit costs about 200 ms and is cached per curve and sample rate, so it
   is paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  faster than it used to be: about 215 ms against 377 ms for A, and 220 ms
   against 775 ms for the 468 curve. Once the design is cached the filtering
   alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -43276,9 +43276,9 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 260 ms and is cached per curve and sample rate, so it
+- The fit costs about 200 ms and is cached per curve and sample rate, so it
   is paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  faster than it used to be: about 215 ms against 377 ms for A, and 220 ms
   against 775 ms for the 468 curve. Once the design is cached the filtering
   alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 

--- a/site/public/llms/llms-signals-levels.txt
+++ b/site/public/llms/llms-signals-levels.txt
@@ -385,9 +385,9 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 260 ms and is cached per curve and sample rate, so it
+- The fit costs about 200 ms and is cached per curve and sample rate, so it
   is paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  faster than it used to be: about 215 ms against 377 ms for A, and 220 ms
   against 775 ms for the 468 curve. Once the design is cached the filtering
   alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 

--- a/site/src/content/docs/es/signals/levels/weighting.mdx
+++ b/site/src/content/docs/es/signals/levels/weighting.mdx
@@ -427,10 +427,10 @@ plt.show()
   `high_accuracy` son independientes, stateful usa por defecto el diseño
   ajustado como todo lo demás, y los bloques concatenados reproducen
   exactamente una llamada única.
-- El ajuste cuesta unos 260 ms y se cachea por curva y frecuencia de
+- El ajuste cuesta unos 200 ms y se cachea por curva y frecuencia de
   muestreo, así que se paga una sola vez. Incluso contándolo, ponderar un
-  minuto de audio a 44,1 kHz es más rápido que antes: unos 280 ms frente a
-  377 ms para la A y 285 ms frente a 775 ms para la 468. Con el diseño ya
+  minuto de audio a 44,1 kHz es más rápido que antes: unos 215 ms frente a
+  377 ms para la A y 220 ms frente a 775 ms para la 468. Con el diseño ya
   cacheado, el filtrado solo son unos 18 ms, y retiene 21 MB de intermedios
   en vez de 169 MB.
 

--- a/site/src/content/docs/reference/api/filters/weighting.md
+++ b/site/src/content/docs/reference/api/filters/weighting.md
@@ -83,8 +83,8 @@ each of them used to be a documented limitation of this module:
 * one minute of 44.1 kHz audio costs about 18 ms instead of 377 ms for A and
   775 ms for 468, and holds 21 MB of intermediates instead of 169 MB
   (measured back to back in one process, mean of five runs). The design
-  itself costs about 260 ms and is cached, so even a first call is quicker
-  than the path it replaces: about 280 ms against 377 for A, 285 against
+  itself costs about 200 ms and is cached, so even a first call is quicker
+  than the path it replaces: about 215 ms against 377 for A, 220 against
   775 for 468.
 
 > Auto-generated from the source docstrings by `scripts/generate_api_docs.py` (`make api-docs`). Do not edit by hand.

--- a/site/src/content/docs/signals/levels/weighting.mdx
+++ b/site/src/content/docs/signals/levels/weighting.mdx
@@ -413,9 +413,9 @@ plt.show()
   second-order sections at the input rate, so `stateful` and `high_accuracy`
   are independent, stateful defaults to the fitted design like everything
   else, and stitched blocks reproduce a single call exactly.
-- The fit costs about 260 ms and is cached per curve and sample rate, so it
+- The fit costs about 200 ms and is cached per curve and sample rate, so it
   is paid once. Even including it, weighting one minute of 44.1 kHz audio is
-  faster than it used to be: about 280 ms against 377 ms for A, and 285 ms
+  faster than it used to be: about 215 ms against 377 ms for A, and 220 ms
   against 775 ms for the 468 curve. Once the design is cached the filtering
   alone is about 18 ms, and it holds 21 MB of intermediates instead of 169 MB.
 

--- a/src/phonometry/filters/_pinned_log.py
+++ b/src/phonometry/filters/_pinned_log.py
@@ -29,11 +29,12 @@ replacement:
   :math:`[1 - 2^{-7}, 1 + 2^{-7}]`, Sterbenz's lemma makes ``p - 1.0`` exact,
   so ``(p - 1.0) + e`` rounds the very real number the fused operation rounds,
   once.
-* The four multiply-adds the compiler fused in the near-one polynomial
-  (``x`` within :math:`[1 - 2^{-4}, 1 + 0x1.09p{-4}]`). Those are emulated
-  exactly by :func:`_fused_multiply_add`, the error-free-transformation
-  emulation: split the product, sum with the addend through two exact sums,
-  and the two roundings that remain land on the fused result.
+* The multiply-adds the compiler fused on its own in the near-one
+  polynomial (``x`` within :math:`[1 - 2^{-4}, 1 + 0x1.09p{-4}]`). The four
+  sites observed to move the result -- found by searching the space of
+  contraction choices against the shipped binary's own answers -- are
+  emulated exactly by :func:`_fused_multiply_add`; the remaining sites agree
+  as plain pairs on every input thrown at them.
 * The table lookups, which are numpy takes.
 
 The tables and polynomial coefficients are copied digit for digit from ARM's
@@ -47,11 +48,24 @@ exactly.
 What "without touching a single output bit" rests on, measured on this
 project's own corpus rather than asserted: over the 91 658 333 distinct
 values the weighting fit feeds its logarithm across 133 (curve, rate)
-designs, plus twenty million draws over the full exponent range, forty
-million in the near-one band, two million subnormals and the window edges,
-this function and ``math.log`` return identical bit patterns on every input
--- zero exceptions. ``tests/filters/test_pinned_log.py`` pins a deterministic
-slice of that comparison, including the inputs an actual design evaluates.
+designs, this function and glibc's ``log`` return identical bit patterns --
+zero exceptions, and that is the fact the shipped designs stand on. Beyond
+the corpus the agreement is statistical rather than structural. The compiled
+binary carries multiply-adds the compiler fused on its own, which this
+module spells as plain pairs where they were never observed to matter, and
+an adversarial search of the band just outside the near-one window -- where
+the logarithm is smallest and the final rounding tightest -- found about one
+input in thirty million whose true logarithm falls almost exactly between
+two doubles and the two implementations part by that last ulp: the first
+found is ``0x1.1fa63fbb5acd3p+0``, whose true logarithm sits 0.491 ulp from
+one answer and 0.509 from the other, both inside the routine's documented
+0.519 ulp worst case. A further hundred million draws over the full exponent
+range, the near-one band, the subnormals and the window edges found no other
+kind of divergence. None of it can reach a design: on the design path this
+function is the definition, and its own bits are the same on every
+conforming machine. ``tests/filters/test_pinned_log.py`` pins a
+deterministic slice of the comparison, including the inputs an actual design
+evaluates and the found boundary inputs held to one ulp.
 
 One consequence is worth stating plainly. ``math.log`` is whatever ``log``
 the platform's C library ships, and only glibc ships this routine: Apple's
@@ -434,12 +448,14 @@ def _fused_multiply_add(
     b: np.ndarray | np.float64,
     c: np.ndarray | np.float64,
 ) -> np.ndarray:
-    """``fl(a * b + c)`` with one rounding, in plain IEEE 754 operations.
+    """``fl(a * b + c)`` emulated in plain IEEE 754 operations.
 
     The error-free-transformation emulation: the product and the first sum
-    are made exact, and the two roundings that remain reproduce the fused
-    result. Verified bit for bit against :func:`math.fma` over eighty million
-    draws covering this module's three call sites and a general
+    are made exact, and the two roundings that remain land on the fused
+    result. Not correctly rounded for *every* triple -- a doubly-tied case
+    can land one ulp off the true fused answer -- but exact on the domains of
+    this module's call sites: verified bit for bit against :func:`math.fma`
+    over eighty million draws covering them and a general
     :math:`[-1, 1]^3` sweep, with zero mismatches; the sites' operands are
     comfortably inside the no-underflow range the transformation needs.
 
@@ -464,9 +480,12 @@ def _main_path(x: np.ndarray) -> np.ndarray:
     ``x = 2^k z`` with ``z`` in ``[0x1.6p-1, 0x1.6p0)``; the subinterval table
     gives ``1/c`` and ``log c``, and ``log x = k ln2 + log c + log1p(r)`` with
     ``r = z/c - 1`` small enough for a degree-five polynomial. ``r`` is the
-    one fused operation of the C routine's fast path, and it needs no
+    one fused operation the C source spells explicitly, and it needs no
     emulation: ``z * invc`` lands within :math:`2^{-7}` of one, so Sterbenz
-    makes ``p - 1.0`` exact and ``(p - 1.0) + e`` is the fused result.
+    makes ``p - 1.0`` exact and ``(p - 1.0) + e`` is the fused result. The
+    compiler fuses further sites of this path on its own; those are spelled
+    as plain pairs here, which is where the roughly one-in-thirty-million
+    boundary divergence the module docstring bounds comes from.
 
     :param x: Positive normal doubles.
     :type x: np.ndarray
@@ -539,8 +558,8 @@ def pinned_log(values: np.ndarray) -> np.ndarray:
     time: same bits on every input the weighting fit produces (and on every
     positive double thrown at it in validation), two orders of magnitude
     less interpreter overhead. Domain errors follow :func:`math.log`: any
-    non-positive finite element raises :class:`ValueError`; ``inf`` and
-    ``nan`` propagate.
+    non-positive finite element raises :class:`ValueError`; ``inf``
+    propagates and ``nan`` propagates canonicalised.
 
     :param values: Any real array-like of positive values.
     :type values: np.ndarray

--- a/src/phonometry/filters/_pinned_log.py
+++ b/src/phonometry/filters/_pinned_log.py
@@ -398,6 +398,11 @@ _NEAR_SPAN = (
 #: Smallest normal double, as a bit pattern.
 _TINY = np.uint64(0x0010000000000000)
 
+#: ``1.0`` as a bit pattern: the C routine fixes ``log(1.0)`` to ``+0.0`` by
+#: comparing ``asuint64(x)``, and so does this one -- an integer comparison,
+#: not a floating-point one.
+_ONE = np.uint64(0x3FF0000000000000)
+
 
 def _two_product(
     a: np.ndarray, b: np.ndarray | np.float64
@@ -548,7 +553,7 @@ def _near_one_path(x: np.ndarray) -> np.ndarray:
     lo = (_B[0] * r_lo) * (r_hi + r) + lo
     y = _fused_multiply_add(r3, head, lo)
     y = y + hi
-    return np.where(x == 1.0, 0.0, y)
+    return np.where(x.view(np.uint64) == _ONE, 0.0, y)
 
 
 def pinned_log(values: np.ndarray) -> np.ndarray:

--- a/src/phonometry/filters/_pinned_log.py
+++ b/src/phonometry/filters/_pinned_log.py
@@ -85,6 +85,32 @@ import numpy as np
 
 __all__ = ["pinned_log"]
 
+# The table and polynomial constants below are copied from ARM's
+# optimized-routines, math/log_data.c, and are redistributed under that
+# project's MIT license, whose notice the license requires to travel with
+# them:
+#
+#   Copyright (c) 2018, Arm Limited.
+#
+#   Permission is hereby granted, free of charge, to any person obtaining
+#   a copy of this software and associated documentation files (the
+#   "Software"), to deal in the Software without restriction, including
+#   without limitation the rights to use, copy, modify, merge, publish,
+#   distribute, sublicense, and/or sell copies of the Software, and to
+#   permit persons to whom the Software is furnished to do so, subject to
+#   the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included
+#   in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+#   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+#   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+#   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+#   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 _LN2HI = "0x1.62e42fefa3800p-1"
 _LN2LO = "0x1.ef35793c76730p-45"
 _POLY1_HEX = (

--- a/src/phonometry/filters/_pinned_log.py
+++ b/src/phonometry/filters/_pinned_log.py
@@ -52,6 +52,17 @@ million in the near-one band, two million subnormals and the window edges,
 this function and ``math.log`` return identical bit patterns on every input
 -- zero exceptions. ``tests/filters/test_pinned_log.py`` pins a deterministic
 slice of that comparison, including the inputs an actual design evaluates.
+
+One consequence is worth stating plainly. ``math.log`` is whatever ``log``
+the platform's C library ships, and only glibc ships this routine: Apple's
+and musl's round a handful of inputs to the other neighbour, never further
+(both are within about half an ulp of the true logarithm, so the two answers
+are floating-point neighbours wherever they part). The elementwise loop this
+module replaces therefore returned *different designs on macOS than on
+Linux*, silently. This function returns its own bits everywhere, so the
+designs are now identical across platforms as well as across CPUs -- on a
+non-glibc platform they moved by that last ulp once, to the values every
+other platform already shipped.
 """
 
 from __future__ import annotations

--- a/src/phonometry/filters/_pinned_log.py
+++ b/src/phonometry/filters/_pinned_log.py
@@ -1,0 +1,566 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+r"""The natural logarithm, spelled in arithmetic IEEE 754 pins.
+
+:mod:`phonometry.filters._weighting_design` fits every weighting curve with a
+fixed sequence of operations, and what made that sequence return the same
+filter on every machine was taking each transcendental from :mod:`math` one
+element at a time: numpy's ``log`` is dispatched on what the CPU offers and
+its AVX512 kernels do not agree to the last bit with the ones a machine
+without AVX512 runs, while the C library's scalar ``log`` does not move. The
+price was the Python loop. ``log`` runs inside the fit -- once per grid point
+per factor per Levenberg-Marquardt step, three quarters of a million calls
+per design -- and paying interpreter overhead on every one of them multiplied
+the cost of a design by about four.
+
+This module removes the loop without touching a single output bit. It spells
+the C library's own ``log`` -- the table-driven routine from ARM's
+optimized-routines, which glibc has shipped as ``__ieee754_log`` since 2.28 --
+in numpy array arithmetic restricted to operations IEEE 754 pins exactly:
+addition, subtraction, multiplication, comparisons, and integer bit work.
+Nothing here is dispatched on a vector unit's taste; every operation is
+correctly rounded by the standard, so the result is the same bit pattern on
+every conforming machine, AVX512 or not, glibc or not.
+
+Three places in the C routine are not plain arithmetic, and each has an exact
+replacement:
+
+* ``r = fma (z, invc, -1.0)``. The product is split exactly with Dekker's
+  algorithm, :func:`_two_product`, and because ``z * invc`` lands within
+  :math:`[1 - 2^{-7}, 1 + 2^{-7}]`, Sterbenz's lemma makes ``p - 1.0`` exact,
+  so ``(p - 1.0) + e`` rounds the very real number the fused operation rounds,
+  once.
+* The four multiply-adds the compiler fused in the near-one polynomial
+  (``x`` within :math:`[1 - 2^{-4}, 1 + 0x1.09p{-4}]`). Those are emulated
+  exactly by :func:`_fused_multiply_add`, the error-free-transformation
+  emulation: split the product, sum with the addend through two exact sums,
+  and the two roundings that remain land on the fused result.
+* The table lookups, which are numpy takes.
+
+The tables and polynomial coefficients are copied digit for digit from ARM's
+optimized-routines ``math/log_data.c`` (MIT-licensed; Arm Limited, 2018), the
+file glibc's ``e_log_data.c`` carries verbatim for this configuration
+(``N == 128``, ``LOG_POLY_ORDER == 6``, ``LOG_POLY1_ORDER == 12``). The
+second table of the C file, ``tab2``, exists only for machines without a fast
+fused multiply-add and is not needed here: the Dekker split takes its place
+exactly.
+
+What "without touching a single output bit" rests on, measured on this
+project's own corpus rather than asserted: over the 91 658 333 distinct
+values the weighting fit feeds its logarithm across 133 (curve, rate)
+designs, plus twenty million draws over the full exponent range, forty
+million in the near-one band, two million subnormals and the window edges,
+this function and ``math.log`` return identical bit patterns on every input
+-- zero exceptions. ``tests/filters/test_pinned_log.py`` pins a deterministic
+slice of that comparison, including the inputs an actual design evaluates.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = ["pinned_log"]
+
+_LN2HI = "0x1.62e42fefa3800p-1"
+_LN2LO = "0x1.ef35793c76730p-45"
+_POLY1_HEX = (
+    "-0x1.0000000000000p-1",
+    "0x1.5555555555577p-2",
+    "-0x1.ffffffffffdcbp-3",
+    "0x1.999999995dd0cp-3",
+    "-0x1.55555556745a7p-3",
+    "0x1.24924a344de30p-3",
+    "-0x1.fffffa4423d65p-4",
+    "0x1.c7184282ad6cap-4",
+    "-0x1.999eb43b068ffp-4",
+    "0x1.78182f7afd085p-4",
+    "-0x1.5521375d145cdp-4",
+)
+_POLY_HEX = (
+    "-0x1.0000000000001p-1",
+    "0x1.555555551305bp-2",
+    "-0x1.fffffffeb4590p-3",
+    "0x1.999b324f10111p-3",
+    "-0x1.55575e506c89fp-3",
+)
+_INVC_HEX = (
+    "0x1.734f0c3e0de9fp+0",
+    "0x1.713786a2ce91fp+0",
+    "0x1.6f26008fab5a0p+0",
+    "0x1.6d1a61f138c7dp+0",
+    "0x1.6b1490bc5b4d1p+0",
+    "0x1.69147332f0cbap+0",
+    "0x1.6719f18224223p+0",
+    "0x1.6524f99a51ed9p+0",
+    "0x1.63356aa8f24c4p+0",
+    "0x1.614b36b9ddc14p+0",
+    "0x1.5f66452c65c4cp+0",
+    "0x1.5d867b5912c4fp+0",
+    "0x1.5babccb5b90dep+0",
+    "0x1.59d61f2d91a78p+0",
+    "0x1.5805612465687p+0",
+    "0x1.56397cee76bd3p+0",
+    "0x1.54725e2a77f93p+0",
+    "0x1.52aff42064583p+0",
+    "0x1.50f22dbb2bddfp+0",
+    "0x1.4f38f4734ded7p+0",
+    "0x1.4d843cfde2840p+0",
+    "0x1.4bd3ec078a3c8p+0",
+    "0x1.4a27fc3e0258ap+0",
+    "0x1.4880524d48434p+0",
+    "0x1.46dce1b192d0bp+0",
+    "0x1.453d9d3391854p+0",
+    "0x1.43a2744b4845ap+0",
+    "0x1.420b54115f8fbp+0",
+    "0x1.40782da3ef4b1p+0",
+    "0x1.3ee8f5d57fe8fp+0",
+    "0x1.3d5d9a00b4ce9p+0",
+    "0x1.3bd60c010c12bp+0",
+    "0x1.3a5242b75dab8p+0",
+    "0x1.38d22cd9fd002p+0",
+    "0x1.3755bc5847a1cp+0",
+    "0x1.35dce49ad36e2p+0",
+    "0x1.34679984dd440p+0",
+    "0x1.32f5cceffcb24p+0",
+    "0x1.3187775a10d49p+0",
+    "0x1.301c8373e3990p+0",
+    "0x1.2eb4ebb95f841p+0",
+    "0x1.2d50a0219a9d1p+0",
+    "0x1.2bef9a8b7fd2ap+0",
+    "0x1.2a91c7a0c1babp+0",
+    "0x1.293726014b530p+0",
+    "0x1.27dfa5757a1f5p+0",
+    "0x1.268b39b1d3bbfp+0",
+    "0x1.2539d838ff5bdp+0",
+    "0x1.23eb7aac9083bp+0",
+    "0x1.22a012ba940b6p+0",
+    "0x1.2157996cc4132p+0",
+    "0x1.201201dd2fc9bp+0",
+    "0x1.1ecf4494d480bp+0",
+    "0x1.1d8f5528f6569p+0",
+    "0x1.1c52311577e7cp+0",
+    "0x1.1b17c74cb26e9p+0",
+    "0x1.19e010c2c1ab6p+0",
+    "0x1.18ab07bb670bdp+0",
+    "0x1.1778a25efbcb6p+0",
+    "0x1.1648d354c31dap+0",
+    "0x1.151b990275fddp+0",
+    "0x1.13f0ea432d24cp+0",
+    "0x1.12c8b7210f9dap+0",
+    "0x1.11a3028ecb531p+0",
+    "0x1.107fbda8434afp+0",
+    "0x1.0f5ee0f4e6bb3p+0",
+    "0x1.0e4065d2a9fcep+0",
+    "0x1.0d244632ca521p+0",
+    "0x1.0c0a77ce2981ap+0",
+    "0x1.0af2f83c636d1p+0",
+    "0x1.09ddb98a01339p+0",
+    "0x1.08cabaf52e7dfp+0",
+    "0x1.07b9f2f4e28fbp+0",
+    "0x1.06ab58c358f19p+0",
+    "0x1.059eea5ecf92cp+0",
+    "0x1.04949cdd12c90p+0",
+    "0x1.038c6c6f0ada9p+0",
+    "0x1.02865137932a9p+0",
+    "0x1.0182427ea7348p+0",
+    "0x1.008040614b195p+0",
+    "0x1.fe01ff726fa1ap-1",
+    "0x1.fa11cc261ea74p-1",
+    "0x1.f6310b081992ep-1",
+    "0x1.f25f63ceeadcdp-1",
+    "0x1.ee9c8039113e7p-1",
+    "0x1.eae8078cbb1abp-1",
+    "0x1.e741aa29d0c9bp-1",
+    "0x1.e3a91830a99b5p-1",
+    "0x1.e01e009609a56p-1",
+    "0x1.dca01e577bb98p-1",
+    "0x1.d92f20b7c9103p-1",
+    "0x1.d5cac66fb5ccep-1",
+    "0x1.d272caa5ede9dp-1",
+    "0x1.cf26e3e6b2ccdp-1",
+    "0x1.cbe6da2a77902p-1",
+    "0x1.c8b266d37086dp-1",
+    "0x1.c5894bd5d5804p-1",
+    "0x1.c26b533bb9f8cp-1",
+    "0x1.bf583eeece73fp-1",
+    "0x1.bc4fd75db96c1p-1",
+    "0x1.b951e0c864a28p-1",
+    "0x1.b65e2c5ef3e2cp-1",
+    "0x1.b374867c9888bp-1",
+    "0x1.b094b211d304ap-1",
+    "0x1.adbe885f2ef7ep-1",
+    "0x1.aaf1d31603da2p-1",
+    "0x1.a82e63fd358a7p-1",
+    "0x1.a5740ef09738bp-1",
+    "0x1.a2c2a90ab4b27p-1",
+    "0x1.a01a01393f2d1p-1",
+    "0x1.9d79f24db3c1bp-1",
+    "0x1.9ae2505c7b190p-1",
+    "0x1.9852ef297ce2fp-1",
+    "0x1.95cbaeea44b75p-1",
+    "0x1.934c69de74838p-1",
+    "0x1.90d4f2f6752e6p-1",
+    "0x1.8e6528effd79dp-1",
+    "0x1.8bfce9fcc007cp-1",
+    "0x1.899c0dabec30ep-1",
+    "0x1.87427aa2317fbp-1",
+    "0x1.84f00acb39a08p-1",
+    "0x1.82a49e8653e55p-1",
+    "0x1.8060195f40260p-1",
+    "0x1.7e22563e0a329p-1",
+    "0x1.7beb377dcb5adp-1",
+    "0x1.79baa679725c2p-1",
+    "0x1.77907f2170657p-1",
+    "0x1.756cadbd6130cp-1",
+)
+_LOGC_HEX = (
+    "-0x1.7cc7f79e69000p-2",
+    "-0x1.76feec20d0000p-2",
+    "-0x1.713e31351e000p-2",
+    "-0x1.6b85b38287800p-2",
+    "-0x1.65d5590807800p-2",
+    "-0x1.602d076180000p-2",
+    "-0x1.5a8ca86909000p-2",
+    "-0x1.54f4356035000p-2",
+    "-0x1.4f637c36b4000p-2",
+    "-0x1.49da7fda85000p-2",
+    "-0x1.445923989a800p-2",
+    "-0x1.3edf439b0b800p-2",
+    "-0x1.396ce448f7000p-2",
+    "-0x1.3401e17bda000p-2",
+    "-0x1.2e9e2ef468000p-2",
+    "-0x1.2941b3830e000p-2",
+    "-0x1.23ec58cda8800p-2",
+    "-0x1.1e9e129279000p-2",
+    "-0x1.1956d2b48f800p-2",
+    "-0x1.141679ab9f800p-2",
+    "-0x1.0edd094ef9800p-2",
+    "-0x1.09aa518db1000p-2",
+    "-0x1.047e65263b800p-2",
+    "-0x1.feb224586f000p-3",
+    "-0x1.f474a7517b000p-3",
+    "-0x1.ea4443d103000p-3",
+    "-0x1.e020d44e9b000p-3",
+    "-0x1.d60a22977f000p-3",
+    "-0x1.cc00104959000p-3",
+    "-0x1.c202956891000p-3",
+    "-0x1.b81178d811000p-3",
+    "-0x1.ae2c9ccd3d000p-3",
+    "-0x1.a45402e129000p-3",
+    "-0x1.9a877681df000p-3",
+    "-0x1.90c6d69483000p-3",
+    "-0x1.87120a645c000p-3",
+    "-0x1.7d68fb4143000p-3",
+    "-0x1.73cb83c627000p-3",
+    "-0x1.6a39a9b376000p-3",
+    "-0x1.60b3154b7a000p-3",
+    "-0x1.5737d76243000p-3",
+    "-0x1.4dc7b8fc23000p-3",
+    "-0x1.4462c51d20000p-3",
+    "-0x1.3b08abc830000p-3",
+    "-0x1.31b996b490000p-3",
+    "-0x1.2875490a44000p-3",
+    "-0x1.1f3b9f879a000p-3",
+    "-0x1.160c8252ca000p-3",
+    "-0x1.0ce7f57f72000p-3",
+    "-0x1.03cdc49fea000p-3",
+    "-0x1.f57bdbc4b8000p-4",
+    "-0x1.e370896404000p-4",
+    "-0x1.d17983ef94000p-4",
+    "-0x1.bf9674ed8a000p-4",
+    "-0x1.adc79202f6000p-4",
+    "-0x1.9c0c3e7288000p-4",
+    "-0x1.8a646b372c000p-4",
+    "-0x1.78d01b3ac0000p-4",
+    "-0x1.674f145380000p-4",
+    "-0x1.55e0e6d878000p-4",
+    "-0x1.4485cdea1e000p-4",
+    "-0x1.333d94d6aa000p-4",
+    "-0x1.22079f8c56000p-4",
+    "-0x1.10e4698622000p-4",
+    "-0x1.ffa6c6ad20000p-5",
+    "-0x1.dda8d4a774000p-5",
+    "-0x1.bbcece4850000p-5",
+    "-0x1.9a1894012c000p-5",
+    "-0x1.788583302c000p-5",
+    "-0x1.5715e67d68000p-5",
+    "-0x1.35c8a49658000p-5",
+    "-0x1.149e364154000p-5",
+    "-0x1.e72c082eb8000p-6",
+    "-0x1.a55f152528000p-6",
+    "-0x1.63d62cf818000p-6",
+    "-0x1.228fb8caa0000p-6",
+    "-0x1.c317b20f90000p-7",
+    "-0x1.419355daa0000p-7",
+    "-0x1.81203c2ec0000p-8",
+    "-0x1.0040979240000p-9",
+    "0x1.feff384900000p-9",
+    "0x1.7dc41353d0000p-7",
+    "0x1.3cea3c4c28000p-6",
+    "0x1.b9fc114890000p-6",
+    "0x1.1b0d8ce110000p-5",
+    "0x1.58a5bd001c000p-5",
+    "0x1.95c8340d88000p-5",
+    "0x1.d276aef578000p-5",
+    "0x1.07598e598c000p-4",
+    "0x1.253f5e30d2000p-4",
+    "0x1.42edd8b380000p-4",
+    "0x1.606598757c000p-4",
+    "0x1.7da76356a0000p-4",
+    "0x1.9ab434e1c6000p-4",
+    "0x1.b78c7bb0d6000p-4",
+    "0x1.d431332e72000p-4",
+    "0x1.f0a3171de6000p-4",
+    "0x1.067152b914000p-3",
+    "0x1.147858292b000p-3",
+    "0x1.2266ecdca3000p-3",
+    "0x1.303d7a6c55000p-3",
+    "0x1.3dfc33c331000p-3",
+    "0x1.4ba366b7a8000p-3",
+    "0x1.5933928d1f000p-3",
+    "0x1.66acd2418f000p-3",
+    "0x1.740f8ec669000p-3",
+    "0x1.815c0f51af000p-3",
+    "0x1.8e92954f68000p-3",
+    "0x1.9bb3602f84000p-3",
+    "0x1.a8bed1c2c0000p-3",
+    "0x1.b5b515c01d000p-3",
+    "0x1.c2967ccbcc000p-3",
+    "0x1.cf635d5486000p-3",
+    "0x1.dc1bd3446c000p-3",
+    "0x1.e8c01b8cfe000p-3",
+    "0x1.f5509c0179000p-3",
+    "0x1.00e6c121fb800p-2",
+    "0x1.071b80e93d000p-2",
+    "0x1.0d46b9e867000p-2",
+    "0x1.13687334bd000p-2",
+    "0x1.1980d67234800p-2",
+    "0x1.1f8ffe0cc8000p-2",
+    "0x1.2595fd7636800p-2",
+    "0x1.2b9300914a800p-2",
+    "0x1.3187210436000p-2",
+    "0x1.377266dec1800p-2",
+    "0x1.3d54ffbaf3000p-2",
+    "0x1.432eee32fe000p-2",
+)
+
+#: ln 2 split so that ``k * _LN2_HI`` is exact for every reachable ``k``.
+_LN2_HI = float.fromhex(_LN2HI)
+_LN2_LO = float.fromhex(_LN2LO)
+
+#: Near-one polynomial ``B`` and main-path polynomial ``A`` of the C routine.
+_B = tuple(float.fromhex(value) for value in _POLY1_HEX)
+_A = tuple(float.fromhex(value) for value in _POLY_HEX)
+
+#: The 128-entry table: ``invc[i]`` is near the inverse of the subinterval
+#: centre and ``logc[i]`` its logarithm, chosen by the C file so that
+#: ``k * ln2hi + logc`` carries no rounding error.
+_INVC = np.array([float.fromhex(value) for value in _INVC_HEX])
+_LOGC = np.array([float.fromhex(value) for value in _LOGC_HEX])
+
+#: ``x = 2^k z`` decomposition offset: ``z`` lands in ``[0x1.6p-1, 0x1.6p0)``.
+_OFF = np.uint64(0x3FE6000000000000)
+
+#: Veltkamp splitting constant, ``2**27 + 1``.
+_SPLIT = 134217729.0
+
+#: The near-one window ``[1 - 0x1p-4, 1 + 0x1.09p-4]``, as bit patterns, so
+#: membership is one unsigned subtraction exactly as the C routine tests it.
+_NEAR_LOW = np.uint64(np.float64(1.0 - 2.0**-4).view(np.uint64))
+_NEAR_SPAN = (
+    np.uint64(np.float64(1.0 + float.fromhex("0x1.09p-4")).view(np.uint64)) - _NEAR_LOW
+)
+
+#: Smallest normal double, as a bit pattern.
+_TINY = np.uint64(0x0010000000000000)
+
+
+def _two_product(
+    a: np.ndarray, b: np.ndarray | np.float64
+) -> tuple[np.ndarray, np.ndarray]:
+    """Dekker's exact product: ``a * b == p + e`` with ``p = fl(a * b)``.
+
+    Exact whenever neither the split nor the product overflows, which the two
+    call sites guarantee: their operands live within a few binades of one.
+
+    :param a: First factor.
+    :type a: np.ndarray
+    :param b: Second factor.
+    :type b: np.ndarray
+    :return: The rounded product and its exact error.
+    :rtype: tuple[np.ndarray, np.ndarray]
+    """
+    p = a * b
+    ta = a * _SPLIT
+    a_hi = ta - (ta - a)
+    a_lo = a - a_hi
+    tb = b * _SPLIT
+    b_hi = tb - (tb - b)
+    b_lo = b - b_hi
+    e = ((a_hi * b_hi - p) + a_hi * b_lo + a_lo * b_hi) + a_lo * b_lo
+    return p, e
+
+
+def _two_sum(
+    a: np.ndarray | np.float64, b: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Knuth's exact sum: ``a + b == s + e`` with ``s = fl(a + b)``.
+
+    :param a: First addend.
+    :type a: np.ndarray
+    :param b: Second addend.
+    :type b: np.ndarray
+    :return: The rounded sum and its exact error.
+    :rtype: tuple[np.ndarray, np.ndarray]
+    """
+    s = a + b
+    t = s - a
+    e = (a - (s - t)) + (b - t)
+    return s, e
+
+
+def _fused_multiply_add(
+    a: np.ndarray,
+    b: np.ndarray | np.float64,
+    c: np.ndarray | np.float64,
+) -> np.ndarray:
+    """``fl(a * b + c)`` with one rounding, in plain IEEE 754 operations.
+
+    The error-free-transformation emulation: the product and the first sum
+    are made exact, and the two roundings that remain reproduce the fused
+    result. Verified bit for bit against :func:`math.fma` over eighty million
+    draws covering this module's three call sites and a general
+    :math:`[-1, 1]^3` sweep, with zero mismatches; the sites' operands are
+    comfortably inside the no-underflow range the transformation needs.
+
+    :param a: First factor.
+    :type a: np.ndarray
+    :param b: Second factor.
+    :type b: np.ndarray
+    :param c: Addend.
+    :type c: np.ndarray
+    :return: The fused multiply-add, correctly rounded once.
+    :rtype: np.ndarray
+    """
+    p, p_err = _two_product(a, b)
+    s, s_err = _two_sum(c, p_err)
+    total, total_err = _two_sum(p, s)
+    return np.asarray(total + (total_err + s_err))
+
+
+def _main_path(x: np.ndarray) -> np.ndarray:
+    """The table-driven path: every ``x`` outside the near-one window.
+
+    ``x = 2^k z`` with ``z`` in ``[0x1.6p-1, 0x1.6p0)``; the subinterval table
+    gives ``1/c`` and ``log c``, and ``log x = k ln2 + log c + log1p(r)`` with
+    ``r = z/c - 1`` small enough for a degree-five polynomial. ``r`` is the
+    one fused operation of the C routine's fast path, and it needs no
+    emulation: ``z * invc`` lands within :math:`2^{-7}` of one, so Sterbenz
+    makes ``p - 1.0`` exact and ``(p - 1.0) + e`` is the fused result.
+
+    :param x: Positive normal doubles.
+    :type x: np.ndarray
+    :return: Their logarithms, bit for bit the C routine's.
+    :rtype: np.ndarray
+    """
+    bits = x.view(np.uint64)
+    offset = bits - _OFF
+    index = ((offset >> np.uint64(45)) & np.uint64(127)).astype(np.intp)
+    k = (offset.view(np.int64) >> np.int64(52)).astype(np.float64)
+    z = (bits - (offset & (np.uint64(0xFFF) << np.uint64(52)))).view(np.float64)
+    invc = _INVC[index]
+    logc = _LOGC[index]
+    p, e = _two_product(z, invc)
+    r = (p - 1.0) + e
+    w = k * _LN2_HI + logc
+    hi = w + r
+    lo = w - hi + r + k * _LN2_LO
+    r2 = r * r
+    return np.asarray(
+        lo + r2 * _A[0] + r * r2 * (_A[1] + r * _A[2] + r2 * (_A[3] + r * _A[4])) + hi
+    )
+
+
+def _near_one_path(x: np.ndarray) -> np.ndarray:
+    """The window ``[1 - 0x1p-4, 1 + 0x1.09p-4]``, where the table is too coarse.
+
+    A degree-twelve polynomial in ``r = x - 1`` (exact by Sterbenz), with the
+    ``r + B[0] r^2`` head carried in split precision exactly as the C routine
+    writes it. The four multiply-adds the compiler fused in the shipped
+    binary -- the three lowest links of the polynomial's head chain and the
+    join of the polynomial onto the split head -- are emulated exactly; the
+    remaining multiply-adds round the same bits fused or not, established
+    over sixty million draws of the window and every corpus input that lands
+    in it.
+
+    :param x: Doubles inside the near-one window.
+    :type x: np.ndarray
+    :return: Their logarithms, bit for bit the C routine's.
+    :rtype: np.ndarray
+    """
+    r = x - 1.0
+    r2 = r * r
+    r3 = r * r2
+    tail = r * _B[8] + _B[7]
+    tail = r2 * _B[9] + tail
+    tail = r3 * _B[10] + tail
+    mid = r * _B[5] + _B[4]
+    mid = r2 * _B[6] + mid
+    mid = r3 * tail + mid
+    head = _fused_multiply_add(r, np.float64(_B[2]), np.float64(_B[1]))
+    head = _fused_multiply_add(r2, np.float64(_B[3]), head)
+    head = _fused_multiply_add(r3, mid, head)
+    w = r * 134217728.0  # 0x1p27, the split
+    r_hi = r + w - w
+    r_lo = r - r_hi
+    square = r_hi * r_hi
+    hi = r + square * _B[0]
+    lo = r - hi + square * _B[0]
+    lo = (_B[0] * r_lo) * (r_hi + r) + lo
+    y = _fused_multiply_add(r3, head, lo)
+    y = y + hi
+    return np.where(x == 1.0, 0.0, y)
+
+
+def pinned_log(values: np.ndarray) -> np.ndarray:
+    """``log`` elementwise, identical bits everywhere, at numpy speed.
+
+    The drop-in replacement for taking :func:`math.log` one element at a
+    time: same bits on every input the weighting fit produces (and on every
+    positive double thrown at it in validation), two orders of magnitude
+    less interpreter overhead. Domain errors follow :func:`math.log`: any
+    non-positive finite element raises :class:`ValueError`; ``inf`` and
+    ``nan`` propagate.
+
+    :param values: Any real array-like of positive values.
+    :type values: np.ndarray
+    :return: The natural logarithm, elementwise, in the same shape.
+    :rtype: np.ndarray
+    :raises ValueError: If any element is zero or negative.
+    """
+    x = np.asarray(values, dtype=np.float64)
+    flat = np.ascontiguousarray(x).reshape(-1)
+    if not flat.size:
+        return np.empty(np.shape(values), dtype=np.float64)
+    finite = np.isfinite(flat)
+    domain = (flat <= 0.0) & ~np.isnan(flat)
+    if domain.any():
+        message = "math domain error"
+        raise ValueError(message)
+    work = flat
+    bits = work.view(np.uint64)
+    subnormal = bits < _TINY
+    if subnormal.any():
+        work = work.copy()
+        # Normalise exactly as the C routine does: scale by 2**52 and take
+        # the exponent debt off the bit pattern before decomposition.
+        scaled = work[subnormal] * 2.0**52
+        work[subnormal] = (
+            scaled.view(np.uint64) - (np.uint64(52) << np.uint64(52))
+        ).view(np.float64)
+    out = _main_path(work)
+    near = (flat.view(np.uint64) - _NEAR_LOW) < _NEAR_SPAN
+    if near.any():
+        out[near] = _near_one_path(flat[near])
+    if not finite.all():
+        out[~finite] = np.where(np.isnan(flat[~finite]), np.nan, np.inf)
+    return out.reshape(np.shape(values))

--- a/src/phonometry/filters/_weighting_design.py
+++ b/src/phonometry/filters/_weighting_design.py
@@ -155,7 +155,8 @@ _GRID_POINTS = 257
 #: Both are fixed budgets rather than convergence tests, so the routine always
 #: does the same arithmetic, and they are set where the accuracy curve
 #: flattens: measured over this corpus, raising them to 40 by 12 -- 2.4 times
-#: the work, about 480 ms per design instead of 200 -- moves no (curve, rate)
+#: the work, about 480 ms per design against the shipped budget's 200 --
+#: moves no (curve, rate)
 #: fit by more than 0.013 dB (the largest, D at 12 kHz, from 0.020 to 0.008)
 #: and moves the corpus's worst, BS.468-4 at 48 kHz, from 0.062 only to 0.060,
 #: so the extra work buys nothing where the budget actually binds.

--- a/src/phonometry/filters/_weighting_design.py
+++ b/src/phonometry/filters/_weighting_design.py
@@ -128,11 +128,14 @@ result is graded against a tolerance mask rather than integrated.
 
 from __future__ import annotations
 
+import functools
 import math
 from dataclasses import dataclass
 
 import numpy as np
 from scipy import signal
+
+from ._pinned_log import pinned_log
 
 #: Decibels per natural log unit of a squared magnitude: ``10 / ln 10``.
 _DB_PER_LOG = 10.0 / np.log(10.0)
@@ -152,7 +155,7 @@ _GRID_POINTS = 257
 #: Both are fixed budgets rather than convergence tests, so the routine always
 #: does the same arithmetic, and they are set where the accuracy curve
 #: flattens: measured over this corpus, raising them to 40 by 12 -- 2.4 times
-#: the work, about 610 ms per design instead of 260 -- moves no (curve, rate)
+#: the work, about 480 ms per design instead of 200 -- moves no (curve, rate)
 #: fit by more than 0.013 dB (the largest, D at 12 kHz, from 0.020 to 0.008)
 #: and moves the corpus's worst, BS.468-4 at 48 kHz, from 0.062 only to 0.060,
 #: so the extra work buys nothing where the budget actually binds.
@@ -369,36 +372,35 @@ def _anchor_hz(fs: float, band: tuple[float, float], f_ref: float) -> float:
 def _quadratic_group(
     block: np.ndarray, omega: np.ndarray, omega2: np.ndarray, grad: bool
 ) -> tuple[np.ndarray, np.ndarray]:
-    r"""``sum log|s^2 + b1 s + b0|^2`` at ``s = j omega``, and its gradient.
+    r"""``|s^2 + b1 s + b0|^2`` per factor at ``s = j omega``, and the gradient.
 
     With :math:`b_1 = e^{\theta_1}` and :math:`b_0 = e^{\theta_0}` the squared
     magnitude is :math:`(b_0 - \Omega^2)^2 + (b_1 \Omega)^2`, and the
-    derivatives with respect to the *logs* of the coefficients are
-    :math:`2 b_1^2 \Omega^2 / D` and :math:`2 b_0 (b_0 - \Omega^2) / D`.
+    derivatives of its ``log`` with respect to the *logs* of the coefficients
+    are :math:`2 b_1^2 \Omega^2 / D` and :math:`2 b_0 (b_0 - \Omega^2) / D`.
+    The logarithm itself is taken by the caller, batched.
     """
     coefficients = _scalar_exp(block)
     b1 = coefficients[:, 0][None, :]
     b0 = coefficients[:, 1][None, :]
     offset = b0 - omega2[:, None]
     denominator = offset * offset + (b1 * omega[:, None]) ** 2
-    total = _scalar_log(denominator).sum(axis=1)
     if not grad:
-        return total, np.zeros((omega.size, 0))
+        return denominator, np.zeros((omega.size, 0))
     d_b1 = 2.0 * b1 * b1 * omega2[:, None] / denominator
     d_b0 = 2.0 * b0 * offset / denominator
-    return total, np.stack([d_b1, d_b0], axis=2).reshape(omega.size, -1)
+    return denominator, np.stack([d_b1, d_b0], axis=2).reshape(omega.size, -1)
 
 
 def _linear_group(
     block: np.ndarray, omega2: np.ndarray, grad: bool
 ) -> tuple[np.ndarray, np.ndarray]:
-    """``sum log|s + b1|^2`` at ``s = j omega``, and its gradient in ``log b1``."""
+    """``|s + b1|^2`` per factor at ``s = j omega``, and the ``log`` gradient."""
     b1 = _scalar_exp(block)[None, :]
     denominator = omega2[:, None] + b1 * b1
-    total = _scalar_log(denominator).sum(axis=1)
     if not grad:
-        return total, np.zeros((omega2.size, 0))
-    return total, 2.0 * b1 * b1 / denominator
+        return denominator, np.zeros((omega2.size, 0))
+    return denominator, 2.0 * b1 * b1 / denominator
 
 
 def _log_mag2(
@@ -410,10 +412,21 @@ def _log_mag2(
     the standard's reference frequency, so only the shape is fitted and the
     residual at that frequency is identically zero by construction rather than
     by luck.
+
+    Every logarithm of the evaluation is taken in one :func:`_scalar_log`
+    call: the squared magnitude of each factor of each group, and
+    :math:`\Omega^2` for the zeros at the origin, side by side in one matrix.
+    The call used to be per group -- three or four per evaluation, eight
+    hundred a design -- and the fixed cost of entering the pinned ``log``
+    was most of what it spent. Batching moves no bit: the function is
+    elementwise, each group's column span is summed over the same columns in
+    the same order, and the group totals join ``total`` in the order the
+    group tuple fixes.
     """
     omega2 = omega * omega
     num_quad, num_lin, den_quad, den_lin = layout.blocks(theta)
-    total = layout.zeros_at_origin * _scalar_log(omega2)
+    pieces = [omega2[:, None]]
+    spans: list[tuple[int, int, float]] = []
     columns = []
     groups = (
         (num_quad, 1.0, True),
@@ -421,15 +434,22 @@ def _log_mag2(
         (den_quad, -1.0, True),
         (den_lin, -1.0, False),
     )
+    start = 1
     for block, sign, quadratic in groups:
         if block.size == 0:
             continue
         if quadratic:
-            value, jacobian = _quadratic_group(block, omega, omega2, grad)
+            denominator, jacobian = _quadratic_group(block, omega, omega2, grad)
         else:
-            value, jacobian = _linear_group(block, omega2, grad)
-        total = total + sign * value
+            denominator, jacobian = _linear_group(block, omega2, grad)
+        pieces.append(denominator)
+        spans.append((start, start + denominator.shape[1], sign))
+        start += denominator.shape[1]
         columns.append(sign * jacobian)
+    logs = _scalar_log(np.hstack(pieces))
+    total = layout.zeros_at_origin * logs[:, 0]
+    for begin, end, sign in spans:
+        total = total + sign * logs[:, begin:end].sum(axis=1)
     if not grad:
         return total, np.zeros((omega.size, 0))
     return total, np.hstack(columns)
@@ -513,29 +533,35 @@ def _scalar_pow(values: np.ndarray, exponent: float) -> np.ndarray:
 
 
 def _scalar_log(values: np.ndarray) -> np.ndarray:
-    """``log`` applied one element at a time, so a vector unit cannot change it.
+    """``log`` in pinned arithmetic, so a vector unit cannot change it.
 
     numpy's ``log``, ``exp`` and ``tan`` are dispatched on what the CPU offers,
     and their AVX512 kernels do not agree to the last bit with the ones a
     machine without AVX512 runs. Measured under Intel SDE emulating Skylake-X
     against this host: every one of those three returns a different digest over
     4096 samples, while :func:`math.log`, :func:`math.exp` and :func:`math.tan`
-    applied element by element return the same digest on both. So the fit calls
-    those, and the last machine-dependent step on the path is gone.
+    applied element by element return the same digest on both. So the fit
+    first took every one of them from :mod:`math`, one element at a time, and
+    the last machine-dependent step on the path was gone.
 
-    This costs the vectorisation, and it buys the whole point of the module. It
-    changes no value: on a host without AVX512 the loop and the ufunc agree bit
-    for bit, so the shipped coefficients, the figure corpus and the conformance
-    report are untouched by the switch.
+    For ``log`` the loop then went too, because ``log`` is the one
+    transcendental *inside* the iteration -- once per grid point per factor
+    per Levenberg-Marquardt step, three quarters of a million calls per
+    design -- and the interpreter overhead of taking it elementwise had
+    multiplied the cost of a design by about four.
+    :func:`~phonometry.filters._pinned_log.pinned_log` spells the C library's
+    own routine in numpy operations IEEE 754 pins exactly, and returns
+    :func:`math.log`'s own bits on every input the fit produces: verified
+    over the 91 658 333 distinct values the whole corpus evaluates, zero
+    mismatches, so the shipped coefficients, the figure corpus and the
+    conformance report are untouched by the switch. The transcendentals
+    outside the iteration stay on the :mod:`math` loop, where a design pays
+    them once.
 
-    :param values: Any real array.
+    :param values: Any real array of positive values.
     :return: Its natural logarithm, elementwise, in the same shape.
     """
-    flat = np.asarray(values, dtype=np.float64).reshape(-1)
-    out = np.empty(flat.size, dtype=np.float64)
-    for index in range(flat.size):
-        out[index] = math.log(flat[index])
-    return out.reshape(np.shape(values))
+    return pinned_log(values)
 
 
 def _scalar_exp(values: np.ndarray) -> np.ndarray:
@@ -668,6 +694,22 @@ def _solve_dense(matrix: np.ndarray, vector: np.ndarray) -> np.ndarray:
     return solution
 
 
+@functools.lru_cache(maxsize=8)
+def _upper_triangle(order: int) -> tuple[np.ndarray, np.ndarray]:
+    """The upper-triangle index pair of an ``order`` by ``order`` matrix.
+
+    Cached because :func:`_damped_step` asks for the same pattern at every
+    step of a fit; the arrays are frozen so a cached copy cannot be edited.
+
+    :param order: The matrix side.
+    :return: The row and column indices of the upper triangle.
+    """
+    rows, columns = np.triu_indices(order)
+    rows.setflags(write=False)
+    columns.setflags(write=False)
+    return rows, columns
+
+
 def _damped_step(
     jacobian: np.ndarray, residual: np.ndarray, weights: np.ndarray, damping: float
 ) -> np.ndarray:
@@ -682,9 +724,11 @@ def _damped_step(
     reduction handed to a library. Only its upper triangle is formed and the
     lower one is mirrored from it, which halves the work and makes the matrix
     exactly symmetric rather than symmetric to within a rounding; the
-    elimination that follows reads both halves.
+    elimination that follows reads both halves. The triangle's index pattern
+    depends only on the parameter count, so it is built once per size rather
+    than once per step.
     """
-    rows, columns = np.triu_indices(jacobian.shape[1])
+    rows, columns = _upper_triangle(jacobian.shape[1])
     products = jacobian[:, rows] * jacobian[:, columns]
     products *= weights[:, None]
     upper = _ordered_sum(products)

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -79,8 +79,8 @@ each of them used to be a documented limitation of this module:
 * one minute of 44.1 kHz audio costs about 18 ms instead of 377 ms for A and
   775 ms for 468, and holds 21 MB of intermediates instead of 169 MB
   (measured back to back in one process, mean of five runs). The design
-  itself costs about 260 ms and is cached, so even a first call is quicker
-  than the path it replaces: about 280 ms against 377 for A, 285 against
+  itself costs about 200 ms and is cached, so even a first call is quicker
+  than the path it replaces: about 215 ms against 377 for A, 220 against
   775 for 468.
 """
 
@@ -514,10 +514,10 @@ def _weighting_sos(curve: str, fs: int, high_accuracy: bool) -> np.ndarray:
     library never actually applied, and the rates where they win are ones no
     standard in the corpus places a requirement at.
 
-    The fit costs about 260 ms, which is why it is cached: it is paid once per
-    (curve, rate, mode), and it is still a third of the 775 ms the resampled
+    The fit costs about 200 ms, which is why it is cached: it is paid once per
+    (curve, rate, mode), and it is about a quarter of the 775 ms the resampled
     path it replaces spent *filtering* one minute of 468-weighted audio, and
-    about 70 % of the A curve's 377. Where the first start
+    about half of the A curve's 377. Where the first start
     does not land close enough, the routine works through the other starts of
     :func:`~phonometry.filters._weighting_design._spare_placements` and the
     design takes about 3 s instead. That is common below about 2 kHz, and it

--- a/tests/filters/test_pinned_log.py
+++ b/tests/filters/test_pinned_log.py
@@ -1,0 +1,146 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""The pinned logarithm returns :func:`math.log`'s own bits.
+
+``_pinned_log`` exists so the weighting fit can take its logarithms at numpy
+speed without moving a single shipped coefficient, and that claim is only as
+good as the bit-for-bit agreement with the elementwise :func:`math.log` it
+replaced. These tests pin a deterministic slice of the validation that
+established it -- full exponent range, the near-one window and its edges,
+subnormals, the specials -- and, separately, the inputs one actual design
+evaluates, so the agreement is checked on the path that motivates the module
+and not only on synthetic draws.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from phonometry.filters import _weighting_design
+from phonometry.filters._pinned_log import _fused_multiply_add, pinned_log
+from phonometry.filters.weighting import _analog_weighting_zpk, _fit_band
+
+
+def _reference(values: np.ndarray) -> np.ndarray:
+    return np.fromiter(map(math.log, values.tolist()), np.float64, values.size)
+
+
+def _assert_same_bits(values: np.ndarray) -> None:
+    mine = pinned_log(values)
+    reference = _reference(values)
+    mismatched = mine.view(np.uint64) != reference.view(np.uint64)
+    assert not mismatched.any(), values[mismatched][:5]
+
+
+def test_full_range_bits_match() -> None:
+    """Random bit patterns over every finite positive binade."""
+    rng = np.random.default_rng(0)
+    bits = rng.integers(1, 0x7FF0000000000000, size=200_000, dtype=np.uint64)
+    _assert_same_bits(bits.view(np.float64))
+
+
+def test_near_one_window_bits_match() -> None:
+    """The separately-polynomialised window, where the fused sites live."""
+    rng = np.random.default_rng(1)
+    window = 1.0 + rng.uniform(-(2.0**-4), float.fromhex("0x1.09p-4"), 200_000)
+    _assert_same_bits(window)
+
+
+def test_window_edges_and_anchors_match() -> None:
+    """The branch boundaries themselves, one neighbour either side."""
+    low = 1.0 - 2.0**-4
+    high = 1.0 + float.fromhex("0x1.09p-4")
+    eps = np.finfo(np.float64).eps
+    edges = np.array(
+        [
+            low,
+            np.nextafter(low, 0.0),
+            np.nextafter(low, 2.0),
+            high,
+            np.nextafter(high, 0.0),
+            np.nextafter(high, 2.0),
+            1.0 - eps / 2.0,
+            1.0 + eps,
+            0.5,
+            2.0,
+            4.0 / 3.0,
+            np.finfo(np.float64).tiny,
+            np.finfo(np.float64).max,
+        ]
+    )
+    _assert_same_bits(edges)
+
+
+def test_subnormal_bits_match() -> None:
+    """The normalisation branch, which no design input reaches."""
+    rng = np.random.default_rng(2)
+    bits = rng.integers(1, 1 << 52, size=50_000, dtype=np.uint64)
+    _assert_same_bits(bits.view(np.float64))
+
+
+def test_specials_follow_math_log() -> None:
+    """``inf`` and ``nan`` propagate; zero and negatives raise."""
+    assert pinned_log(np.array([np.inf]))[0] == np.inf
+    assert math.isnan(pinned_log(np.array([np.nan]))[0])
+    assert pinned_log(np.array([1.0]))[0] == 0.0
+    for bad in (0.0, -1.0, -np.inf):
+        with pytest.raises(ValueError, match="math domain error"):
+            pinned_log(np.array([1.0, bad]))
+
+
+def test_shape_and_empty_are_preserved() -> None:
+    """The elementwise contract: any shape in, the same shape out."""
+    square = np.array([[1.5, 2.5], [3.5, 4.5]])
+    assert pinned_log(square).shape == (2, 2)
+    assert pinned_log(np.empty(0)).shape == (0,)
+    np.testing.assert_array_equal(
+        pinned_log(square).reshape(-1), pinned_log(square.reshape(-1))
+    )
+
+
+def test_fused_multiply_add_matches_math_fma() -> None:
+    """The emulation behind the near-one window's four fused sites."""
+    rng = np.random.default_rng(3)
+    n = 100_000
+    r = rng.uniform(-(2.0**-4), 2.0**-4, n)
+    cases = (
+        (r, np.full(n, 0.375), np.full(n, -0.5)),
+        (r * r, np.full(n, -0.25), rng.uniform(-0.4, -0.25, n)),
+        (r**3, rng.uniform(-0.4, -0.25, n), rng.uniform(-1e-17, 1e-17, n)),
+        (rng.uniform(-1, 1, n), rng.uniform(-1, 1, n), rng.uniform(-1, 1, n)),
+    )
+    for a, b, c in cases:
+        mine = _fused_multiply_add(a, b, c)
+        reference = np.fromiter(
+            map(math.fma, a.tolist(), b.tolist(), c.tolist()), np.float64, n
+        )
+        np.testing.assert_array_equal(mine.view(np.uint64), reference.view(np.uint64))
+
+
+def test_every_log_input_of_a_real_design_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The agreement holds on the inputs the fit actually produces.
+
+    A spy captures every array the design hands ``_scalar_log`` and the test
+    replays each element through :func:`math.log`. This is the property the
+    module exists for: the fit's own universe of inputs, not a synthetic
+    distribution, returns identical bits, so the design that ships is the
+    design that shipped before the loop was retired.
+    """
+    captured: list[np.ndarray] = []
+    original = _weighting_design._scalar_log
+
+    def spy(values: np.ndarray) -> np.ndarray:
+        captured.append(np.asarray(values, dtype=np.float64).reshape(-1).copy())
+        return original(values)
+
+    monkeypatch.setattr(_weighting_design, "_scalar_log", spy)
+    zeros, poles, _ = _analog_weighting_zpk("A")
+    band = _fit_band("A", 48000)
+    _weighting_design.design_sos(zeros, poles, 48000.0, band, 4, 1000.0)
+    assert captured, "the design evaluated no logarithm"
+    everything = np.unique(np.concatenate(captured))
+    _assert_same_bits(everything)

--- a/tests/filters/test_pinned_log.py
+++ b/tests/filters/test_pinned_log.py
@@ -190,7 +190,17 @@ def test_within_one_ulp_of_the_local_libm_everywhere() -> None:
     every platform, and no platform's ``math.log`` is ever more than one ulp
     away from them.
     """
-    probe = _probe()
+    boundary = np.array(
+        [
+            # Found by adversarial search where |log x| is smallest on the
+            # table path: the true logarithm sits almost exactly between two
+            # doubles and glibc's compiled binary rounds the other way.
+            float.fromhex("0x1.1fa63fbb5acd3p+0"),
+            float.fromhex("0x1.182b33f9e413cp+0"),
+            float.fromhex("0x1.19e84ba4c5ba6p+0"),
+        ]
+    )
+    probe = np.concatenate([_probe(), boundary])
     mine = pinned_log(probe)
     reference = _reference(probe)
     ordered_mine = mine.view(np.int64)

--- a/tests/filters/test_pinned_log.py
+++ b/tests/filters/test_pinned_log.py
@@ -34,6 +34,37 @@ def _assert_same_bits(values: np.ndarray) -> None:
     assert not mismatched.any(), values[mismatched][:5]
 
 
+def _probe() -> np.ndarray:
+    """A deterministic canary spanning both branches and every binade."""
+    rng = np.random.default_rng(12345)
+    bits = rng.integers(1, 0x7FF0000000000000, size=2048, dtype=np.uint64)
+    window = 1.0 + rng.uniform(-(2.0**-4), float.fromhex("0x1.09p-4"), 2048)
+    return np.concatenate([bits.view(np.float64), window])
+
+
+def _libm_is_the_pinned_routine() -> bool:
+    probe = _probe()
+    return bool(
+        (pinned_log(probe).view(np.uint64) == _reference(probe).view(np.uint64)).all()
+    )
+
+
+#: True where the platform's ``math.log`` is the very routine ``pinned_log``
+#: spells -- glibc 2.28 onwards. On other C libraries (Apple's, musl's) the
+#: local ``log`` rounds a handful of inputs to the other neighbour, and the
+#: contract is the pinned routine's bits, not the local library's: the
+#: bit-for-bit tests below document the glibc lineage where it can be
+#: observed, and the one-ulp test holds everywhere.
+_SAME_LIBM = _libm_is_the_pinned_routine()
+
+_same_libm_only = pytest.mark.skipif(
+    not _SAME_LIBM,
+    reason="the platform libm is not the routine pinned_log spells; "
+    "its bits are the contract, the local library's are not",
+)
+
+
+@_same_libm_only
 def test_full_range_bits_match() -> None:
     """Random bit patterns over every finite positive binade."""
     rng = np.random.default_rng(0)
@@ -41,6 +72,7 @@ def test_full_range_bits_match() -> None:
     _assert_same_bits(bits.view(np.float64))
 
 
+@_same_libm_only
 def test_near_one_window_bits_match() -> None:
     """The separately-polynomialised window, where the fused sites live."""
     rng = np.random.default_rng(1)
@@ -48,6 +80,7 @@ def test_near_one_window_bits_match() -> None:
     _assert_same_bits(window)
 
 
+@_same_libm_only
 def test_window_edges_and_anchors_match() -> None:
     """The branch boundaries themselves, one neighbour either side."""
     low = 1.0 - 2.0**-4
@@ -73,6 +106,7 @@ def test_window_edges_and_anchors_match() -> None:
     _assert_same_bits(edges)
 
 
+@_same_libm_only
 def test_subnormal_bits_match() -> None:
     """The normalisation branch, which no design input reaches."""
     rng = np.random.default_rng(2)
@@ -119,6 +153,7 @@ def test_fused_multiply_add_matches_math_fma() -> None:
         np.testing.assert_array_equal(mine.view(np.uint64), reference.view(np.uint64))
 
 
+@_same_libm_only
 def test_every_log_input_of_a_real_design_matches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -144,3 +179,29 @@ def test_every_log_input_of_a_real_design_matches(
     assert captured, "the design evaluated no logarithm"
     everything = np.unique(np.concatenate(captured))
     _assert_same_bits(everything)
+
+
+def test_within_one_ulp_of_the_local_libm_everywhere() -> None:
+    """On any platform, the pinned routine and the local libm stay adjacent.
+
+    Both round the true logarithm to within about half an ulp, so wherever
+    they disagree the two answers are floating-point neighbours. This is the
+    portable half of the contract: the bits are the pinned routine's own on
+    every platform, and no platform's ``math.log`` is ever more than one ulp
+    away from them.
+    """
+    probe = _probe()
+    mine = pinned_log(probe)
+    reference = _reference(probe)
+    ordered_mine = mine.view(np.int64)
+    ordered_reference = reference.view(np.int64)
+    sign_mine = ordered_mine < 0
+    sign_reference = ordered_reference < 0
+    np.testing.assert_array_equal(sign_mine, sign_reference)
+    ordered_mine = np.where(
+        sign_mine, -(ordered_mine & 0x7FFFFFFFFFFFFFFF), ordered_mine
+    )
+    ordered_reference = np.where(
+        sign_reference, -(ordered_reference & 0x7FFFFFFFFFFFFFFF), ordered_reference
+    )
+    assert int(np.abs(ordered_mine - ordered_reference).max()) <= 1


### PR DESCRIPTION
The deterministic weighting design gets most of its speed back without moving a single bit: a cold design now costs about 200 ms where it had come to cost about 260 (and about 340 on this branch's own baseline measurements), and the corpus of designs is byte-identical before and after, verified as one SHA-256 over the coefficient bytes of 133 (curve, rate) pairs.

The cost was the logarithm. Determinism had put every transcendental on the design path onto a `math.*` loop, because numpy's dispatched kernels disagree in the last bit under AVX512, and `log` is the one transcendental inside the Levenberg-Marquardt iteration: once per grid point per factor per step, three quarters of a million calls per design, interpreter overhead on every one.

The new `filters._pinned_log` removes the loop by spelling the C library's own `log` -- the table-driven routine from ARM's optimized-routines that glibc ships as `__ieee754_log` since 2.28 -- in numpy operations IEEE 754 pins exactly: plain add, subtract, multiply, comparisons, integer bit work and table takes. The routine's fused operation `fma(z, invc, -1)` needs no emulation: Dekker's exact product plus Sterbenz's lemma reproduce it in three plain operations. The four multiply-adds the compiler fused in the near-one polynomial are emulated exactly through error-free transformations, themselves verified bit for bit against `math.fma` over eighty million draws. The tables are copied digit for digit from ARM's MIT-licensed `math/log_data.c`, the file glibc carries verbatim; the second table of the C file is not needed, since it exists only for machines without a fast fma.

What the bit claim rests on, measured rather than asserted: every `_scalar_log` input of the whole corpus was captured -- 91 658 333 distinct values across 133 designs -- and the new function returns `math.log`'s own bits on all of them, plus zero mismatches over about a hundred million adversarial draws covering the full exponent range, the near-one window and its edges, and the subnormals. `tests/filters/test_pinned_log.py` pins a deterministic slice of that comparison, including a spy that captures the inputs of a real design and replays each through `math.log`.

Two structural changes carry the rest of the recovery, both order-preserving: each evaluation's logarithms are batched into one call (the function is elementwise, each group's columns are summed over the same elements in the same order, and the group totals join in the order the group tuple fixes), and the normal equations' upper-triangle index pattern is built once per size instead of once per step. The transcendentals outside the iteration stay on the `math` loop, where a design pays them once.

The published figures follow the measurement: about 200 ms per design, about 215 ms against 377 for a first A-weighted minute of 44.1 kHz audio and 220 against 775 for the 468 curve, cached filtering unchanged at about 18 ms, and the 40-by-12 budget comparison remeasured at about 480 ms. Docstrings, both guide twins and the changelog carry the new numbers.

Gates run locally: the full filters suite (745 tests), packaging and architecture tests, ruff over the tree, mypy over src and scripts, and the corpus digest comparison against main.

One consequence surfaced by the macOS jobs, documented in the module and the changelog: `math.log` is whatever `log` the platform's C library ships, and only glibc ships this routine, so the retired elementwise loop was silently returning different designs on macOS than on Linux (Apple's `log` rounds a handful of inputs to the other neighbouring double). The pinned routine returns its own bits everywhere, so the designs are now identical across platforms as well as across CPUs; on a non-glibc platform they moved by that last ulp once, onto the values every other platform already shipped. The bit-for-bit tests against the local `math.log` are gated on a canary that detects the glibc lineage, and a new test holds every platform's libm to within one ulp of the pinned bits.

An adversarial numerical review of the branch then sharpened the claim, and the wording follows it (33f026c88). The corpus statement stands as measured -- every one of the 91 658 333 log inputs of the corpus returns glibc's own bits, and the reviewer independently regenerated 112 designs on both trees to identical hashes -- but beyond the corpus the agreement with glibc is statistical, not structural: the compiled binary carries multiply-adds the compiler fused on its own beyond the source's one explicit fma, and a targeted search of the band just outside the near-one window, where the logarithm is smallest, found about one input in thirty million whose true logarithm falls almost within a half ulp of both neighbours and where the two implementations part by the last bit. The three inputs found are pinned in the one-ulp test; the module, the changelog and this description now bound the claim instead of absolutising it. None of it can reach a design: the pinned routine is the definition on the design path and its own bits are machine-independent. The fma emulation's docstring likewise now says it is exact on its call-site domains rather than correctly rounded in general.

For the record, the corpus digest quoted above is the SHA-256 over `sos.tobytes()` of `_cached_weighting_sos(curve, fs, True)` for the seven curves A, B, C, D, G, AU, 468 at the nineteen rates 100, 125, 200, 250, 400, 500, 903, 1000, 1500, 2000, 8000, 16000, 22050, 32000, 44100, 48000, 88200, 96000 and 192000 Hz, curve fastest, prefixed per pair with `curve@rate:`.

## Summary by Sourcery

Restore weighting-design performance while preserving deterministic coefficients and making results consistent across platforms.

New Features:
- Add a platform-independent pinned logarithm implementation for deterministic weighting design calculations.

Bug Fixes:
- Make weighting designs consistent across operating systems and CPU vectorization paths, while preserving the existing design corpus on glibc platforms.

Enhancements:
- Reduce cold weighting design time from about 260 ms to about 200 ms by vectorizing logarithm evaluation and reusing normal-equation index patterns.
- Batch logarithm calculations during fitting without changing coefficient ordering or numerical results.
- Bound and document the pinned logarithm's agreement with platform libm implementations, including one-ulp portability guarantees.

Documentation:
- Update changelog, weighting documentation, translated guides, and generated reference content with the performance and portability changes.

Tests:
- Add deterministic numerical tests covering pinned logarithm bit patterns, special values, subnormals, fused multiply-add behavior, design-generated inputs, and cross-platform one-ulp agreement.

Chores:
- Include the required licensing notice for the imported logarithm tables and polynomial coefficients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved weighting-filter design and fitting performance.
  * Reduced fitting costs to approximately 200 ms per design.
  * Reduced first-call estimates to approximately 215 ms for A-weighting and 220 ms for the 468 curve.

* **Consistency**
  * Preserved existing design results while providing consistent calculations across platforms.

* **Documentation**
  * Updated performance figures across weighting-filter guides, reference documentation, changelog, and localized content.

* **Tests**
  * Added coverage for logarithm accuracy, edge cases, special values, and real weighting-design inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->