### PR TITLE
Refuse a temperature at or below absolute zero across the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,7 +482,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- A temperature below absolute zero is refused rather than computed with.
+- A temperature at or below absolute zero is refused rather than computed
+  with.
   `sea_water_sound_speed(-273.15, 35.0, 0.0)` returned -31 457 m/s, a negative
   speed of sound; `sound_speed_profile` checked only that its temperatures were
   finite, so -300 degC went straight through to [-44 562, -45 333] m/s; and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,9 +491,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   next to the 0,0185 dB/km of real cold water.
 
   `require_above_absolute_zero` in the internal validation now says it once,
-  and the sites that had written it by hand use it: the air absorption of
-  ISO 9613-1, the ASTM C423 absorption, the intensity sound power, the airport
-  impedance adjustment and the ocean ambient noise. One of those was spelling
+  with an array companion for the profiles, and every site that had written it
+  by hand uses one of the two: the air absorption of ISO 9613-1, the ASTM C423
+  absorption, the intensity sound power, the airport impedance adjustment, the
+  ocean ambient noise, the two ocean sound-speed entry points and the five air
+  helpers of `materials`. One of those was spelling
   its message with a Unicode minus and a degree sign where the rest of the tree
   uses ASCII.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,6 +482,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A temperature below absolute zero is refused rather than computed with.
+  `sea_water_sound_speed(-273.15, 35.0, 0.0)` returned -31 457 m/s, a negative
+  speed of sound; `sound_speed_profile` checked only that its temperatures were
+  finite, so -300 degC went straight through to [-44 562, -45 333] m/s; and
+  `seawater_absorption(1e3, temperature=-300.0)` returned 0,495 dB/km, which is
+  the dangerous one, because nothing about that number says where it came from
+  next to the 0,0185 dB/km of real cold water.
+
+  `require_above_absolute_zero` in the internal validation now says it once,
+  and the sites that had written it by hand use it: the air absorption of
+  ISO 9613-1, the ASTM C423 absorption, the intensity sound power, the airport
+  impedance adjustment and the ocean ambient noise. One of those was spelling
+  its message with a Unicode minus and a degree sign where the rest of the tree
+  uses ASCII.
+
+  Three guards deliberately do **not** migrate, and a test pins them by name.
+  They protect the pole of the formula their own clause prints, `sqrt(273 + θ)`
+  in ISO 3741 and ISO 3745 and `1245/(273 + t)` in Francois-Garrison, with the
+  273 the standard prints rather than the physical 273,15. Their pole sits
+  0,15 degC higher, so migrating them would leave a band of a sixth of a degree
+  that clears the check and then overflows.
+
+  Francois-Garrison needs both: the physical bound in front, and its own pole
+  behind it. The band (-273,15, -273,0] used to raise `OverflowError` or
+  `ZeroDivisionError`, neither of which names the argument that caused it.
+
+
 - The weighting filter design gave different coefficients on different CPUs.
   The fit that removes the bilinear warp reaches its answer through a sequence
   of small dense solves, and the reductions inside them, the normal equations,

--- a/site/src/content/docs/es/environment/propagation/outdoor-propagation.mdx
+++ b/site/src/content/docs/es/environment/propagation/outdoor-propagation.mdx
@@ -160,7 +160,7 @@ $\pm 10$ % (apartado 7.1). Las entradas fuera de los rangos tabulados
 (−20…+50 °C, 10…100 % HR, 50…10 000 Hz, o por encima de la envolvente de validez
 de 200 kPa) siguen calculándose pero emiten una `AtmosphericAbsorptionWarning`;
 las entradas no físicas (frecuencia no positiva, humedad fuera de 0…100 %,
-temperatura bajo el cero absoluto) lanzan `ValueError`. `air_attenuation_m`
+temperatura igual o inferior al cero absoluto) lanzan `ValueError`. `air_attenuation_m`
 compone $\alpha$ con la conversión de la ISO 354 $m = \alpha/(10 \log_{10} e)$, de modo
 que quien use la ISO 354 puede alimentar condiciones atmosféricas reales
 directamente a `absorption_area` / `absorption_coefficient` en vez de introducir

--- a/site/src/content/docs/reference/api/aeroacoustics/airport-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/airport-noise.md
@@ -254,7 +254,7 @@ added to the NPD levels. Under the standard atmosphere it is +0.074 dB.
 
 | Exception | When |
 | :--- | :--- |
-| ValueError | If the pressure is not positive or inputs are non-finite. |
+| ValueError | If the pressure is not positive, the temperature is at or below -273,15 degC, or either input is non-finite. |
 
 ## lateral_attenuation
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -153,7 +153,25 @@ def _as_float64(x: ArrayLike, name: str) -> np.ndarray:
     A string element raises numpy's anonymous "could not convert string to
     float", and an unconvertible object a bare ``TypeError``; both would
     escape the array guards below without saying which parameter refused.
