### PR TITLE
Shade the evaluation zones in the order they are in

### DIFF
--- a/.github/images/industrial_machine_zones.svg
+++ b/.github/images/industrial_machine_zones.svg
@@ -962,7 +962,7 @@ L 112.633516 404.980484
 L 112.633516 341.810158 
 L 61.744156 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 61.744156 341.810158 
@@ -970,7 +970,7 @@ L 112.633516 341.810158
 L 112.633516 281.386367 
 L 61.744156 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 61.744156 281.386367 
@@ -978,7 +978,7 @@ L 112.633516 281.386367
 L 112.633516 209.976433 
 L 61.744156 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 61.744156 209.976433 
@@ -986,7 +986,7 @@ L 112.633516 209.976433
 L 112.633516 47.930812 
 L 61.744156 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 138.849247 404.980484 
@@ -994,7 +994,7 @@ L 189.738607 404.980484
 L 189.738607 308.851727 
 L 138.849247 308.851727 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 138.849247 308.851727 
@@ -1002,7 +1002,7 @@ L 189.738607 308.851727
 L 189.738607 209.976433 
 L 138.849247 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 138.849247 209.976433 
@@ -1010,7 +1010,7 @@ L 189.738607 209.976433
 L 189.738607 102.861531 
 L 138.849247 102.861531 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 138.849247 102.861531 
@@ -1018,7 +1018,7 @@ L 189.738607 102.861531
 L 189.738607 47.930812 
 L 138.849247 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 215.954338 404.980484 
@@ -1026,7 +1026,7 @@ L 266.843699 404.980484
 L 266.843699 366.528981 
 L 215.954338 366.528981 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 215.954338 366.528981 
@@ -1034,7 +1034,7 @@ L 266.843699 366.528981
 L 266.843699 328.077478 
 L 215.954338 328.077478 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 215.954338 328.077478 
@@ -1042,7 +1042,7 @@ L 266.843699 328.077478
 L 266.843699 281.386367 
 L 215.954338 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 215.954338 281.386367 
@@ -1050,7 +1050,7 @@ L 266.843699 281.386367
 L 266.843699 47.930812 
 L 215.954338 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 293.05943 404.980484 
@@ -1058,7 +1058,7 @@ L 343.94879 404.980484
 L 343.94879 341.810158 
 L 293.05943 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 293.05943 341.810158 
@@ -1066,7 +1066,7 @@ L 343.94879 341.810158
 L 343.94879 281.386367 
 L 293.05943 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 293.05943 281.386367 
@@ -1074,7 +1074,7 @@ L 343.94879 281.386367
 L 343.94879 209.976433 
 L 293.05943 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 293.05943 209.976433 
@@ -1082,7 +1082,7 @@ L 343.94879 209.976433
 L 343.94879 47.930812 
 L 293.05943 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 40.925781 404.980484 
@@ -1997,7 +1997,7 @@ L 506.353516 404.980484
 L 506.353516 342.2263 
 L 455.464156 342.2263 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 455.464156 342.2263 
@@ -2005,7 +2005,7 @@ L 506.353516 342.2263
 L 506.353516 281.636052 
 L 455.464156 281.636052 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 455.464156 281.636052 
@@ -2013,7 +2013,7 @@ L 506.353516 281.636052
 L 506.353516 210.226118 
 L 455.464156 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 455.464156 210.226118 
@@ -2021,7 +2021,7 @@ L 506.353516 210.226118
 L 506.353516 47.930812 
 L 455.464156 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 532.569247 404.980484 
@@ -2029,7 +2029,7 @@ L 583.458607 404.980484
 L 583.458607 307.603301 
 L 532.569247 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 532.569247 307.603301 
@@ -2037,7 +2037,7 @@ L 583.458607 307.603301
 L 583.458607 210.226118 
 L 532.569247 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 532.569247 210.226118 
@@ -2045,7 +2045,7 @@ L 583.458607 210.226118
 L 583.458607 102.029248 
 L 532.569247 102.029248 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 532.569247 102.029248 
@@ -2053,7 +2053,7 @@ L 583.458607 102.029248
 L 583.458607 47.930812 
 L 532.569247 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 609.674338 404.980484 
@@ -2061,7 +2061,7 @@ L 660.563699 404.980484
 L 660.563699 357.373861 
 L 609.674338 357.373861 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 609.674338 357.373861 
@@ -2069,7 +2069,7 @@ L 660.563699 357.373861
 L 660.563699 307.603301 
 L 609.674338 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 609.674338 307.603301 
@@ -2077,7 +2077,7 @@ L 660.563699 307.603301
 L 660.563699 251.340929 
 L 609.674338 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 609.674338 251.340929 
@@ -2085,7 +2085,7 @@ L 660.563699 251.340929
 L 660.563699 47.930812 
 L 609.674338 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 686.77943 404.980484 
@@ -2093,7 +2093,7 @@ L 737.66879 404.980484
 L 737.66879 324.9148 
 L 686.77943 324.9148 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 686.77943 324.9148 
@@ -2101,7 +2101,7 @@ L 737.66879 324.9148
 L 737.66879 251.340929 
 L 686.77943 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 686.77943 251.340929 
@@ -2109,7 +2109,7 @@ L 737.66879 251.340929
 L 737.66879 160.455558 
 L 686.77943 160.455558 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 686.77943 160.455558 
@@ -2117,7 +2117,7 @@ L 737.66879 160.455558
 L 737.66879 47.930812 
 L 686.77943 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 434.645781 404.980484 
@@ -2581,7 +2581,7 @@ L 105.687734 457.881891
 L 105.687734 451.581891 
 L 87.687734 451.581891 
 z
-" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_62">
     <!-- zone A: newly commissioned -->
@@ -2635,7 +2635,7 @@ L 279.228828 457.881891
 L 279.228828 451.581891 
 L 261.228828 451.581891 
 z
-" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_63">
     <!-- zone B: unrestricted operation -->
@@ -2678,7 +2678,7 @@ L 459.493203 457.881891
 L 459.493203 451.581891 
 L 441.493203 451.581891 
 z
-" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_64">
     <!-- zone C: limited operation -->
@@ -2716,7 +2716,7 @@ L 616.322422 457.881891
 L 616.322422 451.581891 
 L 598.322422 451.581891 
 z
-" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_65">
     <!-- zone D: damage -->

--- a/.github/images/industrial_machine_zones_dark.svg
+++ b/.github/images/industrial_machine_zones_dark.svg
@@ -962,7 +962,7 @@ L 112.633516 404.980484
 L 112.633516 341.810158 
 L 61.744156 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 61.744156 341.810158 
@@ -970,7 +970,7 @@ L 112.633516 341.810158
 L 112.633516 281.386367 
 L 61.744156 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 61.744156 281.386367 
@@ -978,7 +978,7 @@ L 112.633516 281.386367
 L 112.633516 209.976433 
 L 61.744156 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 61.744156 209.976433 
@@ -986,7 +986,7 @@ L 112.633516 209.976433
 L 112.633516 47.930812 
 L 61.744156 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 138.849247 404.980484 
@@ -994,7 +994,7 @@ L 189.738607 404.980484
 L 189.738607 308.851727 
 L 138.849247 308.851727 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 138.849247 308.851727 
@@ -1002,7 +1002,7 @@ L 189.738607 308.851727
 L 189.738607 209.976433 
 L 138.849247 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 138.849247 209.976433 
@@ -1010,7 +1010,7 @@ L 189.738607 209.976433
 L 189.738607 102.861531 
 L 138.849247 102.861531 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 138.849247 102.861531 
@@ -1018,7 +1018,7 @@ L 189.738607 102.861531
 L 189.738607 47.930812 
 L 138.849247 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 215.954338 404.980484 
@@ -1026,7 +1026,7 @@ L 266.843699 404.980484
 L 266.843699 366.528981 
 L 215.954338 366.528981 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 215.954338 366.528981 
@@ -1034,7 +1034,7 @@ L 266.843699 366.528981
 L 266.843699 328.077478 
 L 215.954338 328.077478 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 215.954338 328.077478 
@@ -1042,7 +1042,7 @@ L 266.843699 328.077478
 L 266.843699 281.386367 
 L 215.954338 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 215.954338 281.386367 
@@ -1050,7 +1050,7 @@ L 266.843699 281.386367
 L 266.843699 47.930812 
 L 215.954338 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 293.05943 404.980484 
@@ -1058,7 +1058,7 @@ L 343.94879 404.980484
 L 343.94879 341.810158 
 L 293.05943 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 293.05943 341.810158 
@@ -1066,7 +1066,7 @@ L 343.94879 341.810158
 L 343.94879 281.386367 
 L 293.05943 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 293.05943 281.386367 
@@ -1074,7 +1074,7 @@ L 343.94879 281.386367
 L 343.94879 209.976433 
 L 293.05943 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 293.05943 209.976433 
@@ -1082,7 +1082,7 @@ L 343.94879 209.976433
 L 343.94879 47.930812 
 L 293.05943 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 40.925781 404.980484 
@@ -1997,7 +1997,7 @@ L 506.353516 404.980484
 L 506.353516 342.2263 
 L 455.464156 342.2263 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 455.464156 342.2263 
@@ -2005,7 +2005,7 @@ L 506.353516 342.2263
 L 506.353516 281.636052 
 L 455.464156 281.636052 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 455.464156 281.636052 
@@ -2013,7 +2013,7 @@ L 506.353516 281.636052
 L 506.353516 210.226118 
 L 455.464156 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 455.464156 210.226118 
@@ -2021,7 +2021,7 @@ L 506.353516 210.226118
 L 506.353516 47.930812 
 L 455.464156 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 532.569247 404.980484 
@@ -2029,7 +2029,7 @@ L 583.458607 404.980484
 L 583.458607 307.603301 
 L 532.569247 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 532.569247 307.603301 
@@ -2037,7 +2037,7 @@ L 583.458607 307.603301
 L 583.458607 210.226118 
 L 532.569247 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 532.569247 210.226118 
@@ -2045,7 +2045,7 @@ L 583.458607 210.226118
 L 583.458607 102.029248 
 L 532.569247 102.029248 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 532.569247 102.029248 
@@ -2053,7 +2053,7 @@ L 583.458607 102.029248
 L 583.458607 47.930812 
 L 532.569247 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 609.674338 404.980484 
@@ -2061,7 +2061,7 @@ L 660.563699 404.980484
 L 660.563699 357.373861 
 L 609.674338 357.373861 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 609.674338 357.373861 
@@ -2069,7 +2069,7 @@ L 660.563699 357.373861
 L 660.563699 307.603301 
 L 609.674338 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 609.674338 307.603301 
@@ -2077,7 +2077,7 @@ L 660.563699 307.603301
 L 660.563699 251.340929 
 L 609.674338 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 609.674338 251.340929 
@@ -2085,7 +2085,7 @@ L 660.563699 251.340929
 L 660.563699 47.930812 
 L 609.674338 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 686.77943 404.980484 
