### PR TITLE
Say what the nominal solids are, and stop writing one stiffness twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `corrugated_plate_stiffness` computes its `Bx` by calling
+  `plate_bending_stiffness` instead of spelling out `E h^3 / (12 (1 - nu^2))` a
+  second time. `Bx` is that stiffness divided by the profile factor, so the two
+  were the same derivation written twice; `Bxz` keeps its own expression, since
+  its denominator is `(1 + nu)` and it shares only the `E h^3 / 12`. Results move
+  by at most one unit in the last place, from the order of the divisions.
+
+- The three nominal solids of the elastic solver say where they stand. They
+  carry **bulk** wave speeds, which is what the solver integrates, consistent to
+  a per cent or two with the textbook modulus, Poisson's ratio and density of
+  each material, and transcribed from no standard.
+
+  The note also records the citation not to make. EN 12354-1 Table B.3 is the
+  obvious candidate and the wrong one: it tabulates the quasi-longitudinal phase
+  velocity of a *plate*, a different quantity that runs eleven per cent below
+  the bulk speed for steel and fifteen for aluminium, and it lists neither steel
+  nor aluminium at all. A test holds the three constants to the bulk formulas
+  and to being above the plate ones, so re-sourcing them from that table would
+  fail rather than quietly change the physics.
+
 ### Fixed
 
 - `phonometry.environment` publishes all six digits of the CNOSSOS-EU track

--- a/src/phonometry/building/prediction/panel_transmission.py
+++ b/src/phonometry/building/prediction/panel_transmission.py
@@ -100,6 +100,7 @@ from ..._internal.validation import (
     require_ranks,
     require_same_length,
 )
+from ...vibration.structural.point_mobility import plate_bending_stiffness
 from ...vibration.structural.radiation_efficiency import coincidence_frequency
 
 if TYPE_CHECKING:
