### PR TITLE
Settle the three loose ends the fence sweep exposed

### DIFF
--- a/docs/devices/emission/sound-power.md
+++ b/docs/devices/emission/sound-power.md
@@ -71,8 +71,13 @@ pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
                                      "hemisphere", radius=2.0,
                                      frequencies=freqs)
 # ISO 9614-2: uniform normal intensity scanned over six 0.5 m2 segments.
+# In this free field Lp reads the intensity level, and the probe's
+# delta_pI0 = 18 dB makes the clause 10.6 b screening evaluable.
 i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+lp = np.tile(lw_true - 10.0 * np.log10(3.0), (6, 1))
 inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       pressure_levels=lp,
+                                       pressure_residual_index=18.0,
                                        frequencies=freqs, band_type="octave")
 # ISO 3741: comparison against a reference source of known LW = 84 dB per band.
 comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),

--- a/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
+++ b/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
@@ -142,7 +142,7 @@ definition, a 1 kHz tone at 60 dB,
 Fastl & Zwicker models; the normative Sottek-model fluctuation strength of
 ECMA-418-2 Clause 9 lives in [Sound Quality Metrics](sound-quality.md).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB of its Table 1 literature cross-check, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -169,8 +169,8 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-# Right panel, the signal model on the AM tone it was calibrated for:
-# 1 kHz at 70 dB, over the same modulation sweep.
+# Right panel, the signal model on the AM tone of its literature cross-check
+# (Osses 2016 Table 1): 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
 carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []

--- a/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
+++ b/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
@@ -142,7 +142,7 @@ definition, a 1 kHz tone at 60 dB,
 Fastl & Zwicker models; the normative Sottek-model fluctuation strength of
 ECMA-418-2 Clause 9 lives in [Sound Quality Metrics](sound-quality.md).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Fluctuation strength versus modulation frequency on a log axis: the closed-form AM broadband-noise curve and the AM-tone signal-model sweep both show a band-pass characteristic peaking at 4 Hz" width="82%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -152,31 +152,46 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import psychoacoustics
 
-# Exact closed form (Eq. 10.2), AM broadband noise at 60 dB, 100 % modulation:
+# Left panel, the two models on the same stimulus: AM broadband noise at
+# 60 dB, 100 % modulation.
+fs = 48000
 fmod = np.logspace(np.log10(0.5), np.log10(32.0), 240)
 f_bbn = [psychoacoustics.fluctuation_strength_am_noise(60.0, 1.0, fm) for fm in fmod]
 
-# Osses 2016 signal model on a 1 kHz / 70 dB AM tone over the same sweep:
-fs = 48000
+rng = np.random.default_rng(3)
+tn = np.arange(int(4.0 * fs)) / fs
+noise = rng.standard_normal(tn.size)
+fm_noise = [0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+f_noise = []
+for fm in fm_noise:
+    am = (1.0 + np.sin(2 * np.pi * fm * tn)) * noise
+    am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (60 / 20)
+    f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
+
+# Right panel, the signal model on the AM tone it was calibrated for:
+# 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
-carrier = np.sin(2 * np.pi * 1000 * t)
-fm_tone = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []
-for fm in fm_tone:
+for fm in fm_noise:
     am = (1.0 + np.sin(2 * np.pi * fm * t)) * carrier
     am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (70 / 20)
     f_tone.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(max(f_tone), 2))   # 1.09, at the 4 Hz point
 
