### PR TITLE
Say which unit ISO 3747 prints, and which one the family uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -657,9 +657,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   says so. It is alone in the ISO 3740 family in doing so: ISO 3741:2010,
   ISO 3744:2010 and ISO 3745:2012 all print kilopascals, and
   `sound_power_in_situ` follows those three so that one unit serves the whole
-  family. Nothing moves, because C2 depends only on the ratio ps/ps,0. What
-  changes is that a reader comparing the docstring with the printed page is
-  told which is which instead of finding an unexplained unit.
+  family. Nothing moves: C2 carries a pressure term and a temperature term,
+  and the pressure enters only as the ratio ps/ps,0, so converting both
+  together leaves the correction alone. What changes is that a reader
+  comparing the docstring with the printed page is told which is which
+  instead of finding an unexplained unit.
 
 - The air behind ISO 9053-2's thermal correction is the air IEC 61094-2:2009
   actually publishes. `thermal_boundary_layer_thickness` and `effective_kappa`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -653,6 +653,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- ISO 3747's Annex C prints its static pressure in pascals, and the library
+  says so. It is alone in the ISO 3740 family in doing so: ISO 3741:2010,
+  ISO 3744:2010 and ISO 3745:2012 all print kilopascals, and
+  `sound_power_in_situ` follows those three so that one unit serves the whole
+  family. Nothing moves, because C2 depends only on the ratio ps/ps,0. What
+  changes is that a reader comparing the docstring with the printed page is
+  told which is which instead of finding an unexplained unit.
+
 - The air behind ISO 9053-2's thermal correction is the air IEC 61094-2:2009
   actually publishes. `thermal_boundary_layer_thickness` and `effective_kappa`
   defaulted to the five properties ISO 9053-2:2020 Annex A.3 prints, which that

--- a/site/src/content/docs/reference/api/power/sound-power-in-situ.md
+++ b/site/src/content/docs/reference/api/power/sound-power-in-situ.md
@@ -305,7 +305,7 @@ time-averaged, over 30 s (7.6), exactly as for a steady source.
 | `background_levels_ref` | Background for the reference-source measurement; `None` reuses `background_levels` (7.5). |
 | `integration_time` | The integration time `T` of the event measurement, in seconds. `None` applies Eq. (14) as printed, subtracting the time-averaged background from the single event level; a value carries the background to the same interval first, $L_{pi(\mathrm{B})} + 10 \log_{10}(T/T_0)$ with `T0` = 1 s (3.4, NOTE 1), so that the margin compares like with like. The two coincide at `T` = 1 s. |
 | `temperature` | Air temperature at the test, in degrees Celsius. |
