### PR TITLE
Skip the mirror on pushes that cannot carry its key

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -35,7 +35,13 @@ jobs:
   repository:
     name: Mirror repository
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Pushes made by Dependabot run with Dependabot secrets, not Actions
+    # secrets, so the SSH key below arrives empty and the guard fails the
+    # job on every dependabot/* branch. Skip those pushes: the merge commit
+    # on main and the six-hourly schedule keep the mirror current.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Configure GitLab SSH key
         env:


### PR DESCRIPTION
## What

The GitLab mirror workflow triggers on every branch push, but pushes made by Dependabot run with Dependabot secrets instead of Actions secrets, so `GITLAB_MIRROR_SSH_KEY` arrives empty and the job's own guard fails it. Every Dependabot PR therefore shows a red "Mirror repository" check that has nothing to do with the update under review (#653 and #654 both carry one today).

This adds `github.actor != 'dependabot[bot]'` to the job's condition so those pushes skip the job instead of failing it. Nothing is lost: the mirror pushes every ref from a fresh clone, so the merge commit on main and the six-hourly schedule keep GitLab current, exactly as they already do for any branch pushed between schedule ticks.

The releases job is untouched; it never ran on branch pushes in the first place.

## Validation

- YAML parses.
- The skip condition reproduces the documented behaviour of Dependabot-triggered workflow runs: they receive the Dependabot secret store, where this key does not exist.
- After merge, a `@dependabot rebase` on #653/#654 will re-trigger their pushes and the job should show as skipped there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

