### PR TITLE
Say where each transcribed cell was read, since the source is a scan

### DIFF
--- a/scripts/conformance/domains/machine_vibration.py
+++ b/scripts/conformance/domains/machine_vibration.py
@@ -40,7 +40,12 @@ _PRINTED_MAGNITUDE_CHANGE = -0.5
 #: The annex prints one decimal.
 _TOLERANCE = 0.05
 
-#: Table C.1: the range each boundary is typically drawn from, mm/s r.m.s.
+#: Table C.1 on printed folio 29 (PDF page 35): the range each boundary is
+#: typically drawn from, mm/s r.m.s. Read against the rendered page on
+#: 2026-09-05 together with the fourteen rungs of the ladder the table is drawn
+#: on, which live in ``TYPICAL_BOUNDARY_LADDER_MM_S``; nothing differs. Nine of
+#: the ladder's thirteen steps are the factor of about 1,6 that makes it R5,
+#: and the four in the middle of the run are closer together than that.
 _PRINTED_RANGES = {
     "A/B": (0.71, 4.5),
     "B/C": (1.8, 9.3),
@@ -352,8 +357,14 @@ def _chk_significant_change() -> Outcome:
 # ---------------------------------------------------------------------------
 # ISO 20816-9:2020: the rating system gear units are graded by
 # ---------------------------------------------------------------------------
-#: Tables 2, 3 and 4 on printed folios 7 and 8, transcribed from the page. The
-#: unit of each is the one Table 1 fixes for that quantity.
+#: Tables 2, 3 and 4 on printed folios 7 and 8 (PDF pages 13 and 14),
+#: transcribed from the rendered page. The unit of each is the one Table 1
+#: fixes for that quantity.
+#:
+#: This is deliberately a **second** transcription: ``GEAR_UNIT_ZONES`` in the
+#: library is the first, and a row that compared the library with itself would
+#: certify nothing. The two were read against the printed page separately on
+#: 2026-09-05, 57 cells each, and neither differs from it.
 _PRINTED_GEAR_ZONES: dict[str, tuple[str, dict[float, tuple[float, float, float]]]] = {
     "displacement": (
         "um",

--- a/scripts/conformance/domains/vdi2081.py
+++ b/scripts/conformance/domains/vdi2081.py
@@ -13,6 +13,35 @@ Method: VDI 2081 Part 1:2001-07, Section 4.3 on printed folios 18 to 25.
 Both prints are superseded, by Part 1:2022-04 and Part 2:2022-10, and neither
 successor is held. The pair is self-consistent: Part 2:2005 was written against
 Part 1:2001 and every cross-reference in its tables resolves there.
+
+Where the ``_PRINTED_*`` constants were read
+--------------------------------------------
+
+The Part 2 PDF held here **has no text layer**: ``pdftotext`` returns nothing
+for any of its 48 pages, so every constant below was read by rendering the page
+and looking at it. They were checked again cell by cell on 2026-09-05, 126
+cells, and none differs from the print:
+
+===================================== ===== ==================================
+Constant                              Folio Row
+===================================== ===== ==================================
+``_PRINTED_KA``                       3     Section 1.1, the ``K_A`` table
+``_PRINTED_SPECTRUM``                 12    element 1, "Ventilatorspektrum"
+``_SILENCER_ATTENUATION``             12    element 2, ``dL_W`` (dB/Okt)
+``_PRINTED_SILENCER_NOISE``           12    element 2, "Strömungsrauschen"
+``_PRINTED_BANDS``                    12-16 header "Frequenzen", on every folio
+``_PRINTED_A_WEIGHTING``              12-16 header "A-Korrektur", likewise
+``_PRINTED_JUNCTION_NOISE``           13    element 3, "Strömungsrauschen"
+``_PRINTED_AFTER_JUNCTION``           13    element 3, ``SL_W`` (log)
+``_PRINTED_RECT``                     13    element 5, ``dL_W`` (dB/Okt)
+``_PRINTED_ROUND``                    15    element 13, ``dL_W/m`` (dB/Okt)
+``_PRINTED_BEND``                     15    element 14, ``dL_W`` (dB/Okt)
+``_PRINTED_BEND_NOISE``               15    element 14, ``L_W`` (dB/Okt)
+``_EXAMPLE_SPEED``, 1245 Hz           15    element 14, ``f_G`` (Hz)
+``_PRINTED_NOZZLE``                   16    element 18, ``dL_W`` before the cap
+``_PRINTED_ROOM_ATTENUATION``         16    element 20, "Raumdämpfung"
+``_PRINTED_ROOM_LEVELS`` and totals   16    element 20, ``L_p`` and ``L_pA``
+===================================== ===== ==================================
 """
 
 from __future__ import annotations
@@ -41,7 +70,11 @@ _PRINTED_SPECTRUM = (90.4, 88.8, 86.3, 82.9, 78.6, 73.4, 67.2, 60.2)
 _PRINTED_BANDS = (63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0)
 #: Table 1, row "A-Korrektur", dB.
 _PRINTED_A_WEIGHTING = (-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1)
-#: The table prints one decimal.
+#: The table prints one decimal, and Section 1.3 on printed folio 5 says why
+#: that is the resolution to judge it at: the spreadsheet rounds each result to
+#: whole decibels and "kleine Differenzen (< 0,1 dB) in den Berechnungen"
+#: follow from it. Half of that 0,1 dB is the tolerance, 0,05 dB, and not half
+#: of the whole decibel the rounding is to.
 _PRINTED_TOLERANCE = 0.05
 
 


### PR DESCRIPTION
## What and why

The VDI 2081 Part 2 example and the ISO 20816 zone tables were transcribed from a PDF with no text layer. `pdftotext` returns nothing for either, so the constants were read by rasterising the page and looking at it, and nothing in the tree said so. This writes the provenance down: which folio each block came from, which row of which element, and that the cell-by-cell collation found no discrepancy.

No value changes. If this layer moved a number it would be a finding, not a provenance note.

`_PRINTED_GEAR_ZONES` gets the reason it is deliberately a second transcription of what `GEAR_UNIT_ZONES` already holds: a row that compared the library with itself would prove nothing, so the two were read from the page separately.

## Validation

Nothing new to validate: the oracles are the ones already in the tree, and the collation that produced these tables is what the note records.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files touched
- [x] `mypy src scripts`
- [x] `pytest -q`

Always:

- [x] CHANGELOG entry under `[Unreleased]` (not needed: no behaviour changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the provenance and verification details for machine vibration reference ranges and gear-zone data.
  * Documented the source-reading and cell-by-cell verification process for VDI 2081 Part 2 constants.
  * Added context on printed precision, spreadsheet rounding, and tolerance handling for VDI 2081 values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->