### PR TITLE
Make every page's fences read top to bottom, and keep them that way

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -285,6 +285,30 @@ jobs:
     - name: Check the errata evidence
       run: python scripts/check_errata_evidence.py
 
+  # The Python fences of a page form one sequential example: a later fence may
+  # use names an earlier fence defined, never the reverse. One shipped page
+  # used names its own figure block defined further down, while a same-named
+  # variable from a different room sat in scope, so reading top to bottom gave
+  # numbers that were not the annotated ones. Reader-owned placeholders (the
+  # reader's measurement, never invented by the page) are registered in the
+  # script. See scripts/check_fence_names.py and CONTRIBUTING.md.
+  fence-names:
+    name: Documentation fences read in order
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.13"
+    # Stdlib-only checker: it parses the fences and imports nothing else.
+    - name: Check the fence reading order
+      run: python scripts/check_fence_names.py
+
   # Coverage gate for the curated quick table in docs/reference/api/index.md: every
   # phonometry.__all__ name must have a table row (extra rows such as methods
   # or namespace entries are fine). See scripts/check_api_reference.py.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,6 +382,41 @@ by standard: one plotting module holds the figures of a dozen of them, so the
 file is not the scope in which a letter has one meaning. The guide that embeds
 the figure is, and its snippets are read here.
 
+### 8. Writing the code fences of a documentation page
+
+The Python fences of one page form **one sequential example**: a later fence
+may use names an earlier fence defined, so a page can build a result step by
+step without repeating a prelude in every block. Two rules keep that
+readable, and the first is enforced in CI by
+[`scripts/check_fence_names.py`](scripts/check_fence_names.py)
+(`make fence-names`):
+
+1. **A fence may only use names defined by an earlier fence of the same
+   page** — never a later one, never another page. One shipped page used
+   names its own figure block defined further down, while a same-named
+   variable from a different room sat in scope, so reading the page top to
+   bottom produced numbers that were not the annotated ones, with no visible
+   error. That is the failure mode the gate exists for.
+2. **When a value carries an annotated output** (`# 62.9 dB`), the fence
+   that annotates should define it itself or stand right after the fence
+   that does, not a section away. This one is editorial: no script can tell
+   which values matter.
+
+Names the reader owns — their measurement, their recording, their stream —
+are deliberately never defined by the page, because inventing a value would
+replace the reader's data with the page's. Register each one in the
+`PLACEHOLDERS` table at the top of the script, keyed by the page's route
+with the `es/` prefix stripped, so the Spanish twin is held to the same set;
+the page must introduce the name as the reader's own, in prose or in the
+fence's own marker comment (`# audio_blocks: successive frames of your
+microphone recording`), which travels with the code wherever the fence is
+copied. Binding the name to `...` (Ellipsis) with the same comment is the
+older idiom and also valid: it defines the name, so no registry line is
+needed, at the price of a fence that cannot run. A page's language twins
+(site English, site Spanish, `docs/` mirror) are fixed together, never one
+at a time; the `docs/` mirror is hand-written for GitHub and may carry fewer
+examples, but what it does carry follows the same rules.
+
 ## 🏷️ Naming Conventions
 
 All identifiers follow PEP 8 with the project-specific rules below (validated

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,15 @@ subscripts:
 decimal-comma:
 	$(PYTHON) scripts/check_decimal_comma.py
 
+# The Python fences of a documentation page form one sequential example, and
+# one shipped page used names its own figure block defined further down --
+# while a same-named variable from a different room sat in scope, so reading
+# top to bottom produced numbers that were not the annotated ones. This reads
+# every page's fences in order and fails on a name no earlier fence defined,
+# unless the page registers it as a reader-owned placeholder. Stdlib only.
+fence-names:
+	$(PYTHON) scripts/check_fence_names.py
+
 # The Spanish variant of a figure is the English one with its strings looked
 # up in a table at save time, so a string nobody added to the table ships in
 # English inside `X_es.svg` and every other gate stays green: the page is
@@ -369,4 +378,4 @@ check: lint security test
 	figure-annotations figures reports \
 	animations animation-freshness posters brand lighthouse \
 	llms pypi-readme api-docs site-reports conformance install-hooks test test-perf test-gpu coverage check \
-	snippets snippets-static claims subscripts
+	snippets snippets-static claims subscripts fence-names decimal-comma

--- a/docs/aircraft/aircraft-noise.md
+++ b/docs/aircraft/aircraft-noise.md
@@ -30,7 +30,7 @@ $$
 ```python
 from phonometry import aircraft
 
-noys = aircraft.perceived_noisiness(spl)      # per-band noys (spl = 24 band levels, dB)
+noys = aircraft.perceived_noisiness(spl)      # spl: your measured half-second of unweighted third-octave levels (24 bands, dB)
 pnl = aircraft.perceived_noise_level(spl)      # PNdB
 ```
 
@@ -76,7 +76,15 @@ so $\mathrm{EPNL} = \mathrm{PNLTM} + D$ with the duration correction $D$.
 import numpy as np
 from phonometry import aircraft
 
-# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
+# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s,
+# here the synthetic flyover of the figure above
+k, dt = 41, 0.5
+idx = np.arange(k)
+shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
+gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
+spectra = (55.0 + shape)[None, :] + gain[:, None]
+spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
+
 res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 print(res.epnl, res.pnltm, res.duration_correction, res.band_limits)
 res.plot()   # PNL/PNLT time history (needs matplotlib)
@@ -94,15 +102,6 @@ duration/limit machinery directly from a $\mathrm{PNLT}$ series.
 <summary>Show the code for this figure</summary>
 
 ```python
-import numpy as np
-from phonometry import aircraft
-
-k, dt = 41, 0.5
-idx = np.arange(k)
-shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
-gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
-spectra = (55.0 + shape)[None, :] + gain[:, None]
-spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
 aircraft.effective_perceived_noise_level(spectra, dt).plot()
 ```
 

--- a/docs/aircraft/rotorcraft-noise.md
+++ b/docs/aircraft/rotorcraft-noise.md
@@ -41,8 +41,13 @@ continuous with their measured corners.
 import numpy as np
 from phonometry import aircraft
 
-# A hemisphere: band levels of shape (azimuth, polar, frequency) at 60 m.
-h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta, levels=levels)
+# A hemisphere: band levels of shape (azimuth, polar, frequency) at 60 m. The
+# band centres and the angle grid are the NORAH format's; the (19, 19, 31)
+# block of levels is the campaign's own.
+freqs = 1000.0 * 10.0 ** (np.arange(-20, 11) / 10.0)   # 10 Hz-10 kHz thirds
+phi, theta = np.arange(-90.0, 91.0, 10.0), np.arange(0.0, 181.0, 10.0)
+h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta,
+                                  levels=measured_levels)
 h.plot()                                   # fore-aft directivity (needs matplotlib)
 lv = aircraft.hemisphere_source_level(h, 0.0, 90.0)   # level per band abeam-below
 ```
@@ -79,16 +84,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+f_thirds = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 hs, hr, dp = 150.0, 1.5, 500.0                          # overflight geometry
-grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
-asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+grass = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="G")
 
 fig, ax = plt.subplots()
 ax.axhline(0.0, color="0.5", linewidth=1.0)
-ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+ax.semilogx(f_thirds, asphalt, marker="o", markersize=3,
             label="Hard (asphalt/concrete, class G)")
-ax.semilogx(freqs, grass, marker="s", markersize=3,
+ax.semilogx(f_thirds, grass, marker="s", markersize=3,
             label="Soft (grass/pasture, class D)")
 ax.set(xlabel="One-third-octave-band centre frequency [Hz]",
        ylabel="Ground-effect adjustment ΔLg [dB]",
@@ -101,10 +106,8 @@ plt.show()
 </details>
 
 ```python
-import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 r = 500.0
 received = (lv
             + aircraft.spherical_spreading_adjustment(r)

--- a/docs/buildings/design/detailed-prediction.md
+++ b/docs/buildings/design/detailed-prediction.md
@@ -155,8 +155,37 @@ Assembling the direct path and all twelve flanking paths gives the apparent
 index per band, its energy split and the ISO 717-1 rating in one call:
 
 ```python
-# `paths` holds the twelve flanking paths of the four elements, built the
-# way `d1` was above; the code block under the figure builds all of them.
+# The other three flanking elements, built the way `wall` was above, each with
+# its own area and perimeter sum (Formula C.4); `situ` then holds all five.
+specs = (("ext2", 13.75, 5.0, 2.75, 219.0, 92.6, 0.0125, 2.548, 600.0, 1900.0),
+         ("int1", 11.0, 4.0, 2.75, 360.0, 128.4, 0.01, 1.636, 1800.0, 2500.0),
+         ("int2", 13.75, 5.0, 2.75, 360.0, 128.4, 0.01, 1.839, 1800.0, 2500.0))
+situ = {"floor": el, "ext1": wall}
+for spec in specs:
+    situ[spec[0]] = building.in_situ_element(
+        building.HomogeneousElement(*spec), bands)
+
+# The twelve flanking paths, three per flanking element, each built the way
+# `d1` was above.
+paths = []
+for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
+                       ("3", "int1", 4.0), ("4", "int2", 5.0)):
+    flank = situ[name]
+    cross = k_floor_ext if name.startswith("ext") else k_floor_int
+    through = k_ext_ext if name.startswith("ext") else k_int_int
+    paths += [
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=flank, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=flank,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=flank,
+                                        element_j=flank, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
+    ]
+
 res = building.detailed_airborne_prediction(
     bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
                                                         delta_r_source=delta),
@@ -257,11 +286,13 @@ The impact side of the same building runs on the same `situ` dictionary:
 ```python
 from phonometry import building
 
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
 direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
     building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
                                   vibration_reduction_index=(
-                             k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
+                             k_floor_ext if name.startswith("ext") else k_floor_int),
                                   coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
@@ -299,6 +330,11 @@ flanking impact level $L_\mathrm{n,f}$.
 from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
+r_wall_leaf = ...   # measured R of the inner leaf per band, dB (ISO 10140-2)
+dv_n = ...          # normalized junction velocity level difference, dB (ISO 10848-2)
+dnf_13 = ...        # laboratory normalized flanking level difference Dn,f, dB
+lnf_13 = ...        # laboratory normalized flanking impact level Ln,f, dB
+
 r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
                                                  critical_frequency=2200.0)   # +8 dB below fc
 r_ff = building.flanking_reduction_index_from_normalized_difference(

--- a/docs/buildings/insulation/flanking-lab.md
+++ b/docs/buildings/insulation/flanking-lab.md
@@ -249,8 +249,15 @@ shifted contour at 500 Hz (clause 5.5).
 ```python
 from phonometry import building
 
-# ASTM E1414 normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
-dnc = building.normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
+# Dn,c from the measured pair: source- and receiving-room levels over the
+# common plenum and the receiving room's absorption area, per band. ASTM E1414
+# normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
+l1_c = [80.0] * 16                       # source room, per band
+l2_c = [45.0] * 16                       # receiving room, over the plenum path
+absorption = [12.0] * 16                 # receiving-room A per band (m2)
+astm = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
+iso140_9 = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption)
+print(round(float(astm[0]), 2), round(float(iso140_9[0]), 2))   # 35.0 34.21
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,

--- a/docs/devices/electroacoustics/electroacoustics.md
+++ b/docs/devices/electroacoustics/electroacoustics.md
@@ -73,15 +73,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-n = fs                     # 1 s -> 1 Hz bins; harmonics land on bins
-t = np.arange(n) / fs
+fs_hd = 48000
+n = fs_hd                  # 1 s -> 1 Hz bins; harmonics land on bins
+t = np.arange(n) / fs_hd
 f0 = 1000.0
 amps = {1: 1.0, 2: 0.02, 3: 0.012, 4: 0.006, 5: 0.003}
 sig = sum(a * np.sin(2 * np.pi * k * f0 * t) for k, a in amps.items())
 sig = sig + np.random.default_rng(2026).standard_normal(n) * 1.2e-2
 
-res = electroacoustics.harmonic_analysis(sig, fs, f0, n_harmonics=len(amps))
+res = electroacoustics.harmonic_analysis(sig, fs_hd, f0, n_harmonics=len(amps))
 res.plot()
 plt.show()
 ```
@@ -159,7 +159,7 @@ from phonometry import electroacoustics
 # is digital full scale.
 dr = electroacoustics.dynamic_range(output, fs, 997.0)     # dB CCIR-RMS
 # Idle channel noise: capture the output with a digital-zero input.
-idle = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
+icn = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
 ```
 
 Both reuse the notch and the ITU-R 468 curve of the THD+N chain, and both are
@@ -227,12 +227,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-t = np.arange(fs) / fs                        # 1 s -> tones land on FFT bins
-x = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
-signal = x + 0.04 * x**2 + 0.012 * x**3       # weakly non-linear device output
+fs_md = 48000
+t = np.arange(fs_md) / fs_md                  # 1 s -> tones land on FFT bins
+src = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
+sig = src + 0.04 * src**2 + 0.012 * src**3    # weakly non-linear device output
 
-md = electroacoustics.modulation_distortion(signal, fs, f_low=60.0, f_high=7000.0)
+md = electroacoustics.modulation_distortion(sig, fs_md, f_low=60.0, f_high=7000.0)
 md.plot()
 plt.show()
 ```
@@ -281,15 +281,15 @@ import numpy as np
 from scipy import signal as sp
 from phonometry import electroacoustics
 
-fs = 48000
+fs_fr = 48000
 n = 400000
 rng = np.random.default_rng(7)
-x = rng.standard_normal(n)
-b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs)   # device under test
-y = sp.lfilter(b, a, x)
-y = y + rng.standard_normal(n) * np.sqrt(np.mean(y ** 2)) * 0.05   # output noise
+src = rng.standard_normal(n)
+b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs_fr)   # device under test
+sig = sp.lfilter(b, a, src)
+sig = sig + rng.standard_normal(n) * np.sqrt(np.mean(sig ** 2)) * 0.05  # output noise
 
-res = electroacoustics.transfer_function(x, y, fs, estimator="H1")
+res = electroacoustics.transfer_function(src, sig, fs_fr, estimator="H1")
 res.plot()
 plt.show()
 ```

--- a/docs/devices/electroacoustics/swept-sine-distortion.md
+++ b/docs/devices/electroacoustics/swept-sine-distortion.md
@@ -57,6 +57,7 @@ from phonometry import electroacoustics
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # a memoryless cubic stands in for the recording
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
@@ -162,6 +163,7 @@ filter.
 from phonometry import electroacoustics, room
 
 x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+y = x + 0.12 * x**2 + 0.08 * x**3                   # the same cubic, recorded from the ESS
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
@@ -191,7 +193,17 @@ all-pass parts:
 
 ```python
 import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+gain_a = 10.0 ** (6.0 / 40.0)          # the measured device: a +6 dB peaking EQ
+w0 = 2.0 * np.pi * 1000.0 / fs         # at 1 kHz, Q = 1, through a 2.5 ms latency
+alpha = np.sin(w0) / 2.0
+b = np.array([1 + alpha * gain_a, -2 * np.cos(w0), 1 - alpha * gain_a])
+a = np.array([1 + alpha / gain_a, -2 * np.cos(w0), 1 - alpha / gain_a])
+imp = np.zeros(16384)
+imp[int(0.0025 * fs)] = 1.0
+ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
 h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone

--- a/docs/devices/emission/intensity.md
+++ b/docs/devices/emission/intensity.md
@@ -214,6 +214,19 @@ back **per band**, and the result is plottable in one line, the form in which
 the criteria are actually checked (each band passes or fails on its own):
 
 ```python
+# The scan the figure below is drawn from: ten positions over six octave
+# bands, a nearly uniform surface pressure, and a normal intensity per band
+# that turns the field reactive towards low frequency, with two inward-flowing
+# positions in the 125 Hz band (rescaled so the band mean keeps its target).
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+delta_pi = np.array([10.5, 8.5, 6.0, 4.5, 3.5, 3.0])   # target Lp − L|In|
+rng = np.random.default_rng(9614)
+lp_bands = 78.0 + rng.normal(0.0, 0.4, (10, freqs.size))
+i_mean = 10.0 ** ((78.0 - delta_pi) / 10.0) * 1.0e-12
+in_bands = i_mean[None, :] * (1.0 + rng.normal(0.0, 0.18, (10, freqs.size)))
+in_bands[:2, 0] = -0.35 * i_mean[0]
+in_bands[2:, 0] *= (10.0 * i_mean[0] - in_bands[:2, 0].sum()) / in_bands[2:, 0].sum()
+
 fi = emission.field_indicators(lp_bands, in_bands, freqs)   # (positions, bands)
 fi.plot(dynamic_capability=ld)   # F2/F3 per band vs Ld, F4 on a twin axis (needs matplotlib)
 ```
@@ -327,17 +340,17 @@ masks band by band and returns the class the chain actually meets:
 the loosest class every band clears, or `None` when some band clears neither:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # The band centres Table 2 is defined on, and the measured residual index of
 # the chain: one value per band, taken with the spacer that will be fitted in
 # the field. Replace the placeholder with your own residual-intensity test.
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=0.012)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=0.012)
 measured_delta_pi0 = [11.0, 11.9, 11.2, 10.0, 13.2, 15.9, 17.0, 18.0,
                       19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 24.0, 24.0,
                       24.0, 24.0, 24.0, 24.0, 24.0, 24.0]   # dB, 22 bands
 
-res = metrology.intensity_class_compliance(measured_delta_pi0, freqs,
+res = emission.intensity_class_compliance(measured_delta_pi0, freqs,
                                            device="instrument", spacing=0.012)
 print(res.overall_class)          # 2: one band misses the class 1 minimum
 print(res.binding_margin())       # smallest per-band margin to that class [dB]
@@ -362,7 +375,7 @@ whole chain is graded class 2.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import metrology
+from phonometry import emission
 
 # A complete instrument with the common 12 mm spacer. The measured index is
 # modelled from the physics behind Table 2: a residual phase mismatch φs reads
@@ -370,13 +383,13 @@ from phonometry import metrology
 # climbs 10 dB per decade, and above 1 kHz the mismatch of a real chain grows
 # with frequency, so the index levels off.
 spacing = 0.012
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=spacing)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=spacing)
 phase_mismatch = 0.05 * np.maximum(1.0, freqs / 1000.0)          # degrees
-measured = metrology.residual_index_from_phase_mismatch(phase_mismatch, freqs,
+measured = emission.residual_index_from_phase_mismatch(phase_mismatch, freqs,
                                                         spacing)
 measured = measured - 4.0 * np.exp(-((np.log(freqs / 100.0) / 0.25) ** 2))
 
-res = metrology.intensity_class_compliance(measured, freqs, spacing=spacing)
+res = emission.intensity_class_compliance(measured, freqs, spacing=spacing)
 res.plot()
 plt.show()
 ```
@@ -413,14 +426,14 @@ $$
 and the two conversions run both ways:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # 20 dB of residual index at 1 kHz over a 25 mm spacer:
-phi = metrology.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
+phi = emission.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
 print(round(float(phi), 2))     # 0.26 degrees, a hundredth of kd
 
 # And back, for a chain whose channels are matched to 0.05°:
