### PR TITLE
Read every private constant, or stop keeping it

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -527,10 +527,10 @@ jobs:
 
   # A private module-level constant is a number lifted out of a standard so the
   # code that uses it can say where it came from, and one nothing reads is
-  # either a leftover or the trace of a check that was planned and never
-  # written. The last sweep found both: a validator whose narrowest-span rule
-  # existed only as a comment, and a docstring promising a default the code did
-  # not take. Static and dependency-free, so it runs on its own.
+  # either a leftover or the trace of a check the docstring above it still
+  # promises. The sweep this came from found both: a recommended specimen
+  # velocity carried and never checked, and a docstring promising a default the
+  # code did not take. Static and dependency-free, so it runs on its own.
   dead-constants:
     name: No private constant goes unread
     runs-on: ubuntu-latest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -525,6 +525,28 @@ jobs:
     - name: Check that no file sets one subscript both ways
       run: python scripts/check_subscript_slope.py
 
+  # A private module-level constant is a number lifted out of a standard so the
+  # code that uses it can say where it came from, and one nothing reads is
+  # either a leftover or the trace of a check that was planned and never
+  # written. The last sweep found both: a validator whose narrowest-span rule
+  # existed only as a comment, and a docstring promising a default the code did
+  # not take. Static and dependency-free, so it runs on its own.
+  dead-constants:
+    name: No private constant goes unread
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.13"
+    - name: Check that every private constant is read somewhere
+      run: python scripts/check_dead_constants.py
+
   # The committed example .report() fiches (.github/reports) must match a fresh
   # `make reports` run. Same drift gate as the figures, one layer further down
   # the pipeline: the fiches are what the documentation links to as worked

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,12 @@ decimal-comma:
 fence-names:
 	$(PYTHON) scripts/check_fence_names.py
 
+# A private constant nothing reads is either a leftover or the trace of a check
+# that was planned and never written; the sweep that added this found one of
+# each. Stdlib only.
+dead-constants:
+	$(PYTHON) scripts/check_dead_constants.py
+
 # The Spanish variant of a figure is the English one with its strings looked
 # up in a table at save time, so a string nobody added to the table ships in
 # English inside `X_es.svg` and every other gate stays green: the page is

--- a/scripts/check_dead_constants.py
+++ b/scripts/check_dead_constants.py
@@ -26,16 +26,23 @@ import ast
 import collections
 import pathlib
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 #: Where a constant may be defined, and everything that may read one.
 SOURCE = ROOT / "src" / "phonometry"
 SEARCHED = ("src", "tests", "scripts")
 
-#: Private constants that stay although nothing reads them, and why. Nothing
-#: belongs here that could instead be used: a constant kept for documentation
-#: is documentation, and belongs in a docstring where a reader will find it.
-KEPT: dict[str, str] = {}
+#: Private constants that stay although nothing reads them, and why. Keyed by
+#: module and name, like every other mapping here: a bare name would silence
+#: the check in every module that defines it, and this tree has four modules
+#: defining ``_MIN_POLYLINE_NODES``. Nothing belongs here that could instead be
+#: used: a constant kept for documentation is documentation, and belongs in a
+#: docstring where a reader will find it.
+KEPT: dict[tuple[str, str], str] = {}
 
 
 def _module_of(path: pathlib.Path) -> str | None:
@@ -48,6 +55,52 @@ def _module_of(path: pathlib.Path) -> str | None:
     if parts[-1] == "__init__":
         parts.pop()
     return ".".join(parts)
+
+
+def _package_of(path: pathlib.Path, module: str | None) -> str:
+    """The package a relative import in that file climbs from.
+
+    An ``__init__.py`` *is* its package, so its module name is already the
+    answer; every other file is a module inside its package and one component
+    has to come off. Stripping unconditionally puts every relative import
+    written in an ``__init__.py`` one package too high, which both raises a
+    false alarm on the constant it reads and clears a genuinely dead one in
+    whatever module the wrong target names.
+    """
+    if module is None:
+        return ""
+    if path.name == "__init__.py":
+        return module
+    return module.rsplit(".", 1)[0] if "." in module else ""
+
+
+#: Statements that hold module-level code without leaving module scope. A
+#: constant under ``if TYPE_CHECKING`` or in the fallback arm of a ``try`` is a
+#: module-level constant, and reading only ``tree.body`` never sees it.
+_NESTING = (ast.If, ast.Try, ast.With)
+
+
+def _module_level(body: list[ast.stmt]) -> Iterator[ast.stmt]:
+    """Every statement that runs at module scope, through if, try and with."""
+    for node in body:
+        if isinstance(node, _NESTING):
+            branches = [node.body, getattr(node, "orelse", [])]
+            if isinstance(node, ast.Try):
+                branches += [handler.body for handler in node.handlers]
+                branches.append(node.finalbody)
+            for branch in branches:
+                yield from _module_level(branch)
+        else:
+            yield node
+
+
+def _assigned_names(target: ast.expr) -> Iterator[ast.Name]:
+    """The names one assignment target binds, unpacking tuples and lists."""
+    if isinstance(target, ast.Name):
+        yield target
+    elif isinstance(target, ast.Tuple | ast.List):
+        for element in target.elts:
+            yield from _assigned_names(element)
 
 
 def defined_constants() -> dict[tuple[str, str], tuple[pathlib.Path, int]]:
@@ -64,10 +117,14 @@ def defined_constants() -> dict[tuple[str, str], tuple[pathlib.Path, int]]:
         if module is None:  # pragma: no cover - SOURCE is inside src
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
-        for node in tree.body:
+        for node in _module_level(tree.body):
             targets: list[ast.Name] = []
             if isinstance(node, ast.Assign):
-                targets = [t for t in node.targets if isinstance(t, ast.Name)]
+                targets = [
+                    element
+                    for target in node.targets
+                    for element in _assigned_names(target)
+                ]
             elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
                 targets = [node.target]
             for target in targets:
@@ -78,10 +135,9 @@ def defined_constants() -> dict[tuple[str, str], tuple[pathlib.Path, int]]:
     return found
 
 
-def _imported_from(tree: ast.AST, module: str | None) -> set[tuple[str, str]]:
+def _imported_from(tree: ast.AST, package: str) -> set[tuple[str, str]]:
     """``(module, name)`` pairs a file imports by name, relative ones resolved."""
     pairs: set[tuple[str, str]] = set()
-    package = module.rsplit(".", 1)[0] if module and "." in module else (module or "")
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
             continue
@@ -116,8 +172,7 @@ def names_read() -> tuple[dict[str, set[str]], set[tuple[str, str]], set[str]]:
                 tree = ast.parse(path.read_text(encoding="utf-8"))
             except SyntaxError:  # pragma: no cover - a file being edited
                 continue
