### PR TITLE
The PyPI page may only name paths the tag will carry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,12 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
+          # The tag has to name the commit these checks ran on. Left out,
+          # the tag is cut from whatever the default branch points at when
+          # this step runs, so a push landing meanwhile would be inside a
+          # release nobody built or tested, and the description uploaded a
+          # few steps earlier would name a tree the tag does not hold.
+          target_commitish: ${{ github.sha }}
           name: Release ${{ steps.version.outputs.tag }}
           body: |
             See the [changelog](https://github.com/jmrplens/phonometry/blob/main/CHANGELOG.md) for the full details of this release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A release tag names the commit its checks ran on. The release step passed
+  the tag name and nothing else, and without a commit to point at the tag is
+  cut from whatever the default branch holds when that step runs, which is
+  not necessarily the commit that was built, tested and uploaded minutes
+  earlier. A push landing in that window would be inside a release nobody
+  ran anything against, and the description already sent to PyPI would name
+  a tree the tag does not carry. The step names the triggering commit now.
+
+  The same distinction reached the page itself. Every repository link on the
+  frozen description is pinned to the release tag, and what held that up was
+  a check that the path exists in the working tree. A tag points at a
+  commit and a commit carries tracked files, so a generated artefact that is
+  present and never added passes that check and is missing from the release
+  all the same: a URL that answers in a checkout and 404s on the tag, which
+  is what #735 reported for the brand images and the conformance badge. The
+  paths are asked of git now rather than of the filesystem.
+
 - The accessibility audit drives the browser this site installs. Every audit
   behind `scripts/with-preview.mjs` needs a headless Chrome and they were not
   all asking the same package for one: the in-house scripts use `puppeteer`,

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -162,14 +162,18 @@ def test_pinned_pypi_links_resolve_in_this_checkout() -> None:
     )
 
 
-def _tracked(paths: list[str]) -> set[str]:
-    """The subset of *paths* git has under version control.
+def _tracked(paths: list[str], root: pathlib.Path = _ROOT) -> set[str]:
+    """The subset of *paths* git has under version control, inside *root*.
 
     One call for the whole list: ``git ls-files`` echoes back only what it