-fig, ax = plt.subplots()
-ax.semilogx(fmod, f_bbn, label="AM broadband noise (closed form)")
-ax2 = ax.twinx()
-ax2.plot(fm_tone, f_tone, "s--", color="tab:green", label="AM tone (signal model)")
+fig, (ax, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+ax.semilogx(fmod, f_bbn, label="closed form, Eq. 10.2")
+ax.semilogx(fm_noise, f_noise, "s--", label="Osses 2016 signal model")
 ax.axvline(4.0, ls="--", color="0.4")
 ax.set_xlabel("Modulation frequency f_mod [Hz]")
 ax.set_ylabel("Fluctuation strength F [vacil]")
-h1, l1 = ax.get_legend_handles_labels()
-h2, l2 = ax2.get_legend_handles_labels()
-ax.legend(h1 + h2, l1 + l2, loc="upper right")
+ax.set_title("Both models, AM broadband noise at 60 dB")
+ax.legend(loc="upper right")
+ax2.semilogx(fm_noise, f_tone, "s--", color="tab:green")
+ax2.axvline(4.0, ls="--", color="0.4")
+ax2.set_xlabel("Modulation frequency f_mod [Hz]")
+ax2.set_title("Signal model, AM tone at 70 dB")
 plt.show()
 ```
 

--- a/docs/signals/spectra/time-frequency.md
+++ b/docs/signals/spectra/time-frequency.md
@@ -136,13 +136,19 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
+import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
+     + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
+
 res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
-print(res.bin_spacing)                   # fs/N by default
-print(res.resolution_bandwidth)          # Be of the tapered record
+print(res.bin_spacing)                   # 1.0 (fs/N by default)
+print(res.resolution_bandwidth)          # 1.5 (Be of the tapered record)
 peak = res.amplitude.argmax()
-print(res.frequencies[peak], res.amplitude[peak])
+print(res.frequencies[peak], res.amplitude[peak])   # 997.0 0.8, the stronger tone
 res.plot()                               # power spectrum in dB over the band
 ```
 

--- a/docs/signals/spectra/time-frequency.md
+++ b/docs/signals/spectra/time-frequency.md
@@ -140,7 +140,7 @@ import numpy as np
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 
@@ -171,7 +171,7 @@ from scipy import signal
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17597,8 +17597,13 @@ pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
                                      "hemisphere", radius=2.0,
                                      frequencies=freqs)
 # ISO 9614-2: uniform normal intensity scanned over six 0.5 m2 segments.
+# In this free field Lp reads the intensity level, and the probe's
+# delta_pI0 = 18 dB makes the clause 10.6 b screening evaluable.
 i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+lp = np.tile(lw_true - 10.0 * np.log10(3.0), (6, 1))
 inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       pressure_levels=lp,
+                                       pressure_residual_index=18.0,
                                        frequencies=freqs, band_type="octave")
 # ISO 3741: comparison against a reference source of known LW = 84 dB per band.
 comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),
