### PR TITLE
Guard the whole class of comma decimals, not one message's number

### DIFF
--- a/src/phonometry/building/measurement/heavy_impact.py
+++ b/src/phonometry/building/measurement/heavy_impact.py
@@ -503,7 +503,7 @@ def check_heavy_impact_source(
     if measured.shape != (n,):
         msg = (
             f"'force_exposure_level' must hold {n} octave-band values "
-            f"(31,5 Hz to 500 Hz)."
+            f"(31.5 Hz to 500 Hz)."
         )
         raise ValueError(msg)
     nominal = np.asarray(spec.force_exposure_level, dtype=np.float64)

--- a/src/phonometry/emission/sound_power_in_duct.py
+++ b/src/phonometry/emission/sound_power_in_duct.py
@@ -864,7 +864,7 @@ def _check_informative_bands(frequencies: np.ndarray, flow_velocity: float) -> N
     msg = (
         f"'flow_velocity' must satisfy |U| <= {limit:g} m/s for the "
         "one-third-octave bands above 10 kHz: ISO 5136 Annex A gives the "
-        "12,5 kHz to 20 kHz coefficients for that range only (the band "
+        "12.5 kHz to 20 kHz coefficients for that range only (the band "
         f"header and footnote of Tables A.1 to A.6); got {flow_velocity:g} "
         f"m/s with {above[0]:g} Hz in 'frequencies'."
     )

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -774,7 +774,7 @@ def sti_from_impulse_response(
     if fs < _MIN_FS:
         msg = (
             f"Sample rate 'fs' must be >= {_MIN_FS} Hz: the 8 kHz octave band "
-            "extends to 11,2 kHz (IEC 61260-1)."
+            "extends to 11.2 kHz (IEC 61260-1)."
         )
         raise ValueError(msg)
     if not np.any(ir_proc):
@@ -975,7 +975,7 @@ def stipa(
     if fs < _MIN_FS:
         msg = (
             f"Sample rate 'fs' must be >= {_MIN_FS} Hz: the 8 kHz octave band "
-            "extends to 11,2 kHz (IEC 61260-1)."
+            "extends to 11.2 kHz (IEC 61260-1)."
         )
         raise ValueError(msg)
 
@@ -1048,7 +1048,7 @@ def stipa_signal(
     if fs < _MIN_FS:
         msg = (
             f"Sample rate 'fs' must be >= {_MIN_FS} Hz: the 8 kHz half-octave "
-            "carrier extends beyond 9,4 kHz."
+            "carrier extends beyond 9.4 kHz."
         )
         raise ValueError(msg)
     if seconds <= 0:

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -441,7 +441,8 @@ def test_no_error_message_carries_a_comma_decimal() -> None:
     """
     offenders: list[str] = []
     for path in sorted(Path("src/phonometry").rglob("*.py")):
-        for number, line in enumerate(path.read_text().splitlines(), 1):
+        text = path.read_text(encoding="utf-8")
+        for number, line in enumerate(text.splitlines(), 1):
             stripped = line.strip()
             if not stripped.startswith("msg = "):
                 continue

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -421,6 +421,31 @@ def test_no_public_name_is_published_by_two_domains() -> None:
     assert not shared, f"names published by more than one domain: {shared}"
 
 
+def _message_text(node: ast.Assign) -> str | None:
+    """The literal text of a ``msg = ...`` assignment, or ``None``.
+
+    Refusals are written as one assignment and raised on the next line, and
+    most of them are parenthesised over several lines, which the parser has
+    already folded into a single constant. An f-string keeps only its literal
+    runs: what an interpolation puts there is not visible statically.
+    """
+    if len(node.targets) != 1:
+        return None
+    target = node.targets[0]
+    if not isinstance(target, ast.Name) or target.id != "msg":
+        return None
+    value = node.value
+    if isinstance(value, ast.Constant):
+        return value.value if isinstance(value.value, str) else None
+    if isinstance(value, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in value.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return None
+
+
 def test_no_error_message_carries_a_comma_decimal() -> None:
     """Error messages are English prose, and English prose takes a point.
 
@@ -435,19 +460,28 @@ def test_no_error_message_carries_a_comma_decimal() -> None:
     edition of a figure and a comma inside ``$...$`` sets with the wrong
     spacing. An error message is neither drawn nor translated.
 
-    Prose that quotes a standard's own notation is a different matter and
-    keeps the separator of the source it cites, which is why this reads the
-    ``msg`` assignments the tree raises from rather than every string in it.
+    This reads the ``msg`` assignments a module raises from, and reads them
+    through the parser rather than line by line: nearly every refusal here is
+    a parenthesised string spanning several lines, and a scan that saw only
+    the ``msg = (`` line saw none of the text.
+
+    A comma between digits is a decimal only when a letter does not precede
+    it. Subscript pairs are written the same way and are notation rather than
+    numbers, so ``k2,1`` and ``F2,b`` stay as they are while ``31,5 Hz``
+    does not.
     """
     offenders: list[str] = []
     for path in sorted(Path("src/phonometry").rglob("*.py")):
-        text = path.read_text(encoding="utf-8")
-        for number, line in enumerate(text.splitlines(), 1):
-            stripped = line.strip()
-            if not stripped.startswith("msg = "):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
                 continue
-            if re.search(r"\d,\d", stripped):
-                offenders.append(f"{path}:{number}  {stripped}")
+            text = _message_text(node)
+            if text is None:
+                continue
+            found = re.search(r"(?<![A-Za-z])\d,\d", text)
+            if found:
+                offenders.append(f"{path}:{node.lineno}  ...{found.group(0)}...")
     assert not offenders, "comma decimal in an English message:\n" + "\n".join(
         offenders
     )

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -10,6 +10,7 @@ an edge is an explicit, reviewed decision.
 from __future__ import annotations
 
 import ast
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -418,3 +419,34 @@ def test_no_public_name_is_published_by_two_domains() -> None:
 
     shared = {name: owners for name, owners in published.items() if len(owners) > 1}
     assert not shared, f"names published by more than one domain: {shared}"
+
+
+def test_no_error_message_carries_a_comma_decimal() -> None:
+    """Error messages are English prose, and English prose takes a point.
+
+    The library writes its own numbers into refusals: a temperature floor at
+    absolute zero, the thermodynamic bound on a Poisson ratio. Seven of them
+    had drifted to a comma, four of them the same -273,15, while eleven
+    comparable messages used a point and one of the two spellings of the same
+    0.5 sat in each camp.
+
+    Nothing could see it. The figure gate that does police decimal commas
+    reads drawn labels, not exceptions, because its subject is the Spanish
+    edition of a figure and a comma inside ``$...$`` sets with the wrong
+    spacing. An error message is neither drawn nor translated.
+
+    Prose that quotes a standard's own notation is a different matter and
+    keeps the separator of the source it cites, which is why this reads the
+    ``msg`` assignments the tree raises from rather than every string in it.
+    """
+    offenders: list[str] = []
+    for path in sorted(Path("src/phonometry").rglob("*.py")):
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if not stripped.startswith("msg = "):
+                continue
+            if re.search(r"\d,\d", stripped):
+                offenders.append(f"{path}:{number}  {stripped}")
+    assert not offenders, "comma decimal in an English message:\n" + "\n".join(
+        offenders
+    )


### PR DESCRIPTION
## What and why

The library writes its own numbers into the refusals it raises: a temperature floor at absolute zero, the thermodynamic bound on a Poisson ratio. Those messages are English prose, and English prose takes a point. Seven of them had drifted to a comma, four of them the same `-273,15`, while eleven comparable messages used a point and the two spellings of the same `0.5` sat one in each camp.

The messages themselves were put right some time ago. What never landed is the check that stops them drifting back, and this is that check and nothing else: `pytest -q` is green on `main` before it and after it.

## Why nothing caught it

The gate that does police decimal commas, `scripts/check_decimal_comma.py`, reads the string literals a figure draws, because its subject is the Spanish edition of a figure and a bare comma inside `$...$` sets with the wrong spacing. An error message is neither drawn nor translated, so it falls outside that gate entirely, and no other check reads exception text.

It is not a hypothetical drift either. Two comma decimals in English prose were caught by review this week, in text a person had written by hand.

## What it reads, and what it deliberately does not

Only the `msg = ` assignments the tree raises from. Prose that quotes a standard's own notation keeps the separator of the source it cites, which is the rule the errata registry follows, so a check over every string in the tree would fight that convention instead of serving it.

## Validation

Proved in both directions before this was pushed:

- Green on `main` as it stands: the class it guards is currently empty, zero offenders across `src/phonometry`.
- Red on the defect it exists for: injecting `at -273,15 degC` into one refusal in `emission/sound_power_in_situ.py` fails the test, naming the file, the line and the message. Reverted, green again.

## Checklist

- [x] `ruff check .`, `ruff format --check`
- [x] `mypy src scripts`
- [x] `pytest -q tests/test_package_architecture.py`
- [x] No new API, no regenerated artefact, no documentation change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new test case `test_no_error_message_carries_a_comma_decimal` to enforce decimal point usage in error messages.</li>
<li>The new test scans `src/phonometry` for `msg = ` assignments containing decimal commas and asserts they are absent.</li>
</ul></div>

## Summary by Sourcery

Prevent comma decimal notation from returning to English error messages by enforcing decimal-point usage across refusal text.

Bug Fixes:
- Replace comma decimal separators in English error messages with decimal points.

Enhancements:
- Add an architecture test that statically checks `msg` assignments for comma decimals while preserving notation such as subscript pairs.

Tests:
- Extend package architecture tests to detect decimal commas in exception messages and report their source locations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an architecture check to detect English error messages using comma-decimal notation.
  * The check scans source files consistently using UTF-8 encoding, helping prevent inconsistent decimal formatting in user-visible error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->