+
+    A complex array is refused rather than converted. ``np.asarray(z,
+    dtype=float64)`` does not fail on one: it drops the imaginary part and
+    emits a ``ComplexWarning``, which is a warning and not an error, so
+    ``np.array([1 + 2j])`` would arrive at the guards below as ``[1.0]`` and
+    pass every one of them. A list of complex numbers already raised here, so
+    the two spellings of the same input disagreed.
     """
+    try:
+        complex_input = np.iscomplexobj(x)
+    except (TypeError, ValueError) as exc:
+        # `iscomplexobj` builds the array to read its dtype, so a ragged list
+        # fails here rather than below and would escape without naming the
+        # parameter. Its refusal is the same refusal, in the same words.
+        msg = f"'{name}' must be numeric."
+        raise ValueError(msg) from exc
+    if complex_input:
+        msg = f"'{name}' must be real, not complex."
+        raise ValueError(msg)
     try:
         return np.asarray(x, dtype=np.float64)
     except (TypeError, ValueError) as exc:

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -64,6 +64,27 @@ def require_above_absolute_zero(value: float, name: str) -> float:
     return float(value)
 
 
+def require_above_absolute_zero_array(x: ArrayLike, name: str) -> np.ndarray:
+    """Require every temperature in ``x`` to be finite and above absolute zero.
+
+    The array companion of :func:`require_above_absolute_zero`. A profile is
+    where this bites hardest: one element below absolute zero among a hundred
+    good ones still poisons the whole returned array, and the caller has no
+    reason to look at any single element of it.
+
+    :param x: Temperatures, in degrees Celsius.
+    :param name: Parameter name used in the error message.
+    :return: The temperatures as a ``float64`` array.
+    :raises ValueError: if any element is non-finite or at or below
+        -273,15 degC.
+    """
+    values = _as_float64(x, name)
+    if not np.all(np.isfinite(values)) or np.any(values <= ABSOLUTE_ZERO_C):
+        msg = f"'{name}' must be finite temperatures above -273.15 degC."
+        raise ValueError(msg)
+    return values
+
+
 def require_non_negative(value: float, name: str) -> float:
     """Require a non-negative finite number (rejects NaN and infinities).
 

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -46,8 +46,8 @@ def require_above_absolute_zero(value: float, name: str) -> float:
 
     The one bound a temperature always has. A model may state a narrower domain
     for itself, and that is a warning rather than a refusal, because a fit past
-    its validated range is still arithmetic; a temperature below absolute zero
-    is not a state at all, and the arithmetic below one is not wrong so much as
+    its validated range is still arithmetic; a temperature at or below absolute
+    zero is not a state at all, and the arithmetic below one is not wrong so much as
     meaningless. Left unguarded it does not raise, it returns: a sea-water sound
     speed comes back at -31 457 m/s, and an absorption at -300 degC comes back
     at a plausible-looking 0,495 dB/km.
