### PR TITLE
Cite the guideline that owns the law, not the handbook that quotes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   test holds the class shut: a standard's number always follows its body, so a
   designation with no digit whose clause opens with one has lost it.
 
+- `flow_noise_straight_duct` was credited to Bies, Hansen & Howard 5e
+  Eq. (8.251), a second-hand citation of a law this project holds the primary
+  source for. The printed page settles it: Bies gives that equation as "(VDI
+  2081-1, 2003)", and VDI 2081 Part 1 prints the two halves in two places on
+  the same page. Equation (16) is the overall level, and the level difference
+  the octave spectrum needs is printed inside Figure 16 itself, on an abscissa
+  of `f_m / v`. The docstring now cites the guideline first and the handbook as
+  the place the two are written on one line.
+
+  With that in hand the "does not sum back" sentence gets the reason it was
+  missing. The difference Figure 16 prints tends to `-2 - 26 lg 1,14`, which is
+  `-2,5` dB, as `f_m / v` falls, so the energy sum grows with however many
+  octaves are taken and no fixed shortfall can be quoted. Over the range the
+  figure is actually drawn for it lands within half a decibel of the overall.
+
 - Three railway coefficient rows cited `Appendix G` with no document, which is
   the CNOSSOS-EU case the override file exists for: the appendix belongs to
   Annex II of Directive 2002/49/EC and the tables inside each row are owned by
@@ -437,7 +452,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   at a time. It wrapped `evaluation_zone`, which has always taken an array, and
   then applied the most-restrictive rule of 5.2.3 by comparing the two gradings
   as text: with an array in, that text was the array's own repr, so a month of
-  daily readings came back as the eighteen-character string `"['A' 'C' 'D']"`.
+  daily readings came back as the thirteen-character string `"['A' 'C' 'D']"`.
   The rule is applied to the zone indices now and the letters looked up once at
   the end, so an array in gives one letter per reading and a scalar still gives
   a letter. A scalar and an array together broadcast, which is the shape of

--- a/docs/devices/noise-control/vdi2081-air-systems.md
+++ b/docs/devices/noise-control/vdi2081-air-systems.md
@@ -149,8 +149,11 @@ nothing else left to hear. VDI 2081 gives it in closed form.
 - **A straight run** (Section 5.2.1, Equations (16) and (17) with Figure 16),
   through `flow_noise_straight_duct_overall` for the two overall levels and
   `flow_noise_straight_duct` for the octave spectrum, which is the first of
-  them with the relative shape of Figure 16 on it. That shape is a fit and not
-  a partition, so the bands do not sum back to the overall.
+  them with the relative shape of Figure 16 on it. What that figure prints is a
+  level difference, not a share: it tends to $-2{,}5$ dB as $f_\mathrm{m}/v$
+  falls, so the bands do not sum back to the overall and the shortfall depends
+  on how many octaves are taken. Over the range the figure is drawn for it
+  lands within half a decibel of the overall.
 - **A bend or a branch** (Section 5.2.2, Equation (18) with Figures 17 and 18),
   through `flow_noise_bend`. It is written on a Strouhal number built from the
   element's own diameter and the flow speed through it, and both figures state

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -21949,8 +21949,11 @@ nothing else left to hear. VDI 2081 gives it in closed form.
 - **A straight run** (Section 5.2.1, Equations (16) and (17) with Figure 16),
   through `flow_noise_straight_duct_overall` for the two overall levels and
   `flow_noise_straight_duct` for the octave spectrum, which is the first of
-  them with the relative shape of Figure 16 on it. That shape is a fit and not
-  a partition, so the bands do not sum back to the overall.
+  them with the relative shape of Figure 16 on it. What that figure prints is a
+  level difference, not a share: it tends to $-2{,}5$ dB as $f_\mathrm{m}/v$
+  falls, so the bands do not sum back to the overall and the shortfall depends
+  on how many octaves are taken. Over the range the figure is drawn for it
+  lands within half a decibel of the overall.
 - **A bend or a branch** (Section 5.2.2, Equation (18) with Figures 17 and 18),
   through `flow_noise_bend`. It is written on a Strouhal number built from the
   element's own diameter and the flow speed through it, and both figures state

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -2401,8 +2401,11 @@ nothing else left to hear. VDI 2081 gives it in closed form.
 - **A straight run** (Section 5.2.1, Equations (16) and (17) with Figure 16),
   through `flow_noise_straight_duct_overall` for the two overall levels and
   `flow_noise_straight_duct` for the octave spectrum, which is the first of
