### PR TITLE
Let the accessibility audit drive the browser we actually install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,14 +119,26 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
-      - name: Enable latest pnpm via corepack
+      - name: Enable the pnpm this site pins, via corepack
         # corepack ships with Node and installs pnpm cleanly. We avoid
         # pnpm/action-setup, whose bundled installer crashes while self-updating
         # to the latest release ("Cannot use 'in' operator ... integrity").
+        #
+        # The version comes from `packageManager` in site/package.json, not
+        # from `pnpm@latest`: taking whatever shipped that morning makes the
+        # build depend on a date. It did, and the cost was not a loud install
+        # failure but a policy change three releases later that stopped
+        # dependency lifecycle scripts from running, which surfaced as an
+        # accessibility audit blaming a page for a browser that was never
+        # downloaded.
         run: |
           corepack enable
-          corepack prepare pnpm@latest --activate
           pnpm --version
+        # From site/, because that is where the package.json carrying
+        # `packageManager` lives; corepack reads the nearest one, and the
+        # repository root has none, so a check run from there would report
+        # whatever pnpm corepack defaults to rather than the pinned version.
+        working-directory: site
       - name: Resolve pnpm store path
         # Derive the store path from pnpm itself rather than hardcoding it: it
         # varies with pnpm version and XDG configuration.
@@ -138,6 +150,15 @@ jobs:
           path: ${{ env.PNPM_STORE }}
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('site/pnpm-lock.yaml') }}
           restore-keys: pnpm-store-${{ runner.os }}-
+      - name: Cache the browser the audits drive
+        # Keyed on the lockfile, because the version puppeteer resolves is
+        # pinned there; a lockfile bump downloads a fresh one and everything
+        # else restores.
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('site/pnpm-lock.yaml') }}
+          restore-keys: puppeteer-${{ runner.os }}-
       - name: Check the overview and glossary mirrors, then regenerate llms.txt
         run: |
           python3 scripts/mirror_overviews.py --check
@@ -161,6 +182,17 @@ jobs:
         working-directory: site
       - name: Build site
         run: pnpm install --frozen-lockfile && pnpm build
+        working-directory: site
+      - name: Install the browser the audits drive
+        # After the install, because this asks pnpm to run a binary the install
+        # is what puts there. Explicit, rather than left to puppeteer's own
+        # install script: since pnpm 10 a dependency's lifecycle scripts do not
+        # run unless they are allow-listed, so the download quietly stopped
+        # happening. Nothing failed at install time; the accessibility audit
+        # failed much later, on a page that was fine, with "Could not find
+        # Chrome". Asking for the browser in as many words cannot go quiet that
+        # way, whatever the package manager decides about scripts next.
+        run: pnpm exec puppeteer browsers install chrome
         working-directory: site
       - name: Check no published address was left behind
         # Renaming a page changes its URL, and nothing here noticed: Astro does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The accessibility audit drives the browser this site installs. Every audit
+  behind `scripts/with-preview.mjs` needs a headless Chrome and they were not
+  all asking the same package for one: the in-house scripts use `puppeteer`,
+  whose browser `pnpm install` puts in the cache, while `pa11y-ci` carries its
+  own older `puppeteer-core` and looks for whatever Chrome that was built
+  against. Two browsers wanted, one downloaded.
+
+  On a developer machine the cache accumulates versions and both are usually
+  there, so nothing showed. On a fresh worker only one exists and the audit
+  died with "Could not find Chrome (ver. 148.0.7778.97)" on pages that are
+  perfectly fine, and died *intermittently*, because a warm runner cache could
+  still hold the older build. The wrapper now resolves the browser once and
+  passes it to every child, and an explicit `PUPPETEER_EXECUTABLE_PATH` still
+  wins for anyone pointing an audit at a system Chrome.
+
+  Underneath that sat the reason no browser was there to find. Since pnpm 10 a
+  dependency's lifecycle scripts do not run unless they are allow-listed, so
+  puppeteer's install script quietly stopped downloading anything. Nothing
+  failed at install time; the audit failed much later and blamed a page. The
+  workflow asks for the browser in as many words now, and caches it on the
+  lockfile.
+
+  The reason it changed under us at all is that the workflow installed
+  `pnpm@latest`, so the build depended on whatever shipped that morning. The
+  version comes from a pinned `packageManager` field now, the way jmrp.io
+  already does it, and corepack reads it.
+
 ### Added
 
 - `noise_control.flow_noise_straight_duct_overall`, the two closed forms VDI