@@ -68,8 +68,8 @@ def require_above_absolute_zero_array(x: ArrayLike, name: str) -> np.ndarray:
     """Require every temperature in ``x`` to be finite and above absolute zero.
 
     The array companion of :func:`require_above_absolute_zero`. A profile is
-    where this bites hardest: one element below absolute zero among a hundred
-    good ones still poisons the whole returned array, and the caller has no
+    where this bites hardest: one element at or below absolute zero among a
+    hundred good ones still poisons the whole returned array, and the caller has no
     reason to look at any single element of it.
 
     :param x: Temperatures, in degrees Celsius.

--- a/src/phonometry/_internal/validation.py
+++ b/src/phonometry/_internal/validation.py
@@ -33,6 +33,37 @@ def require_positive(value: float, name: str) -> float:
     return float(value)
 
 
+#: Absolute zero, in degrees Celsius. The bound on a temperature that has to be
+#: a temperature. It is not the same number as the ``-273`` that several ISO 3740
+#: clauses print inside their own ``sqrt(273 + theta)``: those guards protect the
+#: pole of the formula the clause states, which sits 0,15 degC higher, and they
+#: stay where they are.
+ABSOLUTE_ZERO_C = -273.15
+
+
+def require_above_absolute_zero(value: float, name: str) -> float:
+    """Require a finite temperature in degrees Celsius above absolute zero.
+
+    The one bound a temperature always has. A model may state a narrower domain
+    for itself, and that is a warning rather than a refusal, because a fit past
+    its validated range is still arithmetic; a temperature below absolute zero
+    is not a state at all, and the arithmetic below one is not wrong so much as
+    meaningless. Left unguarded it does not raise, it returns: a sea-water sound
+    speed comes back at -31 457 m/s, and an absorption at -300 degC comes back
+    at a plausible-looking 0,495 dB/km.
+
+    :param value: The temperature to validate, in degrees Celsius.
+    :param name: Parameter name used in the error message.
+    :return: The validated temperature as a ``float``.
+    :raises ValueError: for a non-finite temperature, or one at or below
+        -273,15 degC.
+    """
+    if not math.isfinite(value) or value <= ABSOLUTE_ZERO_C:
+        msg = f"'{name}' must be a finite temperature above -273.15 degC."
+        raise ValueError(msg)
+    return float(value)
+
+
 def require_non_negative(value: float, name: str) -> float:
     """Require a non-negative finite number (rejects NaN and infinities).
 

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import numpy as np
 
 from .._internal.validation import (
+    require_above_absolute_zero,
     require_choice,
     require_equal_counts,
     require_ranks,
@@ -202,9 +203,7 @@ def impedance_adjustment(
     if not (np.isfinite(t) and np.isfinite(p) and p > 0.0):
         msg = "'pressure' must be positive and inputs finite."
         raise ValueError(msg)
-    if t <= _ABS_ZERO_C:
-        msg = "'temperature' must be above absolute zero (−273.15 °C)."
-        raise ValueError(msg)
+    require_above_absolute_zero(t, "temperature")
     delta = p / _P0_KPA
     theta = (t + 273.15) / (_T0_C + 273.15)
     zc = _ZC_STD * delta / np.sqrt(theta)

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -196,7 +196,8 @@ def impedance_adjustment(
     :param temperature: Aerodrome air temperature ``T``, in °C (default 15 °C).
     :param pressure: Aerodrome air pressure ``p``, in kPa (default 101.325 kPa).
     :return: The impedance adjustment, in dB (added to the NPD level).
-    :raises ValueError: If the pressure is not positive or inputs are non-finite.
+    :raises ValueError: If the pressure is not positive, the temperature is at
+        or below -273,15 degC, or either input is non-finite.
     """
     t = float(temperature)
     p = float(pressure)

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -102,6 +102,7 @@ if TYPE_CHECKING:
 from .._internal.levels_math import energy_mean, weighted_energy_mean
 from .._internal.validation import (
     check_engine,
+    require_above_absolute_zero,
     require_equal_shapes,
     require_finite_fields,
     require_per_band,
@@ -1454,9 +1455,7 @@ def sound_power_intensity_precision(
     if np.any(seg <= 0.0):
         msg = "All 'areas' must be positive."
         raise ValueError(msg)
-    if temperature <= _ABS_ZERO_C:
-        msg = "'temperature' must be above -273.15 degrees Celsius."
-        raise ValueError(msg)
+    require_above_absolute_zero(float(temperature), "temperature")
     if barometric_pressure <= 0.0:
         msg = "'barometric_pressure' must be positive (Pa)."
         raise ValueError(msg)

--- a/src/phonometry/environment/propagation/air_absorption.py
+++ b/src/phonometry/environment/propagation/air_absorption.py
@@ -72,7 +72,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_same_shape
+from ..._internal.validation import (
+    require_above_absolute_zero,
+    require_same_shape,
+)
 from ..._internal.warnings import PhonometryWarning
 from ...materials.absorbers.sound_absorption import attenuation_from_alpha
 
@@ -142,9 +145,7 @@ def _validate(
     if np.any(freqs <= 0.0):
         msg = "'frequencies' must be positive."
         raise ValueError(msg)
-    if temperature <= -_KELVIN:
-        msg = "'temperature' must be above absolute zero (-273.15 degC)."
-        raise ValueError(msg)
+    require_above_absolute_zero(float(temperature), "temperature")
     if not 0.0 <= relative_humidity <= _MAX_RELATIVE_HUMIDITY_PERCENT:
         msg = "'relative_humidity' must be within [0, 100] %."
         raise ValueError(msg)

--- a/src/phonometry/materials/absorbers/four_microphone.py
+++ b/src/phonometry/materials/absorbers/four_microphone.py
@@ -34,7 +34,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
-from ..._internal.validation import require_positive
+from ..._internal.validation import (
+    require_above_absolute_zero_array,
+    require_positive,
+)
 from .impedance_tube import (
     _DIAMETER_POSITIVE,
     ImpedanceTubeWarning,
@@ -101,10 +104,7 @@ def speed_of_sound_astm(*, temperature_c: ArrayLike) -> Real:
     :return: Speed of sound ``c``, in metres per second.
     :raises ValueError: if any temperature is at or below -273.15 degC.
     """
-    t = np.asarray(temperature_c, dtype=np.float64)
-    if np.any(t <= -_ASTM_T0):
-        msg = "'temperature_c' must exceed -273.15 degC."
-        raise ValueError(msg)
+    t = require_above_absolute_zero_array(temperature_c, "temperature_c")
     return np.asarray(_ASTM_C_CONST * np.sqrt(_ASTM_T0 + t), dtype=np.float64)
 
 
@@ -124,11 +124,8 @@ def air_density_astm(
     :raises ValueError: if any temperature is at or below -273.15 degC, or any
         pressure is not positive.
     """
-    t = np.asarray(temperature_c, dtype=np.float64)
+    t = require_above_absolute_zero_array(temperature_c, "temperature_c")
     p = np.asarray(atmospheric_pressure_kpa, dtype=np.float64)
-    if np.any(t <= -_ASTM_T0):
-        msg = "'temperature_c' must exceed -273.15 degC."
-        raise ValueError(msg)
     if np.any(p <= 0.0):
         msg = "'atmospheric_pressure_kpa' must be positive (kPa)."
         raise ValueError(msg)

--- a/src/phonometry/materials/absorbers/impedance_tube.py
+++ b/src/phonometry/materials/absorbers/impedance_tube.py
@@ -39,6 +39,7 @@ from numpy.typing import ArrayLike, NDArray
 
 from ..._internal.validation import (
     check_engine,
+    require_above_absolute_zero_array,
     require_equal_shapes,
     require_per_band,
     require_ranks,
@@ -131,10 +132,9 @@ def speed_of_sound_iso10534(*, temperature_c: ArrayLike) -> Real:
     :return: Speed of sound ``c0``, in metres per second.
     :raises ValueError: if any temperature is at or below -273.15 degC.
     """
-    kelvin = _ABSOLUTE_ZERO_C_OFFSET + np.asarray(temperature_c, dtype=np.float64)
-    if np.any(kelvin <= 0.0):
-        msg = "'temperature_c' must exceed -273.15 degC."
-        raise ValueError(msg)
+    kelvin = _ABSOLUTE_ZERO_C_OFFSET + require_above_absolute_zero_array(
+        temperature_c, "temperature_c"
+    )
     return np.asarray(_ISO_C_REF * np.sqrt(kelvin / _ISO_T_REF), dtype=np.float64)
 
 
@@ -156,7 +156,9 @@ def air_density_iso10534(
     :raises ValueError: if any temperature is at or below -273.15 degC, or any
         pressure is not positive.
     """
-    kelvin = _ABSOLUTE_ZERO_C_OFFSET + np.asarray(temperature_c, dtype=np.float64)
+    kelvin = _ABSOLUTE_ZERO_C_OFFSET + require_above_absolute_zero_array(
+        temperature_c, "temperature_c"
+    )
     pa = np.asarray(atmospheric_pressure_kpa, dtype=np.float64)
     if kelvin.ndim != 0 and pa.ndim != 0:
         require_equal_shapes(
@@ -164,9 +166,6 @@ def air_density_iso10534(
             {"temperature_c": kelvin.shape, "atmospheric_pressure_kpa": pa.shape},
             "measurement",
         )
-    if np.any(kelvin <= 0.0):
-        msg = "'temperature_c' must exceed -273.15 degC."
-        raise ValueError(msg)
     if np.any(pa <= 0.0):
         msg = "'atmospheric_pressure_kpa' must be positive (kPa)."
         raise ValueError(msg)

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -150,8 +150,8 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
 
     Warns when the speed is derived from a temperature outside the 15..30 degC
     validity range of Eq. (6). An explicit ``speed_of_sound`` bypasses the check.
-    Rejects a physically impossible ``temperature`` outright: Eq. (6) applied
-    below absolute zero would hand back a zero or negative speed of sound.
+    Rejects a physically impossible ``temperature`` outright: Eq. (6) applied at
+    or below absolute zero would hand back a zero or negative speed of sound.
     """
     if speed_of_sound is not None:
         # NaN passes a bare <= comparison and propagates into every derived

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -61,6 +61,7 @@ import numpy as np
 
 from ..._internal.validation import (
     check_engine,
+    require_above_absolute_zero,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -161,9 +162,7 @@ def _resolve_speed(temperature: float, speed_of_sound: float | None) -> float:
         return float(speed_of_sound)
     # NaN is named alongside the bound: a NaN temperature would otherwise
     # propagate through Eq. (6) into every derived quantity.
-    if math.isnan(temperature) or temperature <= -_KELVIN:
-        msg = "'temperature' must be above absolute zero (-273.15 degC)."
-        raise ValueError(msg)
+    require_above_absolute_zero(float(temperature), "temperature")
     lo, hi = _EQ6_TEMPERATURE_RANGE
     if not lo <= temperature <= hi:
         warnings.warn(

--- a/src/phonometry/materials/diffusers/reverberation_room_scattering.py
+++ b/src/phonometry/materials/diffusers/reverberation_room_scattering.py
@@ -34,6 +34,7 @@ import numpy as np
 
 from ..._internal.validation import (
     check_engine,
+    require_above_absolute_zero_array,
     require_equal_shapes,
     require_ranks,
     require_same_length,
@@ -194,11 +195,7 @@ def speed_of_sound_iso17497(*, temperature_c: ArrayLike) -> Real:
     :return: Speed of sound ``c``, in metres per second.
     :raises ValueError: if any temperature is at or below -273.15 degC.
     """
-    t = np.asarray(temperature_c, dtype=np.float64)
-    kelvin = _T0 + t
-    if np.any(kelvin <= 0.0):
-        msg = "'temperature_c' must exceed -273.15 degC."
-        raise ValueError(msg)
+    kelvin = _T0 + require_above_absolute_zero_array(temperature_c, "temperature_c")
     return np.asarray(_C_REF * np.sqrt(kelvin / _T_REF_K), dtype=np.float64)
 
 

--- a/src/phonometry/underwater/propagation/closed_form.py
+++ b/src/phonometry/underwater/propagation/closed_form.py
@@ -38,7 +38,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    require_above_absolute_zero,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -118,6 +122,12 @@ def _thorp(f_khz: NDArray[np.float64]) -> NDArray[np.float64]:
     return 1.0936 * (
         0.1 * f_khz**2 / (1.0 + f_khz**2) + 40.0 * f_khz**2 / (4100.0 + f_khz**2)
     )
+
+
+#: The Celsius-to-kelvin offset Francois & Garrison print inside their two
+#: relaxation frequencies. It is 273, not 273,15, and it is normative: the pole
+#: of this model therefore sits 0,15 degC above absolute zero.
+_FG_KELVIN_OFFSET = 273.0
 
 
 def _francois_garrison(
@@ -202,10 +212,24 @@ def seawater_absorption(
     if s < 0.0 or z < 0.0:
         msg = "'salinity' and 'depth' must be non-negative."
         raise ValueError(msg)
+    require_above_absolute_zero(t, "temperature")
     key = model.strip().lower()
     if key == "thorp":
         return _thorp(f_khz)
     if key == "francois-garrison":
+        # This model has a pole of its own, 0,15 degC above absolute zero: its
+        # relaxation frequencies are written 1245/(273 + t) and 1990/(273 + t)
+        # with the 273 the paper prints, so the whole band (-273,15, -273,0]
+        # clears the check above and then overflows or divides by zero, neither
+        # of which names the argument that caused it. The printed 273 is
+        # normative and stays; the guard goes in front of it.
+        if _FG_KELVIN_OFFSET + t <= 0.0:
+            msg = (
+                "'temperature' must exceed -273 degC for the francois-garrison "
+                "model, whose relaxation frequencies are printed as "
+                "1245/(273 + t) and 1990/(273 + t)."
+            )
+            raise ValueError(msg)
         return _francois_garrison(f_khz, t, s, z, float(ph))
     if key == "ainslie-mccolm":
         return _ainslie_mccolm(f_khz, t, s, z / _M_PER_KM, float(ph))

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -35,7 +35,12 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ..._internal.validation import require_ranks, require_same_length
+from ..._internal.validation import (
+    ABSOLUTE_ZERO_C,
+    require_above_absolute_zero,
+    require_ranks,
+    require_same_length,
+)
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -263,7 +268,7 @@ def sea_water_sound_speed(
         Ainslie's words) and drifts by a few m/s against the UNESCO standard
         away from mid-range temperatures and shallow depths.
     """
-    t = _finite(temperature, "temperature")
+    t = require_above_absolute_zero(_finite(temperature, "temperature"), "temperature")
     s = _finite(salinity, "salinity")
     if s < 0.0:
         msg = "'salinity' must be non-negative."
@@ -383,6 +388,9 @@ def sound_speed_profile(
     sal = np.broadcast_to(np.asarray(salinities, dtype=np.float64), z.shape)
     if not (np.all(np.isfinite(temp)) and np.all(np.isfinite(sal))):
         msg = "'temperatures' and 'salinities' must be finite."
+        raise ValueError(msg)
+    if np.any(temp <= ABSOLUTE_ZERO_C):
+        msg = "'temperatures' must be finite temperatures above -273.15 degC."
         raise ValueError(msg)
     if np.any(sal < 0.0):
         msg = "'salinities' must be non-negative."

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -36,8 +36,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
-    ABSOLUTE_ZERO_C,
     require_above_absolute_zero,
+    require_above_absolute_zero_array,
     require_ranks,
     require_same_length,
 )
@@ -389,9 +389,7 @@ def sound_speed_profile(
     if not (np.all(np.isfinite(temp)) and np.all(np.isfinite(sal))):
         msg = "'temperatures' and 'salinities' must be finite."
         raise ValueError(msg)
-    if np.any(temp <= ABSOLUTE_ZERO_C):
-        msg = "'temperatures' must be finite temperatures above -273.15 degC."
-        raise ValueError(msg)
+    require_above_absolute_zero_array(temp, "temperatures")
     if np.any(sal < 0.0):
         msg = "'salinities' must be non-negative."
         raise ValueError(msg)

--- a/src/phonometry/underwater/sources/ambient_noise.py
+++ b/src/phonometry/underwater/sources/ambient_noise.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ..._internal.validation import (
+    require_above_absolute_zero,
     require_equal_shapes,
     require_finite_array,
     require_non_negative,
@@ -113,10 +114,7 @@ def thermal_noise_spectrum(
     :raises ValueError: If the inputs are invalid.
     """
     f = require_positive_array(frequency_hz, "frequency_hz")
-    t_kelvin = float(temperature) + 273.15
-    if not np.isfinite(t_kelvin) or t_kelvin <= 0.0:
-        msg = "'temperature' must be above absolute zero."
-        raise ValueError(msg)
+    t_kelvin = require_above_absolute_zero(float(temperature), "temperature") + 273.15
     rho = require_positive(density, "density")
     c = require_positive(sound_speed, "sound_speed")
     p2 = 4.0 * np.pi * _BOLTZMANN * t_kelvin * rho * f**2 / c

--- a/tests/aircraft/test_airport_noise.py
+++ b/tests/aircraft/test_airport_noise.py
@@ -705,7 +705,9 @@ def test_event_level_invalid_inputs() -> None:
 def test_impedance_adjustment_rejects_absolute_zero() -> None:
     from phonometry.aircraft.airport_noise import impedance_adjustment
 
-    with pytest.raises(ValueError, match=r"'temperature' must be above absolute zero"):
+    with pytest.raises(
+        ValueError, match=r"'temperature' must be a finite temperature above"
+    ):
         impedance_adjustment(-300.0, 101.325)
 
 

--- a/tests/emission/test_sound_power_precision.py
+++ b/tests/emission/test_sound_power_precision.py
@@ -535,7 +535,9 @@ def test_intensity_temperature_below_absolute_zero_raises() -> None:
     """
     intensity = np.full((2,), 1e-5)
     areas = np.array([1.0, 1.0])
-    with pytest.raises(ValueError, match="'temperature' must be above"):
+    with pytest.raises(
+        ValueError, match="'temperature' must be a finite temperature above"
+    ):
         sound_power_intensity_precision(intensity, areas, temperature=-300.0)
 
 

--- a/tests/environment/propagation/test_air_absorption.py
+++ b/tests/environment/propagation/test_air_absorption.py
@@ -168,7 +168,7 @@ def test_out_of_range_frequency_warns() -> None:
         (
             (1000.0,),
             {"temperature": -273.15},
-            "'temperature' must be above absolute zero",
+            "'temperature' must be a finite temperature above",
         ),
         # negative RH
         ((1000.0,), {"relative_humidity": -1.0}, "'relative_humidity' must be within"),

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -104,9 +104,9 @@ def test_air_density_reference_values() -> None:
 
 
 def test_air_property_domain_errors() -> None:
-    with pytest.raises(ValueError, match="'temperature_c' must exceed"):
+    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
         speed_of_sound_iso10534(temperature_c=-300.0)
-    with pytest.raises(ValueError, match="'temperature_c' must exceed"):
+    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
         speed_of_sound_astm(temperature_c=-300.0)
     with pytest.raises(ValueError, match="'atmospheric_pressure_kpa' must be positive"):
         air_density_iso10534(temperature_c=19.85, atmospheric_pressure_kpa=-1.0)
@@ -122,7 +122,7 @@ def test_air_density_astm_rejects_temperature_below_absolute_zero() -> None:
     reduction builds on. The temperature is refused at the door, exactly as
     ``speed_of_sound_astm`` refuses it above.
     """
-    with pytest.raises(ValueError, match="'temperature_c' must exceed"):
+    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
         air_density_astm(temperature_c=-300.0, atmospheric_pressure_kpa=101.325)
 
 
@@ -171,7 +171,7 @@ def test_air_helpers_bound_only_absolute_zero(
     """
     for temperature_c in (-272.0, -50.0, 0.0, 100.0, 500.0):
         assert np.isfinite(float(helper(temperature_c=temperature_c, **extra)))  # type: ignore[operator]
-    with pytest.raises(ValueError, match="'temperature_c' must exceed"):
+    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
         helper(temperature_c=-273.15, **extra)  # type: ignore[operator]
 
 

--- a/tests/materials/absorbers/test_impedance_tube.py
+++ b/tests/materials/absorbers/test_impedance_tube.py
@@ -104,9 +104,13 @@ def test_air_density_reference_values() -> None:
 
 
 def test_air_property_domain_errors() -> None:
-    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
+    with pytest.raises(
+        ValueError, match="'temperature_c' must be finite temperatures above"
+    ):
         speed_of_sound_iso10534(temperature_c=-300.0)
-    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
+    with pytest.raises(
+        ValueError, match="'temperature_c' must be finite temperatures above"
+    ):
         speed_of_sound_astm(temperature_c=-300.0)
     with pytest.raises(ValueError, match="'atmospheric_pressure_kpa' must be positive"):
         air_density_iso10534(temperature_c=19.85, atmospheric_pressure_kpa=-1.0)
@@ -122,7 +126,9 @@ def test_air_density_astm_rejects_temperature_below_absolute_zero() -> None:
     reduction builds on. The temperature is refused at the door, exactly as
     ``speed_of_sound_astm`` refuses it above.
     """
-    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
+    with pytest.raises(
+        ValueError, match="'temperature_c' must be finite temperatures above"
+    ):
         air_density_astm(temperature_c=-300.0, atmospheric_pressure_kpa=101.325)
 
 
@@ -171,7 +177,9 @@ def test_air_helpers_bound_only_absolute_zero(
     """
     for temperature_c in (-272.0, -50.0, 0.0, 100.0, 500.0):
         assert np.isfinite(float(helper(temperature_c=temperature_c, **extra)))  # type: ignore[operator]
-    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
+    with pytest.raises(
+        ValueError, match="'temperature_c' must be finite temperatures above"
+    ):
         helper(temperature_c=-273.15, **extra)  # type: ignore[operator]
 
 

--- a/tests/materials/absorbers/test_sound_absorption.py
+++ b/tests/materials/absorbers/test_sound_absorption.py
@@ -333,12 +333,16 @@ def test_temperature_outside_eq6_range_warns() -> None:
 def test_temperature_below_absolute_zero_raises() -> None:
     # Below -273,15 degC Eq. (6) would hand back a non-positive speed of
     # sound; the refusal is a hard error, not the out-of-range advisory.
-    with pytest.raises(ValueError, match="'temperature' must be above absolute zero"):
+    with pytest.raises(
+        ValueError, match="'temperature' must be a finite temperature above"
+    ):
         materials.absorption_area(3.0, 200.0, temperature=-600.0)
 
 
 def test_nan_temperature_raises() -> None:
-    with pytest.raises(ValueError, match="'temperature' must be above absolute zero"):
+    with pytest.raises(
+        ValueError, match="'temperature' must be a finite temperature above"
+    ):
         materials.absorption_area(3.0, 200.0, temperature=float("nan"))
 
 

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -496,7 +496,7 @@ def test_speed_of_sound_rejects_temperature_below_absolute_zero() -> None:
     hands back a NaN, which would then travel silently into the Sabine
     Eqs. (1)/(4) that consume c. The temperature is refused first.
     """
-    with pytest.raises(ValueError, match="'temperature_c' must exceed"):
+    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
         speed_of_sound_iso17497(temperature_c=-300.0)
 
 

--- a/tests/materials/diffusers/test_scattering_diffusion.py
+++ b/tests/materials/diffusers/test_scattering_diffusion.py
@@ -496,7 +496,9 @@ def test_speed_of_sound_rejects_temperature_below_absolute_zero() -> None:
     hands back a NaN, which would then travel silently into the Sabine
     Eqs. (1)/(4) that consume c. The temperature is refused first.
     """
-    with pytest.raises(ValueError, match="'temperature_c' must be finite temperatures above"):
+    with pytest.raises(
+        ValueError, match="'temperature_c' must be finite temperatures above"
+    ):
         speed_of_sound_iso17497(temperature_c=-300.0)
 
 

--- a/tests/test_internal_validation.py
+++ b/tests/test_internal_validation.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 from phonometry._internal.validation import (
     check_engine,
     require_1d_signal,
+    require_above_absolute_zero_array,
     require_equal_shapes,
     require_finite_array,
     require_finite_fields,
@@ -267,6 +268,38 @@ def test_garbage_input_is_refused_naming_the_parameter(
     for garbage in (("bad",), object(), {"a": 1}):
         with pytest.raises(ValueError, match="'x' must be numeric"):
             validator(garbage, "x", *args)
+
+
+@pytest.mark.parametrize(
+    ("validator", "args"),
+    [
+        (require_positive_array, ()),
+        (require_finite_array, ()),
+        (require_per_band, (np.array([100.0, 200.0]),)),
+        (require_1d_signal, ()),
+        (require_above_absolute_zero_array, ()),
+    ],
+)
+@pytest.mark.parametrize(
+    "complex_input",
+    [[1 + 2j], np.array([1 + 2j]), np.complex128(1 + 2j)],
+)
+def test_a_complex_input_is_refused_rather_than_flattened(
+    validator: Callable[..., object],
+    args: tuple[object, ...],
+    complex_input: object,
+) -> None:
+    """A complex array must not arrive as its real part.
+
+    ``np.asarray(z, dtype=float64)`` does not fail on a complex array: it
+    drops the imaginary part and emits a ``ComplexWarning``, which is a
+    warning and not an error, so ``np.array([1 + 2j])`` used to reach the
+    guards as ``[1.0]`` and satisfy every one of them. A *list* of complex
+    numbers raised, because that path fails the conversion outright, so the
+    two spellings of the same input disagreed with each other.
+    """
+    with pytest.raises(ValueError, match="'x' must be real, not complex"):
+        validator(complex_input, "x", *args)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -546,3 +546,29 @@ def test_no_error_message_carries_a_comma_decimal() -> None:
     assert not offenders, "comma decimal in an English message:\n" + "\n".join(
         offenders
     )
+
+
+def test_clause_poles_are_not_migrated_to_the_physical_bound() -> None:
+    """Two different guards wear the same clothes, and only one of them shares.
+
+    ``require_above_absolute_zero`` bounds a temperature at -273,15 degC,
+    because below that it is not a temperature. Three clauses guard something
+    else: their own formula is printed as ``sqrt(273 + theta)`` or
+    ``1245/(273 + t)``, with the 273 the standard prints, so what breaks there
+    sits 0,15 degC higher. Migrating those onto the shared helper would leave a
+    band of a sixth of a degree that clears the check and then overflows.
+
+    The three are pinned by name, so a later harmonising sweep has to read this
+    before it reaches them.
+    """
+    clause_poles = {
+        "emission/_shared.py": "273",
+        "emission/sound_power_anechoic.py": "273",
+        "building/measurement/intensity_insulation.py": "273",
+    }
+    for relative, printed in clause_poles.items():
+        text = (SRC / relative).read_text(encoding="utf-8")
+        assert "require_above_absolute_zero" not in text, (
+            f"{relative} guards the pole of its own clause, printed with "
+            f"{printed}, not absolute zero"
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,6 @@ def test_typesignal_refuses_none_as_the_whole_signal() -> None:
         pytest.param("hello", id="string"),
         pytest.param({"a": 1.0}, id="dict"),
         pytest.param(object(), id="object"),
-        pytest.param(1 + 2j, id="complex"),
         pytest.param([[1.0, 2.0], [3.0]], id="ragged"),
     ],
 )
@@ -48,6 +47,18 @@ def test_typesignal_refuses_what_is_not_numeric_by_name(bad: Any) -> None:  # no
     """
     with pytest.raises(ValueError, match=r"'x' must be numeric"):
         _typesignal(bad)
+
+
+def test_typesignal_refuses_a_complex_signal_saying_so() -> None:
+    """A complex input gets its own message, because it is its own mistake.
+
+    It used to share the "must be numeric" refusal, which was true of the list
+    spelling only: numpy converts a complex *array* to float64 by dropping the
+    imaginary part, under a warning rather than an error. Saying "not complex"
+    tells a caller who passed an analytic signal what actually happened.
+    """
+    with pytest.raises(ValueError, match=r"'x' must be real, not complex"):
+        _typesignal(1 + 2j)
 
 
 @pytest.mark.parametrize(

--- a/tests/underwater/test_absolute_zero_guard.py
+++ b/tests/underwater/test_absolute_zero_guard.py
@@ -1,0 +1,72 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""A temperature below absolute zero is refused, not computed with.
+
+Left unguarded these did not raise, they returned: a negative speed of sound,
+and an absorption that looks like a plausible measurement. The second is the
+dangerous one, because nothing about 0,495 dB/km says it came from air at
+-300 degC.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phonometry import underwater
+from phonometry._internal.validation import ABSOLUTE_ZERO_C
+
+
+def test_sea_water_sound_speed_refuses_absolute_zero() -> None:
+    """It used to return -31 457 m/s, a negative speed of sound."""
+    with pytest.raises(ValueError, match="'temperature' must be a finite temperature"):
+        underwater.sea_water_sound_speed(ABSOLUTE_ZERO_C, 35.0, 0.0)
+
+
+def test_sound_speed_profile_refuses_absolute_zero() -> None:
+    """The array path checked only finiteness, so -300 degC went straight through."""
+    with pytest.raises(ValueError, match="'temperatures' must be finite temperatures"):
+        underwater.sound_speed_profile([0.0, 100.0], -300.0, 35.0)
+
+
+def test_seawater_absorption_refuses_absolute_zero() -> None:
+    """It returned 0.495 dB/km at -300 degC, beside 0.0185 for real cold water."""
+    with pytest.raises(ValueError, match="'temperature' must be a finite temperature"):
+        underwater.seawater_absorption(1e3, temperature=-300.0)
+
+
+@pytest.mark.parametrize("temperature_c", [-273.1, -273.05, -273.0])
+def test_francois_garrison_refuses_its_own_pole(temperature_c: float) -> None:
+    """Its pole sits 0,15 degC above absolute zero, so the physical bound misses it.
+
+    The relaxation frequencies are printed 1245/(273 + t) and 1990/(273 + t)
+    with the 273 the paper prints. The whole band (-273,15, -273,0] therefore
+    clears the physical check and then overflows or divides by zero. Both
+    escaped as OverflowError and ZeroDivisionError, neither of which names the
+    argument that caused it.
+    """
+    with pytest.raises(ValueError, match="francois-garrison"):
+        underwater.seawater_absorption(
+            1e3, temperature=temperature_c, model="francois-garrison"
+        )
+
+
+def test_just_above_the_pole_still_answers() -> None:
+    """The guard is drawn at the pole, not above it: -272,9 degC is computable."""
+    value = underwater.seawater_absorption(
+        1e3, temperature=-272.9, model="francois-garrison"
+    )
+    assert np.all(np.isfinite(value))
+
+
+@pytest.mark.parametrize("model", ["thorp", "ainslie-mccolm"])
+def test_the_other_models_have_no_pole_of_their_own(model: str) -> None:
+    """Only the Francois-Garrison branch needs the second guard."""
+    value = underwater.seawater_absorption(1e3, temperature=-272.9, model=model)
+    assert np.all(np.isfinite(value))
+
+
+def test_ordinary_water_is_untouched() -> None:
+    """The guards bound what cannot exist and nothing else."""
+    assert underwater.sea_water_sound_speed(10.0, 35.0, 0.0) == pytest.approx(
+        1489.832, abs=1e-3
+    )


### PR DESCRIPTION
Three functions returned a number instead of raising when handed a temperature below absolute zero. Reproduced before the fix:

```
sea_water_sound_speed(-273.15, 35.0, 0.0)        -> -31 457 m/s
sound_speed_profile([0, 100], -300.0, 35.0)      -> [-44 562, -45 333] m/s
seawater_absorption(1e3, temperature=-300.0)     ->  0.495 dB/km
```

The third is the one that matters. A negative speed of sound announces itself; 0,495 dB/km sits beside the 0,0185 dB/km of real cold water and looks like a measurement.

`sound_speed_profile` checked only that its temperatures were finite, so -300 °C went straight through the array path.

## One guard, said once

`require_above_absolute_zero` and its array companion now carry the bound, and every site that had written it out by hand uses one of the two: the ISO 9613-1 air absorption, the ASTM C423 absorption, the intensity sound power, the airport impedance adjustment, the ocean ambient noise, both ocean sound-speed entry points and the five air helpers of `materials`. One of them was spelling its message with a Unicode minus and a degree sign where the rest of the tree uses ASCII.

The array companion is not symmetry for its own sake. In a profile, one element below absolute zero among a hundred good ones poisons the whole returned array, and nothing in the result points at which element it was.

## Two guards that deliberately do not migrate

Three sites protect something else, and a test pins them by name so a later harmonising sweep has to read why before it reaches them:

| Site | Guards | Because its clause prints |
| :--- | :--- | :--- |
| `emission/_shared.py` | -273 | `sqrt(273 + θ)` |
| `emission/sound_power_anechoic.py` | -273 | `sqrt(273 + θ)` |
| `building/measurement/intensity_insulation.py` | -273 | `sqrt(273 + θ)` |

Their pole sits 0,15 °C above absolute zero, so migrating them onto the physical bound would open a band of a sixth of a degree that clears the check and then overflows.

Francois-Garrison needs **both**. Its relaxation frequencies are printed `1245/(273 + t)` and `1990/(273 + t)`, with the 273 the paper prints, so the band (-273,15, -273,0] cleared the physical check and then raised `OverflowError` or `ZeroDivisionError` — neither of which names the argument that caused it. The printed 273 is normative and stays; the guard goes in front of it.

The triage that found this listed `intensity_insulation.py` for migration. Reading it showed it uses `_ANNEX_A_KELVIN = 273.0`, so it belongs to the second class. That is why the test pins the three rather than trusting a comment.

## Gates

Full suite 11991 passed / 16 skipped; conformance 616 checks over 61 domains; 2840 figures within tolerance; 126 errata entries; ruff and mypy clean.

## Summary by Sourcery

Reject nonphysical temperatures consistently across the library while preserving model-specific safeguards and improving validation of numeric inputs.

Bug Fixes:
- Reject temperatures at or below absolute zero across affected air, materials, and underwater propagation APIs instead of returning invalid or misleading computed values.
- Prevent the Francois-Garrison model from reaching its separate formula pole near -273 °C by reporting a clear validation error.

Enhancements:
- Centralize absolute-zero validation for scalar and array temperatures, including consistent error messages and whole-array validation for profiles.
- Reject complex-valued inputs explicitly rather than silently discarding their imaginary components during array conversion.
- Preserve formula-specific guards where standards-defined constants create poles above physical absolute zero.

Documentation:
- Update changelog and API documentation to describe rejection of temperatures at or below absolute zero.

Tests:
- Add coverage for absolute-zero rejection in underwater sound-speed and absorption APIs, Francois-Garrison pole handling, shared validation, complex inputs, and protected formula-specific guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CNOSSOS-EU track descriptors now publish all six descriptor digits, including track measures and rail joints.
  * Added humid-air property calculations with immutable results, assumptions, validation warnings, and clear errors for unavailable properties.

* **Bug Fixes**
  * Temperatures at or below absolute zero, including non-finite values, are now rejected consistently across acoustic calculations.
  * Underwater sound-speed profiles validate every temperature value.
  * The Francois–Garrison model now reports temperatures near its mathematical limit instead of producing runtime errors.

* **Documentation**
  * Clarified temperature validation requirements in English and Spanish documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->