-print(round(float(metrology.residual_index_from_phase_mismatch(
+print(round(float(emission.residual_index_from_phase_mismatch(
     0.05, 1000.0, 0.012)), 1))  # 24.0 dB
 ```
 

--- a/docs/devices/emission/sound-power.md
+++ b/docs/devices/emission/sound-power.md
@@ -181,11 +181,12 @@ and renders the ISO 4871 fiche through `.report()`. The quickest route is to
 
 ```python
 import numpy as np
-import phonometry as ph
+from phonometry import emission
 from phonometry import ReportMetadata
 
-# ... a measured LWA from ISO 3744 ...
-result = ph.sound_power_pressure(levels, "hemisphere", radius=1.0,
+# ISO 3744: SPL at 10 positions on a hemisphere, r = 1 m (10 lg(S/S0) = 8 dB).
+levels = np.tile(lw_true - 8.0, (10, 1))
+result = emission.sound_power_pressure(levels, "hemisphere", radius=1.0,
                                  frequencies=freqs)
 
 declaration = result.declare(
@@ -206,17 +207,17 @@ Or build the declaration directly, reproducing the ISO 4871 Annex B example
 declared $L_{W\mathrm{Ad}} = 90$ and 97 dB):
 
 ```python
-mode1 = ph.OperatingModeDeclaration(
+mode1 = emission.OperatingModeDeclaration(
     "Operating mode 1", sound_power_level=88.0, sound_power_uncertainty=2.0,
     emission_pressure_level=78.0, emission_pressure_uncertainty=2.0,
     verification_level=89.0,          # passes: 89 <= 90
 )
-mode2 = ph.OperatingModeDeclaration(
+mode2 = emission.OperatingModeDeclaration(
     "Operating mode 2", sound_power_level=95.0, sound_power_uncertainty=2.0,
     emission_pressure_level=86.0, emission_pressure_uncertainty=2.0,
     verification_level=98.0,          # fails: 98 > 97
 )
-ph.NoiseEmissionDeclaration(
+emission.NoiseEmissionDeclaration(
     (mode1, mode2), machine="Type 990, Model 11-TC",
     basic_standards=("ISO 3744", "ISO 11202"), form="dual-number",
 ).report("iso4871.pdf")

--- a/docs/environment/assessment/impulsive-sound.md
+++ b/docs/environment/assessment/impulsive-sound.md
@@ -156,25 +156,11 @@ print(round(onset.prominence, 2))                              # 8.95
 From a calibrated time signal (in pascal) the whole chain runs end to end:
 
 ```python
-result = environment.impulsive_sound_adjustment(signal, fs)
-print(result.category)                  # e.g. 'highly impulsive'
-print(round(result.adjustment, 1))      # KI in dB (0.0 to about 9 dB in typical cases)
-print(round(result.adjusted_laeq, 1))   # LAeq + KI
-
-result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
-```
-
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg" alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.8 dB is annotated, and the title reports a prominence of 11.34 with an adjustment of 11.42 dB, category highly impulsive" width="90%"></picture>
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
 import numpy as np
-import matplotlib.pyplot as plt
 from phonometry import environment
 
-# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz.
+# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz, in place of
+# a calibrated recording.
 fs = 48000
 rng = np.random.default_rng(7)
 t = np.arange(int(6.0 * fs)) / fs
@@ -188,13 +174,29 @@ for onset_time in (1.0, 2.6, 4.2):
     strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
     signal += strike
 
-res = environment.impulsive_sound_adjustment(signal, fs)
-print(res.category, round(res.prominence, 2), round(res.adjustment, 2))
-# highly impulsive 11.34 11.42
+result = environment.impulsive_sound_adjustment(signal, fs)
+print(result.category)                  # 'highly impulsive'
+print(round(result.adjustment, 1))      # 11.4  dB (KI, uncapped; typical cases fall between 0.0 and 9 dB)
+print(round(result.adjusted_laeq, 1))   # 91.1  dB (LAeq + KI)
+
+result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
+```
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg" alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.9 dB is annotated, and the title reports a prominence of 11.31 with an adjustment of 11.36 dB, category highly impulsive" width="90%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+
+# `result` is the three-strike chain of this section.
+print(result.category, round(result.prominence, 2), round(result.adjustment, 2))
+# highly impulsive 11.31 11.36
 
 # One line: the level history with the onsets, the fitted onset lines and
 # the governing level difference.
-res.plot()
+result.plot()
 plt.show()
 ```
 

--- a/docs/materials/absorbers/impedance-tube.md
+++ b/docs/materials/absorbers/impedance-tube.md
@@ -340,19 +340,45 @@ fiche embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 `language="es"` for a Spanish fiche (translated fixed strings and a comma
 decimal separator).
 
+The block below is the specimen of the fiche underneath it: a resistive facing
+of normalised flow resistance $\theta = 1$ over an 86 mm rigidly-backed air
+cavity, whose surface impedance $z = \theta - \mathrm{j}\cot(k_0 L)$ is known
+in closed form, so the printed $\alpha$ can be checked by hand: 1.00 at the
+1 kHz quarter-wave resonance, where the matched screen gives $z = 1$ and
+$r = 0$; 0.80 at 500 Hz, where $k_0 L = \pi/4$ and $z = 1 - \mathrm{j}$.
+
 ```python
+import numpy as np
 from phonometry import materials, ReportMetadata
 
-result = materials.two_microphone_impedance(
-    h12, frequency=freqs, spacing=0.05, x1=0.10,
-    speed_of_sound=c0, characteristic_impedance=rho_c, diameter=0.10,
+# 100 mm tube, s = 50 mm, far microphone at x1 = 100 mm, 20 degC / 101 kPa.
+c0 = float(materials.speed_of_sound_iso(293.15))                    # 343.29 m/s
+rho_c = materials.characteristic_impedance(
+    float(materials.air_density_iso(293.15, 101.0)), c0)            # 405.6 Pa.s/m
+diameter, spacing, x1 = 0.100, 0.050, 0.100
+theta, cavity = 1.0, c0 / (4.0 * 1000.0)          # quarter-wave at 1 kHz: 86 mm
+freqs = np.array([400, 500, 630, 800, 1000, 1250, 1600], dtype=float)
+
+# The transfer function the tube would measure, synthesised from the known r.
+k0 = materials.tube_wavenumber(freqs, c0)
+z = theta - 1j / np.tan(2 * np.pi * freqs / c0 * cavity)
+r_known = (z - 1.0) / (z + 1.0)
+x2 = x1 - spacing
+h12_fiche = (np.exp(1j*k0*x2) + r_known*np.exp(-1j*k0*x2)) / \
+            (np.exp(1j*k0*x1) + r_known*np.exp(-1j*k0*x1))
+
+fiche = materials.two_microphone_impedance(
+    h12_fiche, frequency=freqs, spacing=spacing, x1=x1,
+    speed_of_sound=c0, characteristic_impedance=rho_c, diameter=diameter,
 )
-result.report(
+print(np.round(fiche.absorption, 2))    # [0.68 0.8  0.9  0.97 1.   0.96 0.68]
+
+fiche.report(
     "alpha_fiche.pdf",
     metadata=ReportMetadata(
         specimen="Resistive facing over an 86 mm rigidly-backed air cavity",
-        tube_diameter=0.10,            # m (printed as 100 mm)
-        mic_spacing=0.05,              # m (printed as 50 mm)
+        tube_diameter=diameter,        # m (printed as 100 mm)
+        mic_spacing=spacing,           # m (printed as 50 mm)
         measurement_standard="ISO 10534-2",
         laboratory="Phonometry Reference Laboratory",
     ),

--- a/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
+++ b/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
@@ -80,7 +80,7 @@ returns the annoyance together with the two intermediate weightings:
 from phonometry import psychoacoustics
 
 res = psychoacoustics.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)   # N5, S, F, R
-print(round(res.annoyance, 4))   # 37.0478
+print(round(res.annoyance, 4))   # 37.0477
 print(round(res.w_s, 4), round(res.w_fr, 4))   # 0.1001 0.2125
 
 res.plot()   # PA beside its wS and wFR weightings (needs matplotlib)
@@ -107,10 +107,19 @@ signal
 model.
 
 ```python
+import numpy as np
 from phonometry import psychoacoustics
 
+# A raw recording plus its calibration so the guide runs standalone. There is
+# no calibration_factor argument here, so x must already be in pascals.
+fs = 48000
+t = np.arange(int(5.0 * fs)) / fs
+x = (1.0 + 0.8 * np.sin(2 * np.pi * 4.0 * t)) * np.sin(2 * np.pi * 1000 * t)
+x *= 2e-5 * 10 ** (70 / 20) / np.sqrt(np.mean(x**2))   # calibrated to 70 dB SPL
+
 res = psychoacoustics.psychoacoustic_annoyance_from_signal(x, fs, field="free")
-print(res.annoyance, res.n5, res.sharpness, res.roughness, res.fluctuation_strength)
+print(f"PA = {res.annoyance:.1f}  (N5 = {res.n5:.1f} sone, S = {res.sharpness:.2f} acum,"
+      f" R = {res.roughness:.2f} asper, F = {res.fluctuation_strength:.2f} vacil)")
 
 res.plot()   # the same PA / wS / wFR view, now from the four derived sensations
 ```
@@ -209,7 +218,7 @@ trace.
 from phonometry import psychoacoustics
 
 res = psychoacoustics.fluctuation_strength(x, fs)
-print(res.fluctuation_strength)   # vacil
+print(round(res.fluctuation_strength, 2))   # 0.65 vacil for the signal above
 res.plot()   # specific fluctuation strength F′(z) over the Bark axis (needs matplotlib)
 ```
 

--- a/docs/signals/filters/block-processing.md
+++ b/docs/signals/filters/block-processing.md
@@ -88,10 +88,10 @@ octave_filter = filters.OctaveFilterBank(
 )
 afilter = filters.WeightingFilter(fs, "A", stateful=True)
 
-for block in sf.blocks("measurement.wav", blocksize=256, overlap=0):
+for frame in sf.blocks("measurement.wav", blocksize=256, overlap=0):
 
     # Apply A-filter
-    weighted = afilter.filter(block)
+    weighted = afilter.filter(frame)
 
     # Split into octave bands
     block_spl, _, block_output = octave_filter.filter(weighted, sigbands=True, detrend=False)
@@ -181,7 +181,7 @@ env = filters.TimeWeighting(fs, mode="fast")  # the class is inherently stateful
 for x in audio_stream(block):            # your capture callback
     y = env.process(aw.filter(x))
     spl = 10 * np.log10(y[..., -1] / (2e-5) ** 2)  # instantaneous LAF
-    display(spl)
+    print(spl)  # your display update
 ```
 
 ### Stateful-mode constraints

--- a/docs/signals/levels/time-weighting.md
+++ b/docs/signals/levels/time-weighting.md
@@ -177,18 +177,20 @@ tone = np.sin(2 * np.pi * 4000 * t)
 # Steady-state Fast reference of the continuous tone
 reference = filters.time_weighting(tone, fs, mode='fast')[int(1.5 * fs):].mean()
 
-# 200 ms burst of the same tone (IEC 61672-1 Table 4 target: -1.0 dB)
-burst = np.zeros_like(t)
-burst[int(0.5 * fs):int(0.7 * fs)] = tone[int(0.5 * fs):int(0.7 * fs)]
-envelope = filters.time_weighting(burst, fs, mode='fast')
-env_db = 10 * np.log10(np.maximum(envelope / reference, 1e-6))
-
-plt.figure()
-plt.plot(t, env_db, label='Fast envelope')
-plt.axhline(-1.0, linestyle='--', label='IEC target −1.0 dB')
-plt.xlabel('Time [s]')
-plt.ylabel('Level re steady state [dB]')
-plt.legend()
+# The three Table 4 rows the published figure draws, with their targets
+cases = [(0.200, -1.0), (0.050, -4.8), (0.010, -11.1)]
+fig, axes = plt.subplots(len(cases), 1, sharey=True, figsize=(8, 8))
+for ax, (t_b, target) in zip(axes, cases):
+    burst = np.zeros_like(t)
+    stop = int(0.5 * fs) + int(t_b * fs)
+    burst[int(0.5 * fs):stop] = tone[int(0.5 * fs):stop]
+    envelope = filters.time_weighting(burst, fs, mode='fast')
+    env_db = 10 * np.log10(np.maximum(envelope / reference, 1e-6))
+    ax.plot(t, env_db, label=f'Fast envelope, {t_b * 1e3:.0f} ms burst')
+    ax.axhline(target, linestyle='--', label=f'IEC target {target} dB')
+    ax.set_ylabel('Level re steady state [dB]')
+    ax.legend(loc='upper right')
+axes[-1].set_xlabel('Time [s]')
 plt.show()
 ```
 

--- a/docs/signals/spectra/correlation-delay.md
+++ b/docs/signals/spectra/correlation-delay.md
@@ -34,6 +34,12 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+delay = 102                                  # 12.45 ms
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
+y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
+
 res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
@@ -199,7 +205,16 @@ $$
 $$
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+fs = 8192.0
+delay = 20  # samples
+b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
 res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
                          nperseg=2048, upsample=16, signal_bandwidth=1000.0)
@@ -224,9 +239,17 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
 
-t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+fs = 48000.0
+t = np.arange(int(0.03 * fs)) / fs
+# Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
+ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
+
+t_arrival = signals.impulse_response_delay(ir_b, fs)            # seconds from t = 0
 dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
 res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
@@ -302,7 +325,12 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
+import numpy as np
 from phonometry import signals
+
+fs = 8192.0
+t = np.arange(int(0.4 * fs)) / fs
+x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 
 res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)

--- a/docs/signals/spectra/miso-coherence.md
+++ b/docs/signals/spectra/miso-coherence.md
@@ -162,9 +162,12 @@ The ordinary and multiple coherences do not depend on the conditioning order,
 but the partial coherences and the coherent-output decomposition do: each
 input is conditioned on whatever precedes it. Absent a physical ordering,
 Bendat & Piersol (Section 7.2.4) recommend ordering the inputs by descending
-ordinary coherence with the output. Pass `order` to choose:
+ordinary coherence with the output. Suppose a third, weakly coupled source is
+recorded alongside the two above, coherent with neither. Pass `order` to
+choose:
 
 ```python
+x3 = signals.noise_signal(fs, 32.0, color="white", seed=4)   # the third, weak source
 res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order

--- a/docs/signals/spectra/spectral-analysis.md
+++ b/docs/signals/spectra/spectral-analysis.md
@@ -58,7 +58,11 @@ freedom and a correspondingly wider interval.
 ```python
 from phonometry import signals
 
-res = signals.power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
+# record: one channel of a calibrated capture, in pascals (see the Calibration
+#   guide below); in dBFS work it is the raw [-1, 1] array and the result is
+#   FS^2/Hz.
+fs = 48000.0                                      # its sample rate in Hz
+res = signals.power_spectral_density(record, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -142,8 +146,12 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
+import numpy as np
 from phonometry import signals
 
+delay = int(0.002 * fs)                                     # a 2 ms delay path
+noise = signals.noise_signal(fs, 20.0, rms=0.3, seed=9)     # uncorrelated noise
+y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
@@ -306,12 +314,17 @@ squared first, dB levels converted and back), so band power is conserved
 rather than amplitude, and a flat spectrum passes through exactly unchanged.
 
 ```python
+import numpy as np
 from phonometry import signals
 
-smooth_psd = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
-smooth_mag = signals.fractional_octave_smoothing(freqs, np.abs(response), 6.0,
+res = signals.power_spectral_density(record, fs)   # the section 1 estimate
+freqs = res.frequencies
+smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
+magnitude = np.sqrt(res.psd)               # any linear |H| would do here
+smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,
                                                  domain="amplitude")  # an FRF |H|
-smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
+levels = 10.0 * np.log10(res.psd)          # any dB curve would do here
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -431,7 +444,7 @@ Larger $NW$ admits more tapers (lower variance) at the cost of resolution.
 ```python
 from phonometry import signals
 
-res = signals.multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(record, fs)                 # NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band

--- a/docs/signals/spectra/time-frequency.md
+++ b/docs/signals/spectra/time-frequency.md
@@ -41,7 +41,15 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
+import numpy as np
 from phonometry import signals
+
+# The 70 dB SPL siren of the figure below, in pascals.
+fs = 16000.0
+t = np.arange(int(4.0 * fs)) / fs
+x = 2e-5 * 10.0 ** (70.0 / 20.0) * np.sqrt(2.0) * np.cos(
+    2.0 * np.pi * 900.0 * t - 600.0 * np.cos(np.pi * t)
+)
 
 res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)

--- a/docs/underwater/underwater-acoustics.md
+++ b/docs/underwater/underwater-acoustics.md
@@ -26,7 +26,12 @@ squared pressure over the record (Formulae 3–4); the peak level is the
 zero-to-peak value.
 
 ```python
+import numpy as np
 from phonometry import underwater
+
+# A captured hydrophone record (here a synthetic 250 Hz tone of 1 s).
+fs = 48000
+pressure = 0.5 * np.sin(2 * np.pi * 250.0 * np.arange(fs) / fs)
 
 spl = underwater.sound_pressure_level(pressure)        # dB re 1 µPa
 sel = underwater.sound_exposure_level(pressure, fs)     # dB re 1 µPa²·s
@@ -82,11 +87,21 @@ res.plot()
 </details>
 
 ```python
+import numpy as np
 from phonometry import underwater
 
-lrn = underwater.radiated_noise_level(2e-6, 100.0)   # p_rms = 2 µPa, r = 100 m
-res = underwater.monopole_source_level(lrn, 200.0, draught=6.0)
-print(res.source_level, res.surface_correction, res.source_depth)
+# Band r.m.s. pressures measured at 100 m from a merchant ship, in pascals.
+freqs = np.array([31.5, 63.0, 125.0, 250.0, 500.0, 1000.0])
+p_rms = np.array([4.3, 2.8, 1.9, 1.2, 0.8, 0.54])
+rnl = np.array([underwater.radiated_noise_level(float(x), 100.0) for x in p_rms])
+print(np.round(rnl, 1))   # [172.7 168.9 165.6 161.6 158.1 154.6] dB re 1 uPa.m
+
+# The surface correction is frequency-dependent, so the conversion is normally
+# run on the whole band vector at once.
+res = underwater.monopole_source_level(rnl, freqs, draught=6.0)
+print(np.round(res.source_level, 1))       # [177.8 168.4 161.7 157.8 154.8 151.6]
+print(np.round(res.surface_correction, 2))  # [ 5.15 -0.51 -3.86 -3.78 -3.27 -3.08]
+print(round(res.source_depth, 2))           # 4.2 m = 0.7 x draught
 res.plot()   # RNL, Ls and ΔL vs frequency (needs matplotlib)
 ```
 
@@ -143,8 +158,8 @@ from phonometry import underwater
 fs = 48000
 t = np.arange(int(0.3 * fs)) / fs
 envelope = np.where(t < 0.01, t / 0.01, np.exp(-(t - 0.01) / 0.04))
-pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
-res = underwater.pile_strike_metrics(pressure, fs)
+strike_pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
+res = underwater.pile_strike_metrics(strike_pressure, fs)
 res.plot()
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -583,7 +583,7 @@ $$
 ```python
 from phonometry import aircraft
 
-noys = aircraft.perceived_noisiness(spl)      # per-band noys (spl = 24 band levels, dB)
+noys = aircraft.perceived_noisiness(spl)      # spl: your measured half-second of unweighted third-octave levels (24 bands, dB)
 pnl = aircraft.perceived_noise_level(spl)      # PNdB
 ```
 
@@ -629,7 +629,15 @@ so $\mathrm{EPNL} = \mathrm{PNLTM} + D$ with the duration correction $D$.
 import numpy as np
 from phonometry import aircraft
 
-# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
+# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s,
+# here the synthetic flyover of the figure above
+k, dt = 41, 0.5
+idx = np.arange(k)
+shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
+gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
+spectra = (55.0 + shape)[None, :] + gain[:, None]
+spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
+
 res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 print(res.epnl, res.pnltm, res.duration_correction, res.band_limits)
 res.plot()   # PNL/PNLT time history (needs matplotlib)
@@ -647,15 +655,6 @@ duration/limit machinery directly from a $\mathrm{PNLT}$ series.
 <summary>Show the code for this figure</summary>
 
 ```python
-import numpy as np
-from phonometry import aircraft
-
-k, dt = 41, 0.5
-idx = np.arange(k)
-shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
-gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
-spectra = (55.0 + shape)[None, :] + gain[:, None]
-spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
 aircraft.effective_perceived_noise_level(spectra, dt).plot()
 ```
 
@@ -1646,8 +1645,13 @@ continuous with their measured corners.
 import numpy as np
 from phonometry import aircraft
 
-# A hemisphere: band levels of shape (azimuth, polar, frequency) at 60 m.
-h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta, levels=levels)
+# A hemisphere: band levels of shape (azimuth, polar, frequency) at 60 m. The
+# band centres and the angle grid are the NORAH format's; the (19, 19, 31)
+# block of levels is the campaign's own.
+freqs = 1000.0 * 10.0 ** (np.arange(-20, 11) / 10.0)   # 10 Hz-10 kHz thirds
+phi, theta = np.arange(-90.0, 91.0, 10.0), np.arange(0.0, 181.0, 10.0)
+h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta,
+                                  levels=measured_levels)
 h.plot()                                   # fore-aft directivity (needs matplotlib)
 lv = aircraft.hemisphere_source_level(h, 0.0, 90.0)   # level per band abeam-below
 ```
@@ -1684,16 +1688,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+f_thirds = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 hs, hr, dp = 150.0, 1.5, 500.0                          # overflight geometry
-grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
-asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+grass = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="G")
 
 fig, ax = plt.subplots()
 ax.axhline(0.0, color="0.5", linewidth=1.0)
-ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+ax.semilogx(f_thirds, asphalt, marker="o", markersize=3,
             label="Hard (asphalt/concrete, class G)")
-ax.semilogx(freqs, grass, marker="s", markersize=3,
+ax.semilogx(f_thirds, grass, marker="s", markersize=3,
             label="Soft (grass/pasture, class D)")
 ax.set(xlabel="One-third-octave-band centre frequency [Hz]",
        ylabel="Ground-effect adjustment ΔLg [dB]",
@@ -1706,10 +1710,8 @@ plt.show()
 </details>
 
 ```python
-import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 r = 500.0
 received = (lv
             + aircraft.spherical_spreading_adjustment(r)
@@ -2402,8 +2404,37 @@ Assembling the direct path and all twelve flanking paths gives the apparent
 index per band, its energy split and the ISO 717-1 rating in one call:
 
 ```python
-# `paths` holds the twelve flanking paths of the four elements, built the
-# way `d1` was above; the code block under the figure builds all of them.
+# The other three flanking elements, built the way `wall` was above, each with
+# its own area and perimeter sum (Formula C.4); `situ` then holds all five.
+specs = (("ext2", 13.75, 5.0, 2.75, 219.0, 92.6, 0.0125, 2.548, 600.0, 1900.0),
+         ("int1", 11.0, 4.0, 2.75, 360.0, 128.4, 0.01, 1.636, 1800.0, 2500.0),
+         ("int2", 13.75, 5.0, 2.75, 360.0, 128.4, 0.01, 1.839, 1800.0, 2500.0))
+situ = {"floor": el, "ext1": wall}
+for spec in specs:
+    situ[spec[0]] = building.in_situ_element(
+        building.HomogeneousElement(*spec), bands)
+
+# The twelve flanking paths, three per flanking element, each built the way
+# `d1` was above.
+paths = []
+for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
+                       ("3", "int1", 4.0), ("4", "int2", 5.0)):
+    flank = situ[name]
+    cross = k_floor_ext if name.startswith("ext") else k_floor_int
+    through = k_ext_ext if name.startswith("ext") else k_int_int
+    paths += [
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=flank, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=flank,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=flank,
+                                        element_j=flank, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
+    ]
+
 res = building.detailed_airborne_prediction(
     bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
                                                         delta_r_source=delta),
@@ -2504,11 +2535,13 @@ The impact side of the same building runs on the same `situ` dictionary:
 ```python
 from phonometry import building
 
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
 direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
     building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
                                   vibration_reduction_index=(
-                             k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
+                             k_floor_ext if name.startswith("ext") else k_floor_int),
                                   coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
@@ -2546,6 +2579,11 @@ flanking impact level $L_\mathrm{n,f}$.
 from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
+r_wall_leaf = ...   # measured R of the inner leaf per band, dB (ISO 10140-2)
+dv_n = ...          # normalized junction velocity level difference, dB (ISO 10848-2)
+dnf_13 = ...        # laboratory normalized flanking level difference Dn,f, dB
+lnf_13 = ...        # laboratory normalized flanking impact level Ln,f, dB
+
 r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
                                                  critical_frequency=2200.0)   # +8 dB below fc
 r_ff = building.flanking_reduction_index_from_normalized_difference(
@@ -6381,8 +6419,15 @@ shifted contour at 500 Hz (clause 5.5).
 ```python
 from phonometry import building
 
-# ASTM E1414 normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
-dnc = building.normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
+# Dn,c from the measured pair: source- and receiving-room levels over the
+# common plenum and the receiving room's absorption area, per band. ASTM E1414
+# normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
+l1_c = [80.0] * 16                       # source room, per band
+l2_c = [45.0] * 16                       # receiving room, over the plenum path
+absorption = [12.0] * 16                 # receiving-room A per band (m2)
+astm = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
+iso140_9 = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption)
+print(round(float(astm[0]), 2), round(float(iso140_9[0]), 2))   # 35.0 34.21
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
@@ -13597,15 +13642,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-n = fs                     # 1 s -> 1 Hz bins; harmonics land on bins
-t = np.arange(n) / fs
+fs_hd = 48000
+n = fs_hd                  # 1 s -> 1 Hz bins; harmonics land on bins
+t = np.arange(n) / fs_hd
 f0 = 1000.0
 amps = {1: 1.0, 2: 0.02, 3: 0.012, 4: 0.006, 5: 0.003}
 sig = sum(a * np.sin(2 * np.pi * k * f0 * t) for k, a in amps.items())
 sig = sig + np.random.default_rng(2026).standard_normal(n) * 1.2e-2
 
-res = electroacoustics.harmonic_analysis(sig, fs, f0, n_harmonics=len(amps))
+res = electroacoustics.harmonic_analysis(sig, fs_hd, f0, n_harmonics=len(amps))
 res.plot()
 plt.show()
 ```
@@ -13683,7 +13728,7 @@ from phonometry import electroacoustics
 # is digital full scale.
 dr = electroacoustics.dynamic_range(output, fs, 997.0)     # dB CCIR-RMS
 # Idle channel noise: capture the output with a digital-zero input.
-idle = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
+icn = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
 ```
 
 Both reuse the notch and the ITU-R 468 curve of the THD+N chain, and both are
@@ -13751,12 +13796,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-t = np.arange(fs) / fs                        # 1 s -> tones land on FFT bins
-x = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
-signal = x + 0.04 * x**2 + 0.012 * x**3       # weakly non-linear device output
+fs_md = 48000
+t = np.arange(fs_md) / fs_md                  # 1 s -> tones land on FFT bins
+src = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
+sig = src + 0.04 * src**2 + 0.012 * src**3    # weakly non-linear device output
 
-md = electroacoustics.modulation_distortion(signal, fs, f_low=60.0, f_high=7000.0)
+md = electroacoustics.modulation_distortion(sig, fs_md, f_low=60.0, f_high=7000.0)
 md.plot()
 plt.show()
 ```
@@ -13805,15 +13850,15 @@ import numpy as np
 from scipy import signal as sp
 from phonometry import electroacoustics
 
-fs = 48000
+fs_fr = 48000
 n = 400000
 rng = np.random.default_rng(7)
-x = rng.standard_normal(n)
-b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs)   # device under test
-y = sp.lfilter(b, a, x)
-y = y + rng.standard_normal(n) * np.sqrt(np.mean(y ** 2)) * 0.05   # output noise
+src = rng.standard_normal(n)
+b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs_fr)   # device under test
+sig = sp.lfilter(b, a, src)
+sig = sig + rng.standard_normal(n) * np.sqrt(np.mean(sig ** 2)) * 0.05  # output noise
 
-res = electroacoustics.transfer_function(x, y, fs, estimator="H1")
+res = electroacoustics.transfer_function(src, sig, fs_fr, estimator="H1")
 res.plot()
 plt.show()
 ```
@@ -14904,6 +14949,7 @@ from phonometry import electroacoustics
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # a memoryless cubic stands in for the recording
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
@@ -15009,6 +15055,7 @@ filter.
 from phonometry import electroacoustics, room
 
 x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+y = x + 0.12 * x**2 + 0.08 * x**3                   # the same cubic, recorded from the ESS
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
@@ -15038,7 +15085,17 @@ all-pass parts:
 
 ```python
 import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+gain_a = 10.0 ** (6.0 / 40.0)          # the measured device: a +6 dB peaking EQ
+w0 = 2.0 * np.pi * 1000.0 / fs         # at 1 kHz, Q = 1, through a 2.5 ms latency
+alpha = np.sin(w0) / 2.0
+b = np.array([1 + alpha * gain_a, -2 * np.cos(w0), 1 - alpha * gain_a])
+a = np.array([1 + alpha / gain_a, -2 * np.cos(w0), 1 - alpha / gain_a])
+imp = np.zeros(16384)
+imp[int(0.0025 * fs)] = 1.0
+ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
 h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone
@@ -15497,6 +15554,19 @@ back **per band**, and the result is plottable in one line, the form in which
 the criteria are actually checked (each band passes or fails on its own):
 
 ```python
+# The scan the figure below is drawn from: ten positions over six octave
+# bands, a nearly uniform surface pressure, and a normal intensity per band
+# that turns the field reactive towards low frequency, with two inward-flowing
+# positions in the 125 Hz band (rescaled so the band mean keeps its target).
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+delta_pi = np.array([10.5, 8.5, 6.0, 4.5, 3.5, 3.0])   # target Lp − L|In|
+rng = np.random.default_rng(9614)
+lp_bands = 78.0 + rng.normal(0.0, 0.4, (10, freqs.size))
+i_mean = 10.0 ** ((78.0 - delta_pi) / 10.0) * 1.0e-12
+in_bands = i_mean[None, :] * (1.0 + rng.normal(0.0, 0.18, (10, freqs.size)))
+in_bands[:2, 0] = -0.35 * i_mean[0]
+in_bands[2:, 0] *= (10.0 * i_mean[0] - in_bands[:2, 0].sum()) / in_bands[2:, 0].sum()
+
 fi = emission.field_indicators(lp_bands, in_bands, freqs)   # (positions, bands)
 fi.plot(dynamic_capability=ld)   # F2/F3 per band vs Ld, F4 on a twin axis (needs matplotlib)
 ```
@@ -15610,17 +15680,17 @@ masks band by band and returns the class the chain actually meets:
 the loosest class every band clears, or `None` when some band clears neither:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # The band centres Table 2 is defined on, and the measured residual index of
 # the chain: one value per band, taken with the spacer that will be fitted in
 # the field. Replace the placeholder with your own residual-intensity test.
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=0.012)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=0.012)
 measured_delta_pi0 = [11.0, 11.9, 11.2, 10.0, 13.2, 15.9, 17.0, 18.0,
                       19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 24.0, 24.0,
                       24.0, 24.0, 24.0, 24.0, 24.0, 24.0]   # dB, 22 bands
 
-res = metrology.intensity_class_compliance(measured_delta_pi0, freqs,
+res = emission.intensity_class_compliance(measured_delta_pi0, freqs,
                                            device="instrument", spacing=0.012)
 print(res.overall_class)          # 2: one band misses the class 1 minimum
 print(res.binding_margin())       # smallest per-band margin to that class [dB]
@@ -15645,7 +15715,7 @@ whole chain is graded class 2.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import metrology
+from phonometry import emission
 
 # A complete instrument with the common 12 mm spacer. The measured index is
 # modelled from the physics behind Table 2: a residual phase mismatch φs reads
@@ -15653,13 +15723,13 @@ from phonometry import metrology
 # climbs 10 dB per decade, and above 1 kHz the mismatch of a real chain grows
 # with frequency, so the index levels off.
 spacing = 0.012
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=spacing)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=spacing)
 phase_mismatch = 0.05 * np.maximum(1.0, freqs / 1000.0)          # degrees
-measured = metrology.residual_index_from_phase_mismatch(phase_mismatch, freqs,
+measured = emission.residual_index_from_phase_mismatch(phase_mismatch, freqs,
                                                         spacing)
 measured = measured - 4.0 * np.exp(-((np.log(freqs / 100.0) / 0.25) ** 2))
 
-res = metrology.intensity_class_compliance(measured, freqs, spacing=spacing)
+res = emission.intensity_class_compliance(measured, freqs, spacing=spacing)
 res.plot()
 plt.show()
 ```
@@ -15696,14 +15766,14 @@ $$
 and the two conversions run both ways:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # 20 dB of residual index at 1 kHz over a 25 mm spacer:
-phi = metrology.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
+phi = emission.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
 print(round(float(phi), 2))     # 0.26 degrees, a hundredth of kd
 
 # And back, for a chain whose channels are matched to 0.05°:
-print(round(float(metrology.residual_index_from_phase_mismatch(
+print(round(float(emission.residual_index_from_phase_mismatch(
     0.05, 1000.0, 0.012)), 1))  # 24.0 dB
 ```
 
@@ -17637,11 +17707,12 @@ and renders the ISO 4871 fiche through `.report()`. The quickest route is to
 
 ```python
 import numpy as np
-import phonometry as ph
+from phonometry import emission
 from phonometry import ReportMetadata
 
-# ... a measured LWA from ISO 3744 ...
-result = ph.sound_power_pressure(levels, "hemisphere", radius=1.0,
+# ISO 3744: SPL at 10 positions on a hemisphere, r = 1 m (10 lg(S/S0) = 8 dB).
+levels = np.tile(lw_true - 8.0, (10, 1))
+result = emission.sound_power_pressure(levels, "hemisphere", radius=1.0,
                                  frequencies=freqs)
 
 declaration = result.declare(
@@ -17662,17 +17733,17 @@ Or build the declaration directly, reproducing the ISO 4871 Annex B example
 declared $L_{W\mathrm{Ad}} = 90$ and 97 dB):
 
 ```python
-mode1 = ph.OperatingModeDeclaration(
+mode1 = emission.OperatingModeDeclaration(
     "Operating mode 1", sound_power_level=88.0, sound_power_uncertainty=2.0,
     emission_pressure_level=78.0, emission_pressure_uncertainty=2.0,
     verification_level=89.0,          # passes: 89 <= 90
 )
-mode2 = ph.OperatingModeDeclaration(
+mode2 = emission.OperatingModeDeclaration(
     "Operating mode 2", sound_power_level=95.0, sound_power_uncertainty=2.0,
     emission_pressure_level=86.0, emission_pressure_uncertainty=2.0,
     verification_level=98.0,          # fails: 98 > 97
 )
-ph.NoiseEmissionDeclaration(
+emission.NoiseEmissionDeclaration(
     (mode1, mode2), machine="Type 990, Model 11-TC",
     basic_standards=("ISO 3744", "ISO 11202"), form="dual-number",
 ).report("iso4871.pdf")
@@ -20866,25 +20937,11 @@ print(round(onset.prominence, 2))                              # 8.95
 From a calibrated time signal (in pascal) the whole chain runs end to end:
 
 ```python
-result = environment.impulsive_sound_adjustment(signal, fs)
-print(result.category)                  # e.g. 'highly impulsive'
-print(round(result.adjustment, 1))      # KI in dB (0.0 to about 9 dB in typical cases)
-print(round(result.adjusted_laeq, 1))   # LAeq + KI
-
-result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
-```
-
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg" alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.8 dB is annotated, and the title reports a prominence of 11.34 with an adjustment of 11.42 dB, category highly impulsive" width="90%"></picture>
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
 import numpy as np
-import matplotlib.pyplot as plt
 from phonometry import environment
 
-# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz.
+# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz, in place of
+# a calibrated recording.
 fs = 48000
 rng = np.random.default_rng(7)
 t = np.arange(int(6.0 * fs)) / fs
@@ -20898,13 +20955,29 @@ for onset_time in (1.0, 2.6, 4.2):
     strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
     signal += strike
 
-res = environment.impulsive_sound_adjustment(signal, fs)
-print(res.category, round(res.prominence, 2), round(res.adjustment, 2))
-# highly impulsive 11.34 11.42
+result = environment.impulsive_sound_adjustment(signal, fs)
+print(result.category)                  # 'highly impulsive'
+print(round(result.adjustment, 1))      # 11.4  dB (KI, uncapped; typical cases fall between 0.0 and 9 dB)
+print(round(result.adjusted_laeq, 1))   # 91.1  dB (LAeq + KI)
+
+result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
+```
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg" alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.9 dB is annotated, and the title reports a prominence of 11.31 with an adjustment of 11.36 dB, category highly impulsive" width="90%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+
+# `result` is the three-strike chain of this section.
+print(result.category, round(result.prominence, 2), round(result.adjustment, 2))
+# highly impulsive 11.31 11.36
 
 # One line: the level history with the onsets, the fitted onset lines and
 # the governing level difference.
-res.plot()
+result.plot()
 plt.show()
 ```
 
@@ -26128,19 +26201,45 @@ fiche embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 `language="es"` for a Spanish fiche (translated fixed strings and a comma
 decimal separator).
 
+The block below is the specimen of the fiche underneath it: a resistive facing
+of normalised flow resistance $\theta = 1$ over an 86 mm rigidly-backed air
+cavity, whose surface impedance $z = \theta - \mathrm{j}\cot(k_0 L)$ is known
+in closed form, so the printed $\alpha$ can be checked by hand: 1.00 at the
+1 kHz quarter-wave resonance, where the matched screen gives $z = 1$ and
+$r = 0$; 0.80 at 500 Hz, where $k_0 L = \pi/4$ and $z = 1 - \mathrm{j}$.
+
 ```python
+import numpy as np
 from phonometry import materials, ReportMetadata
 
-result = materials.two_microphone_impedance(
-    h12, frequency=freqs, spacing=0.05, x1=0.10,
-    speed_of_sound=c0, characteristic_impedance=rho_c, diameter=0.10,
+# 100 mm tube, s = 50 mm, far microphone at x1 = 100 mm, 20 degC / 101 kPa.
+c0 = float(materials.speed_of_sound_iso(293.15))                    # 343.29 m/s
+rho_c = materials.characteristic_impedance(
+    float(materials.air_density_iso(293.15, 101.0)), c0)            # 405.6 Pa.s/m
+diameter, spacing, x1 = 0.100, 0.050, 0.100
+theta, cavity = 1.0, c0 / (4.0 * 1000.0)          # quarter-wave at 1 kHz: 86 mm
+freqs = np.array([400, 500, 630, 800, 1000, 1250, 1600], dtype=float)
+
+# The transfer function the tube would measure, synthesised from the known r.
+k0 = materials.tube_wavenumber(freqs, c0)
+z = theta - 1j / np.tan(2 * np.pi * freqs / c0 * cavity)
+r_known = (z - 1.0) / (z + 1.0)
+x2 = x1 - spacing
+h12_fiche = (np.exp(1j*k0*x2) + r_known*np.exp(-1j*k0*x2)) / \
+            (np.exp(1j*k0*x1) + r_known*np.exp(-1j*k0*x1))
+
+fiche = materials.two_microphone_impedance(
+    h12_fiche, frequency=freqs, spacing=spacing, x1=x1,
+    speed_of_sound=c0, characteristic_impedance=rho_c, diameter=diameter,
 )
-result.report(
+print(np.round(fiche.absorption, 2))    # [0.68 0.8  0.9  0.97 1.   0.96 0.68]
+
+fiche.report(
     "alpha_fiche.pdf",
     metadata=ReportMetadata(
         specimen="Resistive facing over an 86 mm rigidly-backed air cavity",
-        tube_diameter=0.10,            # m (printed as 100 mm)
-        mic_spacing=0.05,              # m (printed as 50 mm)
+        tube_diameter=diameter,        # m (printed as 100 mm)
+        mic_spacing=spacing,           # m (printed as 50 mm)
         measurement_standard="ISO 10534-2",
         laboratory="Phonometry Reference Laboratory",
     ),
@@ -31656,7 +31755,7 @@ returns the annoyance together with the two intermediate weightings:
 from phonometry import psychoacoustics
 
 res = psychoacoustics.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)   # N5, S, F, R
-print(round(res.annoyance, 4))   # 37.0478
+print(round(res.annoyance, 4))   # 37.0477
 print(round(res.w_s, 4), round(res.w_fr, 4))   # 0.1001 0.2125
 
 res.plot()   # PA beside its wS and wFR weightings (needs matplotlib)
@@ -31683,10 +31782,19 @@ signal
 model.
 
 ```python
+import numpy as np
 from phonometry import psychoacoustics
 
+# A raw recording plus its calibration so the guide runs standalone. There is
+# no calibration_factor argument here, so x must already be in pascals.
+fs = 48000
+t = np.arange(int(5.0 * fs)) / fs
+x = (1.0 + 0.8 * np.sin(2 * np.pi * 4.0 * t)) * np.sin(2 * np.pi * 1000 * t)
+x *= 2e-5 * 10 ** (70 / 20) / np.sqrt(np.mean(x**2))   # calibrated to 70 dB SPL
+
 res = psychoacoustics.psychoacoustic_annoyance_from_signal(x, fs, field="free")
-print(res.annoyance, res.n5, res.sharpness, res.roughness, res.fluctuation_strength)
+print(f"PA = {res.annoyance:.1f}  (N5 = {res.n5:.1f} sone, S = {res.sharpness:.2f} acum,"
+      f" R = {res.roughness:.2f} asper, F = {res.fluctuation_strength:.2f} vacil)")
 
 res.plot()   # the same PA / wS / wFR view, now from the four derived sensations
 ```
@@ -31785,7 +31893,7 @@ trace.
 from phonometry import psychoacoustics
 
 res = psychoacoustics.fluctuation_strength(x, fs)
-print(res.fluctuation_strength)   # vacil
+print(round(res.fluctuation_strength, 2))   # 0.65 vacil for the signal above
 res.plot()   # specific fluctuation strength F′(z) over the Bark axis (needs matplotlib)
 ```
 
@@ -39891,10 +39999,10 @@ octave_filter = filters.OctaveFilterBank(
 )
 afilter = filters.WeightingFilter(fs, "A", stateful=True)
 
-for block in sf.blocks("measurement.wav", blocksize=256, overlap=0):
+for frame in sf.blocks("measurement.wav", blocksize=256, overlap=0):
 
     # Apply A-filter
-    weighted = afilter.filter(block)
+    weighted = afilter.filter(frame)
 
     # Split into octave bands
     block_spl, _, block_output = octave_filter.filter(weighted, sigbands=True, detrend=False)
@@ -39984,7 +40092,7 @@ env = filters.TimeWeighting(fs, mode="fast")  # the class is inherently stateful
 for x in audio_stream(block):            # your capture callback
     y = env.process(aw.filter(x))
     spl = 10 * np.log10(y[..., -1] / (2e-5) ** 2)  # instantaneous LAF
-    display(spl)
+    print(spl)  # your display update
 ```
 
 ### Stateful-mode constraints
@@ -42850,18 +42958,20 @@ tone = np.sin(2 * np.pi * 4000 * t)
 # Steady-state Fast reference of the continuous tone
 reference = filters.time_weighting(tone, fs, mode='fast')[int(1.5 * fs):].mean()
 
-# 200 ms burst of the same tone (IEC 61672-1 Table 4 target: -1.0 dB)
-burst = np.zeros_like(t)
-burst[int(0.5 * fs):int(0.7 * fs)] = tone[int(0.5 * fs):int(0.7 * fs)]
-envelope = filters.time_weighting(burst, fs, mode='fast')
-env_db = 10 * np.log10(np.maximum(envelope / reference, 1e-6))
-
-plt.figure()
-plt.plot(t, env_db, label='Fast envelope')
-plt.axhline(-1.0, linestyle='--', label='IEC target −1.0 dB')
-plt.xlabel('Time [s]')
-plt.ylabel('Level re steady state [dB]')
-plt.legend()
+# The three Table 4 rows the published figure draws, with their targets
+cases = [(0.200, -1.0), (0.050, -4.8), (0.010, -11.1)]
+fig, axes = plt.subplots(len(cases), 1, sharey=True, figsize=(8, 8))
+for ax, (t_b, target) in zip(axes, cases):
+    burst = np.zeros_like(t)
+    stop = int(0.5 * fs) + int(t_b * fs)
+    burst[int(0.5 * fs):stop] = tone[int(0.5 * fs):stop]
+    envelope = filters.time_weighting(burst, fs, mode='fast')
+    env_db = 10 * np.log10(np.maximum(envelope / reference, 1e-6))
+    ax.plot(t, env_db, label=f'Fast envelope, {t_b * 1e3:.0f} ms burst')
+    ax.axhline(target, linestyle='--', label=f'IEC target {target} dB')
+    ax.set_ylabel('Level re steady state [dB]')
+    ax.legend(loc='upper right')
+axes[-1].set_xlabel('Time [s]')
 plt.show()
 ```
 
@@ -45522,6 +45632,12 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+delay = 102                                  # 12.45 ms
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
+y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
+
 res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
@@ -45687,7 +45803,16 @@ $$
 $$
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+fs = 8192.0
+delay = 20  # samples
+b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
 res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
                          nperseg=2048, upsample=16, signal_bandwidth=1000.0)
@@ -45712,9 +45837,17 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
 
-t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+fs = 48000.0
+t = np.arange(int(0.03 * fs)) / fs
+# Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
+ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
+
+t_arrival = signals.impulse_response_delay(ir_b, fs)            # seconds from t = 0
 dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
 res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
@@ -45790,7 +45923,12 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
+import numpy as np
 from phonometry import signals
+
+fs = 8192.0
+t = np.arange(int(0.4 * fs)) / fs
+x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 
 res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)
@@ -46264,9 +46402,12 @@ The ordinary and multiple coherences do not depend on the conditioning order,
 but the partial coherences and the coherent-output decomposition do: each
 input is conditioned on whatever precedes it. Absent a physical ordering,
 Bendat & Piersol (Section 7.2.4) recommend ordering the inputs by descending
-ordinary coherence with the output. Pass `order` to choose:
+ordinary coherence with the output. Suppose a third, weakly coupled source is
+recorded alongside the two above, coherent with neither. Pass `order` to
+choose:
 
 ```python
+x3 = signals.noise_signal(fs, 32.0, color="white", seed=4)   # the third, weak source
 res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order
@@ -46388,7 +46529,11 @@ freedom and a correspondingly wider interval.
 ```python
 from phonometry import signals
 
-res = signals.power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
+# record: one channel of a calibrated capture, in pascals (see the Calibration
+#   guide below); in dBFS work it is the raw [-1, 1] array and the result is
+#   FS^2/Hz.
+fs = 48000.0                                      # its sample rate in Hz
+res = signals.power_spectral_density(record, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -46472,8 +46617,12 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
+import numpy as np
 from phonometry import signals
 
+delay = int(0.002 * fs)                                     # a 2 ms delay path
+noise = signals.noise_signal(fs, 20.0, rms=0.3, seed=9)     # uncorrelated noise
+y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
@@ -46636,12 +46785,17 @@ squared first, dB levels converted and back), so band power is conserved
 rather than amplitude, and a flat spectrum passes through exactly unchanged.
 
 ```python
+import numpy as np
 from phonometry import signals
 
-smooth_psd = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
-smooth_mag = signals.fractional_octave_smoothing(freqs, np.abs(response), 6.0,
+res = signals.power_spectral_density(record, fs)   # the section 1 estimate
+freqs = res.frequencies
+smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
+magnitude = np.sqrt(res.psd)               # any linear |H| would do here
+smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,
                                                  domain="amplitude")  # an FRF |H|
-smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
+levels = 10.0 * np.log10(res.psd)          # any dB curve would do here
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -46761,7 +46915,7 @@ Larger $NW$ admits more tapers (lower variance) at the cost of resolution.
 ```python
 from phonometry import signals
 
-res = signals.multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(record, fs)                 # NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band
@@ -47969,7 +48123,15 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
+import numpy as np
 from phonometry import signals
+
+# The 70 dB SPL siren of the figure below, in pascals.
+fs = 16000.0
+t = np.arange(int(4.0 * fs)) / fs
+x = 2e-5 * 10.0 ** (70.0 / 20.0) * np.sqrt(2.0) * np.cos(
+    2.0 * np.pi * 900.0 * t - 600.0 * np.cos(np.pi * t)
+)
 
 res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)
@@ -50811,7 +50973,12 @@ squared pressure over the record (Formulae 3–4); the peak level is the
 zero-to-peak value.
 
 ```python
+import numpy as np
 from phonometry import underwater
+
+# A captured hydrophone record (here a synthetic 250 Hz tone of 1 s).
+fs = 48000
+pressure = 0.5 * np.sin(2 * np.pi * 250.0 * np.arange(fs) / fs)
 
 spl = underwater.sound_pressure_level(pressure)        # dB re 1 µPa
 sel = underwater.sound_exposure_level(pressure, fs)     # dB re 1 µPa²·s
@@ -50867,11 +51034,21 @@ res.plot()
 </details>
 
 ```python
+import numpy as np
 from phonometry import underwater
 
-lrn = underwater.radiated_noise_level(2e-6, 100.0)   # p_rms = 2 µPa, r = 100 m
-res = underwater.monopole_source_level(lrn, 200.0, draught=6.0)
-print(res.source_level, res.surface_correction, res.source_depth)
+# Band r.m.s. pressures measured at 100 m from a merchant ship, in pascals.
+freqs = np.array([31.5, 63.0, 125.0, 250.0, 500.0, 1000.0])
+p_rms = np.array([4.3, 2.8, 1.9, 1.2, 0.8, 0.54])
+rnl = np.array([underwater.radiated_noise_level(float(x), 100.0) for x in p_rms])
+print(np.round(rnl, 1))   # [172.7 168.9 165.6 161.6 158.1 154.6] dB re 1 uPa.m
+
+# The surface correction is frequency-dependent, so the conversion is normally
+# run on the whole band vector at once.
+res = underwater.monopole_source_level(rnl, freqs, draught=6.0)
+print(np.round(res.source_level, 1))       # [177.8 168.4 161.7 157.8 154.8 151.6]
+print(np.round(res.surface_correction, 2))  # [ 5.15 -0.51 -3.86 -3.78 -3.27 -3.08]
+print(round(res.source_depth, 2))           # 4.2 m = 0.7 x draught
 res.plot()   # RNL, Ls and ΔL vs frequency (needs matplotlib)
 ```
 
@@ -50928,8 +51105,8 @@ from phonometry import underwater
 fs = 48000
 t = np.arange(int(0.3 * fs)) / fs
 envelope = np.where(t < 0.01, t / 0.01, np.exp(-(t - 0.01) / 0.04))
-pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
-res = underwater.pile_strike_metrics(pressure, fs)
+strike_pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
+res = underwater.pile_strike_metrics(strike_pressure, fs)
 res.plot()
 ```
 

--- a/scripts/check_doc_snippets.py
+++ b/scripts/check_doc_snippets.py
@@ -70,22 +70,16 @@ _SKIP: dict[str, str] = {
     # one an earlier block still relies on. Reading order and running order
     # are not the same thing on these pages, and that is the author's call.
     "aircraft-noise": "excerpt: starts from the spl of the prose",
-    "correlation-delay": "excerpt: starts from the record of the prose",
-    "detailed-prediction": "excerpt: starts from the paths of the prose",
+    "detailed-prediction": "excerpt: starts from the measured spectra of the prose",
     "electroacoustics": "excerpt: starts from the captured signal of the prose",
-    "impulsive-sound": "excerpt: starts from the recording of the prose",
     "intensity": "excerpt: starts from the band levels of the prose",
     "panel-sound-insulation": "excerpt: two scenarios share a variable name",
     "room-to-room": "excerpt: two scenarios share the band vector name",
     "rotorcraft-noise": "excerpt: starts from the measured spectrum",
-    "sound-power": "excerpt: starts from the surface levels of the prose",
     "spectral-analysis": "excerpt: starts from the record of the prose",
-    "swept-sine-distortion": "excerpt: starts from the captured response",
     "synchronous-averaging": "excerpt: a later block shortens the record an "
     "earlier one averages",
-    "time-frequency": "excerpt: starts from the record of the prose",
     "time-weighting": "excerpt: starts from the block stream of the prose",
-    "underwater-acoustics": "excerpt: starts from the hydrophone record",
 }
 
 #: Timeout per page, generous enough for the FDTD and ECMA pages.

--- a/scripts/check_doc_snippets.py
+++ b/scripts/check_doc_snippets.py
@@ -72,7 +72,6 @@ _SKIP: dict[str, str] = {
     "aircraft-noise": "excerpt: starts from the spl of the prose",
     "detailed-prediction": "excerpt: starts from the measured spectra of the prose",
     "electroacoustics": "excerpt: starts from the captured signal of the prose",
-    "intensity": "excerpt: starts from the band levels of the prose",
     "panel-sound-insulation": "excerpt: two scenarios share a variable name",
     "room-to-room": "excerpt: two scenarios share the band vector name",
     "rotorcraft-noise": "excerpt: starts from the measured spectrum",

--- a/scripts/check_fence_names.py
+++ b/scripts/check_fence_names.py
@@ -1,0 +1,296 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""Guard the reading order of every Python fence in the documentation.
+
+The code blocks of a page form one sequential example: a later fence may use
+names an earlier fence defined, and 200-odd pages lean on that to build a
+result step by step without repeating a prelude. What the convention cannot
+survive is the *reverse* reference. One shipped page used ``ir`` and ``fs``
+defined only in the figure block further down -- and an ``ir`` from an
+earlier, different room was in scope, so reading the page top to bottom
+produced numbers that were not the annotated ones, with no visible error.
+The llms.txt shards inherit the fences verbatim, so a machine reader pays for
+the same slip more readily than a human.
+
+Hence the rule this script enforces, over every documentation page that
+carries Python fences: **a fence may only use names defined by an earlier
+fence of the same page** (or by itself, or by Python's builtins). Never a
+later fence, never another page.
+
+Two kinds of name are exempt, both deliberately:
+
+* **Placeholders.** Some pages address the reader's own data -- "your
+  measured ``spl``", "the ``audio_blocks`` of your capture" -- and never
+  define it, because defining it would replace the reader's measurement with
+  an invented one. Those names are declared in :data:`PLACEHOLDERS`, keyed by
+  the page's route with the ``es/`` prefix stripped, so the Spanish twin is
+  held to exactly the same set as the English page. A new placeholder means a
+  new registry line, which is the point: it puts the choice in review instead
+  of letting a missing definition pass as one. The page must introduce the
+  name as the reader's own, in prose or in the fence's own marker comment
+  (``# audio_blocks: successive frames of your microphone recording``); the
+  comment form travels with the code wherever the fence is copied, which is
+  what the llms shards do to it. A page may instead bind the name to
+  ``...`` (Ellipsis) with the same comment, which is the older idiom some
+  pages carry: that defines the name, so no registry line is needed, at the
+  price of a fence that cannot run.
+* **Builtins**, plus ``_`` as the conventional throwaway.
+
+A companion rule is editorial and not enforced here, because it is not
+mechanisable: when a name's *value* carries an annotated output
+(``# 0.60 (D)``), the fence that annotates should define it itself or stand
+immediately after the fence that does, not a section away.
+
+Usage::
+
+    python scripts/check_fence_names.py
+
+Exit status 0 when every fence reads in order, 1 otherwise, with one line per
+offence naming the page, the fence and the names.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import os
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: The documentation trees that carry sequential examples. The generated API
+#: reference is excluded: its fences are signatures rendered from docstrings,
+#: not a narrative.
+CONTENT = ROOT / "site" / "src" / "content" / "docs"
+DOCS = ROOT / "docs"
+
+#: A Python fence, opening attributes tolerated, non-greedy to the closer.
+_FENCE = re.compile(r"^```python[^\n]*\n(.*?)^```", re.DOTALL | re.MULTILINE)
+
+#: Names a fence may always use.
+_BUILTINS = frozenset(dir(builtins)) | {"_"}
+
+#: Reader-owned names, per page route (``es/`` stripped, suffix kept off), so
+#: the English page and its Spanish twin carry the same set. The prose of the
+#: page introduces each one as the reader's own data; defining it in code
+#: would replace the reader's measurement with an invented one.
+PLACEHOLDERS: dict[str, frozenset[str]] = {
+    "aircraft/aircraft-noise": frozenset({"spl"}),
+    "aircraft/rotorcraft-noise": frozenset(
+        {
+            "h_50_level",
+            "h_60_climb",
+            "h_70_level",
+            "hemispheres",
+            "measured_levels",
+            "positions",
+            "times",
+            "tx",
+            "ty",
+            "tz",
+        }
+    ),
+    "devices/electroacoustics/electroacoustics": frozenset(
+        {"fs", "idle", "idle_output", "output", "signal", "x", "y"}
+    ),
+    "docs/aircraft/aircraft-noise": frozenset({"spl"}),
+    "docs/aircraft/rotorcraft-noise": frozenset(
+        {
+            "h_50_level",
+            "h_60_climb",
+            "h_70_level",
+            "hemispheres",
+            "measured_levels",
+            "positions",
+            "times",
+            "tx",
+            "ty",
+            "tz",
+        }
+    ),
+    "docs/devices/electroacoustics/electroacoustics": frozenset(
+        {"fs", "idle_output", "output", "signal", "x", "y"}
+    ),
+    "docs/signals/filters/block-processing": frozenset(
+        {"audio_blocks", "audio_stream"}
+    ),
+    "docs/signals/levels/time-weighting": frozenset({"audio_blocks"}),
+    "docs/signals/spectra/spectral-analysis": frozenset({"record"}),
+    "signals/filters/block-processing": frozenset({"audio_blocks", "audio_stream"}),
+    "signals/levels/time-weighting": frozenset({"audio_blocks"}),
+    "signals/spectra/spectral-analysis": frozenset({"record"}),
+}
+
+
+def _route(path: pathlib.Path) -> str:
+    """The registry key of a page: tree-relative, ``es/`` stripped, no suffix.
+
+    :param path: A documentation page.
+    :type path: pathlib.Path
+    :return: The route both language twins share.
+    :rtype: str
+    """
+    if path.is_relative_to(CONTENT):
+        relative = path.relative_to(CONTENT)
+    elif path.is_relative_to(DOCS):
+        relative = pathlib.Path("docs") / path.relative_to(DOCS)
+    else:
+        # A page outside the tree (the tests build them in a temporary
+        # directory): its own name is its route.
+        relative = pathlib.Path(path.name)
+    parts = relative.parts
+    if parts and parts[0] == "es":
+        parts = parts[1:]
+    return str(pathlib.PurePosixPath(*parts).with_suffix(""))
+
+
+def _defined(tree: ast.AST) -> set[str]:
+    """Every name a fence binds, at any depth.
+
+    Comprehension targets and function arguments are scoped tighter than the
+    module in real Python; counting them as page-wide definitions is
+    deliberately permissive, because this check hunts reading-order breaks,
+    not scope leaks.
+
+    :param tree: A parsed fence.
+    :type tree: ast.AST
+    :return: The bound names.
+    :rtype: set[str]
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for entry in node.names:
+                names.add((entry.asname or entry.name).split(".")[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            names.add(node.id)
+        elif isinstance(node, ast.arg):
+            names.add(node.arg)
+        elif isinstance(node, (ast.ExceptHandler, ast.MatchAs)) and node.name:
+            names.add(node.name)
+    return names
+
+
+def _used(tree: ast.AST) -> set[str]:
+    """Every bare name a fence reads."""
+    return {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+
+
+def _pages() -> list[pathlib.Path]:
+    """Every documentation page the rule applies to, in a fixed order."""
+    found: list[pathlib.Path] = []
+    for path in sorted(CONTENT.rglob("*.md*")):
+        if "reference/api" in path.as_posix():
+            continue
+        found.append(path)
+    for path in sorted(DOCS.rglob("*.md")):
+        if "superpowers" in path.parts or "reference/api" in path.as_posix():
+            continue
+        found.append(path)
+    return found
+
+
+def check_page(path: pathlib.Path) -> list[str]:
+    """The reading-order offences of one page.
+
+    :param path: The page to check.
+    :type path: pathlib.Path
+    :return: One message per offending fence, empty when the page reads in
+        order.
+    :rtype: list[str]
+    """
+    text = path.read_text(encoding="utf8")
+    blocks = _FENCE.findall(text)
+    if not blocks:
+        return []
+    trees: list[ast.AST | None] = []
+    problems: list[str] = []
+    relative = path.relative_to(ROOT) if path.is_relative_to(ROOT) else path
+    for index, block in enumerate(blocks, start=1):
+        try:
+            trees.append(ast.parse(block))
+        except SyntaxError as error:
+            trees.append(None)
+            problems.append(
+                f"{relative}: fence {index} does not parse as Python "
+                f"(line {error.lineno}: {error.msg}). A fragment that cannot "
+                "be read cannot be checked; make it parse or drop the "
+                "``python`` tag."
+            )
+    allowed = PLACEHOLDERS.get(_route(path), frozenset())
+    definitions = [_defined(tree) if tree else set() for tree in trees]
+    seen: set[str] = set()
+    for index, tree in enumerate(trees):
+        if tree is None:
+            seen |= definitions[index]
+            continue
+        seen |= definitions[index]
+        missing = _used(tree) - seen - _BUILTINS - allowed
+        if not missing:
+            continue
+        later: set[str] = set()
+        for later_definitions in definitions[index + 1 :]:
+            later |= later_definitions
+        forward = sorted(missing & later)
+        nowhere = sorted(missing - later)
+        if forward:
+            problems.append(
+                f"{relative}: fence {index + 1} uses "
+                f"{', '.join(forward)} before the page defines "
+                "them. The fences of a page read top to bottom; move the "
+                "definition above this fence or define the name here."
+            )
+        if nowhere:
+            problems.append(
+                f"{relative}: fence {index + 1} uses "
+                f"{', '.join(nowhere)}, which no fence of the page defines. "
+                "Define it in an earlier fence, or declare it a "
+                "reader-owned placeholder in PLACEHOLDERS at the top of "
+                "scripts/check_fence_names.py."
+            )
+    return problems
+
+
+def _stale_placeholder_routes() -> list[str]:
+    """Registry lines whose route no longer has a page, so the line is dead."""
+    routes = {_route(path) for path in _pages()}
+    return sorted(set(PLACEHOLDERS) - routes)
+
+
+def main() -> int:
+    """Check every page and report.
+
+    :return: ``0`` when clean, ``1`` otherwise.
+    :rtype: int
+    """
+    problems: list[str] = []
+    for path in _pages():
+        problems.extend(check_page(path))
+    problems.extend(
+        f"scripts/check_fence_names.py: PLACEHOLDERS entry {route!r} "
+        "matches no page; delete the line."
+        for route in _stale_placeholder_routes()
+    )
+    in_ci = os.environ.get("GITHUB_ACTIONS") == "true"
+    for problem in problems:
+        target, _, message = problem.partition(": ")
+        print(f"::error file={target}::{message}" if in_ci else problem)
+    if not problems:
+        pages = _pages()
+        fences = sum(len(_FENCE.findall(p.read_text(encoding="utf8"))) for p in pages)
+        print(
+            f"{fences} fences on {len(pages)} pages read in order; "
+            f"{len(PLACEHOLDERS)} pages carry declared placeholders."
+        )
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/public/llms/llms-aircraft.txt
+++ b/site/public/llms/llms-aircraft.txt
@@ -165,7 +165,7 @@ $$
 ```python
 from phonometry import aircraft
 
-noys = aircraft.perceived_noisiness(spl)      # per-band noys (spl = 24 band levels, dB)
+noys = aircraft.perceived_noisiness(spl)      # spl: your measured half-second of unweighted third-octave levels (24 bands, dB)
 pnl = aircraft.perceived_noise_level(spl)      # PNdB
 ```
 
@@ -211,7 +211,15 @@ so $\mathrm{EPNL} = \mathrm{PNLTM} + D$ with the duration correction $D$.
 import numpy as np
 from phonometry import aircraft
 
-# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
+# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s,
+# here the synthetic flyover of the figure above
+k, dt = 41, 0.5
+idx = np.arange(k)
+shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
+gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
+spectra = (55.0 + shape)[None, :] + gain[:, None]
+spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
+
 res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 print(res.epnl, res.pnltm, res.duration_correction, res.band_limits)
 res.plot()   # PNL/PNLT time history (needs matplotlib)
@@ -229,15 +237,6 @@ duration/limit machinery directly from a $\mathrm{PNLT}$ series.
 <summary>Show the code for this figure</summary>
 
 ```python
-import numpy as np
-from phonometry import aircraft
-
-k, dt = 41, 0.5
-idx = np.arange(k)
-shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
-gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
-spectra = (55.0 + shape)[None, :] + gain[:, None]
-spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
 aircraft.effective_perceived_noise_level(spectra, dt).plot()
 ```
 
@@ -1100,8 +1099,13 @@ continuous with their measured corners.
 import numpy as np
 from phonometry import aircraft
 
-# A hemisphere: band levels of shape (azimuth, polar, frequency) at 60 m.
-h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta, levels=levels)
+# A hemisphere: band levels of shape (azimuth, polar, frequency) at 60 m. The
+# band centres and the angle grid are the NORAH format's; the (19, 19, 31)
+# block of levels is the campaign's own.
+freqs = 1000.0 * 10.0 ** (np.arange(-20, 11) / 10.0)   # 10 Hz-10 kHz thirds
+phi, theta = np.arange(-90.0, 91.0, 10.0), np.arange(0.0, 181.0, 10.0)
+h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta,
+                                  levels=measured_levels)
 h.plot()                                   # fore-aft directivity (needs matplotlib)
 lv = aircraft.hemisphere_source_level(h, 0.0, 90.0)   # level per band abeam-below
 ```
@@ -1138,16 +1142,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+f_thirds = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 hs, hr, dp = 150.0, 1.5, 500.0                          # overflight geometry
-grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
-asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+grass = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="G")
 
 fig, ax = plt.subplots()
 ax.axhline(0.0, color="0.5", linewidth=1.0)
-ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+ax.semilogx(f_thirds, asphalt, marker="o", markersize=3,
             label="Hard (asphalt/concrete, class G)")
-ax.semilogx(freqs, grass, marker="s", markersize=3,
+ax.semilogx(f_thirds, grass, marker="s", markersize=3,
             label="Soft (grass/pasture, class D)")
 ax.set(xlabel="One-third-octave-band centre frequency [Hz]",
        ylabel="Ground-effect adjustment ΔLg [dB]",
@@ -1160,10 +1164,8 @@ plt.show()
 </details>
 
 ```python
-import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 r = 500.0
 received = (lv
             + aircraft.spherical_spreading_adjustment(r)

--- a/site/public/llms/llms-buildings-design.txt
+++ b/site/public/llms/llms-buildings-design.txt
@@ -728,8 +728,37 @@ Assembling the direct path and all twelve flanking paths gives the apparent
 index per band, its energy split and the ISO 717-1 rating in one call:
 
 ```python
-# `paths` holds the twelve flanking paths of the four elements, built the
-# way `d1` was above; the code block under the figure builds all of them.
+# The other three flanking elements, built the way `wall` was above, each with
+# its own area and perimeter sum (Formula C.4); `situ` then holds all five.
+specs = (("ext2", 13.75, 5.0, 2.75, 219.0, 92.6, 0.0125, 2.548, 600.0, 1900.0),
+         ("int1", 11.0, 4.0, 2.75, 360.0, 128.4, 0.01, 1.636, 1800.0, 2500.0),
+         ("int2", 13.75, 5.0, 2.75, 360.0, 128.4, 0.01, 1.839, 1800.0, 2500.0))
+situ = {"floor": el, "ext1": wall}
+for spec in specs:
+    situ[spec[0]] = building.in_situ_element(
+        building.HomogeneousElement(*spec), bands)
+
+# The twelve flanking paths, three per flanking element, each built the way
+# `d1` was above.
+paths = []
+for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
+                       ("3", "int1", 4.0), ("4", "int2", 5.0)):
+    flank = situ[name]
+    cross = k_floor_ext if name.startswith("ext") else k_floor_int
+    through = k_ext_ext if name.startswith("ext") else k_int_int
+    paths += [
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=flank, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=flank,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=flank,
+                                        element_j=flank, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
+    ]
+
 res = building.detailed_airborne_prediction(
     bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
                                                         delta_r_source=delta),
@@ -830,11 +859,13 @@ The impact side of the same building runs on the same `situ` dictionary:
 ```python
 from phonometry import building
 
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
 direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
     building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
                                   vibration_reduction_index=(
-                             k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
+                             k_floor_ext if name.startswith("ext") else k_floor_int),
                                   coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
@@ -872,6 +903,11 @@ flanking impact level $L_\mathrm{n,f}$.
 from phonometry import building
 
 # ISO 12354-1 L.2.1: a wood frame building, floor 20 m2, junction 4 m.
+r_wall_leaf = ...   # measured R of the inner leaf per band, dB (ISO 10140-2)
+dv_n = ...          # normalized junction velocity level difference, dB (ISO 10848-2)
+dnf_13 = ...        # laboratory normalized flanking level difference Dn,f, dB
+lnf_13 = ...        # laboratory normalized flanking impact level Ln,f, dB
+
 r_star = building.resonant_sound_reduction_index(r_wall_leaf, bands,
                                                  critical_frequency=2200.0)   # +8 dB below fc
 r_ff = building.flanking_reduction_index_from_normalized_difference(

--- a/site/public/llms/llms-buildings-insulation.txt
+++ b/site/public/llms/llms-buildings-insulation.txt
@@ -1055,8 +1055,15 @@ shifted contour at 500 Hz (clause 5.5).
 ```python
 from phonometry import building
 
-# ASTM E1414 normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
-dnc = building.normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
+# Dn,c from the measured pair: source- and receiving-room levels over the
+# common plenum and the receiving room's absorption area, per band. ASTM E1414
+# normalizes to A0 = 12 m2, ISO 140-9 to A0 = 10 m2.
+l1_c = [80.0] * 16                       # source room, per band
+l2_c = [45.0] * 16                       # receiving room, over the plenum path
+absorption = [12.0] * 16                 # receiving-room A per band (m2)
+astm = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption, reference_area=12.0)
+iso140_9 = building.normalized_ceiling_attenuation(l1_c, l2_c, absorption)
+print(round(float(astm[0]), 2), round(float(iso140_9[0]), 2))   # 35.0 34.21
 
 # A 28 mm perforated plaster acoustic tile, measured to ASTM E1414 (CAC 34).
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,

--- a/site/public/llms/llms-devices-electroacoustics.txt
+++ b/site/public/llms/llms-devices-electroacoustics.txt
@@ -184,15 +184,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-n = fs                     # 1 s -> 1 Hz bins; harmonics land on bins
-t = np.arange(n) / fs
+fs_hd = 48000
+n = fs_hd                  # 1 s -> 1 Hz bins; harmonics land on bins
+t = np.arange(n) / fs_hd
 f0 = 1000.0
 amps = {1: 1.0, 2: 0.02, 3: 0.012, 4: 0.006, 5: 0.003}
 sig = sum(a * np.sin(2 * np.pi * k * f0 * t) for k, a in amps.items())
 sig = sig + np.random.default_rng(2026).standard_normal(n) * 1.2e-2
 
-res = electroacoustics.harmonic_analysis(sig, fs, f0, n_harmonics=len(amps))
+res = electroacoustics.harmonic_analysis(sig, fs_hd, f0, n_harmonics=len(amps))
 res.plot()
 plt.show()
 ```
@@ -270,7 +270,7 @@ from phonometry import electroacoustics
 # is digital full scale.
 dr = electroacoustics.dynamic_range(output, fs, 997.0)     # dB CCIR-RMS
 # Idle channel noise: capture the output with a digital-zero input.
-idle = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
+icn = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
 ```
 
 Both reuse the notch and the ITU-R 468 curve of the THD+N chain, and both are
@@ -338,12 +338,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-t = np.arange(fs) / fs                        # 1 s -> tones land on FFT bins
-x = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
-signal = x + 0.04 * x**2 + 0.012 * x**3       # weakly non-linear device output
+fs_md = 48000
+t = np.arange(fs_md) / fs_md                  # 1 s -> tones land on FFT bins
+src = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
+sig = src + 0.04 * src**2 + 0.012 * src**3    # weakly non-linear device output
 
-md = electroacoustics.modulation_distortion(signal, fs, f_low=60.0, f_high=7000.0)
+md = electroacoustics.modulation_distortion(sig, fs_md, f_low=60.0, f_high=7000.0)
 md.plot()
 plt.show()
 ```
@@ -392,15 +392,15 @@ import numpy as np
 from scipy import signal as sp
 from phonometry import electroacoustics
 
-fs = 48000
+fs_fr = 48000
 n = 400000
 rng = np.random.default_rng(7)
-x = rng.standard_normal(n)
-b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs)   # device under test
-y = sp.lfilter(b, a, x)
-y = y + rng.standard_normal(n) * np.sqrt(np.mean(y ** 2)) * 0.05   # output noise
+src = rng.standard_normal(n)
+b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs_fr)   # device under test
+sig = sp.lfilter(b, a, src)
+sig = sig + rng.standard_normal(n) * np.sqrt(np.mean(sig ** 2)) * 0.05  # output noise
 
-res = electroacoustics.transfer_function(x, y, fs, estimator="H1")
+res = electroacoustics.transfer_function(src, sig, fs_fr, estimator="H1")
 res.plot()
 plt.show()
 ```
@@ -1387,6 +1387,7 @@ from phonometry import electroacoustics
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # a memoryless cubic stands in for the recording
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
@@ -1492,6 +1493,7 @@ filter.
 from phonometry import electroacoustics, room
 
 x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+y = x + 0.12 * x**2 + 0.08 * x**3                   # the same cubic, recorded from the ESS
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
@@ -1521,7 +1523,17 @@ all-pass parts:
 
 ```python
 import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+gain_a = 10.0 ** (6.0 / 40.0)          # the measured device: a +6 dB peaking EQ
+w0 = 2.0 * np.pi * 1000.0 / fs         # at 1 kHz, Q = 1, through a 2.5 ms latency
+alpha = np.sin(w0) / 2.0
+b = np.array([1 + alpha * gain_a, -2 * np.cos(w0), 1 - alpha * gain_a])
+a = np.array([1 + alpha / gain_a, -2 * np.cos(w0), 1 - alpha / gain_a])
+imp = np.zeros(16384)
+imp[int(0.0025 * fs)] = 1.0
+ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
 h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone

--- a/site/public/llms/llms-devices-emission.txt
+++ b/site/public/llms/llms-devices-emission.txt
@@ -285,11 +285,12 @@ and renders the ISO 4871 fiche through `.report()`. The quickest route is to
 
 ```python
 import numpy as np
-import phonometry as ph
+from phonometry import emission
 from phonometry import ReportMetadata
 
-# ... a measured LWA from ISO 3744 ...
-result = ph.sound_power_pressure(levels, "hemisphere", radius=1.0,
+# ISO 3744: SPL at 10 positions on a hemisphere, r = 1 m (10 lg(S/S0) = 8 dB).
+levels = np.tile(lw_true - 8.0, (10, 1))
+result = emission.sound_power_pressure(levels, "hemisphere", radius=1.0,
                                  frequencies=freqs)
 
 declaration = result.declare(
@@ -310,17 +311,17 @@ Or build the declaration directly, reproducing the ISO 4871 Annex B example
 declared $L_{W\mathrm{Ad}} = 90$ and 97 dB):
 
 ```python
-mode1 = ph.OperatingModeDeclaration(
+mode1 = emission.OperatingModeDeclaration(
     "Operating mode 1", sound_power_level=88.0, sound_power_uncertainty=2.0,
     emission_pressure_level=78.0, emission_pressure_uncertainty=2.0,
     verification_level=89.0,          # passes: 89 <= 90
 )
-mode2 = ph.OperatingModeDeclaration(
+mode2 = emission.OperatingModeDeclaration(
     "Operating mode 2", sound_power_level=95.0, sound_power_uncertainty=2.0,
     emission_pressure_level=86.0, emission_pressure_uncertainty=2.0,
     verification_level=98.0,          # fails: 98 > 97
 )
-ph.NoiseEmissionDeclaration(
+emission.NoiseEmissionDeclaration(
     (mode1, mode2), machine="Type 990, Model 11-TC",
     basic_standards=("ISO 3744", "ISO 11202"), form="dual-number",
 ).report("iso4871.pdf")
@@ -1961,6 +1962,19 @@ back **per band**, and the result is plottable in one line, the form in which
 the criteria are actually checked (each band passes or fails on its own):
 
 ```python
+# The scan the figure below is drawn from: ten positions over six octave
+# bands, a nearly uniform surface pressure, and a normal intensity per band
+# that turns the field reactive towards low frequency, with two inward-flowing
+# positions in the 125 Hz band (rescaled so the band mean keeps its target).
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+delta_pi = np.array([10.5, 8.5, 6.0, 4.5, 3.5, 3.0])   # target Lp − L|In|
+rng = np.random.default_rng(9614)
+lp_bands = 78.0 + rng.normal(0.0, 0.4, (10, freqs.size))
+i_mean = 10.0 ** ((78.0 - delta_pi) / 10.0) * 1.0e-12
+in_bands = i_mean[None, :] * (1.0 + rng.normal(0.0, 0.18, (10, freqs.size)))
+in_bands[:2, 0] = -0.35 * i_mean[0]
+in_bands[2:, 0] *= (10.0 * i_mean[0] - in_bands[:2, 0].sum()) / in_bands[2:, 0].sum()
+
 fi = emission.field_indicators(lp_bands, in_bands, freqs)   # (positions, bands)
 fi.plot(dynamic_capability=ld)   # F2/F3 per band vs Ld, F4 on a twin axis (needs matplotlib)
 ```
@@ -2074,17 +2088,17 @@ masks band by band and returns the class the chain actually meets:
 the loosest class every band clears, or `None` when some band clears neither:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # The band centres Table 2 is defined on, and the measured residual index of
 # the chain: one value per band, taken with the spacer that will be fitted in
 # the field. Replace the placeholder with your own residual-intensity test.
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=0.012)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=0.012)
 measured_delta_pi0 = [11.0, 11.9, 11.2, 10.0, 13.2, 15.9, 17.0, 18.0,
                       19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 24.0, 24.0,
                       24.0, 24.0, 24.0, 24.0, 24.0, 24.0]   # dB, 22 bands
 
-res = metrology.intensity_class_compliance(measured_delta_pi0, freqs,
+res = emission.intensity_class_compliance(measured_delta_pi0, freqs,
                                            device="instrument", spacing=0.012)
 print(res.overall_class)          # 2: one band misses the class 1 minimum
 print(res.binding_margin())       # smallest per-band margin to that class [dB]
@@ -2109,7 +2123,7 @@ whole chain is graded class 2.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import metrology
+from phonometry import emission
 
 # A complete instrument with the common 12 mm spacer. The measured index is
 # modelled from the physics behind Table 2: a residual phase mismatch φs reads
@@ -2117,13 +2131,13 @@ from phonometry import metrology
 # climbs 10 dB per decade, and above 1 kHz the mismatch of a real chain grows
 # with frequency, so the index levels off.
 spacing = 0.012
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=spacing)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=spacing)
 phase_mismatch = 0.05 * np.maximum(1.0, freqs / 1000.0)          # degrees
-measured = metrology.residual_index_from_phase_mismatch(phase_mismatch, freqs,
+measured = emission.residual_index_from_phase_mismatch(phase_mismatch, freqs,
                                                         spacing)
 measured = measured - 4.0 * np.exp(-((np.log(freqs / 100.0) / 0.25) ** 2))
 
-res = metrology.intensity_class_compliance(measured, freqs, spacing=spacing)
+res = emission.intensity_class_compliance(measured, freqs, spacing=spacing)
 res.plot()
 plt.show()
 ```
@@ -2160,14 +2174,14 @@ $$
 and the two conversions run both ways:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # 20 dB of residual index at 1 kHz over a 25 mm spacer:
-phi = metrology.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
+phi = emission.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
 print(round(float(phi), 2))     # 0.26 degrees, a hundredth of kd
 
 # And back, for a chain whose channels are matched to 0.05°:
-print(round(float(metrology.residual_index_from_phase_mismatch(
+print(round(float(emission.residual_index_from_phase_mismatch(
     0.05, 1000.0, 0.012)), 1))  # 24.0 dB
 ```
 

--- a/site/public/llms/llms-environment-assessment.txt
+++ b/site/public/llms/llms-environment-assessment.txt
@@ -488,25 +488,11 @@ print(round(onset.prominence, 2))                              # 8.95
 From a calibrated time signal (in pascal) the whole chain runs end to end:
 
 ```python
-result = environment.impulsive_sound_adjustment(signal, fs)
-print(result.category)                  # e.g. 'highly impulsive'
-print(round(result.adjustment, 1))      # KI in dB (0.0 to about 9 dB in typical cases)
-print(round(result.adjusted_laeq, 1))   # LAeq + KI
-
-result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
-```
-
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg" alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.8 dB is annotated, and the title reports a prominence of 11.34 with an adjustment of 11.42 dB, category highly impulsive" width="90%"></picture>
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
 import numpy as np
-import matplotlib.pyplot as plt
 from phonometry import environment
 
-# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz.
+# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz, in place of
+# a calibrated recording.
 fs = 48000
 rng = np.random.default_rng(7)
 t = np.arange(int(6.0 * fs)) / fs
@@ -520,13 +506,29 @@ for onset_time in (1.0, 2.6, 4.2):
     strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
     signal += strike
 
-res = environment.impulsive_sound_adjustment(signal, fs)
-print(res.category, round(res.prominence, 2), round(res.adjustment, 2))
-# highly impulsive 11.34 11.42
+result = environment.impulsive_sound_adjustment(signal, fs)
+print(result.category)                  # 'highly impulsive'
+print(round(result.adjustment, 1))      # 11.4  dB (KI, uncapped; typical cases fall between 0.0 and 9 dB)
+print(round(result.adjusted_laeq, 1))   # 91.1  dB (LAeq + KI)
+
+result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
+```
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg" alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.9 dB is annotated, and the title reports a prominence of 11.31 with an adjustment of 11.36 dB, category highly impulsive" width="90%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+
+# `result` is the three-strike chain of this section.
+print(result.category, round(result.prominence, 2), round(result.adjustment, 2))
+# highly impulsive 11.31 11.36
 
 # One line: the level history with the onsets, the fitted onset lines and
 # the governing level difference.
-res.plot()
+result.plot()
 plt.show()
 ```
 

--- a/site/public/llms/llms-materials-absorbers.txt
+++ b/site/public/llms/llms-materials-absorbers.txt
@@ -1293,19 +1293,45 @@ fiche embeds, matplotlib (`pip install "phonometry[report,plot]"`); only
 `language="es"` for a Spanish fiche (translated fixed strings and a comma
 decimal separator).
 
+The block below is the specimen of the fiche underneath it: a resistive facing
+of normalised flow resistance $\theta = 1$ over an 86 mm rigidly-backed air
+cavity, whose surface impedance $z = \theta - \mathrm{j}\cot(k_0 L)$ is known
+in closed form, so the printed $\alpha$ can be checked by hand: 1.00 at the
+1 kHz quarter-wave resonance, where the matched screen gives $z = 1$ and
+$r = 0$; 0.80 at 500 Hz, where $k_0 L = \pi/4$ and $z = 1 - \mathrm{j}$.
+
 ```python
+import numpy as np
 from phonometry import materials, ReportMetadata
 
-result = materials.two_microphone_impedance(
-    h12, frequency=freqs, spacing=0.05, x1=0.10,
-    speed_of_sound=c0, characteristic_impedance=rho_c, diameter=0.10,
+# 100 mm tube, s = 50 mm, far microphone at x1 = 100 mm, 20 degC / 101 kPa.
+c0 = float(materials.speed_of_sound_iso(293.15))                    # 343.29 m/s
+rho_c = materials.characteristic_impedance(
+    float(materials.air_density_iso(293.15, 101.0)), c0)            # 405.6 Pa.s/m
+diameter, spacing, x1 = 0.100, 0.050, 0.100
+theta, cavity = 1.0, c0 / (4.0 * 1000.0)          # quarter-wave at 1 kHz: 86 mm
+freqs = np.array([400, 500, 630, 800, 1000, 1250, 1600], dtype=float)
+
+# The transfer function the tube would measure, synthesised from the known r.
+k0 = materials.tube_wavenumber(freqs, c0)
+z = theta - 1j / np.tan(2 * np.pi * freqs / c0 * cavity)
+r_known = (z - 1.0) / (z + 1.0)
+x2 = x1 - spacing
+h12_fiche = (np.exp(1j*k0*x2) + r_known*np.exp(-1j*k0*x2)) / \
+            (np.exp(1j*k0*x1) + r_known*np.exp(-1j*k0*x1))
+
+fiche = materials.two_microphone_impedance(
+    h12_fiche, frequency=freqs, spacing=spacing, x1=x1,
+    speed_of_sound=c0, characteristic_impedance=rho_c, diameter=diameter,
 )
-result.report(
+print(np.round(fiche.absorption, 2))    # [0.68 0.8  0.9  0.97 1.   0.96 0.68]
+
+fiche.report(
     "alpha_fiche.pdf",
     metadata=ReportMetadata(
         specimen="Resistive facing over an 86 mm rigidly-backed air cavity",
-        tube_diameter=0.10,            # m (printed as 100 mm)
-        mic_spacing=0.05,              # m (printed as 50 mm)
+        tube_diameter=diameter,        # m (printed as 100 mm)
+        mic_spacing=spacing,           # m (printed as 50 mm)
         measurement_standard="ISO 10534-2",
         laboratory="Phonometry Reference Laboratory",
     ),

--- a/site/public/llms/llms-perception-psychoacoustics.txt
+++ b/site/public/llms/llms-perception-psychoacoustics.txt
@@ -1945,7 +1945,7 @@ returns the annoyance together with the two intermediate weightings:
 from phonometry import psychoacoustics
 
 res = psychoacoustics.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)   # N5, S, F, R
-print(round(res.annoyance, 4))   # 37.0478
+print(round(res.annoyance, 4))   # 37.0477
 print(round(res.w_s, 4), round(res.w_fr, 4))   # 0.1001 0.2125
 
 res.plot()   # PA beside its wS and wFR weightings (needs matplotlib)
@@ -1972,10 +1972,19 @@ signal
 model.
 
 ```python
+import numpy as np
 from phonometry import psychoacoustics
 
+# A raw recording plus its calibration so the guide runs standalone. There is
+# no calibration_factor argument here, so x must already be in pascals.
+fs = 48000
+t = np.arange(int(5.0 * fs)) / fs
+x = (1.0 + 0.8 * np.sin(2 * np.pi * 4.0 * t)) * np.sin(2 * np.pi * 1000 * t)
+x *= 2e-5 * 10 ** (70 / 20) / np.sqrt(np.mean(x**2))   # calibrated to 70 dB SPL
+
 res = psychoacoustics.psychoacoustic_annoyance_from_signal(x, fs, field="free")
-print(res.annoyance, res.n5, res.sharpness, res.roughness, res.fluctuation_strength)
+print(f"PA = {res.annoyance:.1f}  (N5 = {res.n5:.1f} sone, S = {res.sharpness:.2f} acum,"
+      f" R = {res.roughness:.2f} asper, F = {res.fluctuation_strength:.2f} vacil)")
 
 res.plot()   # the same PA / wS / wFR view, now from the four derived sensations
 ```
@@ -2074,7 +2083,7 @@ trace.
 from phonometry import psychoacoustics
 
 res = psychoacoustics.fluctuation_strength(x, fs)
-print(res.fluctuation_strength)   # vacil
+print(round(res.fluctuation_strength, 2))   # 0.65 vacil for the signal above
 res.plot()   # specific fluctuation strength F′(z) over the Bark axis (needs matplotlib)
 ```
 

--- a/site/public/llms/llms-signals-filters.txt
+++ b/site/public/llms/llms-signals-filters.txt
@@ -1407,10 +1407,10 @@ octave_filter = filters.OctaveFilterBank(
 )
 afilter = filters.WeightingFilter(fs, "A", stateful=True)
 
-for block in sf.blocks("measurement.wav", blocksize=256, overlap=0):
+for frame in sf.blocks("measurement.wav", blocksize=256, overlap=0):
 
     # Apply A-filter
-    weighted = afilter.filter(block)
+    weighted = afilter.filter(frame)
 
     # Split into octave bands
     block_spl, _, block_output = octave_filter.filter(weighted, sigbands=True, detrend=False)
@@ -1500,7 +1500,7 @@ env = filters.TimeWeighting(fs, mode="fast")  # the class is inherently stateful
 for x in audio_stream(block):            # your capture callback
     y = env.process(aw.filter(x))
     spl = 10 * np.log10(y[..., -1] / (2e-5) ** 2)  # instantaneous LAF
-    display(spl)
+    print(spl)  # your display update
 ```
 
 ### Stateful-mode constraints

--- a/site/public/llms/llms-signals-levels.txt
+++ b/site/public/llms/llms-signals-levels.txt
@@ -1035,18 +1035,20 @@ tone = np.sin(2 * np.pi * 4000 * t)
 # Steady-state Fast reference of the continuous tone
 reference = filters.time_weighting(tone, fs, mode='fast')[int(1.5 * fs):].mean()
 
-# 200 ms burst of the same tone (IEC 61672-1 Table 4 target: -1.0 dB)
-burst = np.zeros_like(t)
-burst[int(0.5 * fs):int(0.7 * fs)] = tone[int(0.5 * fs):int(0.7 * fs)]
-envelope = filters.time_weighting(burst, fs, mode='fast')
-env_db = 10 * np.log10(np.maximum(envelope / reference, 1e-6))
-
-plt.figure()
-plt.plot(t, env_db, label='Fast envelope')
-plt.axhline(-1.0, linestyle='--', label='IEC target −1.0 dB')
-plt.xlabel('Time [s]')
-plt.ylabel('Level re steady state [dB]')
-plt.legend()
+# The three Table 4 rows the published figure draws, with their targets
+cases = [(0.200, -1.0), (0.050, -4.8), (0.010, -11.1)]
+fig, axes = plt.subplots(len(cases), 1, sharey=True, figsize=(8, 8))
+for ax, (t_b, target) in zip(axes, cases):
+    burst = np.zeros_like(t)
+    stop = int(0.5 * fs) + int(t_b * fs)
+    burst[int(0.5 * fs):stop] = tone[int(0.5 * fs):stop]
+    envelope = filters.time_weighting(burst, fs, mode='fast')
+    env_db = 10 * np.log10(np.maximum(envelope / reference, 1e-6))
+    ax.plot(t, env_db, label=f'Fast envelope, {t_b * 1e3:.0f} ms burst')
+    ax.axhline(target, linestyle='--', label=f'IEC target {target} dB')
+    ax.set_ylabel('Level re steady state [dB]')
+    ax.legend(loc='upper right')
+axes[-1].set_xlabel('Time [s]')
 plt.show()
 ```
 

--- a/site/public/llms/llms-signals-spectra.txt
+++ b/site/public/llms/llms-signals-spectra.txt
@@ -251,7 +251,11 @@ freedom and a correspondingly wider interval.
 ```python
 from phonometry import signals
 
-res = signals.power_spectral_density(signal, fs)          # Hann, 50 % overlap, 95 % CI
+# record: one channel of a calibrated capture, in pascals (see the Calibration
+#   guide below); in dBFS work it is the raw [-1, 1] array and the result is
+#   FS^2/Hz.
+fs = 48000.0                                      # its sample rate in Hz
+res = signals.power_spectral_density(record, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
 res.plot()                                        # PSD in dB with the CI band
@@ -335,8 +339,12 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
+import numpy as np
 from phonometry import signals
 
+delay = int(0.002 * fs)                                     # a 2 ms delay path
+noise = signals.noise_signal(fs, 20.0, rms=0.3, seed=9)     # uncorrelated noise
+y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
@@ -499,12 +507,17 @@ squared first, dB levels converted and back), so band power is conserved
 rather than amplitude, and a flat spectrum passes through exactly unchanged.
 
 ```python
+import numpy as np
 from phonometry import signals
 
-smooth_psd = signals.fractional_octave_smoothing(res.frequencies, res.psd, 3.0)
-smooth_mag = signals.fractional_octave_smoothing(freqs, np.abs(response), 6.0,
+res = signals.power_spectral_density(record, fs)   # the section 1 estimate
+freqs = res.frequencies
+smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
+magnitude = np.sqrt(res.psd)               # any linear |H| would do here
+smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,
                                                  domain="amplitude")  # an FRF |H|
-smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")  # dB curve
+levels = 10.0 * np.log10(res.psd)          # any dB curve would do here
+smooth_db = signals.fractional_octave_smoothing(freqs, levels, 3.0, domain="db")
 ```
 
 A single spectral line with PSD ordinate $P$ (units²/Hz) in a bin of width
@@ -624,7 +637,7 @@ Larger $NW$ admits more tapers (lower variance) at the cost of resolution.
 ```python
 from phonometry import signals
 
-res = signals.multitaper_psd(signal, fs)                 # NW = 4, K = 7, adaptive
+res = signals.multitaper_psd(record, fs)                 # NW = 4, K = 7, adaptive
 print(res.degrees_of_freedom.mean())             # ~2K from one record
 print(res.eigenvalues)                           # taper concentrations
 res.plot()                                       # density with the CI band
@@ -940,9 +953,12 @@ The ordinary and multiple coherences do not depend on the conditioning order,
 but the partial coherences and the coherent-output decomposition do: each
 input is conditioned on whatever precedes it. Absent a physical ordering,
 Bendat & Piersol (Section 7.2.4) recommend ordering the inputs by descending
-ordinary coherence with the output. Pass `order` to choose:
+ordinary coherence with the output. Suppose a third, weakly coupled source is
+recorded alongside the two above, coherent with neither. Pass `order` to
+choose:
 
 ```python
+x3 = signals.noise_signal(fs, 32.0, color="white", seed=4)   # the third, weak source
 res = signals.miso_coherence([x1, x2, x3], y, fs, order=(2, 0, 1))
 res.order            # (2, 0, 1): the order actually applied
 res.plot()           # the two panels, recomputed in the applied order
@@ -1047,7 +1063,15 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
+import numpy as np
 from phonometry import signals
+
+# The 70 dB SPL siren of the figure below, in pascals.
+fs = 16000.0
+t = np.arange(int(4.0 * fs)) / fs
+x = 2e-5 * 10.0 ** (70.0 / 20.0) * np.sqrt(2.0) * np.cos(
+    2.0 * np.pi * 900.0 * t - 600.0 * np.cos(np.pi * t)
+)
 
 res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)
@@ -2039,6 +2063,12 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+delay = 102                                  # 12.45 ms
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
+y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
+
 res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
@@ -2204,7 +2234,16 @@ $$
 $$
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+fs = 8192.0
+delay = 20  # samples
+b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
 res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
                          nperseg=2048, upsample=16, signal_bandwidth=1000.0)
@@ -2229,9 +2268,17 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
 
-t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+fs = 48000.0
+t = np.arange(int(0.03 * fs)) / fs
+# Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
+ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
+
+t_arrival = signals.impulse_response_delay(ir_b, fs)            # seconds from t = 0
 dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
 res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
@@ -2307,7 +2354,12 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
+import numpy as np
 from phonometry import signals
+
+fs = 8192.0
+t = np.arange(int(0.4 * fs)) / fs
+x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 
 res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)

--- a/site/public/llms/llms-underwater.txt
+++ b/site/public/llms/llms-underwater.txt
@@ -490,7 +490,12 @@ squared pressure over the record (Formulae 3–4); the peak level is the
 zero-to-peak value.
 
 ```python
+import numpy as np
 from phonometry import underwater
+
+# A captured hydrophone record (here a synthetic 250 Hz tone of 1 s).
+fs = 48000
+pressure = 0.5 * np.sin(2 * np.pi * 250.0 * np.arange(fs) / fs)
 
 spl = underwater.sound_pressure_level(pressure)        # dB re 1 µPa
 sel = underwater.sound_exposure_level(pressure, fs)     # dB re 1 µPa²·s
@@ -546,11 +551,21 @@ res.plot()
 </details>
 
 ```python
+import numpy as np
 from phonometry import underwater
 
-lrn = underwater.radiated_noise_level(2e-6, 100.0)   # p_rms = 2 µPa, r = 100 m
-res = underwater.monopole_source_level(lrn, 200.0, draught=6.0)
-print(res.source_level, res.surface_correction, res.source_depth)
+# Band r.m.s. pressures measured at 100 m from a merchant ship, in pascals.
+freqs = np.array([31.5, 63.0, 125.0, 250.0, 500.0, 1000.0])
+p_rms = np.array([4.3, 2.8, 1.9, 1.2, 0.8, 0.54])
+rnl = np.array([underwater.radiated_noise_level(float(x), 100.0) for x in p_rms])
+print(np.round(rnl, 1))   # [172.7 168.9 165.6 161.6 158.1 154.6] dB re 1 uPa.m
+
+# The surface correction is frequency-dependent, so the conversion is normally
+# run on the whole band vector at once.
+res = underwater.monopole_source_level(rnl, freqs, draught=6.0)
+print(np.round(res.source_level, 1))       # [177.8 168.4 161.7 157.8 154.8 151.6]
+print(np.round(res.surface_correction, 2))  # [ 5.15 -0.51 -3.86 -3.78 -3.27 -3.08]
+print(round(res.source_depth, 2))           # 4.2 m = 0.7 x draught
 res.plot()   # RNL, Ls and ΔL vs frequency (needs matplotlib)
 ```
 
@@ -607,8 +622,8 @@ from phonometry import underwater
 fs = 48000
 t = np.arange(int(0.3 * fs)) / fs
 envelope = np.where(t < 0.01, t / 0.01, np.exp(-(t - 0.01) / 0.04))
-pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
-res = underwater.pile_strike_metrics(pressure, fs)
+strike_pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
+res = underwater.pile_strike_metrics(strike_pressure, fs)
 res.plot()
 ```
 

--- a/site/src/content/docs/aircraft/aircraft-noise.mdx
+++ b/site/src/content/docs/aircraft/aircraft-noise.mdx
@@ -244,9 +244,18 @@ duration correction is $D = -6.56$ dB and $\mathrm{EPNL}$ = 114.01 EPNdB lands
 *below* the peak. A slower flyover over the same peak would score above it.*
 
 ```python
+import numpy as np
 from phonometry import aircraft
 
-# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s
+# spectra: a (K, 24) array of one-third-octave band levels sampled every dt s,
+# here the synthetic flyover of the figure above
+k, dt = 41, 0.5
+idx = np.arange(k)
+shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
+gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
+spectra = (55.0 + shape)[None, :] + gain[:, None]
+spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
+
 res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 print(res.epnl, res.pnltm, res.duration_correction, res.band_limits)
 res.plot()   # PNL/PNLT time history (needs matplotlib)
@@ -267,15 +276,6 @@ $\mathrm{EPNL} = 92.6\ \text{EPNdB}$.
 <summary>Show the code for this figure</summary>
 
 ```python
-import numpy as np
-from phonometry import aircraft
-
-k, dt = 41, 0.5
-idx = np.arange(k)
-shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
-gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
-spectra = (55.0 + shape)[None, :] + gain[:, None]
-spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # 2500 Hz fan tone
 aircraft.effective_perceived_noise_level(spectra, dt).plot()
 ```
 

--- a/site/src/content/docs/aircraft/rotorcraft-noise.mdx
+++ b/site/src/content/docs/aircraft/rotorcraft-noise.mdx
@@ -156,9 +156,15 @@ neighbouring bins (Eq. 13), so partially-measured cells stay continuous with
 their measured corners.
 
 ```python
+import numpy as np
 from phonometry import aircraft
 
-h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta, levels=levels)
+# The band centres and the angle grid are the NORAH format's; the
+# (19, 19, 31) block of levels is the campaign's own.
+freqs = 1000.0 * 10.0 ** (np.arange(-20, 11) / 10.0)   # 10 Hz-10 kHz thirds
+phi, theta = np.arange(-90.0, 91.0, 10.0), np.arange(0.0, 181.0, 10.0)
+h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta,
+                                  levels=measured_levels)
 lv = aircraft.hemisphere_source_level(h, 0.0, 90.0)   # straight down, per band, at 60 m
 h.plot()                                          # fore-aft directivity
 ```
@@ -240,16 +246,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+f_thirds = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 hs, hr, dp = 150.0, 1.5, 500.0                          # overflight geometry
-grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
-asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+grass = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="G")
 
 fig, ax = plt.subplots()
 ax.axhline(0.0, color="0.5", linewidth=1.0)
-ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+ax.semilogx(f_thirds, asphalt, marker="o", markersize=3,
             label="Hard (asphalt/concrete, class G)")
-ax.semilogx(freqs, grass, marker="s", markersize=3,
+ax.semilogx(f_thirds, grass, marker="s", markersize=3,
             label="Soft (grass/pasture, class D)")
 ax.set(xlabel="One-third-octave-band centre frequency [Hz]",
        ylabel="Ground-effect adjustment ΔLg [dB]",
@@ -262,10 +268,8 @@ plt.show()
 </details>
 
 ```python
-import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
 r = 500.0
 received = (lv
             + aircraft.spherical_spreading_adjustment(r)
@@ -591,8 +595,8 @@ smooth = np.column_stack([
     for k in range(3)])
 
 fig, axes = plt.subplots(1, 2, figsize=(12, 5.4))
-for ax, times, pos in ((axes[0], t_radar, raw), (axes[1], t_fine, smooth)):
-    aircraft.flight_path_kinematics(times, pos).plot(ax=ax)
+for ax, t, pos in ((axes[0], t_radar, raw), (axes[1], t_fine, smooth)):
+    aircraft.flight_path_kinematics(t, pos).plot(ax=ax)
 plt.show()
 ```
 
@@ -741,10 +745,10 @@ fig, axes = plt.subplots(1, 2, figsize=(11, 6.4))
 for ax, ground in ((axes[0], aircraft.RotorcraftGround(flow_resistivity="D")),
                    (axes[1], aircraft.RotorcraftGround(flow_resistivity=sigma))):
     res = aircraft.rotorcraft_noise_contour(
-        [h], [speed], [0.0], times, positions, x=x, y=y,
+        [h], [speed], [0.0], t, track, x=x, y=y,
         metric="exposure", ground=ground)
     res.plot(ax=ax)                      # the plot works in kilometres
-    ax.plot(positions[:, 0] / 1000.0, positions[:, 1] / 1000.0, "k--", lw=1.4)
+    ax.plot(track[:, 0] / 1000.0, track[:, 1] / 1000.0, "k--", lw=1.4)
 plt.show()
 ```
 

--- a/site/src/content/docs/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/buildings/design/detailed-prediction.mdx
@@ -186,28 +186,45 @@ resonant_only=True)` does the same on a calculated element.
 
 The four names below (`laboratory_total_loss_factor`,
 `structural_reverberation_time`, `in_situ_reduction_index` and
-`in_situ_impact_level`) are top-level `phonometry` names; add them to the import
-block of the previous section to run this.
+`in_situ_impact_level`) live in the same `building` module as the rest of the
+page, and the block starts from your own measured spectra.
 
 ```python
-# A measured laboratory R and Ln for the 220 mm separating floor, transferred to
-# the building. `el` is the in-situ element of the section above, whose
+import numpy as np
+from phonometry import building
+
+bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
+                  800, 1000, 1250, 1600, 2000, 2500, 3150], float)
+
+# The 220 mm separating floor in situ, the element the next section assembles
+# from its junctions: its perimeter sum is 2.659 m (Formula C.4) and its
 # `reverberation_time` is Ts,situ.
-eta_lab = laboratory_total_loss_factor(bands, mass_per_area=484.0,
-                                       internal_loss_factor=0.005)   # (C.3)
-ts_lab = structural_reverberation_time(bands, eta_lab)               # (C.1)
+el = building.in_situ_element(building.HomogeneousElement(
+    "floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005, 2.659, 2200.0, 3800.0), bands)
+
+# A measured laboratory R and Ln for that same floor, transferred to the
+# building.
+r_measured = ...    # measured R per band, dB (ISO 10140-2 test report)
+ln_measured = ...   # measured Ln per band, dB (ISO 10140-3 test report)
+
+eta_lab = building.laboratory_total_loss_factor(
+    bands, mass_per_area=484.0, internal_loss_factor=0.005)   # (C.3)
+ts_lab = building.structural_reverberation_time(bands, eta_lab)  # (C.1)
 print(np.round(ts_lab[[0, 10]], 3))                    # [0.301 0.089] s
 print(np.round(el.reverberation_time[[0, 10]], 3))     # [0.53  0.152] s, in situ
 
-r_situ = in_situ_reduction_index(r_measured, el.reverberation_time, ts_lab)
-ln_situ = in_situ_impact_level(ln_measured, el.reverberation_time, ts_lab)
+r_situ = building.in_situ_reduction_index(r_measured, el.reverberation_time,
+                                          ts_lab)
+ln_situ = building.in_situ_impact_level(ln_measured, el.reverberation_time,
+                                        ts_lab)
 # This floor is *less* damped in the building than in the test frame (Ts,situ is
 # the longer of the two), so Formula (9) takes 2.0 to 2.5 dB off its index across
 # the range and Part 2 Formula (5) adds the same to its impact level.
 
 # A flanking path takes the resonant-only form of the same measured index;
 # the direct path does not.
-r_flanking = resonant_sound_reduction_index(r_situ, bands, critical_frequency=76.8)
+r_flanking = building.resonant_sound_reduction_index(r_situ, bands,
+                                                     critical_frequency=76.8)
 ```
 
 ### What you need before you start
@@ -308,8 +325,37 @@ Assembling the direct path and all twelve flanking paths gives the apparent
 index per band, its energy split and the ISO 717-1 rating in one call:
 
 ```python
-# `paths` holds the twelve flanking paths of the four elements, built the
-# way `d1` was above; the code block under the figure builds all of them.
+# The other three flanking elements, built the way `wall` was above, each with
+# its own area and perimeter sum (Formula C.4); `situ` then holds all five.
+specs = (("ext2", 13.75, 5.0, 2.75, 219.0, 92.6, 0.0125, 2.548, 600.0, 1900.0),
+         ("int1", 11.0, 4.0, 2.75, 360.0, 128.4, 0.01, 1.636, 1800.0, 2500.0),
+         ("int2", 13.75, 5.0, 2.75, 360.0, 128.4, 0.01, 1.839, 1800.0, 2500.0))
+situ = {"floor": el, "ext1": wall}
+for spec in specs:
+    situ[spec[0]] = building.in_situ_element(
+        building.HomogeneousElement(*spec), bands)
+
+# The twelve flanking paths, three per flanking element, each built the way
+# `d1` was above.
+paths = []
+for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
+                       ("3", "int1", 4.0), ("4", "int2", 5.0)):
+    flank = situ[name]
+    cross = k_floor_ext if name.startswith("ext") else k_floor_int
+    through = k_ext_ext if name.startswith("ext") else k_int_int
+    paths += [
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=flank, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=flank,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=flank,
+                                        element_j=flank, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
+    ]
+
 res = building.detailed_airborne_prediction(
     bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
                                                         delta_r_source=delta),
@@ -410,11 +456,13 @@ The impact side of the same building runs on the same `situ` dictionary:
 ```python
 from phonometry import building
 
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
 direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
     building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
                                   vibration_reduction_index=(
-                             k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
+                             k_floor_ext if name.startswith("ext") else k_floor_int),
                                   coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
@@ -566,8 +614,8 @@ which each path peaks. Both need the ISO 717 rating, so the spectrum must cover
 100 Hz to 3150 Hz (or 125 Hz to 2000 Hz in octaves).
 
 ```python
-airborne.report("airborne-prediction.pdf")   # R'w, thirteen paths
-impact.report("impact-prediction.pdf")       # L'n,w, five paths
+res.report("airborne-prediction.pdf")   # R'w, thirteen paths
+imp.report("impact-prediction.pdf")     # L'n,w, five paths
 ```
 
 The example fiches are regenerated with `make reports` and kept rendered in the

--- a/site/src/content/docs/devices/electroacoustics/electroacoustics.mdx
+++ b/site/src/content/docs/devices/electroacoustics/electroacoustics.mdx
@@ -186,15 +186,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-n = fs                     # 1 s -> 1 Hz bins; harmonics land on bins
-t = np.arange(n) / fs
+fs_hd = 48000
+n = fs_hd                  # 1 s -> 1 Hz bins; harmonics land on bins
+t = np.arange(n) / fs_hd
 f0 = 1000.0
 amps = {1: 1.0, 2: 0.02, 3: 0.012, 4: 0.006, 5: 0.003}
 sig = sum(a * np.sin(2 * np.pi * k * f0 * t) for k, a in amps.items())
 sig = sig + np.random.default_rng(2026).standard_normal(n) * 1.2e-2
 
-res = electroacoustics.harmonic_analysis(sig, fs, f0, n_harmonics=len(amps))
+res = electroacoustics.harmonic_analysis(sig, fs_hd, f0, n_harmonics=len(amps))
 res.plot()
 plt.show()
 ```
@@ -338,7 +338,7 @@ from phonometry import electroacoustics
 # is digital full scale.
 dr = electroacoustics.dynamic_range(output, fs, 997.0)     # dB CCIR-RMS
 # Idle channel noise: capture the output with a digital-zero input.
-idle = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
+icn = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
 ```
 
 Both are measured through the AES17 band (a 20 Hz high-pass plus the standard
@@ -454,12 +454,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-t = np.arange(fs) / fs                        # 1 s -> tones land on FFT bins
-x = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
-signal = x + 0.04 * x**2 + 0.012 * x**3       # weakly non-linear device output
+fs_md = 48000
+t = np.arange(fs_md) / fs_md                  # 1 s -> tones land on FFT bins
+src = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
+sig = src + 0.04 * src**2 + 0.012 * src**3    # weakly non-linear device output
 
-md = electroacoustics.modulation_distortion(signal, fs, f_low=60.0, f_high=7000.0)
+md = electroacoustics.modulation_distortion(sig, fs_md, f_low=60.0, f_high=7000.0)
 md.plot()
 plt.show()
 ```
@@ -490,11 +490,11 @@ import numpy as np
 # `electroacoustics` as imported above; 96 kHz so the DIM products stay in band.
 fs_im = 96000
 t = np.arange(fs_im) / fs_im                 # 1 s -> every tone lands on a bin
-x = 0.5 * (np.sin(2 * np.pi * 13000.0 * t) + np.sin(2 * np.pi * 14000.0 * t))
-y = x + 0.05 * x**2 + 0.02 * x**3            # the same weak non-linearity
+src = 0.5 * (np.sin(2 * np.pi * 13000.0 * t) + np.sin(2 * np.pi * 14000.0 * t))
+sig = src + 0.05 * src**2 + 0.02 * src**3    # the same weak non-linearity
 print(
     electroacoustics.difference_frequency_distortion(
-        y, fs_im, f1=13e3, f2=14e3, order=2
+        sig, fs_im, f1=13e3, f2=14e3, order=2
     )
 )
 ```
@@ -577,11 +577,11 @@ import numpy as np
 from scipy import signal as sp
 from phonometry import electroacoustics
 
-fs = 48000
+fs_fr = 48000
 n = 400000
 rng = np.random.default_rng(7)
 clean_x = rng.standard_normal(n)
-b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs)   # device under test
+b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs_fr)   # device under test
 clean_y = sp.lfilter(b, a, clean_x)
 
 # Both columns: the same path, the noise moved from one channel to the other.
@@ -596,9 +596,9 @@ cases = (("Noise on the output - H1 is unbiased", clean_x, y_out),
 fig, axes = plt.subplots(2, 2, figsize=(11.4, 7.6), sharex=True,
                          gridspec_kw={"height_ratios": [2.0, 1.0]})
 for col, (title, xx, yy) in enumerate(cases):
-    h1 = electroacoustics.transfer_function(xx, yy, fs, estimator="H1")
-    h2 = electroacoustics.transfer_function(xx, yy, fs, estimator="H2")
-    _, h_true = sp.freqz(b, a, worN=h1.frequencies, fs=fs)
+    h1 = electroacoustics.transfer_function(xx, yy, fs_fr, estimator="H1")
+    h2 = electroacoustics.transfer_function(xx, yy, fs_fr, estimator="H2")
+    _, h_true = sp.freqz(b, a, worN=h1.frequencies, fs=fs_fr)
     pos = h1.frequencies > 0.0
     freqs = h1.frequencies[pos]
 
@@ -618,7 +618,7 @@ for col, (title, xx, yy) in enumerate(cases):
     ax_coh.semilogx(freqs, h1.coherence[pos], label="measured")
     ax_coh.semilogx(freqs, snr / (1.0 + snr), ":", label="SNR / (1 + SNR)")
     ax_coh.axhline(0.9, ls="--", lw=1.0)
-    ax_coh.set(xlabel="Frequency [Hz]", ylim=(0.0, 1.05), xlim=(20.0, fs / 2))
+    ax_coh.set(xlabel="Frequency [Hz]", ylim=(0.0, 1.05), xlim=(20.0, fs_fr / 2))
     ax_coh.legend(fontsize=8)
 axes[0][0].set_ylabel("Magnitude [dB]")
 axes[1][0].set_ylabel("Coherence")

--- a/site/src/content/docs/devices/electroacoustics/swept-sine-distortion.mdx
+++ b/site/src/content/docs/devices/electroacoustics/swept-sine-distortion.mdx
@@ -100,6 +100,7 @@ from phonometry import electroacoustics
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # play this...
 # ... record the device response into `y` (include the decay tail) ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # a memoryless cubic stands in for the recording
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # complex H1..H3 on res.frequencies
@@ -132,6 +133,7 @@ import numpy as np
 # `synchronized_sweep_signal` and `swept_sine_distortion` as imported above.
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds, amplitude=0.5, fade=0.02)
 # ... play x, record y, and keep recording until the decay has died ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # the same cubic, now at the level played
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3,
                                              amplitude=0.5, fade=0.02)
 ```
@@ -323,6 +325,7 @@ filter.
 from phonometry import electroacoustics, room
 
 x = room.sweep_signal(fs, f1, f2, seconds)          # the ISO 18233 ESS
+y = x + 0.12 * x**2 + 0.08 * x**3                   # the same cubic, recorded from the ESS
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # same |Hn| + THD(f) panels as the synchronized method (needs matplotlib)
 ```
@@ -398,7 +401,17 @@ all-pass parts:
 
 ```python
 import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+gain_a = 10.0 ** (6.0 / 40.0)          # the measured device: a +6 dB peaking EQ
+w0 = 2.0 * np.pi * 1000.0 / fs         # at 1 kHz, Q = 1, through a 2.5 ms latency
+alpha = np.sin(w0) / 2.0
+b = np.array([1 + alpha * gain_a, -2 * np.cos(w0), 1 - alpha * gain_a])
+a = np.array([1 + alpha / gain_a, -2 * np.cos(w0), 1 - alpha / gain_a])
+imp = np.zeros(16384)
+imp[int(0.0025 * fs)] = 1.0
+ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
 H = np.fft.rfft(ir)                    # one-sided response, DC..Nyquist
 h_min = signals.minimum_phase(np.abs(H))       # phase from the magnitude alone

--- a/site/src/content/docs/devices/emission/intensity.mdx
+++ b/site/src/content/docs/devices/emission/intensity.mdx
@@ -293,6 +293,19 @@ back **per band**, and the result is plottable in one line, the form in which
 the criteria are actually checked (each band passes or fails on its own):
 
 ```python
+# The scan the figure below is drawn from: ten positions over six octave
+# bands, a nearly uniform surface pressure, and a normal intensity per band
+# that turns the field reactive towards low frequency, with two inward-flowing
+# positions in the 125 Hz band (rescaled so the band mean keeps its target).
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+delta_pi = np.array([10.5, 8.5, 6.0, 4.5, 3.5, 3.0])   # target Lp − L|In|
+rng = np.random.default_rng(9614)
+lp_bands = 78.0 + rng.normal(0.0, 0.4, (10, freqs.size))
+i_mean = 10.0 ** ((78.0 - delta_pi) / 10.0) * 1.0e-12
+in_bands = i_mean[None, :] * (1.0 + rng.normal(0.0, 0.18, (10, freqs.size)))
+in_bands[:2, 0] = -0.35 * i_mean[0]
+in_bands[2:, 0] *= (10.0 * i_mean[0] - in_bands[:2, 0].sum()) / in_bands[2:, 0].sum()
+
 fi = emission.field_indicators(lp_bands, in_bands, freqs)   # (positions, bands)
 fi.plot(dynamic_capability=ld)   # F2/F3 per band vs Ld, F4 on a twin axis (needs matplotlib)
 ```
@@ -460,17 +473,17 @@ the class the chain actually meets: the loosest class every band clears, or
 `None` when some band clears neither.
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # The band centres Table 2 is defined on, and the measured residual index of
 # the chain: one value per band, taken with the spacer that will be fitted in
 # the field. Replace the placeholder with your own residual-intensity test.
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=0.012)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=0.012)
 measured_delta_pi0 = [11.0, 11.9, 11.2, 10.0, 13.2, 15.9, 17.0, 18.0,
                       19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 24.0, 24.0,
                       24.0, 24.0, 24.0, 24.0, 24.0, 24.0]   # dB, 22 bands
 
-res = metrology.intensity_class_compliance(measured_delta_pi0, freqs,
+res = emission.intensity_class_compliance(measured_delta_pi0, freqs,
                                            device="instrument", spacing=0.012)
 print(res.overall_class)          # 2: one band misses the class 1 minimum
 print(res.binding_margin())       # smallest per-band margin to that class [dB]
@@ -495,7 +508,7 @@ whole chain is graded class 2.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import metrology
+from phonometry import emission
 
 # A complete instrument with the common 12 mm spacer. The measured index is
 # modelled from the physics behind Table 2: a residual phase mismatch φs reads
@@ -503,13 +516,13 @@ from phonometry import metrology
 # climbs 10 dB per decade, and above 1 kHz the mismatch of a real chain grows
 # with frequency, so the index levels off.
 spacing = 0.012
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=spacing)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=spacing)
 phase_mismatch = 0.05 * np.maximum(1.0, freqs / 1000.0)          # degrees
-measured = metrology.residual_index_from_phase_mismatch(phase_mismatch, freqs,
+measured = emission.residual_index_from_phase_mismatch(phase_mismatch, freqs,
                                                         spacing)
 measured = measured - 4.0 * np.exp(-((np.log(freqs / 100.0) / 0.25) ** 2))
 
-res = metrology.intensity_class_compliance(measured, freqs, spacing=spacing)
+res = emission.intensity_class_compliance(measured, freqs, spacing=spacing)
 res.plot()
 plt.show()
 ```
@@ -552,14 +565,14 @@ $$
 and the two conversions run both ways:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # 20 dB of residual index at 1 kHz over a 25 mm spacer:
-phi = metrology.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
+phi = emission.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
 print(round(float(phi), 2))     # 0.26 degrees, a hundredth of kd
 
 # And back, for a chain whose channels are matched to 0.05°:
-print(round(float(metrology.residual_index_from_phase_mismatch(
+print(round(float(emission.residual_index_from_phase_mismatch(
     0.05, 1000.0, 0.012)), 1))  # 24.0 dB
 ```
 

--- a/site/src/content/docs/devices/emission/sound-power.mdx
+++ b/site/src/content/docs/devices/emission/sound-power.mdx
@@ -319,11 +319,12 @@ measured sound power:
 
 ```python
 import numpy as np
-import phonometry as ph
+from phonometry import emission
 from phonometry import ReportMetadata
 
-# ... a measured LWA from ISO 3744 ...
-result = ph.sound_power_pressure(levels, "hemisphere", radius=1.0,
+# ISO 3744: SPL at 10 positions on a hemisphere, r = 1 m (10 lg(S/S0) = 8 dB).
+levels = np.tile(lw_true - 8.0, (10, 1))
+result = emission.sound_power_pressure(levels, "hemisphere", radius=1.0,
                                  frequencies=freqs)
 
 declaration = result.declare(
@@ -344,17 +345,17 @@ Or build the declaration directly, reproducing the ISO 4871 Annex B example
 declared $L_{W\mathrm{Ad}} = 90$ and 97 dB):
 
 ```python
-mode1 = ph.OperatingModeDeclaration(
+mode1 = emission.OperatingModeDeclaration(
     "Operating mode 1", sound_power_level=88.0, sound_power_uncertainty=2.0,
     emission_pressure_level=78.0, emission_pressure_uncertainty=2.0,
     verification_level=89.0,          # passes: 89 <= 90
 )
-mode2 = ph.OperatingModeDeclaration(
+mode2 = emission.OperatingModeDeclaration(
     "Operating mode 2", sound_power_level=95.0, sound_power_uncertainty=2.0,
     emission_pressure_level=86.0, emission_pressure_uncertainty=2.0,
     verification_level=98.0,          # fails: 98 > 97
 )
-ph.NoiseEmissionDeclaration(
+emission.NoiseEmissionDeclaration(
     (mode1, mode2), machine="Type 990, Model 11-TC",
     basic_standards=("ISO 3744", "ISO 11202"), form="dual-number",
 ).report("iso4871.pdf")

--- a/site/src/content/docs/environment/assessment/impulsive-sound.mdx
+++ b/site/src/content/docs/environment/assessment/impulsive-sound.mdx
@@ -219,10 +219,28 @@ or clipped at either end of the range.
 From a calibrated time signal (in pascal) the whole chain runs end to end:
 
 ```python
+import numpy as np
+from phonometry import environment
+
+# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz, in place of
+# a calibrated recording.
+fs = 48000
+rng = np.random.default_rng(7)
+t = np.arange(int(6.0 * fs)) / fs
+background = rng.standard_normal(t.size)
+background *= 2e-5 * 10 ** (55 / 20) / np.sqrt(np.mean(background ** 2))
+signal = background.copy()
+for onset_time in (1.0, 2.6, 4.2):
+    decay = np.exp(-(t - onset_time) / 0.08) * (t >= onset_time)
+    strike = decay * rng.standard_normal(t.size)
+    window = (t >= onset_time) & (t < onset_time + 0.1)
+    strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
+    signal += strike
+
 result = environment.impulsive_sound_adjustment(signal, fs)
-print(result.category)                  # e.g. 'highly impulsive'
-print(round(result.adjustment, 1))      # KI in dB (0.0 to about 9 dB in typical cases)
-print(round(result.adjusted_laeq, 1))   # LAeq + KI
+print(result.category)                  # 'highly impulsive'
+print(round(result.adjustment, 1))      # 11.4  dB (KI, uncapped; typical cases fall between 0.0 and 9 dB)
+print(round(result.adjusted_laeq, 1))   # 91.1  dB (LAeq + KI)
 
 result.plot()   # the LpAF history with the detected onsets (needs matplotlib)
 ```
@@ -247,7 +265,7 @@ processing itself.
 
 <ThemeImage
   src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets.svg"
-  alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.8 dB is annotated, and the title reports a prominence of 11.34 with an adjustment of 11.42 dB, category highly impulsive"
+  alt="A-weighted Fast level history of three hammer strikes over a 55 dB(A) background across six seconds: each strike rises from about 52 dB to 89 dB, the detected onset start and end points are marked with the least-squares onset line, the governing level difference of 36.9 dB is annotated, and the title reports a prominence of 11.31 with an adjustment of 11.36 dB, category highly impulsive"
   width="90%"
 />
 
@@ -260,31 +278,15 @@ show up as a shallower fitted line on a visibly steep edge.*
 <summary>Show the code for this figure</summary>
 
 ```python
-import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import environment
 
-# Three hammer strikes over a 55 dB(A) background, 6 s at 48 kHz.
-fs = 48000
-rng = np.random.default_rng(7)
-t = np.arange(int(6.0 * fs)) / fs
-background = rng.standard_normal(t.size)
-background *= 2e-5 * 10 ** (55 / 20) / np.sqrt(np.mean(background ** 2))
-signal = background.copy()
-for onset_time in (1.0, 2.6, 4.2):
-    decay = np.exp(-(t - onset_time) / 0.08) * (t >= onset_time)
-    strike = decay * rng.standard_normal(t.size)
-    window = (t >= onset_time) & (t < onset_time + 0.1)
-    strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
-    signal += strike
-
-res = environment.impulsive_sound_adjustment(signal, fs)
-print(res.category, round(res.prominence, 2), round(res.adjustment, 2))
-# highly impulsive 11.34 11.42
+# `result` is the three-strike chain of this section.
+print(result.category, round(result.prominence, 2), round(result.adjustment, 2))
+# highly impulsive 11.31 11.36
 
 # One line: the level history with the onsets, the fitted onset lines and
 # the governing level difference.
-res.plot()
+result.plot()
 plt.show()
 ```
 

--- a/site/src/content/docs/es/aircraft/aircraft-noise.mdx
+++ b/site/src/content/docs/es/aircraft/aircraft-noise.mdx
@@ -260,9 +260,18 @@ $\mathrm{EPNL}$ = 114,01 EPNdB cae *por debajo* del máximo. Un sobrevuelo más
 lento con el mismo máximo puntuaría por encima.*
 
 ```python
+import numpy as np
 from phonometry import aircraft
 
-# spectra: un array (K, 24) de niveles de tercio de octava muestreado cada dt s
+# spectra: un array (K, 24) de niveles de tercio de octava muestreado cada dt s,
+# aquí el sobrevuelo sintético de la figura de arriba
+k, dt = 41, 0.5
+idx = np.arange(k)
+shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
+gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
+spectra = (55.0 + shape)[None, :] + gain[:, None]
+spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # tono de ventilador 2500 Hz
+
 res = aircraft.effective_perceived_noise_level(spectra, dt=0.5)
 print(res.epnl, res.pnltm, res.duration_correction, res.band_limits)
 res.plot()   # historia temporal PNL/PNLT (requiere matplotlib)
@@ -284,15 +293,6 @@ $\mathrm{EPNL} = 92{,}6\ \text{EPNdB}$.
 <summary>Mostrar el código de esta figura</summary>
 
 ```python
-import numpy as np
-from phonometry import aircraft
-
-k, dt = 41, 0.5
-idx = np.arange(k)
-shape = 15.0 * np.exp(-((np.log10(aircraft.NOY_BANDS) - np.log10(400.0)) ** 2) / 0.5)
-gain = 30.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 5.0**2)) - 5.0
-spectra = (55.0 + shape)[None, :] + gain[:, None]
-spectra[:, 17] += 12.0 * np.exp(-((idx - 20.0) ** 2) / (2 * 6.0**2))  # tono de ventilador 2500 Hz
 aircraft.effective_perceived_noise_level(spectra, dt).plot(language="es")
 ```
 

--- a/site/src/content/docs/es/aircraft/rotorcraft-noise.mdx
+++ b/site/src/content/docs/es/aircraft/rotorcraft-noise.mdx
@@ -163,9 +163,15 @@ dominio de energía sobre los cuatro bins vecinos (Ec. 13), de modo que las celd
 parcialmente medidas se mantienen continuas con sus esquinas medidas.
 
 ```python
+import numpy as np
 from phonometry import aircraft
 
-h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta, levels=levels)
+# Los centros de banda y la malla de ángulos son los del formato NORAH; el
+# bloque (19, 19, 31) de niveles es el que midió la campaña.
+freqs = 1000.0 * 10.0 ** (np.arange(-20, 11) / 10.0)   # tercios 10 Hz-10 kHz
+phi, theta = np.arange(-90.0, 91.0, 10.0), np.arange(0.0, 181.0, 10.0)
+h = aircraft.RotorcraftHemisphere(frequencies=freqs, azimuth=phi, polar=theta,
+                                  levels=measured_levels)
 lv = aircraft.hemisphere_source_level(h, 0.0, 90.0)   # recto hacia abajo, por banda, a 60 m
 h.plot()                                          # directividad proa-popa
 ```
@@ -247,16 +253,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # tercios 50 Hz-10 kHz
+f_thirds = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # tercios 50 Hz-10 kHz
 hs, hr, dp = 150.0, 1.5, 500.0                          # geometría de sobrevuelo
-grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
-asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+grass = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(f_thirds, hs, hr, dp, flow_resistivity="G")
 
 fig, ax = plt.subplots()
 ax.axhline(0.0, color="0.5", linewidth=1.0)
-ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+ax.semilogx(f_thirds, asphalt, marker="o", markersize=3,
             label="Duro (asfalto/hormigón, clase G)")
-ax.semilogx(freqs, grass, marker="s", markersize=3,
+ax.semilogx(f_thirds, grass, marker="s", markersize=3,
             label="Blando (hierba/pasto, clase D)")
 ax.set(xlabel="Frecuencia central de banda de tercio de octava [Hz]",
        ylabel="Ajuste por efecto de suelo ΔLg [dB]",
@@ -269,10 +275,8 @@ plt.show()
 </details>
 
 ```python
-import numpy as np
 from phonometry import aircraft
 
-freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # tercios 50 Hz-10 kHz
 r = 500.0
 recibido = (lv
             + aircraft.spherical_spreading_adjustment(r)
@@ -353,7 +357,7 @@ speeds = [50.0, 70.0, 60.0]                # un hemisferio por condición
 angles = [0.0, 0.0, 10.0]                  # ángulos de trayectoria, grados
 weights = aircraft.flight_condition_weights(speeds, angles, 60.0, 2.5)
 lv = aircraft.interpolated_source_level(
-    [h_50_nivel, h_70_nivel, h_60_ascenso], speeds, angles,
+    [h_50_level, h_70_level, h_60_climb], speeds, angles,
     60.0, 2.5, 0.0, 90.0)                  # nivel mezclado por banda
 ```
 
@@ -609,8 +613,8 @@ smooth = np.column_stack([
     for k in range(3)])
 
 fig, axes = plt.subplots(1, 2, figsize=(12, 5.4))
-for ax, times, pos in ((axes[0], t_radar, raw), (axes[1], t_fine, smooth)):
-    aircraft.flight_path_kinematics(times, pos).plot(ax=ax, language="es")
+for ax, t, pos in ((axes[0], t_radar, raw), (axes[1], t_fine, smooth)):
+    aircraft.flight_path_kinematics(t, pos).plot(ax=ax, language="es")
 plt.show()
 ```
 
@@ -764,10 +768,10 @@ fig, axes = plt.subplots(1, 2, figsize=(11, 6.4))
 for ax, ground in ((axes[0], aircraft.RotorcraftGround(flow_resistivity="D")),
                    (axes[1], aircraft.RotorcraftGround(flow_resistivity=sigma))):
     res = aircraft.rotorcraft_noise_contour(
-        [h], [speed], [0.0], times, positions, x=x, y=y,
+        [h], [speed], [0.0], t, track, x=x, y=y,
         metric="exposure", ground=ground)
     res.plot(ax=ax, language="es")        # la gráfica va en kilómetros
-    ax.plot(positions[:, 0] / 1000.0, positions[:, 1] / 1000.0, "k--", lw=1.4)
+    ax.plot(track[:, 0] / 1000.0, track[:, 1] / 1000.0, "k--", lw=1.4)
 plt.show()
 ```
 

--- a/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
@@ -201,21 +201,37 @@ calculado.
 
 Los cuatro nombres de abajo (`laboratory_total_loss_factor`,
 `structural_reverberation_time`, `in_situ_reduction_index` e
-`in_situ_impact_level`) son nombres de primer nivel de `phonometry`; añádelos al
-bloque de importación de la sección anterior para ejecutar esto.
+`in_situ_impact_level`) viven en el mismo módulo `building` que el resto de la
+página, y el bloque parte de tus propios espectros medidos.
 
 ```python
-# Un R y un Ln de laboratorio medidos para el forjado separador de 220 mm,
-# trasladados al edificio. `el` es el elemento in situ de la sección de arriba,
-# cuyo `reverberation_time` es Ts,situ.
-eta_lab = laboratory_total_loss_factor(bands, mass_per_area=484.0,
-                                       internal_loss_factor=0.005)   # (C.3)
-ts_lab = structural_reverberation_time(bands, eta_lab)               # (C.1)
+import numpy as np
+from phonometry import building
+
+bands = np.array([50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
+                  800, 1000, 1250, 1600, 2000, 2500, 3150], float)
+
+# El forjado separador de 220 mm in situ, el elemento que la sección siguiente
+# arma a partir de sus uniones: su suma de perímetro es 2,659 m (fórmula C.4) y
+# su `reverberation_time` es Ts,situ.
+el = building.in_situ_element(building.HomogeneousElement(
+    "floor", 20.0, 5.0, 4.0, 484.0, 76.8, 0.005, 2.659, 2200.0, 3800.0), bands)
+
+# Un R y un Ln de laboratorio medidos para ese mismo forjado, trasladados al
+# edificio.
+r_measured = ...    # R medido por banda, dB (informe de ensayo ISO 10140-2)
+ln_measured = ...   # Ln medido por banda, dB (informe de ensayo ISO 10140-3)
+
+eta_lab = building.laboratory_total_loss_factor(
+    bands, mass_per_area=484.0, internal_loss_factor=0.005)   # (C.3)
+ts_lab = building.structural_reverberation_time(bands, eta_lab)  # (C.1)
 print(np.round(ts_lab[[0, 10]], 3))                    # [0.301 0.089] s
 print(np.round(el.reverberation_time[[0, 10]], 3))     # [0.53  0.152] s, in situ
 
-r_situ = in_situ_reduction_index(r_measured, el.reverberation_time, ts_lab)
-ln_situ = in_situ_impact_level(ln_measured, el.reverberation_time, ts_lab)
+r_situ = building.in_situ_reduction_index(r_measured, el.reverberation_time,
+                                          ts_lab)
+ln_situ = building.in_situ_impact_level(ln_measured, el.reverberation_time,
+                                        ts_lab)
 # Este forjado está *menos* amortiguado en el edificio que en el marco de ensayo
 # (Ts,situ es el mayor de los dos), así que la fórmula (9) le quita de 2,0 a
 # 2,5 dB de índice en todo el rango y la fórmula (5) de la parte 2 se los suma a
@@ -223,7 +239,8 @@ ln_situ = in_situ_impact_level(ln_measured, el.reverberation_time, ts_lab)
 
 # Una trayectoria por flancos toma la forma de transmisión resonante únicamente
 # de ese mismo índice medido; la directa, no.
-r_flanking = resonant_sound_reduction_index(r_situ, bands, critical_frequency=76.8)
+r_flanking = building.resonant_sound_reduction_index(r_situ, bands,
+                                                     critical_frequency=76.8)
 ```
 
 ### Qué necesitas antes de empezar
@@ -327,9 +344,38 @@ aparente por bandas, su reparto de energía y la valoración ISO 717-1 en una
 sola llamada:
 
 ```python
-# `paths` contiene las doce trayectorias por flancos de los cuatro elementos,
-# construidas como `d1` más arriba; el bloque de código bajo la figura las
-# construye todas.
+# Los otros tres elementos de flanco, construidos como `wall` más arriba, cada
+# uno con su superficie y su suma de perímetro (fórmula C.4); `situ` contiene
+# entonces los cinco.
+specs = (("ext2", 13.75, 5.0, 2.75, 219.0, 92.6, 0.0125, 2.548, 600.0, 1900.0),
+         ("int1", 11.0, 4.0, 2.75, 360.0, 128.4, 0.01, 1.636, 1800.0, 2500.0),
+         ("int2", 13.75, 5.0, 2.75, 360.0, 128.4, 0.01, 1.839, 1800.0, 2500.0))
+situ = {"floor": el, "ext1": wall}
+for spec in specs:
+    situ[spec[0]] = building.in_situ_element(
+        building.HomogeneousElement(*spec), bands)
+
+# Las doce trayectorias por flancos, tres por cada elemento de flanco, cada una
+# construida como `d1` más arriba.
+paths = []
+for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
+                       ("3", "int1", 4.0), ("4", "int2", 5.0)):
+    flank = situ[name]
+    cross = k_floor_ext if name.startswith("ext") else k_floor_int
+    through = k_ext_ext if name.startswith("ext") else k_int_int
+    paths += [
+        building.airborne_flanking_path(label=f"D{tag}", kind="Df", element_i=situ["floor"],
+                                        element_j=flank, vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0,
+                                        delta_r_i=delta),
+        building.airborne_flanking_path(label=f"{tag}d", kind="Fd", element_i=flank,
+                                        element_j=situ["floor"], vibration_reduction_index=cross,
+                                        coupling_length=lij, separating_area=20.0),
+        building.airborne_flanking_path(label=f"{tag}{tag}", kind="Ff", element_i=flank,
+                                        element_j=flank, vibration_reduction_index=through,
+                                        coupling_length=lij, separating_area=20.0),
+    ]
+
 res = building.detailed_airborne_prediction(
     bands, direct_index=building.direct_reduction_index(el.sound_reduction_index,
                                                         delta_r_source=delta),
@@ -432,11 +478,13 @@ La parte de impactos del mismo edificio se apoya en el mismo diccionario
 ```python
 from phonometry import building
 
+k_floor_ext = building.junction_vibration_reduction("rigid_t", "corner", 484.0 / 219.0)
+k_floor_int = building.junction_vibration_reduction("rigid_cross", "corner", 360.0 / 484.0)
 direct = building.direct_impact_level(situ["floor"].impact_level, delta_l=delta)
 flanking = [
     building.impact_flanking_path(label=f"Df{tag}", floor=situ["floor"], element_j=situ[name],
                                   vibration_reduction_index=(
-                             k["floor-ext"] if name.startswith("ext") else k["floor-int"]),
+                             k_floor_ext if name.startswith("ext") else k_floor_int),
                                   coupling_length=lij, delta_l=delta)
     for tag, name, lij in (("1", "ext1", 4.0), ("2", "ext2", 5.0),
                            ("3", "int1", 4.0), ("4", "int2", 5.0))
@@ -597,8 +645,8 @@ necesitan la valoración ISO 717, así que el espectro debe cubrir de 100 Hz a
 3150 Hz (o de 125 Hz a 2000 Hz en bandas de octava).
 
 ```python
-airborne.report("prediccion-aereo.pdf", language="es")   # R'w, trece trayectorias
-impact.report("prediccion-impactos.pdf", language="es")  # L'n,w, cinco trayectorias
+res.report("prediccion-aereo.pdf", language="es")       # R'w, trece trayectorias
+imp.report("prediccion-impactos.pdf", language="es")    # L'n,w, cinco trayectorias
 ```
 
 Las fichas de ejemplo se regeneran con `make reports` y se mantienen

--- a/site/src/content/docs/es/devices/electroacoustics/electroacoustics.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/electroacoustics.mdx
@@ -200,15 +200,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-n = fs                     # 1 s -> bins de 1 Hz; los armónicos caen en bins
-t = np.arange(n) / fs
+fs_hd = 48000
+n = fs_hd                  # 1 s -> bins de 1 Hz; los armónicos caen en bins
+t = np.arange(n) / fs_hd
 f0 = 1000.0
 amps = {1: 1.0, 2: 0.02, 3: 0.012, 4: 0.006, 5: 0.003}
 sig = sum(a * np.sin(2 * np.pi * k * f0 * t) for k, a in amps.items())
 sig = sig + np.random.default_rng(2026).standard_normal(n) * 1.2e-2
 
-res = electroacoustics.harmonic_analysis(sig, fs, f0, n_harmonics=len(amps))
+res = electroacoustics.harmonic_analysis(sig, fs_hd, f0, n_harmonics=len(amps))
 res.plot(language="es")
 plt.show()
 ```
@@ -358,7 +358,7 @@ from phonometry import electroacoustics
 # de modo que 1.0 sea plena escala digital.
 dr = electroacoustics.dynamic_range(output, fs, 997.0)     # dB CCIR-RMS
 # Ruido de canal en reposo: captura la salida con entrada de cero digital.
-idle = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
+icn = electroacoustics.idle_channel_noise(idle_output, fs)  # dBFS CCIR-RMS
 ```
 
 Ambas se miden a través de la banda AES17 (un paso alto de 20 Hz más el paso
@@ -480,12 +480,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import electroacoustics
 
-fs = 48000
-t = np.arange(fs) / fs                        # 1 s -> los tonos caen en bins de la FFT
-x = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
-signal = x + 0.04 * x**2 + 0.012 * x**3       # salida de un dispositivo débilmente no lineal
+fs_md = 48000
+t = np.arange(fs_md) / fs_md                  # 1 s -> los tonos caen en bins de la FFT
+src = np.sin(2 * np.pi * 60.0 * t) + 0.25 * np.sin(2 * np.pi * 7000.0 * t)
+sig = src + 0.04 * src**2 + 0.012 * src**3    # salida de un dispositivo débilmente no lineal
 
-md = electroacoustics.modulation_distortion(signal, fs, f_low=60.0, f_high=7000.0)
+md = electroacoustics.modulation_distortion(sig, fs_md, f_low=60.0, f_high=7000.0)
 md.plot(language="es")
 plt.show()
 ```
@@ -517,11 +517,11 @@ import numpy as np
 # `electroacoustics` importado arriba; 96 kHz para que los productos DIM sigan en banda.
 fs_im = 96000
 t = np.arange(fs_im) / fs_im                 # 1 s -> cada tono cae en un bin
-x = 0.5 * (np.sin(2 * np.pi * 13000.0 * t) + np.sin(2 * np.pi * 14000.0 * t))
-y = x + 0.05 * x**2 + 0.02 * x**3            # la misma no linealidad débil
+src = 0.5 * (np.sin(2 * np.pi * 13000.0 * t) + np.sin(2 * np.pi * 14000.0 * t))
+sig = src + 0.05 * src**2 + 0.02 * src**3    # la misma no linealidad débil
 print(
     electroacoustics.difference_frequency_distortion(
-        y, fs_im, f1=13e3, f2=14e3, order=2
+        sig, fs_im, f1=13e3, f2=14e3, order=2
     )
 )
 ```
@@ -608,11 +608,11 @@ import numpy as np
 from scipy import signal as sp
 from phonometry import electroacoustics
 
-fs = 48000
+fs_fr = 48000
 n = 400000
 rng = np.random.default_rng(7)
 clean_x = rng.standard_normal(n)
-b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs)   # dispositivo bajo ensayo
+b, a = sp.butter(2, [400.0, 4000.0], btype="band", fs=fs_fr)   # dispositivo bajo ensayo
 clean_y = sp.lfilter(b, a, clean_x)
 
 # Las dos columnas: el mismo camino, con el ruido pasado de un canal al otro.
@@ -627,9 +627,9 @@ cases = (("Ruido en la salida: H1 es insesgado", clean_x, y_out),
 fig, axes = plt.subplots(2, 2, figsize=(11.4, 7.6), sharex=True,
                          gridspec_kw={"height_ratios": [2.0, 1.0]})
 for col, (title, xx, yy) in enumerate(cases):
-    h1 = electroacoustics.transfer_function(xx, yy, fs, estimator="H1")
-    h2 = electroacoustics.transfer_function(xx, yy, fs, estimator="H2")
-    _, h_true = sp.freqz(b, a, worN=h1.frequencies, fs=fs)
+    h1 = electroacoustics.transfer_function(xx, yy, fs_fr, estimator="H1")
+    h2 = electroacoustics.transfer_function(xx, yy, fs_fr, estimator="H2")
+    _, h_true = sp.freqz(b, a, worN=h1.frequencies, fs=fs_fr)
     pos = h1.frequencies > 0.0
     freqs = h1.frequencies[pos]
 
@@ -649,7 +649,7 @@ for col, (title, xx, yy) in enumerate(cases):
     ax_coh.semilogx(freqs, h1.coherence[pos], label="medida")
     ax_coh.semilogx(freqs, snr / (1.0 + snr), ":", label="SNR / (1 + SNR)")
     ax_coh.axhline(0.9, ls="--", lw=1.0)
-    ax_coh.set(xlabel="Frecuencia [Hz]", ylim=(0.0, 1.05), xlim=(20.0, fs / 2))
+    ax_coh.set(xlabel="Frecuencia [Hz]", ylim=(0.0, 1.05), xlim=(20.0, fs_fr / 2))
     ax_coh.legend(fontsize=8)
 axes[0][0].set_ylabel("Magnitud [dB]")
 axes[1][0].set_ylabel("Coherencia")

--- a/site/src/content/docs/es/devices/electroacoustics/swept-sine-distortion.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/swept-sine-distortion.mdx
@@ -100,6 +100,7 @@ from phonometry import electroacoustics
 fs, f1, f2, seconds = 48000, 20.0, 6000.0, 4.0
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds)   # reproducir esto...
 # ... grabar la respuesta del dispositivo en `y` (con su cola de caída) ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # un cúbico sin memoria hace de grabación
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3)
 
 res.harmonic_responses    # H1..H3 complejas sobre res.frequencies
@@ -133,6 +134,7 @@ import numpy as np
 # `synchronized_sweep_signal` y `swept_sine_distortion` importados arriba.
 x = electroacoustics.synchronized_sweep_signal(fs, f1, f2, seconds, amplitude=0.5, fade=0.02)
 # ... reproduce x, graba y, y sigue grabando hasta que la caída se apague ...
+y = x + 0.12 * x**2 + 0.08 * x**3     # el mismo cúbico, ahora al nivel reproducido
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, n_harmonics=3,
                                              amplitude=0.5, fade=0.02)
 ```
@@ -333,6 +335,7 @@ $f_2$ por el filtro inverso.
 from phonometry import electroacoustics, room
 
 x = room.sweep_signal(fs, f1, f2, seconds)          # el ESS de ISO 18233
+y = x + 0.12 * x**2 + 0.08 * x**3                   # el mismo cúbico, grabado del ESS
 res = electroacoustics.swept_sine_distortion(y, fs, f1=f1, f2=f2, seconds=seconds, method="farina")
 res.plot()   # los mismos paneles |Hn| + THD(f) que el método sincronizado (necesita matplotlib)
 ```
@@ -409,7 +412,17 @@ medida en su parte invertible y su parte paso todo:
 
 ```python
 import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+gain_a = 10.0 ** (6.0 / 40.0)          # el dispositivo medido: un EQ de campana de
+w0 = 2.0 * np.pi * 1000.0 / fs         # +6 dB a 1 kHz, Q = 1, con 2,5 ms de latencia
+alpha = np.sin(w0) / 2.0
+b = np.array([1 + alpha * gain_a, -2 * np.cos(w0), 1 - alpha * gain_a])
+a = np.array([1 + alpha / gain_a, -2 * np.cos(w0), 1 - alpha / gain_a])
+imp = np.zeros(16384)
+imp[int(0.0025 * fs)] = 1.0
+ir = sp_signal.lfilter(b / a[0], a / a[0], imp)
 
 H = np.fft.rfft(ir)                    # respuesta unilateral, DC..Nyquist
 h_min = signals.minimum_phase(np.abs(H))       # la fase solo desde la magnitud

--- a/site/src/content/docs/es/devices/emission/intensity.mdx
+++ b/site/src/content/docs/es/devices/emission/intensity.mdx
@@ -306,6 +306,20 @@ forma en la que realmente se comprueban los criterios (cada banda aprueba o
 falla por sí sola):
 
 ```python
+# El barrido del que sale la figura de abajo: diez posiciones sobre seis
+# bandas de octava, con la presión de superficie casi uniforme y una
+# intensidad normal por banda que vuelve reactivo el campo hacia baja
+# frecuencia, con dos posiciones de flujo entrante en la banda de 125 Hz
+# (reescaladas para que la media de la banda conserve su objetivo).
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+delta_pi = np.array([10.5, 8.5, 6.0, 4.5, 3.5, 3.0])   # objetivo Lp − L|In|
+rng = np.random.default_rng(9614)
+lp_bands = 78.0 + rng.normal(0.0, 0.4, (10, freqs.size))
+i_mean = 10.0 ** ((78.0 - delta_pi) / 10.0) * 1.0e-12
+in_bands = i_mean[None, :] * (1.0 + rng.normal(0.0, 0.18, (10, freqs.size)))
+in_bands[:2, 0] = -0.35 * i_mean[0]
+in_bands[2:, 0] *= (10.0 * i_mean[0] - in_bands[:2, 0].sum()) / in_bands[2:, 0].sum()
+
 fi = emission.field_indicators(lp_bands, in_bands, freqs)   # (posiciones, bandas)
 fi.plot(dynamic_capability=ld)   # F2/F3 por banda frente a Ld, F4 en eje gemelo (requiere matplotlib)
 ```
@@ -482,17 +496,17 @@ lleva la clase que la cadena cumple realmente: la clase más laxa que superan
 todas las bandas, o `None` cuando alguna banda no supera ninguna de las dos.
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # Las frecuencias centrales sobre las que se define la tabla 2, y el índice
 # residual medido de la cadena: un valor por banda, tomado con el espaciador que
 # se montará en campo. Sustituye el marcador por tu propio ensayo residual.
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=0.012)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=0.012)
 measured_delta_pi0 = [11.0, 11.9, 11.2, 10.0, 13.2, 15.9, 17.0, 18.0,
                       19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 24.0, 24.0,
                       24.0, 24.0, 24.0, 24.0, 24.0, 24.0]   # dB, 22 bandas
 
-res = metrology.intensity_class_compliance(measured_delta_pi0, freqs,
+res = emission.intensity_class_compliance(measured_delta_pi0, freqs,
                                            device="instrument", spacing=0.012)
 print(res.overall_class)          # 2: una banda no llega al mínimo de clase 1
 print(res.binding_margin())       # menor margen por banda hasta esa clase [dB]
@@ -519,7 +533,7 @@ clase 2.*
 ```python
 import matplotlib.pyplot as plt
 import numpy as np
-from phonometry import metrology
+from phonometry import emission
 
 # Un instrumento completo con el espaciador habitual de 12 mm. El índice medido
 # se modela a partir de la física que hay tras la tabla 2: un desfase residual
@@ -527,13 +541,13 @@ from phonometry import metrology
 # grados ya sube 10 dB por década y, por encima de 1 kHz, el desfase de una
 # cadena real crece con la frecuencia y el índice se aplana.
 spacing = 0.012
-freqs, _, _ = metrology.residual_index_limits("instrument", spacing=spacing)
+freqs, _, _ = emission.residual_index_limits("instrument", spacing=spacing)
 phase_mismatch = 0.05 * np.maximum(1.0, freqs / 1000.0)          # grados
-measured = metrology.residual_index_from_phase_mismatch(phase_mismatch, freqs,
+measured = emission.residual_index_from_phase_mismatch(phase_mismatch, freqs,
                                                         spacing)
 measured = measured - 4.0 * np.exp(-((np.log(freqs / 100.0) / 0.25) ** 2))
 
-res = metrology.intensity_class_compliance(measured, freqs, spacing=spacing)
+res = emission.intensity_class_compliance(measured, freqs, spacing=spacing)
 res.plot()
 plt.show()
 ```
@@ -577,14 +591,14 @@ $$
 y las dos conversiones funcionan en ambos sentidos:
 
 ```python
-from phonometry import metrology
+from phonometry import emission
 
 # 20 dB de índice residual a 1 kHz con un espaciador de 25 mm:
-phi = metrology.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
+phi = emission.phase_mismatch_from_residual_index(20.0, 1000.0, 0.025)
 print(round(float(phi), 2))     # 0.26 grados, una centésima de kd
 
 # Y a la inversa, para una cadena con los canales emparejados a 0,05°:
-print(round(float(metrology.residual_index_from_phase_mismatch(
+print(round(float(emission.residual_index_from_phase_mismatch(
     0.05, 1000.0, 0.012)), 1))  # 24.0 dB
 ```
 

--- a/site/src/content/docs/es/devices/emission/sound-power.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power.mdx
@@ -336,11 +336,12 @@ directamente a partir de una potencia acústica medida:
 
 ```python
 import numpy as np
-import phonometry as ph
+from phonometry import emission
 from phonometry import ReportMetadata
 
-# ... un LWA medido según ISO 3744 ...
-result = ph.sound_power_pressure(levels, "hemisphere", radius=1.0,
+# ISO 3744: SPL en 10 posiciones de una semiesfera, r = 1 m (10 lg(S/S0) = 8 dB).
+levels = np.tile(lw_true - 8.0, (10, 1))
+result = emission.sound_power_pressure(levels, "hemisphere", radius=1.0,
                                  frequencies=freqs)
 
 declaration = result.declare(
@@ -362,17 +363,17 @@ de ISO 4871 (dos modos de funcionamiento, $L_{W\mathrm{A}} = 88$ y 95 dB con $K_
 dB, que dan los valores declarados $L_{W\mathrm{Ad}} = 90$ y 97 dB):
 
 ```python
-mode1 = ph.OperatingModeDeclaration(
+mode1 = emission.OperatingModeDeclaration(
     "Operating mode 1", sound_power_level=88.0, sound_power_uncertainty=2.0,
     emission_pressure_level=78.0, emission_pressure_uncertainty=2.0,
     verification_level=89.0,          # cumple: 89 <= 90
 )
-mode2 = ph.OperatingModeDeclaration(
+mode2 = emission.OperatingModeDeclaration(
     "Operating mode 2", sound_power_level=95.0, sound_power_uncertainty=2.0,
     emission_pressure_level=86.0, emission_pressure_uncertainty=2.0,
     verification_level=98.0,          # no cumple: 98 > 97
 )
-ph.NoiseEmissionDeclaration(
+emission.NoiseEmissionDeclaration(
     (mode1, mode2), machine="Type 990, Model 11-TC",
     basic_standards=("ISO 3744", "ISO 11202"), form="dual-number",
 ).report("iso4871.pdf", language="es")

--- a/site/src/content/docs/es/environment/assessment/impulsive-sound.mdx
+++ b/site/src/content/docs/es/environment/assessment/impulsive-sound.mdx
@@ -222,10 +222,28 @@ Desde una señal temporal calibrada (en pascales) la cadena completa se ejecuta
 de principio a fin:
 
 ```python
+import numpy as np
+from phonometry import environment
+
+# Tres golpes de martillo sobre un fondo de 55 dB(A), 6 s a 48 kHz, en lugar de
+# una grabación calibrada.
+fs = 48000
+rng = np.random.default_rng(7)
+t = np.arange(int(6.0 * fs)) / fs
+background = rng.standard_normal(t.size)
+background *= 2e-5 * 10 ** (55 / 20) / np.sqrt(np.mean(background ** 2))
+signal = background.copy()
+for onset_time in (1.0, 2.6, 4.2):
+    decay = np.exp(-(t - onset_time) / 0.08) * (t >= onset_time)
+    strike = decay * rng.standard_normal(t.size)
+    window = (t >= onset_time) & (t < onset_time + 0.1)
+    strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
+    signal += strike
+
 result = environment.impulsive_sound_adjustment(signal, fs)
-print(result.category)                  # p. ej. 'highly impulsive'
-print(round(result.adjustment, 1))      # KI en dB (de 0,0 a unos 9 dB en casos típicos)
-print(round(result.adjusted_laeq, 1))   # LAeq + KI
+print(result.category)                  # 'highly impulsive'
+print(round(result.adjustment, 1))      # 11.4  dB (KI, sin tope; los casos típicos caen entre 0,0 y unos 9 dB)
+print(round(result.adjusted_laeq, 1))   # 91.1  dB (LAeq + KI)
 
 result.plot()   # el historial de LpAF con los arranques detectados (necesita matplotlib)
 ```
@@ -250,7 +268,7 @@ como un arranque del propio procesado.
 
 <ThemeImage
   src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/impulsive_sound_onsets_es.svg"
-  alt="Historial de nivel con ponderación A y constante F de tres golpes de martillo sobre un fondo de 55 dB(A) a lo largo de seis segundos: cada golpe sube de unos 52 dB a 89 dB, se marcan los puntos de inicio y fin del crecimiento detectado con la recta de mínimos cuadrados, se anota la diferencia de nivel determinante de 36,8 dB y el título indica una prominencia de 11,34 con un ajuste de 11,42 dB, categoría altamente impulsiva"
+  alt="Historial de nivel con ponderación A y constante F de tres golpes de martillo sobre un fondo de 55 dB(A) a lo largo de seis segundos: cada golpe sube de unos 52 dB a 89 dB, se marcan los puntos de inicio y fin del crecimiento detectado con la recta de mínimos cuadrados, se anota la diferencia de nivel determinante de 36,9 dB y el título indica una prominencia de 11,31 con un ajuste de 11,36 dB, categoría altamente impulsiva"
   width="90%"
 />
 
@@ -264,31 +282,15 @@ más tendida sobre un flanco visiblemente empinado.*
 <summary>Mostrar el código de esta figura</summary>
 
 ```python
-import numpy as np
 import matplotlib.pyplot as plt
-from phonometry import environment
 
-# Tres golpes de martillo sobre un fondo de 55 dB(A), 6 s a 48 kHz.
-fs = 48000
-rng = np.random.default_rng(7)
-t = np.arange(int(6.0 * fs)) / fs
-background = rng.standard_normal(t.size)
-background *= 2e-5 * 10 ** (55 / 20) / np.sqrt(np.mean(background ** 2))
-signal = background.copy()
-for onset_time in (1.0, 2.6, 4.2):
-    decay = np.exp(-(t - onset_time) / 0.08) * (t >= onset_time)
-    strike = decay * rng.standard_normal(t.size)
-    window = (t >= onset_time) & (t < onset_time + 0.1)
-    strike *= 2e-5 * 10 ** (95 / 20) / np.sqrt(np.mean(strike[window] ** 2))
-    signal += strike
-
-res = environment.impulsive_sound_adjustment(signal, fs)
-print(res.category, round(res.prominence, 2), round(res.adjustment, 2))
-# highly impulsive 11.34 11.42
+# `result` es la cadena de los tres golpes de esta sección.
+print(result.category, round(result.prominence, 2), round(result.adjustment, 2))
+# highly impulsive 11.31 11.36
 
 # En una línea: el historial de nivel con los arranques, las rectas ajustadas y
 # la diferencia de nivel determinante.
-res.plot(language="es")
+result.plot(language="es")
 plt.show()
 ```
 

--- a/site/src/content/docs/es/signals/filters/block-processing.mdx
+++ b/site/src/content/docs/es/signals/filters/block-processing.mdx
@@ -142,10 +142,10 @@ octave_filter = filters.OctaveFilterBank(
 )
 afilter = filters.WeightingFilter(fs, "A", stateful=True)
 
-for block in sf.blocks("measurement.wav", blocksize=256, overlap=0):
+for frame in sf.blocks("measurement.wav", blocksize=256, overlap=0):
 
     # Aplicar el filtro A
-    weighted = afilter.filter(block)
+    weighted = afilter.filter(frame)
 
     # Dividir en bandas de octava
     block_spl, _, block_output = octave_filter.filter(weighted, sigbands=True, detrend=False)
@@ -186,7 +186,7 @@ La versión por bandas es el mismo acumulador con un vector a la izquierda:
 ```python
 band_squares = np.zeros(bank.num_bands)   # de tu OctaveFilterBank con estado
 
-for x in audio_stream(block):
+for x in audio_stream(block):        # tu callback de captura
     _, _, bands = bank.filter(x, sigbands=True, detrend=False,
                               calculate_level=False)
     band_squares += np.sum(np.square(bands), axis=-1)
@@ -355,7 +355,7 @@ for x in audio_stream(block):            # tu callback de captura
     y = env.process(aw.filter(x))
     spl = 10 * np.log10(y[..., -1] / (2e-5) ** 2)  # LAF instantáneo
     laf_max = max(laf_max, 10 * np.log10(y.max() / (2e-5) ** 2))
-    display(spl)
+    print(spl)  # tu actualización de la indicación
 ```
 
 `y[..., -1]` es la salida del detector *en el instante en que acaba el bloque*,

--- a/site/src/content/docs/es/signals/spectra/correlation-delay.mdx
+++ b/site/src/content/docs/es/signals/spectra/correlation-delay.mdx
@@ -61,6 +61,12 @@ $\tau = +\tau_0$ (ecuación 5.21). Hay tres normalizaciones disponibles:
 import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+delay = 102                                  # 12,45 ms
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
+y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
+
 res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # retardo y su coeficiente
@@ -307,7 +313,16 @@ $$
 $$
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+fs = 8192.0
+delay = 20  # muestras
+b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # señal común coloreada
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
 res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
                          nperseg=2048, upsample=16, signal_bandwidth=1000.0)
@@ -334,9 +349,17 @@ registros estacionarios, así que se usa el correlador directo en lugar de
 la GCC promediada por Welch):
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
 
-t_arrival = signals.impulse_response_delay(ir, fs)              # segundos desde t = 0
+fs = 48000.0
+t = np.arange(int(0.03 * fs)) / fs
+# Pulso de referencia de banda limitada: ráfaga tonal gaussiana de 2 kHz en 5 ms.
+ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
+
+t_arrival = signals.impulse_response_delay(ir_b, fs)            # segundos desde t = 0
 dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # retardo del par
 
 res = signals.align_impulse_responses(ir_b, ir_a, fs)  # elimina el retardo estimado
@@ -438,7 +461,12 @@ conformidad fija la envolvente AM recuperada y el par $\cos \to \sin$ de
 la Tabla 13.1 al nivel de 1e-9, y la frecuencia instantánea de un barrido sigue su rampa.
 
 ```python
+import numpy as np
 from phonometry import signals
+
+fs = 8192.0
+t = np.arange(int(0.4 * fs)) / fs
+x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # un modo golpeado
 
 res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)

--- a/site/src/content/docs/es/signals/spectra/spectral-analysis.mdx
+++ b/site/src/content/docs/es/signals/spectra/spectral-analysis.mdx
@@ -129,7 +129,8 @@ from phonometry import signals
 
 # record: un canal de una captura calibrada, en pascales (ver la guía de
 #   Calibración más abajo); trabajando en dBFS es el vector bruto en [-1, 1] y
-#   el resultado sale en FS^2/Hz. fs: su frecuencia de muestreo en Hz.
+#   el resultado sale en FS^2/Hz.
+fs = 48000.0                                      # su frecuencia de muestreo en Hz
 res = signals.power_spectral_density(record, fs)          # Hann, solape 50 %, IC 95 %
 print(res.n_averages, res.random_error)           # nd y 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
@@ -295,6 +296,9 @@ retardo de propagación.
 ```python
 from phonometry import signals
 
+delay = int(0.002 * fs)                                     # un retardo de 2 ms
+noise = signals.noise_signal(fs, 20.0, rms=0.3, seed=9)     # ruido no correlacionado
+y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # errores del bin 100
 res.plot()   # magnitud, fase con banda ±sigma, coherencia
@@ -506,9 +510,11 @@ frecuencia (`"amplitude"`, que se eleva antes al cuadrado), o una curva ya en
 decibelios (`"db"`, que se convierte y se vuelve a convertir).
 
 ```python
+import numpy as np
 from phonometry import signals
 
-freqs = res.frequencies                    # de la estimación del §1
+res = signals.power_spectral_density(record, fs)   # la estimación del §1
+freqs = res.frequencies
 smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
 magnitude = np.sqrt(res.psd)               # aquí valdría cualquier |H| lineal
 smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,

--- a/site/src/content/docs/es/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/es/signals/spectra/time-frequency.mdx
@@ -69,7 +69,15 @@ Welch sin eliminación de tendencia, se cumplen tres identidades:
   más la identidad COLA, una de las comprobaciones de conformidad).
 
 ```python
+import numpy as np
 from phonometry import signals
+
+# La sirena a 70 dB SPL de la figura de abajo, en pascales.
+fs = 16000.0
+t = np.arange(int(4.0 * fs)) / fs
+x = 2e-5 * 10.0 ** (70.0 / 20.0) * np.sqrt(2.0) * np.cos(
+    2.0 * np.pi * 900.0 * t - 600.0 * np.cos(np.pi * t)
+)
 
 res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frecuencias, tiempos)

--- a/site/src/content/docs/es/underwater/underwater-acoustics.mdx
+++ b/site/src/content/docs/es/underwater/underwater-acoustics.mdx
@@ -88,7 +88,12 @@ así que averigua qué convención usa un umbral externo antes de restar uno del
 otro.
 
 ```python
+import numpy as np
 from phonometry import underwater
+
+# Un registro de hidrófono capturado (aquí un tono sintético de 250 Hz y 1 s).
+fs = 48000
+pressure = 0.5 * np.sin(2 * np.pi * 250.0 * np.arange(fs) / fs)
 
 spl = underwater.sound_pressure_level(pressure)        # dB re 1 µPa
 sel = underwater.sound_exposure_level(pressure, fs)     # dB re 1 µPa²·s
@@ -327,8 +332,8 @@ from phonometry import underwater
 fs = 48000
 t = np.arange(int(0.3 * fs)) / fs
 envelope = np.where(t < 0.01, t / 0.01, np.exp(-(t - 0.01) / 0.04))
-pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
-res = underwater.pile_strike_metrics(pressure, fs)
+strike_pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
+res = underwater.pile_strike_metrics(strike_pressure, fs)
 res.plot(language="es")
 ```
 

--- a/site/src/content/docs/signals/filters/block-processing.mdx
+++ b/site/src/content/docs/signals/filters/block-processing.mdx
@@ -138,10 +138,10 @@ octave_filter = filters.OctaveFilterBank(
 )
 afilter = filters.WeightingFilter(fs, "A", stateful=True)
 
-for block in sf.blocks("measurement.wav", blocksize=256, overlap=0):
+for frame in sf.blocks("measurement.wav", blocksize=256, overlap=0):
 
     # Apply A-filter
-    weighted = afilter.filter(block)
+    weighted = afilter.filter(frame)
 
     # Split into octave bands
     block_spl, _, block_output = octave_filter.filter(weighted, sigbands=True, detrend=False)
@@ -180,7 +180,7 @@ The band version is the same accumulator with a vector on the left:
 ```python
 band_squares = np.zeros(bank.num_bands)   # from your stateful OctaveFilterBank
 
-for x in audio_stream(block):
+for x in audio_stream(block):        # your capture callback
     _, _, bands = bank.filter(x, sigbands=True, detrend=False,
                               calculate_level=False)
     band_squares += np.sum(np.square(bands), axis=-1)
@@ -343,7 +343,7 @@ for x in audio_stream(block):            # your capture callback
     y = env.process(aw.filter(x))
     spl = 10 * np.log10(y[..., -1] / (2e-5) ** 2)  # instantaneous LAF
     laf_max = max(laf_max, 10 * np.log10(y.max() / (2e-5) ** 2))
-    display(spl)
+    print(spl)  # your display update
 ```
 
 `y[..., -1]` is the detector output *at the instant the block ends*, so the

--- a/site/src/content/docs/signals/spectra/correlation-delay.mdx
+++ b/site/src/content/docs/signals/spectra/correlation-delay.mdx
@@ -59,6 +59,12 @@ $y(t) = \alpha\,x(t-\tau_0) + n(t)$ the estimate peaks at $\tau = +\tau_0$
 import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+delay = 102                                  # 12.45 ms
+x = signals.noise_signal(fs, 2.0, seed=4)
+interference = signals.noise_signal(fs, 2.0, rms=0.5, seed=5)
+y = 0.8 * np.concatenate([np.zeros(delay), x[:-delay]]) + interference
+
 res = signals.correlation(x, y, fs, normalization="coefficient", max_lag=0.05)
 peak = np.argmax(res.values)
 print(res.lags[peak], res.values[peak])   # delay and its coefficient
@@ -292,7 +298,16 @@ $$
 $$
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
+
+fs = 8192.0
+delay = 20  # samples
+b, a = sp_signal.butter(2, 800.0 / (fs / 2.0))   # colored common signal
+s = sp_signal.lfilter(b, a, signals.noise_signal(fs, 4.0, color="white", seed=10))
+x = s + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=11)
+y = np.roll(s, delay) + signals.noise_signal(fs, 4.0, color="white", rms=0.02, seed=12)
 
 res = signals.time_delay(x, y, fs, method="gcc", weighting="ml",
                          nperseg=2048, upsample=16, signal_bandwidth=1000.0)
@@ -317,9 +332,17 @@ stationary records, so the direct correlator is used rather than the
 Welch-averaged GCC):
 
 ```python
+import numpy as np
+from scipy import signal as sp_signal
 from phonometry import signals
 
-t_arrival = signals.impulse_response_delay(ir, fs)              # seconds from t = 0
+fs = 48000.0
+t = np.arange(int(0.03 * fs)) / fs
+# Band-limited reference pulse: a 2 kHz Gaussian tone burst at 5 ms.
+ir_a = sp_signal.gausspulse(t - 0.005, fc=2000.0, bw=0.5)
+ir_b = signals.fractional_delay(ir_a, 7.37)[: ir_a.size]
+
+t_arrival = signals.impulse_response_delay(ir_b, fs)            # seconds from t = 0
 dt = signals.impulse_response_delay(ir_b, fs, reference=ir_a)   # pair delay
 
 res = signals.align_impulse_responses(ir_b, ir_a, fs)  # remove the estimated delay
@@ -416,7 +439,12 @@ recovered AM envelope and the Table 13.1 pair $\cos \to \sin$ at the
 1e-9 level, and the instantaneous frequency of a chirp tracks its sweep.
 
 ```python
+import numpy as np
 from phonometry import signals
+
+fs = 8192.0
+t = np.arange(int(0.4 * fs)) / fs
+x = np.exp(-t / 0.1) * np.sin(2 * np.pi * 250.0 * t)   # a struck mode
 
 res = signals.envelope(x, fs)
 print(res.envelope, res.instantaneous_frequency)

--- a/site/src/content/docs/signals/spectra/spectral-analysis.mdx
+++ b/site/src/content/docs/signals/spectra/spectral-analysis.mdx
@@ -123,7 +123,8 @@ from phonometry import signals
 
 # record: one channel of a calibrated capture, in pascals (see the Calibration
 #   guide below); in dBFS work it is the raw [-1, 1] array and the result is
-#   FS^2/Hz. fs: its sample rate in Hz.
+#   FS^2/Hz.
+fs = 48000.0                                      # its sample rate in Hz
 res = signals.power_spectral_density(record, fs)          # Hann, 50 % overlap, 95 % CI
 print(res.n_averages, res.random_error)           # nd and 1/sqrt(nd)
 print(res.ci_lower[10], res.psd[10], res.ci_upper[10])
@@ -282,8 +283,12 @@ delay path the phase is linear and that slope reads the propagation delay
 directly.
 
 ```python
+import numpy as np
 from phonometry import signals
 
+delay = int(0.002 * fs)                                     # a 2 ms delay path
+noise = signals.noise_signal(fs, 20.0, rms=0.3, seed=9)     # uncorrelated noise
+y = 0.9 * np.concatenate([np.zeros(delay), x[:-delay]]) + noise
 res = signals.cross_spectral_density(x, y, fs)
 print(res.magnitude_random_error[100], res.phase_std[100])  # bin 100 errors
 res.plot()   # magnitude, phase with ±sigma band, coherence
@@ -487,9 +492,11 @@ magnitude such as a frequency-response $|H|$ (`"amplitude"`, squared first), or
 a curve already in decibels (`"db"`, converted and converted back).
 
 ```python
+import numpy as np
 from phonometry import signals
 
-freqs = res.frequencies                    # from the section 1 estimate
+res = signals.power_spectral_density(record, fs)   # the section 1 estimate
+freqs = res.frequencies
 smooth_psd = signals.fractional_octave_smoothing(freqs, res.psd, 3.0)
 magnitude = np.sqrt(res.psd)               # any linear |H| would do here
 smooth_mag = signals.fractional_octave_smoothing(freqs, magnitude, 6.0,

--- a/site/src/content/docs/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/signals/spectra/time-frequency.mdx
@@ -66,7 +66,15 @@ Welch-module scaling with no detrending, three identities hold:
   the conformance checks).
 
 ```python
+import numpy as np
 from phonometry import signals
+
+# The 70 dB SPL siren of the figure below, in pascals.
+fs = 16000.0
+t = np.arange(int(4.0 * fs)) / fs
+x = 2e-5 * 10.0 ** (70.0 / 20.0) * np.sqrt(2.0) * np.cos(
+    2.0 * np.pi * 900.0 * t - 600.0 * np.cos(np.pi * t)
+)
 
 res = signals.spectrogram(x, fs, nperseg=1024, overlap=0.75, scaling="spectrum")
 print(res.power.shape)             # (frequencies, times)

--- a/site/src/content/docs/underwater/underwater-acoustics.mdx
+++ b/site/src/content/docs/underwater/underwater-acoustics.mdx
@@ -86,7 +86,12 @@ rarefactional peaks be reported separately (Clause 8.4.2). A computed
 external threshold uses before subtracting one from the other.
 
 ```python
+import numpy as np
 from phonometry import underwater
+
+# A captured hydrophone record (here a synthetic 250 Hz tone of 1 s).
+fs = 48000
+pressure = 0.5 * np.sin(2 * np.pi * 250.0 * np.arange(fs) / fs)
 
 spl = underwater.sound_pressure_level(pressure)        # dB re 1 µPa
 sel = underwater.sound_exposure_level(pressure, fs)     # dB re 1 µPa²·s
@@ -310,8 +315,8 @@ from phonometry import underwater
 fs = 48000
 t = np.arange(int(0.3 * fs)) / fs
 envelope = np.where(t < 0.01, t / 0.01, np.exp(-(t - 0.01) / 0.04))
-pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
-res = underwater.pile_strike_metrics(pressure, fs)
+strike_pressure = 8000.0 * envelope * np.sin(2 * np.pi * 180.0 * t)
+res = underwater.pile_strike_metrics(strike_pressure, fs)
 res.plot()
 ```
 

--- a/tests/test_check_fence_names.py
+++ b/tests/test_check_fence_names.py
@@ -1,0 +1,109 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""The fence reading-order gate.
+
+``scripts/check_fence_names.py`` holds every documentation page to the
+sequential-example convention: a fence may only use names an earlier fence of
+the same page defined, with reader-owned placeholders registered explicitly.
+These tests pin the failure modes, the placeholder path, the twin-sharing
+route key, and that the shipped tree passes.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import check_fence_names
+
+
+def _page(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+    page = tmp_path / "example.md"
+    page.write_text(body, encoding="utf8")
+    return page
+
+
+def test_a_forward_reference_is_flagged(tmp_path: pathlib.Path) -> None:
+    """A name defined only by a later fence breaks the reading order."""
+    page = _page(
+        tmp_path,
+        "```python\nprint(levels.mean())\n```\n\n"
+        "```python\nlevels = compute()\n```\n\n"
+        "```python\ncompute = min\n```\n",
+    )
+    problems = check_fence_names.check_page(page)
+    assert len(problems) == 2
+    assert "fence 1 uses levels before the page defines" in problems[0]
+    assert "fence 2 uses compute before the page defines" in problems[1]
+
+
+def test_an_ordered_page_passes(tmp_path: pathlib.Path) -> None:
+    """The convention itself: later fences may use earlier names."""
+    page = _page(
+        tmp_path,
+        "```python\nimport numpy as np\nsignal = np.zeros(8)\n```\n\n"
+        "```python\nprint(signal.sum(), np.pi)\n```\n",
+    )
+    assert check_fence_names.check_page(page) == []
+
+
+def test_an_undefined_name_is_flagged_toward_the_registry(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A name no fence defines points the author at the placeholder table."""
+    page = _page(tmp_path, "```python\nprint(spl.max())\n```\n")
+    problems = check_fence_names.check_page(page)
+    assert len(problems) == 1
+    assert "fence 1 uses spl, which no fence of the page defines" in problems[0]
+    assert "PLACEHOLDERS" in problems[0]
+
+
+def test_a_registered_placeholder_is_accepted(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The registry clears exactly the declared names and nothing else."""
+    page = _page(tmp_path, "```python\nprint(spl.max(), other)\n```\n")
+    monkeypatch.setitem(check_fence_names.PLACEHOLDERS, "example", frozenset({"spl"}))
+    problems = check_fence_names.check_page(page)
+    assert len(problems) == 1
+    assert "uses other," in problems[0]
+
+
+def test_a_fence_that_does_not_parse_is_flagged(tmp_path: pathlib.Path) -> None:
+    """An unparseable fence cannot be checked, and says so."""
+    page = _page(tmp_path, "```python\ndef broken(:\n```\n")
+    problems = check_fence_names.check_page(page)
+    assert len(problems) == 1
+    assert "does not parse as Python" in problems[0]
+
+
+def test_the_route_key_is_shared_by_the_language_twins() -> None:
+    """The Spanish twin and the docs mirror resolve to the English route."""
+    english = check_fence_names.CONTENT / "signals" / "levels" / "page.mdx"
+    spanish = check_fence_names.CONTENT / "es" / "signals" / "levels" / "page.mdx"
+    mirror = check_fence_names.DOCS / "signals" / "levels" / "page.md"
+    assert check_fence_names._route(english) == "signals/levels/page"
+    assert check_fence_names._route(spanish) == "signals/levels/page"
+    assert check_fence_names._route(mirror) == "docs/signals/levels/page"
+
+
+def test_a_stale_registry_line_is_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A placeholder route with no page behind it must be deleted."""
+    monkeypatch.setitem(
+        check_fence_names.PLACEHOLDERS, "no/such/page", frozenset({"ghost"})
+    )
+    assert "no/such/page" in check_fence_names._stale_placeholder_routes()
+
+
+def test_the_shipped_tree_reads_in_order() -> None:
+    """Every committed page passes the gate CI runs."""
+    assert check_fence_names.main() == 0


### PR DESCRIPTION
The Python fences of a documentation page form one sequential example, and one shipped page broke the premise invisibly: its section-3 example used names its own figure block defined further down, while a same-named variable from a different room sat in scope, so reading the page top to bottom produced numbers that were not the annotated ones, with no error anywhere. This hardens the convention instead of abandoning it.

The new gate, `scripts/check_fence_names.py` (`make fence-names`, its own CI job beside the errata one), parses every fence of every documentation page and fails on a name no earlier fence of the same page defined. Reader-owned names, the measurement or capture the page deliberately never invents, are declared in a registry keyed by the page's route with the `es/` prefix stripped, so the Spanish twin is held to the same set; the page must introduce each one as the reader's own, in prose or in the fence's own marker comment, which travels with the code wherever the fence is copied, the llms shards included. A companion rule stays editorial, since no script can tell which values matter: a fence that annotates an output defines its inputs itself or stands right after the fence that does. CONTRIBUTING carries both rules and the registry conventions.

Run red first: 139 offences over 18 routes at HEAD, 67 forward references and 72 undefined names, including four routes broken only in the GitHub mirror. Every route was repaired across all its language twins together and each repair was verified by executing the fences in reading order; an adversarial verification pass per route then re-ran the gate, diffed every hunk and re-measured the annotated outputs, and everything it refuted was re-fixed the same way. The gate now reads 2 849 fences on 490 pages in order, with twelve pages carrying declared placeholders, and the tree-wide pass is pinned as a test beside the unit tests of the gate's failure modes.

The sweep surfaced defects beyond name order, fixed here because the runs proved them: two pages still called the root re-exports the 4.0.0 trim retired (`sound_power_pressure` and the four intensity-metrology names, now reached through `emission`, and both pages now execute end to end, so their skip entries in `check_doc_snippets.py` are gone or corrected along with two more whose reasons had gone stale); a stale annotation and figure alt on the impulsive-sound page said 11.34/11.42 and 36.8 dB where the code prints 11.31/11.36 and 36.9; the time-weighting mirror drew one tone burst under an alt text describing three; the underwater mirror taught a physically impossible 2 uPa example its site twins had already outgrown; and a WAV-streaming loop reused `block` as its loop variable, handing later fences an audio frame where they meant a block length.

The llms artifacts are regenerated, and the doc-snippet static checks, decimal-comma, subscript, mathtext and mirror gates all pass locally, with ruff and mypy over the tree.

A scratch PR with a deliberate forward reference will follow to show the new job red in CI before this merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Enforce top-to-bottom execution of documentation examples and repair the affected documentation, mirrors, generated artifacts, and validation coverage.

New Features:
- Add a CI-enforced checker and Make target that verifies documentation Python fences only reference names defined earlier on the same page, with explicit reader-owned placeholder support.

Bug Fixes:
- Repair documentation examples with forward or undefined references, outdated API imports, stale annotations, inconsistent figure descriptions, invalid examples, and variable shadowing across English, Spanish, and mirror pages.

Enhancements:
- Make documentation examples substantially more self-contained and executable by adding synthetic inputs, moving shared setup into reading order, and clarifying reader-provided data.
- Document the sequential-fence and annotated-output conventions, including placeholder registry and language-twin requirements.

Build:
- Include the fence-name validation in the aggregate Make check target.

CI:
- Add a dedicated GitHub Actions job for documentation fence reading-order validation.

Documentation:
- Regenerate the LLM documentation artifacts and synchronize the corrected examples across published documentation variants.

Tests:
- Add unit tests covering forward references, undefined names, placeholders, parse failures, route handling, stale registry entries, and the clean documentation tree.