### PR TITLE
End a suppression comment at its codes

### DIFF
--- a/src/phonometry/aircraft/flight_performance.py
+++ b/src/phonometry/aircraft/flight_performance.py
@@ -1309,7 +1309,8 @@ class _Flight:
             gradient comes from does not exist.
         """
         engines = self.aircraft.engines
-        if engines < 2:  # noqa: PLR2004 -- the N-1 denominator of Eq. B-13
+        # The N-1 denominator of Eq. B-13.
+        if engines < 2:  # noqa: PLR2004
             msg = (
                 "Eq. B-13 minimum reduced thrust does not apply to a "
                 f"single-engine aeroplane; aircraft "

--- a/src/phonometry/building/regulation/spain.py
+++ b/src/phonometry/building/regulation/spain.py
@@ -343,7 +343,8 @@ def _normalise(value: str, aliases: Mapping[str, str], name: str) -> str:
     """Lower-case ``value``, normalise separators and resolve aliases."""
     if not isinstance(value, str):
         msg = f"'{name}' must be a string; got {value!r}."
-        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     key = value.strip().lower().replace(" ", "_").replace("-", "_")
     return aliases.get(key, key)
 

--- a/src/phonometry/environment/assessment/spain.py
+++ b/src/phonometry/environment/assessment/spain.py
@@ -326,7 +326,8 @@ def _normalise(value: str, aliases: Mapping[str, str], name: str) -> str:
     """Lower-case ``value``, replace spaces by underscores and resolve aliases."""
     if not isinstance(value, str):
         msg = f"'{name}' must be a string; got {value!r}."
-        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     key = value.strip().lower().replace(" ", "_").replace("-", "_")
     return aliases.get(key, key)
 

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -795,7 +795,8 @@ class TimeWeightedEnvelope:
         """Length of the leading axis: channels when 2-D, samples for one channel."""
         return int(self.mean_square.shape[0])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
+    # Mirrors ndarray indexing, whose key union numpy does not export.
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401
         """Index the mean square; the result is bare values, not another envelope."""
         return self.mean_square[key]
 

--- a/src/phonometry/io/_sidecar.py
+++ b/src/phonometry/io/_sidecar.py
@@ -174,9 +174,8 @@ def _optional_number(payload: dict[str, object], key: str, path: Path) -> float 
         return None
     if isinstance(value, bool) or not isinstance(value, int | float):
         msg = f"{path}: {key} must be a number or null; got {value!r}"
-        raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            msg
-        )
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     return float(value)
 
 
@@ -196,9 +195,8 @@ def _load_sidecar_payload(source: Path) -> dict[str, object]:
     version = payload.get("schema_version")
     if not isinstance(version, int) or isinstance(version, bool):
         msg = f"{source}: schema_version must be an integer"
-        raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            msg
-        )
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     if version > SIDECAR_VERSION:
         msg = (
             f"{source}: sidecar schema version {version} is newer than the "
@@ -214,9 +212,8 @@ def _required_factor(payload: dict[str, object], source: Path) -> float:
     factor = payload.get("calibration_factor")
     if isinstance(factor, bool) or not isinstance(factor, int | float):
         msg = f"{source}: calibration_factor must be a number; got {factor!r}"
-        raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            msg
-        )
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     return float(factor)
 
 
@@ -229,9 +226,8 @@ def _calibrator_fields(
         calibrator = {}
     if not isinstance(calibrator, dict):
         msg = f"{source}: calibrator must be an object or null"
-        raise ValueError(  # noqa: TRY004 - ValueError keeps the module validation errors uniform
-            msg
-        )
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     model = calibrator.get("model")
     if model is not None and not isinstance(model, str):
         msg = f"{source}: calibrator model must be a string or null"

--- a/src/phonometry/io/_signal.py
+++ b/src/phonometry/io/_signal.py
@@ -150,7 +150,8 @@ class Signal:
     def __len__(self) -> int:
         return int(self._view.shape[0])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
+    # Mirrors ndarray indexing, whose key union numpy does not export.
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401
         return self._view[key]
 
     @property

--- a/src/phonometry/room/impulse_response.py
+++ b/src/phonometry/room/impulse_response.py
@@ -178,7 +178,8 @@ class ImpulseResponseResult:
         """Number of impulse-response samples (the length of ``ir``'s last axis)."""
         return int(self.ir.shape[-1])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
+    # Mirrors ndarray indexing, whose key union numpy does not export.
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401
         """Forward indexing to ``ir``: ``result[key]`` yields ``ir[key]``."""
         return self.ir[key]
 
@@ -909,7 +910,8 @@ class ShapedSweepResult:
         """Number of sweep samples (the length of ``signal``'s last axis)."""
         return int(self.signal.shape[-1])
 
-    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing, whose key union numpy does not export
+    # Mirrors ndarray indexing, whose key union numpy does not export.
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401
         """Forward indexing to ``signal``: ``result[key]`` yields ``signal[key]``."""
         return self.signal[key]
 

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -91,7 +91,8 @@ def _integer(name: str, value: int) -> int:
     """Validate that *value* is an integral scalar (bool is rejected)."""
     if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
         msg = f"{name} must be an integer"
-        raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+        # ValueError keeps the module validation errors uniform.
+        raise ValueError(msg)  # noqa: TRY004
     return int(value)
 
 
@@ -269,7 +270,8 @@ class PlaneWaveSource:
         """
         if not callable(self.waveform):
             msg = "waveform must be callable"
-            raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+            # ValueError keeps the module validation errors uniform.
+            raise ValueError(msg)  # noqa: TRY004
         _finite("amplitude", self.amplitude)
 
 

--- a/tests/building/regulation/test_spanish_building_code.py
+++ b/tests/building/regulation/test_spanish_building_code.py
@@ -855,3 +855,17 @@ def test_window_size_and_assessment_validation() -> None:
     impact_requirement = hr.db_hr_impact_requirement("protected", "other_unit")
     with pytest.raises(ValueError, match=r"'value' must be finite"):
         hr.check_db_hr_requirement(math.nan, impact_requirement)
+
+
+def test_a_table_key_that_is_not_a_string_is_refused_by_name() -> None:
+    """The tables are keyed on words, and a number reaches no row at all.
+
+    Passing something other than a string used to die inside ``str.strip``
+    with an anonymous ``AttributeError``; the refusal names the argument, and
+    it is a ``ValueError`` like every other refusal in this module rather than
+    the ``TypeError`` the isinstance check suggests.
+    """
+    with pytest.raises(ValueError, match=r"'building_use' must be a string"):
+        hr.db_hr_facade_requirement(60.0, 5, "protected")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=r"'room_type' must be a string"):
+        hr.db_hr_facade_requirement(60.0, "residential", None)  # type: ignore[arg-type]

--- a/tests/environment/assessment/test_spain.py
+++ b/tests/environment/assessment/test_spain.py
@@ -753,3 +753,14 @@ def test_a_tonal_correction_refuses_per_band_columns_that_disagree() -> None:
     result = rd.tonal_correction(np.array([50.0, 62.0, 51.0, 50.0, 49.0]), frequencies)
     with pytest.raises(ValueError, match=r"'levels' \(4\)"):
         dataclasses.replace(result, levels=result.levels[:-1])
+
+
+def test_an_area_type_that_is_not_a_string_is_refused_by_name() -> None:
+    """The area tables are keyed on a letter, and a number reaches no row.
+
+    Passing something other than a string used to die inside ``str.strip``
+    with an anonymous ``AttributeError``; the refusal names the argument, and
+    it is a ``ValueError`` like every other refusal in this module.
+    """
+    with pytest.raises(ValueError, match=r"'area_type' must be a string"):
+        rd.infrastructure_limits(5)  # type: ignore[arg-type]

--- a/tests/io/test_io_sidecar.py
+++ b/tests/io/test_io_sidecar.py
@@ -135,6 +135,9 @@ def test_malformed_fields_are_refused(tmp_path: Path) -> None:
     }
     for corruption, message in (
         ({"calibration_factor": "loud"}, "must be a number"),
+        ({"schema_version": "1"}, "schema_version must be an integer"),
+        ({"calibrator": 5}, "calibrator must be an object or null"),
+        ({"calibrator": {"model": 5}}, "calibrator model must be a string or null"),
         (
             {"calibration_factor": -1.0},
             "calibration_factor must be finite and positive",

--- a/tests/test_package_architecture.py
+++ b/tests/test_package_architecture.py
@@ -725,6 +725,38 @@ def test_no_source_compares_a_float_for_equality() -> None:
     )
 
 
+def test_no_suppression_comment_hides_its_reason_from_the_parser() -> None:
+    """A `# noqa` directive ends at its codes, and the reason goes above it.
+
+    Ruff documents the directive as ``# noqa: CODE``, and reads codes until it
+    meets something that is not one. Prose after a code is undefined ground:
+    ruff has tolerated it, the static analyser reports it as a malformed
+    suppression, and a directive that silently stops applying is worse than
+    the lint it was hiding. Thirteen of these had accumulated in three shapes,
+    a dash, a double dash and a second hash, and SonarCloud only saw the
+    fourteenth because it was new code in a pull request. The reason belongs on
+    the line above, where nothing has to parse it.
+    """
+    import pathlib
+    import re
+
+    directive = re.compile(r"#\s*noqa:\s*(?P<tail>.*)$")
+    codes = re.compile(r"^[A-Z]+[0-9]+(?:\s*,\s*[A-Z]+[0-9]+)*\s*$")
+    trailing: list[str] = []
+    for path in sorted(pathlib.Path("src/phonometry").rglob("*.py")):
+        for number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            match = directive.search(line)
+            if match and not codes.match(match.group("tail")):
+                trailing.append(f"{path.relative_to('src')}:{number} {line.strip()}")
+
+    assert not trailing, (
+        "suppression comments carrying prose after their codes:\n  "
+        + "\n  ".join(trailing)
+    )
+
+
 def test_no_error_message_carries_a_comma_decimal() -> None:
     """Error messages are English prose, and English prose takes a point.
 


### PR DESCRIPTION
A suppression comment ends at its codes. Ruff documents the directive as `# noqa: CODE`, and reads codes until it meets something that is not one; what happens to prose after that is undefined ground. Ruff has tolerated it, the static analyser reports it as a malformed suppression, and a directive that silently stops applying is worse than the lint it was hiding.

Thirteen of these had accumulated, in three shapes I had not noticed were the same mistake: a dash, a double dash, and a second hash.

```
raise ValueError(msg)  # noqa: TRY004 - ValueError keeps the module validation errors uniform
if engines < 2:  # noqa: PLR2004 -- the N-1 denominator of Eq. B-13
def __getitem__(self, key: Any) -> Any:  # noqa: ANN401  # mirrors ndarray indexing
```

The reason moves to the line above in all thirteen, where nothing has to parse it, and the directive is left with its code and nothing else. No behaviour changes and no lint is newly suppressed or newly raised.

A guard closes the class. Grepping for the dash form found eight; the guard found five more on its first run, which is the reason it is a guard and not a one-off sweep. It fails when the defect is put back, checked by reintroducing it on one line.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored inline `# noqa` comments to move explanatory text to the line above, ensuring compatibility with static analysis tools.</li>
<li>Updated multiple files to standardize lint suppression formatting.</li>
<li>Added a new test case in `tests/test_package_architecture.py` to enforce that `# noqa` directives do not contain trailing explanatory text.</li>
</ul></div>

## Summary by Sourcery

Standardize suppression comments and strengthen tests for malformed directives and related input validation.

Enhancements:
- Standardize inline `# noqa` directives so explanatory text is placed on the preceding line and suppression comments contain only lint codes.

Tests:
- Add architecture coverage that rejects malformed `# noqa` directives with trailing prose.
- Expand validation tests for invalid building, environmental, and sidecar input fields.