@@ -2093,7 +2093,7 @@ L 737.66879 404.980484
 L 737.66879 324.9148 
 L 686.77943 324.9148 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 686.77943 324.9148 
@@ -2101,7 +2101,7 @@ L 737.66879 324.9148
 L 737.66879 251.340929 
 L 686.77943 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 686.77943 251.340929 
@@ -2109,7 +2109,7 @@ L 737.66879 251.340929
 L 737.66879 160.455558 
 L 686.77943 160.455558 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 686.77943 160.455558 
@@ -2117,7 +2117,7 @@ L 737.66879 160.455558
 L 737.66879 47.930812 
 L 686.77943 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 434.645781 404.980484 
@@ -2581,7 +2581,7 @@ L 105.687734 457.881891
 L 105.687734 451.581891 
 L 87.687734 451.581891 
 z
-" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_62">
     <!-- zone A: newly commissioned -->
@@ -2635,7 +2635,7 @@ L 279.228828 457.881891
 L 279.228828 451.581891 
 L 261.228828 451.581891 
 z
-" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_63">
     <!-- zone B: unrestricted operation -->
@@ -2678,7 +2678,7 @@ L 459.493203 457.881891
 L 459.493203 451.581891 
 L 441.493203 451.581891 
 z
-" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_64">
     <!-- zone C: limited operation -->
@@ -2716,7 +2716,7 @@ L 616.322422 457.881891
 L 616.322422 451.581891 
 L 598.322422 451.581891 
 z
-" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_65">
     <!-- zone D: damage -->

--- a/.github/images/industrial_machine_zones_es.svg
+++ b/.github/images/industrial_machine_zones_es.svg
@@ -982,7 +982,7 @@ L 112.633516 404.980484
 L 112.633516 341.810158 
 L 61.744156 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 61.744156 341.810158 
@@ -990,7 +990,7 @@ L 112.633516 341.810158
 L 112.633516 281.386367 
 L 61.744156 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 61.744156 281.386367 
@@ -998,7 +998,7 @@ L 112.633516 281.386367
 L 112.633516 209.976433 
 L 61.744156 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 61.744156 209.976433 
@@ -1006,7 +1006,7 @@ L 112.633516 209.976433
 L 112.633516 47.930812 
 L 61.744156 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 138.849247 404.980484 
@@ -1014,7 +1014,7 @@ L 189.738607 404.980484
 L 189.738607 308.851727 
 L 138.849247 308.851727 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 138.849247 308.851727 
@@ -1022,7 +1022,7 @@ L 189.738607 308.851727
 L 189.738607 209.976433 
 L 138.849247 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 138.849247 209.976433 
@@ -1030,7 +1030,7 @@ L 189.738607 209.976433
 L 189.738607 102.861531 
 L 138.849247 102.861531 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 138.849247 102.861531 
@@ -1038,7 +1038,7 @@ L 189.738607 102.861531
 L 189.738607 47.930812 
 L 138.849247 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 215.954338 404.980484 
@@ -1046,7 +1046,7 @@ L 266.843699 404.980484
 L 266.843699 366.528981 
 L 215.954338 366.528981 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 215.954338 366.528981 
@@ -1054,7 +1054,7 @@ L 266.843699 366.528981
 L 266.843699 328.077478 
 L 215.954338 328.077478 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 215.954338 328.077478 
@@ -1062,7 +1062,7 @@ L 266.843699 328.077478
 L 266.843699 281.386367 
 L 215.954338 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 215.954338 281.386367 
@@ -1070,7 +1070,7 @@ L 266.843699 281.386367
 L 266.843699 47.930812 
 L 215.954338 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 293.05943 404.980484 
@@ -1078,7 +1078,7 @@ L 343.94879 404.980484
 L 343.94879 341.810158 
 L 293.05943 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 293.05943 341.810158 
@@ -1086,7 +1086,7 @@ L 343.94879 341.810158
 L 343.94879 281.386367 
 L 293.05943 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 293.05943 281.386367 
@@ -1094,7 +1094,7 @@ L 343.94879 281.386367
 L 343.94879 209.976433 
 L 293.05943 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 293.05943 209.976433 
@@ -1102,7 +1102,7 @@ L 343.94879 209.976433
 L 343.94879 47.930812 
 L 293.05943 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 40.925781 404.980484 
@@ -2006,7 +2006,7 @@ L 506.353516 404.980484
 L 506.353516 342.2263 
 L 455.464156 342.2263 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 455.464156 342.2263 
@@ -2014,7 +2014,7 @@ L 506.353516 342.2263
 L 506.353516 281.636052 
 L 455.464156 281.636052 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 455.464156 281.636052 
@@ -2022,7 +2022,7 @@ L 506.353516 281.636052
 L 506.353516 210.226118 
 L 455.464156 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 455.464156 210.226118 
@@ -2030,7 +2030,7 @@ L 506.353516 210.226118
 L 506.353516 47.930812 
 L 455.464156 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 532.569247 404.980484 
@@ -2038,7 +2038,7 @@ L 583.458607 404.980484
 L 583.458607 307.603301 
 L 532.569247 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 532.569247 307.603301 
@@ -2046,7 +2046,7 @@ L 583.458607 307.603301
 L 583.458607 210.226118 
 L 532.569247 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 532.569247 210.226118 
@@ -2054,7 +2054,7 @@ L 583.458607 210.226118
 L 583.458607 102.029248 
 L 532.569247 102.029248 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 532.569247 102.029248 
@@ -2062,7 +2062,7 @@ L 583.458607 102.029248
 L 583.458607 47.930812 
 L 532.569247 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 609.674338 404.980484 
@@ -2070,7 +2070,7 @@ L 660.563699 404.980484
 L 660.563699 357.373861 
 L 609.674338 357.373861 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 609.674338 357.373861 
@@ -2078,7 +2078,7 @@ L 660.563699 357.373861
 L 660.563699 307.603301 
 L 609.674338 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 609.674338 307.603301 
@@ -2086,7 +2086,7 @@ L 660.563699 307.603301
 L 660.563699 251.340929 
 L 609.674338 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 609.674338 251.340929 
@@ -2094,7 +2094,7 @@ L 660.563699 251.340929
 L 660.563699 47.930812 
 L 609.674338 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 686.77943 404.980484 
@@ -2102,7 +2102,7 @@ L 737.66879 404.980484
 L 737.66879 324.9148 
 L 686.77943 324.9148 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 686.77943 324.9148 
@@ -2110,7 +2110,7 @@ L 737.66879 324.9148
 L 737.66879 251.340929 
 L 686.77943 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 686.77943 251.340929 
@@ -2118,7 +2118,7 @@ L 737.66879 251.340929
 L 737.66879 160.455558 
 L 686.77943 160.455558 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 686.77943 160.455558 
@@ -2126,7 +2126,7 @@ L 737.66879 160.455558
 L 737.66879 47.930812 
 L 686.77943 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 434.645781 404.980484 
@@ -2559,7 +2559,7 @@ L 95.199219 457.881891
 L 95.199219 451.581891 
 L 77.199219 451.581891 
 z
-" style="fill: #c8deed; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_62">
     <!-- zona A: recién puesta en servicio -->
@@ -2651,7 +2651,7 @@ L 287.548906 457.881891
 L 287.548906 451.581891 
 L 269.548906 451.581891 
 z
-" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #f2efd2; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_63">
     <!-- zona B: operación sin restricción -->
@@ -2726,7 +2726,7 @@ L 477.43625 457.881891
 L 477.43625 451.581891 
 L 459.43625 451.581891 
 z
-" style="fill: #def0de; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #f8e2ce; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_64">
     <!-- zona C: operación limitada -->
@@ -2765,7 +2765,7 @@ L 641.156094 457.881891
 L 641.156094 451.581891 
 L 623.156094 451.581891 
 z
-" style="fill: #c8c8c8; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #f9dede; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_65">
     <!-- zona D: daño -->

--- a/.github/images/industrial_machine_zones_es_dark.svg
+++ b/.github/images/industrial_machine_zones_es_dark.svg
@@ -982,7 +982,7 @@ L 112.633516 404.980484
 L 112.633516 341.810158 
 L 61.744156 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 61.744156 341.810158 
@@ -990,7 +990,7 @@ L 112.633516 341.810158
 L 112.633516 281.386367 
 L 61.744156 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 61.744156 281.386367 
@@ -998,7 +998,7 @@ L 112.633516 281.386367
 L 112.633516 209.976433 
 L 61.744156 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 61.744156 209.976433 
@@ -1006,7 +1006,7 @@ L 112.633516 209.976433
 L 112.633516 47.930812 
 L 61.744156 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
     <path d="M 138.849247 404.980484 
@@ -1014,7 +1014,7 @@ L 189.738607 404.980484
 L 189.738607 308.851727 
 L 138.849247 308.851727 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
     <path d="M 138.849247 308.851727 
@@ -1022,7 +1022,7 @@ L 189.738607 308.851727
 L 189.738607 209.976433 
 L 138.849247 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
     <path d="M 138.849247 209.976433 
@@ -1030,7 +1030,7 @@ L 189.738607 209.976433
 L 189.738607 102.861531 
 L 138.849247 102.861531 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
     <path d="M 138.849247 102.861531 
@@ -1038,7 +1038,7 @@ L 189.738607 102.861531
 L 189.738607 47.930812 
 L 138.849247 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
     <path d="M 215.954338 404.980484 
@@ -1046,7 +1046,7 @@ L 266.843699 404.980484
 L 266.843699 366.528981 
 L 215.954338 366.528981 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
     <path d="M 215.954338 366.528981 
@@ -1054,7 +1054,7 @@ L 266.843699 366.528981
 L 266.843699 328.077478 
 L 215.954338 328.077478 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
     <path d="M 215.954338 328.077478 
@@ -1062,7 +1062,7 @@ L 266.843699 328.077478
 L 266.843699 281.386367 
 L 215.954338 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
     <path d="M 215.954338 281.386367 
@@ -1070,7 +1070,7 @@ L 266.843699 281.386367
 L 266.843699 47.930812 
 L 215.954338 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
     <path d="M 293.05943 404.980484 
@@ -1078,7 +1078,7 @@ L 343.94879 404.980484
 L 343.94879 341.810158 
 L 293.05943 341.810158 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
     <path d="M 293.05943 341.810158 
@@ -1086,7 +1086,7 @@ L 343.94879 341.810158
 L 343.94879 281.386367 
 L 293.05943 281.386367 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
     <path d="M 293.05943 281.386367 
@@ -1094,7 +1094,7 @@ L 343.94879 281.386367
 L 343.94879 209.976433 
 L 293.05943 209.976433 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
     <path d="M 293.05943 209.976433 
@@ -1102,7 +1102,7 @@ L 343.94879 209.976433
 L 343.94879 47.930812 
 L 293.05943 47.930812 
 z