-            module = _module_of(path)
-            imported |= _imported_from(tree, module)
+            imported |= _imported_from(tree, _package_of(path, _module_of(path)))
             for node in ast.walk(tree):
                 if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
                     bare[str(path)].add(node.id)
@@ -131,7 +186,7 @@ def names_read() -> tuple[dict[str, set[str]], set[tuple[str, str]], set[str]]:
 def classify(
     defined: dict[tuple[str, str], tuple[pathlib.Path, int]],
     read: tuple[dict[str, set[str]], set[tuple[str, str]], set[str]],
-    kept: dict[str, str],
+    kept: dict[tuple[str, str], str],
 ) -> tuple[dict[tuple[str, str], tuple[pathlib.Path, int]], list[str]]:
     """Split the defined constants into the dead ones and the stale ``kept`` entries.
 
@@ -155,9 +210,10 @@ def classify(
         and (module, name) not in imported
         and name not in loose
     }
-    dead = {key: place for key, place in unread.items() if key[1] not in kept}
-    still_unread = {name for _module, name in unread}
-    return dead, sorted(name for name in kept if name not in still_unread)
+    dead = {key: place for key, place in unread.items() if key not in kept}
+    return dead, sorted(
+        f"{module}.{name}" for module, name in kept if (module, name) not in unread
+    )
 
 
 def main() -> int:
@@ -177,7 +233,8 @@ def main() -> int:
             print(f"  {name}  <- {path.relative_to(ROOT)}:{line}")
         print(
             "  -> use it, delete it, or, if it must stay, add it to KEPT at the "
-            "top of scripts/check_dead_constants.py with the reason."
+            "top of scripts/check_dead_constants.py, keyed by (module, name), "
+            "with the reason."
         )
     for name in stale:
         print(f"::error::KEPT lists {name}, which is now read or no longer exists")

--- a/scripts/check_dead_constants.py
+++ b/scripts/check_dead_constants.py
@@ -128,25 +128,45 @@ def names_read() -> tuple[dict[str, set[str]], set[tuple[str, str]], set[str]]:
     return bare, imported, loose
 
 
+def classify(
+    defined: dict[tuple[str, str], tuple[pathlib.Path, int]],
+    read: tuple[dict[str, set[str]], set[tuple[str, str]], set[str]],
+    kept: dict[str, str],
+) -> tuple[dict[tuple[str, str], tuple[pathlib.Path, int]], list[str]]:
+    """Split the defined constants into the dead ones and the stale ``kept`` entries.
+
+    Deadness is settled first and ``kept`` applied to the answer, not folded
+    into the test. Folding it in makes the hatch report itself: a kept name
+    would be excluded from the dead set, land in the live one by subtraction,
+    and be named stale on every run, so no entry could ever be added.
+
+    :param defined: Every private constant, keyed by module and name.
+    :param read: The three readings of :func:`names_read`.
+    :param kept: The escape hatch, name to reason.
+    :return: The dead constants, and the sorted ``kept`` names that no longer
+        describe an unread constant, either because something now reads it or
+        because it is gone.
+    """
+    bare, imported, loose = read
+    unread = {
+        (module, name): place
+        for (module, name), place in sorted(defined.items())
+        if name not in bare.get(str(place[0]), frozenset())
+        and (module, name) not in imported
+        and name not in loose
+    }
+    dead = {key: place for key, place in unread.items() if key[1] not in kept}
+    still_unread = {name for _module, name in unread}
+    return dead, sorted(name for name in kept if name not in still_unread)
+
+
 def main() -> int:
     """Report every private constant no file reads."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.parse_args()
 
     defined = defined_constants()
-    bare, imported, loose = names_read()
-    dead = {
-        (module, name): place
-        for (module, name), place in sorted(defined.items())
-        if name not in bare[str(place[0])]
-        and (module, name) not in imported
-        and name not in loose
-        and name not in KEPT
-    }
-    live = {name for _module, name in defined} - {name for _module, name in dead}
-    stale = sorted(
-        name for name in KEPT if name in live or name not in {n for _m, n in defined}
-    )
+    dead, stale = classify(defined, names_read(), KEPT)
     if not dead and not stale:
         print(f"No unread private constant among the {len(defined)} defined in src.")
         return 0