-| `static_pressure` | Static pressure at the test, in kilopascals. |
+| `static_pressure` | Static pressure at the test, in kilopascals, as for [`sound_power_in_situ`](/phonometry/reference/api/power/sound-power-in-situ/#sound_power_in_situ); Annex C itself prints pascals. |
 | `conditions` | The [`GradeConditions`](/phonometry/reference/api/power/sound-power-in-situ/#gradeconditions) of the determination, as for [`sound_power_in_situ`](/phonometry/reference/api/power/sound-power-in-situ/#sound_power_in_situ). |
 | `sigma_omc` | Operating-and-mounting standard deviation, in decibels. |
 | `coverage_factor` | `k` of Eq. (23), 2 by default. |
@@ -367,7 +367,7 @@ conditions of Annex C, and `sound_power_level_a` is the Annex D total.
 | `background_levels` | Octave-band time-averaged background levels `Lpi(B)`, `(n, bands)` or one `(bands,)` spectrum for every position, in decibels; `None` applies no correction, warns, and leaves `background_requirement_met` `False` in every band, since 7.5 has the background measured at each position and 8.1 needs the margin to declare the measurement valid. |
 | `background_levels_ref` | Background for the reference-source measurement, same shapes; `None` reuses `background_levels`, since the procedure takes one background reading (7.5). |
 | `temperature` | Air temperature at the test, in degrees Celsius. |
-| `static_pressure` | Static pressure at the test, in kilopascals (see [`static_pressure_from_altitude`](/phonometry/reference/api/power/sound-power-in-situ/#static_pressure_from_altitude)). |
+| `static_pressure` | Static pressure at the test, in kilopascals (see [`static_pressure_from_altitude`](/phonometry/reference/api/power/sound-power-in-situ/#static_pressure_from_altitude)). Annex C prints this quantity in pascals, with $p_{\mathrm{s},0}$ = 1,013 25 x 10^5 Pa, and is alone in its family in doing so: ISO 3741:2010, ISO 3744:2010 and ISO 3745:2012 all print kilopascals. This argument follows the three, so that one unit serves the whole ISO 3740 family; `C2` depends only on the ratio $p_\mathrm{s}/p_{\mathrm{s},0}$, so the choice cannot move a result. |
 | `conditions` | The [`GradeConditions`](/phonometry/reference/api/power/sound-power-in-situ/#gradeconditions) Table 2 reads to decide the accuracy grade: the excess of sound pressure level at each microphone position (Annex A) and the range of the directivity survey of the source (7.2). `None`, or either condition left out, leaves the determination at survey grade. |
 | `sigma_omc` | Standard deviation of the operating and mounting conditions of the source (9.2, E.3), in decibels; `None` leaves `sigma_tot` and the expanded uncertainty `NaN`. |
 | `coverage_factor` | `k` of Eq. (23): 2 for the two-sided 95 % interval (default), 1,6 for a one-sided comparison with a limit. |
@@ -393,9 +393,11 @@ $$
 p_\mathrm{s} = p_{\mathrm{s},0}\,(1 - a H_\mathrm{a})^{b}, \qquad a = 2{,}2560 \times 10^{-5}\ \mathrm{m}^{-1}, \quad b = 5{,}255\,3
 $$
 
-with $p_{\mathrm{s},0}$ = 101,325 kPa. The result is in kilopascals
-so that it feeds `static_pressure` of [`sound_power_in_situ`](/phonometry/reference/api/power/sound-power-in-situ/#sound_power_in_situ)
-directly. A site below sea level is admissible (the base exceeds one);
+Annex C prints $p_{\mathrm{s},0}$ = 1,013 25 x 10^5 Pa and states
+the quantity in pascals. The result here is in kilopascals so that it feeds
+`static_pressure` of [`sound_power_in_situ`](/phonometry/reference/api/power/sound-power-in-situ/#sound_power_in_situ) directly, matching
+ISO 3741, ISO 3744 and ISO 3745, which do print kilopascals; the ratio the
+correction uses is the same either way. A site below sea level is admissible (the base exceeds one);
 the formula stops meaning anything where the base reaches zero, some
 44 km up, and that is refused.
 

--- a/site/src/content/docs/reference/api/power/sound-power-in-situ.md
+++ b/site/src/content/docs/reference/api/power/sound-power-in-situ.md
@@ -367,7 +367,7 @@ conditions of Annex C, and `sound_power_level_a` is the Annex D total.
 | `background_levels` | Octave-band time-averaged background levels `Lpi(B)`, `(n, bands)` or one `(bands,)` spectrum for every position, in decibels; `None` applies no correction, warns, and leaves `background_requirement_met` `False` in every band, since 7.5 has the background measured at each position and 8.1 needs the margin to declare the measurement valid. |
 | `background_levels_ref` | Background for the reference-source measurement, same shapes; `None` reuses `background_levels`, since the procedure takes one background reading (7.5). |
 | `temperature` | Air temperature at the test, in degrees Celsius. |
-| `static_pressure` | Static pressure at the test, in kilopascals (see [`static_pressure_from_altitude`](/phonometry/reference/api/power/sound-power-in-situ/#static_pressure_from_altitude)). Annex C prints this quantity in pascals, with $p_{\mathrm{s},0}$ = 1,013 25 x 10^5 Pa, and is alone in its family in doing so: ISO 3741:2010, ISO 3744:2010 and ISO 3745:2012 all print kilopascals. This argument follows the three, so that one unit serves the whole ISO 3740 family; `C2` depends only on the ratio $p_\mathrm{s}/p_{\mathrm{s},0}$, so the choice cannot move a result. |
+| `static_pressure` | Static pressure at the test, in kilopascals (see [`static_pressure_from_altitude`](/phonometry/reference/api/power/sound-power-in-situ/#static_pressure_from_altitude)). Annex C prints this quantity in pascals, with $p_{\mathrm{s},0}$ = 1,013 25 x 10^5 Pa, and is alone in its family in doing so: ISO 3741:2010, ISO 3744:2010 and ISO 3745:2012 all print kilopascals. This argument follows the three, so that one unit serves the whole ISO 3740 family; `C2` carries a pressure term and a temperature term, and the pressure enters only as the ratio $p_\mathrm{s}/p_{\mathrm{s},0}$, so converting both together cannot move a result. |
 | `conditions` | The [`GradeConditions`](/phonometry/reference/api/power/sound-power-in-situ/#gradeconditions) Table 2 reads to decide the accuracy grade: the excess of sound pressure level at each microphone position (Annex A) and the range of the directivity survey of the source (7.2). `None`, or either condition left out, leaves the determination at survey grade. |
 | `sigma_omc` | Standard deviation of the operating and mounting conditions of the source (9.2, E.3), in decibels; `None` leaves `sigma_tot` and the expanded uncertainty `NaN`. |
 | `coverage_factor` | `k` of Eq. (23): 2 for the two-sided 95 % interval (default), 1,6 for a one-sided comparison with a limit. |
@@ -396,8 +396,9 @@ $$
 Annex C prints $p_{\mathrm{s},0}$ = 1,013 25 x 10^5 Pa and states
 the quantity in pascals. The result here is in kilopascals so that it feeds
 `static_pressure` of [`sound_power_in_situ`](/phonometry/reference/api/power/sound-power-in-situ/#sound_power_in_situ) directly, matching
-ISO 3741, ISO 3744 and ISO 3745, which do print kilopascals; the ratio the
-correction uses is the same either way. A site below sea level is admissible (the base exceeds one);
+ISO 3741, ISO 3744 and ISO 3745, which do print kilopascals. The pressure
+reaches `C2` only as $p_\mathrm{s}/p_{\mathrm{s},0}$, so the two
+unit conventions give the same correction. A site below sea level is admissible (the base exceeds one);
 the formula stops meaning anything where the base reaches zero, some
 44 km up, and that is refused.
 

--- a/src/phonometry/emission/sound_power_in_situ.py
+++ b/src/phonometry/emission/sound_power_in_situ.py
@@ -320,9 +320,11 @@ def static_pressure_from_altitude(altitude: float) -> float:
        \qquad a = 2{,}2560 \times 10^{-5}\ \mathrm{m}^{-1},
        \quad b = 5{,}255\,3
 
-    with :math:`p_{\mathrm{s},0}` = 101,325 kPa. The result is in kilopascals
-    so that it feeds ``static_pressure`` of :func:`sound_power_in_situ`
-    directly. A site below sea level is admissible (the base exceeds one);
+    Annex C prints :math:`p_{\mathrm{s},0}` = 1,013 25 x 10^5 Pa and states
+    the quantity in pascals. The result here is in kilopascals so that it feeds
+    ``static_pressure`` of :func:`sound_power_in_situ` directly, matching
+    ISO 3741, ISO 3744 and ISO 3745, which do print kilopascals; the ratio the
+    correction uses is the same either way. A site below sea level is admissible (the base exceeds one);
     the formula stops meaning anything where the base reaches zero, some
     44 km up, and that is refused.
 
@@ -870,7 +872,13 @@ def sound_power_in_situ(
         since the procedure takes one background reading (7.5).
     :param temperature: Air temperature at the test, in degrees Celsius.
     :param static_pressure: Static pressure at the test, in kilopascals
-        (see :func:`static_pressure_from_altitude`).
+        (see :func:`static_pressure_from_altitude`). Annex C prints this
+        quantity in pascals, with :math:`p_{\mathrm{s},0}` = 1,013 25 x 10^5
+        Pa, and is alone in its family in doing so: ISO 3741:2010,
+        ISO 3744:2010 and ISO 3745:2012 all print kilopascals. This argument
+        follows the three, so that one unit serves the whole ISO 3740 family;
+        ``C2`` depends only on the ratio :math:`p_\mathrm{s}/p_{\mathrm{s},0}`,
+        so the choice cannot move a result.
     :param conditions: The :class:`GradeConditions` Table 2 reads to decide
         the accuracy grade: the excess of sound pressure level at each
         microphone position (Annex A) and the range of the directivity survey
@@ -985,7 +993,8 @@ def sound_energy_in_situ(
         (3.4, NOTE 1), so that the margin compares like with like. The two
         coincide at ``T`` = 1 s.
     :param temperature: Air temperature at the test, in degrees Celsius.
-    :param static_pressure: Static pressure at the test, in kilopascals.
+    :param static_pressure: Static pressure at the test, in kilopascals, as
+        for :func:`sound_power_in_situ`; Annex C itself prints pascals.
     :param conditions: The :class:`GradeConditions` of the determination, as
         for :func:`sound_power_in_situ`.
     :param sigma_omc: Operating-and-mounting standard deviation, in decibels.

--- a/src/phonometry/emission/sound_power_in_situ.py
+++ b/src/phonometry/emission/sound_power_in_situ.py
@@ -323,8 +323,9 @@ def static_pressure_from_altitude(altitude: float) -> float:
     Annex C prints :math:`p_{\mathrm{s},0}` = 1,013 25 x 10^5 Pa and states
     the quantity in pascals. The result here is in kilopascals so that it feeds
     ``static_pressure`` of :func:`sound_power_in_situ` directly, matching
-    ISO 3741, ISO 3744 and ISO 3745, which do print kilopascals; the ratio the
-    correction uses is the same either way. A site below sea level is admissible (the base exceeds one);
+    ISO 3741, ISO 3744 and ISO 3745, which do print kilopascals. The pressure
+    reaches ``C2`` only as :math:`p_\mathrm{s}/p_{\mathrm{s},0}`, so the two
+    unit conventions give the same correction. A site below sea level is admissible (the base exceeds one);
     the formula stops meaning anything where the base reaches zero, some
     44 km up, and that is refused.
 
@@ -877,8 +878,10 @@ def sound_power_in_situ(
         Pa, and is alone in its family in doing so: ISO 3741:2010,
         ISO 3744:2010 and ISO 3745:2012 all print kilopascals. This argument
         follows the three, so that one unit serves the whole ISO 3740 family;
-        ``C2`` depends only on the ratio :math:`p_\mathrm{s}/p_{\mathrm{s},0}`,
-        so the choice cannot move a result.
+        ``C2`` carries a pressure term and a temperature term, and the
+        pressure enters only as the ratio
+        :math:`p_\mathrm{s}/p_{\mathrm{s},0}`, so converting both together
+        cannot move a result.
     :param conditions: The :class:`GradeConditions` Table 2 reads to decide
         the accuracy grade: the excess of sound pressure level at each
         microphone position (Annex A) and the range of the directivity survey


### PR DESCRIPTION
Read from the printed page: ISO 3747:2010 Annex C states its static pressure in **pascals**, three times on printed folio 27.

> reference meteorological conditions of static pressure 1,013 25 × 10⁵ Pa
>
> p_s is the static pressure at the time and place of the test, in pascals
>
> p_s,0 is the reference static pressure, 1,013 25 × 10⁵ Pa

The library documents kilopascals here. Before changing anything, the three siblings were read too, and they settle what to do:

| Standard | What it prints |
|---|---|
| ISO 3741:2010 | "in kilopascals", p_s,0 = 101,325 kPa |
| ISO 3744:2010 | "in kilopascals", p_s,0 = 101,325 kPa |
| ISO 3745:2012 | "in kilopascals", p_s,0 = 101,325 kPa |
| **ISO 3747:2010** | **"in pascals"**, p_s,0 = 1,013 25 × 10⁵ Pa |

ISO 3747 is alone in its own family.

## What changes, and what does not

The unit stays kilopascals. Switching this one function to pascals to match its own standard would leave one function of five in the ISO 3740 family taking a different unit from its siblings, which is the hazard, not the fix. C2 depends only on the ratio p_s/p_s,0, so the choice cannot move a result, and `static_pressure_from_altitude` already returns kilopascals so the two compose.

What changes is that the docstrings say all of this. A reader comparing `static_pressure_from_altitude` with Eq. (C.2) on the printed page previously found p_s,0 = 101,325 kPa against a printed 1,013 25 × 10⁵ Pa with nothing to explain the difference; now the page, the family and the reason are named.

This is the same class of correction as #678: the arithmetic was right and the attribution was not.

## Why it matters beyond the docstring

The planned migration of the medium properties assumes a single pressure unit. This says the emission family's kilopascals are normatively printed by three of the four standards it implements, so those literals stay where their clause prints them rather than being swept to pascals. A blanket harmonisation would have fought three clauses to satisfy one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Clarified documentation regarding static pressure units in ISO 3747 Annex C.</li>
<li>Updated docstrings and documentation to explain that while ISO 3747 Annex C uses pascals, the library uses kilopascals to maintain consistency with other ISO 3740 family standards.</li>
<li>Added explanatory notes to `sound_power_in_situ` and `static_pressure_from_altitude` confirming that the unit choice does not affect calculation results as they depend on pressure ratios.</li>
<li>Updated CHANGELOG.md to reflect these documentation improvements.</li>
</ul></div>

## Summary by Sourcery

Clarify ISO 3747 pressure-unit attribution while preserving the library’s family-wide kilopascal interface and calculation behavior.

Enhancements:
- Clarify that ISO 3747 prints static pressure in pascals while the library consistently accepts and returns kilopascals across the ISO 3740 family, without changing calculations.
- Document that the pressure ratio used by Annex C makes the unit convention result-equivalent.

Documentation:
- Update API documentation and docstrings to explain the ISO 3747 pressure-unit discrepancy and the library’s consistent kilopascal interface.

Chores:
- Record the ISO 3747 pressure-unit documentation correction in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the pressure units used by in-situ sound power and energy calculations.
  * Documented the difference between Annex C’s pascal notation and the kilopascal input convention.
  * Explained that altitude-derived static pressure can be used directly in these calculations.
  * Clarified that C2 includes pressure and temperature terms, with pressure applied as a ratio; matching pressure units preserves the correction result.
  * Added references to the applicable ISO standards and related in-situ calculation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->