-  them with the relative shape of Figure 16 on it. That shape is a fit and not
-  a partition, so the bands do not sum back to the overall.
+  them with the relative shape of Figure 16 on it. What that figure prints is a
+  level difference, not a share: it tends to $-2{,}5$ dB as $f_\mathrm{m}/v$
+  falls, so the bands do not sum back to the overall and the shortfall depends
+  on how many octaves are taken. Over the range the figure is drawn for it
+  lands within half a decibel of the overall.
 - **A bend or a branch** (Section 5.2.2, Equation (18) with Figures 17 and 18),
   through `flow_noise_bend`. It is written on a Strouhal number built from the
   element's own diameter and the flow speed through it, and both figures state

--- a/site/src/content/docs/devices/noise-control/vdi2081-air-systems.mdx
+++ b/site/src/content/docs/devices/noise-control/vdi2081-air-systems.mdx
@@ -170,8 +170,11 @@ nothing else left to hear. VDI 2081 gives it in closed form.
 - **A straight run** (Section 5.2.1, Equations (16) and (17) with Figure 16),
   through `flow_noise_straight_duct_overall` for the two overall levels and
   `flow_noise_straight_duct` for the octave spectrum, which is the first of
-  them with the relative shape of Figure 16 on it. That shape is a fit and not
-  a partition, so the bands do not sum back to the overall.
+  them with the relative shape of Figure 16 on it. What that figure prints is a
+  level difference, not a share: it tends to $-2{,}5$ dB as $f_\mathrm{m}/v$
+  falls, so the bands do not sum back to the overall and the shortfall depends
+  on how many octaves are taken. Over the range the figure is drawn for it
+  lands within half a decibel of the overall.
 - **A bend or a branch** (Section 5.2.2, Equation (18) with Figures 17 and 18),
   through `flow_noise_bend`. It is written on a Strouhal number built from the
   element's own diameter and the flow speed through it, and both figures state

--- a/site/src/content/docs/es/devices/noise-control/vdi2081-air-systems.mdx
+++ b/site/src/content/docs/es/devices/noise-control/vdi2081-air-systems.mdx
@@ -170,8 +170,11 @@ menudo no queda otra cosa que oír. La VDI 2081 lo da en forma cerrada.
 - **Un tramo recto** (apartado 5.2.1, Ecuaciones (16) y (17) con la Figura 16),
   con `flow_noise_straight_duct_overall` para los dos niveles globales y
   `flow_noise_straight_duct` para el espectro por octavas, que es el primero de
-  ellos con la forma relativa de la Figura 16 encima. Esa forma es un ajuste y
-  no un reparto, así que las bandas no suman el nivel global.
+  ellos con la forma relativa de la Figura 16 encima. Lo que esa figura imprime
+  es una diferencia de nivel, no un reparto: tiende a $-2{,}5$ dB cuando
+  $f_\mathrm{m}/v$ baja, así que las bandas no suman el nivel global y lo que
+  falta depende de cuántas octavas se tomen. En el rango para el que la figura
+  está dibujada se queda a medio decibelio del global.
 - **Un codo o una ramificación** (apartado 5.2.2, Ecuación (18) con las
   Figuras 17 y 18), con `flow_noise_bend`. Está escrito sobre un número de
   Strouhal construido con el diámetro del propio elemento y la velocidad que lo