-" clip-path="url(#p1e7d6fb770)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p1e7d6fb770)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
     <path d="M 40.925781 404.980484 
@@ -2006,7 +2006,7 @@ L 506.353516 404.980484
 L 506.353516 342.2263 
 L 455.464156 342.2263 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
     <path d="M 455.464156 342.2263 
@@ -2014,7 +2014,7 @@ L 506.353516 342.2263
 L 506.353516 281.636052 
 L 455.464156 281.636052 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
     <path d="M 455.464156 281.636052 
@@ -2022,7 +2022,7 @@ L 506.353516 281.636052
 L 506.353516 210.226118 
 L 455.464156 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
     <path d="M 455.464156 210.226118 
@@ -2030,7 +2030,7 @@ L 506.353516 210.226118
 L 506.353516 47.930812 
 L 455.464156 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
     <path d="M 532.569247 404.980484 
@@ -2038,7 +2038,7 @@ L 583.458607 404.980484
 L 583.458607 307.603301 
 L 532.569247 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
     <path d="M 532.569247 307.603301 
@@ -2046,7 +2046,7 @@ L 583.458607 307.603301
 L 583.458607 210.226118 
 L 532.569247 210.226118 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
     <path d="M 532.569247 210.226118 
@@ -2054,7 +2054,7 @@ L 583.458607 210.226118
 L 583.458607 102.029248 
 L 532.569247 102.029248 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
     <path d="M 532.569247 102.029248 
@@ -2062,7 +2062,7 @@ L 583.458607 102.029248
 L 583.458607 47.930812 
 L 532.569247 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
     <path d="M 609.674338 404.980484 
@@ -2070,7 +2070,7 @@ L 660.563699 404.980484
 L 660.563699 357.373861 
 L 609.674338 357.373861 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
     <path d="M 609.674338 357.373861 
@@ -2078,7 +2078,7 @@ L 660.563699 357.373861
 L 660.563699 307.603301 
 L 609.674338 307.603301 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
     <path d="M 609.674338 307.603301 
@@ -2086,7 +2086,7 @@ L 660.563699 307.603301
 L 660.563699 251.340929 
 L 609.674338 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
     <path d="M 609.674338 251.340929 
@@ -2094,7 +2094,7 @@ L 660.563699 251.340929
 L 660.563699 47.930812 
 L 609.674338 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
     <path d="M 686.77943 404.980484 
@@ -2102,7 +2102,7 @@ L 737.66879 404.980484
 L 737.66879 324.9148 
 L 686.77943 324.9148 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
     <path d="M 686.77943 324.9148 
@@ -2110,7 +2110,7 @@ L 737.66879 324.9148
 L 737.66879 251.340929 
 L 686.77943 251.340929 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
     <path d="M 686.77943 251.340929 
@@ -2118,7 +2118,7 @@ L 737.66879 251.340929
 L 737.66879 160.455558 
 L 686.77943 160.455558 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
     <path d="M 686.77943 160.455558 
@@ -2126,7 +2126,7 @@ L 737.66879 160.455558
 L 737.66879 47.930812 
 L 686.77943 47.930812 
 z
-" clip-path="url(#p2d980873ca)" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" clip-path="url(#p2d980873ca)" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
     <path d="M 434.645781 404.980484 
@@ -2559,7 +2559,7 @@ L 95.199219 457.881891
 L 95.199219 451.581891 
 L 77.199219 451.581891 
 z
-" style="fill: #081e2e; stroke: #1f77b4; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_62">
     <!-- zona A: recién puesta en servicio -->
@@ -2651,7 +2651,7 @@ L 287.548906 457.881891
 L 287.548906 451.581891 
 L 269.548906 451.581891 
 z
-" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #1e1b02; stroke: #b8a70b; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_63">
     <!-- zona B: operación sin restricción -->
@@ -2726,7 +2726,7 @@ L 477.43625 457.881891
 L 477.43625 451.581891 
 L 459.43625 451.581891 
 z
-" style="fill: #071807; stroke: #2ca02c; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #261505; stroke: #e07b1f; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_64">
     <!-- zona C: operación limitada -->
@@ -2765,7 +2765,7 @@ L 641.156094 457.881891
 L 641.156094 451.581891 
 L 623.156094 451.581891 
 z
-" style="fill: #2f2f2f; stroke: #9e9e9e; stroke-width: 1.1; stroke-linejoin: miter"/>
+" style="fill: #1f0606; stroke: #d62728; stroke-width: 1.1; stroke-linejoin: miter"/>
    </g>
    <g id="text_65">
     <!-- zona D: daño -->

--- a/.github/images/machine_alarm_trip.svg
+++ b/.github/images/machine_alarm_trip.svg
@@ -42,7 +42,7 @@ L 676.840937 401.598125
 L 676.840937 336.274125 
 L 34.563281 336.274125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 336.274125 
@@ -50,7 +50,7 @@ L 676.840937 336.274125
 L 676.840937 270.950125 
 L 34.563281 270.950125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 270.950125 
@@ -58,7 +58,7 @@ L 676.840937 270.950125
 L 676.840937 191.628125 
 L 34.563281 191.628125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 191.628125 
@@ -66,7 +66,7 @@ L 676.840937 191.628125
 L 676.840937 28.318125 
 L 34.563281 28.318125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -1884,7 +1884,7 @@ L 428.038437 332.473125
 L 428.038437 326.873125 
 L 412.038437 326.873125 
 z
-" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
     </g>
     <g id="text_23">
      <!-- zone A: newly commissioned -->
@@ -1941,7 +1941,7 @@ L 428.038437 344.47375
 L 428.038437 338.87375 
 L 412.038437 338.87375 
 z
-" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zone B: unrestricted operation -->
@@ -1984,7 +1984,7 @@ L 428.038437 356.474375
 L 428.038437 350.874375 
 L 412.038437 350.874375 
 z
-" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zone C: limited operation -->
@@ -2022,7 +2022,7 @@ L 428.038437 368.475
 L 428.038437 362.875 
 L 412.038437 362.875 
 z
-" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zone D: damage -->

--- a/.github/images/machine_alarm_trip_dark.svg
+++ b/.github/images/machine_alarm_trip_dark.svg
@@ -42,7 +42,7 @@ L 676.840937 401.598125
 L 676.840937 336.274125 
 L 34.563281 336.274125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 336.274125 
@@ -50,7 +50,7 @@ L 676.840937 336.274125
 L 676.840937 270.950125 
 L 34.563281 270.950125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 270.950125 
@@ -58,7 +58,7 @@ L 676.840937 270.950125
 L 676.840937 191.628125 
 L 34.563281 191.628125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 191.628125 
@@ -66,7 +66,7 @@ L 676.840937 191.628125
 L 676.840937 28.318125 
 L 34.563281 28.318125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -1884,7 +1884,7 @@ L 428.038437 332.473125
 L 428.038437 326.873125 
 L 412.038437 326.873125 
 z
-" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
     </g>
     <g id="text_23">
      <!-- zone A: newly commissioned -->
@@ -1941,7 +1941,7 @@ L 428.038437 344.47375
 L 428.038437 338.87375 
 L 412.038437 338.87375 
 z
-" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zone B: unrestricted operation -->
@@ -1984,7 +1984,7 @@ L 428.038437 356.474375
 L 428.038437 350.874375 
 L 412.038437 350.874375 
 z
-" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zone C: limited operation -->
@@ -2022,7 +2022,7 @@ L 428.038437 368.475
 L 428.038437 362.875 
 L 412.038437 362.875 
 z
-" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zone D: damage -->

--- a/.github/images/machine_alarm_trip_es.svg
+++ b/.github/images/machine_alarm_trip_es.svg
@@ -42,7 +42,7 @@ L 676.840937 401.598125
 L 676.840937 336.274125 
 L 34.563281 336.274125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 336.274125 
@@ -50,7 +50,7 @@ L 676.840937 336.274125
 L 676.840937 270.950125 
 L 34.563281 270.950125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 270.950125 
@@ -58,7 +58,7 @@ L 676.840937 270.950125
 L 676.840937 191.628125 
 L 34.563281 191.628125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 191.628125 
@@ -66,7 +66,7 @@ L 676.840937 191.628125
 L 676.840937 28.318125 
 L 34.563281 28.318125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -2059,7 +2059,7 @@ L 416.259687 331.056875
 L 416.259687 325.456875 
 L 400.259687 325.456875 
 z
-" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
     </g>
     <g id="text_23">
      <!-- zona A: recién puesta en servicio -->
@@ -2138,7 +2138,7 @@ L 416.259687 343.3775
 L 416.259687 337.7775 
 L 400.259687 337.7775 
 z
-" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zona B: operación sin restricción -->
@@ -2213,7 +2213,7 @@ L 416.259687 355.698125
 L 416.259687 350.098125 
 L 400.259687 350.098125 
 z
-" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zona C: operación limitada -->
@@ -2252,7 +2252,7 @@ L 416.259687 367.835
 L 416.259687 362.235 
 L 400.259687 362.235 
 z
-" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zona D: daño -->

--- a/.github/images/machine_alarm_trip_es_dark.svg
+++ b/.github/images/machine_alarm_trip_es_dark.svg
@@ -42,7 +42,7 @@ L 676.840937 401.598125
 L 676.840937 336.274125 
 L 34.563281 336.274125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 336.274125 
@@ -50,7 +50,7 @@ L 676.840937 336.274125
 L 676.840937 270.950125 
 L 34.563281 270.950125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 270.950125 
@@ -58,7 +58,7 @@ L 676.840937 270.950125
 L 676.840937 191.628125 
 L 34.563281 191.628125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 191.628125 
@@ -66,7 +66,7 @@ L 676.840937 191.628125
 L 676.840937 28.318125 
 L 34.563281 28.318125 
 z
-" clip-path="url(#p0e2e80df63)" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" clip-path="url(#p0e2e80df63)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -2059,7 +2059,7 @@ L 416.259687 331.056875
 L 416.259687 325.456875 
 L 400.259687 325.456875 
 z
-" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
     </g>
     <g id="text_23">
      <!-- zona A: recién puesta en servicio -->
@@ -2138,7 +2138,7 @@ L 416.259687 343.3775
 L 416.259687 337.7775 
 L 400.259687 337.7775 
 z
-" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zona B: operación sin restricción -->
@@ -2213,7 +2213,7 @@ L 416.259687 355.698125
 L 416.259687 350.098125 
 L 400.259687 350.098125 
 z
-" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zona C: operación limitada -->
@@ -2252,7 +2252,7 @@ L 416.259687 367.835
 L 416.259687 362.235 
 L 400.259687 362.235 
 z
-" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zona D: daño -->

--- a/.github/images/machine_vibration_trend.svg
+++ b/.github/images/machine_vibration_trend.svg
@@ -42,7 +42,7 @@ L 676.840937 386.515781
 L 676.840937 302.936328 
 L 34.563281 302.936328 
 z
-" clip-path="url(#p69c1625862)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 302.936328 
@@ -50,7 +50,7 @@ L 676.840937 302.936328
 L 676.840937 219.356875 
 L 34.563281 219.356875 
 z
-" clip-path="url(#p69c1625862)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 219.356875 
@@ -58,7 +58,7 @@ L 676.840937 219.356875
 L 676.840937 117.867539 
 L 34.563281 117.867539 
 z
-" clip-path="url(#p69c1625862)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 117.867539 
@@ -66,7 +66,7 @@ L 676.840937 117.867539
 L 676.840937 28.318125 
 L 34.563281 28.318125 
 z
-" clip-path="url(#p69c1625862)" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">

--- a/.github/images/machine_vibration_trend_dark.svg
+++ b/.github/images/machine_vibration_trend_dark.svg
@@ -42,7 +42,7 @@ L 676.840937 386.515781
 L 676.840937 302.936328 
 L 34.563281 302.936328 
 z
-" clip-path="url(#p69c1625862)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 302.936328 
@@ -50,7 +50,7 @@ L 676.840937 302.936328
 L 676.840937 219.356875 
 L 34.563281 219.356875 
 z
-" clip-path="url(#p69c1625862)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 219.356875 
@@ -58,7 +58,7 @@ L 676.840937 219.356875
 L 676.840937 117.867539 
 L 34.563281 117.867539 
 z
-" clip-path="url(#p69c1625862)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 117.867539 
@@ -66,7 +66,7 @@ L 676.840937 117.867539
 L 676.840937 28.318125 
 L 34.563281 28.318125 
 z
-" clip-path="url(#p69c1625862)" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" clip-path="url(#p69c1625862)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">

--- a/.github/images/machine_vibration_trend_es.svg
+++ b/.github/images/machine_vibration_trend_es.svg
@@ -42,7 +42,7 @@ L 676.840937 386.720156
 L 676.840937 303.140703 
 L 34.563281 303.140703 
 z
-" clip-path="url(#p15884a022d)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 303.140703 
@@ -50,7 +50,7 @@ L 676.840937 303.140703
 L 676.840937 219.56125 
 L 34.563281 219.56125 
 z
-" clip-path="url(#p15884a022d)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 219.56125 
@@ -58,7 +58,7 @@ L 676.840937 219.56125
 L 676.840937 118.071914 
 L 34.563281 118.071914 
 z
-" clip-path="url(#p15884a022d)" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 118.071914 
@@ -66,7 +66,7 @@ L 676.840937 118.071914
 L 676.840937 28.5225 
 L 34.563281 28.5225 
 z
-" clip-path="url(#p15884a022d)" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">

--- a/.github/images/machine_vibration_trend_es_dark.svg
+++ b/.github/images/machine_vibration_trend_es_dark.svg
@@ -42,7 +42,7 @@ L 676.840937 386.720156
 L 676.840937 303.140703 
 L 34.563281 303.140703 
 z
-" clip-path="url(#p15884a022d)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
     <path d="M 34.563281 303.140703 
@@ -50,7 +50,7 @@ L 676.840937 303.140703
 L 676.840937 219.56125 
 L 34.563281 219.56125 
 z
-" clip-path="url(#p15884a022d)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
     <path d="M 34.563281 219.56125 
@@ -58,7 +58,7 @@ L 676.840937 219.56125
 L 676.840937 118.071914 
 L 34.563281 118.071914 
 z
-" clip-path="url(#p15884a022d)" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
     <path d="M 34.563281 118.071914 
@@ -66,7 +66,7 @@ L 676.840937 118.071914
 L 676.840937 28.5225 
 L 34.563281 28.5225 
 z
-" clip-path="url(#p15884a022d)" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" clip-path="url(#p15884a022d)" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">

--- a/.github/images/machine_vibration_zones.svg
+++ b/.github/images/machine_vibration_zones.svg
@@ -38,7 +38,7 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="m73605709de" d="M 51.700781 -166.207963 
+     <path id="m62e8fb9dc6" d="M 51.700781 -166.207963 
 L 51.700781 70.480459 
 L 52.792263 70.480459 
 L 53.883745 70.480459 
@@ -1241,15 +1241,15 @@ L 53.883745 -167.275934
 L 52.792263 -166.741949 
 L 51.700781 -166.207963 
 z
-" style="stroke: #c8deed"/>
+" style="stroke: #def0de"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#m73605709de" x="0" y="439.035" style="fill: #c8deed; stroke: #c8deed"/>
+     <use xlink:href="#m62e8fb9dc6" x="0" y="439.035" style="fill: #def0de; stroke: #def0de"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="m3d53aac475" d="M 51.700781 -207.320932 
+     <path id="m09f9a733b5" d="M 51.700781 -207.320932 
 L 51.700781 -166.207963 
 L 52.792263 -166.741949 
 L 53.883745 -167.275934 
@@ -2452,15 +2452,15 @@ L 53.883745 -208.388903
 L 52.792263 -207.854917 
 L 51.700781 -207.320932 
 z
-" style="stroke: #f9dede"/>
+" style="stroke: #f2efd2"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#m3d53aac475" x="0" y="439.035" style="fill: #f9dede; stroke: #f9dede"/>
+     <use xlink:href="#m09f9a733b5" x="0" y="439.035" style="fill: #f2efd2; stroke: #f2efd2"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="m4736f98318" d="M 51.700781 -247.396614 
+     <path id="mbe1a586314" d="M 51.700781 -247.396614 
 L 51.700781 -207.320932 
 L 52.792263 -207.854917 
 L 53.883745 -208.388903 
@@ -3663,15 +3663,15 @@ L 53.883745 -248.464585
 L 52.792263 -247.9306 
 L 51.700781 -247.396614 
 z
-" style="stroke: #def0de"/>
+" style="stroke: #f8e2ce"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#m4736f98318" x="0" y="439.035" style="fill: #def0de; stroke: #def0de"/>
+     <use xlink:href="#mbe1a586314" x="0" y="439.035" style="fill: #f8e2ce; stroke: #f8e2ce"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="md2c30d5c25" d="M 51.700781 -533.766634 
+     <path id="m4c01f0b549" d="M 51.700781 -533.766634 
 L 51.700781 -247.396614 
 L 52.792263 -247.9306 
 L 53.883745 -248.464585 
@@ -4874,10 +4874,10 @@ L 53.883745 -533.766634
 L 52.792263 -533.766634 
 L 51.700781 -533.766634 
 z
-" style="stroke: #c8c8c8"/>
+" style="stroke: #f9dede"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#md2c30d5c25" x="0" y="439.035" style="fill: #c8c8c8; stroke: #c8c8c8"/>
+     <use xlink:href="#m4c01f0b549" x="0" y="439.035" style="fill: #f9dede; stroke: #f9dede"/>
     </g>
    </g>
    <g id="matplotlib.axis_1">
@@ -6559,7 +6559,7 @@ L 607.265067 202.435271
 L 622.545813 209.902228 
 L 705.498438 250.485127 
 L 705.498438 250.485127 
-" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 51.700781 231.714068 
@@ -6568,7 +6568,7 @@ L 607.265067 161.322303
 L 622.545813 168.789259 
 L 705.498438 209.372158 
 L 705.498438 209.372158 
-" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 51.700781 191.638386 
@@ -6577,7 +6577,7 @@ L 607.265067 121.24662
 L 622.545813 128.713577 
 L 705.498438 169.296476 
 L 705.498438 169.296476 
-" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 195.583596 400.833437 
@@ -7530,7 +7530,7 @@ z
      <path d="M 399.804688 38.798125 
 L 407.804688 38.798125 
 L 415.804688 38.798125 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_21">
      <!-- limit of zone A ($Z$ = 1) -->
@@ -7564,7 +7564,7 @@ L 415.804688 38.798125
      <path d="M 399.804688 50.8 
 L 407.804688 50.8 
 L 415.804688 50.8 
-" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_22">
      <!-- limit of zone B ($Z$ = 2.56) -->
@@ -7601,7 +7601,7 @@ L 415.804688 50.8
      <path d="M 399.804688 62.801875 
 L 407.804688 62.801875 
 L 415.804688 62.801875 
-" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_23">
      <!-- limit of zone C ($Z$ = 6.4) -->
@@ -7639,7 +7639,7 @@ L 415.804688 77.6025
 L 415.804688 72.0025 
 L 399.804688 72.0025 
 z
-" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zone A: newly commissioned -->
@@ -7693,7 +7693,7 @@ L 570.063438 41.598125
 L 570.063438 35.998125 
 L 554.063438 35.998125 
 z
-" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zone B: unrestricted operation -->
@@ -7736,7 +7736,7 @@ L 570.063438 53.59875
 L 570.063438 47.99875 
 L 554.063438 47.99875 
 z
-" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zone C: limited operation -->
@@ -7774,7 +7774,7 @@ L 570.063438 65.599375
 L 570.063438 59.999375 
 L 554.063438 59.999375 
 z
-" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
     </g>
     <g id="text_27">
      <!-- zone D: damage -->

--- a/.github/images/machine_vibration_zones_dark.svg
+++ b/.github/images/machine_vibration_zones_dark.svg
@@ -38,7 +38,7 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="mf43e5f5b1b" d="M 51.700781 -166.207963 
+     <path id="m3545c91c45" d="M 51.700781 -166.207963 
 L 51.700781 70.480459 
 L 52.792263 70.480459 
 L 53.883745 70.480459 
@@ -1241,15 +1241,15 @@ L 53.883745 -167.275934
 L 52.792263 -166.741949 
 L 51.700781 -166.207963 
 z
-" style="stroke: #081e2e"/>
+" style="stroke: #071807"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#mf43e5f5b1b" x="0" y="439.035" style="fill: #081e2e; stroke: #081e2e"/>
+     <use xlink:href="#m3545c91c45" x="0" y="439.035" style="fill: #071807; stroke: #071807"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="mbce974ce80" d="M 51.700781 -207.320932 
+     <path id="m45ef5b3eec" d="M 51.700781 -207.320932 
 L 51.700781 -166.207963 
 L 52.792263 -166.741949 
 L 53.883745 -167.275934 
@@ -2452,15 +2452,15 @@ L 53.883745 -208.388903
 L 52.792263 -207.854917 
 L 51.700781 -207.320932 
 z
-" style="stroke: #1f0606"/>
+" style="stroke: #1e1b02"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#mbce974ce80" x="0" y="439.035" style="fill: #1f0606; stroke: #1f0606"/>
+     <use xlink:href="#m45ef5b3eec" x="0" y="439.035" style="fill: #1e1b02; stroke: #1e1b02"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="m13064753ab" d="M 51.700781 -247.396614 
+     <path id="maf4f03388a" d="M 51.700781 -247.396614 
 L 51.700781 -207.320932 
 L 52.792263 -207.854917 
 L 53.883745 -208.388903 
@@ -3663,15 +3663,15 @@ L 53.883745 -248.464585
 L 52.792263 -247.9306 
 L 51.700781 -247.396614 
 z
-" style="stroke: #071807"/>
+" style="stroke: #261505"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#m13064753ab" x="0" y="439.035" style="fill: #071807; stroke: #071807"/>
+     <use xlink:href="#maf4f03388a" x="0" y="439.035" style="fill: #261505; stroke: #261505"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="m35bf7e9930" d="M 51.700781 -533.766634 
+     <path id="mc3904c3136" d="M 51.700781 -533.766634 
 L 51.700781 -247.396614 
 L 52.792263 -247.9306 
 L 53.883745 -248.464585 
@@ -4874,10 +4874,10 @@ L 53.883745 -533.766634
 L 52.792263 -533.766634 
 L 51.700781 -533.766634 
 z
-" style="stroke: #2f2f2f"/>
+" style="stroke: #1f0606"/>
     </defs>
     <g clip-path="url(#p120eb9ebd9)">
-     <use xlink:href="#m35bf7e9930" x="0" y="439.035" style="fill: #2f2f2f; stroke: #2f2f2f"/>
+     <use xlink:href="#mc3904c3136" x="0" y="439.035" style="fill: #1f0606; stroke: #1f0606"/>
     </g>
    </g>
    <g id="matplotlib.axis_1">
@@ -6559,7 +6559,7 @@ L 607.265067 202.435271
 L 622.545813 209.902228 
 L 705.498438 250.485127 
 L 705.498438 250.485127 
-" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 51.700781 231.714068 
@@ -6568,7 +6568,7 @@ L 607.265067 161.322303
 L 622.545813 168.789259 
 L 705.498438 209.372158 
 L 705.498438 209.372158 
-" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 51.700781 191.638386 
@@ -6577,7 +6577,7 @@ L 607.265067 121.24662
 L 622.545813 128.713577 
 L 705.498438 169.296476 
 L 705.498438 169.296476 
-" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p120eb9ebd9)" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 195.583596 400.833437 
@@ -7530,7 +7530,7 @@ z
      <path d="M 399.804688 38.798125 
 L 407.804688 38.798125 
 L 415.804688 38.798125 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_21">
      <!-- limit of zone A ($Z$ = 1) -->
@@ -7564,7 +7564,7 @@ L 415.804688 38.798125
      <path d="M 399.804688 50.8 
 L 407.804688 50.8 
 L 415.804688 50.8 
-" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_22">
      <!-- limit of zone B ($Z$ = 2.56) -->
@@ -7601,7 +7601,7 @@ L 415.804688 50.8
      <path d="M 399.804688 62.801875 
 L 407.804688 62.801875 
 L 415.804688 62.801875 
-" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_23">
      <!-- limit of zone C ($Z$ = 6.4) -->
@@ -7639,7 +7639,7 @@ L 415.804688 77.6025
 L 415.804688 72.0025 
 L 399.804688 72.0025 
 z
-" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zone A: newly commissioned -->
@@ -7693,7 +7693,7 @@ L 570.063438 41.598125
 L 570.063438 35.998125 
 L 554.063438 35.998125 
 z
-" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zone B: unrestricted operation -->
@@ -7736,7 +7736,7 @@ L 570.063438 53.59875
 L 570.063438 47.99875 
 L 554.063438 47.99875 
 z
-" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zone C: limited operation -->
@@ -7774,7 +7774,7 @@ L 570.063438 65.599375
 L 570.063438 59.999375 
 L 554.063438 59.999375 
 z
-" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
     </g>
     <g id="text_27">
      <!-- zone D: damage -->

--- a/.github/images/machine_vibration_zones_es.svg
+++ b/.github/images/machine_vibration_zones_es.svg
@@ -38,7 +38,7 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="m73605709de" d="M 51.700781 -166.207963 
+     <path id="m62e8fb9dc6" d="M 51.700781 -166.207963 
 L 51.700781 70.480459 
 L 52.792263 70.480459 
 L 53.883745 70.480459 
@@ -1241,15 +1241,15 @@ L 53.883745 -167.275934
 L 52.792263 -166.741949 
 L 51.700781 -166.207963 
 z
-" style="stroke: #c8deed"/>
+" style="stroke: #def0de"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#m73605709de" x="0" y="439.515" style="fill: #c8deed; stroke: #c8deed"/>
+     <use xlink:href="#m62e8fb9dc6" x="0" y="439.515" style="fill: #def0de; stroke: #def0de"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="m3d53aac475" d="M 51.700781 -207.320932 
+     <path id="m09f9a733b5" d="M 51.700781 -207.320932 
 L 51.700781 -166.207963 
 L 52.792263 -166.741949 
 L 53.883745 -167.275934 
@@ -2452,15 +2452,15 @@ L 53.883745 -208.388903
 L 52.792263 -207.854917 
 L 51.700781 -207.320932 
 z
-" style="stroke: #f9dede"/>
+" style="stroke: #f2efd2"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#m3d53aac475" x="0" y="439.515" style="fill: #f9dede; stroke: #f9dede"/>
+     <use xlink:href="#m09f9a733b5" x="0" y="439.515" style="fill: #f2efd2; stroke: #f2efd2"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="m4736f98318" d="M 51.700781 -247.396614 
+     <path id="mbe1a586314" d="M 51.700781 -247.396614 
 L 51.700781 -207.320932 
 L 52.792263 -207.854917 
 L 53.883745 -208.388903 
@@ -3663,15 +3663,15 @@ L 53.883745 -248.464585
 L 52.792263 -247.9306 
 L 51.700781 -247.396614 
 z
-" style="stroke: #def0de"/>
+" style="stroke: #f8e2ce"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#m4736f98318" x="0" y="439.515" style="fill: #def0de; stroke: #def0de"/>
+     <use xlink:href="#mbe1a586314" x="0" y="439.515" style="fill: #f8e2ce; stroke: #f8e2ce"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="md2c30d5c25" d="M 51.700781 -533.766634 
+     <path id="m4c01f0b549" d="M 51.700781 -533.766634 
 L 51.700781 -247.396614 
 L 52.792263 -247.9306 
 L 53.883745 -248.464585 
@@ -4874,10 +4874,10 @@ L 53.883745 -533.766634
 L 52.792263 -533.766634 
 L 51.700781 -533.766634 
 z
-" style="stroke: #c8c8c8"/>
+" style="stroke: #f9dede"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#md2c30d5c25" x="0" y="439.515" style="fill: #c8c8c8; stroke: #c8c8c8"/>
+     <use xlink:href="#m4c01f0b549" x="0" y="439.515" style="fill: #f9dede; stroke: #f9dede"/>
     </g>
    </g>
    <g id="matplotlib.axis_1">
@@ -6521,7 +6521,7 @@ L 607.265067 202.915271
 L 622.545813 210.382228 
 L 705.498438 250.965127 
 L 705.498438 250.965127 
-" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 51.700781 232.194068 
@@ -6530,7 +6530,7 @@ L 607.265067 161.802303
 L 622.545813 169.269259 
 L 705.498438 209.852158 
 L 705.498438 209.852158 
-" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 51.700781 192.118386 
@@ -6539,7 +6539,7 @@ L 607.265067 121.72662
 L 622.545813 129.193577 
 L 705.498438 169.776476 
 L 705.498438 169.776476 
-" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 195.583596 401.313437 
@@ -7502,7 +7502,7 @@ z
      <path d="M 374.532188 39.598125 
 L 382.532188 39.598125 
 L 390.532188 39.598125 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_21">
      <!-- límite de la zona A ($Z$ = 1) -->
@@ -7558,7 +7558,7 @@ z
      <path d="M 374.532188 51.92 
 L 382.532188 51.92 
 L 390.532188 51.92 
-" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_22">
      <!-- límite de la zona B ($Z$ = 2,56) -->
@@ -7599,7 +7599,7 @@ L 390.532188 51.92
      <path d="M 374.532188 64.241875 
 L 382.532188 64.241875 
 L 390.532188 64.241875 
-" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_23">
      <!-- límite de la zona C ($Z$ = 6,4) -->
@@ -7641,7 +7641,7 @@ L 390.532188 79.3625
 L 390.532188 73.7625 
 L 374.532188 73.7625 
 z
-" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
+" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zona A: recién puesta en servicio -->
@@ -7733,7 +7733,7 @@ L 561.509688 42.398125
 L 561.509688 36.798125 
 L 545.509688 36.798125 
 z
-" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
+" style="fill: #f2efd2; stroke: #f2efd2; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zona B: operación sin restricción -->
@@ -7779,7 +7779,7 @@ L 561.509688 54.71875
 L 561.509688 49.11875 
 L 545.509688 49.11875 
 z
-" style="fill: #def0de; stroke: #def0de; stroke-linejoin: miter"/>
+" style="fill: #f8e2ce; stroke: #f8e2ce; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zona C: operación limitada -->
@@ -7818,7 +7818,7 @@ L 561.509688 66.855625
 L 561.509688 61.255625 
 L 545.509688 61.255625 
 z
-" style="fill: #c8c8c8; stroke: #c8c8c8; stroke-linejoin: miter"/>
+" style="fill: #f9dede; stroke: #f9dede; stroke-linejoin: miter"/>
     </g>
     <g id="text_27">
      <!-- zona D: daño -->

--- a/.github/images/machine_vibration_zones_es_dark.svg
+++ b/.github/images/machine_vibration_zones_es_dark.svg
@@ -38,7 +38,7 @@ z
    </g>
    <g id="FillBetweenPolyCollection_1">
     <defs>
-     <path id="mf43e5f5b1b" d="M 51.700781 -166.207963 
+     <path id="m3545c91c45" d="M 51.700781 -166.207963 
 L 51.700781 70.480459 
 L 52.792263 70.480459 
 L 53.883745 70.480459 
@@ -1241,15 +1241,15 @@ L 53.883745 -167.275934
 L 52.792263 -166.741949 
 L 51.700781 -166.207963 
 z
-" style="stroke: #081e2e"/>
+" style="stroke: #071807"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#mf43e5f5b1b" x="0" y="439.515" style="fill: #081e2e; stroke: #081e2e"/>
+     <use xlink:href="#m3545c91c45" x="0" y="439.515" style="fill: #071807; stroke: #071807"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_2">
     <defs>
-     <path id="mbce974ce80" d="M 51.700781 -207.320932 
+     <path id="m45ef5b3eec" d="M 51.700781 -207.320932 
 L 51.700781 -166.207963 
 L 52.792263 -166.741949 
 L 53.883745 -167.275934 
@@ -2452,15 +2452,15 @@ L 53.883745 -208.388903
 L 52.792263 -207.854917 
 L 51.700781 -207.320932 
 z
-" style="stroke: #1f0606"/>
+" style="stroke: #1e1b02"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#mbce974ce80" x="0" y="439.515" style="fill: #1f0606; stroke: #1f0606"/>
+     <use xlink:href="#m45ef5b3eec" x="0" y="439.515" style="fill: #1e1b02; stroke: #1e1b02"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_3">
     <defs>
-     <path id="m13064753ab" d="M 51.700781 -247.396614 
+     <path id="maf4f03388a" d="M 51.700781 -247.396614 
 L 51.700781 -207.320932 
 L 52.792263 -207.854917 
 L 53.883745 -208.388903 
@@ -3663,15 +3663,15 @@ L 53.883745 -248.464585
 L 52.792263 -247.9306 
 L 51.700781 -247.396614 
 z
-" style="stroke: #071807"/>
+" style="stroke: #261505"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#m13064753ab" x="0" y="439.515" style="fill: #071807; stroke: #071807"/>
+     <use xlink:href="#maf4f03388a" x="0" y="439.515" style="fill: #261505; stroke: #261505"/>
     </g>
    </g>
    <g id="FillBetweenPolyCollection_4">
     <defs>
-     <path id="m35bf7e9930" d="M 51.700781 -533.766634 
+     <path id="mc3904c3136" d="M 51.700781 -533.766634 
 L 51.700781 -247.396614 
 L 52.792263 -247.9306 
 L 53.883745 -248.464585 
@@ -4874,10 +4874,10 @@ L 53.883745 -533.766634
 L 52.792263 -533.766634 
 L 51.700781 -533.766634 
 z
-" style="stroke: #2f2f2f"/>
+" style="stroke: #1f0606"/>
     </defs>
     <g clip-path="url(#p3682366ecf)">
-     <use xlink:href="#m35bf7e9930" x="0" y="439.515" style="fill: #2f2f2f; stroke: #2f2f2f"/>
+     <use xlink:href="#mc3904c3136" x="0" y="439.515" style="fill: #1f0606; stroke: #1f0606"/>
     </g>
    </g>
    <g id="matplotlib.axis_1">
@@ -6521,7 +6521,7 @@ L 607.265067 202.915271
 L 622.545813 210.382228 
 L 705.498438 250.965127 
 L 705.498438 250.965127 
-" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 51.700781 232.194068 
@@ -6530,7 +6530,7 @@ L 607.265067 161.802303
 L 622.545813 169.269259 
 L 705.498438 209.852158 
 L 705.498438 209.852158 
-" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 51.700781 192.118386 
@@ -6539,7 +6539,7 @@ L 607.265067 121.72662
 L 622.545813 129.193577 
 L 705.498438 169.776476 
 L 705.498438 169.776476 
-" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" clip-path="url(#p3682366ecf)" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 195.583596 401.313437 
@@ -7502,7 +7502,7 @@ z
      <path d="M 374.532188 39.598125 
 L 382.532188 39.598125 
 L 390.532188 39.598125 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_21">
      <!-- límite de la zona A ($Z$ = 1) -->
@@ -7558,7 +7558,7 @@ z
      <path d="M 374.532188 51.92 
 L 382.532188 51.92 
 L 390.532188 51.92 
-" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #b8a70b; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_22">
      <!-- límite de la zona B ($Z$ = 2,56) -->
@@ -7599,7 +7599,7 @@ L 390.532188 51.92
      <path d="M 374.532188 64.241875 
 L 382.532188 64.241875 
 L 390.532188 64.241875 
-" style="fill: none; stroke: #2ca02c; stroke-width: 1.8; stroke-linecap: square"/>
+" style="fill: none; stroke: #e07b1f; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
     <g id="text_23">
      <!-- límite de la zona C ($Z$ = 6,4) -->
@@ -7641,7 +7641,7 @@ L 390.532188 79.3625
 L 390.532188 73.7625 
 L 374.532188 73.7625 
 z
-" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
+" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
     </g>
     <g id="text_24">
      <!-- zona A: recién puesta en servicio -->
@@ -7733,7 +7733,7 @@ L 561.509688 42.398125
 L 561.509688 36.798125 
 L 545.509688 36.798125 
 z
-" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
+" style="fill: #1e1b02; stroke: #1e1b02; stroke-linejoin: miter"/>
     </g>
     <g id="text_25">
      <!-- zona B: operación sin restricción -->
@@ -7779,7 +7779,7 @@ L 561.509688 54.71875
 L 561.509688 49.11875 
 L 545.509688 49.11875 
 z
-" style="fill: #071807; stroke: #071807; stroke-linejoin: miter"/>
+" style="fill: #261505; stroke: #261505; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- zona C: operación limitada -->
@@ -7818,7 +7818,7 @@ L 561.509688 66.855625
 L 561.509688 61.255625 
 L 545.509688 61.255625 
 z
-" style="fill: #2f2f2f; stroke: #2f2f2f; stroke-linejoin: miter"/>
+" style="fill: #1f0606; stroke: #1f0606; stroke-linejoin: miter"/>
     </g>
     <g id="text_27">
      <!-- zona D: daño -->

--- a/.github/images/vdi2081_flow_noise.svg
+++ b/.github/images/vdi2081_flow_noise.svg
@@ -2526,20 +2526,108 @@ L 806.303125 28.48
    </g>
    <g id="text_38">
     <g id="patch_17">
-     <path d="M 622.822868 66.405837 
+     <path d="M 602.118727 66.405837 
 L 801.245837 66.405837 
 Q 803.965837 66.405837 803.965837 63.685837 
 L 803.965837 43.281189 
 Q 803.965837 40.561189 801.245837 40.561189 
-L 622.822868 40.561189 
-Q 620.102868 40.561189 620.102868 43.281189 
-L 620.102868 63.685837 
-Q 620.102868 66.405837 622.822868 66.405837 
+L 602.118727 40.561189 
+Q 599.398727 40.561189 599.398727 43.281189 
+L 599.398727 63.685837 
+Q 599.398727 66.405837 602.118727 66.405837 
 z
 " style="fill: #f0f2f5; stroke: #e0e0e0; stroke-linejoin: miter"/>
     </g>
-    <!-- the bands do not sum back to the overall: -->
-    <g transform="translate(622.822868 50.590691) scale(0.085 -0.085)">
+    <!-- Figure 16 prints a level difference, not a share: -->
+    <g transform="translate(602.118727 50.590691) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-13ae" d="M 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 4378 3500 
+L 4378 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4595 
+Q 3397 4863 3988 4863 
+L 4531 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-29"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(50.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(78.015625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(141.5 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(204.875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(243.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(305.3125 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(337.09375 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(400.71875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(464.34375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(496.125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(559.609375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(600.71875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(628.5 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(691.875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(731.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(783.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(814.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(876.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(908.015625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(935.796875 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(997.328125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1056.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1118.046875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1145.828125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1177.609375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1241.09375 0)"/>
+     <use xlink:href="#DejaVuSans-13ae" transform="translate(1268.875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1337.765625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1399.296875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1438.203125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1499.734375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1563.109375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1618.09375 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1679.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1711.40625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1743.1875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1806.5625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1867.75 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1906.953125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1938.734375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2000.015625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2031.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2083.890625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2147.265625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2208.546875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2247.453125 0)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(2308.984375 0)"/>
+    </g>
+    <!-- the bands do not sum back to the overall -->
+    <g transform="translate(625.686305 60.793015) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-45" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -2608,47 +2696,6 @@ z
      <use xlink:href="#DejaVuSans-44" transform="translate(1948.5625 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(2009.84375 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(2037.625 0)"/>
-     <use xlink:href="#DejaVuSans-1d" transform="translate(2065.40625 0)"/>
-    </g>
-    <!-- Figure 16 is a shape, not a partition -->
-    <g transform="translate(650.014899 60.793015) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-29"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(50.234375 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(78.015625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(141.5 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(204.875 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(243.78125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(305.3125 0)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(337.09375 0)"/>
-     <use xlink:href="#DejaVuSans-19" transform="translate(400.71875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(464.34375 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(496.125 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(523.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(576 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(607.78125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(669.0625 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(700.84375 0)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(752.9375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(816.3125 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(877.59375 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(941.078125 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(1002.609375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1034.390625 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1066.171875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1129.546875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1190.734375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1229.9375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1261.71875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1323 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1354.78125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1418.265625 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1479.546875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1520.65625 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1559.859375 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1587.640625 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1626.84375 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1654.625 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1715.8125 0)"/>
     </g>
    </g>
    <g id="text_39">

--- a/.github/images/vdi2081_flow_noise_dark.svg
+++ b/.github/images/vdi2081_flow_noise_dark.svg
@@ -2526,20 +2526,108 @@ L 806.303125 28.48
    </g>
    <g id="text_38">
     <g id="patch_17">
-     <path d="M 622.822868 66.405837 
+     <path d="M 602.118727 66.405837 
 L 801.245837 66.405837 
 Q 803.965837 66.405837 803.965837 63.685837 
 L 803.965837 43.281189 
 Q 803.965837 40.561189 801.245837 40.561189 
-L 622.822868 40.561189 
-Q 620.102868 40.561189 620.102868 43.281189 
-L 620.102868 63.685837 
-Q 620.102868 66.405837 622.822868 66.405837 
+L 602.118727 40.561189 
+Q 599.398727 40.561189 599.398727 43.281189 
+L 599.398727 63.685837 
+Q 599.398727 66.405837 602.118727 66.405837 
 z
 " style="fill: #1c2128; stroke: #555555; stroke-linejoin: miter"/>
     </g>
-    <!-- the bands do not sum back to the overall: -->
-    <g style="fill: #ffffff" transform="translate(622.822868 50.590691) scale(0.085 -0.085)">
+    <!-- Figure 16 prints a level difference, not a share: -->
+    <g style="fill: #ffffff" transform="translate(602.118727 50.590691) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-13ae" d="M 4531 4863 
+L 4531 4384 
+L 3981 4384 
+Q 3672 4384 3551 4259 
+Q 3431 4134 3431 3809 
+L 3431 3500 
+L 4378 3500 
+L 4378 3053 
+L 3431 3053 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1394 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2853 3500 
+L 2853 3744 
+Q 2853 4328 3125 4595 
+Q 3397 4863 3988 4863 
+L 4531 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-29"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(50.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(78.015625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(141.5 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(204.875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(243.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(305.3125 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(337.09375 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(400.71875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(464.34375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(496.125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(559.609375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(600.71875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(628.5 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(691.875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(731.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(783.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(814.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(876.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(908.015625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(935.796875 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(997.328125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1056.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1118.046875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1145.828125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1177.609375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1241.09375 0)"/>
+     <use xlink:href="#DejaVuSans-13ae" transform="translate(1268.875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1337.765625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1399.296875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1438.203125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1499.734375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1563.109375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1618.09375 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1679.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1711.40625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1743.1875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1806.5625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1867.75 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1906.953125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1938.734375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2000.015625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2031.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2083.890625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2147.265625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2208.546875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2247.453125 0)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(2308.984375 0)"/>
+    </g>
+    <!-- the bands do not sum back to the overall -->
+    <g style="fill: #ffffff" transform="translate(625.686305 60.793015) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-45" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -2608,47 +2696,6 @@ z
      <use xlink:href="#DejaVuSans-44" transform="translate(1948.5625 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(2009.84375 0)"/>
      <use xlink:href="#DejaVuSans-4f" transform="translate(2037.625 0)"/>
-     <use xlink:href="#DejaVuSans-1d" transform="translate(2065.40625 0)"/>
-    </g>
-    <!-- Figure 16 is a shape, not a partition -->
-    <g style="fill: #ffffff" transform="translate(650.014899 60.793015) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-29"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(50.234375 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(78.015625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(141.5 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(204.875 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(243.78125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(305.3125 0)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(337.09375 0)"/>
-     <use xlink:href="#DejaVuSans-19" transform="translate(400.71875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(464.34375 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(496.125 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(523.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(576 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(607.78125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(669.0625 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(700.84375 0)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(752.9375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(816.3125 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(877.59375 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(941.078125 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(1002.609375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1034.390625 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1066.171875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1129.546875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1190.734375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1229.9375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1261.71875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1323 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1354.78125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1418.265625 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1479.546875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1520.65625 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1559.859375 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1587.640625 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1626.84375 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1654.625 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1715.8125 0)"/>
     </g>
    </g>
    <g id="text_39">

--- a/.github/images/vdi2081_flow_noise_es.svg
+++ b/.github/images/vdi2081_flow_noise_es.svg
@@ -2542,59 +2542,20 @@ L 806.703125 28.48
    </g>
    <g id="text_38">
     <g id="patch_17">
-     <path d="M 629.629743 66.405837 
+     <path d="M 547.501149 66.405837 
 L 801.645837 66.405837 
 Q 804.365837 66.405837 804.365837 63.685837 
 L 804.365837 43.281189 
 Q 804.365837 40.561189 801.645837 40.561189 
-L 629.629743 40.561189 
-Q 626.909743 40.561189 626.909743 43.281189 
-L 626.909743 63.685837 
-Q 626.909743 66.405837 629.629743 66.405837 
+L 547.501149 40.561189 
+Q 544.781149 40.561189 544.781149 43.281189 
+L 544.781149 63.685837 
+Q 544.781149 66.405837 547.501149 66.405837 
 z
 " style="fill: #f0f2f5; stroke: #e0e0e0; stroke-linejoin: miter"/>
     </g>
-    <!-- las bandas no suman el nivel global: -->
-    <g transform="translate(646.385368 50.590691) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-4f"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(89.0625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(141.15625 0)"/>
-     <use xlink:href="#DejaVuSans-45" transform="translate(172.9375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(236.421875 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(297.703125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(361.078125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(424.5625 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(485.84375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(537.9375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(569.71875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(633.09375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(694.28125 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(726.0625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(778.15625 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(841.53125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(938.9375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1000.21875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1063.59375 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1095.375 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1156.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1184.6875 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1216.46875 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1279.84375 0)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(1307.625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1366.8125 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1428.34375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1456.125 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(1487.90625 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1551.390625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1579.171875 0)"/>
-     <use xlink:href="#DejaVuSans-45" transform="translate(1640.359375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1703.84375 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1765.125 0)"/>
-     <use xlink:href="#DejaVuSans-1d" transform="translate(1792.90625 0)"/>
-    </g>
-    <!-- la Figura 16 es una forma, no un reparto -->
-    <g transform="translate(629.629743 60.793015) scale(0.085 -0.085)">
+    <!-- la Figura 16 imprime una diferencia de nivel, no un reparto: -->
+    <g transform="translate(547.501149 50.590691) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-49" d="M 2375 4863 
 L 2375 4384 
@@ -2631,33 +2592,91 @@ z
      <use xlink:href="#DejaVuSans-14" transform="translate(459.890625 0)"/>
      <use xlink:href="#DejaVuSans-19" transform="translate(523.515625 0)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(587.140625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(618.921875 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(680.453125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(732.546875 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(764.328125 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(827.703125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(891.078125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(952.359375 0)"/>
-     <use xlink:href="#DejaVuSans-49" transform="translate(984.140625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1019.34375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1080.53125 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1119.890625 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1217.296875 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(1278.578125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1310.359375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1342.140625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1405.515625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1466.703125 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(1498.484375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1561.859375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1625.234375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1657.015625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1695.921875 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1757.453125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1820.9375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1882.21875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1923.328125 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1962.53125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(618.921875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(646.703125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(744.109375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(807.59375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(848.703125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(876.484375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(973.890625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1035.421875 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1067.203125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1130.578125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1193.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1255.234375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1287.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1350.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1378.28125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1413.484375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1475.015625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1513.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1575.453125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1638.828125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1693.8125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1721.59375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1782.875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1814.65625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1878.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1939.671875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1971.453125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2034.828125 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(2062.609375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2121.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2183.328125 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(2211.109375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2242.890625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2274.671875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2338.046875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2399.234375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2431.015625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2494.390625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2557.765625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2589.546875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2628.453125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(2689.984375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2753.46875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2814.75 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2855.859375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2895.0625 0)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(2956.25 0)"/>
+    </g>
+    <!-- las bandas no suman el nivel global -->
+    <g transform="translate(649.248805 60.793015) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(141.15625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(172.9375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(236.421875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(297.703125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(361.078125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(424.5625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(485.84375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(537.9375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(569.71875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(633.09375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(694.28125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(726.0625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(778.15625 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(841.53125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(938.9375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1000.21875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1063.59375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1095.375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1156.90625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1184.6875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1216.46875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1279.84375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1307.625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1366.8125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1428.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1456.125 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(1487.90625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1551.390625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1579.171875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1640.359375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1703.84375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1765.125 0)"/>
     </g>
    </g>
    <g id="text_39">

--- a/.github/images/vdi2081_flow_noise_es_dark.svg
+++ b/.github/images/vdi2081_flow_noise_es_dark.svg
@@ -2542,59 +2542,20 @@ L 806.703125 28.48
    </g>
    <g id="text_38">
     <g id="patch_17">
-     <path d="M 629.629743 66.405837 
+     <path d="M 547.501149 66.405837 
 L 801.645837 66.405837 
 Q 804.365837 66.405837 804.365837 63.685837 
 L 804.365837 43.281189 
 Q 804.365837 40.561189 801.645837 40.561189 
-L 629.629743 40.561189 
-Q 626.909743 40.561189 626.909743 43.281189 
-L 626.909743 63.685837 
-Q 626.909743 66.405837 629.629743 66.405837 
+L 547.501149 40.561189 
+Q 544.781149 40.561189 544.781149 43.281189 
+L 544.781149 63.685837 
+Q 544.781149 66.405837 547.501149 66.405837 
 z
 " style="fill: #1c2128; stroke: #555555; stroke-linejoin: miter"/>
     </g>
-    <!-- las bandas no suman el nivel global: -->
-    <g style="fill: #ffffff" transform="translate(646.385368 50.590691) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-4f"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(89.0625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(141.15625 0)"/>
-     <use xlink:href="#DejaVuSans-45" transform="translate(172.9375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(236.421875 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(297.703125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(361.078125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(424.5625 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(485.84375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(537.9375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(569.71875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(633.09375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(694.28125 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(726.0625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(778.15625 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(841.53125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(938.9375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1000.21875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1063.59375 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1095.375 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1156.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1184.6875 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1216.46875 0)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1279.84375 0)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(1307.625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1366.8125 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1428.34375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1456.125 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(1487.90625 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1551.390625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1579.171875 0)"/>
-     <use xlink:href="#DejaVuSans-45" transform="translate(1640.359375 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1703.84375 0)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1765.125 0)"/>
-     <use xlink:href="#DejaVuSans-1d" transform="translate(1792.90625 0)"/>
-    </g>
-    <!-- la Figura 16 es una forma, no un reparto -->
-    <g style="fill: #ffffff" transform="translate(629.629743 60.793015) scale(0.085 -0.085)">
+    <!-- la Figura 16 imprime una diferencia de nivel, no un reparto: -->
+    <g style="fill: #ffffff" transform="translate(547.501149 50.590691) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-49" d="M 2375 4863 
 L 2375 4384 
@@ -2631,33 +2592,91 @@ z
      <use xlink:href="#DejaVuSans-14" transform="translate(459.890625 0)"/>
      <use xlink:href="#DejaVuSans-19" transform="translate(523.515625 0)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(587.140625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(618.921875 0)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(680.453125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(732.546875 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(764.328125 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(827.703125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(891.078125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(952.359375 0)"/>
-     <use xlink:href="#DejaVuSans-49" transform="translate(984.140625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1019.34375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1080.53125 0)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1119.890625 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1217.296875 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(1278.578125 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1310.359375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1342.140625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1405.515625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1466.703125 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(1498.484375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1561.859375 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1625.234375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1657.015625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1695.921875 0)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1757.453125 0)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1820.9375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1882.21875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1923.328125 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(1962.53125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(618.921875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(646.703125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(744.109375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(807.59375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(848.703125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(876.484375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(973.890625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1035.421875 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1067.203125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1130.578125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1193.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1255.234375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1287.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1350.5 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1378.28125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1413.484375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1475.015625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1513.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1575.453125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1638.828125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1693.8125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1721.59375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1782.875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1814.65625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1878.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1939.671875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1971.453125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2034.828125 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(2062.609375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2121.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2183.328125 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(2211.109375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2242.890625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2274.671875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2338.046875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2399.234375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2431.015625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2494.390625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2557.765625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2589.546875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2628.453125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(2689.984375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2753.46875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2814.75 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2855.859375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2895.0625 0)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(2956.25 0)"/>
+    </g>
+    <!-- las bandas no suman el nivel global -->
+    <g style="fill: #ffffff" transform="translate(649.248805 60.793015) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(141.15625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(172.9375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(236.421875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(297.703125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(361.078125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(424.5625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(485.84375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(537.9375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(569.71875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(633.09375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(694.28125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(726.0625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(778.15625 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(841.53125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(938.9375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1000.21875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1063.59375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1095.375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1156.90625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1184.6875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1216.46875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1279.84375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1307.625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1366.8125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1428.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1456.125 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(1487.90625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1551.390625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1579.171875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1640.359375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1703.84375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1765.125 0)"/>
     </g>
    </g>
    <g id="text_39">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   test holds the class shut: a standard's number always follows its body, so a
   designation with no digit whose clause opens with one has lost it.
 
+- The evaluation zones were shaded with the series palette, which told the
+  reader the opposite of what the scale says. Zone B, "unrestricted
+  operation", came out red and zone C, "limited operation", came out green, so
+  the better of the two looked like the alarming one, and zone D, damage, was
+  a neutral grey behind both. Four figures did it: the Table C.1 zone
+  criterion, the ISO 10816-3 boundary bars, the ALARM and TRIP settings and
+  the twelve-month trend.
+
+  A categorical palette on an ordered scale is the defect, so the zones get a
+  ramp of their own that runs one way, calm to alarming, and the letter drawn
+  in each band and the order of the bands repeat the same information for a
+  reader who does not separate red from green. Nothing else in the corpus
+  moved: the other 2388 figures reproduce byte for byte.
+
+  The flow-noise figure's own note is redrawn to match the prose above it:
+  what Figure 16 prints is a level difference, not a share.
+
 - `flow_noise_straight_duct` was credited to Bies, Hansen & Howard 5e
   Eq. (8.251), a second-hand citation of a law this project holds the primary
   source for. The printed page settles it: Bies gives that equation as "(VDI

--- a/scripts/figures/devices.py
+++ b/scripts/figures/devices.py
@@ -6196,8 +6196,8 @@ def generate_vdi2081_flow_noise(output_dir: str) -> None:
     ax2.text(
         0.985,
         0.955,
-        "the bands do not sum back to the overall:\n"
-        "Figure 16 is a shape, not a partition",
+        "Figure 16 prints a level difference, not a share:\n"
+        "the bands do not sum back to the overall",
         transform=ax2.transAxes,
         ha="right",
         va="top",

--- a/scripts/figures/i18n.py
+++ b/scripts/figures/i18n.py
@@ -65,7 +65,7 @@ _ES_EXACT = {
     "Eq. (17): $-25 + 70\\,\\lg v + 10\\,\\lg S$": "Ec. (17): $-25 + 70\\,\\lg v + 10\\,\\lg S$",
     "Faster Air Is Louder, and Flatter": "Cuanto más rápido el aire, más ruido y más plano",
     "Band sound power level (dB)": "Nivel de potencia acústica por banda (dB)",
-    "the bands do not sum back to the overall:\nFigure 16 is a shape, not a partition": "las bandas no suman el nivel global:\nla Figura 16 es una forma, no un reparto",
+    "Figure 16 prints a level difference, not a share:\nthe bands do not sum back to the overall": "la Figura 16 imprime una diferencia de nivel, no un reparto:\nlas bandas no suman el nivel global",
     # Gear-unit rating curves (ISO 20816-9 Annex A).
     "Shaft Displacement: Flat, Then 10 dB per Decade": "Desplazamiento del eje: plano y luego 10 dB por década",
     "Peak-to-peak displacement (µm)": "Desplazamiento pico a pico (µm)",

--- a/scripts/figures/theme.py
+++ b/scripts/figures/theme.py
@@ -57,6 +57,22 @@ COLOR_GRID = "#e0e0e0"
 # into the one it is drawn on.
 COLOR_MUTED = "#9e9e9e"
 
+# Shading for an *ordered* scale, the evaluation zones of ISO 20816 and
+# ISO 10816 above all. The series colours were used for these, and a
+# categorical palette on an ordered scale tells the reader the opposite of
+# what the scale says: zone B, "unrestricted operation", came out red and
+# zone C, "limited operation", came out green, so the better of the two
+# looked like the alarming one and zone D, damage, was a neutral grey. These
+# run one way, calm to alarming, and the letter drawn in each band and the
+# order of the bands themselves repeat the same information for a reader who
+# does not separate red from green.
+COLOR_ZONE_A = "#2ca02c"
+COLOR_ZONE_B = "#b8a70b"
+COLOR_ZONE_C = "#e07b1f"
+COLOR_ZONE_D = "#d62728"
+#: The four in order, for a figure that zips them against its own band edges.
+COLOR_ZONES = (COLOR_ZONE_A, COLOR_ZONE_B, COLOR_ZONE_C, COLOR_ZONE_D)
+
 # Theme state: every figure is generated twice (light + "_dark" suffix).
 # COLOR_FG replaces literal black so annotations stay visible on dark bg.
 COLOR_FG = "black"

--- a/scripts/figures/vibration.py
+++ b/scripts/figures/vibration.py
@@ -40,6 +40,10 @@ from .theme import (
     COLOR_QUATERNARY,
     COLOR_SECONDARY,
     COLOR_TERTIARY,
+    COLOR_ZONE_A,
+    COLOR_ZONE_B,
+    COLOR_ZONE_C,
+    COLOR_ZONE_D,
     LABEL_FREQ_HZ,
     _band_index_axis,
     save_figure,
@@ -2304,9 +2308,9 @@ def generate_machine_vibration_zones(output_dir: str) -> None:
     v_a = 1.12
     freq = np.logspace(np.log10(2.0), np.log10(3000.0), 600)
     curves = [
-        ("A", vibration.ZONE_LIMIT_FACTORS["A"], COLOR_PRIMARY),
-        ("B", vibration.ZONE_LIMIT_FACTORS["B"], COLOR_SECONDARY),
-        ("C", vibration.ZONE_LIMIT_FACTORS["C"], COLOR_TERTIARY),
+        ("A", vibration.ZONE_LIMIT_FACTORS["A"], COLOR_ZONE_A),
+        ("B", vibration.ZONE_LIMIT_FACTORS["B"], COLOR_ZONE_B),
+        ("C", vibration.ZONE_LIMIT_FACTORS["C"], COLOR_ZONE_C),
     ]
 
     _fig, ax = plt.subplots(figsize=(10, 6.2))
@@ -2333,10 +2337,10 @@ def generate_machine_vibration_zones(output_dir: str) -> None:
     floor = np.full_like(freq, 1.0e-3)
     ceiling = np.full_like(freq, 1.0e3)
     bands = (
-        (floor, limits["A"], COLOR_PRIMARY, "zone A: newly commissioned"),
-        (limits["A"], limits["B"], COLOR_SECONDARY, "zone B: unrestricted operation"),
-        (limits["B"], limits["C"], COLOR_TERTIARY, "zone C: limited operation"),
-        (limits["C"], ceiling, COLOR_MUTED, "zone D: damage"),
+        (floor, limits["A"], COLOR_ZONE_A, "zone A: newly commissioned"),
+        (limits["A"], limits["B"], COLOR_ZONE_B, "zone B: unrestricted operation"),
+        (limits["B"], limits["C"], COLOR_ZONE_C, "zone C: limited operation"),
+        (limits["C"], ceiling, COLOR_ZONE_D, "zone D: damage"),
     )
     for lower, upper, colour, label in bands:
         ax.fill_between(
@@ -2452,10 +2456,10 @@ def generate_industrial_machine_zones(output_dir: str) -> None:
         ),
     )
     zones = (
-        ("A", COLOR_PRIMARY, "zone A: newly commissioned"),
-        ("B", COLOR_SECONDARY, "zone B: unrestricted operation"),
-        ("C", COLOR_TERTIARY, "zone C: limited operation"),
-        ("D", COLOR_MUTED, "zone D: damage"),
+        ("A", COLOR_ZONE_A, "zone A: newly commissioned"),
+        ("B", COLOR_ZONE_B, "zone B: unrestricted operation"),
+        ("C", COLOR_ZONE_C, "zone C: limited operation"),
+        ("D", COLOR_ZONE_D, "zone D: damage"),
     )
     fig, axes = plt.subplots(1, 2, figsize=(11.0, 6.6))
     positions = np.arange(len(classes), dtype=float)
@@ -2574,10 +2578,10 @@ def generate_machine_alarm_trip(output_dir: str) -> None:
 
     _fig, ax = plt.subplots(figsize=(9.6, 6.0))
     bands = (
-        (0.0, a_b, COLOR_PRIMARY, "A", "zone A: newly commissioned"),
-        (a_b, b_c, COLOR_SECONDARY, "B", "zone B: unrestricted operation"),
-        (b_c, c_d, COLOR_TERTIARY, "C", "zone C: limited operation"),
-        (c_d, ceiling, COLOR_MUTED, "D", "zone D: damage"),
+        (0.0, a_b, COLOR_ZONE_A, "A", "zone A: newly commissioned"),
+        (a_b, b_c, COLOR_ZONE_B, "B", "zone B: unrestricted operation"),
+        (b_c, c_d, COLOR_ZONE_C, "C", "zone C: limited operation"),
+        (c_d, ceiling, COLOR_ZONE_D, "D", "zone D: damage"),
     )
     for lower, upper, colour, letter, legend in bands:
         ax.axhspan(lower, upper, color=theme_fill(colour, ax), zorder=0, label=legend)
@@ -2852,10 +2856,10 @@ def generate_machine_vibration_trend(output_dir: str) -> None:
 
     _fig, ax = plt.subplots(figsize=(9.6, 6.0))
     for lower, upper, colour, letter in (
-        (0.0, a_b, COLOR_PRIMARY, "A"),
-        (a_b, b_c, COLOR_SECONDARY, "B"),
-        (b_c, c_d, COLOR_TERTIARY, "C"),
-        (c_d, ceiling, COLOR_MUTED, "D"),
+        (0.0, a_b, COLOR_ZONE_A, "A"),
+        (a_b, b_c, COLOR_ZONE_B, "B"),
+        (b_c, c_d, COLOR_ZONE_C, "C"),
+        (c_d, ceiling, COLOR_ZONE_D, "D"),
     ):
         ax.axhspan(lower, upper, color=theme_fill(colour, ax), zorder=0)
         # Chipped, because the baseline crosses zone A where its letter sits.


### PR DESCRIPTION
## What and why

This started as a look at the eight dark and Spanish figure variants that nobody had actually opened, and found something the light English one had been showing all along.

The evaluation zones were shaded with the series palette. On an ordered scale that tells the reader the opposite of what the scale says: zone B, "unrestricted operation", came out red and zone C, "limited operation", came out green, so the better of the two looked like the alarming one, and zone D, damage, was a neutral grey behind both. Four figures did it, which is why this is a ramp of its own rather than four local choices:

- `machine_vibration_zones`, the Table C.1 frequency-shaped criterion
- `industrial_machine_zones`, the ISO 10816-3 boundary bars
- `machine_alarm_trip`, the ALARM and TRIP settings
- `machine_vibration_trend`, the twelve-month trend

`COLOR_ZONES` runs one way, calm to alarming. The letter drawn in each band and the order of the bands themselves repeat the same information, so a reader who does not separate red from green still has two ways to read it.

The flow-noise note is redrawn in the same run to match the prose the layer below corrects: what Figure 16 prints is a level difference, not a share.

The other three variants held up. The Spanish and dark editions of `vdi2081_flow_noise` and `iso17534_qa_cases` carry their decimal commas, their translated annotations and their chips correctly, and read at full zoom on both pages.

## Validation

A full `make graphs`, since the language and annotation audits are per run and a targeted regeneration cannot answer for the tree. Exactly 20 files changed, the five figure families in four variants each; the other 2388 reproduce byte for byte, which is the check that this touched nothing it should not have.

- `scripts/check_figure_contrast.py`: all 5158 filled regions in 2408 figures clear dE00 10, the new zone washes included, on both pages.
- `scripts/check_figure_language.py`: no new untranslated text, baseline unchanged.
- `scripts/check_figure_annotations.py`: no unreadable annotation, 938 drawings measured.
- Every changed figure rasterised and looked at, light and dark, both editions.

The alt text of the four figures says "coloured bands" and names the zones by letter and order rather than by colour, so it stays true.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files touched
- [x] `mypy src scripts`
- [x] `pytest -q` on the plotting suites

Regenerated:

- [x] `make graphs`, with the regenerated images committed
- [x] `make llms`

Always:

- [x] Documentation updated in English and Spanish, kept in step
- [x] CHANGELOG entry under `[Unreleased]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with clarified figure and visualization notes.
  - Revised the Figure 16 annotation and translation to clarify that it shows a level difference, not a share, and that bands do not sum to the overall level.

- **Bug Fixes**
  - Corrected evaluation-zone shading across four vibration figures with a calm-to-alarming color progression.
  - Added letter and band ordering to reinforce zone information for readers who may have difficulty distinguishing red and green.
  - Confirmed that the remaining 2,388 figures are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->