--- a/site/package.json
+++ b/site/package.json
@@ -2,6 +2,7 @@
   "name": "phonometry-docs",
   "type": "module",
   "version": "1.0.0",
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "private": true,
   "scripts": {
     "build": "astro build",

--- a/site/scripts/with-preview.mjs
+++ b/site/scripts/with-preview.mjs
@@ -87,7 +87,39 @@ try {
   process.exit(1);
 }
 
-const child = spawn(command[0], command.slice(1), { stdio: 'inherit', shell: false });
+// Every audit run through here drives a headless Chrome, and they do not all
+// ask the same package for it: the in-house scripts use `puppeteer`, which is
+// the version this site pins and the one whose browser `pnpm install` puts in
+// the cache, while `pa11y-ci` carries its own older `puppeteer-core` and asks
+// for whatever Chrome *that* was built against. Two different browsers, one
+// downloaded.
+//
+// On a developer machine the cache accumulates versions and both are usually
+// present, so the mismatch is invisible; on a fresh CI worker only the one
+// `puppeteer` installs exists, and pa11y dies with "Could not find Chrome
+// (ver. ...)" on a page that is perfectly fine. Worse, it dies intermittently,
+// because a warm runner cache can still hold the older build.
+//
+// So the browser is decided here, once, and every child is told which one to
+// drive. An explicit PUPPETEER_EXECUTABLE_PATH in the environment still wins,
+// for the reader who wants to point an audit at a system Chrome.
+const env = { ...process.env };
+if (!env.PUPPETEER_EXECUTABLE_PATH) {
+  try {
+    // Through the shared resolver, not a bare import: it falls back to the
+    // pnpm virtual store when the package is not linked at the top level, and
+    // a resolution that misses here would silently leave pa11y-ci picking its
+    // own browser again, which is the whole thing this is here to stop.
+    const { loadPuppeteer } = await import('./shared/audit.mjs');
+    env.PUPPETEER_EXECUTABLE_PATH = await loadPuppeteer().executablePath();
+  } catch (error) {
+    // Not fatal: a command that needs no browser runs perfectly well without
+    // this, and one that does will fail with its own clearer message.
+    console.error(`with-preview: could not resolve a browser (${error.message})`);
+  }
+}
+
+const child = spawn(command[0], command.slice(1), { stdio: 'inherit', shell: false, env });
 child.on('exit', (code, signal) => {
   stop();
   process.exit(signal ? 1 : (code ?? 1));


### PR DESCRIPTION
## What and why

The accessibility job started failing on pages that are perfectly fine, with `Could not find Chrome (ver. 148.0.7778.97)`. Two faults sit behind that one message.

**No browser was being installed.** pnpm 10 stopped running a dependency's lifecycle scripts unless they are allow-listed, and this workflow takes `pnpm@latest`, so puppeteer's install script quietly stopped downloading anything. Nothing failed at install time; the failure surfaced much later and blamed a page. The workflow now asks for the browser in as many words, `pnpm exec puppeteer browsers install chrome`, and caches `~/.cache/puppeteer` on the lockfile.

**The audits did not agree on which browser to want.** Everything behind `scripts/with-preview.mjs` drives a headless Chrome, but not through the same package: the in-house scripts use `puppeteer`, which this site pins at 25.9.0, while `pa11y-ci` carries its own older `puppeteer-core` and asks for whatever Chrome *that* was built against. On a developer machine the cache accumulates versions and both are usually there, which is why this never showed locally. The wrapper resolves the browser once now and hands it to every child, so the two cannot drift apart again; an explicit `PUPPETEER_EXECUTABLE_PATH` still wins for anyone pointing an audit at a system Chrome.

The intermittency was the tell. The last green run on `main` was 33a4bc7e at 16:54, with no dependency change since: a warm runner cache still held an older build, and the job passed until the cache rotated.

## Validation

Both halves were reproduced and then watched to fail differently, which is what confirmed the diagnosis. With only the wrapper change, CI stopped hunting for 148 and started reporting `Tried to find the browser at the configured path (chrome/linux-152.0.7977.54), but no executable was found` — the right path, and nothing at it. That is what pointed at the missing install.

Locally, `pnpm exec puppeteer browsers install chrome` resolves and places `chrome@152.0.7977.54`, `puppeteer.executablePath()` returns that same path, and `pa11y-ci` driven through the wrapper reports 0 errors on the pages it was given.

This is deliberately not folded into the feature branch it was blocking: it is a toolchain fix and belongs on its own.

## Checklist

- [x] `node --check` on the changed script, YAML parsed
- [x] `pa11y-ci` run end to end against a built preview
- [x] CHANGELOG entry under `[Unreleased]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser availability for documentation audits by explicitly installing and caching the required Chrome browser.
  * Audit processes now consistently share the resolved browser executable, while explicit browser path overrides continue to be honored.
  * Commands that do not require a browser can continue running when browser resolution fails.

* **Chores**
  * Documentation workflows now use the project’s pinned package manager version for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->