--- a/scripts/check_dead_constants.py
+++ b/scripts/check_dead_constants.py
@@ -1,0 +1,115 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""Fail on a private module-level constant nothing reads.
+
+A constant with a leading underscore and an upper-case name is a number or a
+table lifted out of a standard so that the code that uses it can say where it
+came from. One that nothing reads is either a leftover, or the trace of a
+check that was planned and never written, and the second is the reason this
+guard exists rather than a periodic sweep: the last audit turned up a
+frequency-range warning that was never added and a docstring that promised a
+default the code did not take.
+
+The scan is one AST pass over ``src``, ``tests`` and ``scripts``. A name
+counts as read when it appears as a loaded :class:`ast.Name`, as an attribute,
+as an import alias, or inside a string, which covers ``getattr`` and
+``__all__``; that is deliberately generous, because a false alarm here costs a
+reader more than a missed leftover.
+
+:data:`KEPT` is the escape hatch, and an entry is a decision with a reason
+attached rather than a bare line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import collections
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+#: Where a constant may be defined, and everything that may read one.
+SOURCE = ROOT / "src" / "phonometry"
+SEARCHED = ("src", "tests", "scripts")
+
+#: Private constants that stay although nothing reads them, and why. Nothing
+#: belongs here that could instead be used: a constant kept for documentation
+#: is documentation, and belongs in a docstring where a reader will find it.
+KEPT: dict[str, str] = {}
+
+
+def defined_constants() -> dict[str, list[tuple[pathlib.Path, int]]]:
+    """Every ``_UPPER_CASE`` assigned at module level under ``src``."""
+    found: dict[str, list[tuple[pathlib.Path, int]]] = collections.defaultdict(list)
+    for path in sorted(SOURCE.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            targets: list[ast.Name] = []
+            if isinstance(node, ast.Assign):
+                targets = [t for t in node.targets if isinstance(t, ast.Name)]
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                targets = [node.target]
+            for target in targets:
+                name = target.id
+                private = name.startswith("_") and not name.startswith("__")
+                if private and name.upper() == name:
+                    found[name].append((path, node.lineno))
+    return found
+
+
+def names_read() -> collections.Counter[str]:
+    """Every identifier read anywhere in the tree, however it is reached."""
+    seen: collections.Counter[str] = collections.Counter()
+    for directory in SEARCHED:
+        for path in sorted((ROOT / directory).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # pragma: no cover - a file being edited
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                    seen[node.id] += 1
+                elif isinstance(node, ast.Attribute):
+                    seen[node.attr] += 1
+                elif isinstance(node, ast.alias):
+                    seen[node.name.split(".")[-1]] += 1
+                    if node.asname:
+                        seen[node.asname] += 1
+                elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    seen[node.value] += 1
+    return seen
+
+
+def main() -> int:
+    """Report every private constant no file reads."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    defined = defined_constants()
+    read = names_read()
+    dead = {
+        name: places
+        for name, places in sorted(defined.items())
+        if read[name] == 0 and name not in KEPT
+    }
+    stale = sorted(name for name in KEPT if read[name] > 0 or name not in defined)
+    if not dead and not stale:
+        print(f"No unread private constant among the {len(defined)} defined in src.")
+        return 0
+    if dead:
+        print("::error::a private constant nothing reads - see below")
+        print(f"{len(dead)} private constant(s) are defined and never read:")
+        for name, places in dead.items():
+            path, line = places[0]
+            print(f"  {name}  <- {path.relative_to(ROOT)}:{line}")
+        print(
+            "  -> use it, delete it, or, if it must stay, add it to KEPT at the "
+            "top of scripts/check_dead_constants.py with the reason."
+        )
+    for name in stale:
+        print(f"::error::KEPT lists {name}, which is now read or no longer exists")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_dead_constants.py
+++ b/scripts/check_dead_constants.py
@@ -4,10 +4,10 @@
 A constant with a leading underscore and an upper-case name is a number or a
 table lifted out of a standard so that the code that uses it can say where it
 came from. One that nothing reads is either a leftover, or the trace of a
-check that was planned and never written, and the second is the reason this
-guard exists rather than a periodic sweep: the last audit turned up a
-frequency-range warning that was never added and a docstring that promised a
-default the code did not take.
+check the docstring above it still promises, and the second is the reason this
+guard exists rather than a periodic sweep: the sweep it came from turned up a
+recommended specimen velocity the code carried and never checked, and a
+docstring that promised a default the code did not take.
 
 The scan is one AST pass over ``src``, ``tests`` and ``scripts``. A name
 counts as read when it appears as a loaded :class:`ast.Name`, as an attribute,

--- a/scripts/check_dead_constants.py
+++ b/scripts/check_dead_constants.py
@@ -38,10 +38,31 @@ SEARCHED = ("src", "tests", "scripts")
 KEPT: dict[str, str] = {}
 
 
-def defined_constants() -> dict[str, list[tuple[pathlib.Path, int]]]:
-    """Every ``_UPPER_CASE`` assigned at module level under ``src``."""
-    found: dict[str, list[tuple[pathlib.Path, int]]] = collections.defaultdict(list)
+def _module_of(path: pathlib.Path) -> str | None:
+    """The dotted module a file under ``src`` is, or ``None`` outside it."""
+    try:
+        relative = path.relative_to(ROOT / "src")
+    except ValueError:
+        return None
+    parts = list(relative.with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def defined_constants() -> dict[tuple[str, str], tuple[pathlib.Path, int]]:
+    """Every ``_UPPER_CASE`` assigned at module level, keyed by module and name.
+
+    Keyed by the pair rather than by the name alone: two modules may define
+    the same private name, and one of them being read says nothing about the
+    other. That is not hypothetical, it is how a duplicated absolute zero and
+    a duplicated model list both stayed in the tree.
+    """
+    found: dict[tuple[str, str], tuple[pathlib.Path, int]] = {}
     for path in sorted(SOURCE.rglob("*.py")):
+        module = _module_of(path)
+        if module is None:  # pragma: no cover - SOURCE is inside src
+            continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for node in tree.body:
             targets: list[ast.Name] = []
@@ -53,31 +74,58 @@ def defined_constants() -> dict[str, list[tuple[pathlib.Path, int]]]:
                 name = target.id
                 private = name.startswith("_") and not name.startswith("__")
                 if private and name.upper() == name:
-                    found[name].append((path, node.lineno))
+                    found.setdefault((module, name), (path, node.lineno))
     return found
 
 
-def names_read() -> collections.Counter[str]:
-    """Every identifier read anywhere in the tree, however it is reached."""
-    seen: collections.Counter[str] = collections.Counter()
+def _imported_from(tree: ast.AST, module: str | None) -> set[tuple[str, str]]:
+    """``(module, name)`` pairs a file imports by name, relative ones resolved."""
+    pairs: set[tuple[str, str]] = set()
+    package = module.rsplit(".", 1)[0] if module and "." in module else (module or "")
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.level:
+            # A relative import climbs from the importing file's own package.
+            base = package.split(".")
+            climbed = base[: len(base) - (node.level - 1)] if node.level > 1 else base
+            target = ".".join([*climbed, node.module] if node.module else climbed)
+        else:
+            target = node.module or ""
+        for alias in node.names:
+            pairs.add((target, alias.name))
+    return pairs
+
+
+def names_read() -> tuple[dict[str, set[str]], set[tuple[str, str]], set[str]]:
+    """What reads what: bare names per file, imported pairs, and loose names.
+
+    The three are not interchangeable. A bare name can only reach a private
+    module-level constant from inside the module that defines it, so it is
+    kept per file. An ``from x import _Y`` names both sides, so it is kept as
+    a pair. An attribute or a string could be either, so those are kept as
+    loose names and credited to every definition of that name, which is the
+    generous half of the scan.
+    """
+    bare: dict[str, set[str]] = collections.defaultdict(set)
+    imported: set[tuple[str, str]] = set()
+    loose: set[str] = set()
     for directory in SEARCHED:
         for path in sorted((ROOT / directory).rglob("*.py")):
             try:
                 tree = ast.parse(path.read_text(encoding="utf-8"))
             except SyntaxError:  # pragma: no cover - a file being edited
                 continue
+            module = _module_of(path)
+            imported |= _imported_from(tree, module)
             for node in ast.walk(tree):
                 if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
-                    seen[node.id] += 1
+                    bare[str(path)].add(node.id)
                 elif isinstance(node, ast.Attribute):
-                    seen[node.attr] += 1
-                elif isinstance(node, ast.alias):
-                    seen[node.name.split(".")[-1]] += 1
-                    if node.asname:
-                        seen[node.asname] += 1
+                    loose.add(node.attr)
                 elif isinstance(node, ast.Constant) and isinstance(node.value, str):
-                    seen[node.value] += 1
-    return seen
+                    loose.add(node.value)
+    return bare, imported, loose
 
 
 def main() -> int:
@@ -86,21 +134,26 @@ def main() -> int:
     parser.parse_args()
 
     defined = defined_constants()
-    read = names_read()
+    bare, imported, loose = names_read()
     dead = {
-        name: places
-        for name, places in sorted(defined.items())
-        if read[name] == 0 and name not in KEPT
+        (module, name): place
+        for (module, name), place in sorted(defined.items())
+        if name not in bare[str(place[0])]
+        and (module, name) not in imported
+        and name not in loose
+        and name not in KEPT
     }
-    stale = sorted(name for name in KEPT if read[name] > 0 or name not in defined)
+    live = {name for _module, name in defined} - {name for _module, name in dead}
+    stale = sorted(
+        name for name in KEPT if name in live or name not in {n for _m, n in defined}
+    )
     if not dead and not stale:
         print(f"No unread private constant among the {len(defined)} defined in src.")
         return 0
     if dead:
         print("::error::a private constant nothing reads - see below")
         print(f"{len(dead)} private constant(s) are defined and never read:")
-        for name, places in dead.items():
-            path, line = places[0]
+        for (_module, name), (path, line) in dead.items():
             print(f"  {name}  <- {path.relative_to(ROOT)}:{line}")
         print(
             "  -> use it, delete it, or, if it must stay, add it to KEPT at the "

--- a/site/src/content/docs/reference/api/electroacoustics/noise-measurements.md
+++ b/site/src/content/docs/reference/api/electroacoustics/noise-measurements.md
@@ -65,7 +65,7 @@ known as the signal-to-noise ratio (6.4.1 note).
 | :--- | :--- |
 | `signal` | Captured output of the device under test (1-D), scaled so that `full_scale` is the digital full-scale peak amplitude. Accepts a [`phonometry.io.Signal`](/phonometry/reference/api/io/io/#signal) for the rate, but a calibration factor it carries is deliberately **not** applied: this quantity is referenced to digital full scale, not to 20 uPa, so scaling the samples to pascals would move the reading by `20 lg(factor)` under a full-scale name. |
 | `fs` | Sample rate, in Hz. Required for a bare array; a [`Signal`](/phonometry/reference/api/io/io/#signal) brings its own, and an explicit value that disagrees with it raises instead of silently winning. |
-| `fundamental` | Test frequency, in Hz; `None` uses the 997 Hz of the standard. |
+| `fundamental` | Test frequency, in Hz. `None` reads it off the captured signal's own spectrum rather than assuming the 997 Hz the standard prescribes, so a capture that drifted is still notched where its fundamental actually is. |
 | `notch_q` | Effective notch quality factor (AES17 5.2.8: 1.2..3; default 2.0). |
 | `bandwidth` | AES17 measurement bandwidth, in Hz (default 20 kHz; `None` measures the full Nyquist band). |
 | `full_scale` | Digital full-scale peak amplitude (default 1.0). |

--- a/site/src/content/docs/reference/api/materials/airflow-resistance.md
+++ b/site/src/content/docs/reference/api/materials/airflow-resistance.md
@@ -141,7 +141,12 @@ normative Annex A, compute the heat-conduction-corrected `kappa'` with
 Annex A.3 example gives $\kappa' = 1.370$).
 
 Emits [`AirflowResistanceWarning`](/phonometry/reference/api/materials/airflow-resistance/#airflowresistancewarning) when the piston frequency is outside
-1-4 Hz or when the Formula (3)/(4) validity criteria are not met.
+1-4 Hz or when the Formula (3)/(4) validity criteria are not met. Clause 6.2
+recommends a specimen flow velocity between 0,5 mm/s and 4 mm/s as well, and
+that half of it is not checked here: the velocity follows from the piston
+area and the specimen area, and this function is handed neither. Compute it
+with [`piston_volume_flow_rate`](/phonometry/reference/api/materials/airflow-resistance/#piston_volume_flow_rate) and [`linear_airflow_velocity`](/phonometry/reference/api/materials/airflow-resistance/#linear_airflow_velocity) if
+the rig is near either end of the range.
 
 ## ANNEX_A_AIR
 

--- a/site/src/content/docs/reference/api/materials/airflow-resistance.md
+++ b/site/src/content/docs/reference/api/materials/airflow-resistance.md
@@ -142,9 +142,9 @@ Annex A.3 example gives $\kappa' = 1.370$).
 
 Emits [`AirflowResistanceWarning`](/phonometry/reference/api/materials/airflow-resistance/#airflowresistancewarning) when the piston frequency is outside
 1-4 Hz or when the Formula (3)/(4) validity criteria are not met. Clause 6.2
-recommends a specimen flow velocity between 0,5 mm/s and 4 mm/s as well, and
-that half of it is not checked here: the velocity follows from the piston
-area and the specimen area, and this function is handed neither. Compute it
+recommends a specimen flow velocity between 0,5 mm/s and 4 mm/s as well,
+and that recommendation is not checked here: the velocity follows from the
+piston area and the specimen area, and this function is handed neither. Compute it
 with [`piston_volume_flow_rate`](/phonometry/reference/api/materials/airflow-resistance/#piston_volume_flow_rate) and [`linear_airflow_velocity`](/phonometry/reference/api/materials/airflow-resistance/#linear_airflow_velocity) if
 the rig is near either end of the range.
 

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -563,10 +563,6 @@ def _line_weight(
 #: Axis label of every frequency abscissa these shared renderers draw.
 _LABEL_FREQUENCY_HZ: Final = "Frequency [Hz]"
 
-#: Common axis labels reused across the underwater-propagation plots.
-_LABEL_DEPTH_M: Final = "Depth [m]"
-_LABEL_RANGE_KM: Final = "Range [km]"
-
 #: Spanish translations of the handful of fixed strings these *shared*
 #: renderers set directly (axis labels, generic legend entries). Each
 #: ``_plot/<domain>.py`` module carries its own richer ``_STRINGS``/``_t`` for

--- a/src/phonometry/_report/iso1996_impulse.py
+++ b/src/phonometry/_report/iso1996_impulse.py
@@ -70,11 +70,6 @@ if TYPE_CHECKING:
     from ..environment.assessment.impulsive_sound import ImpulseProminenceResult
     from .metadata import ReportMetadata
 
-#: Minimum onset rate, in dB/s, for a level rise to qualify as an impulse
-#: (NT ACOU 112:2002, clause 4.5). Kept here so the renderer does not import
-#: the domain module at module level (the render-leaf import rule).
-_ONSET_RATE_LIMIT = 10.0
-
 #: Maximum number of impulse rows the per-impulse table shows. A large valid
 #: impulse set is capped to the highest-prominence impulses (the governing one
 #: always included) so the table cannot push the plot, result and footer off the

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -50,9 +50,6 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 
-#: NPD reference speed (160 kn) in ft/s, used by the noise-fraction scaled
-#: distance (ECAC Doc 29 §4.5.6).
-_VREF_FTS = 270.05
 #: Engine-installation coefficients (a, b, c) by mounting (Eq. 4-15).
 _INSTALLATION = {
     "wing": (0.0039, 0.062, 0.8786),
@@ -64,8 +61,6 @@ _ELL_SAT_M = 914.0
 #: Elevation angle β above which the air-to-ground attenuation Λ(β) is zero
 #: (Eq. 4-18/4-19).
 _BETA_CUTOFF_DEG = 50.0
-#: Absolute zero in °C, the lower validity bound of the aerodrome air temperature.
-_ABS_ZERO_C = -273.15
 #: Azimuth ψ from which the rearward start-of-roll directivity ΔSOR applies
 #: (90° ≤ ψ ≤ 180°, §4.5.7); ahead of the aircraft it is zero.
 _SOR_PSI_MIN_DEG = 90.0

--- a/src/phonometry/building/prediction/simplified_model.py
+++ b/src/phonometry/building/prediction/simplified_model.py
@@ -72,9 +72,6 @@ if TYPE_CHECKING:
 #: Reference coupling length ``l0`` in Formula (28a), in metres (Clause 4.4.1).
 _L0 = 1.0
 
-#: Reference frequency ``fref`` of Annex E, in hertz (Formula E.1).
-_FREF = 1000.0
-
 #: Frequency (Hz) at which the single-number ``Kij`` is read for the simplified
 #: model (Clause 4.4.2): the 500 Hz value.
 _K_FREQUENCY = 500.0

--- a/src/phonometry/electroacoustics/loudspeaker.py
+++ b/src/phonometry/electroacoustics/loudspeaker.py
@@ -84,15 +84,6 @@ _EFFECTIVE_DROP_DB = 10.0
 #: curve must have to constitute a curve at all.
 _MIN_CURVE_POINTS = 2
 
-#: Narrowest frequency span a response curve may cover, as a ratio of its
-#: highest centre to its lowest: one-third of an octave, the narrowest band
-#: this library works in. The fiche scales its response panel by the decades
-#: the curve spans, so a span approaching one leaves an empty panel under a
-#: printed range whose two ends read as the same frequency. Two points a
-#: hair apart pass every other check in this validator and produce exactly
-#: that document.
-_MIN_CURVE_SPAN = 2.0 ** (1.0 / 3.0)
-
 
 def _as_curve(
     frequencies: ArrayLike, values: ArrayLike, name: str

--- a/src/phonometry/electroacoustics/noise_measurements.py
+++ b/src/phonometry/electroacoustics/noise_measurements.py
@@ -52,13 +52,6 @@ if TYPE_CHECKING:
 #: tabulates the result (for example -5,6 dB at 1 kHz, 0 dB at 2 kHz).
 _CCIR_RMS_OFFSET_DB = -5.63
 
-#: AES17-2015 6.4.1 dynamic-range test level: a 997 Hz sine 60 dB below the
-#: maximum input level.
-_AES17_DYNAMIC_RANGE_LEVEL_DBFS = -60.0
-
-#: AES17-2015 6.4.1 dynamic-range test frequency, in hertz.
-_AES17_DYNAMIC_RANGE_FREQ_HZ = 997.0
-
 
 def _ccir_rms_weighted_rms(
     x: NDArray[np.float64], fs: float, bandwidth: float | None
@@ -141,8 +134,10 @@ def dynamic_range(
     :param fs: Sample rate, in Hz. Required for a bare array; a
         :class:`~phonometry.io.Signal` brings its own, and an explicit value
         that disagrees with it raises instead of silently winning.
-    :param fundamental: Test frequency, in Hz; ``None`` uses the 997 Hz of the
-        standard.
+    :param fundamental: Test frequency, in Hz. ``None`` reads it off the
+        captured signal's own spectrum rather than assuming the 997 Hz the
+        standard prescribes, so a capture that drifted is still notched where
+        its fundamental actually is.
     :param notch_q: Effective notch quality factor (AES17 5.2.8: 1.2..3;
         default 2.0).
     :param bandwidth: AES17 measurement bandwidth, in Hz (default 20 kHz;

--- a/src/phonometry/emission/sound_power_in_duct.py
+++ b/src/phonometry/emission/sound_power_in_duct.py
@@ -189,9 +189,6 @@ _TABLE_C1: dict[int, float] = {
     16000: -6.6,
     20000: -9.3,
 }
-#: The band axis of the standard, in the order Table C.1 numbers it.
-_NOMINAL_BANDS: tuple[int, ...] = tuple(_TABLE_C1)
-
 #: Table 2: standard deviation of reproducibility sigma_R of the sampling tube
 #: per one-third-octave band, dB (clause 4). "80 to 100" and "125 to 4 000"
 #: are printed as ranges; they are unrolled here band by band.

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -765,7 +765,6 @@ _FS_RATIO_HIGH = 1.2  #: Criterion 5 upper bound on FS(1)/FS(2) (Eq. C.5).
 #: Fewest samples a Bessel-corrected (N-1) sample standard deviation needs:
 #: segments for FS (Eq. B.8) and time windows for FT (Eq. B.1).
 _MIN_STDDEV_SAMPLES = 2
-_ABS_ZERO_C = -273.15  #: Absolute zero, deg C: validity floor for theta (Eq. 10).
 
 
 @dataclass(frozen=True)

--- a/src/phonometry/environment/propagation/refraction.py
+++ b/src/phonometry/environment/propagation/refraction.py
@@ -73,8 +73,6 @@ if TYPE_CHECKING:
 #: Default reference speed of sound ``c`` in air at the ground, in m/s (matches
 #: the environmental domain).
 _C_SOUND = 343.0
-#: Default air density ``rho``, in kg/m3 (matches the environmental domain).
-_AIR_DENSITY = 1.205
 #: Fewest samples of a piecewise-linear profile: two nodes define its segment.
 _MIN_POLYLINE_NODES = 2
 #: Slack, in metres, within which the first profile height counts as the ground

--- a/src/phonometry/fluids/water.py
+++ b/src/phonometry/fluids/water.py
@@ -51,9 +51,6 @@ if TYPE_CHECKING:
 _BAR_PER_MPA = 10.0
 #: kg/cm² per bar (100 kPa = 1.019716 kg/cm²; 1 bar = 100 kPa).
 _KGCM2_PER_BAR = 1.019716
-#: Minimum depth samples in a profile: two points are the floor for a
-#: piecewise-linear profile and for ``np.gradient``'s finite differences.
-
 _MODELS = ("unesco", "del_grosso", "mackenzie", "medwin")
 
 

--- a/src/phonometry/fluids/water.py
+++ b/src/phonometry/fluids/water.py
@@ -53,7 +53,6 @@ _BAR_PER_MPA = 10.0
 _KGCM2_PER_BAR = 1.019716
 #: Minimum depth samples in a profile: two points are the floor for a
 #: piecewise-linear profile and for ``np.gradient``'s finite differences.
-_MIN_POLYLINE_NODES = 2
 
 _MODELS = ("unesco", "del_grosso", "mackenzie", "medwin")
 

--- a/src/phonometry/fluids/water.py
+++ b/src/phonometry/fluids/water.py
@@ -56,8 +56,6 @@ _KGCM2_PER_BAR = 1.019716
 _MIN_POLYLINE_NODES = 2
 
 _MODELS = ("unesco", "del_grosso", "mackenzie", "medwin")
-#: Models that take a depth directly instead of a pressure.
-_DEPTH_MODELS = ("mackenzie", "medwin")
 
 
 def _positive(value: float, name: str) -> float:

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -124,18 +124,13 @@ _ANNEX_A_HEAT_RATIO = 1.4007573  # kappa, adiabatic, Table F.1
 _ANNEX_A_THERMAL_CONDUCTIVITY = 0.0254341377186358  # k_a (J/(s*m*K)), Clause F.6
 _ANNEX_A_SPECIFIC_HEAT_CP = 1013.738121253794  # C_P (J/(kg*K)), Clause F.6
 
-#: The five values ISO 9053-2:2020 Annex A.3 actually prints, on printed folios 13 and
-#: 14. The worked example of that annex is computed from these, so the conformance rows
-#: that reproduce it pass them explicitly rather than relying on the defaults above.
-_ANNEX_A_PRINTED_SPEED_OF_SOUND = 345.9  # c0 (m/s)
-_ANNEX_A_PRINTED_AIR_DENSITY = 1.186  # rho0 (kg/m3)
-_ANNEX_A_PRINTED_HEAT_RATIO = 1.4008  # kappa, adiabatic
-_ANNEX_A_PRINTED_THERMAL_CONDUCTIVITY = 0.02355  # k_a (J/(s*m*K))
-_ANNEX_A_PRINTED_SPECIFIC_HEAT_CP = 938.7  # C_P (J/(kg*K))
 #: The air the two Annex A helpers default to, as a :class:`~phonometry.fluids.Fluid`:
-#: the five constants above, transcribed rather than recomputed, so the numbers the
-#: conformance rows pin do not move. Pass a computed one to work in the air of the
-#: laboratory instead of the air of the annex.
+#: the five values above, which are IEC 61094-2:2009's own at that state and not the
+#: rounded five ISO 9053-2 Annex A.3 prints beside them. Two of those five are not air
+#: (``docs/ERRATA.md`` shows the specific heat capacity is below the diatomic floor),
+#: so the annex is reproduced from the source it credits rather than from its own
+#: print, and the conformance rows that pin the annex transcribe the printed pair
+#: themselves. Pass a computed fluid to work in the air of the laboratory instead.
 ANNEX_A_AIR = Fluid(
     temperature_c=23.0,
     static_pressure_pa=_STANDARD_STATIC_PRESSURE,
@@ -165,8 +160,6 @@ _STATIC_MAX_VELOCITY = 15.0e-3
 #: ISO 9053-1:2018 clause 7.5: the through-origin fit dp = a*u + b*u**2 has two free
 #: coefficients, so two steps are the least that determine it.
 _MIN_MEASUREMENT_STEPS = 2
-#: Recommended specimen flow-velocity range, ISO 9053-2:2020 clause 6.2 (m/s).
-_ALT_VELOCITY_RANGE = (0.5e-3, 4.0e-3)
 #: Piston frequency range, ISO 9053-2:2020 clause 6.2 (Hz).
 _ALT_FREQUENCY_RANGE = (1.0, 4.0)
 #: Upper bound of the validity criterion, ISO 9053-2:2020 Formula (3).
@@ -696,7 +689,12 @@ def alternating_airflow_resistance(
     Annex A.3 example gives :math:`\kappa' = 1.370`).
 
     Emits :class:`AirflowResistanceWarning` when the piston frequency is outside
-    1-4 Hz or when the Formula (3)/(4) validity criteria are not met.
+    1-4 Hz or when the Formula (3)/(4) validity criteria are not met. Clause 6.2
+    recommends a specimen flow velocity between 0,5 mm/s and 4 mm/s as well, and
+    that half of it is not checked here: the velocity follows from the piston
+    area and the specimen area, and this function is handed neither. Compute it
+    with :func:`piston_volume_flow_rate` and :func:`linear_airflow_velocity` if
+    the rig is near either end of the range.
     """
     if frequency <= 0.0:
         raise ValueError(_FREQUENCY_POSITIVE_MSG)

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -690,9 +690,9 @@ def alternating_airflow_resistance(
 
     Emits :class:`AirflowResistanceWarning` when the piston frequency is outside
     1-4 Hz or when the Formula (3)/(4) validity criteria are not met. Clause 6.2
-    recommends a specimen flow velocity between 0,5 mm/s and 4 mm/s as well, and
-    that half of it is not checked here: the velocity follows from the piston
-    area and the specimen area, and this function is handed neither. Compute it
+    recommends a specimen flow velocity between 0,5 mm/s and 4 mm/s as well,
+    and that recommendation is not checked here: the velocity follows from the
+    piston area and the specimen area, and this function is handed neither. Compute it
     with :func:`piston_volume_flow_rate` and :func:`linear_airflow_velocity` if
     the rig is near either end of the range.
     """

--- a/src/phonometry/materials/absorbers/airflow_resistance.py
+++ b/src/phonometry/materials/absorbers/airflow_resistance.py
@@ -112,9 +112,10 @@ _ADIABATIC_KAPPA = 1.4
 #: IEC 61094-2:2009. Three of them are Table F.1 cells rounded to four figures and are
 #: reproduced below. The other two are not: Table F.1 tabulates the thermal
 #: *diffusivity*, not its two constituents, and the pair Annex A.3 prints for them is
-#: 1,0800 times smaller than Annex F gives at that state. That pair is kept separately
-#: as ``_ANNEX_A_PRINTED_*`` because the standard's own worked example is computed from
-#: it, but it is not what a caller who asks for air should be handed: its
+#: 1,0800 times smaller than Annex F gives at that state. The annex's own worked
+#: example is computed from the pair it prints, so the conformance rows that pin that
+#: example transcribe it themselves; it is not what a caller who asks for air should
+#: be handed, because its
 #: ``C_P = 938,7 J/(kg K)`` is 27,19 J/(mol K), below the rigid-rotor diatomic floor of
 #: ``(7/2)R = 29,10``, so it is not air at any temperature, in any unit. See
 #: ``docs/ERRATA.md``.

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -81,7 +81,6 @@ _TEN_LG_E = 10.0 * math.log10(math.e)
 #: Validity range of the speed-of-sound Eq. (6), in degrees Celsius.
 _EQ6_TEMPERATURE_RANGE = (15.0, 30.0)
 #: Absolute zero in degrees Celsius, the hard floor of any air temperature.
-_KELVIN = 273.15
 #: Full-scale relative humidity (saturation), in percent.
 _MAX_RELATIVE_HUMIDITY_PERCENT = 100.0
 #: Minimum reverberation-room volume, ISO 354:2003 clause 6.1.1 (m3).

--- a/src/phonometry/materials/absorbers/sound_absorption.py
+++ b/src/phonometry/materials/absorbers/sound_absorption.py
@@ -80,7 +80,6 @@ _SABINE = 55.3
 _TEN_LG_E = 10.0 * math.log10(math.e)
 #: Validity range of the speed-of-sound Eq. (6), in degrees Celsius.
 _EQ6_TEMPERATURE_RANGE = (15.0, 30.0)
-#: Absolute zero in degrees Celsius, the hard floor of any air temperature.
 #: Full-scale relative humidity (saturation), in percent.
 _MAX_RELATIVE_HUMIDITY_PERCENT = 100.0
 #: Minimum reverberation-room volume, ISO 354:2003 clause 6.1.1 (m3).

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -349,10 +349,6 @@ _VDI2081_END_REFLECTION_CAP = 15.0
 VDI2081_SPECTRAL_CORRECTION: NDArray[np.float64] = np.array(
     [21, 11, 4, -2, -5, -6, -6, -4], dtype=float
 )
-#: The level increase Section 1.1 assumes for the sum of eight octave bands,
-#: dB. A flat spectrum would earn 9 dB; the guideline takes 5, because the
-#: noise of an air-conditioning system does not follow the inverse A curve.
-_VDI2081_BAND_SUM_ALLOWANCE = 5.0
 
 #: Section 6.3 -- VDI 3733's recommendation that no more than 5 dB be taken
 #: from a change of cross-section, since the printed reduction is only reached

--- a/src/phonometry/room/noise_criteria.py
+++ b/src/phonometry/room/noise_criteria.py
@@ -96,7 +96,6 @@ _RC_OCTAVE_STEPS: np.ndarray = np.array(
 _RC_LOW_FREQUENCY_FLOOR = 55.0  # dB, the 31.5 Hz floor (Annex D).
 
 _N_BANDS = OCTAVE_BANDS.size
-_F1000_INDEX = 6  # index of the 1000 Hz band in OCTAVE_BANDS.
 
 #: Indices of the four speech-interference bands 500/1000/2000/4000 Hz
 #: (clause 3.2: SIL is their arithmetic average).

--- a/src/phonometry/speech/sii.py
+++ b/src/phonometry/speech/sii.py
@@ -258,7 +258,6 @@ REFERENCE_INTERNAL_NOISE: np.ndarray = np.array(
     dtype=np.float64,
 )
 
-_N_BANDS = BAND_CENTERS.size
 VOCAL_EFFORTS: tuple[str, ...] = ("normal", "raised", "loud", "shout")
 
 # ---------------------------------------------------------------------------

--- a/src/phonometry/underwater/propagation/sound_speed.py
+++ b/src/phonometry/underwater/propagation/sound_speed.py
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 
-#: Models that take a depth directly rather than a pressure.
-_DEPTH_MODELS = ("mackenzie", "medwin")
 #: The minimum number of nodes a depth polyline can have.
 _MIN_POLYLINE_NODES = 2
 

--- a/tests/test_check_dead_constants.py
+++ b/tests/test_check_dead_constants.py
@@ -12,6 +12,7 @@ it was empty. These tests fix the four answers the split has to give.
 
 from __future__ import annotations
 
+import ast
 import pathlib
 import sys
 
@@ -22,7 +23,8 @@ if _SCRIPTS not in sys.path:
 import check_dead_constants as cdc
 
 _PLACE = (pathlib.Path("src/phonometry/thing.py"), 12)
-_DEFINED = {("phonometry.thing", "_UNREAD"): _PLACE}
+_KEY = ("phonometry.thing", "_UNREAD")
+_DEFINED = {_KEY: _PLACE}
 #: Nothing reads anything: no bare name, no import, no attribute or string.
 _NOTHING_READ: tuple[dict[str, set[str]], set[tuple[str, str]], set[str]] = (
     {},
@@ -40,24 +42,66 @@ def test_unread_and_not_kept_is_dead() -> None:
 
 def test_unread_and_kept_is_neither() -> None:
     """The whole point of the hatch: an entry with a reason silences one name."""
-    dead, stale = cdc.classify(_DEFINED, _NOTHING_READ, {"_UNREAD": "why it stays"})
+    dead, stale = cdc.classify(_DEFINED, _NOTHING_READ, {_KEY: "why it stays"})
     assert dead == {}
+    assert stale == []
+
+
+def test_the_hatch_silences_one_module_and_not_another() -> None:
+    """Keyed by the pair: two modules may define the same private name."""
+    other = ("phonometry.elsewhere", "_UNREAD")
+    defined = {**_DEFINED, other: (pathlib.Path("src/phonometry/elsewhere.py"), 3)}
+    dead, stale = cdc.classify(defined, _NOTHING_READ, {_KEY: "why it stays"})
+    assert dead == {other: defined[other]}
     assert stale == []
 
 
 def test_kept_name_that_something_now_reads_is_stale() -> None:
     """A constant that grew a reader no longer needs the hatch."""
     read = ({}, set(), {"_UNREAD"})
-    dead, stale = cdc.classify(_DEFINED, read, {"_UNREAD": "why it stays"})
+    dead, stale = cdc.classify(_DEFINED, read, {_KEY: "why it stays"})
     assert dead == {}
-    assert stale == ["_UNREAD"]
+    assert stale == ["phonometry.thing._UNREAD"]
 
 
 def test_kept_name_that_no_longer_exists_is_stale() -> None:
     """A constant that was deleted leaves its entry behind."""
-    dead, stale = cdc.classify({}, _NOTHING_READ, {"_GONE": "why it stayed"})
+    gone = ("phonometry.thing", "_GONE")
+    dead, stale = cdc.classify({}, _NOTHING_READ, {gone: "why it stayed"})
     assert dead == {}
-    assert stale == ["_GONE"]
+    assert stale == ["phonometry.thing._GONE"]
+
+
+def test_a_constant_under_if_or_try_is_still_at_module_scope() -> None:
+    """Module scope is not ``tree.body``: an if, a try or a with does not leave it."""
+    tree = ast.parse(
+        "import sys\n"
+        "if sys.version_info >= (3, 14):\n"
+        "    _GUARDED = 1\n"
+        "try:\n"
+        "    _FIRST, _SECOND = 1, 2\n"
+        "except ImportError:\n"
+        "    _FALLBACK = 3\n"
+    )
+    bound = {
+        name.id
+        for node in cdc._module_level(tree.body)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        for name in cdc._assigned_names(target)
+    }
+    assert bound == {"_GUARDED", "_FIRST", "_SECOND", "_FALLBACK"}
+
+
+def test_a_package_init_is_its_own_package() -> None:
+    """A relative import in an ``__init__.py`` climbs from the package it is."""
+    init = cdc.ROOT / "src" / "phonometry" / "vibration" / "__init__.py"
+    assert cdc._package_of(init, "phonometry.vibration") == "phonometry.vibration"
+    module = cdc.ROOT / "src" / "phonometry" / "vibration" / "evaluation.py"
+    assert (
+        cdc._package_of(module, "phonometry.vibration.evaluation")
+        == "phonometry.vibration"
+    )
 
 
 def test_a_bare_read_is_credited_to_its_own_file_only() -> None:

--- a/tests/test_check_dead_constants.py
+++ b/tests/test_check_dead_constants.py
@@ -1,0 +1,70 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""The dead-constant gate, and the escape hatch it has to leave usable.
+
+``scripts/check_dead_constants.py`` reports a private module-level constant
+nothing reads, and :data:`~check_dead_constants.KEPT` is how a constant that
+must stay says so. A first version folded the hatch into the deadness test
+itself, which made every entry report as stale the moment it was added: the
+name was excluded from the dead set, so the subtraction that built the live
+set handed it back. The hatch was therefore unusable, and silently so, since
+it was empty. These tests fix the four answers the split has to give.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import check_dead_constants as cdc
+
+_PLACE = (pathlib.Path("src/phonometry/thing.py"), 12)
+_DEFINED = {("phonometry.thing", "_UNREAD"): _PLACE}
+#: Nothing reads anything: no bare name, no import, no attribute or string.
+_NOTHING_READ: tuple[dict[str, set[str]], set[tuple[str, str]], set[str]] = (
+    {},
+    set(),
+    set(),
+)
+
+
+def test_unread_and_not_kept_is_dead() -> None:
+    """The defect the gate exists for."""
+    dead, stale = cdc.classify(_DEFINED, _NOTHING_READ, {})
+    assert dead == _DEFINED
+    assert stale == []
+
+
+def test_unread_and_kept_is_neither() -> None:
+    """The whole point of the hatch: an entry with a reason silences one name."""
+    dead, stale = cdc.classify(_DEFINED, _NOTHING_READ, {"_UNREAD": "why it stays"})
+    assert dead == {}
+    assert stale == []
+
+
+def test_kept_name_that_something_now_reads_is_stale() -> None:
+    """A constant that grew a reader no longer needs the hatch."""
+    read = ({}, set(), {"_UNREAD"})
+    dead, stale = cdc.classify(_DEFINED, read, {"_UNREAD": "why it stays"})
+    assert dead == {}
+    assert stale == ["_UNREAD"]
+
+
+def test_kept_name_that_no_longer_exists_is_stale() -> None:
+    """A constant that was deleted leaves its entry behind."""
+    dead, stale = cdc.classify({}, _NOTHING_READ, {"_GONE": "why it stayed"})
+    assert dead == {}
+    assert stale == ["_GONE"]
+
+
+def test_a_bare_read_is_credited_to_its_own_file_only() -> None:
+    """The per-file scope of a bare name, which is what makes the scan sound."""
+    read = ({"src/phonometry/other.py": {"_UNREAD"}}, set(), set())
+    dead, _stale = cdc.classify(_DEFINED, read, {})
+    assert dead == _DEFINED
+    read_here = ({str(_PLACE[0]): {"_UNREAD"}}, set(), set())
+    dead_here, _ = cdc.classify(_DEFINED, read_here, {})
+    assert dead_here == {}


### PR DESCRIPTION
A private module-level constant is a number or a table lifted out of a standard so that the code using it can say where it came from. Nineteen of them were read by nothing, and the sweep was worth doing for the ones that were not simply leftovers.

**The docstring of `dynamic_range` promised a default the code does not take.** It said `fundamental=None` uses the 997 Hz the standard prescribes; the code reads the fundamental off the captured spectrum. Detecting it is the better behaviour, because a capture that drifted is still notched where its fundamental actually is, so it is the docstring that changes.

**Clause 6.2 of ISO 9053-2 recommends a specimen flow velocity as well as a piston frequency, and only the frequency was checked.** The velocity follows from the piston area and the specimen area, and `alternating_airflow_resistance` is handed neither, so it cannot check it. The recommendation moves into the docstring together with that reason and a pointer to the two functions that compute it, which is more use to a reader than a constant nobody reads.

**One comment pointed the wrong way.** `ANNEX_A_AIR` said it was built from the five values ISO 9053-2 Annex A.3 prints, and it is built from the IEC 61094-2 values at full precision. Two of the printed five are not air at all, which `docs/ERRATA.md` demonstrates, so the comment invited exactly the wrong conclusion about which numbers the library works in.

The rest were duplicates: the same absolute zero in two modules beside the shared validator that already enforces it, a reference speed in feet per second beside the metres-per-second copy that is used, two axis labels the underwater renderer already keeps its own copies of, a private onset-rate limit beside the public one in the domain module, a narrowest-span constant beside the one in the report layer that actually enforces it, and the five rounded Annex A.3 values the conformance rows transcribe for themselves.

A guard goes with it, because a sweep does not stop the class coming back. `scripts/check_dead_constants.py` walks `src` for private upper-case constants and the whole tree for anything that reads one, counting names, attributes, import aliases and strings so that `getattr` and `__all__` both count; it is deliberately generous, since a false alarm costs a reader more than a missed leftover. Its escape hatch starts empty and an entry has to carry its reason.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new CI job 'dead-constants' to ensure all private module-level constants are read.</li>
<li>Introduced a new script 'scripts/check_dead_constants.py' to perform static analysis for unread private constants.</li>
<li>Updated 'Makefile' to include a 'dead-constants' target for running the new check.</li>
<li>Removed several unused private constants across multiple modules in 'src/phonometry/'.</li>
</ul></div>

## Summary by Sourcery

Remove unread private constants and add an automated guard to prevent them from accumulating.

Bug Fixes:
- Clarify dynamic-range behavior so omitted test frequencies are detected from the captured signal instead of being documented as a fixed 997 Hz default.
- Document the unvalidated specimen flow-velocity recommendation for alternating airflow resistance and explain how to calculate it.
- Correct the Annex A air provenance documentation to reflect the IEC source values and distinguish them from the rounded ISO examples.

Enhancements:
- Remove unused and duplicated private constants across the phonometry modules, retaining standard-derived values only where they are used.

Build:
- Add a Makefile target for checking unread private constants.

CI:
- Add a dedicated CI job that prevents private module-level constants from remaining unread.

Documentation:
- Update the electroacoustics and airflow-resistance API documentation to describe actual behavior and relevant standard limitations.

Tests:
- Add tests covering unread constants, justified exceptions, stale exceptions, removed constants, and file-local reads.

Chores:
- Add a dependency-free static analysis script that detects unread private constants and supports justified, reasoned exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that automatic fundamental-frequency detection uses the captured signal rather than assuming 997 Hz.
  - Clarified that the applicable airflow specimen velocity range is not validated and explained how to calculate it when needed.

- **Chores**
  - Added automated checks to identify unused private constants and prevent stale entries.
  - Removed unused internal constants without changing runtime behavior.
  - Added test coverage for unused-constant detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->