### PR TITLE
A release candidate can reach PyPI, and it goes out marked as one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,31 @@ jobs:
         id: version
         run: |
           VERSION=$(tr -d ' \n' < VERSION)
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.]+)?$'; then
-            echo "::error::VERSION file does not contain a valid semver: '$VERSION'"
+          # The PEP 440 normal form, which is what the build back end writes
+          # into the artefact names a few steps down: a pre-release marker
+          # carries no separator (4.0.0rc1, never 4.0.0-rc1), so accepting the
+          # hyphen here would pass a version whose wheel is then named
+          # something else and fail at the artefact check instead.
+          if ! echo "$VERSION" |
+            grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?(\.post[0-9]+)?(\.dev[0-9]+)?$'; then
+            echo "::error::VERSION is not a PEP 440 normal-form version: '$VERSION'"
             exit 1
           fi
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
             echo "::notice::Tag v$VERSION already exists — nothing to release."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+          # A release candidate is published as a pre-release, so it does not
+          # become the repository's "Latest release" and pip leaves it alone
+          # without --pre. Read off the version rather than set by hand: the
+          # VERSION file is the only thing that decides a release here, and a
+          # flag somebody has to remember is a flag that goes out wrong.
+          if echo "$VERSION" |
+            grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+|\.dev[0-9]+)'; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -162,6 +179,6 @@ jobs:
             See the [changelog](https://github.com/jmrplens/phonometry/blob/main/CHANGELOG.md) for the full details of this release.
           generate_release_notes: true
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.version.outputs.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,13 @@ jobs:
         run: |
           VERSION=$(tr -d ' \n' < VERSION)
           # The PEP 440 normal form, which is what the build back end writes
-          # into the artefact names a few steps down: a pre-release marker
-          # carries no separator (4.0.0rc1, never 4.0.0-rc1), so accepting the
-          # hyphen here would pass a version whose wheel is then named
-          # something else and fail at the artefact check instead.
-          if ! echo "$VERSION" |
-            grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?(\.post[0-9]+)?(\.dev[0-9]+)?$'; then
+          # into the artefact names a few steps down. Two ways to get that
+          # wrong both end at the same failure, an artefact whose name is not
+          # the one this file says: a pre-release marker carries no separator
+          # (4.0.0rc1, never 4.0.0-rc1), and no numeric component carries a
+          # leading zero (4.0.0, never 04.00.00, and rc1, never rc01). Both are
+          # normalised by the back end and neither is normalised here.
+          if ! echo "$VERSION" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$'; then
             echo "::error::VERSION is not a PEP 440 normal-form version: '$VERSION'"
             exit 1
           fi
@@ -54,8 +55,11 @@ jobs:
           # without --pre. Read off the version rather than set by hand: the
           # VERSION file is the only thing that decides a release here, and a
           # flag somebody has to remember is a flag that goes out wrong.
-          if echo "$VERSION" |
-            grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+|\.dev[0-9]+)'; then
+          # PEP 440 counts a developmental release as a pre-release too, and
+          # one can follow a post-release (4.0.0.post1.dev1), so the marker is
+          # looked for anywhere rather than right after the release segment.
+          # The string is already validated above, so nothing else can match.
+          if echo "$VERSION" | grep -Eq '(a|b|rc)[0-9]+|\.dev[0-9]+'; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -348,9 +348,11 @@ def test_pinning_leaves_other_repositories_alone() -> None:
 #: Every version the release workflow has to decide about, with what it must
 #: decide: whether the VERSION file is valid at all, and whether the GitHub
 #: Release it creates is a pre-release. The forms with a separator are here