@@ -31817,7 +31822,7 @@ definition, a 1 kHz tone at 60 dB,
 Fastl & Zwicker models; the normative Sottek-model fluctuation strength of
 ECMA-418-2 Clause 9 lives in [Sound Quality Metrics](https://jmrplens.github.io/phonometry/perception/psychoacoustics/sound-quality/).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Fluctuation strength versus modulation frequency on a log axis: the closed-form AM broadband-noise curve and the AM-tone signal-model sweep both show a band-pass characteristic peaking at 4 Hz" width="82%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -31827,31 +31832,46 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import psychoacoustics
 
-# Exact closed form (Eq. 10.2), AM broadband noise at 60 dB, 100 % modulation:
+# Left panel, the two models on the same stimulus: AM broadband noise at
+# 60 dB, 100 % modulation.
+fs = 48000
 fmod = np.logspace(np.log10(0.5), np.log10(32.0), 240)
 f_bbn = [psychoacoustics.fluctuation_strength_am_noise(60.0, 1.0, fm) for fm in fmod]
 
-# Osses 2016 signal model on a 1 kHz / 70 dB AM tone over the same sweep:
-fs = 48000
+rng = np.random.default_rng(3)
+tn = np.arange(int(4.0 * fs)) / fs
+noise = rng.standard_normal(tn.size)
+fm_noise = [0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+f_noise = []
+for fm in fm_noise:
+    am = (1.0 + np.sin(2 * np.pi * fm * tn)) * noise
+    am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (60 / 20)
+    f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
+
+# Right panel, the signal model on the AM tone it was calibrated for:
+# 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
-carrier = np.sin(2 * np.pi * 1000 * t)
-fm_tone = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []
-for fm in fm_tone:
+for fm in fm_noise:
     am = (1.0 + np.sin(2 * np.pi * fm * t)) * carrier
     am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (70 / 20)
     f_tone.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(max(f_tone), 2))   # 1.09, at the 4 Hz point
 
-fig, ax = plt.subplots()
-ax.semilogx(fmod, f_bbn, label="AM broadband noise (closed form)")
-ax2 = ax.twinx()
-ax2.plot(fm_tone, f_tone, "s--", color="tab:green", label="AM tone (signal model)")
+fig, (ax, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+ax.semilogx(fmod, f_bbn, label="closed form, Eq. 10.2")
+ax.semilogx(fm_noise, f_noise, "s--", label="Osses 2016 signal model")
 ax.axvline(4.0, ls="--", color="0.4")
 ax.set_xlabel("Modulation frequency f_mod [Hz]")
 ax.set_ylabel("Fluctuation strength F [vacil]")
-h1, l1 = ax.get_legend_handles_labels()
-h2, l2 = ax2.get_legend_handles_labels()
-ax.legend(h1 + h2, l1 + l2, loc="upper right")
+ax.set_title("Both models, AM broadband noise at 60 dB")
+ax.legend(loc="upper right")
+ax2.semilogx(fm_noise, f_tone, "s--", color="tab:green")
+ax2.axvline(4.0, ls="--", color="0.4")
+ax2.set_xlabel("Modulation frequency f_mod [Hz]")
+ax2.set_title("Signal model, AM tone at 70 dB")
 plt.show()
 ```
 
@@ -48218,13 +48238,19 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
+import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
+     + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
+
 res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
-print(res.bin_spacing)                   # fs/N by default
-print(res.resolution_bandwidth)          # Be of the tapered record
+print(res.bin_spacing)                   # 1.0 (fs/N by default)
+print(res.resolution_bandwidth)          # 1.5 (Be of the tapered record)
 peak = res.amplitude.argmax()
-print(res.frequencies[peak], res.amplitude[peak])
+print(res.frequencies[peak], res.amplitude[peak])   # 997.0 0.8, the stronger tone
 res.plot()                               # power spectrum in dB over the band
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -31822,7 +31822,7 @@ definition, a 1 kHz tone at 60 dB,
 Fastl & Zwicker models; the normative Sottek-model fluctuation strength of
 ECMA-418-2 Clause 9 lives in [Sound Quality Metrics](https://jmrplens.github.io/phonometry/perception/psychoacoustics/sound-quality/).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB of its Table 1 literature cross-check, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -31849,8 +31849,8 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-# Right panel, the signal model on the AM tone it was calibrated for:
-# 1 kHz at 70 dB, over the same modulation sweep.
+# Right panel, the signal model on the AM tone of its literature cross-check
+# (Osses 2016 Table 1): 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
 carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []
@@ -48242,7 +48242,7 @@ import numpy as np
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 
@@ -48273,7 +48273,7 @@ from scipy import signal
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 

--- a/scripts/figures/perception.py
+++ b/scripts/figures/perception.py
@@ -1644,7 +1644,7 @@ def generate_fluctuation_strength(output_dir: str) -> None:
     bbn_peak = int(np.argmax(f_bbn))
 
     # The Osses 2016 signal model on the same AM broadband noise, and on the
-    # AM tone it was calibrated for.
+    # 70 dB AM tone of its Table 1 literature cross-check.
     fm_noise, f_noise = _fluctuation_am_noise_sweep()
     fm_tone, f_tone = _fluctuation_am_tone_sweep()
     tone_peak = int(np.argmax(f_tone))
@@ -1735,7 +1735,7 @@ def generate_fluctuation_strength(output_dir: str) -> None:
         },
     )
 
-    # The stimulus the signal model was calibrated on, on its own axes.
+    # The 70 dB AM tone of the literature cross-check, on its own axes.
     ax2.semilogx(
         fm_tone,
         f_tone,

--- a/site/public/llms/llms-devices-emission.txt
+++ b/site/public/llms/llms-devices-emission.txt
@@ -175,8 +175,13 @@ pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
                                      "hemisphere", radius=2.0,
                                      frequencies=freqs)
 # ISO 9614-2: uniform normal intensity scanned over six 0.5 m2 segments.
+# In this free field Lp reads the intensity level, and the probe's
+# delta_pI0 = 18 dB makes the clause 10.6 b screening evaluable.
 i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+lp = np.tile(lw_true - 10.0 * np.log10(3.0), (6, 1))
 inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       pressure_levels=lp,
+                                       pressure_residual_index=18.0,
                                        frequencies=freqs, band_type="octave")
 # ISO 3741: comparison against a reference source of known LW = 84 dB per band.
 comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),

--- a/site/public/llms/llms-perception-psychoacoustics.txt
+++ b/site/public/llms/llms-perception-psychoacoustics.txt
@@ -2007,7 +2007,7 @@ definition, a 1 kHz tone at 60 dB,
 Fastl & Zwicker models; the normative Sottek-model fluctuation strength of
 ECMA-418-2 Clause 9 lives in [Sound Quality Metrics](https://jmrplens.github.io/phonometry/perception/psychoacoustics/sound-quality/).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Fluctuation strength versus modulation frequency on a log axis: the closed-form AM broadband-noise curve and the AM-tone signal-model sweep both show a band-pass characteristic peaking at 4 Hz" width="82%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -2017,31 +2017,46 @@ import matplotlib.pyplot as plt
 import numpy as np
 from phonometry import psychoacoustics
 
-# Exact closed form (Eq. 10.2), AM broadband noise at 60 dB, 100 % modulation:
+# Left panel, the two models on the same stimulus: AM broadband noise at
+# 60 dB, 100 % modulation.
+fs = 48000
 fmod = np.logspace(np.log10(0.5), np.log10(32.0), 240)
 f_bbn = [psychoacoustics.fluctuation_strength_am_noise(60.0, 1.0, fm) for fm in fmod]
 
-# Osses 2016 signal model on a 1 kHz / 70 dB AM tone over the same sweep:
-fs = 48000
+rng = np.random.default_rng(3)
+tn = np.arange(int(4.0 * fs)) / fs
+noise = rng.standard_normal(tn.size)
+fm_noise = [0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+f_noise = []
+for fm in fm_noise:
+    am = (1.0 + np.sin(2 * np.pi * fm * tn)) * noise
+    am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (60 / 20)
+    f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
+
+# Right panel, the signal model on the AM tone it was calibrated for:
+# 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
-carrier = np.sin(2 * np.pi * 1000 * t)
-fm_tone = [1.0, 2.0, 4.0, 8.0, 16.0, 32.0]
+carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []
-for fm in fm_tone:
+for fm in fm_noise:
     am = (1.0 + np.sin(2 * np.pi * fm * t)) * carrier
     am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (70 / 20)
     f_tone.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(max(f_tone), 2))   # 1.09, at the 4 Hz point
 
-fig, ax = plt.subplots()
-ax.semilogx(fmod, f_bbn, label="AM broadband noise (closed form)")
-ax2 = ax.twinx()
-ax2.plot(fm_tone, f_tone, "s--", color="tab:green", label="AM tone (signal model)")
+fig, (ax, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+ax.semilogx(fmod, f_bbn, label="closed form, Eq. 10.2")
+ax.semilogx(fm_noise, f_noise, "s--", label="Osses 2016 signal model")
 ax.axvline(4.0, ls="--", color="0.4")
 ax.set_xlabel("Modulation frequency f_mod [Hz]")
 ax.set_ylabel("Fluctuation strength F [vacil]")
-h1, l1 = ax.get_legend_handles_labels()
-h2, l2 = ax2.get_legend_handles_labels()
-ax.legend(h1 + h2, l1 + l2, loc="upper right")
+ax.set_title("Both models, AM broadband noise at 60 dB")
+ax.legend(loc="upper right")
+ax2.semilogx(fm_noise, f_tone, "s--", color="tab:green")
+ax2.axvline(4.0, ls="--", color="0.4")
+ax2.set_xlabel("Modulation frequency f_mod [Hz]")
+ax2.set_title("Signal model, AM tone at 70 dB")
 plt.show()
 ```
 

--- a/site/public/llms/llms-perception-psychoacoustics.txt
+++ b/site/public/llms/llms-perception-psychoacoustics.txt
@@ -2007,7 +2007,7 @@ definition, a 1 kHz tone at 60 dB,
 Fastl & Zwicker models; the normative Sottek-model fluctuation strength of
 ECMA-418-2 Clause 9 lives in [Sound Quality Metrics](https://jmrplens.github.io/phonometry/perception/psychoacoustics/sound-quality/).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB of its Table 1 literature cross-check, peaking at 1.09 vacil at 4 Hz" width="82%"></picture>
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -2034,8 +2034,8 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-# Right panel, the signal model on the AM tone it was calibrated for:
-# 1 kHz at 70 dB, over the same modulation sweep.
+# Right panel, the signal model on the AM tone of its literature cross-check
+# (Osses 2016 Table 1): 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
 carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []

--- a/site/public/llms/llms-signals-spectra.txt
+++ b/site/public/llms/llms-signals-spectra.txt
@@ -1162,7 +1162,7 @@ import numpy as np
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 
@@ -1193,7 +1193,7 @@ from scipy import signal
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 

--- a/site/public/llms/llms-signals-spectra.txt
+++ b/site/public/llms/llms-signals-spectra.txt
@@ -1158,13 +1158,19 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
+import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
+     + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
+
 res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
-print(res.bin_spacing)                   # fs/N by default
-print(res.resolution_bandwidth)          # Be of the tapered record
+print(res.bin_spacing)                   # 1.0 (fs/N by default)
+print(res.resolution_bandwidth)          # 1.5 (Be of the tapered record)
 peak = res.amplitude.argmax()
-print(res.frequencies[peak], res.amplitude[peak])
+print(res.frequencies[peak], res.amplitude[peak])   # 997.0 0.8, the stronger tone
 res.plot()                               # power spectrum in dB over the band
 ```
 

--- a/site/src/content/docs/devices/emission/sound-power.mdx
+++ b/site/src/content/docs/devices/emission/sound-power.mdx
@@ -123,8 +123,13 @@ pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
                                      "hemisphere", radius=2.0,
                                      frequencies=freqs)
 # ISO 9614-2: uniform normal intensity scanned over six 0.5 m2 segments.
+# In this free field Lp reads the intensity level, and the probe's
+# delta_pI0 = 18 dB makes the clause 10.6 b screening evaluable.
 i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+lp = np.tile(lw_true - 10.0 * np.log10(3.0), (6, 1))
 inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       pressure_levels=lp,
+                                       pressure_residual_index=18.0,
                                        frequencies=freqs, band_type="octave")
 # ISO 3741: comparison against a reference source of known LW = 84 dB per band.
 comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),

--- a/site/src/content/docs/es/devices/emission/sound-power.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power.mdx
@@ -132,8 +132,13 @@ pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
                                      "hemisphere", radius=2.0,
                                      frequencies=freqs)
 # ISO 9614-2: intensidad normal uniforme barrida sobre seis segmentos de 0.5 m2.
+# En este campo libre Lp lee el nivel de intensidad, y el delta_pI0 = 18 dB
+# de la sonda hace evaluable el cribado del apartado 10.6 b.
 i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+lp = np.tile(lw_true - 10.0 * np.log10(3.0), (6, 1))
 inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       pressure_levels=lp,
+                                       pressure_residual_index=18.0,
                                        frequencies=freqs, band_type="octave")
 # ISO 3741: comparación con una fuente de referencia de LW = 84 dB conocido por banda.
 comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),

--- a/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -270,14 +270,14 @@ ECMA-418-2), en vacil_HMS, está en
 ojo con que la unidad de esta página es el vacil y la de aquella el vacil_HMS,
 así que las dos no son el mismo número para el mismo sonido.
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_es.svg" alt="A la izquierda, la intensidad de fluctuación de forma cerrada y la del modelo de señal para el mismo ruido de banda ancha modulado en amplitud a 60 dB frente a la frecuencia de modulación, ambas de paso de banda en torno a 4 Hz, con el modelo de señal alcanzando 5,5 vacil frente a los 3,7 de la forma cerrada, un exceso de factor 1,5 a 4 Hz. A la derecha, el modelo de señal sobre el tono de 1 kHz a 70 dB modulado en amplitud para el que se calibró, con máximo de 1,09 vacil a 4 Hz" width="88%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_es.svg" alt="A la izquierda, la intensidad de fluctuación de forma cerrada y la del modelo de señal para el mismo ruido de banda ancha modulado en amplitud a 60 dB frente a la frecuencia de modulación, ambas de paso de banda en torno a 4 Hz, con el modelo de señal alcanzando 5,5 vacil frente a los 3,7 de la forma cerrada, un exceso de factor 1,5 a 4 Hz. A la derecha, el modelo de señal sobre el tono de 1 kHz a 70 dB modulado en amplitud de su contraste bibliográfico de la Tabla 1, con máximo de 1,09 vacil a 4 Hz" width="88%" />
 
 *Los dos modelos sobre el mismo estímulo, que es la comparación que el aviso de
 abajo convierte en regla. Los dos son pasos de banda centrados cerca de 4 Hz,
 pero sobre ruido de banda ancha AM el modelo de señal supera a la forma
 cerrada en alrededor de la mitad, porque acumula la modulación banda a banda a
-lo largo de todo el eje de Bark. Sobre el tono AM para el que se calibró, a la
-derecha, se porta bien.*
+lo largo de todo el eje de Bark. Sobre el tono AM a 70 dB de su contraste
+bibliográfico, a la derecha, se porta bien.*
 
 <details>
 <summary>Mostrar el código de esta figura</summary>
@@ -303,8 +303,9 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-# Panel derecho, el modelo de señal sobre el tono AM para el que se calibró:
-# 1 kHz a 70 dB, con el mismo barrido de modulación.
+# Panel derecho, el modelo de señal sobre el tono AM de su contraste
+# bibliográfico (Osses 2016, Tabla 1): 1 kHz a 70 dB, con el mismo barrido
+# de modulación.
 t = np.arange(int(2.0 * fs)) / fs
 carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []

--- a/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -303,13 +303,29 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-fig, ax = plt.subplots()
+# Panel derecho, el modelo de señal sobre el tono AM para el que se calibró:
+# 1 kHz a 70 dB, con el mismo barrido de modulación.
+t = np.arange(int(2.0 * fs)) / fs
+carrier = np.sin(2 * np.pi * 1000.0 * t)
+f_tone = []
+for fm in fm_noise:
+    am = (1.0 + np.sin(2 * np.pi * fm * t)) * carrier
+    am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (70 / 20)
+    f_tone.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(max(f_tone), 2))   # 1.09, en el punto de 4 Hz
+
+fig, (ax, ax2) = plt.subplots(1, 2, figsize=(12, 5))
 ax.semilogx(fmod, f_bbn, label="forma cerrada, Ec. 10.2")
 ax.semilogx(fm_noise, f_noise, "s--", label="modelo de señal de Osses 2016")
 ax.axvline(4.0, ls="--", color="0.4")
 ax.set_xlabel("Frecuencia de modulación f_mod [Hz]")
 ax.set_ylabel("Intensidad de fluctuación F [vacil]")
+ax.set_title("Los dos modelos, ruido de banda ancha AM a 60 dB")
 ax.legend(loc="upper right")
+ax2.semilogx(fm_noise, f_tone, "s--", color="tab:green")
+ax2.axvline(4.0, ls="--", color="0.4")
+ax2.set_xlabel("Frecuencia de modulación f_mod [Hz]")
+ax2.set_title("Modelo de señal, tono AM a 70 dB")
 plt.show()
 ```
 

--- a/site/src/content/docs/es/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/es/signals/spectra/time-frequency.mdx
@@ -242,13 +242,19 @@ ventana, así que una sinusoide de amplitud de pico $A$ sobre una frecuencia de
 análisis lee `amplitude` $= A$ y `power` $= A^2/2$ exactamente:
 
 ```python
+import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+t = np.arange(8192) / fs                 # registro de 1 s: resolución de 1 Hz
+x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
+     + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
+
 res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # malla a la resolución del registro
-print(res.bin_spacing)                   # fs/N por defecto
-print(res.resolution_bandwidth)          # Be del registro con ventana
+print(res.bin_spacing)                   # 1.0 (fs/N por defecto)
+print(res.resolution_bandwidth)          # 1.5 (Be del registro con ventana)
 peak = res.amplitude.argmax()
-print(res.frequencies[peak], res.amplitude[peak])
+print(res.frequencies[peak], res.amplitude[peak])   # 997.0 0.8, el tono más fuerte
 res.plot(language="es")                  # espectro de potencia en dB
 ```
 

--- a/site/src/content/docs/es/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/es/signals/spectra/time-frequency.mdx
@@ -246,7 +246,7 @@ import numpy as np
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # registro de 1 s: resolución de 1 Hz
+t = np.arange(8192) / fs                 # registro de 1 s: espaciado de bins de 1 Hz
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 
@@ -321,7 +321,7 @@ from scipy import signal
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # registro de 1 s: resolución de 1 Hz
+t = np.arange(8192) / fs                 # registro de 1 s: espaciado de bins de 1 Hz
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 

--- a/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -287,13 +287,29 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-fig, ax = plt.subplots()
+# Right panel, the signal model on the AM tone it was calibrated for:
+# 1 kHz at 70 dB, over the same modulation sweep.
+t = np.arange(int(2.0 * fs)) / fs
+carrier = np.sin(2 * np.pi * 1000.0 * t)
+f_tone = []
+for fm in fm_noise:
+    am = (1.0 + np.sin(2 * np.pi * fm * t)) * carrier
+    am = am / np.sqrt(np.mean(am ** 2)) * 2e-5 * 10 ** (70 / 20)
+    f_tone.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
+print(round(max(f_tone), 2))   # 1.09, at the 4 Hz point
+
+fig, (ax, ax2) = plt.subplots(1, 2, figsize=(12, 5))
 ax.semilogx(fmod, f_bbn, label="closed form, Eq. 10.2")
 ax.semilogx(fm_noise, f_noise, "s--", label="Osses 2016 signal model")
 ax.axvline(4.0, ls="--", color="0.4")
 ax.set_xlabel("Modulation frequency f_mod [Hz]")
 ax.set_ylabel("Fluctuation strength F [vacil]")
+ax.set_title("Both models, AM broadband noise at 60 dB")
 ax.legend(loc="upper right")
+ax2.semilogx(fm_noise, f_tone, "s--", color="tab:green")
+ax2.axvline(4.0, ls="--", color="0.4")
+ax2.set_xlabel("Modulation frequency f_mod [Hz]")
+ax2.set_title("Signal model, AM tone at 70 dB")
 plt.show()
 ```
 

--- a/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -255,13 +255,13 @@ in [Sound Quality Metrics](/phonometry/perception/psychoacoustics/sound-quality/
 note that this page's unit is the vacil and that one the vacil_HMS, so the two
 are not the same number for the same sound.
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB it was calibrated for, peaking at 1.09 vacil at 4 Hz" width="88%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Left: the closed-form and signal-model fluctuation strength of the same amplitude-modulated broadband noise at 60 dB against modulation frequency, both band-pass around 4 Hz, the signal model peaking at 5.5 vacil against the closed form's 3.7, a factor 1.5 overshoot at 4 Hz. Right: the signal model on the amplitude-modulated 1 kHz tone at 70 dB of its Table 1 literature cross-check, peaking at 1.09 vacil at 4 Hz" width="88%" />
 
 *The two models on the same stimulus, which is the comparison the caution box
 below turns into a rule. Both are band-passes centred near 4 Hz, but on AM
 broadband noise the signal model overshoots the closed form by about half
 again, because it accumulates modulation band by band across the whole Bark
-axis. On the AM tone it was calibrated for, right, it behaves.*
+axis. On the 70 dB AM tone of its literature cross-check, right, it behaves.*
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -287,8 +287,8 @@ for fm in fm_noise:
     f_noise.append(psychoacoustics.fluctuation_strength(am, float(fs)).fluctuation_strength)
 print(round(f_noise[3], 1), round(f_bbn[np.argmin(np.abs(fmod - 4.0))], 1))   # 5.5 3.7
 
-# Right panel, the signal model on the AM tone it was calibrated for:
-# 1 kHz at 70 dB, over the same modulation sweep.
+# Right panel, the signal model on the AM tone of its literature cross-check
+# (Osses 2016 Table 1): 1 kHz at 70 dB, over the same modulation sweep.
 t = np.arange(int(2.0 * fs)) / fs
 carrier = np.sin(2 * np.pi * 1000.0 * t)
 f_tone = []

--- a/site/src/content/docs/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/signals/spectra/time-frequency.mdx
@@ -224,13 +224,19 @@ the taper's coherent gain, so a sine of peak amplitude $A$ on an analysis
 frequency reads `amplitude` $= A$ and `power` $= A^2/2$ exactly:
 
 ```python
+import numpy as np
 from phonometry import signals
 
+fs = 8192.0
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
+     + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
+
 res = signals.zoom_fft(x, fs, f_min=980.0, f_max=1016.0)     # grid at the record resolution
-print(res.bin_spacing)                   # fs/N by default
-print(res.resolution_bandwidth)          # Be of the tapered record
+print(res.bin_spacing)                   # 1.0 (fs/N by default)
+print(res.resolution_bandwidth)          # 1.5 (Be of the tapered record)
 peak = res.amplitude.argmax()
-print(res.frequencies[peak], res.amplitude[peak])
+print(res.frequencies[peak], res.amplitude[peak])   # 997.0 0.8, the stronger tone
 res.plot()                               # power spectrum in dB over the band
 ```
 

--- a/site/src/content/docs/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/signals/spectra/time-frequency.mdx
@@ -228,7 +228,7 @@ import numpy as np
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 
@@ -297,7 +297,7 @@ from scipy import signal
 from phonometry import signals
 
 fs = 8192.0
-t = np.arange(8192) / fs                 # 1 s record: 1 Hz resolution
+t = np.arange(8192) / fs                 # 1 s record: 1 Hz bin spacing
 x = (0.8 * np.cos(2.0 * np.pi * 997.0 * t)
      + 0.5 * np.cos(2.0 * np.pi * 1000.0 * t))
 


### PR DESCRIPTION
Three loose ends the fence-order sweep surfaced and its verifiers documented, each proven by execution before and after.

The fluctuation-strength figure fences catch up with the two-panel figure the pages embed. The generator draws both models on AM broadband noise on the left and the signal model on the AM tone it was calibrated for on the right; the page fences drew only the left panel (and the GitHub mirror still drew the retired single-axis version, under an alt text describing it). All three twins now carry the two-panel fence, and the mirror's alt describes what the image shows. The printed anchors were re-measured before annotating: 5.5 against 3.7 vacil at 4 Hz on the left, a 1.09 vacil peak at 4 Hz on the right.

The zoom-FFT example owns the record its section describes. Read top to bottom it zoomed the spectrogram section's 16 kHz siren over 980-1016 Hz, printing a meaningless 1007 Hz peak; its own section opens with two tones 3 Hz apart that an 8 Hz-bin FFT cannot separate. The fence now builds that record, the same 997/1000 Hz pair its figure uses, and its prints are annotated with the measured values: 1.0 Hz bin spacing, 1.5 Hz resolution bandwidth, and the stronger tone read at exactly 997.0 and 0.8, which is the calibration the prose promises.

The sound-power comparison stops warning on its own first route. The intensity scan passed no pressure levels, so every run emitted the SoundPowerWarning about the missing ISO 9614-2 clause 10.6 b screening. In this free-field example the pressure level reads the intensity level, so the fence now passes the segment Lp and a probe residual index of 18 dB, the screening is evaluable, no band is omitted, and the A-weighted total is unchanged to the last digit (93.2059 dB before and after).

All three pages execute end to end, the fence gate reads the tree in order, the static snippet checks pass, and the llms artifacts are regenerated.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated sound power documentation to include pressure level calculations for ISO 9614-2 screening.</li>
<li>Refactored psychoacoustic annoyance documentation figure code to compare closed-form and signal models for AM broadband noise and AM tones.</li>
<li>Updated documentation figures and code examples for time-frequency analysis.</li>
<li>Updated various LLM context files and MDX documentation files to reflect these changes.</li>
</ul></div>

## Summary by Sourcery

Synchronize documentation examples and generated figures with their validated executions, resolving inaccurate results and warning-producing inputs.

Bug Fixes:
- Align fluctuation-strength documentation figures, embedded pages, and mirror metadata with the generated two-panel comparison.
- Correct the zoom-FFT example to analyze and report the two tones described by its section.
- Provide pressure levels and residual screening inputs in the sound-power example to eliminate the ISO 9614-2 warning without changing its result.

Enhancements:
- Regenerate synchronized LLM context artifacts and update English and Spanish documentation examples and annotations.

Documentation:
- Update psychoacoustic annoyance documentation with the corrected two-panel fluctuation-strength comparison and measured reference values.
- Clarify zoom-FFT bin spacing, resolution bandwidth, and peak results in time-frequency documentation.
- Document pressure-level screening inputs for the sound-power comparison example in English and Spanish.

Tests:
- Verify all three documentation pages execute end to end, pass fence and static snippet checks, and preserve the sound-power total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved the ISO 9614-2 sound power example with pressure-level screening inputs.
  - Updated fluctuation-strength visuals to compare broadband noise and AM tone results in two panels.
  - Made the zoom FFT example self-contained, with clearer resolution values and expected peak output.
  - Synchronized these documentation updates across translated and generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->