@@ -794,7 +795,10 @@ def corrugated_plate_stiffness(
     nu = float(poisson_ratio)
     shape = (math.pi * amplitude / wavelength) ** 2
     flat = e * h**3 / 12.0
-    b_x = flat / ((1.0 - nu**2) * (1.0 + shape))
+    # B_x is the flat-plate bending stiffness divided by the profile factor, so
+    # it is `plate_bending_stiffness` rather than a second spelling of it. B_xz
+    # below shares only the E h^3 / 12, since its denominator is (1 + nu).
+    b_x = plate_bending_stiffness(e, h, nu) / (1.0 + shape)
     b_z = (
         0.5
         * e

--- a/src/phonometry/simulation/elastic_fdtd.py
+++ b/src/phonometry/simulation/elastic_fdtd.py
@@ -244,13 +244,28 @@ AIR = Material(c_p=343.0, c_s=0.0, rho=1.2)
 #: Fresh water at room temperature (fluid).
 WATER = Material(c_p=1480.0, c_s=0.0, rho=1000.0)
 
-#: Structural steel (nominal bulk wave speeds).
+# The three solids below carry representative **bulk** wave speeds, the
+# quantities this solver integrates: c_p from (lambda + 2 mu) / rho and c_s from
+# mu / rho, both in an unbounded medium. Each is consistent to a per cent or two
+# with the textbook Young's modulus, Poisson's ratio and density of its material,
+# and none is transcribed from a standard, which is why they are called nominal.
+#
+# They are demonstration defaults, not a sourced table. What a sourced table
+# would have to avoid is worth writing down, because the obvious candidate is
+# the wrong one: EN 12354-1 Table B.3 tabulates the quasi-longitudinal phase
+# velocity of a *plate*, sqrt(E / (rho (1 - nu^2))), which is a different
+# quantity from the bulk c_p, sqrt(E (1 - nu) / (rho (1 + nu) (1 - 2 nu))). For
+# steel the two are 5 291 and 5 856 m/s, an eleven per cent gap that grows to
+# fifteen for aluminium; the table also lists neither steel nor aluminium at
+# all. Reading c_L into c_p would put the wrong physics behind a citation.
+
+#: Structural steel (nominal bulk wave speeds; see the note above).
 STEEL = Material(c_p=5900.0, c_s=3200.0, rho=7850.0)
 
-#: Aluminium (nominal bulk wave speeds).
+#: Aluminium (nominal bulk wave speeds; see the note above).
 ALUMINIUM = Material(c_p=6320.0, c_s=3130.0, rho=2700.0)
 
-#: Dense concrete (nominal bulk wave speeds).
+#: Dense concrete (nominal bulk wave speeds; see the note above).
 CONCRETE = Material(c_p=3800.0, c_s=2250.0, rho=2400.0)
 
 

--- a/tests/simulation/test_elastic_fdtd.py
+++ b/tests/simulation/test_elastic_fdtd.py
@@ -29,6 +29,9 @@ from scipy.optimize import brentq
 
 from phonometry.building.prediction.panel_transmission import mass_law_transmission_loss
 from phonometry.simulation.elastic_fdtd import (
+    ALUMINIUM,
+    CONCRETE,
+    STEEL,
     ElasticBoundaries,
     ElasticFDTD2D,
     ElasticFDTDResult,
@@ -43,6 +46,40 @@ from phonometry.simulation.fdtd import FDTD2D, GaussianPulse
 CP_AL, CS_AL, RHO_AL = 6320.0, 3130.0, 2700.0
 CP_ST, CS_ST, RHO_ST = 5900.0, 3200.0, 7850.0
 CP_W, RHO_W = 1480.0, 1000.0
+
+
+def test_the_nominal_solids_are_bulk_speeds_not_plate_speeds() -> None:
+    """The three defaults follow the bulk speeds, not the plate ones.
+
+    Their comment says so, and the claim is worth a test because the obvious
+    source for a citation would contradict it: EN 12354-1 Table B.3 tabulates
+    the quasi-longitudinal phase velocity of a plate, which is a different
+    quantity and is roughly a tenth lower. Anyone re-sourcing these constants
+    from that table would change the physics the solver integrates while
+    appearing to add provenance.
+    """
+    import math
+
+    def plate(e: float, nu: float, rho: float) -> float:
+        return math.sqrt(e / (rho * (1.0 - nu**2)))
+
+    def bulk(e: float, nu: float, rho: float) -> float:
+        return math.sqrt(e * (1.0 - nu) / (rho * (1.0 + nu) * (1.0 - 2.0 * nu)))
+
+    def shear(e: float, nu: float, rho: float) -> float:
+        return math.sqrt(e / (2.0 * rho * (1.0 + nu)))
+
+    # Textbook Young's modulus and Poisson's ratio for each material.
+    for material, youngs, poisson in (
+        (STEEL, 200.0e9, 0.30),
+        (ALUMINIUM, 70.0e9, 0.33),
+        (CONCRETE, 30.0e9, 0.20),
+    ):
+        rho = material.rho
+        assert material.c_p == pytest.approx(bulk(youngs, poisson, rho), rel=0.03)
+        assert material.c_s == pytest.approx(shear(youngs, poisson, rho), rel=0.03)
+        # And distinctly not the plate speed: the gap is the point.
+        assert material.c_p > plate(youngs, poisson, rho)
 
 
 def _rayleigh_speed(c_p: float, c_s: float) -> float:


### PR DESCRIPTION
Two follow-ups from deciding **not** to build a `solids` package.

The three conditions recorded as justifying one do not hold. The duplicated derivation was two sites rather than a pattern; of thirteen public entry points that ask for an elastic modulus, only four take the Young and Poisson pair, the rest being Biot shear moduli, a loudspeaker impedance modulus and derived bulk moduli; and no solid density is hard-coded outside `simulation`, so there is none of the silent drift that made `fluids` necessary. What is worth doing is the residue, and it is small.

## The duplication

`corrugated_plate_stiffness` computed `E h³ / (12 (1 − ν²))` a second time. Its `Bx` is exactly `plate_bending_stiffness` divided by the profile factor, so it calls it now. `Bxz` keeps its own expression, since its denominator is `(1 + ν)` and it shares only the `E h³ / 12`.

Checked across 216 combinations of thickness, amplitude, wavelength, modulus and Poisson's ratio: the largest change is `2,9e-16` relative, one or two units in the last place, from a division by a product becoming two divisions.

## The provenance, and the citation not to make

The three nominal solids carried "nominal bulk wave speeds" with nothing to say where the numbers came from. The obvious source is the wrong one, and that is the part worth writing down.

EN 12354-1 Table B.3 tabulates the quasi-longitudinal phase velocity of a **plate**, `sqrt(E / (ρ (1 − ν²)))`. The solver integrates the **bulk** speed, `sqrt(E (1 − ν) / (ρ (1 + ν) (1 − 2ν)))`. They are different quantities:

| | bulk c_p (ours) | plate c_L (Table B.3) | gap |
|---|---|---|---|
| steel | 5 900 | 5 291 | 10,7 % |
| aluminium | 6 320 | 5 394 | 14,9 % |
| concrete | 3 800 | 3 608 | 3,3 % |

The table also lists neither steel nor aluminium; "aluminium" does not appear in the standard at all. Our constants follow the bulk column to within 0,3 to 2,2 per cent of the textbook modulus, Poisson's ratio and density, so re-sourcing them from B.3 would have moved the physics while appearing to add provenance.

The comment now says what the constants are, that they are transcribed from no standard, and which citation would be wrong. A test holds all three to the bulk formulas and to sitting above the plate ones, so a future re-sourcing from that table fails the build rather than passing quietly.

## What stays open

A properly sourced table of solid properties, with every field each calculation needs rather than a subset. Cremer, Heckl & Petersson is in reach but its text layer is shifted and loses digits, so its tables have to be read from rendered pages; and a source for steel and aluminium is still missing. Not urgent, and tracked separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that nominal steel, aluminium, and concrete wave-speed values represent bulk and shear wave speeds.
  - Added formulas, rationale, and references explaining the distinction between bulk-wave speeds and plate quasi-longitudinal velocities.
  - Documented the basis and consistency of the elastic solver’s material constants.

- **Tests**
  - Added conformance checks confirming the default material values match expected bulk and shear wave-speed calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->