-    tracks, so what it leaves out is the answer.
+    tracks, so what it leaves out is the answer. It reads the index, which
+    is what the next commit will carry, and the release commit is made and
+    tagged in one step, so the index and that commit are the same thing
+    where this runs. *root* is a parameter so the predicate can be asked
+    about a repository built for the purpose.
     """
     listed = subprocess.run(  # noqa: S603 - fixed argv, paths from our own page
-        ["git", "-C", str(_ROOT), "ls-files", "-z", "--", *paths],  # noqa: S607
+        ["git", "-C", str(root), "ls-files", "-z", "--", *paths],  # noqa: S607
         capture_output=True,
         text=True,
         check=True,
@@ -177,17 +181,37 @@ def _tracked(paths: list[str]) -> set[str]:
     return set(listed.split("\0")) - {""}
 
 
-def test_tracked_reports_what_git_does_not_carry() -> None:
-    """The predicate above answers both ways, or it proves nothing.
+def _git(root: pathlib.Path, *args: str) -> None:
+    """Run one git command in *root*, for building a fixture repository."""
+    subprocess.run(  # noqa: S603 - fixed argv, arguments from this file
+        ["git", "-C", str(root), *args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
 
-    A check that can only say yes would pass on a page full of dead links,
-    so it is asked about a path that is not in the repository and about one
-    that is.
+
+def test_tracked_reports_a_file_that_is_there_and_untracked(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The predicate answers both ways, or it proves nothing.
+
+    The failure this guards against is not a missing file, it is a file that
+    is *there* and absent from the commit anyway, so that is what it is
+    asked about: a repository with one committed page and one generated
+    artefact beside it that nobody added. `exists()` cannot tell them apart
+    and this must.
     """
-    if not (_ROOT / ".git").exists():
-        pytest.skip("not a git checkout, so there is nothing to ask git about")
-    assert _tracked(["docs/a-path-no-release-will-ever-carry.md"]) == set()
-    assert _tracked(["README.md"]) == {"README.md"}
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "config", "user.email", "packaging@example.invalid")
+    _git(tmp_path, "config", "user.name", "packaging test")
+    (tmp_path / "README.md").write_text("committed\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "--quiet", "-m", "initial")
+    (tmp_path / "generated.svg").write_text("<svg/>\n", encoding="utf-8")
+    assert (tmp_path / "generated.svg").exists()
+    assert _tracked(["README.md", "generated.svg"], tmp_path) == {"README.md"}
+    assert _tracked(["never-written.svg"], tmp_path) == set()
 
 
 def test_pinned_pypi_links_are_tracked_by_git() -> None:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,7 +10,11 @@ guides that had since been filed into subdirectories. The generator pins those
 links to the release tag instead, and the tests below hold that pin: no ``main``
 ref may reach the page, every ref must be the tag of the version in ``VERSION``,
 and every path behind one must exist in this checkout, which is the tree the tag
-will be cut from.
+will be cut from, and be tracked, because a tag carries a commit and a commit
+carries only what git has been told about. Existing is the weaker half of that
+pair: a generated artefact that is present and never added passes it and is
+absent from the release all the same, which is the failure reported in #735 for
+the brand images and the conformance badge.
 
 Those three hold the page PyPI serves, not the copy committed here. Between
 releases ``VERSION`` still names the last release, so the committed copy pins
@@ -33,8 +37,11 @@ here can gate, so the prose keeps the mechanism and drops the number.
 
 import pathlib
 import re
+import subprocess
 import sys
 import tomllib
+
+import pytest
 
 import phonometry
 
@@ -152,6 +159,58 @@ def test_pinned_pypi_links_resolve_in_this_checkout() -> None:
     assert not dangling, (
         "README_PYPI.md links to paths that are not in this checkout, so they "
         f"will not be in the release tag either: {dangling}"
+    )
+
+
+def _tracked(paths: list[str]) -> set[str]:
+    """The subset of *paths* git has under version control.
+
+    One call for the whole list: ``git ls-files`` echoes back only what it
+    tracks, so what it leaves out is the answer.
+    """
+    listed = subprocess.run(  # noqa: S603 - fixed argv, paths from our own page
+        ["git", "-C", str(_ROOT), "ls-files", "-z", "--", *paths],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return set(listed.split("\0")) - {""}
+
+
+def test_tracked_reports_what_git_does_not_carry() -> None:
+    """The predicate above answers both ways, or it proves nothing.
+
+    A check that can only say yes would pass on a page full of dead links,
+    so it is asked about a path that is not in the repository and about one
+    that is.
+    """
+    if not (_ROOT / ".git").exists():
+        pytest.skip("not a git checkout, so there is nothing to ask git about")
+    assert _tracked(["docs/a-path-no-release-will-ever-carry.md"]) == set()
+    assert _tracked(["README.md"]) == {"README.md"}
+
+
+def test_pinned_pypi_links_are_tracked_by_git() -> None:
+    """Existing in the tree is not enough: the tag carries only what is tracked.
+
+    A tag points at a commit, and a commit holds tracked files. A path that
+    is present but ignored or simply never added satisfies the test above
+    and is still absent from the release, which is the shape of the report
+    in #735: a URL that answers on a working tree and 404s on the tag. Every
+    generated artefact this page names (the conformance badge, the brand
+    images, the animation posters) is committed today, and this is what says
+    so at the release commit rather than after the upload.
+    """
+    if not (_ROOT / ".git").exists():
+        pytest.skip("not a git checkout, so there is nothing to ask git about")
+    paths = sorted(
+        {match["path"] for match in _REPO_URL.finditer(_committed_pypi_readme())}
+    )
+    assert paths, "no repository links found; the pattern stopped matching"
+    untracked = sorted(set(paths) - _tracked(paths))
+    assert not untracked, (
+        "README_PYPI.md links to paths git does not track, so the release tag "
+        f"will not carry them however present they look here: {untracked}"
     )
 
 


### PR DESCRIPTION
A URL on the frozen PyPI description has to survive the tag being cut, and the check that held that end up asked the working tree whether the file was there.

Present and tracked are not the same thing. A generated artefact that is on disk and never added answers yes to `exists()` and is missing from the commit the tag points at, so the link resolves in a checkout and 404s on the tag. That is the shape of the failure reported in #735: the brand images and the conformance badge do 404 at `v3.3.0`, because they landed 22 hours after it was cut.

The pinned paths are now asked of git rather than of the filesystem, one `git ls-files` for the whole list, and the predicate is tested both ways so it cannot pass by only ever saying yes. Every path the page names today is tracked, so this changes no artefact; it closes the class.

Note for the reader of #735: the description published for 3.3.0 does not carry those URLs. `README_PYPI.md` postdates that tag, and the nine images of the uploaded page all answer 200. The report was about the copy on `main`, which names the previous release between releases by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added packaging checks to verify that repository links in the committed PyPI README point to files tracked by version control.
  - Added coverage for distinguishing tracked and untracked paths, helping prevent broken links to generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->