--- a/site/src/content/docs/reference/api/noise_control/hvac.md
+++ b/site/src/content/docs/reference/api/noise_control/hvac.md
@@ -679,21 +679,25 @@ flow_noise_straight_duct(
 ) -> HvacSpectrumResult
 ```
 
-Flow-generated octave-band sound power of a straight duct (Bies Eq. (8.251)).
+Flow-generated octave-band sound power of a straight duct (VDI 2081-1, 5.2.1).
 
 $$
-L_{W\mathrm{B}} = 7 + 50 \log_{10}(U) + 10 \log_{10}(S) - 2 - 26 \log_{10}(1.14 + 0.02 f / U)
+L_{W\mathrm{B}} = \underbrace{7 + 50 \log_{10}(v) + 10 \log_{10}(S)}_{(16)} \underbrace{- 2 - 26 \log_{10}(1.14 + 0.02 f_\mathrm{m} / v)}_{\text{Figure 16}}
 $$
 
-in dB re 1e-12 W (VDI 2081-1), for airflow speed `U` in a duct of area
-`S`.
+in dB re 1e-12 W, for airflow speed `v` in a duct of area `S`. The two
+halves come from two places on the same page of VDI 2081 Part 1: Equation
+(16) is the overall level, and the level difference
+$\Delta L_W = L_{W\mathrm{Okt}} - L_W$ is printed inside Figure 16,
+whose abscissa is $f_\mathrm{m}/v$. Bies, Hansen & Howard 5e
+Eq. (8.251) prints the two as one line and credits the same guideline.
 
 **Parameters**
 
 | Name | Description |
 | :--- | :--- |
-| `frequencies` | Octave-band centre frequencies `f`, Hz (1-D array). |
-| `flow_velocity` | Mean flow speed `U`, m/s. |
+| `frequencies` | Octave-band centre frequencies `f_m`, Hz (1-D array). |
+| `flow_velocity` | Mean flow speed `v` in the duct, m/s. |
 | `area` | Duct cross-sectional area `S`, m2. |
 
 **Returns:** A [`HvacSpectrumResult`](/phonometry/reference/api/noise_control/hvac/#hvacspectrumresult) of the band sound power level, dB re 1e-12 W.
@@ -730,10 +734,13 @@ power of the speed, and seventy is a seventh, because raising the speed
 also moves the spectrum up into the part of the curve the weighting stops
 attenuating. Faster air is worse than the unweighted number says.
 
-[`flow_noise_straight_duct`](/phonometry/reference/api/noise_control/hvac/#flow_noise_straight_duct) is the same law spread over the octaves,
-Equation (16) with the relative spectrum of Figure 16; the band levels do
-not sum back to this overall, because that figure is a shape and not a
-partition.
+[`flow_noise_straight_duct`](/phonometry/reference/api/noise_control/hvac/#flow_noise_straight_duct) is this level with the relative spectrum
+of Figure 16 on it. The band levels do not sum back here, and not by a
+fixed amount either: the difference the figure prints tends to
+$-2 - 26 \lg 1{,}14 = -2{,}5$ dB as $f_\mathrm{m}/v$ falls, so
+the energy sum grows with however many octaves are taken. Over the range
+the figure is drawn for it lands within half a decibel of this number, and
+outside it the sum means nothing.
 
 **Parameters**
 

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -1008,18 +1008,22 @@ def flow_noise_straight_duct(
     flow_velocity: float,
     area: float,
 ) -> HvacSpectrumResult:
-    r"""Flow-generated octave-band sound power of a straight duct (Bies Eq. (8.251)).
+    r"""Flow-generated octave-band sound power of a straight duct (VDI 2081-1, 5.2.1).
 
     .. math::
 
-       L_{W\mathrm{B}} = 7 + 50 \log_{10}(U) + 10 \log_{10}(S) - 2
-       - 26 \log_{10}(1.14 + 0.02 f / U)
+       L_{W\mathrm{B}} = \underbrace{7 + 50 \log_{10}(v) + 10 \log_{10}(S)}_{(16)}
+       \underbrace{- 2 - 26 \log_{10}(1.14 + 0.02 f_\mathrm{m} / v)}_{\text{Figure 16}}
 
-    in dB re 1e-12 W (VDI 2081-1), for airflow speed ``U`` in a duct of area
-    ``S``.
+    in dB re 1e-12 W, for airflow speed ``v`` in a duct of area ``S``. The two
+    halves come from two places on the same page of VDI 2081 Part 1: Equation
+    (16) is the overall level, and the level difference
+    :math:`\Delta L_W = L_{W\mathrm{Okt}} - L_W` is printed inside Figure 16,
+    whose abscissa is :math:`f_\mathrm{m}/v`. Bies, Hansen & Howard 5e
+    Eq. (8.251) prints the two as one line and credits the same guideline.
 
-    :param frequencies: Octave-band centre frequencies ``f``, Hz (1-D array).
-    :param flow_velocity: Mean flow speed ``U``, m/s.
+    :param frequencies: Octave-band centre frequencies ``f_m``, Hz (1-D array).
+    :param flow_velocity: Mean flow speed ``v`` in the duct, m/s.
     :param area: Duct cross-sectional area ``S``, m2.
     :return: A :class:`HvacSpectrumResult` of the band sound power level,
         dB re 1e-12 W.
@@ -1067,10 +1071,13 @@ def flow_noise_straight_duct_overall(
     also moves the spectrum up into the part of the curve the weighting stops
     attenuating. Faster air is worse than the unweighted number says.
 
-    :func:`flow_noise_straight_duct` is the same law spread over the octaves,
-    Equation (16) with the relative spectrum of Figure 16; the band levels do
-    not sum back to this overall, because that figure is a shape and not a
-    partition.
+    :func:`flow_noise_straight_duct` is this level with the relative spectrum
+    of Figure 16 on it. The band levels do not sum back here, and not by a
+    fixed amount either: the difference the figure prints tends to
+    :math:`-2 - 26 \lg 1{,}14 = -2{,}5` dB as :math:`f_\mathrm{m}/v` falls, so
+    the energy sum grows with however many octaves are taken. Over the range
+    the figure is drawn for it lands within half a decibel of this number, and
+    outside it the sum means nothing.
 
     :param flow_velocity: Mean flow speed ``v`` in the duct, m/s.
     :param area: Duct cross-sectional area ``S``, m2.


### PR DESCRIPTION
## What and why

`flow_noise_straight_duct` was credited to Bies, Hansen & Howard 5e Eq. (8.251), which is a second-hand citation of a law this project holds the primary source for. The printed page settles it twice over. Bies gives that equation as "(VDI 2081-1, 2003)", and VDI 2081 Part 1 prints the two halves of it in two places on the same page: Equation (16) is the overall level, and the level difference the octave spectrum needs, $\Delta L_W = L_{W\mathrm{Okt}} - L_W = -2 - 26 \lg (1{,}14 + 0{,}02\, f_\mathrm{m}/v)$, is printed inside Figure 16 itself, on an abscissa of $f_\mathrm{m}/v$. The docstring cites the guideline first now, and the handbook as the place where the two appear on one line. The report fiche already did it that way round.

Having the figure in hand also supplies the reason the "does not sum back to the overall" sentence was missing. What Figure 16 prints is a level difference, not a share, and it tends to $-2 - 26 \lg 1{,}14 = -2{,}5$ dB as $f_\mathrm{m}/v$ falls, so the energy sum grows with however many octaves are taken and no fixed shortfall can be quoted. Over the range the figure is actually drawn for, $f_\mathrm{m}/v$ from 6,3 to 800, it lands within half a decibel of the overall. Both guide editions and both docstrings say that now instead of "a shape and not a partition".

Last, the array repr quoted in the CHANGELOG is thirteen characters, not eighteen.

## Validation

The attribution was read off the two printed pages, not inferred: Bies 5e Section 8.15.1 for Eq. (8.251) and its "(VDI2081-1, 2003)" credit, and VDI 2081 Blatt 1:2001 Figure 16 for the level difference and its abscissa. The half-decibel claim was measured against the library over the figure's own range, and the divergence outside it by extending the band set.

No numbers move: this changes what the documentation says the source is, not what the functions compute.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files touched
- [x] `mypy src scripts`
- [x] `pytest -q` on the affected suites
- [x] `check:math`, `check:i18n`, `check_doc_snippets.py`, `check_decimal_comma.py`

Regenerated:

- [x] `make api-docs` and `make llms`, committed

Always:

- [x] Documentation updated in English and Spanish, kept in step
- [x] CHANGELOG entry under `[Unreleased]`