-#: because they are the trap: ``4.0.0-rc1`` reads like a version, and the
-#: build back end normalises it to ``4.0.0rc1``, so the artefact check two
-#: steps later would look for a wheel that does not exist.
+#: because they are the trap: ``4.0.0-rc1`` and ``04.00.00`` both read like a
+#: version, and the build back end normalises both, so the artefact check two
+#: steps later would look for a wheel that does not exist. A developmental
+#: release of a post-release is here because PEP 440 counts it as a
+#: pre-release and the marker does not sit where the others do.
 _RELEASE_VERSIONS = (
     ("3.3.0", True, False),
     ("4.0.0", True, False),
@@ -359,11 +361,14 @@ _RELEASE_VERSIONS = (
     ("4.0.0b2", True, True),
     ("4.0.0.dev3", True, True),
     ("4.0.0.post1", True, False),
+    ("4.0.0.post1.dev1", True, True),
     ("4.0.0-rc1", False, False),
     ("4.0.0_rc1", False, False),
     ("4.0", False, False),
     ("v4.0.0", False, False),
     ("4.0.0rc", False, False),
+    ("04.00.00", False, False),
+    ("4.0.0rc01", False, False),
 )
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -340,3 +340,63 @@ def test_pinning_leaves_other_repositories_alone() -> None:
     assert "numpy/numpy/tree/main/doc/" in pinned
     assert "scipy/scipy/main/doc/logo.svg" in pinned
     assert "jmrplens/phonometry/blob/v9.9.9/LICENSE" in pinned
+
+
+# ==========================================================================
+# The release workflow's two version regexes
+# ==========================================================================
+#: Every version the release workflow has to decide about, with what it must
+#: decide: whether the VERSION file is valid at all, and whether the GitHub
+#: Release it creates is a pre-release. The forms with a separator are here
+#: because they are the trap: ``4.0.0-rc1`` reads like a version, and the
+#: build back end normalises it to ``4.0.0rc1``, so the artefact check two
+#: steps later would look for a wheel that does not exist.
+_RELEASE_VERSIONS = (
+    ("3.3.0", True, False),
+    ("4.0.0", True, False),
+    ("4.0.0rc1", True, True),
+    ("4.0.0a1", True, True),
+    ("4.0.0b2", True, True),
+    ("4.0.0.dev3", True, True),
+    ("4.0.0.post1", True, False),
+    ("4.0.0-rc1", False, False),
+    ("4.0.0_rc1", False, False),
+    ("4.0", False, False),
+    ("v4.0.0", False, False),
+    ("4.0.0rc", False, False),
+)
+
+
+def _release_workflow_patterns() -> tuple[str, str]:
+    """The valid-version and the pre-release regex, read off the workflow."""
+    text = (_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    found = re.findall(r"grep -Eq '([^']+)'", text)
+    assert len(found) == 2, f"expected two version regexes, found {len(found)}"
+    return found[0], found[1]
+
+
+@pytest.mark.parametrize(("version", "valid", "pre"), _RELEASE_VERSIONS)
+def test_release_workflow_accepts_exactly_the_pep440_normal_form(
+    version: str, valid: bool, pre: bool
+) -> None:
+    """A release candidate has to reach PyPI, and a mis-typed one must not.
+
+    ``prerelease: false`` used to be a literal and the guard rejected any
+    version whose suffix carried no separator, so ``4.0.0rc1`` could not be
+    released at all and ``4.0.0-rc1`` would have gone out marked as the
+    latest stable release.
+    """
+    del pre
+    accepted, _ = _release_workflow_patterns()
+    assert bool(re.search(accepted, version)) is valid
+
+
+@pytest.mark.parametrize(("version", "valid", "pre"), _RELEASE_VERSIONS)
+def test_release_workflow_marks_a_candidate_as_a_pre_release(
+    version: str, valid: bool, pre: bool
+) -> None:
+    """The flag is read off the version, never set by hand."""
+    if not valid:
+        pytest.skip("not a version the workflow would release at all")
+    _, prerelease = _release_workflow_patterns()
+    assert bool(re.search(prerelease, version)) is pre


### PR DESCRIPTION
Two things stood between the VERSION file and a 4.0.0rc1.

The guard on the version string accepted a pre-release suffix only when it carried a separator, `[.-]`. PEP 440 writes a candidate without one, so `4.0.0rc1` failed the guard and the job stopped on the first step. The form the guard did accept, `4.0.0-rc1`, would have got further and failed worse: the build back end normalises it to `4.0.0rc1`, so the step that checks the built artefact would have looked for `phonometry-4.0.0-rc1-py3-none-any.whl` and not found it, after the version had already been validated and the CI conclusion read.

The pattern is now the PEP 440 normal form the back end actually writes: `4.0.0`, `4.0.0rc1`, `4.0.0a1`, `4.0.0b2`, `4.0.0.post1` and `4.0.0.dev3` pass; `4.0.0-rc1`, `4.0.0_rc1`, `4.0`, `v4.0.0` and `4.0.0rc` do not.

The second was `prerelease: false`, a literal since the workflow was written. A candidate published with it would have become the repository's Latest release, and the release notes on the front page would have pointed at a version nobody should install by default. The flag is now read off the version, because the VERSION file is the only thing that decides a release here and a flag somebody has to remember is a flag that eventually goes out wrong.

Twelve versions pin both regexes in `tests/test_packaging.py`. They are read off the workflow rather than restated there, so an edit to either pattern has to move the table with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release automation now supports PEP 440 version formats, including alpha, beta, release-candidate, postrelease, and development versions.
  * Prerelease versions are automatically marked as prereleases on GitHub.

* **Tests**
  * Added coverage to verify accepted version formats and correct prerelease labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->