### PR TITLE
Force satori's fflate forward to the release that cannot loop

### DIFF
--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   undici: ^6.28.0
   brace-expansion@^1: ^1.1.18
   '@puppeteer/browsers@<3': ^3.1.0
+  fflate@0.7.3: ^0.7.5
 
 importers:
 
@@ -1599,9 +1600,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  fflate@0.7.3:
-    resolution: {integrity: sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==}
 
   fflate@0.7.5:
     resolution: {integrity: sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==}
@@ -4639,8 +4637,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.7
 
-  fflate@0.7.3: {}
-
   fflate@0.7.5: {}
 
   file-url@3.0.0: {}
@@ -6218,7 +6214,7 @@ snapshots:
       css-to-react-native: 3.2.0
       emoji-regex-xs: 2.0.1
       escape-html: 1.0.3
-      fflate: 0.7.3
+      fflate: 0.7.5
       harfbuzzjs: 0.10.0
       linebreak: 1.1.0
       parse-css-color: 0.2.1

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -29,3 +29,9 @@ overrides:
   # against it (verified by running the pa11y audit); the pin only matters at
   # install time, so this can go once pa11y ships on puppeteer 25.
   "@puppeteer/browsers@<3": ^3.1.0
+  # satori pins fflate at exactly 0.7.3, whose unzipSync can be walked into
+  # an infinite loop by a malformed ZIP64 archive. The site never unzips
+  # anything, so this is reachable by nothing here, but the patch release is
+  # a drop-in and the tree already carries 0.7.5 for another parent. Goes
+  # once satori floats past the pin.
+  "fflate@0.7.3": ^0.7.5


### PR DESCRIPTION
Dependabot flags fflate below 0.7.5: `unzipSync` can be walked into an infinite loop by a malformed ZIP64 archive.

satori pins fflate at exactly 0.7.3, so the range cannot float past it on its own. The override goes beside the others in `pnpm-workspace.yaml`, which is where pnpm 11 reads them from now, and comes out again once satori moves. The tree already carried 0.7.5 for another parent, so this only collapses the two copies onto the patched one.

Nothing here reaches the loop: the site never unzips anything, satori uses fflate to inflate the font subsets it is handed. The build and the redirect, HTML and structured-data validators all pass on the new resolution.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated fflate dependency from 0.7.3 to 0.7.5 in pnpm-lock.yaml.</li>
<li>Added an override in pnpm-workspace.yaml to force fflate 0.7.5, addressing a potential infinite loop vulnerability in the 0.7.3 version used by satori.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a transitive compression dependency used by rendering functionality to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->